### PR TITLE
Extract active context source resolution

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceContextResolver.swift
+++ b/Sources/QuillCodeApp/WorkspaceContextResolver.swift
@@ -1,6 +1,11 @@
 import Foundation
 import QuillCodeCore
 
+struct WorkspaceActiveContextSources: Sendable, Hashable {
+    var instructions: [ProjectInstruction]
+    var memories: [MemoryNote]
+}
+
 struct WorkspaceContextResolver: Sendable {
     var projects: [ProjectRef]
     var globalMemories: [MemoryNote]
@@ -12,6 +17,13 @@ struct WorkspaceContextResolver: Sendable {
 
     func memoryNotes(for projectID: UUID?) -> [MemoryNote] {
         globalMemories + (project(id: projectID)?.memories ?? [])
+    }
+
+    func activeSources(for thread: ChatThread?) -> WorkspaceActiveContextSources {
+        WorkspaceActiveContextSources(
+            instructions: activeInstructions(for: thread),
+            memories: activeMemories(for: thread)
+        )
     }
 
     func selectedLocalAction(withID id: String) -> LocalEnvironmentAction? {
@@ -38,5 +50,19 @@ struct WorkspaceContextResolver: Sendable {
     private func project(id: UUID?) -> ProjectRef? {
         guard let id else { return nil }
         return projects.first { $0.id == id }
+    }
+
+    private func activeInstructions(for thread: ChatThread?) -> [ProjectInstruction] {
+        if let thread, !thread.instructions.isEmpty {
+            return thread.instructions
+        }
+        return selectedProject?.instructions ?? []
+    }
+
+    private func activeMemories(for thread: ChatThread?) -> [MemoryNote] {
+        if let thread, !thread.memories.isEmpty {
+            return thread.memories
+        }
+        return globalMemories + (selectedProject?.memories ?? [])
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -68,18 +68,11 @@ public extension QuillCodeWorkspaceModel {
         let computerUse = topBarState.computerUseStatus
         let toolCards = currentToolCards
         let runtimeIssue = runtimeIssueSurface()
-        let activeInstructions: [ProjectInstruction]
-        if let thread, !thread.instructions.isEmpty {
-            activeInstructions = thread.instructions
-        } else {
-            activeInstructions = selectedProject?.instructions ?? []
-        }
-        let activeMemories: [MemoryNote]
-        if let thread, !thread.memories.isEmpty {
-            activeMemories = thread.memories
-        } else {
-            activeMemories = root.globalMemories + (selectedProject?.memories ?? [])
-        }
+        let activeSources = WorkspaceContextResolver(
+            projects: root.projects,
+            globalMemories: root.globalMemories,
+            selectedProject: selectedProject
+        ).activeSources(for: thread)
         let sidebarSelectedThreadIDs = sidebarSelection.isActive
             ? Set(selectedSidebarThreadIDs())
             : []
@@ -96,8 +89,8 @@ public extension QuillCodeWorkspaceModel {
             topBarState: topBarState,
             thread: thread,
             projectName: root.topBar.projectName,
-            instructions: activeInstructions,
-            memories: activeMemories,
+            instructions: activeSources.instructions,
+            memories: activeSources.memories,
             modelCatalog: root.modelCatalog,
             defaultModelID: root.config.defaultModel,
             favoriteModelIDs: root.config.favoriteModels,
@@ -131,14 +124,14 @@ public extension QuillCodeWorkspaceModel {
             ),
             memories: WorkspaceMemoriesSurface(
                 isVisible: memories.isVisible,
-                notes: activeMemories
+                notes: activeSources.memories
             ),
             activity: WorkspaceActivitySurface(
                 isVisible: activity.isVisible,
                 thread: thread,
                 toolCards: toolCards,
-                instructions: activeInstructions,
-                memories: activeMemories,
+                instructions: activeSources.instructions,
+                memories: activeSources.memories,
                 agentStatus: topBarState.agentStatus,
                 collapsedSectionIDs: activity.collapsedSectionIDs
             ),

--- a/Tests/QuillCodeAppTests/WorkspaceContextResolverTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceContextResolverTests.swift
@@ -43,6 +43,90 @@ final class WorkspaceContextResolverTests: XCTestCase {
         )
     }
 
+    func testActiveSourcesPreferThreadContextWhenPresent() {
+        let project = Self.project(
+            instructionTitle: "Project instruction",
+            memoryTitle: "Project memory"
+        )
+        let resolver = WorkspaceContextResolver(
+            projects: [project],
+            globalMemories: [
+                Self.memory(id: "global", scope: .global, title: "Global memory")
+            ],
+            selectedProject: project
+        )
+        let thread = ChatThread(
+            title: "Thread",
+            instructions: [
+                Self.instruction(title: "Thread instruction")
+            ],
+            memories: [
+                Self.memory(id: "thread", scope: .project, title: "Thread memory")
+            ]
+        )
+
+        let sources = resolver.activeSources(for: thread)
+
+        XCTAssertEqual(sources.instructions.map(\.title), ["Thread instruction"])
+        XCTAssertEqual(sources.memories.map(\.title), ["Thread memory"])
+    }
+
+    func testActiveSourcesFallBackToSelectedProjectAndGlobalMemories() {
+        let project = Self.project(
+            instructionTitle: "Project instruction",
+            memoryTitle: "Project memory"
+        )
+        let resolver = WorkspaceContextResolver(
+            projects: [project],
+            globalMemories: [
+                Self.memory(id: "global", scope: .global, title: "Global memory")
+            ],
+            selectedProject: project
+        )
+
+        let sources = resolver.activeSources(for: nil)
+
+        XCTAssertEqual(sources.instructions.map(\.title), ["Project instruction"])
+        XCTAssertEqual(sources.memories.map(\.title), ["Global memory", "Project memory"])
+    }
+
+    func testActiveSourcesFallbacksAreIndependent() {
+        let project = Self.project(
+            instructionTitle: "Project instruction",
+            memoryTitle: "Project memory"
+        )
+        let resolver = WorkspaceContextResolver(
+            projects: [project],
+            globalMemories: [
+                Self.memory(id: "global", scope: .global, title: "Global memory")
+            ],
+            selectedProject: project
+        )
+
+        let instructionOnlyThread = ChatThread(
+            title: "Thread",
+            instructions: [
+                Self.instruction(title: "Thread instruction")
+            ],
+            memories: []
+        )
+        let memoryOnlyThread = ChatThread(
+            title: "Thread",
+            instructions: [],
+            memories: [
+                Self.memory(id: "thread", scope: .project, title: "Thread memory")
+            ]
+        )
+
+        let instructionSources = resolver.activeSources(for: instructionOnlyThread)
+        XCTAssertEqual(instructionSources.instructions.map(\.title), ["Thread instruction"])
+        XCTAssertEqual(instructionSources.memories.map(\.title), ["Global memory", "Project memory"])
+
+        let memorySources = resolver.activeSources(for: memoryOnlyThread)
+        XCTAssertEqual(memorySources.instructions.map(\.title), ["Project instruction"])
+        XCTAssertEqual(memorySources.memories.map(\.title), ["Thread memory"])
+    }
+
     func testResolvesSelectedLocalActionByExactID() {
         let action = Self.localAction(
             id: "local-env:.quillcode/actions/test.sh",
@@ -100,17 +184,21 @@ final class WorkspaceContextResolverTests: XCTestCase {
             name: "Project",
             path: "/tmp/project-\(id.uuidString)",
             instructions: instructionTitle.map {
-                [ProjectInstruction(
-                    path: "AGENTS.md",
-                    title: $0,
-                    content: "Instruction",
-                    byteCount: 11
-                )]
+                [Self.instruction(title: $0)]
             } ?? [],
             localActions: localActions,
             memories: memoryTitle.map {
                 [Self.memory(id: "project-\(id.uuidString)", scope: .project, title: $0)]
             } ?? []
+        )
+    }
+
+    private static func instruction(title: String) -> ProjectInstruction {
+        ProjectInstruction(
+            path: "AGENTS.md",
+            title: title,
+            content: "Instruction",
+            byteCount: 11
         )
     }
 

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -382,19 +382,27 @@ final class ParityGateTests: XCTestCase {
 
     func testWorkspaceModelDelegatesContextResolving() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let resolverText = try Self.appSourceText(named: "WorkspaceContextResolver.swift")
 
+        XCTAssertTrue(resolverText.contains("struct WorkspaceActiveContextSources"), "Active workspace context source records should live beside the resolver.")
         XCTAssertTrue(resolverText.contains("struct WorkspaceContextResolver"), "Workspace context lookup should live in a focused resolver.")
         XCTAssertTrue(resolverText.contains("func instructions(for projectID:"), "Project instruction lookup should be directly testable.")
         XCTAssertTrue(resolverText.contains("func memoryNotes(for projectID:"), "Global/project memory merging should be directly testable.")
+        XCTAssertTrue(resolverText.contains("func activeSources(for thread:"), "Active instruction and memory fallback should be directly testable.")
         XCTAssertTrue(resolverText.contains("func selectedLocalAction(withID"), "Local action ID lookup should be directly testable.")
         XCTAssertTrue(resolverText.contains("func selectedLocalAction(matching"), "Local action alias matching should be directly testable.")
         XCTAssertTrue(modelText.contains("WorkspaceContextResolver("), "WorkspaceModel should delegate context lookup through the resolver.")
+        XCTAssertTrue(surfaceText.contains("WorkspaceContextResolver("), "WorkspaceSurface should delegate active context-source lookup through the resolver.")
         XCTAssertFalse(modelText.contains("private func instructions(for projectID"), "WorkspaceModel should not own project instruction lookup.")
         XCTAssertFalse(modelText.contains("private func memoryNotes(for projectID"), "WorkspaceModel should not own memory merging.")
         XCTAssertFalse(modelText.contains("private func localAction(withID"), "WorkspaceModel should not own local action ID lookup.")
         XCTAssertFalse(modelText.contains("private func localAction(matching"), "WorkspaceModel should not own local action matching.")
         XCTAssertFalse(modelText.contains("private static func normalizedActionName"), "WorkspaceModel should not own local action alias normalization.")
+        XCTAssertFalse(surfaceText.contains("thread.instructions.isEmpty"), "WorkspaceSurface should not own thread/project instruction fallback.")
+        XCTAssertFalse(surfaceText.contains("thread.memories.isEmpty"), "WorkspaceSurface should not own thread/project memory fallback.")
+        XCTAssertFalse(surfaceText.contains("selectedProject?.instructions ?? []"), "WorkspaceSurface should not own project instruction fallback.")
+        XCTAssertFalse(surfaceText.contains("root.globalMemories +"), "WorkspaceSurface should not own global/project memory merging.")
     }
 
     func testWorkspaceModelDelegatesAgentProgressStatusCopy() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -26,7 +26,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
 | `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A- | The shell is now mostly chrome composition, state, and routing. Transcript layout and workspace sheet presentation live in focused files; keep future modal families and command workflow rules out of the root shell. |
 | `Sources/QuillCodeApp/QuillCodeToolCardView.swift` | A- | Native tool-card composition is now separate from reusable controls, artifact previews, and raw detail blocks. Keep future status/action chrome in `QuillCodeToolCardControls.swift` and artifact rendering in `QuillCodeToolArtifactViews.swift`. |
-| `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
+| `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, active context-source selection, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
 | `Sources/QuillCodeApp/WorkspaceHTMLRenderer.swift` | A- | Static HTML harness rendering is still broad, but top-bar HTML delegates to `WorkspaceHTMLTopBarRenderer`, sidebar HTML delegates to `WorkspaceHTMLSidebarRenderer`, tool-card/artifact preview HTML delegates to `WorkspaceHTMLToolCardRenderer`, review pane HTML delegates to `WorkspaceHTMLReviewRenderer`, secondary pane HTML delegates to `WorkspaceHTMLSecondaryPaneRenderer`, browser pane HTML delegates to `WorkspaceHTMLBrowserRenderer`, terminal pane HTML delegates to `WorkspaceHTMLTerminalRenderer`, and shared escaping/context chips live in `WorkspaceHTMLPrimitives`. Next step is extracting another transcript/composer family only when renderer drift appears. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
 | `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback and project-import resolution now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
@@ -48,6 +48,24 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
+
+## 2026-06-24 Active Context Source Pass
+
+Overall grade after this slice: **A context-source boundary, A behavior preservation, A regression guard**.
+
+`WorkspaceSurface` still chose active instruction and memory sources inline. The rules are subtle because thread instructions and thread memories override project/global fallbacks independently, so the aggregate surface method was carrying business policy that should be directly tested.
+
+Code quality changes:
+
+- Added `WorkspaceActiveContextSources` beside `WorkspaceContextResolver`.
+- Moved active instruction selection and active memory selection into `WorkspaceContextResolver.activeSources(for:)`.
+- Preserved independent fallback behavior: thread instructions can override project instructions while memories still fall back to global/project notes, and vice versa.
+- Simplified `WorkspaceSurface.surface()` so top bar, memories pane, and activity pane share one resolved active context source record.
+- Added focused resolver tests and a parity gate keeping active context-source selection out of `WorkspaceSurface`.
+
+Remaining risk:
+
+- `WorkspaceSurface.surface()` still coordinates many independent panes. Continue extracting only when pane-specific policy appears there; avoid replacing a readable aggregate with an oversized god builder.
 
 ## 2026-06-24 Top-Bar Surface Builder Pass
 


### PR DESCRIPTION
## Summary
- Add `WorkspaceActiveContextSources` so active instructions and memories resolve through `WorkspaceContextResolver`.
- Replace inline thread/project/global fallback logic in `WorkspaceSurface`.
- Add focused resolver tests plus a parity guard that keeps this selection logic out of the surface layer.

## Validation
- `swift test --filter WorkspaceContextResolverTests`
- `swift test --filter ParityGateTests/testWorkspaceModelDelegatesContextResolving`
- `swift test --filter WorkspaceSurfaceTests`
- `swift test`
- `git diff --check HEAD~1 HEAD`