### PR TITLE
Make review tool cards actionable

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -1629,12 +1629,46 @@
       box-shadow: 0 16px 38px rgba(0,0,0,.22);
     }
     .tool-card.failed { border-color: rgba(255,93,82,.44); }
-    .tool-card.review { border-color: rgba(248,184,78,.48); }
+    .tool-card.review { border-color: rgba(255,255,255,.11); }
     .tool-card[data-density="collapsed"] {
       min-height: 58px;
     }
     .tool-card header { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
     .tool-card header [data-testid="tool-card-status"] { flex: none; }
+    .tool-card-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 10px;
+    }
+    .tool-card-actions button {
+      min-height: 40px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.10);
+      padding: 0 12px;
+      font: inherit;
+      font-size: 13px;
+      font-weight: 700;
+      cursor: pointer;
+      transition-property: transform, border-color, background;
+      transition-duration: 120ms;
+      transition-timing-function: var(--ease-out);
+    }
+    .tool-card-actions button:active { transform: scale(0.96); }
+    .tool-card-actions button[data-action-style="primary"] {
+      color: #fff;
+      background: var(--accent);
+      border-color: rgba(255,255,255,.14);
+    }
+    .tool-card-actions button[data-action-style="secondary"] {
+      color: var(--text);
+      background: rgba(255,255,255,.08);
+    }
+    .tool-card-actions button[data-action-style="destructive"] {
+      color: #ff7a70;
+      background: rgba(255,93,82,.14);
+      border-color: rgba(255,93,82,.26);
+    }
     .tool-artifacts {
       display: flex;
       flex-wrap: wrap;
@@ -3310,6 +3344,62 @@
       card.isExpanded = card.density === 'expanded';
     }
 
+    function runToolCardAction(kind, requestID, timelineID) {
+      const item = state.transcript.timelineItems.find(item => item.id === timelineID);
+      const card = item?.toolCard || state.transcript.toolCards.find(card => (
+        (card.actions || []).some(action => action.requestID === requestID)
+      ));
+      if (!card) return;
+      card.actions = [];
+      card.status = 'done';
+      card.subtitle = toolCardSubtitle(kind === 'approve' ? 'Approved' : 'Skipped', card.title, card.inputJSON);
+      card.outputJSON = JSON.stringify({
+        requestID,
+        verdict: kind === 'approve' ? 'approve' : 'deny',
+        rationale: kind === 'approve' ? 'Approved from the tool card.' : 'Skipped from the tool card.'
+      }, null, 2);
+      card.density = toolCardDensity(card.status, false);
+      card.isExpanded = false;
+
+      if (kind === 'approve') {
+        addToolCard({
+          title: card.title,
+          subtitle: 'Completed',
+          status: 'done',
+          inputJSON: card.inputJSON,
+          outputJSON: mockApprovedToolOutput(card.title, card.inputJSON)
+        });
+        addMessage('assistant', 'Approved and ran the tool.');
+      } else {
+        addMessage('assistant', `Skipped ${card.title}.`);
+      }
+      render();
+    }
+
+    function mockApprovedToolOutput(toolName, inputJSON) {
+      const args = safeJSON(inputJSON);
+      if (toolName === 'host.shell.run') {
+        const cmd = String(args.cmd || '').trim();
+        const stdout = cmd === 'whoami'
+          ? 'mock-user\n'
+          : `ran: ${cmd || 'command'}\n`;
+        return JSON.stringify({ ok: true, stdout, stderr: '', exitCode: 0 }, null, 2);
+      }
+      if (toolName === 'host.file.write') {
+        const path = String(args.path || 'file.txt');
+        return JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2);
+      }
+      return JSON.stringify({ ok: true, stdout: 'Completed.\n' }, null, 2);
+    }
+
+    function safeJSON(text) {
+      try {
+        return JSON.parse(text || '{}') || {};
+      } catch {
+        return {};
+      }
+    }
+
     function artifactsFromOutput(outputJSON) {
       if (!outputJSON) return [];
       try {
@@ -4067,6 +4157,12 @@
             ${card.inputJSON ? `<pre data-testid="tool-card-input">${escapeHTML(card.inputJSON)}</pre>` : ''}
             ${card.outputJSON ? `<pre data-testid="tool-card-output">${escapeHTML(card.outputJSON)}</pre>` : ''}
           </details>` : '';
+      const renderToolActions = card => (card.actions || []).length ? `
+          <div class="tool-card-actions" data-testid="tool-card-actions">
+            ${card.actions.map(action => `
+              <button type="button" data-testid="tool-card-action" data-action-kind="${escapeHTML(action.kind)}" data-action-style="${escapeHTML(action.style)}" data-request-id="${escapeHTML(action.requestID)}">${escapeHTML(action.title)}</button>
+            `).join('')}
+          </div>` : '';
       const renderToolCard = (card, timelineID = '') => `
         <article class="tool-card ${escapeHTML(card.status)}${activeClass(timelineID)}" data-testid="tool-card" data-status="${escapeHTML(card.status)}" data-density="${escapeHTML(card.density || toolCardDensity(card.status, card.isExpanded))}" data-timeline-id="${escapeHTML(timelineID)}"${card.executionContext ? ` data-execution-context="${escapeHTML(card.executionContext.kind)}"` : ''} aria-label="${escapeHTML(card.title)}, ${escapeHTML(card.status)}, ${escapeHTML(card.density || toolCardDensity(card.status, card.isExpanded))}${card.executionContext ? `, ${card.executionContext.label} ${card.executionContext.detail}` : ''}">
           <header>
@@ -4077,6 +4173,7 @@
             <span data-testid="tool-card-status">${escapeHTML(card.status)}</span>
           </header>
           <p data-testid="tool-card-subtitle">${escapeHTML(card.subtitle)}</p>
+          ${renderToolActions(card)}
           ${copyButton('tool-card-copy', timelineID || card.id, card.outputJSON ? 'Copy output' : card.inputJSON ? 'Copy input' : 'Copy')}
           ${renderArtifacts(card.artifacts)}
           ${renderTextPreviews(card.artifacts)}
@@ -4378,6 +4475,16 @@
       document.querySelectorAll('[data-copy-id]').forEach(button => {
         button.addEventListener('click', event => {
           copyTranscriptItem(event.currentTarget.getAttribute('data-copy-id'));
+        });
+      });
+      document.querySelectorAll('[data-testid="tool-card-action"]').forEach(button => {
+        button.addEventListener('click', event => {
+          const cardElement = event.currentTarget.closest('[data-testid="tool-card"]');
+          runToolCardAction(
+            event.currentTarget.getAttribute('data-action-kind'),
+            event.currentTarget.getAttribute('data-request-id'),
+            cardElement?.getAttribute('data-timeline-id') || ''
+          );
         });
       });
       document.querySelectorAll('[data-feedback-value]').forEach(button => {

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -139,6 +139,59 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('message-use-as-draft')).toHaveCount(2);
 });
 
+test('mock harness exposes actionable approval buttons on review cards', async ({ page }) => {
+  await page.goto('file://' + process.cwd() + '/../harness/index.html');
+
+  await page.evaluate(() => {
+    const harness = window as typeof window & {
+      addToolCard: (card: Record<string, unknown>) => void;
+      render: () => void;
+    };
+    harness.addToolCard({
+      id: 'shell-review',
+      title: 'host.shell.run',
+      subtitle: 'Needs your okay · whoami',
+      status: 'review',
+      density: 'expanded',
+      inputJSON: JSON.stringify({ cmd: 'whoami' }, null, 2),
+      isExpanded: true,
+      actions: [
+        {
+          id: 'tool-card-action-approve-approval-1',
+          title: 'Allow once',
+          kind: 'approve',
+          requestID: 'approval-1',
+          style: 'primary'
+        },
+        {
+          id: 'tool-card-action-deny-approval-1',
+          title: 'Skip',
+          kind: 'deny',
+          requestID: 'approval-1',
+          style: 'secondary'
+        }
+      ]
+    });
+    harness.render();
+  });
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(1);
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'review');
+  await expect(page.getByTestId('tool-card-actions')).toBeVisible();
+  await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Allow once' })).toBeVisible();
+  await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Skip' })).toBeVisible();
+
+  await page.getByTestId('tool-card-action').filter({ hasText: 'Allow once' }).click();
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(2);
+  await expect(page.getByTestId('tool-card').first()).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-subtitle').first()).toHaveText('Approved · whoami');
+  await expect(page.getByTestId('tool-card-actions')).toHaveCount(0);
+  await expect(page.getByTestId('tool-card').nth(1)).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-output').last()).toContainText('mock-user');
+  await expect(page.getByTestId('message').last()).toContainText('Approved and ran the tool.');
+});
+
 test('mock harness opens utilities from the top-bar overflow', async ({ page }) => {
   await page.goto('file://' + process.cwd() + '/../harness/index.html');
 

--- a/Sources/QuillCodeAgent/AgentToolStepRunner.swift
+++ b/Sources/QuillCodeAgent/AgentToolStepRunner.swift
@@ -63,6 +63,7 @@ extension AgentRunner {
             await appendBlockedReview(
                 review,
                 for: call,
+                definition: definition,
                 to: &thread,
                 onProgress: onProgress
             )
@@ -193,10 +194,18 @@ extension AgentRunner {
     private func appendBlockedReview(
         _ review: SafetyReview,
         for call: ToolCall,
+        definition: ToolDefinition?,
         to thread: inout ChatThread,
         onProgress: AgentRunProgressHandler?
     ) async {
         let text: String
+        let request = ApprovalRequest(
+            toolCall: call.redactedForTranscript(),
+            toolDefinition: definition,
+            reason: review.rationale,
+            recommendedVerdict: review.verdict
+        )
+        let requestJSON = try? JSONHelpers.encodePretty(request)
         switch review.verdict {
         case .clarify:
             text = "I need a little more detail before running \(call.name): \(review.rationale)"
@@ -207,7 +216,8 @@ extension AgentRunner {
         }
         thread.events.append(.init(
             kind: .approvalRequested,
-            summary: "\(review.verdict.rawValue): \(review.rationale)"
+            summary: "\(review.verdict.rawValue): \(review.rationale)",
+            payloadJSON: requestJSON
         ))
         thread.messages.append(.init(role: .assistant, content: text))
         thread.events.append(.init(kind: .message, summary: text))

--- a/Sources/QuillCodeApp/QuillCodeToolCardSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolCardSurface.swift
@@ -8,6 +8,42 @@ public enum ToolCardStatus: String, Codable, Sendable, Hashable {
     case review
 }
 
+public enum ToolCardActionKind: String, Codable, Sendable, Hashable {
+    case approve
+    case deny
+}
+
+public enum ToolCardActionStyle: String, Codable, Sendable, Hashable {
+    case primary
+    case secondary
+    case destructive
+}
+
+public struct ToolCardActionSurface: Codable, Sendable, Hashable, Identifiable {
+    public var id: String
+    public var title: String
+    public var kind: ToolCardActionKind
+    public var requestID: String
+    public var style: ToolCardActionStyle
+    public var systemImage: String?
+
+    public init(
+        id: String? = nil,
+        title: String,
+        kind: ToolCardActionKind,
+        requestID: String,
+        style: ToolCardActionStyle,
+        systemImage: String? = nil
+    ) {
+        self.id = id ?? "tool-card-action-\(kind.rawValue)-\(requestID)"
+        self.title = title
+        self.kind = kind
+        self.requestID = requestID
+        self.style = style
+        self.systemImage = systemImage
+    }
+}
+
 public enum ToolCardDensity: String, Codable, Sendable, Hashable {
     case collapsed
     case peek
@@ -451,6 +487,7 @@ public struct ToolCardState: Codable, Sendable, Hashable, Identifiable {
     public var inputJSON: String?
     public var outputJSON: String?
     public var artifacts: [ToolArtifactState]
+    public var actions: [ToolCardActionSurface]
     public var isExpanded: Bool
     public var density: ToolCardDensity
 
@@ -463,6 +500,7 @@ public struct ToolCardState: Codable, Sendable, Hashable, Identifiable {
         inputJSON: String? = nil,
         outputJSON: String? = nil,
         artifacts: [ToolArtifactState] = [],
+        actions: [ToolCardActionSurface] = [],
         isExpanded: Bool = false,
         density: ToolCardDensity? = nil
     ) {
@@ -474,6 +512,7 @@ public struct ToolCardState: Codable, Sendable, Hashable, Identifiable {
         self.inputJSON = inputJSON
         self.outputJSON = outputJSON
         self.artifacts = artifacts
+        self.actions = actions
         self.isExpanded = isExpanded
         self.density = density ?? Self.defaultDensity(status: status, isExpanded: isExpanded)
     }
@@ -487,6 +526,7 @@ public struct ToolCardState: Codable, Sendable, Hashable, Identifiable {
         case inputJSON
         case outputJSON
         case artifacts
+        case actions
         case isExpanded
         case density
     }
@@ -501,6 +541,7 @@ public struct ToolCardState: Codable, Sendable, Hashable, Identifiable {
         self.inputJSON = try container.decodeIfPresent(String.self, forKey: .inputJSON)
         self.outputJSON = try container.decodeIfPresent(String.self, forKey: .outputJSON)
         self.artifacts = try container.decodeIfPresent([ToolArtifactState].self, forKey: .artifacts) ?? []
+        self.actions = try container.decodeIfPresent([ToolCardActionSurface].self, forKey: .actions) ?? []
         self.isExpanded = try container.decodeIfPresent(Bool.self, forKey: .isExpanded) ?? false
         self.density = try container.decodeIfPresent(ToolCardDensity.self, forKey: .density)
             ?? Self.defaultDensity(status: status, isExpanded: isExpanded)

--- a/Sources/QuillCodeApp/QuillCodeToolCardView.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolCardView.swift
@@ -5,19 +5,29 @@ struct QuillCodeToolCardView: View {
     var card: ToolCardState
     var isCopied: Bool
     var onCopy: () -> Void
+    var onAction: (ToolCardActionSurface) -> Void
     @State private var isDetailsOpen: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    init(card: ToolCardState, isCopied: Bool = false, onCopy: @escaping () -> Void = {}) {
+    init(
+        card: ToolCardState,
+        isCopied: Bool = false,
+        onCopy: @escaping () -> Void = {},
+        onAction: @escaping (ToolCardActionSurface) -> Void = { _ in }
+    ) {
         self.card = card
         self.isCopied = isCopied
         self.onCopy = onCopy
+        self.onAction = onAction
         self._isDetailsOpen = State(initialValue: card.opensDetailsByDefault)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             toolHeader
+            if !card.actions.isEmpty {
+                QuillCodeToolCardActionRow(actions: card.actions, onAction: onAction)
+            }
             HStack {
                 QuillCodeTranscriptCopyButton(
                     label: copyActionLabel,
@@ -189,7 +199,9 @@ struct QuillCodeToolCardView: View {
         switch card.status {
         case .queued, .running, .done:
             return Color.white.opacity(0.09)
-        case .failed, .review:
+        case .review:
+            return Color.white.opacity(0.11)
+        case .failed:
             return statusColor.opacity(0.42)
         }
     }
@@ -255,6 +267,80 @@ struct QuillCodeToolCardView: View {
             ", \($0.label) \($0.detail)"
         } ?? ""
         return "\(card.title), \(card.status.rawValue), \(card.densityAccessibilityLabel)\(context)"
+    }
+}
+
+private struct QuillCodeToolCardActionRow: View {
+    var actions: [ToolCardActionSurface]
+    var onAction: (ToolCardActionSurface) -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(actions) { action in
+                Button {
+                    onAction(action)
+                } label: {
+                    Label {
+                        Text(action.title)
+                    } icon: {
+                        if let systemImage = action.systemImage {
+                            Image(systemName: systemImage)
+                        }
+                    }
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                    .padding(.horizontal, 12)
+                    .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
+                    .frame(minWidth: action.style == .primary ? 118 : 82)
+                    .foregroundStyle(foregroundColor(for: action.style))
+                    .background(backgroundColor(for: action.style))
+                    .overlay(
+                        Capsule()
+                            .stroke(strokeColor(for: action.style), lineWidth: 1)
+                    )
+                    .clipShape(Capsule())
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(QuillCodePressableButtonStyle())
+                .help(action.title)
+                .accessibilityLabel(action.title)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.top, 2)
+    }
+
+    private func foregroundColor(for style: ToolCardActionStyle) -> Color {
+        switch style {
+        case .primary:
+            return Color.white
+        case .secondary:
+            return QuillCodePalette.text
+        case .destructive:
+            return QuillCodePalette.red
+        }
+    }
+
+    private func backgroundColor(for style: ToolCardActionStyle) -> Color {
+        switch style {
+        case .primary:
+            return QuillCodePalette.blue
+        case .secondary:
+            return QuillCodePalette.selection.opacity(0.55)
+        case .destructive:
+            return QuillCodePalette.red.opacity(0.14)
+        }
+    }
+
+    private func strokeColor(for style: ToolCardActionStyle) -> Color {
+        switch style {
+        case .primary:
+            return Color.white.opacity(0.14)
+        case .secondary:
+            return Color.white.opacity(0.10)
+        case .destructive:
+            return QuillCodePalette.red.opacity(0.26)
+        }
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -14,6 +14,7 @@ struct QuillCodeTranscriptView: View {
     var onContextCommand: (WorkspaceCommandSurface) -> Void
     var onRuntimeIssueAction: (() -> Void)?
     var onReviewAction: (WorkspaceReviewActionSurface) -> Void
+    var onToolCardAction: (ToolCardActionSurface) -> Void
     var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     var onCopyTranscriptItem: (String, String) -> Void
     var onUseMessageAsDraft: (String) -> Void
@@ -148,6 +149,9 @@ struct QuillCodeTranscriptView: View {
                         isCopied: copiedTranscriptItemID == item.id,
                         onCopy: {
                             onCopyTranscriptItem(item.id, copyText(for: card))
+                        },
+                        onAction: { action in
+                            onToolCardAction(action)
                         }
                     )
                 }

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -18,6 +18,7 @@ enum WorkspaceHTMLToolCardRenderer {
             <span data-testid="tool-card-status">\(escape(card.status.rawValue))</span>
           </header>
           <p data-testid="tool-card-subtitle">\(escape(card.subtitle))</p>
+          \(renderActions(card.actions))
           <footer class="transcript-actions">
             <button type="button" data-testid="tool-card-copy" data-copy-id="\(escape(copyID))">\(escape(copyActionLabel(for: card)))</button>
           </footer>
@@ -38,6 +39,20 @@ enum WorkspaceHTMLToolCardRenderer {
             return "Copy input"
         }
         return "Copy"
+    }
+
+    private static func renderActions(_ actions: [ToolCardActionSurface]) -> String {
+        guard !actions.isEmpty else { return "" }
+        let buttons = actions.map { action in
+            """
+            <button type="button" data-testid="tool-card-action" data-action-kind="\(escape(action.kind.rawValue))" data-action-style="\(escape(action.style.rawValue))" data-request-id="\(escape(action.requestID))">\(escape(action.title))</button>
+            """
+        }.joined(separator: "\n")
+        return """
+        <div class="tool-card-actions" data-testid="tool-card-actions">
+          \(buttons)
+        </div>
+        """
     }
 
     private static func renderDetails(_ card: ToolCardState) -> String {

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -1163,6 +1163,35 @@ public final class QuillCodeWorkspaceModel {
     }
 
     @discardableResult
+    public func runToolCardAction(_ action: ToolCardActionSurface, workspaceRoot: URL) -> Bool {
+        guard let request = pendingApprovalRequest(id: action.requestID) else {
+            lastError = "Approval request is no longer available."
+            refreshTopBar(agentStatus: TopBarAgentStatusLabel.failed)
+            return false
+        }
+
+        appendApprovalDecision(ApprovalDecision(
+            requestID: action.requestID,
+            verdict: action.kind.approvalVerdict,
+            rationale: action.kind == .approve
+                ? "Approved from the tool card."
+                : "Skipped from the tool card."
+        ))
+
+        switch action.kind {
+        case .approve:
+            _ = runToolCall(request.toolCall, workspaceRoot: workspaceRoot)
+        case .deny:
+            appendAssistantNotice("Skipped \(request.toolCall.name).")
+            if let thread = selectedThread {
+                try? threadStore?.save(thread)
+            }
+            refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        }
+        return true
+    }
+
+    @discardableResult
     public func addReviewComment(path: String, text: String) -> Bool {
         addReviewComment(path: path, lineNumber: nil, endLineNumber: nil, lineKind: nil, text: text)
     }
@@ -2093,6 +2122,41 @@ public final class QuillCodeWorkspaceModel {
         try? automationStore?.save(automations.items)
     }
 
+    private func pendingApprovalRequest(id: String) -> ApprovalRequest? {
+        selectedThread?.events.lazy.compactMap { event -> ApprovalRequest? in
+            guard event.kind == .approvalRequested,
+                  let request = Self.decodePayload(ApprovalRequest.self, from: event.payloadJSON),
+                  request.id == id
+            else {
+                return nil
+            }
+            return request
+        }.last
+    }
+
+    private func appendApprovalDecision(_ decision: ApprovalDecision) {
+        let payloadJSON = try? JSONHelpers.encodePretty(decision)
+        mutateSelectedThread { thread in
+            thread.events.append(ThreadEvent(
+                kind: .approvalDecided,
+                summary: "\(decision.verdict.rawValue): \(decision.rationale)",
+                payloadJSON: payloadJSON
+            ))
+        }
+    }
+
+    private func appendAssistantNotice(_ text: String) {
+        mutateSelectedThread { thread in
+            thread.messages.append(.init(role: .assistant, content: text))
+            thread.events.append(.init(kind: .message, summary: text))
+        }
+    }
+
+    private static func decodePayload<T: Decodable>(_ type: T.Type, from payloadJSON: String?) -> T? {
+        guard let payloadJSON else { return nil }
+        return try? JSONHelpers.decode(type, from: payloadJSON)
+    }
+
     private static func defaultProjectName(for url: URL) -> String {
         WorkspaceProjectEngine.defaultProjectName(for: url)
     }
@@ -2101,4 +2165,15 @@ public final class QuillCodeWorkspaceModel {
         WorkspaceProjectEngine.defaultSSHProjectName(for: connection)
     }
 
+}
+
+private extension ToolCardActionKind {
+    var approvalVerdict: ApprovalVerdict {
+        switch self {
+        case .approve:
+            return .approve
+        case .deny:
+            return .deny
+        }
+    }
 }

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -28,6 +28,7 @@ public struct QuillCodeWorkspaceView: View {
     public var onSaveSettings: (WorkspaceSettingsUpdate) -> Void
     public var onStartTrustedRouterSignIn: () -> Void
     public var onReviewAction: (WorkspaceReviewActionSurface) -> Void
+    public var onToolCardAction: (ToolCardActionSurface) -> Void
     public var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     public var onCreateWorktree: (WorkspaceWorktreeCreateRequest) -> Void
     public var onRemoveWorktree: (WorkspaceWorktreeRemoveRequest) -> Void
@@ -76,6 +77,7 @@ public struct QuillCodeWorkspaceView: View {
         onSaveSettings: @escaping (WorkspaceSettingsUpdate) -> Void,
         onStartTrustedRouterSignIn: @escaping () -> Void,
         onReviewAction: @escaping (WorkspaceReviewActionSurface) -> Void,
+        onToolCardAction: @escaping (ToolCardActionSurface) -> Void = { _ in },
         onAddReviewComment: @escaping (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void,
         onCreateWorktree: @escaping (WorkspaceWorktreeCreateRequest) -> Void,
         onRemoveWorktree: @escaping (WorkspaceWorktreeRemoveRequest) -> Void,
@@ -108,6 +110,7 @@ public struct QuillCodeWorkspaceView: View {
         self.onSaveSettings = onSaveSettings
         self.onStartTrustedRouterSignIn = onStartTrustedRouterSignIn
         self.onReviewAction = onReviewAction
+        self.onToolCardAction = onToolCardAction
         self.onAddReviewComment = onAddReviewComment
         self.onCreateWorktree = onCreateWorktree
         self.onRemoveWorktree = onRemoveWorktree
@@ -161,6 +164,7 @@ public struct QuillCodeWorkspaceView: View {
                                 onContextCommand: handleCommand,
                                 onRuntimeIssueAction: runtimeIssueAction(for: surface.runtimeIssue),
                                 onReviewAction: onReviewAction,
+                                onToolCardAction: onToolCardAction,
                                 onAddReviewComment: onAddReviewComment,
                                 onCopyTranscriptItem: onCopyTranscriptItem,
                                 onUseMessageAsDraft: useMessageAsDraft,

--- a/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
@@ -16,6 +16,7 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
     func toolCards() -> [ToolCardState] {
         var cards: [ToolCardState] = []
         var activeToolCardIndex: Int?
+        var activeApprovalCardIndex: Int?
 
         func updateActiveToolCard(status: ToolCardStatus, stateLabel: String, outputJSON: String? = nil) {
             guard let index = activeToolCardIndex else {
@@ -56,8 +57,23 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
                     outputJSON: event.payloadJSON
                 )
             case .approvalRequested:
-                cards.append(Self.safetyReviewCard(for: event))
-            case .message, .messageFeedback, .approvalDecided, .reviewComment, .notice:
+                let reviewCard = Self.approvalReviewCard(
+                    for: event,
+                    fallback: activeToolCardIndex.flatMap { cards.indices.contains($0) ? cards[$0] : nil }
+                )
+                if let index = activeToolCardIndex, cards.indices.contains(index) {
+                    cards[index] = reviewCard
+                    activeApprovalCardIndex = index
+                    activeToolCardIndex = nil
+                } else {
+                    cards.append(reviewCard)
+                    activeApprovalCardIndex = cards.count - 1
+                }
+            case .approvalDecided:
+                guard let index = activeApprovalCardIndex, cards.indices.contains(index) else { continue }
+                Self.updateApprovalCard(&cards[index], decisionJSON: event.payloadJSON)
+                activeApprovalCardIndex = nil
+            case .message, .messageFeedback, .reviewComment, .notice:
                 continue
             }
         }
@@ -75,6 +91,7 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         var consumedMessageIDs = Set<UUID>()
         var items: [TranscriptTimelineItemSurface] = []
         var activeToolItemIndex: Int?
+        var activeApprovalItemIndex: Int?
 
         func appendMessage(matching summary: String) {
             guard let message = thread.messages.first(where: {
@@ -142,8 +159,25 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
                     outputJSON: event.payloadJSON
                 )
             case .approvalRequested:
-                items.append(.toolCard(Self.safetyReviewCard(for: event)))
-            case .messageFeedback, .approvalDecided, .reviewComment, .notice:
+                let fallback = activeToolItemIndex.flatMap { items.indices.contains($0) ? items[$0].toolCard : nil }
+                let reviewCard = Self.approvalReviewCard(for: event, fallback: fallback)
+                if let index = activeToolItemIndex, items.indices.contains(index) {
+                    items[index] = .toolCard(reviewCard)
+                    activeApprovalItemIndex = index
+                    activeToolItemIndex = nil
+                } else {
+                    items.append(.toolCard(reviewCard))
+                    activeApprovalItemIndex = items.count - 1
+                }
+            case .approvalDecided:
+                guard let index = activeApprovalItemIndex,
+                      items.indices.contains(index),
+                      var card = items[index].toolCard
+                else { continue }
+                Self.updateApprovalCard(&card, decisionJSON: event.payloadJSON)
+                items[index] = .toolCard(card)
+                activeApprovalItemIndex = nil
+            case .messageFeedback, .reviewComment, .notice:
                 continue
             }
         }
@@ -154,15 +188,89 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         return items
     }
 
-    private static func safetyReviewCard(for event: ThreadEvent) -> ToolCardState {
-        ToolCardState(
-            id: event.id.uuidString,
-            title: "Safety Check",
-            subtitle: event.summary,
+    private static func approvalReviewCard(for event: ThreadEvent, fallback: ToolCardState? = nil) -> ToolCardState {
+        let request = decode(ApprovalRequest.self, event.payloadJSON)
+        let toolCall = request?.toolCall
+        let title = toolCall?.name ?? fallback?.title ?? "Approval needed"
+        let inputJSON = toolCall?.argumentsJSON ?? fallback?.inputJSON ?? event.payloadJSON
+        let actions = request.flatMap { Self.approvalActions(for: $0) } ?? []
+
+        return ToolCardState(
+            id: fallback?.id ?? toolCall?.id ?? event.id.uuidString,
+            title: title,
+            subtitle: Self.approvalSubtitle(
+                title: title,
+                inputJSON: inputJSON,
+                reason: request?.reason ?? event.summary,
+                recommendedVerdict: request?.recommendedVerdict
+            ),
             status: .review,
-            inputJSON: event.payloadJSON,
+            inputJSON: inputJSON,
+            actions: actions,
             isExpanded: true
         )
+    }
+
+    private static func approvalActions(for request: ApprovalRequest) -> [ToolCardActionSurface]? {
+        guard request.recommendedVerdict != .deny else {
+            return nil
+        }
+        return [
+            ToolCardActionSurface(
+                title: "Allow once",
+                kind: .approve,
+                requestID: request.id,
+                style: .primary,
+                systemImage: "checkmark"
+            ),
+            ToolCardActionSurface(
+                title: "Skip",
+                kind: .deny,
+                requestID: request.id,
+                style: .secondary,
+                systemImage: "xmark"
+            )
+        ]
+    }
+
+    private static func approvalSubtitle(
+        title: String,
+        inputJSON: String?,
+        reason: String,
+        recommendedVerdict: ApprovalVerdict?
+    ) -> String {
+        let stateLabel = recommendedVerdict == .deny ? "Blocked" : "Needs your okay"
+        let base = toolSubtitle(stateLabel: stateLabel, title: title, inputJSON: inputJSON)
+        let cleanedReason = reason
+            .replacingOccurrences(of: #"^(approve|deny|clarify):\s*"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedReason.isEmpty,
+              cleanedReason != base
+        else {
+            return base
+        }
+        return "\(base) · \(cleanedReason)"
+    }
+
+    private static func updateApprovalCard(_ card: inout ToolCardState, decisionJSON: String?) {
+        let decision = decode(ApprovalDecision.self, decisionJSON)
+        let stateLabel: String
+        switch decision?.verdict {
+        case .approve:
+            stateLabel = "Approved"
+        case .deny:
+            stateLabel = "Skipped"
+        case .clarify:
+            stateLabel = "Needs detail"
+        case .none:
+            stateLabel = "Updated"
+        }
+        card.status = .done
+        card.subtitle = toolSubtitle(stateLabel: stateLabel, title: card.title, inputJSON: card.inputJSON)
+        card.outputJSON = decisionJSON
+        card.actions = []
+        card.density = ToolCardState.defaultDensity(status: card.status, isExpanded: false)
+        card.isExpanded = false
     }
 
     private static func updateCard(

--- a/Sources/QuillCodeCore/Models.swift
+++ b/Sources/QuillCodeCore/Models.swift
@@ -332,17 +332,20 @@ public struct ApprovalRequest: Codable, Sendable, Hashable, Identifiable {
     public var toolCall: ToolCall
     public var toolDefinition: ToolDefinition?
     public var reason: String
+    public var recommendedVerdict: ApprovalVerdict?
 
     public init(
         id: String = "approval-\(UUID().uuidString)",
         toolCall: ToolCall,
         toolDefinition: ToolDefinition?,
-        reason: String
+        reason: String,
+        recommendedVerdict: ApprovalVerdict? = nil
     ) {
         self.id = id
         self.toolCall = toolCall
         self.toolDefinition = toolDefinition
         self.reason = reason
+        self.recommendedVerdict = recommendedVerdict
     }
 }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -68,6 +68,7 @@ private struct QuillCodeDesktopRootView: View {
             onSaveSettings: controller.saveSettings,
             onStartTrustedRouterSignIn: controller.startTrustedRouterSignIn,
             onReviewAction: controller.runReviewAction,
+            onToolCardAction: controller.runToolCardAction,
             onAddReviewComment: controller.addReviewComment,
             onCreateWorktree: controller.createWorktree,
             onRemoveWorktree: controller.removeWorktree,

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -248,6 +248,11 @@ final class QuillCodeDesktopController: ObservableObject {
         refresh()
     }
 
+    func runToolCardAction(_ action: ToolCardActionSurface) {
+        _ = model.runToolCardAction(action, workspaceRoot: model.activeWorkspaceRoot ?? workspaceRoot)
+        refresh()
+    }
+
     func runTerminalCommand() {
         let command = terminalDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !command.isEmpty, !tasks.isRunning(.terminal) else { return }

--- a/Tests/QuillCodeAppTests/WorkspaceModelTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceModelTests.swift
@@ -4088,17 +4088,76 @@ final class WorkspaceModelTests: XCTestCase {
         XCTAssertEqual(retry.category, WorkspaceCommandPalette.controlCategory)
     }
 
-    func testToolCardsRepresentSafetyReview() {
-        let event = ThreadEvent(kind: .approvalRequested, summary: "clarify: needs target")
+    func testToolCardsRepresentActionableApprovalReview() throws {
+        let call = ToolCall(
+            id: "approval-tool",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "whoami"])
+        )
+        let request = ApprovalRequest(
+            id: "approval-request",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "review required"
+        )
+        let event = ThreadEvent(
+            kind: .approvalRequested,
+            summary: "clarify: needs target",
+            payloadJSON: try JSONHelpers.encodePretty(request)
+        )
         let thread = ChatThread(events: [event])
 
         let cards = WorkspaceTranscriptSurfaceBuilder(thread: thread).toolCards()
 
         XCTAssertEqual(cards.count, 1)
-        XCTAssertEqual(cards[0].title, "Safety Check")
+        XCTAssertEqual(cards[0].title, ToolDefinition.shellRun.name)
         XCTAssertEqual(cards[0].status, .review)
         XCTAssertTrue(cards[0].isExpanded)
         XCTAssertEqual(cards[0].density, .expanded)
+        XCTAssertEqual(cards[0].inputJSON, ToolArguments.json(["cmd": "whoami"]))
+        XCTAssertEqual(cards[0].actions.map(\.title), ["Allow once", "Skip"])
+    }
+
+    func testToolCardApprovalActionRecordsDecisionAndRunsTool() throws {
+        let root = try makeTempDirectory()
+        let call = ToolCall(
+            id: "approval-tool-run",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "whoami"])
+        )
+        let request = ApprovalRequest(
+            id: "approval-run",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "review required"
+        )
+        let thread = ChatThread(events: [
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: "review required",
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )
+        ])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let didRun = model.runToolCardAction(ToolCardActionSurface(
+            title: "Allow once",
+            kind: .approve,
+            requestID: "approval-run",
+            style: .primary
+        ), workspaceRoot: root)
+
+        XCTAssertTrue(didRun)
+        let events = try XCTUnwrap(model.selectedThread?.events)
+        XCTAssertTrue(events.contains { $0.kind == .approvalDecided })
+        XCTAssertTrue(events.contains { $0.kind == .toolQueued })
+        XCTAssertTrue(events.contains { $0.kind == .toolCompleted })
+        let cards = model.currentToolCards
+        XCTAssertTrue(cards.contains { $0.status == .done && $0.subtitle == "Approved · whoami" })
+        XCTAssertTrue(cards.contains { $0.title == ToolDefinition.shellRun.name && $0.outputJSON?.contains("exitCode") == true })
     }
 
     func testToolCardsRepresentStoppedActiveToolAsFailed() throws {

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -1691,6 +1691,38 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertTrue(html.contains("Show details"))
     }
 
+    func testHTMLToolCardRendererIncludesApprovalActions() {
+        let card = ToolCardState(
+            id: "shell-review",
+            title: ToolDefinition.shellRun.name,
+            subtitle: "Needs your okay · whoami",
+            status: .review,
+            inputJSON: ToolArguments.json(["cmd": "whoami"]),
+            actions: [
+                ToolCardActionSurface(
+                    title: "Allow once",
+                    kind: .approve,
+                    requestID: "approval-html",
+                    style: .primary
+                ),
+                ToolCardActionSurface(
+                    title: "Skip",
+                    kind: .deny,
+                    requestID: "approval-html",
+                    style: .secondary
+                )
+            ],
+            isExpanded: true
+        )
+
+        let html = WorkspaceHTMLToolCardRenderer.render(card, timelineItemID: "timeline-approval")
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-actions""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-action" data-action-kind="approve" data-action-style="primary" data-request-id="approval-html">Allow once"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-action" data-action-kind="deny" data-action-style="secondary" data-request-id="approval-html">Skip"#))
+        XCTAssertTrue(html.contains(#"data-timeline-id="timeline-approval""#))
+    }
+
     func testHTMLRendererIncludesToolCardArtifacts() async throws {
         let root = try makeTempDirectory()
         let model = QuillCodeWorkspaceModel()

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -93,10 +93,26 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(timeline[3].message?.text, unmatchedAssistant.content)
     }
 
-    func testSafetyReviewAndOrphanToolEventsRemainVisible() throws {
+    func testApprovalRequestTurnsActiveToolCardIntoActionableReview() throws {
+        let call = ToolCall(
+            id: "shell-approval-1",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "ls"])
+        )
+        let request = ApprovalRequest(
+            id: "approval-1",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "review required"
+        )
         let failedResult = ToolResult(ok: false, error: "stopped")
         let thread = ChatThread(events: [
-            ThreadEvent(kind: .approvalRequested, summary: "approve shell", payloadJSON: #"{"cmd":"ls"}"#),
+            ThreadEvent(kind: .toolQueued, summary: "queued", payloadJSON: try JSONHelpers.encodePretty(call)),
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: "approve shell",
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            ),
             ThreadEvent(kind: .toolFailed, summary: "failed", payloadJSON: try JSONHelpers.encodePretty(failedResult))
         ])
 
@@ -105,12 +121,86 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
             .compactMap(\.toolCard)
 
         XCTAssertEqual(timelineCards.count, 2)
-        XCTAssertEqual(timelineCards[0].title, "Safety Check")
+        XCTAssertEqual(timelineCards[0].id, "shell-approval-1")
+        XCTAssertEqual(timelineCards[0].title, ToolDefinition.shellRun.name)
         XCTAssertEqual(timelineCards[0].status, .review)
+        XCTAssertEqual(timelineCards[0].subtitle, "Needs your okay · ls · review required")
         XCTAssertTrue(timelineCards[0].isExpanded)
+        XCTAssertEqual(timelineCards[0].actions.map(\.title), ["Allow once", "Skip"])
+        XCTAssertEqual(timelineCards[0].actions.map(\.requestID), ["approval-1", "approval-1"])
         XCTAssertEqual(timelineCards[1].title, "Tool")
         XCTAssertEqual(timelineCards[1].status, .failed)
         XCTAssertEqual(timelineCards[1].subtitle, "Failed")
+    }
+
+    func testApprovalDecisionCollapsesReviewCardAndClearsActions() throws {
+        let call = ToolCall(
+            id: "shell-approval-2",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "whoami"])
+        )
+        let request = ApprovalRequest(
+            id: "approval-2",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "review required"
+        )
+        let decision = ApprovalDecision(
+            requestID: "approval-2",
+            verdict: .approve,
+            rationale: "Approved from the tool card."
+        )
+        let thread = ChatThread(events: [
+            ThreadEvent(kind: .toolQueued, summary: "queued", payloadJSON: try JSONHelpers.encodePretty(call)),
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: "approve shell",
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            ),
+            ThreadEvent(
+                kind: .approvalDecided,
+                summary: "approve: Approved from the tool card.",
+                payloadJSON: try JSONHelpers.encodePretty(decision)
+            )
+        ])
+
+        let card = try XCTUnwrap(WorkspaceTranscriptSurfaceBuilder(thread: thread).toolCards().first)
+
+        XCTAssertEqual(card.status, .done)
+        XCTAssertEqual(card.subtitle, "Approved · whoami")
+        XCTAssertFalse(card.isExpanded)
+        XCTAssertEqual(card.density, .collapsed)
+        XCTAssertEqual(card.actions, [])
+        XCTAssertTrue(card.outputJSON?.contains("Approved from the tool card.") == true)
+    }
+
+    func testDeniedApprovalRequestDoesNotExposeApproveAction() throws {
+        let call = ToolCall(
+            id: "shell-denied",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "rm -rf /"])
+        )
+        let request = ApprovalRequest(
+            id: "approval-denied",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "Auto mode blocks high-risk command pattern: rm -rf /.",
+            recommendedVerdict: .deny
+        )
+        let thread = ChatThread(events: [
+            ThreadEvent(kind: .toolQueued, summary: "queued", payloadJSON: try JSONHelpers.encodePretty(call)),
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: "deny: Auto mode blocks high-risk command pattern: rm -rf /.",
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )
+        ])
+
+        let card = try XCTUnwrap(WorkspaceTranscriptSurfaceBuilder(thread: thread).toolCards().first)
+
+        XCTAssertEqual(card.status, .review)
+        XCTAssertEqual(card.subtitle, "Blocked · rm -rf / · Auto mode blocks high-risk command pattern: rm -rf /.")
+        XCTAssertEqual(card.actions, [])
     }
 
     func testToolCardSubtitleBuilderSummarizesKnownArguments() {

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -56,6 +56,27 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(modelText.contains("ToolArtifactPreviewBuilder.textPreview"), "WorkspaceModel should not own artifact-preview requests.")
     }
 
+    func testActionableReviewCardsStayWiredThroughSurfaces() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let toolCardSurfaceText = try Self.appSourceText(named: "QuillCodeToolCardSurface.swift")
+        let toolCardViewText = try Self.appSourceText(named: "QuillCodeToolCardView.swift")
+        let transcriptViewText = try Self.appSourceText(named: "QuillCodeTranscriptView.swift")
+        let workspaceViewText = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
+        let htmlRendererText = try Self.appSourceText(named: "WorkspaceHTMLToolCardRenderer.swift")
+        let desktopAppText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let desktopControllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+
+        XCTAssertTrue(toolCardSurfaceText.contains("public struct ToolCardActionSurface"), "Tool-card actions should be first-class surface state.")
+        XCTAssertTrue(toolCardSurfaceText.contains("public var actions: [ToolCardActionSurface]"), "Tool-card state should carry available user actions.")
+        XCTAssertTrue(transcriptViewText.contains("onToolCardAction"), "Transcript should route action taps out of row rendering.")
+        XCTAssertTrue(toolCardViewText.contains("QuillCodeToolCardActionRow"), "Native cards should render action buttons directly on review cards.")
+        XCTAssertTrue(workspaceViewText.contains("onToolCardAction"), "Workspace view should expose review-card actions to the host app.")
+        XCTAssertTrue(modelText.contains("public func runToolCardAction"), "Workspace model should execute approved review-card actions.")
+        XCTAssertTrue(htmlRendererText.contains("data-testid=\"tool-card-actions\""), "HTML harness should expose action buttons for Playwright.")
+        XCTAssertTrue(desktopAppText.contains("controller.runToolCardAction"), "Desktop app should connect UI actions to the controller.")
+        XCTAssertTrue(desktopControllerText.contains("model.runToolCardAction"), "Desktop controller should forward review-card actions to the model.")
+    }
+
     func testWorkspaceModelDelegatesExecutionContextSurfaceBuilding() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceExecutionContextSurfaceBuilder.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -2062,3 +2062,28 @@ Code quality changes:
 - Kept summaries bounded and whitespace-normalized so long commands do not destabilize collapsed card layout.
 - Added focused Swift coverage for known tool summaries, fallback behavior, and transcript lifecycle projection.
 - Added Playwright coverage proving the mock command flow shows the command in the collapsed card subtitle.
+
+## 2026-06-23 Actionable Review Card Pass
+
+Overall grade after this slice: **A- interaction clarity, A surface wiring, A regression coverage**.
+
+Claude CLI's interface review called out review cards as the highest-value interaction fix: the old flow could show a queued tool, then a separate safety/review card, leaving the user to infer what action was expected. Review now lives on the affected tool card itself with direct actions.
+
+| Surface | Before | After |
+| --- | --- | --- |
+| Review cards | A separate warning-styled `Safety Check` card appeared after the queued tool. | The queued tool card becomes a neutral review card with `Allow once` and `Skip` actions. |
+| Safety tone | Review states used a warning perimeter even when the model had not found danger. | Review states use neutral chrome; failure remains red and actual denial can still carry stronger copy. |
+| Action path | Approval state was represented in transcript events but had no first-class card action. | `ToolCardActionSurface` flows from transcript projection through SwiftUI, HTML, desktop controller, and workspace model execution. |
+
+Code quality changes:
+
+- Added first-class `ToolCardActionSurface` state instead of embedding action affordances in view-only code.
+- Updated transcript projection so `approvalRequested` replaces the active queued tool card, preserving context and avoiding duplicate cards.
+- Added model execution for card actions: approve appends an `ApprovalDecision` and dispatches the original `ToolCall`; skip records the decision and adds a short assistant notice.
+- Carried the reviewer verdict into `ApprovalRequest`, so hard-denied commands remain visible as blocked review cards without exposing an approval override.
+- Added Swift and Playwright coverage for native projection, model dispatch, HTML rendering, and harness click behavior.
+
+Remaining risk:
+
+- The current approval action reruns from the serialized redacted tool call, which is correct for shell/file arguments covered today. If future tools need non-transcript-safe in-memory fields, the runner should retain a pending approval registry keyed by request ID.
+- The review UI now handles approve/skip. A later pass should add a lightweight "edit command before running" path for commands where the user wants to fix arguments instead of approving or skipping.


### PR DESCRIPTION
## Summary
- Turn approval requests into actionable review states on the affected tool card instead of appending a separate Safety Check card.
- Add `ToolCardActionSurface` and wire Allow once / Skip through SwiftUI, HTML harness, desktop controller, and workspace model execution.
- Preserve hard-denied commands as blocked review cards without an approval override by carrying the reviewer verdict in `ApprovalRequest`.

## Verification
- `swift test` — 801 tests passed
- `cd E2E/playwright && npm test` — 59 tests passed
- Captured a Playwright screenshot of the review-card state locally to verify the visual surface.