### PR TITLE
Cover bulk thread deletion lifecycle

### DIFF
--- a/Tests/QuillCodeAppTests/WorkspaceThreadLifecycleEngineTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceThreadLifecycleEngineTests.swift
@@ -195,4 +195,19 @@ final class WorkspaceThreadLifecycleEngineTests: XCTestCase {
         XCTAssertEqual(Set(result.changedThreads.map(\.id)), Set([first.id, second.id]))
         XCTAssertTrue(threads.allSatisfy { !$0.isArchived })
     }
+
+    func testDeleteThreadsRemovesAndReturnsTargets() throws {
+        let first = ChatThread(title: "First")
+        let second = ChatThread(title: "Second")
+        let untouched = ChatThread(title: "Untouched")
+        var threads = [first, second, untouched]
+
+        let result = try XCTUnwrap(WorkspaceThreadLifecycleEngine.deleteThreads(
+            [first.id, second.id],
+            threads: &threads
+        ))
+
+        XCTAssertEqual(result.removedThreads.map(\.id), [first.id, second.id])
+        XCTAssertEqual(threads.map(\.id), [untouched.id])
+    }
 }


### PR DESCRIPTION
## Summary
- Add focused coverage for bulk thread deletion through WorkspaceThreadLifecycleEngine.
- Keeps the lifecycle extraction guarded for sidebar bulk delete behavior.

## Validation
- swift test --filter WorkspaceBrowserLocationResolverTests
- swift test --filter WorkspaceThreadLifecycleEngineTests
- swift test --filter ParityGateTests
- swift test
- ./scripts/smoke.sh