### PR TITLE
Summarize collapsed tool cards

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3138,6 +3138,10 @@
         executionContext: card.executionContext || executionContextForTool(card.title),
         density: card.density || toolCardDensity(card.status, card.isExpanded)
       };
+      const stateLabel = toolCardStateLabel(toolCard.status);
+      if (!toolCard.subtitle || toolCard.subtitle === stateLabel) {
+        toolCard.subtitle = toolCardSubtitle(stateLabel, toolCard.title, toolCard.inputJSON);
+      }
       state.transcript.toolCards.push(toolCard);
       state.transcript.timelineItems.push({
         id: `timeline-${state.nextTimelineIndex++}`,
@@ -3239,9 +3243,69 @@
       return 'collapsed';
     }
 
+    function toolCardStateLabel(status) {
+      if (status === 'queued') return 'Queued';
+      if (status === 'running') return 'Running';
+      if (status === 'failed') return 'Failed';
+      if (status === 'review') return 'Review';
+      return 'Completed';
+    }
+
+    function toolCardSubtitle(stateLabel, toolName, inputJSON) {
+      const detail = toolCardDetail(toolName, inputJSON);
+      return detail ? `${stateLabel} · ${detail}` : stateLabel;
+    }
+
+    function toolCardDetail(toolName, inputJSON) {
+      if (!inputJSON) return '';
+      let args = {};
+      try {
+        args = JSON.parse(inputJSON);
+      } catch {
+        return '';
+      }
+      const pathTools = new Set([
+        'host.file.read',
+        'host.file.write',
+        'host.git.stage',
+        'host.git.restore',
+        'host.git.stage_hunk',
+        'host.git.restore_hunk',
+        'host.git.pr.diff',
+        'host.git.worktree.remove'
+      ]);
+      if (toolName === 'host.shell.run') return toolCardSanitized(args.cmd);
+      if (pathTools.has(toolName)) return toolCardSanitized(args.path);
+      if (toolName === 'host.apply_patch') return 'patch';
+      if (toolName === 'host.git.diff') return args.staged === true ? 'staged diff' : 'working tree';
+      if (toolName === 'host.git.commit') return toolCardSanitized(args.message);
+      if (toolName === 'host.git.push') {
+        const remote = toolCardSanitized(args.remote);
+        const branch = toolCardSanitized(args.branch);
+        if (remote && branch) return `${remote}/${branch}`;
+        return remote || branch || '';
+      }
+      if (toolName === 'host.git.pr.create') return toolCardSanitized(args.title);
+      if (toolName?.startsWith('host.git.pr.')) return toolCardSanitized(args.selector);
+      if (toolName === 'host.git.worktree.create') return toolCardSanitized(args.branch) || toolCardSanitized(args.path);
+      if (toolName === 'host.plan.update') return 'plan';
+      if (toolName === 'host.browser.inspect') return toolCardSanitized(args.url);
+      if (toolName === 'host.memory.remember') return toolCardSanitized(args.content);
+      if (toolName === 'host.mcp.call') return toolCardSanitized(args.tool);
+      if (toolName === 'host.mcp.read_resource' || toolName === 'host.mcp.get_prompt') {
+        return toolCardSanitized(args.name) || toolCardSanitized(args.uri);
+      }
+      return '';
+    }
+
+    function toolCardSanitized(value) {
+      const collapsed = String(value || '').split(/\s+/).filter(Boolean).join(' ').trim();
+      return collapsed.length > 72 ? `${collapsed.slice(0, 72)}...` : collapsed;
+    }
+
     function updateToolCardLifecycle(card, status, subtitle) {
       card.status = status;
-      card.subtitle = subtitle;
+      card.subtitle = toolCardSubtitle(subtitle, card.title, card.inputJSON);
       card.density = toolCardDensity(status, card.isExpanded);
       card.isExpanded = card.density === 'expanded';
     }

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -99,6 +99,7 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode - Auto');
   await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
   await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-subtitle')).toHaveText('Completed · whoami');
   await expect(page.getByTestId('tool-card')).toHaveAttribute('data-density', 'collapsed');
   await expect(page.getByTestId('tool-card-input')).toContainText('whoami');
   await expect(page.getByTestId('tool-card-output')).toContainText('mock-user');

--- a/Sources/QuillCodeApp/WorkspaceToolCardSubtitleBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolCardSubtitleBuilder.swift
@@ -1,0 +1,87 @@
+import Foundation
+import QuillCodeCore
+
+enum WorkspaceToolCardSubtitleBuilder {
+    private static let detailLimit = 72
+
+    static func subtitle(stateLabel: String, toolName: String, inputJSON: String?) -> String {
+        guard let detail = detail(toolName: toolName, inputJSON: inputJSON) else {
+            return stateLabel
+        }
+        return "\(stateLabel) · \(detail)"
+    }
+
+    private static func detail(toolName: String, inputJSON: String?) -> String? {
+        guard let inputJSON, let arguments = try? ToolArguments(inputJSON) else {
+            return nil
+        }
+
+        switch toolName {
+        case "host.shell.run":
+            return sanitized(arguments.string("cmd"))
+        case "host.file.read", "host.file.write",
+             "host.git.stage", "host.git.restore",
+             "host.git.stage_hunk", "host.git.restore_hunk",
+             "host.git.pr.diff", "host.git.worktree.remove":
+            return sanitized(arguments.string("path"))
+        case "host.apply_patch":
+            return "patch"
+        case "host.git.status":
+            return nil
+        case "host.git.diff":
+            return arguments.bool("staged") == true ? "staged diff" : "working tree"
+        case "host.git.commit":
+            return sanitized(arguments.string("message"))
+        case "host.git.push":
+            return pushDetail(arguments)
+        case "host.git.pr.create":
+            return sanitized(arguments.string("title"))
+        case "host.git.pr.view", "host.git.pr.checks", "host.git.pr.checkout",
+             "host.git.pr.reviewers", "host.git.pr.labels", "host.git.pr.comment",
+             "host.git.pr.review", "host.git.pr.merge":
+            return sanitized(arguments.string("selector"))
+        case "host.git.worktree.create":
+            return sanitized(arguments.string("branch")) ?? sanitized(arguments.string("path"))
+        case "host.plan.update":
+            return "plan"
+        case "host.browser.inspect":
+            return sanitized(arguments.string("url"))
+        case "host.memory.remember":
+            return sanitized(arguments.string("content"))
+        case "host.mcp.call":
+            return sanitized(arguments.string("tool"))
+        case "host.mcp.read_resource", "host.mcp.get_prompt":
+            return sanitized(arguments.string("name")) ?? sanitized(arguments.string("uri"))
+        default:
+            return nil
+        }
+    }
+
+    private static func pushDetail(_ arguments: ToolArguments) -> String? {
+        let remote = sanitized(arguments.string("remote"))
+        let branch = sanitized(arguments.string("branch"))
+        switch (remote, branch) {
+        case (.some(let remote), .some(let branch)):
+            return "\(remote)/\(branch)"
+        case (.some(let remote), nil):
+            return remote
+        case (nil, .some(let branch)):
+            return branch
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    private static func sanitized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let collapsed = value
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > detailLimit else { return collapsed }
+        let end = collapsed.index(collapsed.startIndex, offsetBy: detailLimit)
+        return String(collapsed[..<end]) + "..."
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
@@ -17,11 +17,11 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         var cards: [ToolCardState] = []
         var activeToolCardIndex: Int?
 
-        func updateActiveToolCard(status: ToolCardStatus, subtitle: String, outputJSON: String? = nil) {
+        func updateActiveToolCard(status: ToolCardStatus, stateLabel: String, outputJSON: String? = nil) {
             guard let index = activeToolCardIndex else {
                 return
             }
-            Self.updateCard(&cards, at: index, status: status, subtitle: subtitle, outputJSON: outputJSON)
+            Self.updateCard(&cards, at: index, status: status, stateLabel: stateLabel, outputJSON: outputJSON)
             if status.isTerminal {
                 activeToolCardIndex = nil
             }
@@ -31,26 +31,28 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
             switch event.kind {
             case .toolQueued:
                 let call = Self.decode(ToolCall.self, event.payloadJSON)
+                let title = call?.name ?? "Tool"
+                let inputJSON = call?.argumentsJSON ?? event.payloadJSON
                 cards.append(ToolCardState(
                     id: call?.id ?? event.id.uuidString,
-                    title: call?.name ?? "Tool",
-                    subtitle: "Queued",
+                    title: title,
+                    subtitle: Self.toolSubtitle(stateLabel: "Queued", title: title, inputJSON: inputJSON),
                     status: .queued,
-                    inputJSON: call?.argumentsJSON ?? event.payloadJSON
+                    inputJSON: inputJSON
                 ))
                 activeToolCardIndex = cards.count - 1
             case .toolRunning:
-                updateActiveToolCard(status: .running, subtitle: "Running")
+                updateActiveToolCard(status: .running, stateLabel: "Running")
             case .toolCompleted:
                 updateActiveToolCard(
                     status: .done,
-                    subtitle: "Completed",
+                    stateLabel: "Completed",
                     outputJSON: event.payloadJSON
                 )
             case .toolFailed:
                 updateActiveToolCard(
                     status: .failed,
-                    subtitle: "Failed",
+                    stateLabel: "Failed",
                     outputJSON: event.payloadJSON
                 )
             case .approvalRequested:
@@ -89,21 +91,21 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
             activeToolItemIndex = items.count - 1
         }
 
-        func updateActiveToolCard(status: ToolCardStatus, subtitle: String, outputJSON: String? = nil) {
+        func updateActiveToolCard(status: ToolCardStatus, stateLabel: String, outputJSON: String? = nil) {
             guard let index = activeToolItemIndex,
                   var card = items[index].toolCard
             else {
                 appendToolCard(ToolCardState(
                     id: "orphan-\(UUID().uuidString)",
                     title: "Tool",
-                    subtitle: subtitle,
+                    subtitle: stateLabel,
                     status: status,
                     outputJSON: outputJSON,
                     artifacts: outputJSON.map(Self.artifacts(from:)) ?? []
                 ))
                 return
             }
-            Self.updateCard(&card, status: status, subtitle: subtitle, outputJSON: outputJSON)
+            Self.updateCard(&card, status: status, stateLabel: stateLabel, outputJSON: outputJSON)
             items[index] = .toolCard(card)
             if status.isTerminal {
                 activeToolItemIndex = nil
@@ -116,25 +118,27 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
                 appendMessage(matching: event.summary)
             case .toolQueued:
                 let call = Self.decode(ToolCall.self, event.payloadJSON)
+                let title = call?.name ?? "Tool"
+                let inputJSON = call?.argumentsJSON ?? event.payloadJSON
                 appendToolCard(ToolCardState(
                     id: call?.id ?? event.id.uuidString,
-                    title: call?.name ?? "Tool",
-                    subtitle: "Queued",
+                    title: title,
+                    subtitle: Self.toolSubtitle(stateLabel: "Queued", title: title, inputJSON: inputJSON),
                     status: .queued,
-                    inputJSON: call?.argumentsJSON ?? event.payloadJSON
+                    inputJSON: inputJSON
                 ))
             case .toolRunning:
-                updateActiveToolCard(status: .running, subtitle: "Running")
+                updateActiveToolCard(status: .running, stateLabel: "Running")
             case .toolCompleted:
                 updateActiveToolCard(
                     status: .done,
-                    subtitle: "Completed",
+                    stateLabel: "Completed",
                     outputJSON: event.payloadJSON
                 )
             case .toolFailed:
                 updateActiveToolCard(
                     status: .failed,
-                    subtitle: "Failed",
+                    stateLabel: "Failed",
                     outputJSON: event.payloadJSON
                 )
             case .approvalRequested:
@@ -165,21 +169,21 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         _ cards: inout [ToolCardState],
         at index: Int,
         status: ToolCardStatus,
-        subtitle: String,
+        stateLabel: String,
         outputJSON: String? = nil
     ) {
         guard cards.indices.contains(index) else { return }
-        updateCard(&cards[index], status: status, subtitle: subtitle, outputJSON: outputJSON)
+        updateCard(&cards[index], status: status, stateLabel: stateLabel, outputJSON: outputJSON)
     }
 
     private static func updateCard(
         _ card: inout ToolCardState,
         status: ToolCardStatus,
-        subtitle: String,
+        stateLabel: String,
         outputJSON: String? = nil
     ) {
         card.status = status
-        card.subtitle = subtitle
+        card.subtitle = toolSubtitle(stateLabel: stateLabel, title: card.title, inputJSON: card.inputJSON)
         card.density = ToolCardState.defaultDensity(status: status, isExpanded: card.isExpanded)
         card.isExpanded = card.density == .expanded
         if let outputJSON {
@@ -197,6 +201,10 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
             .map { value in
                 ToolArtifactState(value: value, textPreview: ToolArtifactPreviewBuilder.textPreview(for: value))
             }
+    }
+
+    private static func toolSubtitle(stateLabel: String, title: String, inputJSON: String?) -> String {
+        WorkspaceToolCardSubtitleBuilder.subtitle(stateLabel: stateLabel, toolName: title, inputJSON: inputJSON)
     }
 
     private static func messageFeedbackByMessageID(for thread: ChatThread) -> [UUID: MessageFeedbackValue] {

--- a/Tests/QuillCodeAppTests/WorkspaceModelTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceModelTests.swift
@@ -4123,7 +4123,7 @@ final class WorkspaceModelTests: XCTestCase {
 
         XCTAssertEqual(cards.count, 1)
         XCTAssertEqual(cards[0].status, .failed)
-        XCTAssertEqual(cards[0].subtitle, "Failed")
+        XCTAssertEqual(cards[0].subtitle, "Failed · sleep 10")
         XCTAssertEqual(cards[0].density, .expanded)
         XCTAssertEqual(cards[0].outputJSON, #"{"ok":false,"error":"Stopped by user"}"#)
         XCTAssertEqual(timeline.compactMap(\.toolCard).first?.status, .failed)

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -56,7 +56,7 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(cards.count, 1)
         XCTAssertEqual(cards[0].id, "tool-call-1")
         XCTAssertEqual(cards[0].title, ToolDefinition.fileWrite.name)
-        XCTAssertEqual(cards[0].subtitle, "Completed")
+        XCTAssertEqual(cards[0].subtitle, "Completed · hello.txt")
         XCTAssertEqual(cards[0].status, .done)
         XCTAssertEqual(cards[0].inputJSON, call.argumentsJSON)
         XCTAssertEqual(cards[0].artifacts.map(\.label), ["hello.txt"])
@@ -88,6 +88,7 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(timeline[0].message?.text, user.content)
         XCTAssertEqual(timeline[1].toolCard?.id, "shell-1")
         XCTAssertEqual(timeline[1].toolCard?.status, .done)
+        XCTAssertEqual(timeline[1].toolCard?.subtitle, "Completed · whoami")
         XCTAssertEqual(timeline[2].message?.text, assistant.content)
         XCTAssertEqual(timeline[3].message?.text, unmatchedAssistant.content)
     }
@@ -110,5 +111,51 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(timelineCards[1].title, "Tool")
         XCTAssertEqual(timelineCards[1].status, .failed)
         XCTAssertEqual(timelineCards[1].subtitle, "Failed")
+    }
+
+    func testToolCardSubtitleBuilderSummarizesKnownArguments() {
+        XCTAssertEqual(
+            WorkspaceToolCardSubtitleBuilder.subtitle(
+                stateLabel: "Running",
+                toolName: "host.shell.run",
+                inputJSON: ToolArguments.json(["cmd": "printf 'hello'\n && whoami"])
+            ),
+            "Running · printf 'hello' && whoami"
+        )
+        XCTAssertEqual(
+            WorkspaceToolCardSubtitleBuilder.subtitle(
+                stateLabel: "Completed",
+                toolName: "host.git.diff",
+                inputJSON: ToolArguments.json(["staged": true])
+            ),
+            "Completed · staged diff"
+        )
+        XCTAssertEqual(
+            WorkspaceToolCardSubtitleBuilder.subtitle(
+                stateLabel: "Completed",
+                toolName: "host.git.push",
+                inputJSON: ToolArguments.json(["remote": "origin", "branch": "main"])
+            ),
+            "Completed · origin/main"
+        )
+    }
+
+    func testToolCardSubtitleBuilderFallsBackForInvalidOrUnknownInput() {
+        XCTAssertEqual(
+            WorkspaceToolCardSubtitleBuilder.subtitle(
+                stateLabel: "Completed",
+                toolName: "host.shell.run",
+                inputJSON: "{}"
+            ),
+            "Completed"
+        )
+        XCTAssertEqual(
+            WorkspaceToolCardSubtitleBuilder.subtitle(
+                stateLabel: "Completed",
+                toolName: "host.unknown",
+                inputJSON: ToolArguments.json(["cmd": "whoami"])
+            ),
+            "Completed"
+        )
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -2009,3 +2009,22 @@ Remaining risk:
 
 - The mode picker still cycles modes in the HTML harness instead of opening a menu like the native SwiftUI control. That is acceptable for fixture coverage today, but a future harness parity pass should model the menu if mode-specific explanations or warnings move into the picker.
 - Review and Read-only modes still do not add an ambient composer cue. A later interaction pass should consider a subtle non-color-only indicator when the user is outside Auto.
+
+## 2026-06-23 Tool Card Subtitle Builder Pass
+
+Overall grade after this slice: **A- UI scanability, A presentation boundary, A regression coverage**.
+
+Collapsed completed tool cards now preserve the concrete action in their subtitle, so users can scan a long transcript without expanding raw JSON. The behavior is presentation-only and lives behind one focused builder instead of spreading argument parsing through transcript projection.
+
+| Surface | Before | After |
+| --- | --- | --- |
+| Completed tool cards | Collapsed to generic `Completed`, losing the command or file path. | Collapse to labels such as `Completed · whoami` and `Completed · hello.txt`. |
+| Transcript projection | Lifecycle labels were hardcoded in both card and timeline paths. | Both paths call `WorkspaceToolCardSubtitleBuilder` through the transcript builder. |
+| Mock harness | Demo cards repeated native subtitle drift manually. | Plain lifecycle subtitles are enriched with the same argument summary rules. |
+
+Code quality changes:
+
+- Added `WorkspaceToolCardSubtitleBuilder` as the single presenter for safe, compact tool-card action summaries.
+- Kept summaries bounded and whitespace-normalized so long commands do not destabilize collapsed card layout.
+- Added focused Swift coverage for known tool summaries, fallback behavior, and transcript lifecycle projection.
+- Added Playwright coverage proving the mock command flow shows the command in the collapsed card subtitle.


### PR DESCRIPTION
## Summary
- add a focused `WorkspaceToolCardSubtitleBuilder` for compact tool action summaries
- show collapsed tool cards as labels like `Completed · whoami` and `Completed · hello.txt`
- mirror the behavior in the Playwright harness and document the code-quality pass

## Validation
- `swift test --filter WorkspaceTranscriptSurfaceBuilderTests`
- `swift test`
- `./node_modules/.bin/playwright test` from `E2E/playwright`
- `./scripts/smoke.sh`

## Screenshot
- `/tmp/quillcode-tool-card-subtitles-2026-06-23.png`