### PR TITLE
Make mode control explicit

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -183,32 +183,18 @@
       border-color: rgba(255,255,255,.16);
       background: rgba(255,255,255,.075);
     }
-    .mode-dot {
-      width: 7px;
-      height: 7px;
-      border-radius: 999px;
-      background: var(--green);
-      box-shadow: 0 0 0 3px rgba(82,210,115,.18);
+    .mode-icon,
+    .mode-prefix,
+    .mode-separator {
+      color: var(--muted);
     }
-    .mode-pill-button[data-mode-tone="review"] .mode-dot {
-      background: var(--yellow);
-      box-shadow: 0 0 0 3px rgba(248,184,78,.18);
+    .mode-icon {
+      font-size: 12px;
+      line-height: 1;
+      transform: translateY(-.5px);
     }
-    .mode-pill-button[data-mode-tone="read-only"] .mode-dot {
-      background: var(--blue);
-      box-shadow: 0 0 0 3px rgba(65,184,232,.18);
-    }
-    .mode-pill-button[data-mode-tone="review"] {
-      color: var(--text);
-    }
-    .mode-pill-button[data-mode-tone="review"]:hover {
-      color: var(--text);
-    }
-    .mode-pill-button[data-mode-tone="read-only"] {
-      color: var(--text);
-    }
-    .mode-pill-button[data-mode-tone="read-only"]:hover {
-      color: var(--text);
+    .mode-separator {
+      opacity: .8;
     }
     .topbar-action-cluster button {
       width: 40px;
@@ -4253,7 +4239,9 @@
                     ${modelBrowser}
                   </div>
                   <button type="button" class="mode-pill-button" data-testid="mode-picker-button" data-mode-tone="${escapeHTML(modeTone(state.topBar.modeLabel))}" aria-label="Auto safety mode: ${escapeHTML(state.topBar.modeLabel)}">
-                    <span class="mode-dot" aria-hidden="true"></span>
+                    <span class="mode-icon" aria-hidden="true">◇</span>
+                    <span class="mode-prefix">Mode</span>
+                    <span class="mode-separator" aria-hidden="true">·</span>
                     <span data-testid="mode-pill">${escapeHTML(state.topBar.modeLabel)}</span>
                   </button>
                 </div>

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -49,7 +49,9 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('model-picker-button')).toHaveText('Nike 1.0');
   await expect(page.getByTestId('model-picker-button')).not.toContainText('Auto');
   await expect(page.getByTestId('mode-picker-button')).toBeVisible();
+  await expect(page.getByTestId('mode-picker-button')).toContainText('Mode');
   await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+  await expect(page.locator('[data-testid="mode-picker-button"] .mode-dot')).toHaveCount(0);
   await expect(page.getByTestId('composer-agent-status')).toHaveCount(0);
   const modelButtonBox = await page.getByTestId('model-picker-button').boundingBox();
   const modeButtonBox = await page.getByTestId('mode-picker-button').boundingBox();

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -173,9 +173,17 @@ struct QuillCodeModePickerButton: View {
             }
         } label: {
             HStack(spacing: 6) {
-                Circle()
-                    .fill(modeColor(for: selectedMode))
-                    .frame(width: 7, height: 7)
+                Image(systemName: "shield")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .accessibilityHidden(true)
+                Text("Mode")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .lineLimit(1)
+                Text("·")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted.opacity(0.8))
                 Text(modeLabel)
                     .font(.caption.weight(.semibold))
                     .lineLimit(1)
@@ -198,17 +206,6 @@ struct QuillCodeModePickerButton: View {
         .buttonStyle(QuillCodePressableButtonStyle())
         .help("Choose Auto safety mode")
         .accessibilityLabel("Auto safety mode, \(modeLabel)")
-    }
-
-    private func modeColor(for mode: AgentMode) -> Color {
-        switch mode {
-        case .auto:
-            return QuillCodePalette.green
-        case .review:
-            return QuillCodePalette.yellow
-        case .readOnly:
-            return QuillCodePalette.blue
-        }
     }
 }
 

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -42,7 +42,9 @@ enum WorkspaceHTMLTranscriptRenderer {
           <div class="composer-controls" data-testid="composer-controls" aria-label="Composer controls">
             <button type="button" class="composer-model-button" data-testid="model-picker-button" aria-label="Model: \(escape(topBar.modelLabel))">◇ <span data-testid="model-pill">\(escape(topBar.modelLabel))</span></button>
             <button type="button" class="mode-pill-button" data-testid="mode-picker-button" data-mode-tone="\(modeTone(for: topBar.modeLabel))" aria-label="Auto safety mode: \(escape(topBar.modeLabel))">
-              <span class="mode-dot" aria-hidden="true"></span>
+              <span class="mode-icon" aria-hidden="true">◇</span>
+              <span class="mode-prefix">Mode</span>
+              <span class="mode-separator" aria-hidden="true">·</span>
               <span data-testid="mode-pill">\(escape(topBar.modeLabel))</span>
             </button>
           </div>

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -1547,6 +1547,8 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="composer-controls""#))
         XCTAssertTrue(html.contains(#"data-testid="model-picker-button""#))
         XCTAssertTrue(html.contains(#"data-testid="mode-picker-button""#))
+        XCTAssertTrue(html.contains(#"class="mode-prefix">Mode"#))
+        XCTAssertFalse(html.contains(#"class="mode-dot""#))
         XCTAssertTrue(html.contains(#"data-testid="project-instructions-status""#))
         XCTAssertTrue(html.contains("1 instruction file loaded"))
         XCTAssertTrue(html.contains("AGENTS.md"))

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1080,6 +1080,8 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(composerViewText.contains("QuillCodeModelPickerView"), "Composer should expose send-time model selection.")
         XCTAssertTrue(composerViewText.contains("QuillCodeModePickerButton"), "Composer should expose a dedicated approval-mode control.")
         XCTAssertTrue(topBarViewText.contains("Choose Auto safety mode"), "The mode control should advertise Auto safety intent.")
+        XCTAssertTrue(topBarViewText.contains(#"Text("Mode")"#), "Native mode control should name the control instead of relying on a color dot.")
+        XCTAssertFalse(topBarViewText.contains("modeColor(for:"), "Native mode control should not reuse health-status color semantics.")
         XCTAssertFalse(composerViewText.contains("topBar.agentStatus"), "Composer should not duplicate the top-bar agent status.")
         XCTAssertFalse(modelPickerText.contains("modeLabel"), "The model picker trigger and popover must not merge approval mode back into model selection.")
         XCTAssertNil(
@@ -1093,6 +1095,8 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(htmlTopBarText.contains("data-testid=\"model-picker-button\""), "HTML top bar should not expose the model control.")
         XCTAssertTrue(htmlTranscriptText.contains("data-testid=\"model-picker-button\""), "HTML composer should expose a model control.")
         XCTAssertTrue(htmlTranscriptText.contains("data-testid=\"mode-picker-button\""), "HTML composer should expose a separate mode control.")
+        XCTAssertTrue(htmlTranscriptText.contains("mode-prefix"), "HTML mode control should name the control instead of relying on a color dot.")
+        XCTAssertFalse(htmlTranscriptText.contains("mode-dot"), "HTML mode control should not reuse health-status dot semantics.")
         XCTAssertFalse(htmlTopBarText.contains(" · "), "HTML top bar must not render model and mode as one combined label.")
     }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1956,3 +1956,22 @@ Remaining risk:
 
 - `GitToolExecutor` still exposes compatibility wrappers for older call sites. They are now simple delegates, but new code should use `GitInputValidator`, `GitHubPullRequestInputValidator`, or `GitHubPullRequestOutputParser` directly.
 - `GitHubPullRequestToolExecutor` still owns per-operation argument construction. That is the right boundary for now; if GitHub issue/release tools appear, add new focused executors rather than broadening this PR executor.
+
+## 2026-06-23 Explicit Mode Control Pass
+
+Overall grade after this slice: **A UI hierarchy, A regression coverage, B+ interaction depth**.
+
+The composer mode control now reads as an explicit safety mode selector instead of a color-coded status dot. Before this pass, the Auto/Review/Read-only control used the same dot language as the top-bar agent status, which made health state and safety mode visually compete. The control now uses a neutral shield affordance and the label "Mode · Auto", while preserving the existing value hook for tests and automation.
+
+Code quality changes:
+
+- Replaced the native SwiftUI mode dot with a neutral shield icon and explicit "Mode" label.
+- Removed native mode-specific color mapping so approval mode does not reuse health-status color semantics.
+- Updated the HTML renderer and Playwright harness to emit the same explicit mode structure.
+- Removed mode-dot CSS from the harness and kept the mode pill neutral across Auto, Review, and Read-only.
+- Added parity and E2E coverage that prevents the mode control from drifting back to a color-dot-only affordance.
+
+Remaining risk:
+
+- The mode picker still cycles modes in the HTML harness instead of opening a menu like the native SwiftUI control. That is acceptable for fixture coverage today, but a future harness parity pass should model the menu if mode-specific explanations or warnings move into the picker.
+- Review and Read-only modes still do not add an ambient composer cue. A later interaction pass should consider a subtle non-color-only indicator when the user is outside Auto.


### PR DESCRIPTION
## Summary
- replace the mode picker's color-only dot with a neutral shield and explicit `Mode · <value>` label
- update SwiftUI, static HTML, and Playwright harness markup to share the same mode-control structure
- add parity, unit, and E2E coverage preventing mode controls from drifting back to status-dot semantics

## Claude CLI design review
- Claude recommended keeping the top bar calm and moving model/mode controls into the composer footer. This slice follows that existing architecture and focuses on making the composer mode control readable without adding more top-bar chrome.
- Broader follow-ups from the review: collapse completed tool cards by default, continue simplifying left sidebar hierarchy, and keep keyboard-first command palette flows prominent.

## Validation
- `git diff --check`
- `swift test --filter ParityGateTests/testComposerSeparatesModelAndApprovalModeControls`
- `swift test --filter WorkspaceSurfaceTests/testHTMLRendererEscapesAndLabelsPrimaryRegions`
- `cd E2E/playwright && npm ci && ./node_modules/.bin/playwright test -g 'simple command flow|changes approval mode'`\n- `swift test`\n- `cd E2E/playwright && ./node_modules/.bin/playwright test`\n- `./scripts/smoke.sh`\n\n## Screenshot\n- `/tmp/quillcode-explicit-mode-control-2026-06-23.png`