### PR TITLE
Harden TrustedRouter action parsing

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
@@ -193,6 +193,9 @@ public enum AgentActionJSONParser {
     public static func parse(_ text: String) throws -> AgentAction {
         let trimmed = stripFences(text.trimmingCharacters(in: .whitespacesAndNewlines))
         guard let object = actionObject(in: trimmed) else {
+            if let recovered = recoveredShellAction(from: trimmed) {
+                return recovered
+            }
             throw TrustedRouterAgentError.invalidActionJSON(text)
         }
         let rawType = (object["type"] as? String) ?? (toolName(in: object) == nil ? nil : "tool")
@@ -206,7 +209,12 @@ public enum AgentActionJSONParser {
             guard let name = toolName(in: object) else {
                 throw TrustedRouterAgentError.invalidActionJSON(text)
             }
-            let arguments = canonicalArguments(for: name, in: object)
+            var arguments = canonicalArguments(for: name, in: object)
+            if name == ToolDefinition.shellRun.name,
+               arguments["cmd"] == nil,
+               let recoveredCommand = recoverExplicitShellCommand(from: trimmed) {
+                arguments["cmd"] = recoveredCommand
+            }
             if arguments.isEmpty && Self.requiresNonEmptyArguments(name) {
                 throw TrustedRouterAgentError.emptyToolArguments(name)
             }
@@ -287,6 +295,106 @@ public enum AgentActionJSONParser {
         }
 
         return candidates
+    }
+
+    private static func recoveredShellAction(from text: String) -> AgentAction? {
+        guard let command = recoverExplicitShellCommand(from: text) else {
+            return nil
+        }
+        return .tool(.init(
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": command])
+        ))
+    }
+
+    private static func recoverExplicitShellCommand(from text: String) -> String? {
+        let spans = inlineCodeSpans(in: text)
+        for span in spans {
+            let command = span.code.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isPlausibleShellCommand(command),
+                  hasExecutionIntent(before: span.range.lowerBound, in: text)
+            else {
+                continue
+            }
+            return command
+        }
+        return nil
+    }
+
+    private static func inlineCodeSpans(in text: String) -> [(code: String, range: Range<String.Index>)] {
+        var spans: [(String, Range<String.Index>)] = []
+        var searchIndex = text.startIndex
+        while searchIndex < text.endIndex,
+              let opening = text[searchIndex...].firstIndex(of: "`") {
+            let afterOpening = text.index(after: opening)
+            guard afterOpening < text.endIndex else { break }
+            if text[afterOpening] == "`" {
+                searchIndex = afterOpening
+                continue
+            }
+            guard let closing = text[afterOpening...].firstIndex(of: "`") else { break }
+            if text[text.index(before: closing)] != "`" {
+                spans.append((String(text[afterOpening..<closing]), opening..<text.index(after: closing)))
+            }
+            searchIndex = text.index(after: closing)
+        }
+        return spans
+    }
+
+    private static func hasExecutionIntent(before index: String.Index, in text: String) -> Bool {
+        let lowerBound = text.index(index, offsetBy: -96, limitedBy: text.startIndex) ?? text.startIndex
+        let prefix = text[lowerBound..<index]
+            .lowercased()
+            .replacingOccurrences(of: "\n", with: " ")
+        let negativeIntents = [
+            "do not run",
+            "don't run",
+            "will not run",
+            "won't run",
+            "cannot run",
+            "can't run",
+            "should not run",
+            "do not execute",
+            "don't execute",
+            "will not execute",
+            "won't execute"
+        ]
+        guard !negativeIntents.contains(where: { prefix.contains($0) }) else {
+            return false
+        }
+        let intents = [
+            "i'll run",
+            "i’ll run",
+            "i will run",
+            "i'll execute",
+            "i’ll execute",
+            "i will execute",
+            "i'll check",
+            "i’ll check",
+            "i will check",
+            "i am running",
+            "i'm running",
+            "i’m running",
+            "running",
+            "run ",
+            "execute "
+        ]
+        return intents.contains { prefix.contains($0) }
+    }
+
+    private static func isPlausibleShellCommand(_ command: String) -> Bool {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              !trimmed.contains("\n"),
+              trimmed.count <= 500
+        else {
+            return false
+        }
+        let firstWord = trimmed.split(separator: " ", maxSplits: 1).first.map(String.init) ?? trimmed
+        guard firstWord.range(of: #"^[A-Za-z0-9_./:-]+$"#, options: .regularExpression) != nil else {
+            return false
+        }
+        return true
     }
 
     private static func toolName(in object: [String: Any]) -> String? {

--- a/Tests/QuillCodeAgentTests/TrustedRouterAdapterTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterAdapterTests.swift
@@ -61,6 +61,56 @@ final class TrustedRouterAdapterTests: XCTestCase {
         XCTAssertTrue(call.argumentsJSON.contains(#""cmd":"whoami""#))
     }
 
+    func testActionParserRecoversExplicitBacktickedShellCommandFromProse() throws {
+        let action = try AgentActionJSONParser.parse("I'll run `whoami` on the device.")
+
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected recovered shell tool action")
+        }
+        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(try arguments.requiredString("cmd"), "whoami")
+    }
+
+    func testActionParserRecoversCurlyApostropheExecutionIntent() throws {
+        let action = try AgentActionJSONParser.parse("I’ll check `df -h /` now.")
+
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected recovered shell tool action")
+        }
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(try arguments.requiredString("cmd"), "df -h /")
+    }
+
+    func testActionParserRepairsEmptyShellArgumentsFromExplicitNearbyCommand() throws {
+        let action = try AgentActionJSONParser.parse("""
+        I'll execute `command -v openclaw || which openclaw || echo 'not found'`.
+        {"type":"tool","name":"host.shell.run","arguments":{}}
+        """)
+
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected repaired shell tool action")
+        }
+        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(
+            try arguments.requiredString("cmd"),
+            "command -v openclaw || which openclaw || echo 'not found'"
+        )
+    }
+
+    func testActionParserDoesNotRecoverPassiveBacktickedTextAsCommand() {
+        XCTAssertThrowsError(try AgentActionJSONParser.parse("You can use `whoami` if you want.")) { error in
+            XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))
+        }
+    }
+
+    func testActionParserDoesNotRecoverNegativeBacktickedCommandIntent() {
+        XCTAssertThrowsError(try AgentActionJSONParser.parse("I will not run `rm -rf /`.")) { error in
+            XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))
+        }
+    }
+
     func testActionParserKeepsMalformedTextActionable() {
         XCTAssertThrowsError(try AgentActionJSONParser.parse("I will do it, but no JSON.")) { error in
             XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -2104,3 +2104,26 @@ Remaining risk:
 
 - The current approval action reruns from the serialized redacted tool call, which is correct for shell/file arguments covered today. If future tools need non-transcript-safe in-memory fields, the runner should retain a pending approval registry keyed by request ID.
 - The review UI now handles approve/skip. A later pass should add a lightweight "edit command before running" path for commands where the user wants to fix arguments instead of approving or skipping.
+
+## 2026-06-23 Agent Action Parser Hardening Pass
+
+Overall grade after this slice: **A parser resilience, A safety boundary, A regression coverage**.
+
+The TrustedRouter action parser now recovers from two common live-model formatting failures without moving command inference into the UI: an explicit prose response such as "I'll run `whoami`" and a `host.shell.run` JSON action with empty arguments beside an explicit backticked command. This closes the failure mode where QuillCode could show an empty shell card and then fail with "No shell command was specified" even though the model text already named the command.
+
+| Case | Before | After |
+| --- | --- | --- |
+| Prose-only model action | Rejected as invalid action JSON. | Recovered only when the model explicitly says it will run/execute/check a backticked command. |
+| Empty shell arguments | Threw or produced an empty command path depending on call shape. | Repairs `cmd` from an adjacent explicit command before validation. |
+| Passive or negative prose | Risk of becoming future over-broad recovery if added casually. | Tests reject passive text and "I will not run `...`" negative intent. |
+
+Code quality changes:
+
+- Kept recovery in the model-output parser boundary, not in transcript UI, tool cards, or user-prompt heuristics.
+- Added bounded inline-code extraction with execution-intent and negative-intent checks.
+- Preserved hard validation for `host.shell.run`: a non-empty `cmd` is still required before any tool call is emitted.
+- Added focused adapter tests covering recovered prose, repaired empty shell arguments, passive prose rejection, and negative-intent rejection.
+
+Remaining risk:
+
+- Recovery is intentionally conservative and only handles explicit backticked shell commands. Broader malformed tool output should be solved with stronger structured-response/tool-calling support rather than more natural-language inference.


### PR DESCRIPTION
## Summary
- recover explicit backticked shell commands from model prose like "I'll run \jperla" without moving inference into the UI
- repair empty host.shell.run argument objects when the surrounding model text explicitly names the command
- guard against passive and negative prose so recovery stays conservative
- document the parser-hardening pass in the code quality audit

## Validation
- swift test --filter TrustedRouterAdapterTests
- swift test