### PR TITLE
Simplify native top bar

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum QuillCodeMetrics {
     static let minimumHitTarget: CGFloat = 40
+    static let topBarHeight: CGFloat = 40
     static let toolCardMinimumHeight: CGFloat = 74
     static let compactToolCardMinimumHeight: CGFloat = 58
     static let toolCardHeaderHeight: CGFloat = 44

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -7,80 +7,84 @@ struct QuillCodeTopBarView: View {
     var onCommand: (WorkspaceCommandSurface) -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
-            identityCluster
-                .layoutPriority(3)
-
-            Spacer(minLength: 10)
-
+        ZStack(alignment: .bottom) {
             HStack(spacing: 12) {
-                statusIndicator
+                contextLabel
+                    .layoutPriority(1)
+
+                threadTitle
+                    .layoutPriority(3)
+
                 commandMenu
+                    .layoutPriority(2)
             }
-            .frame(minWidth: 0, alignment: .trailing)
+            .padding(.horizontal, 14)
+            .frame(minHeight: QuillCodeMetrics.topBarHeight)
+
+            if showsActivityHairline {
+                Rectangle()
+                    .fill(activityHairlineColor)
+                    .frame(height: 2)
+                    .accessibilityHidden(true)
+            }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(QuillCodePalette.panel)
+        .background(QuillCodePalette.background)
+        .help(topBarHelp)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(topBarAccessibilityLabel)
     }
 
-    private var identityCluster: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text(topBar.primaryTitle)
-                .font(.headline)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            Text(topBar.subtitle)
-                .font(.caption)
-                .foregroundStyle(QuillCodePalette.muted)
-                .lineLimit(1)
-                .truncationMode(.middle)
-        }
-        .frame(minWidth: 0, alignment: .leading)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(topBar.primaryTitle), \(topBar.subtitle)")
+    private var contextLabel: some View {
+        Text(topBar.subtitle)
+            .font(.caption)
+            .foregroundStyle(QuillCodePalette.muted)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(maxWidth: 240, alignment: .leading)
     }
 
-    private var statusIndicator: some View {
-        let status = topBar.agentStatusPresentation
-        return HStack(spacing: 8) {
-            HStack(spacing: 6) {
-                if status.showsIndicator {
-                    Circle()
-                        .fill(statusColor(for: status.tone))
-                        .frame(width: 8, height: 8)
-                        .accessibilityHidden(true)
-                }
-                Text(status.label)
-                    .font(.caption.monospacedDigit().weight(.semibold))
-                    .foregroundStyle(QuillCodePalette.text.opacity(0.82))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            .padding(.horizontal, 10)
-            .frame(maxWidth: 170, minHeight: 32)
-            .background(QuillCodePalette.selection.opacity(0.50))
-            .overlay {
-                Capsule()
-                    .stroke(Color.white.opacity(0.10), lineWidth: 1)
-            }
-            .clipShape(Capsule())
-            .help(status.label)
-            .accessibilityLabel(status.accessibilityLabel)
+    private var threadTitle: some View {
+        Text(topBar.primaryTitle)
+            .font(.headline.weight(.semibold))
+            .foregroundStyle(QuillCodePalette.text)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
 
-            if let issue = topBar.runtimeIssuePresentation {
-                QuillCodeTopBarPill(
-                    text: issue.label,
-                    systemImage: "exclamationmark.triangle",
-                    tint: runtimeIssueColor(for: issue.tone),
-                    maxWidth: 180,
-                    layoutPriority: 2
-                )
-                .help(issue.label)
-            }
+    private var agentStatus: TopBarStatusPresentation {
+        topBar.agentStatusPresentation
+    }
+
+    private var runtimeIssue: TopBarRuntimeIssuePresentation? {
+        topBar.runtimeIssuePresentation
+    }
+
+    private var showsActivityHairline: Bool {
+        agentStatus.showsIndicator || runtimeIssue != nil
+    }
+
+    private var activityHairlineColor: Color {
+        if let runtimeIssue {
+            return runtimeIssueColor(for: runtimeIssue.tone)
         }
-        .frame(minWidth: 0, alignment: .trailing)
-        .fixedSize(horizontal: true, vertical: false)
+        return statusColor(for: agentStatus.tone)
+    }
+
+    private var topBarHelp: String {
+        var parts = [topBar.subtitle, agentStatus.accessibilityLabel]
+        if let runtimeIssue {
+            parts.append("Issue: \(runtimeIssue.label)")
+        }
+        return parts.joined(separator: ". ")
+    }
+
+    private var topBarAccessibilityLabel: String {
+        var label = "\(topBar.primaryTitle), \(topBar.subtitle), \(agentStatus.accessibilityLabel)"
+        if let runtimeIssue {
+            label += ", issue: \(runtimeIssue.label)"
+        }
+        return label
     }
 
     private func statusColor(for tone: TopBarStatusTone) -> Color {
@@ -131,11 +135,7 @@ struct QuillCodeTopBarView: View {
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(QuillCodePalette.muted)
                 .frame(width: QuillCodeMetrics.minimumHitTarget, height: QuillCodeMetrics.minimumHitTarget)
-                .background(QuillCodePalette.selection.opacity(0.52))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
-                }
+                .background(QuillCodePalette.selection.opacity(0.22))
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
@@ -206,31 +206,5 @@ struct QuillCodeModePickerButton: View {
         .buttonStyle(QuillCodePressableButtonStyle())
         .help("Choose Auto safety mode")
         .accessibilityLabel("Auto safety mode, \(modeLabel)")
-    }
-}
-
-private struct QuillCodeTopBarPill: View {
-    var text: String
-    var systemImage: String
-    var tint: Color = QuillCodePalette.blue
-    var maxWidth: CGFloat?
-    var layoutPriority: Double = 0
-
-    var body: some View {
-        Label(text, systemImage: systemImage)
-            .font(.caption.monospacedDigit().weight(.medium))
-            .lineLimit(1)
-            .truncationMode(.tail)
-            .padding(.horizontal, 9)
-            .padding(.vertical, 6)
-            .frame(maxWidth: maxWidth, minHeight: 32)
-            .layoutPriority(layoutPriority)
-            .background(tint.opacity(0.14))
-            .foregroundStyle(tint)
-            .overlay {
-                Capsule()
-                    .stroke(tint.opacity(0.22), lineWidth: 1)
-            }
-            .clipShape(Capsule())
     }
 }

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -523,6 +523,18 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(htmlRendererText.contains("runtimeIssueSeverity?.rawValue"), "HTML renderer should not own runtime issue tone fallback logic.")
     }
 
+    func testNativeTopBarKeepsCodexStyleChromeQuiet() throws {
+        let topBarViewText = try Self.appSourceText(named: "QuillCodeTopBarView.swift")
+        let designText = try Self.appSourceText(named: "QuillCodeDesignSystem.swift")
+
+        XCTAssertTrue(topBarViewText.contains("contextLabel"), "Native top bar should preserve a quiet leading context label.")
+        XCTAssertTrue(topBarViewText.contains("threadTitle"), "Native top bar should center the active thread title.")
+        XCTAssertTrue(topBarViewText.contains("showsActivityHairline"), "Native top bar should show run/error state as a subtle hairline instead of another pill.")
+        XCTAssertTrue(designText.contains("static let topBarHeight: CGFloat = 40"), "Native top bar should keep a compact Codex-style height.")
+        XCTAssertFalse(topBarViewText.contains("statusIndicator"), "Native top bar should not reintroduce a permanent status pill.")
+        XCTAssertFalse(topBarViewText.contains("QuillCodeTopBarPill"), "Native top bar should not reintroduce runtime issue pills into the main chrome.")
+    }
+
     func testTopBarAgentStatusLabelsAreSharedByRuntimePaths() throws {
         let appStateText = try Self.appSourceText(named: "AppState.swift")
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -2170,3 +2170,25 @@ Code quality changes:
 Remaining risk:
 
 - `TrustedRouterLLMClient.swift` still owns both system-prompt construction and message-history projection. If prompt rules keep growing, extract a `TrustedRouterPromptBuilder` so auth/transport and model instruction formatting remain separately testable.
+
+## 2026-06-23 Native Top Bar Simplification Pass
+
+Overall grade after this slice: **A- visual hierarchy, A shared-state preservation, A regression coverage**.
+
+Claude CLI's interface critique called out the native top bar as the largest visible gap from Codex: it was carrying title, subtitle, status, runtime issue, and overflow controls at the same weight. The native top bar now keeps the active thread as the visual center, leaves project/model context as quiet metadata, and demotes status/error state to an accessibility label plus a thin activity hairline.
+
+| Surface | Before | After |
+| --- | --- | --- |
+| Native top bar | Visible status and runtime issue pills competed with the active thread title. | Three-slot chrome: quiet context, centered thread title, overflow menu. |
+| Running/error state | Permanent pills added visual weight even when the transcript already showed the active work. | A two-point hairline appears only while an agent state or runtime issue needs attention. |
+| Overflow button | Drew another outlined control in the top bar. | Keeps a 40-point hit target with a softer fill and no extra stroke. |
+
+Code quality changes:
+
+- Kept `TopBarStatusPresentation` and `TopBarRuntimeIssuePresentation` as shared semantics for native, HTML, and accessibility paths.
+- Added `QuillCodeMetrics.topBarHeight` so compact top-bar height is a named design token.
+- Added a parity gate that prevents permanent native status/runtime pills from creeping back into the main chrome.
+
+Remaining risk:
+
+- Model and mode controls still sit in a separate composer controls row. A follow-up UI slice should fold them into the composer itself, matching the Codex-style focused input.


### PR DESCRIPTION
## Summary
- simplify the native top bar into quiet context, centered thread title, and one overflow menu
- demote status/runtime issue chrome to accessibility/help text plus a subtle activity hairline
- add a top-bar height design token and a parity guard against reintroducing status/runtime pills
- document the UI quality pass in the code quality audit

## Validation
- git diff --check
- swift test --filter ParityGateTests/testNativeTopBarKeepsCodexStyleChromeQuiet
- swift test --filter QuillCodeTopBarSurfaceTests
- swift test