### PR TITLE
Prefer Synth model aliases

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -2378,7 +2378,8 @@
             category: 'Recommended',
             models: [
               { id: 'trustedrouter/fast', provider: 'trustedrouter', displayName: 'Nike 1.0', isSelected: true, isFavorite: false, badges: ['Current', 'Default', 'Recommended'] },
-              { id: 'tr/synth', provider: 'trustedrouter', displayName: 'Synth', isSelected: false, isFavorite: false, badges: [] }
+              { id: 'tr/synth', provider: 'trustedrouter', displayName: 'Synth', isSelected: false, isFavorite: false, badges: ['Recommended'] },
+              { id: 'tr/synth-code', provider: 'trustedrouter', displayName: 'Synth Code', isSelected: false, isFavorite: false, badges: ['Recommended'] }
             ]
           },
           {
@@ -4971,6 +4972,7 @@
     function modelDisplayLabel(model) {
       if (model.id === 'trustedrouter/fast') return 'Nike 1.0';
       if (model.id === 'tr/synth') return 'Synth';
+      if (model.id === 'tr/synth-code') return 'Synth Code';
       if (model.provider === 'trustedrouter') return model.id;
       return `${model.provider}/${model.displayName}`;
     }
@@ -5024,6 +5026,7 @@
       if (model.metadataSummary) return model.metadataSummary;
       if (model.id === 'trustedrouter/fast') return 'Fast everyday agent';
       if (model.id === 'tr/synth') return 'Deeper planning and review';
+      if (model.id === 'tr/synth-code') return 'Code-focused model';
       const category = model.category || categoryName || 'Models';
       if (category === 'Safety') return 'Auto safety reviewer';
       return `${category} model`;
@@ -5033,6 +5036,7 @@
       if (model.capabilitySummary) return model.capabilitySummary;
       if (model.id === 'trustedrouter/fast') return 'Nike 1.0 is the fast default for coding, shell, and file-editing turns.';
       if (model.id === 'tr/synth') return 'Synth is the balanced model for deeper coding and review turns.';
+      if (model.id === 'tr/synth-code') return 'Synth Code is the code-focused model for implementation-heavy turns.';
       if ((model.badges || []).includes('Recommended')) return 'Recommended model profile available through TrustedRouter.';
       const category = model.category || categoryName || 'Models';
       if (category === 'Safety') return 'Lightweight reviewer model for Auto safety decisions.';

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -633,8 +633,9 @@ test('mock harness opens model picker from malformed model issue', async ({ page
   await expect(page.getByTestId('model-browser')).toBeVisible();
   await expect(page.getByTestId('model-search')).toBeFocused();
   await page.getByTestId('model-search').fill('synth');
-  await expect(page.getByTestId('model-option')).toHaveCount(1);
-  await expect(page.getByTestId('model-option')).toContainText('Synth');
+  await expect(page.getByTestId('model-option')).toHaveCount(2);
+  await expect(page.getByTestId('model-option').nth(0)).toContainText('Synth');
+  await expect(page.getByTestId('model-option').nth(1)).toContainText('Synth Code');
 });
 
 test('mock harness surfaces rate limits with model-switch recovery and diagnostics', async ({ page }) => {
@@ -1974,12 +1975,17 @@ test('mock harness searches and selects models from the composer', async ({ page
   await expect(page.getByTestId('model-capability')).toContainText('Nike 1.0 is the fast default');
   await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'trustedrouter/fast' })).toBeVisible();
   await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'Current, Default, Recommended' })).toBeVisible();
-  await expect(page.getByTestId('model-option')).toHaveCount(4);
+  await expect(page.getByTestId('model-option')).toHaveCount(5);
 
   await page.getByTestId('model-detail-button').nth(1).click();
   await expect(page.getByTestId('model-detail-button').nth(1)).toHaveAttribute('aria-expanded', 'true');
   await expect(page.getByTestId('model-capability')).toContainText('Synth is the balanced model');
   await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'tr/synth' })).toBeVisible();
+
+  await page.getByTestId('model-detail-button').nth(2).click();
+  await expect(page.getByTestId('model-detail-button').nth(2)).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.getByTestId('model-capability')).toContainText('Synth Code is the code-focused model');
+  await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'tr/synth-code' })).toBeVisible();
 
   await page.getByTestId('model-search').fill('default model');
   await expect(page.getByTestId('model-option')).toHaveCount(1);
@@ -1989,7 +1995,7 @@ test('mock harness searches and selects models from the composer', async ({ page
   await page.getByTestId('model-favorite-button').nth(1).click();
   await expect(page.getByTestId('model-browser')).toBeVisible();
   await expect(page.getByTestId('model-category').first()).toContainText('Favorites');
-  await expect(page.getByTestId('model-option')).toHaveCount(5);
+  await expect(page.getByTestId('model-option')).toHaveCount(6);
   await expect(page.getByTestId('model-favorite-button').first()).toHaveAttribute('aria-label', 'Remove favorite model');
 
   await page.getByTestId('model-search').fill('favorite');

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Agent PRs should merge through the repo merge train instead of racing direct pus
 
 The CLI and desktop shell use a deterministic mock LLM by default so tests and local demos do not require a TrustedRouter account. The desktop shell switches to live TrustedRouter automatically when `QUILLCODE_API_KEY` or `TRUSTEDROUTER_API_KEY` is present, or when an API key is stored in the QuillCode secret store. With a key, the desktop shell also refreshes the TrustedRouter model catalog and groups provider/category/model choices in the top bar. The desktop Settings sheet can save, replace, or clear the local developer key and API base URL. Set `QUILLCODE_USE_MOCK_LLM=true` to force deterministic mock mode.
 
-The default user-facing model is Nike 1.0 (`trustedrouter/fast`). Synth (`tr/synth`, `/synth`) is the next Recommended option for deeper coding and review turns, with Synth Code available as `tr/synth-code` or `/synth-code`. Legacy `trustedrouter/fusion`, `tr/fusion`, `/fusion`, `fusion-code`, and `/fusion-code` IDs remain valid aliases; new configs, slash commands, and picker surfaces prefer Synth naming.
+The default user-facing model is Nike 1.0 (`trustedrouter/fast`). Synth (`tr/synth`, `/synth`) is the next Recommended option for deeper coding and review turns, followed by Synth Code (`tr/synth-code`, `/synth-code`) for code-focused work. Legacy `trustedrouter/fusion`, `tr/fusion`, `/fusion`, `fusion-code`, and `/fusion-code` IDs remain valid aliases; new configs, slash commands, and picker surfaces prefer Synth naming.
 
 To exercise the live TrustedRouter adapter:
 

--- a/Sources/QuillCodeCore/TrustedRouterDefaults.swift
+++ b/Sources/QuillCodeCore/TrustedRouterDefaults.swift
@@ -20,7 +20,7 @@ public enum TrustedRouterDefaults {
     public static let synthSlashAlias = "/synth"
     public static let synthCodeSlashAlias = "/synth-code"
     public static let trustedRouterProviderAliases: [String: String] = ["tr": trustedRouterProvider]
-    public static let recommendedModelIDs = [fastModel, synthModel]
+    public static let recommendedModelIDs = [fastModel, synthModel, synthCodeModel]
     public static let modelIDAliases: [String: String] = [
         "tr/fast": fastModel,
         "tr/synth": synthModel,
@@ -47,6 +47,7 @@ public enum TrustedRouterDefaults {
     public static let bundledModelCatalog: [ModelInfo] = [
         .init(id: fastModel, provider: trustedRouterProvider, displayName: fastModelDisplayName, category: recommendedCategory),
         .init(id: synthModel, provider: trustedRouterProvider, displayName: synthModelDisplayName, category: recommendedCategory),
+        .init(id: synthCodeModel, provider: trustedRouterProvider, displayName: synthCodeModelDisplayName, category: recommendedCategory),
         .init(id: safetyPrimaryCatalogModel, provider: "z-ai", displayName: "GLM 5.2", category: safetyCategory),
         .init(id: safetyFallbackCatalogModel, provider: "moonshotai", displayName: "Kimi K2.6", category: safetyCategory)
     ]

--- a/Tests/QuillCodeAgentTests/TrustedRouterAdapterTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterAdapterTests.swift
@@ -461,9 +461,10 @@ final class TrustedRouterAdapterTests: XCTestCase {
     func testModelCatalogMapsProvidersAndCategories() {
         XCTAssertTrue(TrustedRouterModelCatalog.defaultModels.contains { $0.id == "trustedrouter/fast" })
         XCTAssertTrue(TrustedRouterModelCatalog.defaultModels.contains { $0.id == "tr/synth" })
+        XCTAssertTrue(TrustedRouterModelCatalog.defaultModels.contains { $0.id == "tr/synth-code" })
         XCTAssertTrue(TrustedRouterModelCatalog.defaultModels.contains { $0.id == "z-ai/glm-5.2" })
         XCTAssertTrue(TrustedRouterModelCatalog.defaultModels.contains { $0.id == "moonshotai/kimi-k2.6" })
-        XCTAssertEqual(TrustedRouterModelCatalog.defaultModels.prefix(2).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
+        XCTAssertEqual(TrustedRouterModelCatalog.defaultModels.prefix(3).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
         XCTAssertEqual(TrustedRouterModelCatalogClient.provider(from: "tr/synth"), "trustedrouter")
         XCTAssertEqual(TrustedRouterModelCatalogClient.provider(from: "/synth"), "trustedrouter")
         XCTAssertEqual(TrustedRouterModelCatalogClient.provider(from: "tr/fusion"), "trustedrouter")
@@ -481,7 +482,7 @@ final class TrustedRouterAdapterTests: XCTestCase {
             .init(id: "/synth", provider: "trustedrouter", displayName: "Synth Alias", category: "Recommended")
         ])
 
-        XCTAssertEqual(catalog.models.prefix(2).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
+        XCTAssertEqual(catalog.models.prefix(3).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
         XCTAssertEqual(Array(catalog.categories().prefix(3)), ["Recommended", "Safety", "Coding"])
         XCTAssertEqual(catalog.models.filter { $0.id == TrustedRouterDefaults.fastModel }.count, 1)
         XCTAssertEqual(catalog.models.filter { $0.id == TrustedRouterDefaults.synthModel }.count, 1)

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -31,9 +31,9 @@ final class WorkspaceSurfaceTests: XCTestCase {
         let recommendedModelIDs = surface.topBar.modelCategories
             .first { $0.category == "Recommended" }?
             .models
-            .prefix(2)
+            .prefix(3)
             .map(\.id) ?? []
-        XCTAssertEqual(recommendedModelIDs, [TrustedRouterDefaults.fastModel, TrustedRouterDefaults.synthModel])
+        XCTAssertEqual(recommendedModelIDs, TrustedRouterDefaults.recommendedModelIDs)
         let defaultOption = surface.topBar.modelCategories
             .flatMap(\.models)
             .first { $0.id == TrustedRouterDefaults.defaultModel }
@@ -852,7 +852,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertEqual(surface.topBar.modelLabel, "acme/Code Pro")
         XCTAssertEqual(surface.topBar.modelCategories.map(\.category), ["Recommended", "Safety", "Coding"])
         let recommended = surface.topBar.modelCategories.first { $0.category == "Recommended" }
-        XCTAssertEqual(recommended?.models.prefix(2).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
+        XCTAssertEqual(recommended?.models.prefix(3).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
         let coding = surface.topBar.modelCategories.first { $0.category == "Coding" }
         XCTAssertEqual(coding?.models.map(\.id), ["acme/code-pro", "acme/fast"])
         XCTAssertTrue(coding?.models.first?.isSelected == true)
@@ -873,7 +873,14 @@ final class WorkspaceSurfaceTests: XCTestCase {
 
         XCTAssertEqual(topBar.filteredModelCategories(matching: "coding").flatMap(\.models).map(\.id), ["acme/code-pro"])
         XCTAssertEqual(topBar.filteredModelCategories(matching: "moon k2").flatMap(\.models).map(\.id), ["moonshotai/kimi-k2.6"])
-        XCTAssertEqual(topBar.filteredModelCategories(matching: "synth").flatMap(\.models).map(\.id), [TrustedRouterDefaults.synthModel])
+        XCTAssertEqual(
+            topBar.filteredModelCategories(matching: "synth").flatMap(\.models).map(\.id),
+            [TrustedRouterDefaults.synthModel, TrustedRouterDefaults.synthCodeModel]
+        )
+        XCTAssertEqual(
+            topBar.filteredModelCategories(matching: "tr/synth-code").flatMap(\.models).map(\.id),
+            [TrustedRouterDefaults.synthCodeModel]
+        )
         XCTAssertEqual(topBar.filteredModelCategories(matching: "default model").flatMap(\.models).map(\.id), [TrustedRouterDefaults.synthModel])
         XCTAssertTrue(topBar.filteredModelCategories(matching: "does-not-exist").isEmpty)
     }

--- a/Tests/QuillCodeCoreTests/CoreModelTests.swift
+++ b/Tests/QuillCodeCoreTests/CoreModelTests.swift
@@ -12,7 +12,14 @@ final class CoreModelTests: XCTestCase {
         XCTAssertEqual(TrustedRouterDefaults.displayName(fromModelID: TrustedRouterDefaults.synthModel), "Synth")
         XCTAssertEqual(TrustedRouterDefaults.displayName(fromModelID: TrustedRouterDefaults.synthCodeModel), "Synth Code")
         XCTAssertEqual(TrustedRouterDefaults.defaultModel, TrustedRouterDefaults.fastModel)
-        XCTAssertEqual(TrustedRouterDefaults.recommendedModelIDs, [TrustedRouterDefaults.fastModel, TrustedRouterDefaults.synthModel])
+        XCTAssertEqual(
+            TrustedRouterDefaults.recommendedModelIDs,
+            [
+                TrustedRouterDefaults.fastModel,
+                TrustedRouterDefaults.synthModel,
+                TrustedRouterDefaults.synthCodeModel
+            ]
+        )
         XCTAssertEqual(TrustedRouterDefaults.canonicalProvider("tr"), TrustedRouterDefaults.trustedRouterProvider)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("tr/synth"), TrustedRouterDefaults.synthModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("Synth"), TrustedRouterDefaults.synthModel)
@@ -150,7 +157,7 @@ final class CoreModelTests: XCTestCase {
             .init(id: "tr/fast", provider: "tr", displayName: "Fast Alias", category: "Recommended")
         ])
 
-        XCTAssertEqual(catalog.prefix(2).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
+        XCTAssertEqual(catalog.prefix(3).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
         XCTAssertEqual(catalog.filter { $0.id == TrustedRouterDefaults.fastModel }.count, 1)
         XCTAssertEqual(catalog.filter { $0.id == TrustedRouterDefaults.synthModel }.count, 1)
         XCTAssertEqual(catalog.filter { $0.id == TrustedRouterDefaults.synthCodeModel }.count, 1)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -41,6 +41,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 ## Changes From This Pass
 
 - Kept `trustedrouter/fast` stable and moved the fallback model to preferred `tr/synth`/`/synth` while preserving `trustedrouter/fusion`, `tr/fusion`, `/fusion`, `fusion-code`, and `/fusion-code` legacy aliases. User-facing model surfaces brand the defaults as **Nike 1.0** and **Synth**.
+- Promoted Synth Code (`tr/synth-code`, `/synth-code`) into the bundled Recommended catalog so the preferred code model is visible offline instead of only working as a hidden alias.
 - Centralized the branded default names in `TrustedRouterDefaults`, with tests proving canonical IDs and display names separately.
 - Removed dead provider plumbing from model metadata summary generation.
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -20,7 +20,7 @@
 
 - Product and repository name: **QuillCode**.
 - License: Apache 2.0.
-- Default model: Nike 1.0 (`trustedrouter/fast`); Synth (`tr/synth`, `/synth`) is the next Recommended option and deterministic fallback, with Synth Code as `tr/synth-code`/`/synth-code`. Legacy `trustedrouter/fusion`, `tr/fusion`, `/fusion`, `fusion-code`, and `/fusion-code` inputs stay valid aliases, but new UI/config/slash-command surfaces prefer Synth naming.
+- Default model: Nike 1.0 (`trustedrouter/fast`); Synth (`tr/synth`, `/synth`) is the next Recommended option and deterministic fallback, with Synth Code (`tr/synth-code`, `/synth-code`) as the third bundled Recommended model for code-focused work. Legacy `trustedrouter/fusion`, `tr/fusion`, `/fusion`, `fusion-code`, and `/fusion-code` inputs stay valid aliases, but new UI/config/slash-command surfaces prefer Synth naming.
 - Auth: TrustedRouter OAuth first; hidden developer override for API key/base URL.
 - Tool modes: `Read-only`, `Review`, `Auto`; do not use the label `Full Access`.
 - Auto reviewer: primary `glm-5.2`, fallback `kimi-k2.6`.


### PR DESCRIPTION
## Summary
- Add Synth Code to the bundled Recommended TrustedRouter catalog after Nike 1.0 and Synth
- Keep legacy Fusion IDs as compatibility aliases while docs/UI/tests prefer `/synth` and `/synth-code` naming
- Update the mock E2E model picker to show Synth Code and cover Synth search behavior

## Validation
- `swift test --filter CoreModelTests/testTrustedRouterDefaults`
- `swift test --filter TrustedRouterAdapterTests/testModelCatalog`
- `swift test --filter WorkspaceSurfaceTests/testTopBarFiltersModelCatalogByProviderCategoryAndModel`
- `npm test -- --grep "searches and selects models|malformed model issue"`
- `swift test`
- `npm test`
- `git diff --check`