### PR TITLE
Extract workspace context resolver

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceContextResolver.swift
+++ b/Sources/QuillCodeApp/WorkspaceContextResolver.swift
@@ -1,0 +1,42 @@
+import Foundation
+import QuillCodeCore
+
+struct WorkspaceContextResolver: Sendable {
+    var projects: [ProjectRef]
+    var globalMemories: [MemoryNote]
+    var selectedProject: ProjectRef?
+
+    func instructions(for projectID: UUID?) -> [ProjectInstruction] {
+        project(id: projectID)?.instructions ?? []
+    }
+
+    func memoryNotes(for projectID: UUID?) -> [MemoryNote] {
+        globalMemories + (project(id: projectID)?.memories ?? [])
+    }
+
+    func selectedLocalAction(withID id: String) -> LocalEnvironmentAction? {
+        selectedProject?.localActions.first { $0.id == id }
+    }
+
+    func selectedLocalAction(matching query: String) -> LocalEnvironmentAction? {
+        let normalizedQuery = Self.normalizedActionName(query)
+        return selectedProject?.localActions.first { action in
+            action.id.caseInsensitiveCompare(query) == .orderedSame
+                || action.title.caseInsensitiveCompare(query) == .orderedSame
+                || action.relativePath.caseInsensitiveCompare(query) == .orderedSame
+                || Self.normalizedActionName(action.title) == normalizedQuery
+                || Self.normalizedActionName(action.relativePath) == normalizedQuery
+        }
+    }
+
+    static func normalizedActionName(_ value: String) -> String {
+        value
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber }
+    }
+
+    private func project(id: UUID?) -> ProjectRef? {
+        guard let id else { return nil }
+        return projects.first { $0.id == id }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -158,6 +158,14 @@ public final class QuillCodeWorkspaceModel {
         )
     }
 
+    private var contextResolver: WorkspaceContextResolver {
+        WorkspaceContextResolver(
+            projects: root.projects,
+            globalMemories: root.globalMemories,
+            selectedProject: selectedProject
+        )
+    }
+
     private func project(id: UUID) -> ProjectRef? {
         root.projects.first { $0.id == id }
     }
@@ -523,8 +531,8 @@ public final class QuillCodeWorkspaceModel {
             project: project,
             mode: root.config.mode,
             model: root.config.defaultModel,
-            instructions: instructions(for: projectID),
-            memories: memoryNotes(for: projectID),
+            instructions: contextResolver.instructions(for: projectID),
+            memories: contextResolver.memoryNotes(for: projectID),
             now: now
         )
         return applyAutomationRunDraft(draft)
@@ -658,8 +666,8 @@ public final class QuillCodeWorkspaceModel {
             projectID: effectiveProjectID,
             mode: root.config.mode,
             model: root.config.defaultModel,
-            instructions: instructions(for: effectiveProjectID),
-            memories: memoryNotes(for: effectiveProjectID)
+            instructions: contextResolver.instructions(for: effectiveProjectID),
+            memories: contextResolver.memoryNotes(for: effectiveProjectID)
         ))
         return insertCreatedThread(thread, selectedProjectID: effectiveProjectID, saveThread: false)
     }
@@ -840,8 +848,8 @@ public final class QuillCodeWorkspaceModel {
             refreshProjectMetadata(id)
         }
         if selectedThread?.projectID == id || root.selectedProjectID == id {
-            let refreshedInstructions = instructions(for: id)
-            let refreshedMemories = memoryNotes(for: id)
+            let refreshedInstructions = contextResolver.instructions(for: id)
+            let refreshedMemories = contextResolver.memoryNotes(for: id)
             mutateSelectedThread { thread in
                 guard thread.projectID == id else { return }
                 thread.instructions = refreshedInstructions
@@ -1415,7 +1423,7 @@ public final class QuillCodeWorkspaceModel {
     @discardableResult
     public func runLocalEnvironmentAction(_ actionID: String, workspaceRoot: URL) -> Bool {
         refreshProjectMetadata(root.selectedProjectID)
-        guard let action = localAction(withID: actionID) else {
+        guard let action = contextResolver.selectedLocalAction(withID: actionID) else {
             return false
         }
         runToolCall(
@@ -1473,8 +1481,8 @@ public final class QuillCodeWorkspaceModel {
         }
         let contextProjectID = selectedThread?.projectID ?? root.selectedProjectID
         refreshProjectMetadata(contextProjectID)
-        let refreshedMemories = memoryNotes(for: contextProjectID)
-        let refreshedInstructions = instructions(for: contextProjectID)
+        let refreshedMemories = contextResolver.memoryNotes(for: contextProjectID)
+        let refreshedInstructions = contextResolver.instructions(for: contextProjectID)
         mutateSelectedThread { thread in
             thread.memories = refreshedMemories
             thread.instructions = refreshedInstructions
@@ -1667,8 +1675,8 @@ public final class QuillCodeWorkspaceModel {
             projectID: projectID,
             mode: root.config.mode,
             model: root.config.defaultModel,
-            instructions: instructions(for: projectID),
-            memories: memoryNotes(for: projectID)
+            instructions: contextResolver.instructions(for: projectID),
+            memories: contextResolver.memoryNotes(for: projectID)
         )
     }
 
@@ -1835,7 +1843,7 @@ public final class QuillCodeWorkspaceModel {
             return
         }
 
-        guard let action = localAction(matching: query) else {
+        guard let action = contextResolver.selectedLocalAction(matching: query) else {
             appendLocalCommandTranscript(WorkspaceSlashCommandTranscriptPlanner.environmentActionNotFound(
                 userText: originalPrompt,
                 query: query
@@ -1883,7 +1891,7 @@ public final class QuillCodeWorkspaceModel {
             projectName: selectedProject?.name ?? root.topBar.projectName ?? "No project",
             threadTitle: selectedThread?.title ?? "No chat",
             instructions: selectedProject?.instructions ?? selectedThread?.instructions ?? [],
-            memories: selectedThread?.memories ?? memoryNotes(for: root.selectedProjectID),
+            memories: selectedThread?.memories ?? contextResolver.memoryNotes(for: root.selectedProjectID),
             mode: root.topBar.mode,
             model: root.topBar.model,
             agentStatus: root.topBar.agentStatus
@@ -1967,8 +1975,8 @@ public final class QuillCodeWorkspaceModel {
         let projectID = selectedThread?.projectID ?? root.selectedProjectID
         refreshGlobalMemories()
         refreshProjectMetadata(projectID)
-        let refreshedInstructions = instructions(for: projectID)
-        let refreshedMemories = memoryNotes(for: projectID)
+        let refreshedInstructions = contextResolver.instructions(for: projectID)
+        let refreshedMemories = contextResolver.memoryNotes(for: projectID)
         mutateSelectedThread { thread in
             thread.instructions = refreshedInstructions
             thread.memories = refreshedMemories
@@ -2045,7 +2053,7 @@ public final class QuillCodeWorkspaceModel {
         refreshGlobalMemories()
         let projectID = selectedThread?.projectID ?? root.selectedProjectID
         let update = WorkspaceMemoryContextUpdatePlanner.globalMemoryChanged(
-            memories: memoryNotes(for: projectID),
+            memories: contextResolver.memoryNotes(for: projectID),
             summary: summary,
             relativePath: relativePath
         )
@@ -2058,55 +2066,14 @@ public final class QuillCodeWorkspaceModel {
     private func syncThreadContext(into thread: inout ChatThread) {
         let projectID = thread.projectID ?? root.selectedProjectID
         refreshProjectMetadata(projectID)
-        thread.instructions = instructions(for: projectID)
-        thread.memories = memoryNotes(for: projectID)
+        thread.instructions = contextResolver.instructions(for: projectID)
+        thread.memories = contextResolver.memoryNotes(for: projectID)
     }
 
     private func refreshThreadMemoryContext(_ thread: inout ChatThread) {
         let projectID = thread.projectID ?? root.selectedProjectID
         refreshProjectMetadata(projectID)
-        thread.memories = memoryNotes(for: projectID)
-    }
-
-    private func instructions(for projectID: UUID?) -> [ProjectInstruction] {
-        guard let projectID,
-              let project = root.projects.first(where: { $0.id == projectID })
-        else {
-            return []
-        }
-        return project.instructions
-    }
-
-    private func memoryNotes(for projectID: UUID?) -> [MemoryNote] {
-        let projectMemories: [MemoryNote]
-        if let projectID,
-           let project = root.projects.first(where: { $0.id == projectID }) {
-            projectMemories = project.memories
-        } else {
-            projectMemories = []
-        }
-        return root.globalMemories + projectMemories
-    }
-
-    private func localAction(withID id: String) -> LocalEnvironmentAction? {
-        selectedProject?.localActions.first { $0.id == id }
-    }
-
-    private func localAction(matching query: String) -> LocalEnvironmentAction? {
-        let normalizedQuery = Self.normalizedActionName(query)
-        return selectedProject?.localActions.first { action in
-            action.id.caseInsensitiveCompare(query) == .orderedSame
-                || action.title.caseInsensitiveCompare(query) == .orderedSame
-                || action.relativePath.caseInsensitiveCompare(query) == .orderedSame
-                || Self.normalizedActionName(action.title) == normalizedQuery
-                || Self.normalizedActionName(action.relativePath) == normalizedQuery
-        }
-    }
-
-    private static func normalizedActionName(_ value: String) -> String {
-        value
-            .lowercased()
-            .filter { $0.isLetter || $0.isNumber }
+        thread.memories = contextResolver.memoryNotes(for: projectID)
     }
 
     private func knownProjectID(_ id: UUID?) -> UUID? {

--- a/Tests/QuillCodeAppTests/WorkspaceContextResolverTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceContextResolverTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceContextResolverTests: XCTestCase {
+    func testResolvesInstructionsForKnownProjectOnly() {
+        let targetID = UUID()
+        let otherID = UUID()
+        let resolver = WorkspaceContextResolver(
+            projects: [
+                Self.project(id: targetID, instructionTitle: "Target"),
+                Self.project(id: otherID, instructionTitle: "Other")
+            ],
+            globalMemories: [],
+            selectedProject: nil
+        )
+
+        XCTAssertEqual(resolver.instructions(for: targetID).map(\.title), ["Target"])
+        XCTAssertEqual(resolver.instructions(for: otherID).map(\.title), ["Other"])
+        XCTAssertEqual(resolver.instructions(for: UUID()), [])
+        XCTAssertEqual(resolver.instructions(for: Optional<UUID>.none), [])
+    }
+
+    func testMergesGlobalMemoriesBeforeProjectMemories() {
+        let projectID = UUID()
+        let resolver = WorkspaceContextResolver(
+            projects: [
+                Self.project(id: projectID, memoryTitle: "Project preference")
+            ],
+            globalMemories: [
+                Self.memory(id: "global-profile", scope: .global, title: "Global profile")
+            ],
+            selectedProject: nil
+        )
+
+        XCTAssertEqual(
+            resolver.memoryNotes(for: projectID).map(\.title),
+            ["Global profile", "Project preference"]
+        )
+        XCTAssertEqual(
+            resolver.memoryNotes(for: UUID()).map(\.title),
+            ["Global profile"]
+        )
+    }
+
+    func testResolvesSelectedLocalActionByExactID() {
+        let action = Self.localAction(
+            id: "local-env:.quillcode/actions/test.sh",
+            title: "Run Tests",
+            relativePath: ".quillcode/actions/test.sh"
+        )
+        let resolver = WorkspaceContextResolver(
+            projects: [],
+            globalMemories: [],
+            selectedProject: Self.project(localActions: [action])
+        )
+
+        XCTAssertEqual(resolver.selectedLocalAction(withID: action.id)?.title, "Run Tests")
+        XCTAssertNil(resolver.selectedLocalAction(withID: "missing"))
+    }
+
+    func testMatchesSelectedLocalActionByTitlePathAndNormalizedAliases() {
+        let action = Self.localAction(
+            id: "local-env:.quillcode/actions/build-release.sh",
+            title: "Build Release",
+            relativePath: ".quillcode/actions/build-release.sh"
+        )
+        let resolver = WorkspaceContextResolver(
+            projects: [],
+            globalMemories: [],
+            selectedProject: Self.project(localActions: [action])
+        )
+
+        XCTAssertEqual(resolver.selectedLocalAction(matching: "build release")?.id, action.id)
+        XCTAssertEqual(resolver.selectedLocalAction(matching: "BUILD RELEASE")?.id, action.id)
+        XCTAssertEqual(resolver.selectedLocalAction(matching: ".quillcode/actions/build-release.sh")?.id, action.id)
+        XCTAssertEqual(resolver.selectedLocalAction(matching: "buildrelease")?.id, action.id)
+        XCTAssertNil(resolver.selectedLocalAction(matching: "ship release"))
+    }
+
+    func testNoSelectedProjectMeansNoLocalActionMatch() {
+        let resolver = WorkspaceContextResolver(
+            projects: [],
+            globalMemories: [],
+            selectedProject: nil
+        )
+
+        XCTAssertNil(resolver.selectedLocalAction(withID: "local-env:.quillcode/actions/test.sh"))
+        XCTAssertNil(resolver.selectedLocalAction(matching: "test"))
+    }
+
+    private static func project(
+        id: UUID = UUID(),
+        instructionTitle: String? = nil,
+        memoryTitle: String? = nil,
+        localActions: [LocalEnvironmentAction] = []
+    ) -> ProjectRef {
+        ProjectRef(
+            id: id,
+            name: "Project",
+            path: "/tmp/project-\(id.uuidString)",
+            instructions: instructionTitle.map {
+                [ProjectInstruction(
+                    path: "AGENTS.md",
+                    title: $0,
+                    content: "Instruction",
+                    byteCount: 11
+                )]
+            } ?? [],
+            localActions: localActions,
+            memories: memoryTitle.map {
+                [Self.memory(id: "project-\(id.uuidString)", scope: .project, title: $0)]
+            } ?? []
+        )
+    }
+
+    private static func localAction(
+        id: String,
+        title: String,
+        relativePath: String
+    ) -> LocalEnvironmentAction {
+        LocalEnvironmentAction(
+            id: id,
+            title: title,
+            relativePath: relativePath,
+            command: "bash \(relativePath)"
+        )
+    }
+
+    private static func memory(id: String, scope: MemoryScope, title: String) -> MemoryNote {
+        MemoryNote(
+            id: id,
+            scope: scope,
+            title: title,
+            content: "Remember this",
+            relativePath: "\(id).md",
+            byteCount: 13
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -230,6 +230,23 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(surfaceText.contains("static func modeLabel"), "WorkspaceSurface should not own mode label copy.")
     }
 
+    func testWorkspaceModelDelegatesContextResolving() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let resolverText = try Self.appSourceText(named: "WorkspaceContextResolver.swift")
+
+        XCTAssertTrue(resolverText.contains("struct WorkspaceContextResolver"), "Workspace context lookup should live in a focused resolver.")
+        XCTAssertTrue(resolverText.contains("func instructions(for projectID:"), "Project instruction lookup should be directly testable.")
+        XCTAssertTrue(resolverText.contains("func memoryNotes(for projectID:"), "Global/project memory merging should be directly testable.")
+        XCTAssertTrue(resolverText.contains("func selectedLocalAction(withID"), "Local action ID lookup should be directly testable.")
+        XCTAssertTrue(resolverText.contains("func selectedLocalAction(matching"), "Local action alias matching should be directly testable.")
+        XCTAssertTrue(modelText.contains("WorkspaceContextResolver("), "WorkspaceModel should delegate context lookup through the resolver.")
+        XCTAssertFalse(modelText.contains("private func instructions(for projectID"), "WorkspaceModel should not own project instruction lookup.")
+        XCTAssertFalse(modelText.contains("private func memoryNotes(for projectID"), "WorkspaceModel should not own memory merging.")
+        XCTAssertFalse(modelText.contains("private func localAction(withID"), "WorkspaceModel should not own local action ID lookup.")
+        XCTAssertFalse(modelText.contains("private func localAction(matching"), "WorkspaceModel should not own local action matching.")
+        XCTAssertFalse(modelText.contains("private static func normalizedActionName"), "WorkspaceModel should not own local action alias normalization.")
+    }
+
     func testWorkspaceModelDelegatesAgentProgressStatusCopy() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceAgentStatusBuilder.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -23,7 +23,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 
 | File | Grade | Next Improvement |
 | --- | --- | --- |
-| `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
+| `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
 | `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A- | The shell is now mostly chrome composition, state, and routing. Transcript layout and workspace sheet presentation live in focused files; keep future modal families and command workflow rules out of the root shell. |
 | `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, model catalog presentation, top-bar/model presentation contracts, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
 | `Sources/QuillCodeApp/WorkspaceHTMLRenderer.swift` | A- | Static HTML harness rendering is still broad, but top-bar HTML delegates to `WorkspaceHTMLTopBarRenderer`, sidebar HTML delegates to `WorkspaceHTMLSidebarRenderer`, tool-card/artifact preview HTML delegates to `WorkspaceHTMLToolCardRenderer`, review pane HTML delegates to `WorkspaceHTMLReviewRenderer`, secondary pane HTML delegates to `WorkspaceHTMLSecondaryPaneRenderer`, browser pane HTML delegates to `WorkspaceHTMLBrowserRenderer`, terminal pane HTML delegates to `WorkspaceHTMLTerminalRenderer`, and shared escaping/context chips live in `WorkspaceHTMLPrimitives`. Next step is extracting another transcript/composer family only when renderer drift appears. |
@@ -48,6 +48,19 @@ The architecture is moving in the right direction: core state is value typed, pe
 3. Keep splitting remaining workspace surface assembly into single-purpose builders when behavior grows; avoid adding new transcript or tool-card projection rules outside the transcript builder.
 4. If MCP transports expand beyond stdio, add new launch/session implementations behind `WorkspaceMCPServerLaunching` instead of adding transport-specific branches to the runtime.
 5. Keep the parity matrix updated whenever a feature moves from planned to implemented.
+
+## 2026-06-23 Workspace Context Resolver Pass
+
+Overall grade after this slice: **A- foundation, B+ product surface maturity**.
+
+Workspace context lookup moved out of `WorkspaceModel.swift` into `WorkspaceContextResolver.swift`. The model still owns refresh side effects and persistence, but project instruction lookup, global-plus-project memory merging, selected local-action ID lookup, and local-action alias matching are now pure and directly tested.
+
+Code quality changes:
+
+- Added `WorkspaceContextResolver` as the focused source of truth for active project instructions, merged memory notes, and selected-project local environment actions.
+- Removed private instruction, memory, local-action, and action-normalization helpers from `WorkspaceModel`.
+- Added focused resolver tests for known/unknown project IDs, global memory ordering, project memory merging, exact local-action IDs, case-insensitive titles, relative paths, punctuation-insensitive aliases, and no-selected-project behavior.
+- Added a parity gate that prevents context/action lookup from drifting back into `WorkspaceModel`.
 
 ## 2026-06-22 Workspace Project Engine Refactor Pass
 


### PR DESCRIPTION
## Summary
- Move workspace context lookup out of `WorkspaceModel` into `WorkspaceContextResolver`.
- Centralize project instruction lookup, global/project memory merging, selected local-action ID lookup, and action alias matching.
- Add focused resolver tests plus a parity gate preventing the logic from drifting back into `WorkspaceModel`.
- Update the code quality audit with the new extraction pass.

## Validation
- `swift test` pass: 777 tests, 0 failures.
- `./scripts/smoke.sh` pass: Swift suite and CLI smoke checks.
- `npm ci && npm test` in `E2E/playwright` pass: 58 tests, 0 failures.
- `git diff --check` pass.