### PR TITLE
Extract shell tool call dispatcher

### DIFF
--- a/Sources/QuillCodeTools/ShellToolCallDispatcher.swift
+++ b/Sources/QuillCodeTools/ShellToolCallDispatcher.swift
@@ -1,0 +1,135 @@
+import Foundation
+import QuillCodeCore
+
+struct ShellToolCallDispatcher: Sendable {
+    let workspaceRoot: URL
+    let shell: ShellToolExecutor
+
+    static let definitions: [ToolDefinition] = [
+        .shellRun
+    ]
+
+    private static let toolNames = Set(definitions.map(\.name))
+    private static let minTimeoutSeconds = 1
+    private static let maxTimeoutSeconds = 1_800
+
+    static func handles(_ toolName: String) -> Bool {
+        toolNames.contains(toolName)
+    }
+
+    func execute(name: String, arguments args: ToolArguments) throws -> ToolResult {
+        switch name {
+        case ToolDefinition.shellRun.name:
+            return try runShell(arguments: args)
+        default:
+            return ToolResult(ok: false, error: "Unknown tool: \(name)")
+        }
+    }
+
+    private func runShell(arguments args: ToolArguments) throws -> ToolResult {
+        let command = try args.requiredString("cmd")
+        switch workingDirectory(args.string("cwd")) {
+        case let .allowed(cwd):
+            switch timeoutSeconds(args) {
+            case let .allowed(timeoutSeconds):
+                switch environment(args) {
+                case let .allowed(environment):
+                    var request = ShellExecutionRequest(command: command, cwd: cwd)
+                    if let timeoutSeconds {
+                        request.timeoutSeconds = timeoutSeconds
+                    }
+                    request.environment = environment
+                    return shell.run(request)
+                case let .denied(error):
+                    return ToolResult(ok: false, error: error)
+                }
+            case let .denied(error):
+                return ToolResult(ok: false, error: error)
+            }
+        case let .denied(error):
+            return ToolResult(ok: false, error: error)
+        }
+    }
+
+    private func workingDirectory(_ rawValue: String?) -> WorkingDirectoryResolution {
+        let root = workspaceRoot.standardizedFileURL.resolvingSymlinksInPath()
+        guard let rawValue else {
+            return .allowed(root)
+        }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .allowed(root)
+        }
+        guard !trimmed.contains("\0"),
+              trimmed.rangeOfCharacter(from: .newlines) == nil
+        else {
+            return .denied("Shell cwd must be a single project-relative or in-project path.")
+        }
+
+        let candidate = trimmed.hasPrefix("/")
+            ? URL(fileURLWithPath: trimmed)
+            : root.appendingPathComponent(trimmed)
+        let resolved = candidate.standardizedFileURL.resolvingSymlinksInPath()
+        guard Self.isPath(resolved.path, inside: root.path) else {
+            return .denied("Shell cwd must stay inside the current workspace.")
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: resolved.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            return .denied("Shell cwd does not exist or is not a directory.")
+        }
+        return .allowed(resolved)
+    }
+
+    private func timeoutSeconds(_ args: ToolArguments) -> TimeoutResolution {
+        guard let rawValue = args.string("timeoutSeconds") ?? args.string("timeout_seconds") else {
+            return .allowed(nil)
+        }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let value = Int(trimmed),
+              (Self.minTimeoutSeconds...Self.maxTimeoutSeconds).contains(value)
+        else {
+            return .denied(
+                "Shell timeoutSeconds must be between \(Self.minTimeoutSeconds) and \(Self.maxTimeoutSeconds)."
+            )
+        }
+        return .allowed(TimeInterval(value))
+    }
+
+    private func environment(_ args: ToolArguments) -> EnvironmentResolution {
+        let rawEnvironment = args.stringDictionary("environment") ?? args.stringDictionary("env")
+        switch EnvironmentOverridePolicy.validateOverrides(rawEnvironment) {
+        case let .allowed(overrides):
+            guard !overrides.isEmpty else {
+                return .allowed(nil)
+            }
+            var environment = ProcessInfo.processInfo.environment
+            for (key, value) in overrides {
+                environment[key] = value
+            }
+            return .allowed(environment)
+        case let .denied(error):
+            return .denied(error)
+        }
+    }
+
+    private static func isPath(_ path: String, inside rootPath: String) -> Bool {
+        path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+
+    private enum WorkingDirectoryResolution {
+        case allowed(URL)
+        case denied(String)
+    }
+
+    private enum TimeoutResolution {
+        case allowed(TimeInterval?)
+        case denied(String)
+    }
+
+    private enum EnvironmentResolution {
+        case allowed([String: String]?)
+        case denied(String)
+    }
+}

--- a/Sources/QuillCodeTools/ToolRouter.swift
+++ b/Sources/QuillCodeTools/ToolRouter.swift
@@ -7,8 +7,6 @@ public struct ToolRouter: Sendable {
     public var files: FileToolExecutor
     public var git: GitToolExecutor
     public var patch: PatchToolExecutor
-    private static let minShellTimeoutSeconds = 1
-    private static let maxShellTimeoutSeconds = 1_800
 
     public init(
         workspaceRoot: URL,
@@ -22,8 +20,7 @@ public struct ToolRouter: Sendable {
         self.patch = PatchToolExecutor(workspaceRoot: workspaceRoot, shell: shell)
     }
 
-    public static let definitions: [ToolDefinition] = [
-        .shellRun,
+    public static let definitions: [ToolDefinition] = ShellToolCallDispatcher.definitions + [
         .fileRead,
         .fileWrite,
         .applyPatch
@@ -36,34 +33,15 @@ public struct ToolRouter: Sendable {
     public func execute(_ call: ToolCall) -> ToolResult {
         do {
             let args = try ToolArguments(call.argumentsJSON)
+            if ShellToolCallDispatcher.handles(call.name) {
+                return try ShellToolCallDispatcher(workspaceRoot: workspaceRoot, shell: shell)
+                    .execute(name: call.name, arguments: args)
+            }
             if GitToolCallDispatcher.handles(call.name) {
                 return try GitToolCallDispatcher(workspaceRoot: workspaceRoot, git: git)
                     .execute(name: call.name, arguments: args)
             }
             switch call.name {
-            case ToolDefinition.shellRun.name:
-                let command = try args.requiredString("cmd")
-                switch shellWorkingDirectory(args.string("cwd")) {
-                case let .allowed(cwd):
-                    switch shellTimeoutSeconds(args) {
-                    case let .allowed(timeoutSeconds):
-                        switch shellEnvironment(args) {
-                        case let .allowed(environment):
-                            var request = ShellExecutionRequest(command: command, cwd: cwd)
-                            if let timeoutSeconds {
-                                request.timeoutSeconds = timeoutSeconds
-                            }
-                            request.environment = environment
-                            return shell.run(request)
-                        case let .denied(error):
-                            return ToolResult(ok: false, error: error)
-                        }
-                    case let .denied(error):
-                        return ToolResult(ok: false, error: error)
-                    }
-                case let .denied(error):
-                    return ToolResult(ok: false, error: error)
-                }
             case ToolDefinition.fileRead.name:
                 return files.read(path: try args.requiredString("path"))
             case ToolDefinition.fileWrite.name:
@@ -79,87 +57,5 @@ public struct ToolRouter: Sendable {
         } catch {
             return ToolResult(ok: false, error: String(describing: error))
         }
-    }
-
-    private func shellWorkingDirectory(_ rawValue: String?) -> WorkingDirectoryResolution {
-        let root = workspaceRoot.standardizedFileURL.resolvingSymlinksInPath()
-        guard let rawValue else {
-            return .allowed(root)
-        }
-        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return .allowed(root)
-        }
-        guard !trimmed.contains("\0"),
-              trimmed.rangeOfCharacter(from: .newlines) == nil
-        else {
-            return .denied("Shell cwd must be a single project-relative or in-project path.")
-        }
-
-        let candidate = trimmed.hasPrefix("/")
-            ? URL(fileURLWithPath: trimmed)
-            : root.appendingPathComponent(trimmed)
-        let resolved = candidate.standardizedFileURL.resolvingSymlinksInPath()
-        guard Self.isPath(resolved.path, inside: root.path) else {
-            return .denied("Shell cwd must stay inside the current workspace.")
-        }
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: resolved.path, isDirectory: &isDirectory),
-              isDirectory.boolValue
-        else {
-            return .denied("Shell cwd does not exist or is not a directory.")
-        }
-        return .allowed(resolved)
-    }
-
-    private func shellTimeoutSeconds(_ args: ToolArguments) -> TimeoutResolution {
-        guard let rawValue = args.string("timeoutSeconds") ?? args.string("timeout_seconds") else {
-            return .allowed(nil)
-        }
-        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let value = Int(trimmed),
-              (Self.minShellTimeoutSeconds...Self.maxShellTimeoutSeconds).contains(value)
-        else {
-            return .denied(
-                "Shell timeoutSeconds must be between \(Self.minShellTimeoutSeconds) and \(Self.maxShellTimeoutSeconds)."
-            )
-        }
-        return .allowed(TimeInterval(value))
-    }
-
-    private func shellEnvironment(_ args: ToolArguments) -> EnvironmentResolution {
-        let rawEnvironment = args.stringDictionary("environment") ?? args.stringDictionary("env")
-        switch EnvironmentOverridePolicy.validateOverrides(rawEnvironment) {
-        case let .allowed(overrides):
-            guard !overrides.isEmpty else {
-                return .allowed(nil)
-            }
-            var environment = ProcessInfo.processInfo.environment
-            for (key, value) in overrides {
-                environment[key] = value
-            }
-            return .allowed(environment)
-        case let .denied(error):
-            return .denied(error)
-        }
-    }
-
-    private static func isPath(_ path: String, inside rootPath: String) -> Bool {
-        path == rootPath || path.hasPrefix(rootPath + "/")
-    }
-
-    private enum WorkingDirectoryResolution {
-        case allowed(URL)
-        case denied(String)
-    }
-
-    private enum TimeoutResolution {
-        case allowed(TimeInterval?)
-        case denied(String)
-    }
-
-    private enum EnvironmentResolution {
-        case allowed([String: String]?)
-        case denied(String)
     }
 }

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1491,6 +1491,22 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(routerText.contains("git.createWorktree"), "ToolRouter should not call worktree execution directly.")
     }
 
+    func testToolRouterDelegatesShellToolCallDispatch() throws {
+        let routerText = try Self.toolsSourceText(named: "ToolRouter.swift")
+        let dispatcherText = try Self.toolsSourceText(named: "ShellToolCallDispatcher.swift")
+
+        XCTAssertTrue(dispatcherText.contains("struct ShellToolCallDispatcher"), "Shell tool call routing should live in a focused dispatcher.")
+        XCTAssertTrue(dispatcherText.contains("static let definitions"), "The shell dispatcher should own the shell tool definition list.")
+        XCTAssertTrue(dispatcherText.contains("EnvironmentOverridePolicy.validateOverrides"), "The shell dispatcher should own shell environment override validation.")
+        XCTAssertTrue(dispatcherText.contains("func execute("), "The shell dispatcher should expose a directly testable execution boundary.")
+        XCTAssertTrue(routerText.contains("ShellToolCallDispatcher.definitions"), "ToolRouter should compose shell definitions from the dispatcher.")
+        XCTAssertTrue(routerText.contains("ShellToolCallDispatcher.handles"), "ToolRouter should delegate shell tool dispatch.")
+        XCTAssertFalse(routerText.contains("ToolDefinition.shellRun.name"), "ToolRouter should not own shell route branches.")
+        XCTAssertFalse(routerText.contains("EnvironmentOverridePolicy.validateOverrides"), "ToolRouter should not own shell environment override validation.")
+        XCTAssertFalse(routerText.contains("Shell cwd must stay inside the current workspace."), "ToolRouter should not own shell cwd validation copy.")
+        XCTAssertFalse(routerText.contains("Shell timeoutSeconds must be between"), "ToolRouter should not own shell timeout validation copy.")
+    }
+
     func testGitLocalExecutionLivesOutsideGitExecutor() throws {
         let executorText = try Self.toolsSourceText(named: "GitToolExecutor.swift")
         let localText = try Self.toolsSourceText(named: "GitLocalToolExecutor.swift")

--- a/Tests/QuillCodeToolsTests/ToolTests.swift
+++ b/Tests/QuillCodeToolsTests/ToolTests.swift
@@ -852,6 +852,8 @@ final class ToolTests: XCTestCase {
     func testToolRouterExposesGitStageAndRestoreDefinitions() {
         let definitions = ToolRouter.definitions.map(\.name)
 
+        XCTAssertEqual(definitions.first, "host.shell.run")
+        XCTAssertTrue(definitions.contains("host.shell.run"))
         XCTAssertTrue(definitions.contains("host.git.stage"))
         XCTAssertTrue(definitions.contains("host.git.restore"))
         XCTAssertTrue(definitions.contains("host.git.stage_hunk"))
@@ -871,6 +873,15 @@ final class ToolTests: XCTestCase {
         XCTAssertTrue(definitions.contains("host.git.worktree.list"))
         XCTAssertTrue(definitions.contains("host.git.worktree.create"))
         XCTAssertTrue(definitions.contains("host.git.worktree.remove"))
+    }
+
+    func testShellToolCallDispatcherOwnsShellDefinition() {
+        let routerDefinitions = ToolRouter.definitions.map(\.name)
+        let shellDefinitions = ShellToolCallDispatcher.definitions.map(\.name)
+
+        XCTAssertTrue(ShellToolCallDispatcher.handles(ToolDefinition.shellRun.name))
+        XCTAssertFalse(ShellToolCallDispatcher.handles(ToolDefinition.gitStatus.name))
+        XCTAssertTrue(shellDefinitions.allSatisfy(routerDefinitions.contains))
     }
 
     func testGitToolCallDispatcherOwnsGitDefinitions() {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -75,6 +75,19 @@ Code quality changes:
 - Kept the existing `GitToolExecutor` facade intact, so shell/file/patch routing, tool schemas, and git command behavior stay API-compatible.
 - Added focused dispatcher coverage and a parity gate that prevents local git, GitHub PR, or worktree route branches from drifting back into `ToolRouter`.
 
+## 2026-06-23 Tool Router Shell Dispatch Pass
+
+Overall grade after this slice: **A- foundation, B+ product surface maturity**.
+
+Shell routing had the same drift risk as git routing: the shared router still owned cwd resolution, timeout parsing, environment override validation, and shell request construction. Those policies are important enough to be directly owned and guarded by a focused shell dispatcher.
+
+Code quality changes:
+
+- Added `ShellToolCallDispatcher` as the focused owner for `host.shell.run` definitions and request construction.
+- Moved shell cwd, timeout, and environment override policy out of `ToolRouter`.
+- Reduced `ToolRouter` to tool-family delegation plus file read/write and apply-patch primitives.
+- Added focused dispatcher coverage and a parity gate that prevents shell validation policy from drifting back into `ToolRouter`.
+
 ## 2026-06-22 Workspace Project Engine Refactor Pass
 
 Overall grade after this slice: **A- foundation, B+ product surface maturity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4,6 +4,7 @@
 
 - Codex-style workspace chrome should keep model selection and approval mode as separate controls near the composer, not in the top bar. Model is a long-lived preference, while approval mode is an autonomy/safety posture users may change at send time. The model picker should only select models; Auto/Review/Read-only lives in a compact mode control beside it. Instruction files, memories, Computer Use readiness, and runtime issues remain accessible in the status popover and transcript/settings surfaces, but they should not occupy permanent top-bar width. This keeps the first read calmer while preserving diagnostics and Playwright coverage.
 - Tool-router feature families should delegate before they sprawl. `ToolRouter` owns the common shell/file/patch entry point and composes git definitions from `GitToolCallDispatcher`; local git, GitHub PR, and worktree tool-call argument mapping lives in that dispatcher. This keeps the shared router small while preserving one public `ToolRouter.execute` API for the agent runtime.
+- Shell request policy is a tool-family concern. `ShellToolCallDispatcher` owns `host.shell.run` definitions, cwd containment, timeout bounds, environment override validation, and `ShellExecutionRequest` construction; `ToolRouter` only delegates shell calls before handling file and patch primitives.
 
 ## 2026-06-20
 


### PR DESCRIPTION
## Summary
- add `ShellToolCallDispatcher` as the focused owner for `host.shell.run` definitions and request construction
- move shell cwd, timeout, and environment override policy out of `ToolRouter`
- keep shell definition order stable and add a parity gate so the policy does not drift back into the router

## Validation
- `git diff --check`
- `swift test` (812 tests)
- `scripts/smoke.sh` (812 Swift tests, mock CLI checks, 59 Playwright tests)
