### PR TITLE
Handle CLI live errors cleanly

### DIFF
--- a/Sources/quill-code/main.swift
+++ b/Sources/quill-code/main.swift
@@ -6,7 +6,16 @@ import QuillCodeSafety
 
 @main
 struct QuillCodeCLI {
-    static func main() async throws {
+    static func main() async {
+        do {
+            try await run()
+        } catch {
+            writeError("quill-code: \(error)")
+            exit(1)
+        }
+    }
+
+    private static func run() async throws {
         var args = Array(CommandLine.arguments.dropFirst())
         var live = false
         var apiKey: String?
@@ -136,5 +145,10 @@ struct QuillCodeCLI {
         default:
             print(usage)
         }
+    }
+
+    private static func writeError(_ message: String) {
+        guard let data = "\(message)\n".data(using: .utf8) else { return }
+        FileHandle.standardError.write(data)
     }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -35,6 +35,30 @@ if [[ "$(tr -d '\r' < "$SMOKE_WORKSPACE/hello.txt")" != "hello world" ]]; then
   exit 1
 fi
 
+echo "==> Verifying CLI live-mode errors are readable"
+LIVE_ERROR_STDOUT="$SMOKE_ROOT/live-error.stdout"
+LIVE_ERROR_STDERR="$SMOKE_ROOT/live-error.stderr"
+if env -u QUILLCODE_API_KEY -u TRUSTEDROUTER_API_KEY swift run quill-code \
+  --live \
+  --home "$SMOKE_ROOT/live-home" \
+  --cwd "$SMOKE_WORKSPACE" \
+  "reply with hello" \
+  >"$LIVE_ERROR_STDOUT" \
+  2>"$LIVE_ERROR_STDERR"; then
+  echo "quill-code --live unexpectedly succeeded without a TrustedRouter key" >&2
+  exit 1
+fi
+if ! grep -q "quill-code:" "$LIVE_ERROR_STDERR"; then
+  echo "quill-code --live did not print a readable CLI error prefix" >&2
+  cat "$LIVE_ERROR_STDERR" >&2
+  exit 1
+fi
+if grep -q "Fatal error" "$LIVE_ERROR_STDERR"; then
+  echo "quill-code --live crashed instead of returning a readable error" >&2
+  cat "$LIVE_ERROR_STDERR" >&2
+  exit 1
+fi
+
 if [[ -d "$ROOT_DIR/E2E/playwright/node_modules" ]]; then
   echo "==> Running Playwright E2E suite"
   (cd "$ROOT_DIR/E2E/playwright" && npm test)


### PR DESCRIPTION
## Summary\n- catch CLI runtime errors at the executable boundary and print a readable `quill-code:` error line\n- add smoke coverage that live mode without a key exits cleanly instead of crashing\n\n## Validation\n- `./scripts/smoke.sh`\n- live keyfile smoke with `trustedrouter/fast` returned `QC_LIVE_SMOKE_OK`\n- invalid `deepseekv4flash` smoke now reports `quill-code: [400] Model does not support chat completions: deepseekv4flash` without a fatal crash