### PR TITLE
Calm top bar and tool card chrome

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -85,14 +85,10 @@
     }
     .topbar strong { font-size: 17px; }
     .topbar p {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      margin: -1px;
-      padding: 0;
-      border: 0;
-      overflow: hidden;
-      clip-path: inset(50%);
+      margin: 2px 0 0;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 600;
       white-space: nowrap;
     }
     .topbar-title-group strong,
@@ -166,9 +162,9 @@
       gap: 7px;
       padding: 0 10px;
       border-radius: 999px;
-      color: var(--green);
-      background: rgba(82,210,115,.12);
-      border: 1px solid rgba(82,210,115,.24);
+      color: var(--text);
+      background: rgba(255,255,255,.055);
+      border: 1px solid rgba(255,255,255,.10);
       font-size: 12px;
       font-weight: 700;
       white-space: nowrap;
@@ -184,33 +180,35 @@
     }
     .mode-pill-button:hover {
       color: var(--text);
-      border-color: rgba(82,210,115,.34);
-      background: rgba(82,210,115,.16);
+      border-color: rgba(255,255,255,.16);
+      background: rgba(255,255,255,.075);
     }
     .mode-dot {
       width: 7px;
       height: 7px;
       border-radius: 999px;
-      background: currentColor;
-      box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 18%, transparent);
+      background: var(--green);
+      box-shadow: 0 0 0 3px rgba(82,210,115,.18);
+    }
+    .mode-pill-button[data-mode-tone="review"] .mode-dot {
+      background: var(--yellow);
+      box-shadow: 0 0 0 3px rgba(248,184,78,.18);
+    }
+    .mode-pill-button[data-mode-tone="read-only"] .mode-dot {
+      background: var(--blue);
+      box-shadow: 0 0 0 3px rgba(65,184,232,.18);
     }
     .mode-pill-button[data-mode-tone="review"] {
-      color: var(--yellow);
-      background: rgba(248,184,78,.12);
-      border-color: rgba(248,184,78,.24);
+      color: var(--text);
     }
     .mode-pill-button[data-mode-tone="review"]:hover {
-      border-color: rgba(248,184,78,.34);
-      background: rgba(248,184,78,.16);
+      color: var(--text);
     }
     .mode-pill-button[data-mode-tone="read-only"] {
-      color: var(--blue);
-      background: rgba(65,184,232,.12);
-      border-color: rgba(65,184,232,.24);
+      color: var(--text);
     }
     .mode-pill-button[data-mode-tone="read-only"]:hover {
-      border-color: rgba(65,184,232,.34);
-      background: rgba(65,184,232,.16);
+      color: var(--text);
     }
     .topbar-action-cluster button {
       width: 40px;
@@ -232,11 +230,14 @@
       position: relative;
     }
     .topbar-status-menu summary {
-      width: 40px;
+      width: auto;
+      max-width: 180px;
+      min-width: 40px;
       min-height: 40px;
-      padding: 0;
-      display: grid;
-      place-items: center;
+      padding: 0 10px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       border-radius: 999px;
       border: 1px solid rgba(255,255,255,.10);
       color: var(--muted);
@@ -253,26 +254,48 @@
       border-color: rgba(255,255,255,.16);
     }
     .topbar-status-menu [data-testid="agent-status"] {
-      width: 10px;
-      min-width: 10px;
-      max-width: 10px;
-      height: 10px;
-      min-height: 10px;
-      padding: 0;
+      min-width: 0;
+      max-width: 100%;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: rgba(238,247,250,.88);
+      font-size: 12px;
+      font-weight: 800;
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+    }
+    .agent-status-label {
+      min-width: 0;
       overflow: hidden;
-      color: transparent;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .agent-status-dot {
+      width: 8px;
+      min-width: 8px;
+      height: 8px;
       border-radius: 999px;
       background: var(--green);
       border: 0;
       box-shadow: 0 0 0 3px rgba(82, 210, 115, 0.12);
     }
-    .topbar-status-menu [data-testid="agent-status"][data-tone="warning"] {
+    .topbar-status-menu [data-testid="agent-status"][data-indicator="false"] .agent-status-dot {
+      display: none;
+    }
+    .topbar-status-menu [data-testid="agent-status"][data-tone="warning"] .agent-status-dot,
+    .topbar-status-menu [data-testid="agent-status"][data-tone="running"] .agent-status-dot {
       background: var(--amber);
       box-shadow: 0 0 0 3px rgba(248,184,78,.14);
     }
-    .topbar-status-menu [data-testid="agent-status"][data-tone="error"] {
+    .topbar-status-menu [data-testid="agent-status"][data-tone="error"] .agent-status-dot,
+    .topbar-status-menu [data-testid="agent-status"][data-tone="failed"] .agent-status-dot {
       background: var(--red);
       box-shadow: 0 0 0 3px rgba(255,93,82,.14);
+    }
+    .topbar-status-menu [data-testid="agent-status"][data-tone="stopped"] .agent-status-dot {
+      background: var(--muted);
+      box-shadow: 0 0 0 3px rgba(147,160,166,.12);
     }
     .topbar-status-popover {
       position: absolute;
@@ -1607,8 +1630,8 @@
       width: min(760px, 92%);
       min-height: 74px;
       background: rgba(0,0,0,.22);
-      border: 1px solid rgba(65,184,232,.25);
-      box-shadow: 0 0 0 1px rgba(65,184,232,.18), 0 12px 34px rgba(0,0,0,.18);
+      border: 1px solid rgba(255,255,255,.10);
+      box-shadow: 0 12px 34px rgba(0,0,0,.18);
       transition-property: transform, box-shadow, border-color;
       transition-duration: 150ms;
       transition-timing-function: var(--ease-out);
@@ -1617,9 +1640,8 @@
     }
     .tool-card:hover {
       transform: translateY(-1px);
-      box-shadow: 0 0 0 1px rgba(65,184,232,.24), 0 16px 38px rgba(0,0,0,.22);
+      box-shadow: 0 16px 38px rgba(0,0,0,.22);
     }
-    .tool-card.done { border-color: rgba(82,210,115,.34); }
     .tool-card.failed { border-color: rgba(255,93,82,.44); }
     .tool-card.review { border-color: rgba(248,184,78,.48); }
     .tool-card[data-density="collapsed"] {
@@ -2158,14 +2180,6 @@
       border-radius: 999px;
       background: rgba(255,255,255,.045);
       border: 1px solid rgba(255,255,255,.08);
-    }
-    .composer-agent-status {
-      margin-left: auto;
-      color: var(--muted);
-      font-size: 12px;
-      font-weight: 700;
-      font-variant-numeric: tabular-nums;
-      white-space: nowrap;
     }
     .composer .model-panel {
       top: auto;
@@ -2833,6 +2847,11 @@
       if (state.runtimeIssue?.severity === 'error') return 'error';
       if (state.runtimeIssue) return 'warning';
       return state.topBar.agentStatus === 'Failed' ? 'error' : 'success';
+    }
+
+    function topBarStatusIndicator() {
+      if (state.runtimeIssue) return 'true';
+      return state.topBar.agentStatus === 'Idle' ? 'false' : 'true';
     }
 
     function topBarOverflowTestID(commandID) {
@@ -3985,9 +4004,16 @@
             }).join('')}
           </div>` : '';
       };
+      const detailsLabel = card => {
+        if (card.density === 'expanded') return 'Hide details';
+        if (card.inputJSON && card.outputJSON) return 'Show details';
+        if (card.inputJSON) return 'Show input';
+        if (card.outputJSON) return 'Show output';
+        return 'Show details';
+      };
       const renderToolDetails = card => card.inputJSON || card.outputJSON ? `
           <details class="tool-details" data-testid="tool-card-details" ${card.density === 'expanded' ? 'open' : ''}>
-            <summary>${card.density === 'expanded' ? 'Hide details' : 'Show raw details'}</summary>
+            <summary>${detailsLabel(card)}</summary>
             ${card.inputJSON ? `<pre data-testid="tool-card-input">${escapeHTML(card.inputJSON)}</pre>` : ''}
             ${card.outputJSON ? `<pre data-testid="tool-card-output">${escapeHTML(card.outputJSON)}</pre>` : ''}
           </details>` : '';
@@ -4142,7 +4168,10 @@
               <div class="topbar-cluster topbar-context-cluster" data-testid="top-bar-context-cluster">
                 <details class="topbar-status-menu" data-testid="top-bar-status-menu">
                   <summary data-testid="top-bar-status-button" aria-label="Workspace status" title="${escapeHTML(state.topBar.agentStatus)}">
-                    <span data-testid="agent-status" data-tone="${escapeHTML(topBarStatusTone())}">${escapeHTML(state.topBar.agentStatus)}</span>
+                    <span class="agent-status-chip" data-testid="agent-status" data-tone="${escapeHTML(topBarStatusTone())}" data-indicator="${topBarStatusIndicator()}">
+                      <span class="agent-status-dot" aria-hidden="true"></span>
+                      <span class="agent-status-label">${escapeHTML(state.topBar.agentStatus)}</span>
+                    </span>
                   </summary>
                   <div class="topbar-status-popover" data-testid="top-bar-status-popover">
                     <div class="topbar-status-row">
@@ -4223,11 +4252,10 @@
                     <button class="composer-model-button" type="button" aria-expanded="${state.topBar.modelPickerOpen ? 'true' : 'false'}" aria-label="Model: ${escapeHTML(state.topBar.modelLabel)}" data-testid="model-picker-button">${escapeHTML(state.topBar.modelLabel)}</button>
                     ${modelBrowser}
                   </div>
-                  <button type="button" class="mode-pill-button" data-testid="mode-picker-button" data-mode-tone="${escapeHTML(modeTone(state.topBar.modeLabel))}" aria-label="Approval mode: ${escapeHTML(state.topBar.modeLabel)}">
+                  <button type="button" class="mode-pill-button" data-testid="mode-picker-button" data-mode-tone="${escapeHTML(modeTone(state.topBar.modeLabel))}" aria-label="Auto safety mode: ${escapeHTML(state.topBar.modeLabel)}">
                     <span class="mode-dot" aria-hidden="true"></span>
                     <span data-testid="mode-pill">${escapeHTML(state.topBar.modeLabel)}</span>
                   </button>
-                  <span class="composer-agent-status" data-testid="composer-agent-status">${escapeHTML(state.topBar.agentStatus)}</span>
                 </div>
                 <label for="message">Message</label>
                 <textarea id="message" aria-label="Message" placeholder="${escapeHTML(state.composer.placeholder)}" rows="1" ${state.composer.isSending ? 'disabled' : ''}>${escapeHTML(state.composer.draft)}</textarea>

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -50,6 +50,7 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('model-picker-button')).not.toContainText('Auto');
   await expect(page.getByTestId('mode-picker-button')).toBeVisible();
   await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+  await expect(page.getByTestId('composer-agent-status')).toHaveCount(0);
   const modelButtonBox = await page.getByTestId('model-picker-button').boundingBox();
   const modeButtonBox = await page.getByTestId('mode-picker-button').boundingBox();
   expect(modelButtonBox).not.toBeNull();
@@ -100,6 +101,7 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('tool-card-input')).toContainText('whoami');
   await expect(page.getByTestId('tool-card-output')).toContainText('mock-user');
   await expect(page.getByTestId('tool-card-details')).not.toHaveAttribute('open', '');
+  await expect(page.getByTestId('tool-card-details')).toContainText('Show details');
   await expect(page.getByText('You are `mock-user` in this workspace.')).toBeVisible();
   await expect(page.getByTestId('message-copy').first()).toHaveText('Copy');
   await page.getByTestId('message-copy').first().click();
@@ -395,7 +397,8 @@ test('mock harness keeps status details compact under long labels', async ({ pag
   expect(metrics.instructionTextOverflow).toBe('ellipsis');
   expect(metrics.instructionScrollWidth).toBeGreaterThan(metrics.instructionWidth);
   expect(metrics.agentText).toBe('Idle');
-  expect(metrics.agentWidth).toBeLessThanOrEqual(12);
+  expect(metrics.agentWidth).toBeGreaterThan(12);
+  expect(metrics.agentWidth).toBeLessThanOrEqual(180);
   expect(metrics.statusWidth).toBeLessThanOrEqual(340);
   expect(metrics.statusRight).toBeLessThanOrEqual(metrics.viewportWidth);
   expect(metrics.actionRight).toBeLessThanOrEqual(metrics.topBarRight);

--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -64,12 +64,6 @@ struct QuillCodeComposerView: View {
             )
 
             Spacer(minLength: 8)
-
-            Text(topBar.agentStatus)
-                .font(.caption.monospacedDigit().weight(.semibold))
-                .foregroundStyle(QuillCodePalette.muted)
-                .lineLimit(1)
-                .accessibilityLabel("Agent status, \(topBar.agentStatus)")
         }
         .frame(maxWidth: .infinity, minHeight: QuillCodeMetrics.minimumHitTarget, alignment: .leading)
         .accessibilityElement(children: .contain)

--- a/Sources/QuillCodeApp/QuillCodeToolCardView.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolCardView.swift
@@ -91,7 +91,7 @@ struct QuillCodeToolCardView: View {
                     .padding(.top, 4)
                 } label: {
                     HStack(spacing: 6) {
-                        Text(isDetailsOpen ? "Hide details" : "Show raw details")
+                        Text(detailsToggleLabel)
                         if !isDetailsOpen, card.status == .done {
                             Text("Raw tool data")
                                 .foregroundStyle(QuillCodePalette.muted)
@@ -120,8 +120,6 @@ struct QuillCodeToolCardView: View {
         .overlay(alignment: .leading) {
             if let executionContext = card.executionContext {
                 QuillCodeExecutionRail(context: executionContext)
-            } else if card.status == .done {
-                QuillCodeToolStatusRail(color: QuillCodePalette.green, opacity: 0.55)
             }
         }
         .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: isDetailsOpen)
@@ -189,10 +187,8 @@ struct QuillCodeToolCardView: View {
 
     private var cardStrokeColor: Color {
         switch card.status {
-        case .done:
+        case .queued, .running, .done:
             return Color.white.opacity(0.09)
-        case .queued, .running:
-            return statusColor.opacity(0.32)
         case .failed, .review:
             return statusColor.opacity(0.42)
         }
@@ -200,8 +196,10 @@ struct QuillCodeToolCardView: View {
 
     private var iconName: String {
         switch card.status {
-        case .queued, .running:
-            return "waveform.path"
+        case .queued:
+            return "clock"
+        case .running:
+            return "arrow.triangle.2.circlepath"
         case .done:
             return "checkmark.circle.fill"
         case .failed:
@@ -223,6 +221,22 @@ struct QuillCodeToolCardView: View {
             return "xmark.circle.fill"
         case .review:
             return "checkmark.shield.fill"
+        }
+    }
+
+    private var detailsToggleLabel: String {
+        if isDetailsOpen {
+            return "Hide details"
+        }
+        switch (card.inputJSON != nil, card.outputJSON != nil) {
+        case (true, true):
+            return "Show details"
+        case (true, false):
+            return "Show input"
+        case (false, true):
+            return "Show output"
+        case (false, false):
+            return "Show details"
         }
     }
 
@@ -264,21 +278,6 @@ private struct QuillCodeToolStatusBadge: View {
             .clipShape(Capsule())
             .help(status.rawValue.capitalized)
             .accessibilityLabel("Tool status \(status.rawValue)")
-    }
-}
-
-private struct QuillCodeToolStatusRail: View {
-    var color: Color
-    var opacity: Double
-
-    var body: some View {
-        Rectangle()
-            .fill(color.opacity(opacity))
-            .frame(width: 3)
-            .padding(.vertical, 8)
-            .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
-            .padding(.leading, 1)
-            .accessibilityHidden(true)
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -30,9 +30,13 @@ struct QuillCodeTopBarView: View {
                 .font(.headline)
                 .lineLimit(1)
                 .truncationMode(.tail)
+            Text(topBar.subtitle)
+                .font(.caption)
+                .foregroundStyle(QuillCodePalette.muted)
+                .lineLimit(1)
+                .truncationMode(.middle)
         }
         .frame(minWidth: 0, alignment: .leading)
-        .help(topBar.subtitle)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(topBar.primaryTitle), \(topBar.subtitle)")
     }
@@ -40,13 +44,30 @@ struct QuillCodeTopBarView: View {
     private var statusIndicator: some View {
         let status = topBar.agentStatusPresentation
         return HStack(spacing: 8) {
-            if status.showsIndicator {
-                Circle()
-                    .fill(statusColor(for: status.tone))
-                    .frame(width: 8, height: 8)
-                    .help(status.label)
-                    .accessibilityLabel(status.accessibilityLabel)
+            HStack(spacing: 6) {
+                if status.showsIndicator {
+                    Circle()
+                        .fill(statusColor(for: status.tone))
+                        .frame(width: 8, height: 8)
+                        .accessibilityHidden(true)
+                }
+                Text(status.label)
+                    .font(.caption.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.text.opacity(0.82))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
+            .padding(.horizontal, 10)
+            .frame(maxWidth: 170, minHeight: 32)
+            .background(QuillCodePalette.selection.opacity(0.50))
+            .overlay {
+                Capsule()
+                    .stroke(Color.white.opacity(0.10), lineWidth: 1)
+            }
+            .clipShape(Capsule())
+            .help(status.label)
+            .accessibilityLabel(status.accessibilityLabel)
+
             if let issue = topBar.runtimeIssuePresentation {
                 QuillCodeTopBarPill(
                     text: issue.label,
@@ -163,20 +184,20 @@ struct QuillCodeModePickerButton: View {
                     .font(.caption2.weight(.bold))
                     .foregroundStyle(QuillCodePalette.muted)
             }
-            .foregroundStyle(modeColor(for: selectedMode))
+            .foregroundStyle(QuillCodePalette.text)
             .padding(.horizontal, 10)
             .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
-            .background(modeColor(for: selectedMode).opacity(0.12))
+            .background(QuillCodePalette.selection.opacity(0.62))
             .overlay {
                 Capsule()
-                    .stroke(modeColor(for: selectedMode).opacity(0.24), lineWidth: 1)
+                    .stroke(Color.white.opacity(0.10), lineWidth: 1)
             }
             .clipShape(Capsule())
             .contentShape(Capsule())
         }
         .buttonStyle(QuillCodePressableButtonStyle())
-        .help("Choose approval mode")
-        .accessibilityLabel("Approval mode, \(modeLabel)")
+        .help("Choose Auto safety mode")
+        .accessibilityLabel("Auto safety mode, \(modeLabel)")
     }
 
     private func modeColor(for mode: AgentMode) -> Color {

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -45,11 +45,27 @@ enum WorkspaceHTMLToolCardRenderer {
         let isOpen = card.opensDetailsByDefault
         return """
         <details data-testid="tool-card-details"\(isOpen ? " open" : "")>
-          <summary>\(isOpen ? "Hide details" : "Show raw details")</summary>
+          <summary>\(detailsLabel(for: card, isOpen: isOpen))</summary>
           \(card.inputJSON.map { #"<pre data-testid="tool-card-input">\#(escape($0))</pre>"# } ?? "")
           \(card.outputJSON.map { #"<pre data-testid="tool-card-output">\#(escape($0))</pre>"# } ?? "")
         </details>
         """
+    }
+
+    private static func detailsLabel(for card: ToolCardState, isOpen: Bool) -> String {
+        if isOpen {
+            return "Hide details"
+        }
+        switch (card.inputJSON != nil, card.outputJSON != nil) {
+        case (true, true):
+            return "Show details"
+        case (true, false):
+            return "Show input"
+        case (false, true):
+            return "Show output"
+        case (false, false):
+            return "Show details"
+        }
     }
 
     private static func renderArtifacts(_ artifacts: [ToolArtifactState]) -> String {

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -24,7 +24,10 @@ enum WorkspaceHTMLTopBarRenderer {
         <div class="topbar-cluster topbar-context-cluster" data-testid="top-bar-context-cluster" aria-label="Workspace state">
           <details class="topbar-status-menu" data-testid="top-bar-status-menu">
             <summary data-testid="top-bar-status-button" aria-label="Workspace status" title="\(escape(status.label))">
-              <span class="agent-status-dot" data-testid="agent-status" data-tone="\(escape(status.tone.rawValue))" data-indicator="\(status.showsIndicator)">\(escape(status.label))</span>
+              <span class="agent-status-chip" data-testid="agent-status" data-tone="\(escape(status.tone.rawValue))" data-indicator="\(status.showsIndicator)">
+                <span class="agent-status-dot" aria-hidden="true"></span>
+                <span class="agent-status-label">\(escape(status.label))</span>
+              </span>
             </summary>
             <div class="topbar-status-popover" data-testid="top-bar-status-popover">
               <div class="topbar-status-row">

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -41,11 +41,10 @@ enum WorkspaceHTMLTranscriptRenderer {
         <form class="composer" data-testid="composer">
           <div class="composer-controls" data-testid="composer-controls" aria-label="Composer controls">
             <button type="button" class="composer-model-button" data-testid="model-picker-button" aria-label="Model: \(escape(topBar.modelLabel))">◇ <span data-testid="model-pill">\(escape(topBar.modelLabel))</span></button>
-            <button type="button" class="mode-pill-button" data-testid="mode-picker-button" data-mode-tone="\(modeTone(for: topBar.modeLabel))" aria-label="Approval mode: \(escape(topBar.modeLabel))">
+            <button type="button" class="mode-pill-button" data-testid="mode-picker-button" data-mode-tone="\(modeTone(for: topBar.modeLabel))" aria-label="Auto safety mode: \(escape(topBar.modeLabel))">
               <span class="mode-dot" aria-hidden="true"></span>
               <span data-testid="mode-pill">\(escape(topBar.modeLabel))</span>
             </button>
-            <span class="composer-agent-status" data-testid="composer-agent-status">\(escape(topBar.agentStatus))</span>
           </div>
           <label for="message">Message</label>
           <textarea id="message" aria-label="Message" placeholder="\(escape(composer.placeholder))" rows="1" \(composer.isSending ? "disabled" : "")>\(escape(composer.draft))</textarea>

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -1686,7 +1686,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-copy""#))
         XCTAssertTrue(html.contains("Copy output"))
         XCTAssertTrue(html.contains(#"data-testid="tool-card-output""#))
-        XCTAssertTrue(html.contains("Show raw details"))
+        XCTAssertTrue(html.contains("Show details"))
     }
 
     func testHTMLRendererIncludesToolCardArtifacts() async throws {

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1079,7 +1079,8 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(topBarViewText.contains("QuillCodeModelPickerView"), "Top bar should not carry send-time model selection chrome.")
         XCTAssertTrue(composerViewText.contains("QuillCodeModelPickerView"), "Composer should expose send-time model selection.")
         XCTAssertTrue(composerViewText.contains("QuillCodeModePickerButton"), "Composer should expose a dedicated approval-mode control.")
-        XCTAssertTrue(topBarViewText.contains("Choose approval mode"), "The mode control should advertise approval-mode intent.")
+        XCTAssertTrue(topBarViewText.contains("Choose Auto safety mode"), "The mode control should advertise Auto safety intent.")
+        XCTAssertFalse(composerViewText.contains("topBar.agentStatus"), "Composer should not duplicate the top-bar agent status.")
         XCTAssertFalse(modelPickerText.contains("modeLabel"), "The model picker trigger and popover must not merge approval mode back into model selection.")
         XCTAssertNil(
             modelPickerText.range(of: #"\bvar\s+onSetMode\b"#, options: .regularExpression),

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1900,3 +1900,24 @@ Remaining risk:
 
 - Basic local git file actions (`stage`, `restore`, `commit`, `push`) still live in the facade. They are small and readable, but a later A+ pass can split them into a `GitLocalToolExecutor` once the patch boundary is stable on main.
 - `PatchToolExecutor` has its own diff-path parser for generic apply-patch behavior. That is a separate tool boundary today; if parser behavior needs to converge, extract a neutral diff metadata parser rather than making either executor depend on the other.
+
+## 2026-06-23 Calm Composer And Tool-Card Pass
+
+Overall grade after this slice: **A- UI consistency, A regression coverage, B+ interaction depth**.
+
+The top bar and composer now have clearer ownership: the top bar owns project/status context, while the composer owns send-time model and Auto-safety controls. Before this pass, the composer repeated the top-bar agent status and the Auto/Review/Read-only control tinted the entire pill, which made the send area feel busier than Codex. Tool cards also over-emphasized successful work with green rails and colored strokes that competed with real review/error states.
+
+Code quality changes:
+
+- Rendered the top-bar subtitle as visible secondary context in the native SwiftUI bar instead of hiding it in a tooltip.
+- Promoted the top-bar agent status from a color-only dot to a compact text chip, preserving the dot for active/error states.
+- Removed duplicate agent-status text from native and HTML composers.
+- Renamed the mode affordance to "Auto safety" in help and accessibility copy.
+- Made mode controls neutral except for the small mode dot, preserving the state signal without making the whole control shout.
+- Reduced successful/queued/running tool-card chrome so review and failure states carry the visual emphasis.
+- Replaced generic "Show raw details" copy with details labels that match what is available: input, output, or both.
+
+Remaining risk:
+
+- Review tool cards still need first-class Approve/Reject buttons wired to the approval decision path. That requires a model/action boundary, not just view styling.
+- The top-bar overflow menu still duplicates some sidebar/tool-palette actions. It remains for compatibility in this slice; a later navigation pass should decide whether Settings and utility commands live in the sidebar, command palette, native menu bar, or top bar.


### PR DESCRIPTION
## Summary
- make the top-bar subtitle visible and promote agent status from a color-only dot to a compact text chip
- remove duplicate agent status from the composer and rename the mode affordance to Auto safety
- quiet successful/queued/running tool-card chrome so review and failure states carry the visual emphasis
- clarify tool-card details labels based on whether input, output, or both are available

## Claude CLI design review
Asked Claude CLI for a read-only interface critique of the current top bar, composer, and tool-card direction. The highest-impact immediate recommendation was to make agent status readable in words instead of hue alone; this PR implements that while leaving broader navigation/sidebar changes for later slices.

## Validation
- `swift test` — 782 tests passed
- `./node_modules/.bin/playwright test` from `E2E/playwright` — 58 tests passed
- `./scripts/smoke.sh` — passed Swift, mock CLI shell/file flows, live-mode readable error check, and Playwright
- post-rebase focused checks:
  - `swift test --filter QuillCodeTopBarSurfaceTests --filter WorkspaceSurfaceTests/testHTMLRendererIncludesTopBarSidebarAndEscapedTranscript --filter ParityGateTests/testTopBarViewsDelegateStatusPresentationSemantics --filter ParityGateTests/testComposerSeparatesModelAndApprovalModeControls`
  - `./node_modules/.bin/playwright test -g 'interface polish|status details|simple command flow'`
