### PR TITLE
Extract git tool call dispatcher

### DIFF
--- a/Sources/QuillCodeTools/GitToolCallDispatcher.swift
+++ b/Sources/QuillCodeTools/GitToolCallDispatcher.swift
@@ -1,0 +1,149 @@
+import Foundation
+import QuillCodeCore
+
+struct GitToolCallDispatcher: Sendable {
+    let workspaceRoot: URL
+    let git: GitToolExecutor
+
+    static let definitions: [ToolDefinition] = [
+        .gitStatus,
+        .gitDiff,
+        .gitStage,
+        .gitRestore,
+        .gitStageHunk,
+        .gitRestoreHunk,
+        .gitCommit,
+        .gitPush,
+        .gitPullRequestCreate,
+        .gitPullRequestView,
+        .gitPullRequestChecks,
+        .gitPullRequestDiff,
+        .gitPullRequestCheckout,
+        .gitPullRequestReviewers,
+        .gitPullRequestLabels,
+        .gitPullRequestComment,
+        .gitPullRequestReview,
+        .gitPullRequestMerge,
+        .gitWorktreeList,
+        .gitWorktreeCreate,
+        .gitWorktreeRemove
+    ]
+
+    private static let toolNames = Set(definitions.map(\.name))
+
+    static func handles(_ toolName: String) -> Bool {
+        toolNames.contains(toolName)
+    }
+
+    func execute(name: String, arguments args: ToolArguments) throws -> ToolResult {
+        switch name {
+        case ToolDefinition.gitStatus.name:
+            return git.status(cwd: workspaceRoot)
+        case ToolDefinition.gitDiff.name:
+            return git.diff(cwd: workspaceRoot, staged: args.bool("staged") ?? false)
+        case ToolDefinition.gitStage.name:
+            return git.stage(cwd: workspaceRoot, path: try args.requiredString("path"))
+        case ToolDefinition.gitRestore.name:
+            return git.restore(
+                cwd: workspaceRoot,
+                path: try args.requiredString("path"),
+                staged: args.bool("staged") ?? false
+            )
+        case ToolDefinition.gitStageHunk.name:
+            return git.stageHunk(
+                cwd: workspaceRoot,
+                path: try args.requiredString("path"),
+                patch: try args.requiredString("patch")
+            )
+        case ToolDefinition.gitRestoreHunk.name:
+            return git.restoreHunk(
+                cwd: workspaceRoot,
+                path: try args.requiredString("path"),
+                patch: try args.requiredString("patch")
+            )
+        case ToolDefinition.gitCommit.name:
+            return git.commit(cwd: workspaceRoot, message: try args.requiredString("message"))
+        case ToolDefinition.gitPush.name:
+            return git.push(
+                cwd: workspaceRoot,
+                remote: args.string("remote"),
+                branch: args.string("branch"),
+                setUpstream: args.bool("setUpstream") ?? false
+            )
+        case ToolDefinition.gitPullRequestCreate.name:
+            return git.createPullRequest(
+                cwd: workspaceRoot,
+                title: args.string("title"),
+                body: args.string("body"),
+                base: args.string("base"),
+                head: args.string("head"),
+                draft: args.bool("draft") ?? false,
+                fill: args.bool("fill") ?? false
+            )
+        case ToolDefinition.gitPullRequestView.name:
+            return git.viewPullRequest(cwd: workspaceRoot, selector: args.string("selector"))
+        case ToolDefinition.gitPullRequestChecks.name:
+            return git.pullRequestChecks(cwd: workspaceRoot, selector: args.string("selector"))
+        case ToolDefinition.gitPullRequestDiff.name:
+            return git.diffPullRequest(cwd: workspaceRoot, selector: args.string("selector"))
+        case ToolDefinition.gitPullRequestCheckout.name:
+            return git.checkoutPullRequest(
+                cwd: workspaceRoot,
+                selector: args.string("selector"),
+                branch: args.string("branch")
+            )
+        case ToolDefinition.gitPullRequestReviewers.name:
+            return git.updatePullRequestReviewers(
+                cwd: workspaceRoot,
+                selector: args.string("selector"),
+                add: args.stringArray("add"),
+                remove: args.stringArray("remove")
+            )
+        case ToolDefinition.gitPullRequestLabels.name:
+            return git.updatePullRequestLabels(
+                cwd: workspaceRoot,
+                selector: args.string("selector"),
+                add: args.stringArray("add"),
+                remove: args.stringArray("remove")
+            )
+        case ToolDefinition.gitPullRequestComment.name:
+            return git.commentOnPullRequest(
+                cwd: workspaceRoot,
+                selector: args.string("selector"),
+                body: try args.requiredString("body")
+            )
+        case ToolDefinition.gitPullRequestReview.name:
+            return git.reviewPullRequest(
+                cwd: workspaceRoot,
+                selector: args.string("selector"),
+                action: try args.requiredString("action"),
+                body: args.string("body")
+            )
+        case ToolDefinition.gitPullRequestMerge.name:
+            return git.mergePullRequest(
+                cwd: workspaceRoot,
+                selector: args.string("selector"),
+                method: args.string("method"),
+                auto: args.bool("auto") ?? false,
+                deleteBranch: args.bool("deleteBranch") ?? false
+            )
+        case ToolDefinition.gitWorktreeList.name:
+            return git.listWorktrees(cwd: workspaceRoot)
+        case ToolDefinition.gitWorktreeCreate.name:
+            return git.createWorktree(
+                cwd: workspaceRoot,
+                path: try args.requiredString("path"),
+                branch: args.string("branch"),
+                base: args.string("base")
+            )
+        case ToolDefinition.gitWorktreeRemove.name:
+            return git.removeWorktree(
+                cwd: workspaceRoot,
+                path: try args.requiredString("path"),
+                force: args.bool("force") ?? false
+            )
+        default:
+            return ToolResult(ok: false, error: "Unknown tool: \(name)")
+        }
+    }
+}

--- a/Sources/QuillCodeTools/ToolRouter.swift
+++ b/Sources/QuillCodeTools/ToolRouter.swift
@@ -26,29 +26,8 @@ public struct ToolRouter: Sendable {
         .shellRun,
         .fileRead,
         .fileWrite,
-        .applyPatch,
-        .gitStatus,
-        .gitDiff,
-        .gitStage,
-        .gitRestore,
-        .gitStageHunk,
-        .gitRestoreHunk,
-        .gitCommit,
-        .gitPush,
-        .gitPullRequestCreate,
-        .gitPullRequestView,
-        .gitPullRequestChecks,
-        .gitPullRequestDiff,
-        .gitPullRequestCheckout,
-        .gitPullRequestReviewers,
-        .gitPullRequestLabels,
-        .gitPullRequestComment,
-        .gitPullRequestReview,
-        .gitPullRequestMerge,
-        .gitWorktreeList,
-        .gitWorktreeCreate,
-        .gitWorktreeRemove
-    ]
+        .applyPatch
+    ] + GitToolCallDispatcher.definitions
 
     public func definition(named name: String) -> ToolDefinition? {
         Self.definitions.first { $0.name == name }
@@ -57,6 +36,10 @@ public struct ToolRouter: Sendable {
     public func execute(_ call: ToolCall) -> ToolResult {
         do {
             let args = try ToolArguments(call.argumentsJSON)
+            if GitToolCallDispatcher.handles(call.name) {
+                return try GitToolCallDispatcher(workspaceRoot: workspaceRoot, git: git)
+                    .execute(name: call.name, arguments: args)
+            }
             switch call.name {
             case ToolDefinition.shellRun.name:
                 let command = try args.requiredString("cmd")
@@ -90,111 +73,6 @@ public struct ToolRouter: Sendable {
                 )
             case ToolDefinition.applyPatch.name:
                 return patch.apply(unifiedDiff: try args.requiredString("patch"))
-            case ToolDefinition.gitStatus.name:
-                return git.status(cwd: workspaceRoot)
-            case ToolDefinition.gitDiff.name:
-                return git.diff(cwd: workspaceRoot, staged: args.bool("staged") ?? false)
-            case ToolDefinition.gitStage.name:
-                return git.stage(cwd: workspaceRoot, path: try args.requiredString("path"))
-            case ToolDefinition.gitRestore.name:
-                return git.restore(
-                    cwd: workspaceRoot,
-                    path: try args.requiredString("path"),
-                    staged: args.bool("staged") ?? false
-                )
-            case ToolDefinition.gitStageHunk.name:
-                return git.stageHunk(
-                    cwd: workspaceRoot,
-                    path: try args.requiredString("path"),
-                    patch: try args.requiredString("patch")
-                )
-            case ToolDefinition.gitRestoreHunk.name:
-                return git.restoreHunk(
-                    cwd: workspaceRoot,
-                    path: try args.requiredString("path"),
-                    patch: try args.requiredString("patch")
-                )
-            case ToolDefinition.gitCommit.name:
-                return git.commit(cwd: workspaceRoot, message: try args.requiredString("message"))
-            case ToolDefinition.gitPush.name:
-                return git.push(
-                    cwd: workspaceRoot,
-                    remote: args.string("remote"),
-                    branch: args.string("branch"),
-                    setUpstream: args.bool("setUpstream") ?? false
-                )
-            case ToolDefinition.gitPullRequestCreate.name:
-                return git.createPullRequest(
-                    cwd: workspaceRoot,
-                    title: args.string("title"),
-                    body: args.string("body"),
-                    base: args.string("base"),
-                    head: args.string("head"),
-                    draft: args.bool("draft") ?? false,
-                    fill: args.bool("fill") ?? false
-                )
-            case ToolDefinition.gitPullRequestView.name:
-                return git.viewPullRequest(cwd: workspaceRoot, selector: args.string("selector"))
-            case ToolDefinition.gitPullRequestChecks.name:
-                return git.pullRequestChecks(cwd: workspaceRoot, selector: args.string("selector"))
-            case ToolDefinition.gitPullRequestDiff.name:
-                return git.diffPullRequest(cwd: workspaceRoot, selector: args.string("selector"))
-            case ToolDefinition.gitPullRequestCheckout.name:
-                return git.checkoutPullRequest(
-                    cwd: workspaceRoot,
-                    selector: args.string("selector"),
-                    branch: args.string("branch")
-                )
-            case ToolDefinition.gitPullRequestReviewers.name:
-                return git.updatePullRequestReviewers(
-                    cwd: workspaceRoot,
-                    selector: args.string("selector"),
-                    add: args.stringArray("add"),
-                    remove: args.stringArray("remove")
-                )
-            case ToolDefinition.gitPullRequestLabels.name:
-                return git.updatePullRequestLabels(
-                    cwd: workspaceRoot,
-                    selector: args.string("selector"),
-                    add: args.stringArray("add"),
-                    remove: args.stringArray("remove")
-                )
-            case ToolDefinition.gitPullRequestComment.name:
-                return git.commentOnPullRequest(
-                    cwd: workspaceRoot,
-                    selector: args.string("selector"),
-                    body: try args.requiredString("body")
-                )
-            case ToolDefinition.gitPullRequestReview.name:
-                return git.reviewPullRequest(
-                    cwd: workspaceRoot,
-                    selector: args.string("selector"),
-                    action: try args.requiredString("action"),
-                    body: args.string("body")
-                )
-            case ToolDefinition.gitPullRequestMerge.name:
-                return git.mergePullRequest(
-                    cwd: workspaceRoot,
-                    selector: args.string("selector"),
-                    method: args.string("method"),
-                    auto: args.bool("auto") ?? false,
-                    deleteBranch: args.bool("deleteBranch") ?? false
-                )
-            case ToolDefinition.gitWorktreeList.name:
-                return git.listWorktrees(cwd: workspaceRoot)
-            case ToolDefinition.gitWorktreeCreate.name:
-                return git.createWorktree(
-                    cwd: workspaceRoot,
-                    path: try args.requiredString("path"),
-                    branch: args.string("branch"),
-                    base: args.string("base")
-                )
-            case ToolDefinition.gitWorktreeRemove.name:
-                return git.removeWorktree(
-                    cwd: workspaceRoot,
-                    path: try args.requiredString("path"),
-                    force: args.bool("force") ?? false
-                )
             default:
                 return ToolResult(ok: false, error: "Unknown tool: \(call.name)")
             }

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1475,6 +1475,22 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(executorText.contains("parametersJSON"), "GitToolExecutor should not own JSON schema strings.")
     }
 
+    func testToolRouterDelegatesGitToolCallDispatch() throws {
+        let routerText = try Self.toolsSourceText(named: "ToolRouter.swift")
+        let dispatcherText = try Self.toolsSourceText(named: "GitToolCallDispatcher.swift")
+
+        XCTAssertTrue(dispatcherText.contains("struct GitToolCallDispatcher"), "Git tool call routing should live in a focused dispatcher.")
+        XCTAssertTrue(dispatcherText.contains("static let definitions"), "The git dispatcher should own the git tool definition list.")
+        XCTAssertTrue(dispatcherText.contains("func execute("), "The git dispatcher should expose a directly testable execution boundary.")
+        XCTAssertTrue(routerText.contains("GitToolCallDispatcher.definitions"), "ToolRouter should compose git definitions from the dispatcher.")
+        XCTAssertTrue(routerText.contains("GitToolCallDispatcher.handles"), "ToolRouter should delegate git tool dispatch.")
+        XCTAssertFalse(routerText.contains("ToolDefinition.gitStatus.name"), "ToolRouter should not own local git route branches.")
+        XCTAssertFalse(routerText.contains("ToolDefinition.gitPullRequestCreate.name"), "ToolRouter should not own GitHub PR route branches.")
+        XCTAssertFalse(routerText.contains("ToolDefinition.gitWorktreeCreate.name"), "ToolRouter should not own worktree route branches.")
+        XCTAssertFalse(routerText.contains("git.createPullRequest"), "ToolRouter should not call GitHub PR execution directly.")
+        XCTAssertFalse(routerText.contains("git.createWorktree"), "ToolRouter should not call worktree execution directly.")
+    }
+
     func testGitLocalExecutionLivesOutsideGitExecutor() throws {
         let executorText = try Self.toolsSourceText(named: "GitToolExecutor.swift")
         let localText = try Self.toolsSourceText(named: "GitLocalToolExecutor.swift")

--- a/Tests/QuillCodeToolsTests/ToolTests.swift
+++ b/Tests/QuillCodeToolsTests/ToolTests.swift
@@ -873,6 +873,17 @@ final class ToolTests: XCTestCase {
         XCTAssertTrue(definitions.contains("host.git.worktree.remove"))
     }
 
+    func testGitToolCallDispatcherOwnsGitDefinitions() {
+        let routerDefinitions = ToolRouter.definitions.map(\.name)
+        let gitDefinitions = GitToolCallDispatcher.definitions.map(\.name)
+
+        XCTAssertTrue(GitToolCallDispatcher.handles(ToolDefinition.gitStatus.name))
+        XCTAssertTrue(GitToolCallDispatcher.handles(ToolDefinition.gitPullRequestCreate.name))
+        XCTAssertTrue(GitToolCallDispatcher.handles(ToolDefinition.gitWorktreeRemove.name))
+        XCTAssertFalse(GitToolCallDispatcher.handles(ToolDefinition.shellRun.name))
+        XCTAssertTrue(gitDefinitions.allSatisfy(routerDefinitions.contains))
+    }
+
     func testToolRouterShellAllowsWorkspaceRelativeCWD() throws {
         let root = try makeTempDirectory()
         let subdirectory = root.appendingPathComponent("subdir")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -62,6 +62,19 @@ Code quality changes:
 - Added focused resolver tests for known/unknown project IDs, global memory ordering, project memory merging, exact local-action IDs, case-insensitive titles, relative paths, punctuation-insensitive aliases, and no-selected-project behavior.
 - Added a parity gate that prevents context/action lookup from drifting back into `WorkspaceModel`.
 
+## 2026-06-23 Tool Router Git Dispatch Pass
+
+Overall grade after this slice: **A- foundation, B+ product surface maturity**.
+
+The shared `ToolRouter` was carrying every local git, GitHub pull request, and git worktree route in its main switch. That kept behavior correct, but it made the central router too easy to grow into another feature-specific branch sink as the Codex parity tool surface expands.
+
+Code quality changes:
+
+- Added `GitToolCallDispatcher` as the focused owner for git-family tool definitions and argument-to-executor dispatch.
+- Reduced `ToolRouter` to shell/file/patch primitives plus early delegation to the git dispatcher.
+- Kept the existing `GitToolExecutor` facade intact, so shell/file/patch routing, tool schemas, and git command behavior stay API-compatible.
+- Added focused dispatcher coverage and a parity gate that prevents local git, GitHub PR, or worktree route branches from drifting back into `ToolRouter`.
+
 ## 2026-06-22 Workspace Project Engine Refactor Pass
 
 Overall grade after this slice: **A- foundation, B+ product surface maturity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3,6 +3,7 @@
 ## 2026-06-23
 
 - Codex-style workspace chrome should keep model selection and approval mode as separate controls near the composer, not in the top bar. Model is a long-lived preference, while approval mode is an autonomy/safety posture users may change at send time. The model picker should only select models; Auto/Review/Read-only lives in a compact mode control beside it. Instruction files, memories, Computer Use readiness, and runtime issues remain accessible in the status popover and transcript/settings surfaces, but they should not occupy permanent top-bar width. This keeps the first read calmer while preserving diagnostics and Playwright coverage.
+- Tool-router feature families should delegate before they sprawl. `ToolRouter` owns the common shell/file/patch entry point and composes git definitions from `GitToolCallDispatcher`; local git, GitHub PR, and worktree tool-call argument mapping lives in that dispatcher. This keeps the shared router small while preserving one public `ToolRouter.execute` API for the agent runtime.
 
 ## 2026-06-20
 


### PR DESCRIPTION
## Summary
- add `GitToolCallDispatcher` as the focused owner for git-family tool definitions and argument dispatch
- shrink `ToolRouter` to shell/file/patch primitives plus early git-family delegation
- add focused dispatcher coverage, a parity gate, and audit/decision docs

## Validation
- `git diff --check`
- `swift test` (805 tests)
- `scripts/smoke.sh` (805 Swift tests, mock CLI checks, 59 Playwright tests)
