### PR TITLE
Split model and approval mode controls

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -117,6 +117,9 @@
       align-items: center;
       gap: 8px;
     }
+    .topbar-primary-cluster {
+      gap: 12px;
+    }
     .topbar-primary-cluster,
     .topbar-action-cluster {
       flex-wrap: nowrap;
@@ -125,9 +128,9 @@
       justify-content: flex-end;
       overflow: visible;
     }
-    .topbar-primary-cluster span,
+    .topbar-primary-cluster > span,
     .topbar-primary-cluster select,
-    .topbar-primary-cluster button,
+    .topbar-primary-cluster > button:not(.mode-pill-button),
     .topbar-action-cluster button {
       min-height: 34px;
       padding: 5px 9px;
@@ -164,6 +167,59 @@
     .model-picker-wrap [data-testid="model-picker-button"]:hover {
       background: rgba(255,255,255,.06);
       color: var(--text);
+    }
+    .mode-pill-button {
+      min-height: 40px;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 0 10px;
+      border-radius: 999px;
+      color: var(--green);
+      background: rgba(82,210,115,.12);
+      border: 1px solid rgba(82,210,115,.24);
+      font-size: 12px;
+      font-weight: 700;
+      white-space: nowrap;
+      transition-property: transform, background-color, border-color, color;
+      transition-duration: 150ms;
+      transition-timing-function: var(--ease-out);
+    }
+    .mode-pill-button::after {
+      content: "▾";
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1;
+    }
+    .mode-pill-button:hover {
+      color: var(--text);
+      border-color: rgba(82,210,115,.34);
+      background: rgba(82,210,115,.16);
+    }
+    .mode-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 999px;
+      background: currentColor;
+      box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 18%, transparent);
+    }
+    .mode-pill-button[data-mode-tone="review"] {
+      color: var(--yellow);
+      background: rgba(248,184,78,.12);
+      border-color: rgba(248,184,78,.24);
+    }
+    .mode-pill-button[data-mode-tone="review"]:hover {
+      border-color: rgba(248,184,78,.34);
+      background: rgba(248,184,78,.16);
+    }
+    .mode-pill-button[data-mode-tone="read-only"] {
+      color: var(--blue);
+      background: rgba(65,184,232,.12);
+      border-color: rgba(65,184,232,.24);
+    }
+    .mode-pill-button[data-mode-tone="read-only"]:hover {
+      border-color: rgba(65,184,232,.34);
+      background: rgba(65,184,232,.16);
     }
     .topbar-action-cluster button {
       width: 40px;
@@ -4056,10 +4112,13 @@
             <div class="topbar-clusters" data-testid="top-bar-clusters">
               <div class="topbar-cluster topbar-primary-cluster" data-testid="top-bar-primary-cluster">
                 <div class="model-picker-wrap">
-                  <button type="button" aria-expanded="${state.topBar.modelPickerOpen ? 'true' : 'false'}" data-testid="model-picker-button">${escapeHTML(state.topBar.modelLabel)} · ${escapeHTML(state.topBar.modeLabel)}</button>
+                  <button type="button" aria-expanded="${state.topBar.modelPickerOpen ? 'true' : 'false'}" aria-label="Model: ${escapeHTML(state.topBar.modelLabel)}" data-testid="model-picker-button">${escapeHTML(state.topBar.modelLabel)}</button>
                   ${modelBrowser}
                 </div>
-                <span class="visually-hidden" data-testid="mode-pill">${escapeHTML(state.topBar.modeLabel)}</span>
+                <button type="button" class="mode-pill-button" data-testid="mode-picker-button" data-mode-tone="${escapeHTML(modeTone(state.topBar.modeLabel))}" aria-label="Approval mode: ${escapeHTML(state.topBar.modeLabel)}">
+                  <span class="mode-dot" aria-hidden="true"></span>
+                  <span data-testid="mode-pill">${escapeHTML(state.topBar.modeLabel)}</span>
+                </button>
               </div>
               <div class="topbar-cluster topbar-context-cluster" data-testid="top-bar-context-cluster">
                 <details class="topbar-status-menu" data-testid="top-bar-status-menu">
@@ -4240,6 +4299,9 @@
         state.topBar.modelPickerOpen = !state.topBar.modelPickerOpen;
         state.topBar.expandedModelID = state.topBar.modelPickerOpen ? state.topBar.selectedModelID : null;
         render();
+      });
+      document.querySelector('[data-testid="mode-picker-button"]').addEventListener('click', () => {
+        cycleMode();
       });
       document.querySelector('[data-testid="model-search"]')?.addEventListener('input', event => {
         state.topBar.modelSearch = event.target.value;
@@ -4690,6 +4752,26 @@
         })
       }));
       render();
+    }
+
+    function cycleMode() {
+      const modes = ['Auto', 'Review', 'Read-only'];
+      const currentIndex = modes.indexOf(state.topBar.modeLabel);
+      setModeLabel(modes[(currentIndex + 1) % modes.length]);
+      render();
+    }
+
+    function setModeLabel(nextMode) {
+      state.topBar.modeLabel = nextMode;
+      const selectedProject = state.projects.items.find(project => project.id === state.projects.selectedProjectID);
+      state.topBar.subtitle = `${selectedProject?.name || 'No project'} - ${state.topBar.modeLabel} - ${state.topBar.modelLabel}`;
+    }
+
+    function modeTone(modeLabel) {
+      const normalized = String(modeLabel || '').toLowerCase();
+      if (normalized === 'review') return 'review';
+      if (normalized === 'read-only') return 'read-only';
+      return 'auto';
     }
 
     function modelDisplayLabel(model) {
@@ -7762,10 +7844,8 @@
         const modeMap = { auto: 'Auto', review: 'Review', 'read-only': 'Read-only', readonly: 'Read-only' };
         const nextMode = modeMap[requestedMode] || null;
         if (nextMode) {
-          state.topBar.modeLabel = nextMode;
+          setModeLabel(nextMode);
           addMessage('assistant', `Mode set to ${nextMode}.`);
-          const selectedProject = state.projects.items.find(project => project.id === state.projects.selectedProjectID);
-          state.topBar.subtitle = `${selectedProject?.name || 'No project'} - ${state.topBar.modeLabel} - ${state.topBar.modelLabel}`;
         } else {
           addMessage('assistant', 'Usage: /mode auto, /mode review, or /mode read-only');
         }

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -43,11 +43,18 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('project-item')).toContainText('QuillCode');
   await expect(page.getByTestId('project-item')).toHaveAttribute('aria-current', 'true');
   await expect(page.getByTestId('transcript-empty')).toBeVisible();
-  await expect(page.getByTestId('model-picker-button')).toHaveText('Nike 1.0 · Auto');
+  await expect(page.getByTestId('model-picker-button')).toHaveText('Nike 1.0');
+  await expect(page.getByTestId('model-picker-button')).not.toContainText('Auto');
+  await expect(page.getByTestId('mode-picker-button')).toBeVisible();
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+  const modelButtonBox = await page.getByTestId('model-picker-button').boundingBox();
+  const modeButtonBox = await page.getByTestId('mode-picker-button').boundingBox();
+  expect(modelButtonBox).not.toBeNull();
+  expect(modeButtonBox).not.toBeNull();
+  expect(modeButtonBox!.x - (modelButtonBox!.x + modelButtonBox!.width)).toBeGreaterThanOrEqual(8);
   await page.getByTestId('model-picker-button').click();
   await expect(page.getByTestId('model-category')).toHaveCount(2);
   await page.getByTestId('model-picker-button').click();
-  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
   await expect(page.getByTestId('send-button')).toBeDisabled();
 
   await openTopBarOverflow(page);
@@ -73,7 +80,8 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await page.getByTestId('model-picker-button').click();
   await page.getByTestId('model-search').fill('glm');
   await page.getByTestId('model-option').click();
-  await expect(page.getByTestId('model-picker-button')).toHaveText('z-ai/GLM 5.2 · Auto');
+  await expect(page.getByTestId('model-picker-button')).toHaveText('z-ai/GLM 5.2');
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
 
   await page.getByLabel('Message').fill('run whoami');
   await expect(page.getByTestId('send-button')).toBeEnabled();
@@ -1723,9 +1731,27 @@ test('mock harness handles slash mode locally', async ({ page }) => {
   await page.getByRole('button', { name: 'Send' }).click();
 
   await expect(page.getByTestId('mode-pill')).toHaveText('Review');
+  await expect(page.getByTestId('mode-picker-button')).toContainText('Review');
+  await expect(page.getByTestId('mode-picker-button')).toHaveAttribute('data-mode-tone', 'review');
   await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode - Review');
   await expect(page.getByText('Mode set to Review.')).toBeVisible();
   await expect(page.getByTestId('tool-card')).toHaveCount(0);
+});
+
+test('mock harness changes approval mode independently from model selection', async ({ page }) => {
+  await page.goto('file://' + process.cwd() + '/../harness/index.html');
+
+  await expect(page.getByTestId('model-picker-button')).toHaveText('Nike 1.0');
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+
+  await page.getByTestId('mode-picker-button').click();
+  await expect(page.getByTestId('mode-pill')).toHaveText('Review');
+  await expect(page.getByTestId('model-picker-button')).toHaveText('Nike 1.0');
+
+  await page.getByTestId('mode-picker-button').click();
+  await expect(page.getByTestId('mode-pill')).toHaveText('Read-only');
+  await expect(page.getByTestId('mode-picker-button')).toHaveAttribute('data-mode-tone', 'read-only');
+  await expect(page.getByTestId('model-picker-button')).not.toContainText('Read-only');
 });
 
 test('mock harness routes slash commands to workspace actions', async ({ page }) => {
@@ -1839,7 +1865,8 @@ test('mock harness searches and selects models from the top bar', async ({ page 
   await expect(page.getByTestId('model-option')).toContainText('moonshotai/Kimi K2.6');
 
   await page.getByTestId('model-option').click();
-  await expect(page.getByTestId('model-picker-button')).toHaveText('moonshotai/Kimi K2.6 · Auto');
+  await expect(page.getByTestId('model-picker-button')).toHaveText('moonshotai/Kimi K2.6');
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
   await expect(page.getByTestId('model-browser')).toHaveCount(0);
 
   await page.getByTestId('model-picker-button').click();

--- a/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
@@ -4,7 +4,6 @@ import QuillCodeCore
 struct QuillCodeModelPickerView: View {
     var topBar: TopBarSurface
     @Binding var isPresented: Bool
-    var onSetMode: (AgentMode) -> Void
     var onSetModel: (String) -> Void
     var onToggleModelFavorite: (String) -> Void
 
@@ -29,7 +28,10 @@ struct QuillCodeModelPickerView: View {
             isPresented.toggle()
         } label: {
             HStack(spacing: 6) {
-                Text("\(topBar.modelLabel) · \(topBar.modeLabel)")
+                Image(systemName: "diamond")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                Text(topBar.modelLabel)
                     .font(.callout.weight(.semibold))
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -43,7 +45,8 @@ struct QuillCodeModelPickerView: View {
             .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(QuillCodePressableButtonStyle())
-        .help("Choose model and mode")
+        .help("Choose model")
+        .accessibilityLabel("Model, \(topBar.modelLabel)")
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {
             popoverBody
         }
@@ -64,7 +67,6 @@ struct QuillCodeModelPickerView: View {
     private var popoverBody: some View {
         VStack(alignment: .leading, spacing: 12) {
             header
-            modePicker
             searchField
             modelList
         }
@@ -82,16 +84,6 @@ struct QuillCodeModelPickerView: View {
                 .foregroundStyle(QuillCodePalette.muted)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var modePicker: some View {
-        Picker("Mode", selection: modeBinding) {
-            ForEach(AgentMode.allCases, id: \.rawValue) { mode in
-                Text(mode.title).tag(mode)
-            }
-        }
-        .pickerStyle(.segmented)
-        .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
     }
 
     private var searchField: some View {
@@ -137,17 +129,6 @@ struct QuillCodeModelPickerView: View {
         .padding(12)
         .background(QuillCodePalette.background.opacity(0.72))
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-    }
-
-    private var modeBinding: Binding<AgentMode> {
-        Binding(
-            get: {
-                AgentMode.allCases.first { $0.title == topBar.modeLabel } ?? .auto
-            },
-            set: { mode in
-                onSetMode(mode)
-            }
-        )
     }
 
     private func selectModel(_ option: ModelOptionSurface) {

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -17,15 +17,19 @@ struct QuillCodeTopBarView: View {
 
             Spacer(minLength: 10)
 
-            HStack(spacing: 8) {
+            HStack(spacing: 12) {
                 QuillCodeModelPickerView(
                     topBar: topBar,
                     isPresented: $isModelPickerPresented,
-                    onSetMode: onSetMode,
                     onSetModel: onSetModel,
                     onToggleModelFavorite: onToggleModelFavorite
                 )
                 .layoutPriority(2)
+
+                QuillCodeModePickerButton(
+                    modeLabel: topBar.modeLabel,
+                    onSetMode: onSetMode
+                )
 
                 statusIndicator
                 commandMenu
@@ -134,6 +138,73 @@ struct QuillCodeTopBarView: View {
         .buttonStyle(QuillCodePressableButtonStyle())
         .help("More")
         .accessibilityLabel("More workspace actions")
+    }
+}
+
+private struct QuillCodeModePickerButton: View {
+    var modeLabel: String
+    var onSetMode: (AgentMode) -> Void
+
+    private var selectedMode: AgentMode {
+        AgentMode.allCases.first { $0.title == modeLabel } ?? .auto
+    }
+
+    private var orderedModes: [AgentMode] {
+        [.auto, .review, .readOnly]
+    }
+
+    var body: some View {
+        Menu {
+            ForEach(orderedModes, id: \.rawValue) { mode in
+                Button {
+                    onSetMode(mode)
+                } label: {
+                    HStack {
+                        Text(mode.title)
+                        if mode == selectedMode {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(modeColor(for: selectedMode))
+                    .frame(width: 7, height: 7)
+                Text(modeLabel)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(QuillCodePalette.muted)
+            }
+            .foregroundStyle(modeColor(for: selectedMode))
+            .padding(.horizontal, 10)
+            .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
+            .background(modeColor(for: selectedMode).opacity(0.12))
+            .overlay {
+                Capsule()
+                    .stroke(modeColor(for: selectedMode).opacity(0.24), lineWidth: 1)
+            }
+            .clipShape(Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(QuillCodePressableButtonStyle())
+        .help("Choose approval mode")
+        .accessibilityLabel("Approval mode, \(modeLabel)")
+    }
+
+    private func modeColor(for mode: AgentMode) -> Color {
+        switch mode {
+        case .auto:
+            return QuillCodePalette.green
+        case .review:
+            return QuillCodePalette.yellow
+        case .readOnly:
+            return QuillCodePalette.blue
+        }
     }
 }
 

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -20,12 +20,27 @@ enum WorkspaceHTMLTopBarRenderer {
     }
 
     private static func renderPrimaryCluster(_ topBar: TopBarSurface) -> String {
-        """
+        let tone = modeTone(for: topBar.modeLabel)
+        return """
         <div class="topbar-cluster topbar-primary-cluster" data-testid="top-bar-primary-cluster">
-          <span data-testid="model-pill">\(escape(topBar.modelLabel)) · \(escape(topBar.modeLabel))</span>
-          <span class="visually-hidden" data-testid="mode-pill">\(escape(topBar.modeLabel))</span>
+          <button type="button" class="topbar-model-button" data-testid="model-picker-button" aria-label="Model: \(escape(topBar.modelLabel))">◇ <span data-testid="model-pill">\(escape(topBar.modelLabel))</span></button>
+          <button type="button" class="topbar-mode-button" data-testid="mode-picker-button" data-mode-tone="\(tone)" aria-label="Approval mode: \(escape(topBar.modeLabel))">
+            <span class="topbar-mode-dot" aria-hidden="true"></span>
+            <span data-testid="mode-pill">\(escape(topBar.modeLabel))</span>
+          </button>
         </div>
         """
+    }
+
+    private static func modeTone(for modeLabel: String) -> String {
+        switch modeLabel.lowercased() {
+        case "review":
+            return "review"
+        case "read-only":
+            return "read-only"
+        default:
+            return "auto"
+        }
     }
 
     private static func renderStatusCluster(_ topBar: TopBarSurface) -> String {

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1052,6 +1052,27 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(htmlText.contains("top-bar-overflow-popover"), "WorkspaceHTMLRenderer should not own top-bar overflow markup.")
     }
 
+    func testTopBarSeparatesModelAndApprovalModeControls() throws {
+        let topBarViewText = try Self.appSourceText(named: "QuillCodeTopBarView.swift")
+        let modelPickerText = try Self.appSourceText(named: "QuillCodeModelPickerView.swift")
+        let htmlTopBarText = try Self.appSourceText(named: "WorkspaceHTMLTopBarRenderer.swift")
+
+        XCTAssertTrue(topBarViewText.contains("QuillCodeModePickerButton"), "Approval mode should have a dedicated top-bar control.")
+        XCTAssertTrue(topBarViewText.contains("Choose approval mode"), "The mode control should advertise approval-mode intent.")
+        XCTAssertFalse(modelPickerText.contains("modeLabel"), "The model picker trigger and popover must not merge approval mode back into model selection.")
+        XCTAssertNil(
+            modelPickerText.range(of: #"\bvar\s+onSetMode\b"#, options: .regularExpression),
+            "Model selection should not own approval-mode mutation."
+        )
+        XCTAssertNil(
+            modelPickerText.range(of: #"\bonSetMode\s*:"#, options: .regularExpression),
+            "Model picker initialization should not accept an approval-mode callback."
+        )
+        XCTAssertTrue(htmlTopBarText.contains("data-testid=\"model-picker-button\""), "HTML top bar should expose a model control.")
+        XCTAssertTrue(htmlTopBarText.contains("data-testid=\"mode-picker-button\""), "HTML top bar should expose a separate mode control.")
+        XCTAssertFalse(htmlTopBarText.contains(" · "), "HTML top bar must not render model and mode as one combined label.")
+    }
+
     func testWorkspaceHTMLRendererDelegatesTerminalRendering() throws {
         let htmlText = try Self.appSourceText(named: "WorkspaceHTMLRenderer.swift")
         let terminalText = try Self.appSourceText(named: "WorkspaceHTMLTerminalRenderer.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -163,7 +163,7 @@ The native model picker moved out of `WorkspaceSwiftUIView.swift` into `QuillCod
 Interface polish changes:
 
 - The model trigger now uses the shared `0.96` press feedback instead of a borderless static button.
-- Mode and model search controls keep the shared 40 pt minimum hit target.
+- Model search controls keep the shared 40 pt minimum hit target.
 - Model rows now guarantee a 40 pt selectable summary area and use the shared press style for tactile feedback.
 - Info and favorite controls now use the same press style as other high-frequency icon buttons while preserving 40 pt hit areas.
 - Long provider/model metadata truncates in the middle instead of pushing row actions off-screen.
@@ -181,6 +181,21 @@ Interface polish changes:
 - The overflow menu keeps the shared 40 pt hit target while adding a quiet selected-surface background and 10 pt continuous radius.
 - Runtime issue pills stay inside the top-bar file because they are specific to top-bar status density and use tabular caption numerals for stable changing labels.
 - The identity cluster is a single bounded accessibility element, so long project/thread metadata remains available without visually crowding the bar.
+
+## 2026-06-23 Top Bar Model/Mode Split Pass
+
+Overall grade after this slice: **A- foundation, B+ product surface maturity**.
+
+Claude CLI's design review called out the model/mode pill as the highest-impact interaction ambiguity: model choice is a preference, while approval mode is a safety posture. This pass separates those concepts in both native SwiftUI and the Playwright harness.
+
+Interface and architecture changes:
+
+- `QuillCodeModelPickerView` no longer owns `AgentMode` mutation or renders `modeLabel`.
+- `QuillCodeTopBarView` owns a dedicated `QuillCodeModePickerButton` with Auto, Review, and Read-only choices.
+- The model trigger renders only the selected model and keeps the model browser focused on provider/category/model search.
+- The mode control uses a compact safety capsule with a colored dot, distinct from the quieter model text button.
+- Playwright tests now assert that model and mode are visible, separated controls and that changing mode does not mutate the model selection.
+- A parity gate prevents future regressions that merge model and approval mode into one top-bar label again.
 
 ## 2026-06-22 Sidebar Refactor Pass
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,7 +2,7 @@
 
 ## 2026-06-23
 
-- Codex-style top-bar chrome should default to three visible decisions: thread/project identity, combined model and approval mode, and a compact workspace status control plus overflow. Instruction files, memories, Computer Use readiness, and runtime issues remain accessible in the status popover and transcript/settings surfaces, but they should not occupy permanent top-bar width. This keeps the first read calmer while preserving diagnostics and Playwright coverage.
+- Codex-style top-bar chrome should keep model selection and approval mode as separate controls. Model is a long-lived preference, while approval mode is an autonomy/safety posture users may change mid-session. The model picker should only select models; Auto/Review/Read-only lives in a compact mode control beside it. Instruction files, memories, Computer Use readiness, and runtime issues remain accessible in the status popover and transcript/settings surfaces, but they should not occupy permanent top-bar width. This keeps the first read calmer while preserving diagnostics and Playwright coverage.
 
 ## 2026-06-20
 


### PR DESCRIPTION
## Summary
- split the top-bar model picker from the Auto/Review/Read-only approval mode control
- remove approval-mode mutation from the model picker and add a dedicated mode control
- update the HTML harness, Playwright coverage, parity gate, and docs so the controls stay separate

## Verification
- swift test --filter ParityGateTests/testTopBarSeparatesModelAndApprovalModeControls
- swift test --filter QuillCodeTopBarSurfaceTests
- npm ci && npm test in E2E/playwright
- swift test
- ./scripts/smoke.sh

Screenshot: /tmp/quillcode-model-mode-split.png