### PR TITLE
Show active Stop control in top bar

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -249,6 +249,20 @@
       background: rgba(255,255,255,.07);
       border-color: rgba(255,255,255,.16);
     }
+    .topbar-action-cluster .topbar-stop-button {
+      width: auto;
+      min-width: 64px;
+      padding: 0 12px;
+      color: white;
+      background: rgba(255,91,82,.90);
+      border-color: rgba(255,255,255,.16);
+      box-shadow: 0 8px 24px rgba(255,91,82,.20);
+    }
+    .topbar-action-cluster .topbar-stop-button:hover {
+      color: white;
+      background: rgba(255,91,82,.98);
+      border-color: rgba(255,255,255,.22);
+    }
     .topbar-overflow-popover {
       position: absolute;
       right: 0;
@@ -4274,12 +4288,15 @@
         'search',
         ...(state.settings.computerUseStatus.available ? [] : ['computer-use-setup']),
         'settings',
-        'keyboard-shortcuts',
-        'stop-all'
+        'keyboard-shortcuts'
       ];
       const topBarOverflowCommands = topBarOverflowCommandIDs
         .map(commandByID)
         .filter(Boolean);
+      const topBarStopCommand = commandByID('stop-all');
+      const topBarStopButton = topBarStopCommand?.isEnabled
+        ? `<button type="button" class="topbar-stop-button" data-testid="top-bar-stop-button" data-command-id="stop-all" title="Stop all (${escapeHTML(topBarStopCommand.shortcut || 'Esc')})" aria-label="Stop active work">Stop</button>`
+        : '';
 
       document.getElementById('app').innerHTML = `
         <section class="quillcode-workspace" data-testid="workspace">
@@ -4297,6 +4314,7 @@
             </div>
             <div class="topbar-clusters" data-testid="top-bar-clusters">
               <div class="topbar-cluster topbar-action-cluster" data-testid="top-bar-action-cluster">
+                ${topBarStopButton}
                 <details class="topbar-overflow-menu" data-testid="top-bar-overflow-menu">
                   <summary data-testid="top-bar-overflow-button" aria-label="More" title="More">...</summary>
                   <div class="topbar-overflow-popover">
@@ -4518,7 +4536,7 @@
       document.querySelector('[data-testid="add-project-button"]').addEventListener('click', () => {
         addProject();
       });
-      document.querySelectorAll('.topbar-overflow-popover [data-command-id]').forEach(button => {
+      document.querySelectorAll('.topbar-action-cluster [data-command-id]').forEach(button => {
         button.addEventListener('click', event => {
           runCommand(event.currentTarget.getAttribute('data-command-id'));
         });

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -65,8 +65,8 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('top-bar-overflow-computer-use')).toBeVisible();
   await expect(page.getByTestId('top-bar-overflow-settings')).toBeVisible();
   await expect(page.getByTestId('top-bar-overflow-keyboard-shortcuts')).toBeVisible();
-  await expect(page.getByTestId('top-bar-overflow-stop-all')).toBeVisible();
-  await expect(page.getByTestId('top-bar-overflow-stop-all')).toBeDisabled();
+  await expect(page.getByTestId('top-bar-overflow-stop-all')).toHaveCount(0);
+  await expect(page.getByTestId('top-bar-stop-button')).toHaveCount(0);
   await page.getByTestId('top-bar-overflow-settings').click();
   await expect(page.getByTestId('settings-panel')).toBeVisible();
   await expect(page.getByTestId('settings-key-status')).toHaveText('Not signed in');
@@ -250,7 +250,8 @@ test('mock harness opens utilities from the top-bar overflow', async ({ page }) 
   await page.getByTestId('command-palette-close').click();
 
   await openTopBarOverflow(page);
-  await expect(page.getByTestId('top-bar-overflow-stop-all')).toBeDisabled();
+  await expect(page.getByTestId('top-bar-overflow-stop-all')).toHaveCount(0);
+  await expect(page.getByTestId('top-bar-stop-button')).toHaveCount(0);
 });
 
 test('mock harness shows actionable Computer Use setup in settings', async ({ page }) => {
@@ -534,14 +535,16 @@ test('mock harness stops an active composer run from the composer', async ({ pag
   await page.getByRole('button', { name: 'Send' }).click();
 
   await expect(page.getByTestId('agent-status')).toHaveText('Running');
+  await expect(page.getByTestId('top-bar-stop-button')).toBeVisible();
   await expect(page.getByTestId('stop-button')).toBeVisible();
   await expect(page.getByTestId('send-button')).toHaveCount(0);
   await expect(page.getByLabel('Message')).toBeDisabled();
   await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'running');
 
-  await page.getByTestId('stop-button').click();
+  await page.getByTestId('top-bar-stop-button').click();
 
   await expect(page.getByTestId('agent-status')).toHaveText('Stopped');
+  await expect(page.getByTestId('top-bar-stop-button')).toHaveCount(0);
   await expect(page.getByTestId('stop-button')).toHaveCount(0);
   await expect(page.getByTestId('send-button')).toBeDisabled();
   await expect(page.getByLabel('Message')).toBeEnabled();

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import QuillCodeCore
 
 struct QuillCodeTopBarView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var topBar: TopBarSurface
     var commands: [WorkspaceCommandSurface]
     var onCommand: (WorkspaceCommandSurface) -> Void
@@ -15,7 +17,7 @@ struct QuillCodeTopBarView: View {
                 threadTitle
                     .layoutPriority(3)
 
-                commandMenu
+                topBarActions
                     .layoutPriority(2)
             }
             .padding(.horizontal, 14)
@@ -114,6 +116,47 @@ struct QuillCodeTopBarView: View {
             from: commands,
             showsComputerUseSetup: topBar.showsComputerUseSetup
         )
+    }
+
+    private var activeStopCommand: WorkspaceCommandSurface? {
+        commands.first { $0.id == "stop-all" && $0.isEnabled }
+    }
+
+    private var topBarActions: some View {
+        HStack(spacing: 8) {
+            if let activeStopCommand {
+                stopButton(activeStopCommand)
+                    .transition(reduceMotion ? .identity : .opacity.combined(with: .scale(scale: 0.94)))
+            }
+            commandMenu
+        }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: activeStopCommand?.id)
+    }
+
+    private func stopButton(_ command: WorkspaceCommandSurface) -> some View {
+        Button {
+            onCommand(command)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "stop.fill")
+                    .font(.caption.weight(.bold))
+                    .accessibilityHidden(true)
+                Text("Stop")
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundStyle(Color.white)
+            .padding(.horizontal, 12)
+            .frame(minWidth: 64, minHeight: QuillCodeMetrics.minimumHitTarget)
+            .background(QuillCodePalette.red.opacity(0.90))
+            .overlay {
+                Capsule().stroke(Color.white.opacity(0.16), lineWidth: 1)
+            }
+            .clipShape(Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(QuillCodePressableButtonStyle())
+        .help("Stop active work")
+        .accessibilityLabel("Stop active work")
     }
 
     private var commandMenu: some View {

--- a/Sources/QuillCodeApp/WorkspaceCommandPaletteSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPaletteSurface.swift
@@ -66,8 +66,7 @@ public enum TopBarOverflowCommandCatalog {
         }
         commandIDs.append(contentsOf: [
             "settings",
-            "keyboard-shortcuts",
-            "stop-all"
+            "keyboard-shortcuts"
         ])
         return commandIDs
     }

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -69,6 +69,7 @@ enum WorkspaceHTMLTopBarRenderer {
     ) -> String {
         """
         <div class="topbar-cluster topbar-action-cluster" data-testid="top-bar-action-cluster">
+          \(renderActiveStopButton(commands: commands))
           <details class="topbar-overflow-menu" data-testid="top-bar-overflow-menu">
             <summary data-testid="top-bar-overflow-button" aria-label="More" title="More">...</summary>
             <div class="topbar-overflow-popover">
@@ -77,6 +78,14 @@ enum WorkspaceHTMLTopBarRenderer {
           </details>
         </div>
         """
+    }
+
+    private static func renderActiveStopButton(commands: [WorkspaceCommandSurface]) -> String {
+        guard let command = commands.first(where: { $0.id == "stop-all" && $0.isEnabled }) else {
+            return ""
+        }
+        let title = command.shortcut.map { "\(command.title) (\($0))" } ?? command.title
+        return #"<button type="button" class="topbar-stop-button" data-testid="top-bar-stop-button" data-command-id="stop-all" title="\#(escape(title))" aria-label="Stop active work">Stop</button>"#
     }
 
     private static func renderOverflow(

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -1571,23 +1571,15 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertTrue(idleHTML.contains(#"data-testid="top-bar-overflow-search""#))
         XCTAssertTrue(idleHTML.contains(#"data-testid="top-bar-overflow-settings""#))
         XCTAssertTrue(idleHTML.contains(#"data-testid="top-bar-overflow-keyboard-shortcuts""#))
-        XCTAssertTrue(idleHTML.contains(#"data-testid="top-bar-overflow-stop-all""#))
-        let idleStopAllSnippet = stopAllOverflowSnippet(in: idleHTML)
-        XCTAssertTrue(idleStopAllSnippet.contains("disabled"))
+        XCTAssertFalse(idleHTML.contains(#"data-testid="top-bar-overflow-stop-all""#))
+        XCTAssertFalse(idleHTML.contains(#"data-testid="top-bar-stop-button""#))
 
         let activeHTML = WorkspaceHTMLRenderer.render(
             QuillCodeWorkspaceModel(composer: ComposerState(isSending: true)).surface()
         )
-        let activeStopAllSnippet = stopAllOverflowSnippet(in: activeHTML)
-        XCTAssertFalse(activeStopAllSnippet.contains("disabled"))
-    }
-
-    private func stopAllOverflowSnippet(in html: String) -> String {
-        guard let range = html.range(of: #"data-testid="top-bar-overflow-stop-all""#) else {
-            XCTFail("Expected top-bar Stop All overflow button")
-            return ""
-        }
-        return String(html[range.lowerBound...].prefix(180))
+        XCTAssertFalse(activeHTML.contains(#"data-testid="top-bar-overflow-stop-all""#))
+        XCTAssertTrue(activeHTML.contains(#"data-testid="top-bar-stop-button""#))
+        XCTAssertTrue(activeHTML.contains(#"aria-label="Stop active work""#))
     }
 
     func testHTMLRendererShowsStopButtonDuringActiveSend() {
@@ -1595,6 +1587,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
 
         let html = WorkspaceHTMLRenderer.render(model.surface())
 
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-stop-button""#))
         XCTAssertTrue(html.contains(#"data-testid="stop-button""#))
         XCTAssertTrue(html.contains(">Stop</button>"))
         XCTAssertTrue(html.contains(#"<textarea id="message" aria-label="Message""#))


### PR DESCRIPTION
## Summary
- remove disabled Stop all from the idle top-bar overflow menu
- show a direct top-bar Stop control only while active work is running
- mirror the behavior in the HTML harness and Playwright coverage

## Validation
- swift test
- npx playwright test tests/core.spec.ts