### PR TITLE
Dispatch CI after merge train merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
   merge_group:
   push:

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -12,6 +12,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   checks: read
@@ -41,4 +42,5 @@ jobs:
           MERGE_TRAIN_METHOD: squash
           MERGE_TRAIN_DELETE_BRANCH: "true"
           MERGE_TRAIN_IGNORED_CHECK_RE: "^(Merge Train|train)$"
+          MERGE_TRAIN_POST_MERGE_WORKFLOW: ci.yml
         run: ./scripts/merge-train.sh

--- a/docs/MERGE_TRAIN.md
+++ b/docs/MERGE_TRAIN.md
@@ -20,6 +20,7 @@ The train processes only the oldest eligible PR at a time. It ignores draft PRs 
 - Only one train run can execute at a time.
 
 When the train head is ready, it merges with a squash merge and deletes the source branch.
+After a successful merge, the train dispatches the `CI` workflow on `main` explicitly. GitHub does not automatically create a normal push-triggered run for merges performed with `GITHUB_TOKEN`, so this keeps the latest `main` state visibly validated in Actions.
 
 ## Required Repository Settings
 

--- a/scripts/merge-train.sh
+++ b/scripts/merge-train.sh
@@ -9,6 +9,7 @@ block_label="${MERGE_TRAIN_BLOCK_LABEL:-do-not-merge}"
 merge_method="${MERGE_TRAIN_METHOD:-squash}"
 delete_branch="${MERGE_TRAIN_DELETE_BRANCH:-true}"
 ignored_check_re="${MERGE_TRAIN_IGNORED_CHECK_RE:-^(Merge Train|train)$}"
+post_merge_workflow="${MERGE_TRAIN_POST_MERGE_WORKFLOW:-}"
 dry_run="${MERGE_TRAIN_DRY_RUN:-false}"
 
 case "$merge_method" in
@@ -134,4 +135,13 @@ if [[ "$dry_run" == "true" ]]; then
   printf '\n'
 else
   gh "${merge_args[@]}"
+fi
+
+if [[ -n "$post_merge_workflow" ]]; then
+  echo "Dispatching post-merge workflow $post_merge_workflow on $base_branch."
+  if [[ "$dry_run" == "true" ]]; then
+    echo "DRY RUN: gh workflow run $post_merge_workflow --repo $repo --ref $base_branch"
+  else
+    gh workflow run "$post_merge_workflow" --repo "$repo" --ref "$base_branch"
+  fi
 fi


### PR DESCRIPTION
## Summary
- Add manual CI dispatch support.
- Let the merge train explicitly dispatch CI on main after it merges a PR.
- Document why the post-merge run is explicit when merging with GITHUB_TOKEN.

## Validation
- bash -n scripts/merge-train.sh
- YAML parse for CI and Merge Train workflows
- git diff --check
- dry-run fake ready PR exercises merge and post-merge CI dispatch