### PR TITLE
Extract top-bar surface builder

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -92,29 +92,20 @@ public extension QuillCodeWorkspaceModel {
             selectionIsActive: sidebarSelection.isActive,
             selectedThreadIDs: sidebarSelectedThreadIDs
         ).surface()
-        let modelCatalog = modelCatalogBuilder(selectedModelID: topBarState.model)
+        let topBar = WorkspaceTopBarSurfaceBuilder(
+            topBarState: topBarState,
+            thread: thread,
+            projectName: root.topBar.projectName,
+            instructions: activeInstructions,
+            memories: activeMemories,
+            modelCatalog: root.modelCatalog,
+            defaultModelID: root.config.defaultModel,
+            favoriteModelIDs: root.config.favoriteModels,
+            recentThreads: root.threads,
+            runtimeIssue: runtimeIssue
+        ).surface()
         return WorkspaceSurface(
-            topBar: TopBarSurface(
-                appName: topBarState.appName,
-                primaryTitle: thread?.title ?? "QuillCode",
-                subtitle: WorkspaceStatusTextBuilder.topBarSubtitle(
-                    projectName: root.topBar.projectName ?? "No project",
-                    thread: thread
-                ),
-                instructionLabel: WorkspaceStatusTextBuilder.instructionLabel(for: activeInstructions),
-                instructionSources: activeInstructions.map(\.path),
-                memoryLabel: WorkspaceStatusTextBuilder.memoryLabel(for: activeMemories),
-                memorySources: activeMemories.map(\.relativePath),
-                modelLabel: modelCatalog.modelLabel(),
-                selectedModelID: topBarState.model,
-                modelCategories: modelCatalog.categories(),
-                modeLabel: WorkspaceStatusTextBuilder.modeLabel(topBarState.mode),
-                agentStatus: topBarState.agentStatus,
-                runtimeIssueLabel: runtimeIssue?.title,
-                runtimeIssueSeverity: runtimeIssue?.severity,
-                computerUseLabel: computerUse.message,
-                showsComputerUseSetup: !computerUse.available
-            ),
+            topBar: topBar,
             projects: navigation.projects,
             sidebar: navigation.sidebar,
             transcript: TranscriptSurface(
@@ -188,20 +179,6 @@ public extension QuillCodeWorkspaceModel {
             agentStatus: root.topBar.agentStatus,
             lastError: lastError
         ).surface()
-    }
-
-    private func modelCatalogBuilder(selectedModelID: String) -> WorkspaceModelCatalogSurfaceBuilder {
-        let recentModelIDs = root.threads
-            .filter { !$0.isArchived }
-            .sorted { $0.updatedAt > $1.updatedAt }
-            .map(\.model)
-        return WorkspaceModelCatalogSurfaceBuilder(
-            catalog: root.modelCatalog,
-            selectedModelID: selectedModelID,
-            defaultModelID: root.config.defaultModel,
-            favoriteModelIDs: root.config.favoriteModels,
-            recentModelIDs: recentModelIDs
-        )
     }
 
     private func commandSurfaceBuilder() -> WorkspaceCommandSurfaceBuilder {

--- a/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
@@ -1,0 +1,57 @@
+import Foundation
+import QuillCodeCore
+
+struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
+    var topBarState: TopBarState
+    var thread: ChatThread?
+    var projectName: String?
+    var instructions: [ProjectInstruction]
+    var memories: [MemoryNote]
+    var modelCatalog: [ModelInfo]
+    var defaultModelID: String
+    var favoriteModelIDs: [String]
+    var recentThreads: [ChatThread]
+    var runtimeIssue: RuntimeIssueSurface?
+
+    func surface() -> TopBarSurface {
+        let modelCatalog = modelCatalogBuilder()
+        return TopBarSurface(
+            appName: topBarState.appName,
+            primaryTitle: thread?.title ?? "QuillCode",
+            subtitle: WorkspaceStatusTextBuilder.topBarSubtitle(
+                projectName: projectName ?? "No project",
+                thread: thread
+            ),
+            instructionLabel: WorkspaceStatusTextBuilder.instructionLabel(for: instructions),
+            instructionSources: instructions.map(\.path),
+            memoryLabel: WorkspaceStatusTextBuilder.memoryLabel(for: memories),
+            memorySources: memories.map(\.relativePath),
+            modelLabel: modelCatalog.modelLabel(),
+            selectedModelID: topBarState.model,
+            modelCategories: modelCatalog.categories(),
+            modeLabel: WorkspaceStatusTextBuilder.modeLabel(topBarState.mode),
+            agentStatus: topBarState.agentStatus,
+            runtimeIssueLabel: runtimeIssue?.title,
+            runtimeIssueSeverity: runtimeIssue?.severity,
+            computerUseLabel: topBarState.computerUseStatus.message,
+            showsComputerUseSetup: !topBarState.computerUseStatus.available
+        )
+    }
+
+    private func modelCatalogBuilder() -> WorkspaceModelCatalogSurfaceBuilder {
+        WorkspaceModelCatalogSurfaceBuilder(
+            catalog: modelCatalog,
+            selectedModelID: topBarState.model,
+            defaultModelID: defaultModelID,
+            favoriteModelIDs: favoriteModelIDs,
+            recentModelIDs: recentModelIDs()
+        )
+    }
+
+    private func recentModelIDs() -> [String] {
+        recentThreads
+            .filter { !$0.isArchived }
+            .sorted { $0.updatedAt > $1.updatedAt }
+            .map(\.model)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+import QuillCodeCore
+import QuillComputerUseKit
+@testable import QuillCodeApp
+
+final class WorkspaceTopBarSurfaceBuilderTests: XCTestCase {
+    func testBuildsThreadTopBarWithSourcesRuntimeIssueAndComputerUseState() {
+        let thread = ChatThread(title: "Ship QuillCode", model: TrustedRouterDefaults.synthModel)
+        let instructions = [
+            ProjectInstruction(
+                path: "AGENTS.md",
+                title: "AGENTS.md",
+                content: "Use Swift idioms.",
+                byteCount: 17
+            )
+        ]
+        let memories = [
+            MemoryNote(
+                id: "global",
+                scope: .global,
+                title: "Preference",
+                content: "Prefer small PRs.",
+                relativePath: "memories/preference.md",
+                byteCount: 17
+            )
+        ]
+        let runtimeIssue = RuntimeIssueSurface(
+            severity: .warning,
+            title: "Rate limited",
+            message: "TrustedRouter is retrying."
+        )
+
+        let topBar = WorkspaceTopBarSurfaceBuilder(
+            topBarState: TopBarState(
+                appName: "QuillCode",
+                projectName: "QuillCode",
+                model: TrustedRouterDefaults.synthModel,
+                mode: .review,
+                agentStatus: TopBarAgentStatusLabel.streaming,
+                computerUseStatus: .permissionStatus(
+                    screenRecordingGranted: true,
+                    accessibilityGranted: false
+                )
+            ),
+            thread: thread,
+            projectName: "QuillCode",
+            instructions: instructions,
+            memories: memories,
+            modelCatalog: TrustedRouterDefaults.normalizedModelCatalog([]),
+            defaultModelID: TrustedRouterDefaults.defaultModel,
+            favoriteModelIDs: [],
+            recentThreads: [thread],
+            runtimeIssue: runtimeIssue
+        ).surface()
+
+        XCTAssertEqual(topBar.appName, "QuillCode")
+        XCTAssertEqual(topBar.primaryTitle, "Ship QuillCode")
+        XCTAssertEqual(topBar.subtitle, "QuillCode - Auto - \(TrustedRouterDefaults.synthModel)")
+        XCTAssertEqual(topBar.instructionLabel, "1 instruction file loaded")
+        XCTAssertEqual(topBar.instructionSources, ["AGENTS.md"])
+        XCTAssertEqual(topBar.memoryLabel, "1 memory")
+        XCTAssertEqual(topBar.memorySources, ["memories/preference.md"])
+        XCTAssertEqual(topBar.modelLabel, TrustedRouterDefaults.synthModelDisplayName)
+        XCTAssertEqual(topBar.selectedModelID, TrustedRouterDefaults.synthModel)
+        XCTAssertEqual(topBar.modeLabel, "Review")
+        XCTAssertEqual(topBar.agentStatus, TopBarAgentStatusLabel.streaming)
+        XCTAssertEqual(topBar.runtimeIssueLabel, "Rate limited")
+        XCTAssertEqual(topBar.runtimeIssueSeverity, .warning)
+        XCTAssertEqual(topBar.computerUseLabel, "Needs Accessibility")
+        XCTAssertTrue(topBar.showsComputerUseSetup)
+    }
+
+    func testBuildsFallbackTitleAndNoProjectSubtitle() {
+        let topBar = WorkspaceTopBarSurfaceBuilder(
+            topBarState: TopBarState(),
+            thread: nil,
+            projectName: nil,
+            instructions: [],
+            memories: [],
+            modelCatalog: TrustedRouterDefaults.normalizedModelCatalog([]),
+            defaultModelID: TrustedRouterDefaults.defaultModel,
+            favoriteModelIDs: [],
+            recentThreads: [],
+            runtimeIssue: nil
+        ).surface()
+
+        XCTAssertEqual(topBar.primaryTitle, "QuillCode")
+        XCTAssertEqual(topBar.subtitle, "No project - Not started")
+        XCTAssertEqual(topBar.instructionLabel, "No project instructions")
+        XCTAssertEqual(topBar.memoryLabel, "No memories")
+        XCTAssertEqual(topBar.computerUseLabel, "Needs Screen Recording + Accessibility")
+        XCTAssertTrue(topBar.showsComputerUseSetup)
+    }
+
+    func testBuildsModelCatalogWithFavoritesAndUnarchivedRecents() throws {
+        let favoriteModelID = TrustedRouterDefaults.synthModel
+        let recentModelID = "moonshotai/kimi-k2.6"
+        let archivedRecent = ChatThread(
+            title: "Archived",
+            model: "anthropic/claude-sonnet-4",
+            isArchived: true,
+            updatedAt: Date(timeIntervalSince1970: 30)
+        )
+        let recent = ChatThread(
+            title: "Recent",
+            model: recentModelID,
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+        let older = ChatThread(
+            title: "Older",
+            model: favoriteModelID,
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+
+        let topBar = WorkspaceTopBarSurfaceBuilder(
+            topBarState: TopBarState(
+                model: favoriteModelID,
+                computerUseStatus: .permissionStatus(
+                    screenRecordingGranted: true,
+                    accessibilityGranted: true
+                )
+            ),
+            thread: older,
+            projectName: "QuillCode",
+            instructions: [],
+            memories: [],
+            modelCatalog: TrustedRouterDefaults.normalizedModelCatalog([
+                ModelInfo(
+                    id: recentModelID,
+                    provider: "moonshotai",
+                    displayName: "Kimi K2.6",
+                    category: "Safety"
+                )
+            ]),
+            defaultModelID: TrustedRouterDefaults.defaultModel,
+            favoriteModelIDs: [favoriteModelID],
+            recentThreads: [older, recent, archivedRecent],
+            runtimeIssue: nil
+        ).surface()
+
+        XCTAssertEqual(topBar.computerUseLabel, "Computer Use ready")
+        XCTAssertFalse(topBar.showsComputerUseSetup)
+        XCTAssertEqual(topBar.modelCategories.prefix(2).map(\.category), ["Favorites", "Recent"])
+        XCTAssertEqual(try XCTUnwrap(topBar.modelCategories.first { $0.category == "Favorites" }).models.map(\.id), [favoriteModelID])
+        XCTAssertEqual(try XCTUnwrap(topBar.modelCategories.first { $0.category == "Recent" }).models.map(\.id), [recentModelID])
+        XCTAssertFalse(topBar.modelCategories.flatMap(\.models).contains { $0.id == archivedRecent.model && $0.badges.contains("Recent") })
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -356,6 +356,7 @@ final class ParityGateTests: XCTestCase {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceStatusTextBuilder.swift")
+        let topBarBuilderText = try Self.appSourceText(named: "WorkspaceTopBarSurfaceBuilder.swift")
         let slashTranscriptText = try Self.appSourceText(named: "WorkspaceSlashCommandTranscriptPlanner.swift")
 
         XCTAssertTrue(builderText.contains("struct WorkspaceStatusTextBuilder"), "Workspace status text and labels should live in a focused builder.")
@@ -366,9 +367,12 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(builderText.contains("static func modeLabel"), "Mode labels should be shared by status and UI surfaces.")
         XCTAssertTrue(modelText.contains("WorkspaceStatusTextBuilder.statusText"), "WorkspaceModel should delegate /status copy.")
         XCTAssertTrue(slashTranscriptText.contains("WorkspaceStatusTextBuilder.modeLabel"), "Slash mode transcript copy should delegate shared mode labels.")
-        XCTAssertTrue(surfaceText.contains("WorkspaceStatusTextBuilder.topBarSubtitle"), "WorkspaceSurface should delegate top-bar subtitles.")
-        XCTAssertTrue(surfaceText.contains("WorkspaceStatusTextBuilder.instructionLabel"), "WorkspaceSurface should delegate instruction labels.")
-        XCTAssertTrue(surfaceText.contains("WorkspaceStatusTextBuilder.memoryLabel"), "WorkspaceSurface should delegate memory labels.")
+        XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.topBarSubtitle"), "Top-bar builder should delegate top-bar subtitles.")
+        XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.instructionLabel"), "Top-bar builder should delegate instruction labels.")
+        XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.memoryLabel"), "Top-bar builder should delegate memory labels.")
+        XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.topBarSubtitle"), "WorkspaceSurface should not own top-bar subtitles.")
+        XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.instructionLabel"), "WorkspaceSurface should not own instruction labels.")
+        XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.memoryLabel"), "WorkspaceSurface should not own memory labels.")
         XCTAssertFalse(modelText.contains("No project instructions"), "WorkspaceModel should not own instruction status copy.")
         XCTAssertFalse(modelText.contains("No memories"), "WorkspaceModel should not own memory status copy.")
         XCTAssertFalse(modelText.contains("static func instructionStatusLabel"), "WorkspaceModel should not own instruction status labels.")
@@ -1567,12 +1571,14 @@ final class ParityGateTests: XCTestCase {
     func testWorkspaceSurfaceDelegatesModelCatalogBuilding() throws {
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceModelCatalogSurfaceBuilder.swift")
+        let topBarBuilderText = try Self.appSourceText(named: "WorkspaceTopBarSurfaceBuilder.swift")
 
         XCTAssertTrue(builderText.contains("struct WorkspaceModelCatalogSurfaceBuilder"), "Model picker category construction should live in a focused builder.")
         XCTAssertTrue(builderText.contains("func modelLabel()"), "Model picker label formatting should be directly testable.")
         XCTAssertTrue(builderText.contains("func categories()"), "Model picker category construction should be directly testable.")
         XCTAssertTrue(builderText.contains("normalizedUniqueModelIDs"), "Model picker builder should normalize favorites and recents defensively.")
-        XCTAssertTrue(surfaceText.contains("WorkspaceModelCatalogSurfaceBuilder("), "WorkspaceSurface should delegate model catalog presentation construction.")
+        XCTAssertTrue(topBarBuilderText.contains("WorkspaceModelCatalogSurfaceBuilder("), "Top-bar builder should delegate model catalog presentation construction.")
+        XCTAssertFalse(surfaceText.contains("WorkspaceModelCatalogSurfaceBuilder("), "WorkspaceSurface should not construct model catalog presentation directly.")
         XCTAssertFalse(surfaceText.contains("func modelCategories(selectedModelID:"), "WorkspaceSurface should not own model category construction.")
         XCTAssertFalse(surfaceText.contains("func modelOption("), "WorkspaceSurface should not own model option badge construction.")
         XCTAssertFalse(surfaceText.contains("func favoriteModelIDs()"), "WorkspaceSurface should not own model favorite normalization.")
@@ -1593,6 +1599,18 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(surfaceText.contains("public struct ModelMetadataRowSurface"), "WorkspaceSurface should not own model metadata rows.")
         XCTAssertFalse(surfaceText.contains("public struct ModelOptionSurface"), "WorkspaceSurface should not own model option records.")
         XCTAssertFalse(surfaceText.contains("filteredModelCategories"), "WorkspaceSurface should not own model picker filtering.")
+    }
+
+    func testWorkspaceSurfaceDelegatesTopBarSurfaceBuilding() throws {
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+        let builderText = try Self.appSourceText(named: "WorkspaceTopBarSurfaceBuilder.swift")
+
+        XCTAssertTrue(surfaceText.contains("WorkspaceTopBarSurfaceBuilder("), "WorkspaceSurface should delegate top-bar surface assembly.")
+        XCTAssertTrue(builderText.contains("struct WorkspaceTopBarSurfaceBuilder"), "Top-bar surface assembly should live in a focused builder.")
+        XCTAssertTrue(builderText.contains("func surface() -> TopBarSurface"), "Top-bar surface assembly should be directly testable.")
+        XCTAssertTrue(builderText.contains("recentModelIDs()"), "Recent model projection should live with top-bar model presentation.")
+        XCTAssertFalse(surfaceText.contains("TopBarSurface("), "WorkspaceSurface should not construct top-bar records directly.")
+        XCTAssertFalse(surfaceText.contains("private func modelCatalogBuilder"), "WorkspaceSurface should not own top-bar model catalog builder plumbing.")
     }
 
     func testWorkspaceSurfaceDelegatesSidebarSurfaceContracts() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -49,6 +49,24 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
 
+## 2026-06-24 Top-Bar Surface Builder Pass
+
+Overall grade after this slice: **A top-bar boundary, A behavior preservation, A regression guard**.
+
+`WorkspaceSurface` still assembled the whole top-bar payload inline, including status labels, source lists, runtime issue copy, Computer Use copy, model catalog projection, and recent-model projection. Those are top-bar presentation rules, not aggregate workspace assembly, and they made unrelated surface edits riskier than they needed to be.
+
+Code quality changes:
+
+- Added `WorkspaceTopBarSurfaceBuilder` for `TopBarSurface` assembly.
+- Moved top-bar title/subtitle labels, instruction and memory source lists, runtime issue status, Computer Use setup state, model catalog projection, and recent-model filtering into the focused builder.
+- Simplified `WorkspaceSurface.surface()` to compute shared workspace context once and delegate top-bar construction.
+- Added focused builder tests for thread-backed top bars, empty-project fallback state, model favorites, and unarchived recent-model projection.
+- Added parity gates keeping direct top-bar construction, status-label plumbing, and model-catalog builder ownership out of `WorkspaceSurface`.
+
+Remaining risk:
+
+- `WorkspaceSurface.surface()` still computes active instructions and memories for multiple panes. If those context inputs grow, extract a shared workspace context/source builder instead of pushing more raw state through the surface extension.
+
 ## 2026-06-24 Navigation Surface Builder Pass
 
 Overall grade after this slice: **A navigation boundary, A behavior preservation, A regression guard**.


### PR DESCRIPTION
## Summary
- add WorkspaceTopBarSurfaceBuilder for top-bar assembly
- move top-bar status labels, source lists, runtime issue, Computer Use, and model catalog projection out of WorkspaceSurface
- add focused builder tests and parity gates

## Validation
- swift test --filter WorkspaceTopBarSurfaceBuilderTests
- swift test --filter ParityGateTests/testWorkspaceSurfaceDelegatesTopBarSurfaceBuilding
- swift test --filter ParityGateTests/testWorkspaceModelDelegatesStatusTextAndLabels
- swift test --filter ParityGateTests/testWorkspaceSurfaceDelegatesModelCatalogBuilding
- swift test --filter WorkspaceSurfaceTests
- swift test
- git diff --check HEAD~1 HEAD