### PR TITLE
Simplify top bar status chrome

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -124,55 +124,11 @@
     .topbar-context-cluster {
       justify-content: flex-end;
       overflow: visible;
-      max-width: min(32vw, 300px);
     }
-    .topbar-context-cluster > span {
-      min-width: 0;
-      max-width: 150px;
-      flex: 1 1 auto;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    .topbar-context-cluster > [data-testid="agent-status"],
-    .topbar-context-cluster > [data-testid="runtime-issue-pill"] {
-      flex: 0 0 auto;
-      max-width: 150px;
-    }
-    .topbar-context-cluster > [data-testid="computer-use-status"] {
-      max-width: 180px;
-    }
-    .topbar-context-cluster > [data-testid="agent-status"] {
-      width: 10px;
-      min-width: 10px;
-      max-width: 10px;
-      height: 10px;
-      min-height: 10px;
-      padding: 0;
-      overflow: hidden;
-      color: transparent;
-      border-radius: 999px;
-      background: var(--green);
-      border-color: rgba(82, 210, 115, 0.42);
-      box-shadow: 0 0 0 3px rgba(82, 210, 115, 0.12);
-    }
-    .topbar-context-cluster > [data-testid="project-instructions-status"],
-    .topbar-context-cluster > [data-testid="project-memories-status"],
-    .topbar-context-cluster > [data-testid="computer-use-status"] {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      margin: -1px;
-      padding: 0;
-      border: 0;
-      overflow: hidden;
-      clip-path: inset(50%);
-      white-space: nowrap;
-      background: transparent;
-    }
-    .topbar-cluster span,
-    .topbar-cluster select,
-    .topbar-cluster button {
+    .topbar-primary-cluster span,
+    .topbar-primary-cluster select,
+    .topbar-primary-cluster button,
+    .topbar-action-cluster button {
       min-height: 34px;
       padding: 5px 9px;
       border-radius: 999px;
@@ -181,8 +137,9 @@
       border: 1px solid rgba(255,255,255,.10);
       font-size: 12px;
     }
-    .topbar-cluster select { max-width: 230px; }
-    .topbar-cluster button { font-weight: 600; }
+    .topbar-primary-cluster select { max-width: 230px; }
+    .topbar-primary-cluster button,
+    .topbar-action-cluster button { font-weight: 600; }
     .model-picker-wrap [data-testid="model-picker-button"] {
       min-height: 40px;
       padding: 0 8px;
@@ -223,6 +180,100 @@
     }
     .topbar-overflow-menu {
       position: relative;
+    }
+    .topbar-status-menu {
+      position: relative;
+    }
+    .topbar-status-menu summary {
+      width: 40px;
+      min-height: 40px;
+      padding: 0;
+      display: grid;
+      place-items: center;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.10);
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+      list-style: none;
+      line-height: 1;
+    }
+    .topbar-status-menu summary::-webkit-details-marker { display: none; }
+    .topbar-status-menu[open] summary,
+    .topbar-status-menu summary:hover {
+      color: var(--text);
+      background: rgba(255,255,255,.07);
+      border-color: rgba(255,255,255,.16);
+    }
+    .topbar-status-menu [data-testid="agent-status"] {
+      width: 10px;
+      min-width: 10px;
+      max-width: 10px;
+      height: 10px;
+      min-height: 10px;
+      padding: 0;
+      overflow: hidden;
+      color: transparent;
+      border-radius: 999px;
+      background: var(--green);
+      border: 0;
+      box-shadow: 0 0 0 3px rgba(82, 210, 115, 0.12);
+    }
+    .topbar-status-menu [data-testid="agent-status"][data-tone="warning"] {
+      background: var(--amber);
+      box-shadow: 0 0 0 3px rgba(248,184,78,.14);
+    }
+    .topbar-status-menu [data-testid="agent-status"][data-tone="error"] {
+      background: var(--red);
+      box-shadow: 0 0 0 3px rgba(255,93,82,.14);
+    }
+    .topbar-status-popover {
+      position: absolute;
+      right: 0;
+      top: calc(100% + 8px);
+      z-index: 8;
+      width: min(320px, calc(100vw - 36px));
+      display: grid;
+      gap: 8px;
+      padding: 10px;
+      border-radius: 14px;
+      border: 1px solid rgba(255,255,255,.14);
+      background: rgba(22,33,39,.98);
+      box-shadow: 0 14px 42px rgba(0,0,0,.35);
+      transform-origin: top right;
+    }
+    .topbar-status-row {
+      display: grid;
+      grid-template-columns: minmax(92px, auto) minmax(0, 1fr);
+      gap: 12px;
+      align-items: center;
+      min-height: 30px;
+    }
+    .topbar-status-row span {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+    .topbar-status-row strong {
+      display: block;
+      max-width: 100%;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      justify-self: end;
+      color: rgba(238,247,250,.92);
+      font-size: 12px;
+    }
+    .topbar-status-popover [data-testid="runtime-issue-pill"] {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      justify-self: end;
+      color: rgba(238,247,250,.92);
+      font-size: 12px;
     }
     .topbar-overflow-menu summary {
       width: 40px;
@@ -285,12 +336,19 @@
       background: transparent;
       border-color: transparent;
     }
-    .topbar-cluster [data-testid="runtime-issue-pill"] {
+    .topbar-status-popover [data-testid="runtime-issue-pill"] {
+      justify-self: stretch;
+      min-height: 30px;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding: 0 8px;
+      border-radius: 999px;
       color: #ffe2a3;
       background: rgba(248,184,78,.14);
       border-color: rgba(248,184,78,.28);
     }
-    .topbar-cluster [data-testid="runtime-issue-pill"][data-severity="error"] {
+    .topbar-status-popover [data-testid="runtime-issue-pill"][data-severity="error"] {
       color: #ffc4c0;
       background: rgba(255,93,82,.14);
       border-color: rgba(255,93,82,.30);
@@ -2251,9 +2309,6 @@
       .topbar-cluster {
         flex-wrap: wrap;
       }
-      .topbar-context-cluster {
-        justify-content: flex-start;
-      }
       .message, .tool-card { max-width: 100%; width: 100%; }
     }
   </style>
@@ -2679,6 +2734,12 @@
 
     function commandByID(commandID) {
       return state.commands.find(command => command.id === commandID);
+    }
+
+    function topBarStatusTone() {
+      if (state.runtimeIssue?.severity === 'error') return 'error';
+      if (state.runtimeIssue) return 'warning';
+      return state.topBar.agentStatus === 'Failed' ? 'error' : 'success';
     }
 
     function topBarOverflowTestID(commandID) {
@@ -3987,11 +4048,30 @@
                 <span class="visually-hidden" data-testid="mode-pill">${escapeHTML(state.topBar.modeLabel)}</span>
               </div>
               <div class="topbar-cluster topbar-context-cluster" data-testid="top-bar-context-cluster">
-                <span data-testid="agent-status" title="${escapeHTML(state.topBar.agentStatus)}">${escapeHTML(state.topBar.agentStatus)}</span>
-                ${state.runtimeIssue ? `<span data-testid="runtime-issue-pill" data-severity="${escapeHTML(state.runtimeIssue.severity || 'warning')}">${escapeHTML(state.runtimeIssue.title)}</span>` : ''}
-                <span data-testid="project-instructions-status" title="${escapeHTML(state.topBar.instructionSources.join(', '))}">${escapeHTML(state.topBar.instructionLabel)}</span>
-                <span data-testid="project-memories-status" title="${escapeHTML(state.topBar.memorySources.join(', '))}">${escapeHTML(state.topBar.memoryLabel)}</span>
-                <span data-testid="computer-use-status">${escapeHTML(state.topBar.computerUseLabel)}</span>
+                <details class="topbar-status-menu" data-testid="top-bar-status-menu">
+                  <summary data-testid="top-bar-status-button" aria-label="Workspace status" title="${escapeHTML(state.topBar.agentStatus)}">
+                    <span data-testid="agent-status" data-tone="${escapeHTML(topBarStatusTone())}">${escapeHTML(state.topBar.agentStatus)}</span>
+                  </summary>
+                  <div class="topbar-status-popover" data-testid="top-bar-status-popover">
+                    <div class="topbar-status-row">
+                      <span>Status</span>
+                      <strong>${escapeHTML(state.topBar.agentStatus)}</strong>
+                    </div>
+                    ${state.runtimeIssue ? `<span data-testid="runtime-issue-pill" data-severity="${escapeHTML(state.runtimeIssue.severity || 'warning')}">${escapeHTML(state.runtimeIssue.title)}</span>` : ''}
+                    <div class="topbar-status-row">
+                      <span>Instructions</span>
+                      <strong data-testid="project-instructions-status" title="${escapeHTML(state.topBar.instructionSources.join(', '))}">${escapeHTML(state.topBar.instructionLabel)}</strong>
+                    </div>
+                    <div class="topbar-status-row">
+                      <span>Memories</span>
+                      <strong data-testid="project-memories-status" title="${escapeHTML(state.topBar.memorySources.join(', '))}">${escapeHTML(state.topBar.memoryLabel)}</strong>
+                    </div>
+                    <div class="topbar-status-row">
+                      <span>Computer Use</span>
+                      <strong data-testid="computer-use-status">${escapeHTML(state.topBar.computerUseLabel)}</strong>
+                    </div>
+                  </div>
+                </details>
               </div>
               <div class="topbar-cluster topbar-action-cluster" data-testid="top-bar-action-cluster">
                 <details class="topbar-overflow-menu" data-testid="top-bar-overflow-menu">

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -10,6 +10,11 @@ async function openTopBarOverflow(page: Page) {
   await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');
 }
 
+async function openTopBarStatus(page: Page) {
+  await page.getByTestId('top-bar-status-button').click();
+  await expect(page.getByTestId('top-bar-status-menu')).toHaveAttribute('open', '');
+}
+
 async function openSidebarTools(page: Page) {
   await page.getByTestId('sidebar-tools-button').click();
   await expect(page.getByTestId('sidebar-tools-menu')).toHaveAttribute('open', '');
@@ -325,7 +330,7 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
   expect(transcriptPolish.sidebarMenuHeight).toBeGreaterThanOrEqual(40);
 });
 
-test('mock harness bounds top bar status clusters under long labels', async ({ page }) => {
+test('mock harness keeps status details compact under long labels', async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 760 });
   await page.goto('file://' + process.cwd() + '/../harness/index.html');
 
@@ -341,6 +346,7 @@ test('mock harness bounds top bar status clusters under long labels', async ({ p
   await page.getByTestId('agent-status').evaluate(element => {
     element.textContent = 'Idle';
   });
+  await openTopBarStatus(page);
 
   const metrics = await page.evaluate(() => {
     const styleFor = (selector: string) => getComputedStyle(document.querySelector(selector)!);
@@ -349,6 +355,7 @@ test('mock harness bounds top bar status clusters under long labels', async ({ p
     const agent = document.querySelector('[data-testid="agent-status"]')!;
     const topBarRect = rectFor('[data-testid="top-bar"]');
     const actionRect = rectFor('[data-testid="top-bar-action-cluster"]');
+    const statusRect = rectFor('[data-testid="top-bar-status-popover"]');
     return {
       viewportWidth: document.documentElement.clientWidth,
       scrollWidth: document.documentElement.scrollWidth,
@@ -360,9 +367,10 @@ test('mock harness bounds top bar status clusters under long labels', async ({ p
       instructionWidth: instruction.getBoundingClientRect().width,
       instructionScrollWidth: instruction.scrollWidth,
       agentText: agent.textContent,
-      agentFlexShrink: styleFor('[data-testid="agent-status"]').flexShrink,
       agentWidth: agent.getBoundingClientRect().width,
       agentScrollWidth: agent.scrollWidth,
+      statusRight: statusRect.right,
+      statusWidth: statusRect.width,
       actionRight: actionRect.right,
       topBarRight: topBarRect.right
     };
@@ -376,8 +384,9 @@ test('mock harness bounds top bar status clusters under long labels', async ({ p
   expect(metrics.instructionTextOverflow).toBe('ellipsis');
   expect(metrics.instructionScrollWidth).toBeGreaterThan(metrics.instructionWidth);
   expect(metrics.agentText).toBe('Idle');
-  expect(metrics.agentFlexShrink).toBe('0');
   expect(metrics.agentWidth).toBeLessThanOrEqual(12);
+  expect(metrics.statusWidth).toBeLessThanOrEqual(340);
+  expect(metrics.statusRight).toBeLessThanOrEqual(metrics.viewportWidth);
   expect(metrics.actionRight).toBeLessThanOrEqual(metrics.topBarRight);
 });
 

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -12,7 +12,7 @@ enum WorkspaceHTMLTopBarRenderer {
           </div>
           <div class="topbar-clusters" data-testid="top-bar-clusters">
             \(renderPrimaryCluster(topBar))
-            \(renderContextCluster(topBar))
+            \(renderStatusCluster(topBar))
             \(renderActionCluster(topBar, commands: commands))
           </div>
         </header>
@@ -28,15 +28,34 @@ enum WorkspaceHTMLTopBarRenderer {
         """
     }
 
-    private static func renderContextCluster(_ topBar: TopBarSurface) -> String {
+    private static func renderStatusCluster(_ topBar: TopBarSurface) -> String {
         let status = topBar.agentStatusPresentation
         return """
         <div class="topbar-cluster topbar-context-cluster" data-testid="top-bar-context-cluster" aria-label="Workspace state">
-          <span class="agent-status-dot" data-testid="agent-status" data-tone="\(escape(status.tone.rawValue))" data-indicator="\(status.showsIndicator)" title="\(escape(status.label))">\(escape(status.label))</span>
-          \(renderRuntimeIssuePill(topBar))
-          <span data-testid="project-instructions-status" title="\(escape(topBar.instructionSources.joined(separator: ", ")))">\(escape(topBar.instructionLabel))</span>
-          <span data-testid="project-memories-status" title="\(escape(topBar.memorySources.joined(separator: ", ")))">\(escape(topBar.memoryLabel))</span>
-          <span data-testid="computer-use-status">\(escape(topBar.computerUseLabel))</span>
+          <details class="topbar-status-menu" data-testid="top-bar-status-menu">
+            <summary data-testid="top-bar-status-button" aria-label="Workspace status" title="\(escape(status.label))">
+              <span class="agent-status-dot" data-testid="agent-status" data-tone="\(escape(status.tone.rawValue))" data-indicator="\(status.showsIndicator)">\(escape(status.label))</span>
+            </summary>
+            <div class="topbar-status-popover" data-testid="top-bar-status-popover">
+              <div class="topbar-status-row">
+                <span>Status</span>
+                <strong>\(escape(status.label))</strong>
+              </div>
+              \(renderRuntimeIssuePill(topBar))
+              <div class="topbar-status-row">
+                <span>Instructions</span>
+                <strong data-testid="project-instructions-status" title="\(escape(topBar.instructionSources.joined(separator: ", ")))">\(escape(topBar.instructionLabel))</strong>
+              </div>
+              <div class="topbar-status-row">
+                <span>Memories</span>
+                <strong data-testid="project-memories-status" title="\(escape(topBar.memorySources.joined(separator: ", ")))">\(escape(topBar.memoryLabel))</strong>
+              </div>
+              <div class="topbar-status-row">
+                <span>Computer Use</span>
+                <strong data-testid="computer-use-status">\(escape(topBar.computerUseLabel))</strong>
+              </div>
+            </div>
+          </details>
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -1523,6 +1523,8 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="top-bar-clusters""#))
         XCTAssertTrue(html.contains(#"data-testid="top-bar-primary-cluster""#))
         XCTAssertTrue(html.contains(#"data-testid="top-bar-context-cluster""#))
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-status-menu""#))
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-status-popover""#))
         XCTAssertTrue(html.contains(#"data-testid="sidebar""#))
         XCTAssertTrue(html.contains(#"data-testid="extensions-button" data-primary="true" data-icon="plugins" data-command-id="toggle-extensions">Plugins"#))
         XCTAssertTrue(html.contains(#"data-testid="automations-button" data-primary="true" data-icon="automations" data-command-id="toggle-automations">Automations"#))

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1008,7 +1008,7 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(topBarText.contains("enum WorkspaceHTMLTopBarRenderer"), "HTML top-bar rendering should live in a focused renderer.")
         XCTAssertTrue(topBarText.contains("static func render(_ topBar: TopBarSurface"), "HTML top-bar rendering should expose a directly testable entry point.")
         XCTAssertTrue(topBarText.contains("private static func renderPrimaryCluster"), "Model/mode cluster rendering should live beside top-bar HTML.")
-        XCTAssertTrue(topBarText.contains("private static func renderContextCluster"), "Status cluster rendering should live beside top-bar HTML.")
+        XCTAssertTrue(topBarText.contains("private static func renderStatusCluster"), "Status cluster rendering should live beside top-bar HTML.")
         XCTAssertTrue(topBarText.contains("private static func renderActionCluster"), "Overflow cluster rendering should live beside top-bar HTML.")
         XCTAssertTrue(topBarText.contains("private static func renderRuntimeIssuePill"), "Runtime issue pill rendering should live beside top-bar HTML.")
         XCTAssertTrue(topBarText.contains("TopBarOverflowCommandCatalog.commands"), "Top-bar overflow should use the shared command catalog.")

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,9 @@
 # QuillCode Decisions
 
+## 2026-06-23
+
+- Codex-style top-bar chrome should default to three visible decisions: thread/project identity, combined model and approval mode, and a compact workspace status control plus overflow. Instruction files, memories, Computer Use readiness, and runtime issues remain accessible in the status popover and transcript/settings surfaces, but they should not occupy permanent top-bar width. This keeps the first read calmer while preserving diagnostics and Playwright coverage.
+
 ## 2026-06-20
 
 - Product and repository name: **QuillCode**.


### PR DESCRIPTION
## Summary\n- Ask Claude CLI/design pass highlighted top-bar chrome overload; this PR moves workspace diagnostics into a compact status popover.\n- Keeps model/mode as the primary visible decision, with status dot plus overflow as the remaining chrome.\n- Updates the HTML harness, parity tests, Playwright status/overflow coverage, and records the decision in docs.\n\n## Validation\n- swift test\n- ./scripts/smoke.sh\n- cd E2E/playwright && npm test\n- git diff --check\n\nScreenshot captured locally: /tmp/quillcode-topbar-status.png