### PR TITLE
Extract navigation surface builder

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
@@ -1,0 +1,91 @@
+import Foundation
+import QuillCodeCore
+
+struct WorkspaceNavigationSurface: Sendable, Hashable {
+    var projects: ProjectListSurface
+    var sidebar: SidebarSurface
+}
+
+struct WorkspaceNavigationSurfaceBuilder {
+    var projects: [ProjectRef]
+    var selectedProjectID: UUID?
+    var sidebarItems: [SidebarItem]
+    var selectedThreadID: UUID?
+    var threads: [ChatThread]
+    var selectionIsActive: Bool
+    var selectedThreadIDs: Set<UUID>
+
+    func surface() -> WorkspaceNavigationSurface {
+        let resolvedSelectedThreadIDs = selectionIsActive ? selectedThreadIDs : []
+        return WorkspaceNavigationSurface(
+            projects: ProjectListSurface(
+                items: projectItems(),
+                selectedProjectID: selectedProjectID
+            ),
+            sidebar: SidebarSurface(
+                items: sidebarItems.map {
+                    SidebarItemSurface(
+                        item: $0,
+                        selectedThreadID: selectedThreadID,
+                        selectedThreadIDs: resolvedSelectedThreadIDs
+                    )
+                },
+                selectedThreadID: selectedThreadID,
+                isSelectionMode: selectionIsActive,
+                selectedThreadIDs: resolvedSelectedThreadIDs,
+                bulkActions: sidebarBulkActions(selectedThreadIDs: resolvedSelectedThreadIDs)
+            )
+        )
+    }
+
+    private func projectItems() -> [ProjectItemSurface] {
+        projects
+            .sorted { $0.lastOpenedAt > $1.lastOpenedAt }
+            .map { ProjectItemSurface(project: $0, selectedProjectID: selectedProjectID) }
+    }
+
+    private func sidebarBulkActions(selectedThreadIDs: Set<UUID>) -> [SidebarBulkActionSurface] {
+        guard selectionIsActive else {
+            return [
+                SidebarBulkActionSurface(
+                    kind: .select,
+                    isEnabled: !threads.isEmpty
+                )
+            ]
+        }
+
+        let selectedThreads = threads.filter { selectedThreadIDs.contains($0.id) }
+        let hasSelection = !selectedThreads.isEmpty
+        let hasPinnedSelection = selectedThreads.contains { $0.isPinned }
+        let hasUnarchivedSelection = selectedThreads.contains { !$0.isArchived }
+        let hasArchivedSelection = selectedThreads.contains { $0.isArchived }
+        return [
+            SidebarBulkActionSurface(kind: .clearSelection),
+            SidebarBulkActionSurface(
+                kind: .selectAll,
+                isEnabled: selectedThreadIDs.count < sidebarItems.count
+            ),
+            SidebarBulkActionSurface(
+                kind: .pin,
+                isEnabled: hasUnarchivedSelection
+            ),
+            SidebarBulkActionSurface(
+                kind: .unpin,
+                isEnabled: hasPinnedSelection
+            ),
+            SidebarBulkActionSurface(
+                kind: .archive,
+                isEnabled: hasUnarchivedSelection
+            ),
+            SidebarBulkActionSurface(
+                kind: .unarchive,
+                isEnabled: hasArchivedSelection
+            ),
+            SidebarBulkActionSurface(
+                kind: .delete,
+                isEnabled: hasSelection,
+                isDestructive: true
+            )
+        ]
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -83,6 +83,15 @@ public extension QuillCodeWorkspaceModel {
         let sidebarSelectedThreadIDs = sidebarSelection.isActive
             ? Set(selectedSidebarThreadIDs())
             : []
+        let navigation = WorkspaceNavigationSurfaceBuilder(
+            projects: root.projects,
+            selectedProjectID: root.selectedProjectID,
+            sidebarItems: root.allSidebarItems,
+            selectedThreadID: root.selectedThreadID,
+            threads: root.threads,
+            selectionIsActive: sidebarSelection.isActive,
+            selectedThreadIDs: sidebarSelectedThreadIDs
+        ).surface()
         let modelCatalog = modelCatalogBuilder(selectedModelID: topBarState.model)
         return WorkspaceSurface(
             topBar: TopBarSurface(
@@ -106,23 +115,8 @@ public extension QuillCodeWorkspaceModel {
                 computerUseLabel: computerUse.message,
                 showsComputerUseSetup: !computerUse.available
             ),
-            projects: ProjectListSurface(
-                items: projectItems(),
-                selectedProjectID: root.selectedProjectID
-            ),
-            sidebar: SidebarSurface(
-                items: root.allSidebarItems.map {
-                    SidebarItemSurface(
-                        item: $0,
-                        selectedThreadID: root.selectedThreadID,
-                        selectedThreadIDs: sidebarSelectedThreadIDs
-                    )
-                },
-                selectedThreadID: root.selectedThreadID,
-                isSelectionMode: sidebarSelection.isActive,
-                selectedThreadIDs: sidebarSelectedThreadIDs,
-                bulkActions: sidebarBulkActions(selectedThreadIDs: sidebarSelectedThreadIDs)
-            ),
+            projects: navigation.projects,
+            sidebar: navigation.sidebar,
             transcript: TranscriptSurface(
                 messages: thread.map { WorkspaceTranscriptSurfaceBuilder(thread: $0).messageSurfaces() } ?? [],
                 toolCards: toolCards,
@@ -194,57 +188,6 @@ public extension QuillCodeWorkspaceModel {
             agentStatus: root.topBar.agentStatus,
             lastError: lastError
         ).surface()
-    }
-
-    private func sidebarBulkActions(selectedThreadIDs: Set<UUID>) -> [SidebarBulkActionSurface] {
-        let selectedThreads = root.threads.filter { selectedThreadIDs.contains($0.id) }
-        let hasSelection = !selectedThreads.isEmpty
-        guard sidebarSelection.isActive else {
-            return [
-                SidebarBulkActionSurface(
-                    kind: .select,
-                    isEnabled: !root.threads.isEmpty
-                )
-            ]
-        }
-
-        let hasPinnedSelection = selectedThreads.contains { $0.isPinned }
-        let hasUnarchivedSelection = selectedThreads.contains { !$0.isArchived }
-        let hasArchivedSelection = selectedThreads.contains { $0.isArchived }
-        return [
-            SidebarBulkActionSurface(kind: .clearSelection),
-            SidebarBulkActionSurface(
-                kind: .selectAll,
-                isEnabled: selectedThreadIDs.count < root.allSidebarItems.count
-            ),
-            SidebarBulkActionSurface(
-                kind: .pin,
-                isEnabled: hasUnarchivedSelection
-            ),
-            SidebarBulkActionSurface(
-                kind: .unpin,
-                isEnabled: hasPinnedSelection
-            ),
-            SidebarBulkActionSurface(
-                kind: .archive,
-                isEnabled: hasUnarchivedSelection
-            ),
-            SidebarBulkActionSurface(
-                kind: .unarchive,
-                isEnabled: hasArchivedSelection
-            ),
-            SidebarBulkActionSurface(
-                kind: .delete,
-                isEnabled: hasSelection,
-                isDestructive: true
-            )
-        ]
-    }
-
-    private func projectItems() -> [ProjectItemSurface] {
-        root.projects
-            .sorted { $0.lastOpenedAt > $1.lastOpenedAt }
-            .map { ProjectItemSurface(project: $0, selectedProjectID: root.selectedProjectID) }
     }
 
     private func modelCatalogBuilder(selectedModelID: String) -> WorkspaceModelCatalogSurfaceBuilder {

--- a/Tests/QuillCodeAppTests/WorkspaceNavigationSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceNavigationSurfaceBuilderTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceNavigationSurfaceBuilderTests: XCTestCase {
+    func testBuildsSortedProjectsAndSidebarRows() throws {
+        let olderProject = ProjectRef(
+            name: "Older",
+            path: "/tmp/older",
+            lastOpenedAt: Date(timeIntervalSince1970: 10)
+        )
+        let newerProject = ProjectRef(
+            name: "Newer",
+            path: "/tmp/newer",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+        let selectedThread = ChatThread(title: "Selected")
+        let otherThread = ChatThread(title: "Other")
+
+        let surface = WorkspaceNavigationSurfaceBuilder(
+            projects: [olderProject, newerProject],
+            selectedProjectID: olderProject.id,
+            sidebarItems: [SidebarItem(thread: selectedThread), SidebarItem(thread: otherThread)],
+            selectedThreadID: selectedThread.id,
+            threads: [selectedThread, otherThread],
+            selectionIsActive: false,
+            selectedThreadIDs: []
+        ).surface()
+
+        XCTAssertEqual(surface.projects.items.map(\.name), ["Newer", "Older"])
+        XCTAssertEqual(surface.projects.selectedProjectID, olderProject.id)
+        XCTAssertEqual(surface.projects.items.map(\.isSelected), [false, true])
+        XCTAssertEqual(surface.sidebar.items.map(\.title), ["Selected", "Other"])
+        XCTAssertEqual(surface.sidebar.items.map(\.isSelected), [true, false])
+        XCTAssertEqual(surface.sidebar.bulkActions.map(\.kind), [.select])
+        XCTAssertEqual(surface.sidebar.bulkActions.first?.isEnabled, true)
+    }
+
+    func testInactiveSelectionIgnoresSelectedThreadIDs() throws {
+        let thread = ChatThread(title: "Thread")
+
+        let surface = WorkspaceNavigationSurfaceBuilder(
+            projects: [],
+            selectedProjectID: nil,
+            sidebarItems: [SidebarItem(thread: thread)],
+            selectedThreadID: thread.id,
+            threads: [thread],
+            selectionIsActive: false,
+            selectedThreadIDs: [thread.id]
+        ).surface()
+
+        XCTAssertFalse(surface.sidebar.isSelectionMode)
+        XCTAssertEqual(surface.sidebar.selectedThreadIDs, [])
+        XCTAssertEqual(surface.sidebar.selectionLabel, "No chats selected")
+        XCTAssertFalse(try XCTUnwrap(surface.sidebar.items.first).isBulkSelected)
+        XCTAssertEqual(surface.sidebar.bulkActions.map(\.kind), [.select])
+    }
+
+    func testActiveSelectionBuildsBulkActionAvailability() throws {
+        let active = ChatThread(title: "Active")
+        var pinned = ChatThread(title: "Pinned")
+        pinned.isPinned = true
+        var archived = ChatThread(title: "Archived")
+        archived.isArchived = true
+        let threads = [active, pinned, archived]
+
+        let surface = WorkspaceNavigationSurfaceBuilder(
+            projects: [],
+            selectedProjectID: nil,
+            sidebarItems: threads.map { SidebarItem(thread: $0) },
+            selectedThreadID: active.id,
+            threads: threads,
+            selectionIsActive: true,
+            selectedThreadIDs: [active.id, pinned.id, archived.id]
+        ).surface()
+
+        XCTAssertTrue(surface.sidebar.isSelectionMode)
+        XCTAssertEqual(surface.sidebar.selectedThreadIDs, Set([active.id, pinned.id, archived.id]))
+        XCTAssertEqual(surface.sidebar.selectionLabel, "3 chats selected")
+        XCTAssertEqual(surface.sidebar.items.map(\.isBulkSelected), [true, true, true])
+        XCTAssertEqual(
+            surface.sidebar.bulkActions.map(\.kind),
+            [.clearSelection, .selectAll, .pin, .unpin, .archive, .unarchive, .delete]
+        )
+        XCTAssertEqual(surface.sidebar.bulkActions.first { $0.kind == .selectAll }?.isEnabled, false)
+        XCTAssertEqual(surface.sidebar.bulkActions.first { $0.kind == .pin }?.isEnabled, true)
+        XCTAssertEqual(surface.sidebar.bulkActions.first { $0.kind == .unpin }?.isEnabled, true)
+        XCTAssertEqual(surface.sidebar.bulkActions.first { $0.kind == .archive }?.isEnabled, true)
+        XCTAssertEqual(surface.sidebar.bulkActions.first { $0.kind == .unarchive }?.isEnabled, true)
+        XCTAssertEqual(surface.sidebar.bulkActions.first { $0.kind == .delete }?.isEnabled, true)
+        XCTAssertEqual(surface.sidebar.bulkActions.first { $0.kind == .delete }?.isDestructive, true)
+    }
+
+    func testSelectActionDisablesWhenThereAreNoThreads() {
+        let surface = WorkspaceNavigationSurfaceBuilder(
+            projects: [],
+            selectedProjectID: nil,
+            sidebarItems: [],
+            selectedThreadID: nil,
+            threads: [],
+            selectionIsActive: false,
+            selectedThreadIDs: []
+        ).surface()
+
+        XCTAssertEqual(surface.sidebar.bulkActions.map(\.kind), [.select])
+        XCTAssertEqual(surface.sidebar.bulkActions.first?.isEnabled, false)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1625,6 +1625,21 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(surfaceText.contains("selectionLabel(count:"), "WorkspaceSurface should not own sidebar selection copy.")
     }
 
+    func testWorkspaceSurfaceDelegatesNavigationSurfaceBuilding() throws {
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+        let builderText = try Self.appSourceText(named: "WorkspaceNavigationSurfaceBuilder.swift")
+
+        XCTAssertTrue(surfaceText.contains("WorkspaceNavigationSurfaceBuilder("), "WorkspaceSurface should delegate navigation surface assembly.")
+        XCTAssertTrue(builderText.contains("struct WorkspaceNavigationSurfaceBuilder"), "Navigation surface assembly should live in a focused builder.")
+        XCTAssertTrue(builderText.contains("ProjectListSurface("), "Project list construction should live in the navigation builder.")
+        XCTAssertTrue(builderText.contains("SidebarSurface("), "Sidebar construction should live in the navigation builder.")
+        XCTAssertTrue(builderText.contains("SidebarBulkActionSurface"), "Sidebar bulk-action projection should live in the navigation builder.")
+        XCTAssertFalse(surfaceText.contains("private func sidebarBulkActions"), "WorkspaceSurface should not own sidebar bulk-action projection.")
+        XCTAssertFalse(surfaceText.contains("private func projectItems"), "WorkspaceSurface should not own project row projection.")
+        XCTAssertFalse(surfaceText.contains("ProjectListSurface("), "WorkspaceSurface should not construct project lists directly.")
+        XCTAssertFalse(surfaceText.contains("SidebarSurface("), "WorkspaceSurface should not construct sidebars directly.")
+    }
+
     func testWorkspaceSurfaceDelegatesCommandSurfaceBuilding() throws {
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceCommandSurfaceBuilder.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -16,7 +16,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `QuillCodeSafety` | A- | Small, explicit policy layer. Needs more production prompt telemetry once live Auto reviewer tuning begins. |
 | `QuillCodePersistence` | A | Focused stores, compatibility tests, and clear path ownership. |
 | `QuillComputerUseKit` | B+ | Protocol shape is good and macOS adapter is isolated. Linux adapter, app approvals, and visual feedback loops are still parity gaps. |
-| `QuillCodeApp` surface contracts | A- | Strong shared surface model and broad tests. Settings, runtime issue, model catalog, top-bar/model contracts, sidebar/project contracts, command, command palette, review, review-comment planning, tool override composition, remote-project tool execution, context banner, transcript projection, execution-context enrichment, browser location/state transitions, MCP launch/session creation, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now have focused builders; the main remaining risk is `WorkspaceModel`, `WorkspaceSurface`, and `WorkspaceSwiftUIView` continuing to absorb too many responsibilities. |
+| `QuillCodeApp` surface contracts | A- | Strong shared surface model and broad tests. Settings, runtime issue, model catalog, top-bar/model contracts, navigation assembly, sidebar/project contracts, command, command palette, review, review-comment planning, tool override composition, remote-project tool execution, context banner, transcript projection, execution-context enrichment, browser location/state transitions, MCP launch/session creation, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now have focused builders; the main remaining risk is `WorkspaceModel`, `WorkspaceSurface`, and `WorkspaceSwiftUIView` continuing to absorb too many responsibilities. |
 | Playwright harness | B+ | Valuable parity harness with broad coverage. It intentionally duplicates rendering behavior, so keep it thin and derived from stable surface concepts. |
 
 ## File Hotspots
@@ -26,7 +26,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
 | `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A- | The shell is now mostly chrome composition, state, and routing. Transcript layout and workspace sheet presentation live in focused files; keep future modal families and command workflow rules out of the root shell. |
 | `Sources/QuillCodeApp/QuillCodeToolCardView.swift` | A- | Native tool-card composition is now separate from reusable controls, artifact previews, and raw detail blocks. Keep future status/action chrome in `QuillCodeToolCardControls.swift` and artifact rendering in `QuillCodeToolArtifactViews.swift`. |
-| `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, model catalog presentation, top-bar/model presentation contracts, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
+| `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
 | `Sources/QuillCodeApp/WorkspaceHTMLRenderer.swift` | A- | Static HTML harness rendering is still broad, but top-bar HTML delegates to `WorkspaceHTMLTopBarRenderer`, sidebar HTML delegates to `WorkspaceHTMLSidebarRenderer`, tool-card/artifact preview HTML delegates to `WorkspaceHTMLToolCardRenderer`, review pane HTML delegates to `WorkspaceHTMLReviewRenderer`, secondary pane HTML delegates to `WorkspaceHTMLSecondaryPaneRenderer`, browser pane HTML delegates to `WorkspaceHTMLBrowserRenderer`, terminal pane HTML delegates to `WorkspaceHTMLTerminalRenderer`, and shared escaping/context chips live in `WorkspaceHTMLPrimitives`. Next step is extracting another transcript/composer family only when renderer drift appears. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
 | `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback and project-import resolution now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
@@ -48,6 +48,24 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
+
+## 2026-06-24 Navigation Surface Builder Pass
+
+Overall grade after this slice: **A navigation boundary, A behavior preservation, A regression guard**.
+
+`WorkspaceSurface` still owned project sorting, project row projection, sidebar row construction, and sidebar bulk-action availability. Those rules are presentation policy rather than aggregate workspace assembly, and they were easy to accidentally change while editing unrelated transcript, settings, or command surface code.
+
+Code quality changes:
+
+- Added `WorkspaceNavigationSurfaceBuilder` for `ProjectListSurface` and `SidebarSurface` assembly.
+- Moved project row sorting, sidebar row construction, inactive selection handling, and bulk-action availability into the focused builder.
+- Simplified `WorkspaceSurface.surface()` to resolve selected sidebar IDs once and delegate navigation presentation to the builder.
+- Added focused tests for project ordering, active/inactive selection projection, destructive delete marking, and empty-sidebar select availability.
+- Added a parity gate keeping direct project/sidebar construction out of `WorkspaceSurface`.
+
+Remaining risk:
+
+- `WorkspaceSurface.surface()` still coordinates many independent surface builders. If aggregate assembly grows again, introduce a higher-level `WorkspaceSurfaceBuilder` context object instead of passing more raw model state through the extension.
 
 ## 2026-06-24 Approval Action Planner Pass
 


### PR DESCRIPTION
## Summary
- Add `WorkspaceNavigationSurfaceBuilder` for project list and sidebar assembly.
- Move project ordering, sidebar row construction, inactive selection handling, and bulk-action availability out of `WorkspaceSurface`.
- Add focused builder coverage and a parity gate to keep direct navigation construction out of the aggregate surface.

## Validation
- `swift test --filter WorkspaceNavigationSurfaceBuilderTests`
- `swift test --filter ParityGateTests/testWorkspaceSurfaceDelegatesNavigationSurfaceBuilding`
- `swift test --filter WorkspaceSurfaceTests`
- `swift test` (879 tests)
- `git diff --check`