### PR TITLE
Extract automations surface builder

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceAutomationsSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceAutomationsSurfaceBuilder.swift
@@ -1,0 +1,28 @@
+import Foundation
+import QuillCodeCore
+
+struct WorkspaceAutomationsSurfaceBuilder: Sendable, Hashable {
+    var isVisible: Bool
+    var automations: [QuillAutomation]
+    var hasSelectedThread: Bool
+    var hasSelectedProject: Bool
+
+    func surface() -> WorkspaceAutomationsSurface {
+        WorkspaceAutomationsSurface(
+            isVisible: isVisible,
+            automations: automations,
+            createThreadFollowUpCommand: .automationCreateThreadFollowUp(
+                isEnabled: hasSelectedThread
+            ),
+            createWorkspaceScheduleCommand: .automationCreateWorkspaceSchedule(
+                isEnabled: hasSelectedProject
+            ),
+            scheduleThreadFollowUpCommands: WorkspaceCommandSurface.automationScheduleThreadFollowUpCommands(
+                isEnabled: hasSelectedThread
+            ),
+            scheduleWorkspaceScheduleCommands: WorkspaceCommandSurface.automationScheduleWorkspaceScheduleCommands(
+                isEnabled: hasSelectedProject
+            )
+        )
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -135,22 +135,12 @@ public extension QuillCodeWorkspaceModel {
                 agentStatus: topBarState.agentStatus,
                 collapsedSectionIDs: activity.collapsedSectionIDs
             ),
-            automations: WorkspaceAutomationsSurface(
+            automations: WorkspaceAutomationsSurfaceBuilder(
                 isVisible: automations.isVisible,
                 automations: automations.items,
-                createThreadFollowUpCommand: .automationCreateThreadFollowUp(
-                    isEnabled: thread != nil
-                ),
-                createWorkspaceScheduleCommand: .automationCreateWorkspaceSchedule(
-                    isEnabled: selectedProject != nil
-                ),
-                scheduleThreadFollowUpCommands: WorkspaceCommandSurface.automationScheduleThreadFollowUpCommands(
-                    isEnabled: thread != nil
-                ),
-                scheduleWorkspaceScheduleCommands: WorkspaceCommandSurface.automationScheduleWorkspaceScheduleCommands(
-                    isEnabled: selectedProject != nil
-                )
-            ),
+                hasSelectedThread: thread != nil,
+                hasSelectedProject: selectedProject != nil
+            ).surface(),
             composer: ComposerSurface(composer: composer),
             commands: commandSurfaceBuilder().commands,
             settings: WorkspaceSettingsSurface(

--- a/Tests/QuillCodeAppTests/WorkspaceAutomationsSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAutomationsSurfaceBuilderTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceAutomationsSurfaceBuilderTests: XCTestCase {
+    func testSurfaceIncludesPlannedWorkflowsAndDisabledCommandsWithoutContext() {
+        let surface = WorkspaceAutomationsSurfaceBuilder(
+            isVisible: true,
+            automations: [],
+            hasSelectedThread: false,
+            hasSelectedProject: false
+        ).surface()
+
+        XCTAssertTrue(surface.isVisible)
+        XCTAssertEqual(surface.title, "Automations")
+        XCTAssertEqual(surface.statusLabel, "3 planned")
+        XCTAssertEqual(surface.workflows.map(\.title), [
+            "Thread follow-ups",
+            "Workspace schedules",
+            "Monitors"
+        ])
+        XCTAssertEqual(surface.createThreadFollowUpCommand?.id, "automation-create-thread-follow-up")
+        XCTAssertEqual(surface.createThreadFollowUpCommand?.isEnabled, false)
+        XCTAssertEqual(surface.scheduleThreadFollowUpCommands.map(\.isEnabled), [false, false, false, false])
+        XCTAssertEqual(surface.createWorkspaceScheduleCommand?.id, "automation-create-workspace-schedule")
+        XCTAssertEqual(surface.createWorkspaceScheduleCommand?.isEnabled, false)
+        XCTAssertEqual(surface.scheduleWorkspaceScheduleCommands.map(\.isEnabled), [false, false, false, false])
+    }
+
+    func testSurfaceEnablesThreadAndWorkspaceCommandsIndependently() {
+        let threadOnly = WorkspaceAutomationsSurfaceBuilder(
+            isVisible: false,
+            automations: [],
+            hasSelectedThread: true,
+            hasSelectedProject: false
+        ).surface()
+
+        XCTAssertEqual(threadOnly.createThreadFollowUpCommand?.isEnabled, true)
+        XCTAssertEqual(threadOnly.scheduleThreadFollowUpCommands.map(\.id), [
+            "automation-create-thread-follow-up-after:600",
+            "automation-create-thread-follow-up-after:3600",
+            "automation-create-thread-follow-up-tomorrow",
+            "automation-create-thread-follow-up-every:daily"
+        ])
+        XCTAssertEqual(threadOnly.scheduleThreadFollowUpCommands.map(\.isEnabled), [true, true, true, true])
+        XCTAssertEqual(threadOnly.createWorkspaceScheduleCommand?.isEnabled, false)
+        XCTAssertEqual(threadOnly.scheduleWorkspaceScheduleCommands.map(\.isEnabled), [false, false, false, false])
+
+        let workspaceOnly = WorkspaceAutomationsSurfaceBuilder(
+            isVisible: false,
+            automations: [],
+            hasSelectedThread: false,
+            hasSelectedProject: true
+        ).surface()
+
+        XCTAssertEqual(workspaceOnly.createThreadFollowUpCommand?.isEnabled, false)
+        XCTAssertEqual(workspaceOnly.scheduleThreadFollowUpCommands.map(\.isEnabled), [false, false, false, false])
+        XCTAssertEqual(workspaceOnly.createWorkspaceScheduleCommand?.isEnabled, true)
+        XCTAssertEqual(workspaceOnly.scheduleWorkspaceScheduleCommands.map(\.id), [
+            "automation-create-workspace-schedule-after:600",
+            "automation-create-workspace-schedule-after:3600",
+            "automation-create-workspace-schedule-tomorrow",
+            "automation-create-workspace-schedule-every:daily"
+        ])
+        XCTAssertEqual(workspaceOnly.scheduleWorkspaceScheduleCommands.map(\.isEnabled), [true, true, true, true])
+    }
+
+    func testSurfaceKeepsConfiguredAutomationActions() {
+        let active = QuillAutomation(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000201")!,
+            title: "Nightly repo check",
+            detail: "Run tests and summarize failures.",
+            kind: .workspaceSchedule,
+            scheduleKind: .cron,
+            scheduleDescription: "Every weekday at 6:00 PM"
+        )
+        let paused = QuillAutomation(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000202")!,
+            title: "Paused PR monitor",
+            detail: "Watch the launch PR after review starts.",
+            kind: .monitor,
+            status: .paused,
+            scheduleKind: .event,
+            scheduleDescription: "PR events"
+        )
+
+        let surface = WorkspaceAutomationsSurfaceBuilder(
+            isVisible: true,
+            automations: [active, paused],
+            hasSelectedThread: true,
+            hasSelectedProject: true
+        ).surface()
+
+        XCTAssertEqual(surface.statusLabel, "1 active · 1 paused")
+        XCTAssertEqual(surface.workflows.map(\.title), ["Nightly repo check", "Paused PR monitor"])
+        XCTAssertEqual(surface.workflows.first?.runActionTitle, "Run now")
+        XCTAssertEqual(surface.workflows.first?.runCommandID, "automation-run:00000000-0000-0000-0000-000000000201")
+        XCTAssertEqual(surface.workflows.first?.primaryActionTitle, "Pause")
+        XCTAssertEqual(surface.workflows.first?.primaryCommandID, "automation-pause:00000000-0000-0000-0000-000000000201")
+        XCTAssertEqual(surface.workflows.first?.deleteCommandID, "automation-delete:00000000-0000-0000-0000-000000000201")
+        XCTAssertNil(surface.workflows.last?.runActionTitle)
+        XCTAssertEqual(surface.workflows.last?.primaryActionTitle, "Resume")
+        XCTAssertEqual(surface.workflows.last?.primaryCommandID, "automation-resume:00000000-0000-0000-0000-000000000202")
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1294,6 +1294,21 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(modelText.contains("automations.items.removeAll"), "WorkspaceModel should not delete automation records inline.")
     }
 
+    func testWorkspaceSurfaceDelegatesAutomationsSurfaceBuilding() throws {
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+        let builderText = try Self.appSourceText(named: "WorkspaceAutomationsSurfaceBuilder.swift")
+
+        XCTAssertTrue(builderText.contains("struct WorkspaceAutomationsSurfaceBuilder"), "Automation pane assembly should live in a focused builder.")
+        XCTAssertTrue(builderText.contains("func surface() -> WorkspaceAutomationsSurface"), "Automation pane assembly should be directly testable.")
+        XCTAssertTrue(builderText.contains("hasSelectedThread"), "Thread follow-up command availability should be builder-owned.")
+        XCTAssertTrue(builderText.contains("hasSelectedProject"), "Workspace schedule command availability should be builder-owned.")
+        XCTAssertTrue(surfaceText.contains("WorkspaceAutomationsSurfaceBuilder("), "WorkspaceSurface should delegate automation pane assembly.")
+        XCTAssertFalse(surfaceText.contains("automationCreateThreadFollowUp"), "WorkspaceSurface should not build automation follow-up commands inline.")
+        XCTAssertFalse(surfaceText.contains("automationCreateWorkspaceSchedule"), "WorkspaceSurface should not build automation schedule commands inline.")
+        XCTAssertFalse(surfaceText.contains("automationScheduleThreadFollowUpCommands"), "WorkspaceSurface should not build thread schedule command variants inline.")
+        XCTAssertFalse(surfaceText.contains("automationScheduleWorkspaceScheduleCommands"), "WorkspaceSurface should not build workspace schedule command variants inline.")
+    }
+
     func testWorkspaceModelDelegatesWorktreeOpenRecords() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let requestsText = try Self.appSourceText(named: "WorkspaceWorktreeRequests.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -16,7 +16,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `QuillCodeSafety` | A- | Small, explicit policy layer. Needs more production prompt telemetry once live Auto reviewer tuning begins. |
 | `QuillCodePersistence` | A | Focused stores, compatibility tests, and clear path ownership. |
 | `QuillComputerUseKit` | B+ | Protocol shape is good and macOS adapter is isolated. Linux adapter, app approvals, and visual feedback loops are still parity gaps. |
-| `QuillCodeApp` surface contracts | A- | Strong shared surface model and broad tests. Settings, runtime issue, model catalog, top-bar/model contracts, navigation assembly, sidebar/project contracts, command, command palette, review, review-comment planning, tool override composition, remote-project tool execution, context banner, transcript projection, execution-context enrichment, browser location/state transitions, MCP launch/session creation, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now have focused builders; the main remaining risk is `WorkspaceModel`, `WorkspaceSurface`, and `WorkspaceSwiftUIView` continuing to absorb too many responsibilities. |
+| `QuillCodeApp` surface contracts | A- | Strong shared surface model and broad tests. Settings, runtime issue, model catalog, top-bar/model contracts, navigation assembly, sidebar/project contracts, command, command palette, review, review-comment planning, tool override composition, remote-project tool execution, context banner, transcript projection, execution-context enrichment, browser location/state transitions, MCP launch/session creation, thread seeding, thread lifecycle transitions, sidebar selection transitions, sidebar bulk action planning, and automation pane assembly now have focused builders; the main remaining risk is `WorkspaceModel`, `WorkspaceSurface`, and `WorkspaceSwiftUIView` continuing to absorb too many responsibilities. |
 | Playwright harness | B+ | Valuable parity harness with broad coverage. It intentionally duplicates rendering behavior, so keep it thin and derived from stable surface concepts. |
 
 ## File Hotspots
@@ -26,7 +26,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
 | `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A- | The shell is now mostly chrome composition, state, and routing. Transcript layout and workspace sheet presentation live in focused files; keep future modal families and command workflow rules out of the root shell. |
 | `Sources/QuillCodeApp/QuillCodeToolCardView.swift` | A- | Native tool-card composition is now separate from reusable controls, artifact previews, and raw detail blocks. Keep future status/action chrome in `QuillCodeToolCardControls.swift` and artifact rendering in `QuillCodeToolArtifactViews.swift`. |
-| `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, active context-source selection, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
+| `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, active context-source selection, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, automation pane command wiring, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
 | `Sources/QuillCodeApp/WorkspaceHTMLRenderer.swift` | A- | Static HTML harness rendering is still broad, but top-bar HTML delegates to `WorkspaceHTMLTopBarRenderer`, sidebar HTML delegates to `WorkspaceHTMLSidebarRenderer`, tool-card/artifact preview HTML delegates to `WorkspaceHTMLToolCardRenderer`, review pane HTML delegates to `WorkspaceHTMLReviewRenderer`, secondary pane HTML delegates to `WorkspaceHTMLSecondaryPaneRenderer`, browser pane HTML delegates to `WorkspaceHTMLBrowserRenderer`, terminal pane HTML delegates to `WorkspaceHTMLTerminalRenderer`, and shared escaping/context chips live in `WorkspaceHTMLPrimitives`. Next step is extracting another transcript/composer family only when renderer drift appears. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
 | `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback and project-import resolution now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
@@ -48,6 +48,24 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
+
+## 2026-06-24 Automations Surface Builder Pass
+
+Overall grade after this slice: **A automation-pane boundary, A command availability coverage, A regression guard**.
+
+`WorkspaceSurface` still assembled the Automations pane inline, including create-command availability and every quick schedule command variant. That made the aggregate surface the owner of automation pane policy even though automation state mutation and automation display rows already lived in focused files.
+
+Code quality changes:
+
+- Added `WorkspaceAutomationsSurfaceBuilder` for automation pane assembly.
+- Moved thread follow-up and workspace schedule command availability into the focused builder.
+- Kept thread and workspace command availability independent so a selected thread can enable follow-ups without requiring a selected project, and vice versa.
+- Simplified `WorkspaceSurface.surface()` to delegate automation pane construction.
+- Added focused builder tests for empty/planned state, independent command availability, configured automation action rows, and a parity gate keeping automation command wiring out of `WorkspaceSurface`.
+
+Remaining risk:
+
+- `WorkspaceAutomationsSurface` still owns workflow row projection and status labels beside its Codable contract. That is acceptable while the logic is compact and directly tested; split row projection only if automation display behavior grows.
 
 ## 2026-06-24 Active Context Source Pass
 


### PR DESCRIPTION
## Summary
- Add `WorkspaceAutomationsSurfaceBuilder` for automation pane assembly.
- Move thread follow-up and workspace schedule command availability out of `WorkspaceSurface`.
- Add focused builder tests and a parity guard to keep automation command wiring out of the aggregate surface.
- Update the code quality audit with the new boundary.

## Validation
- `swift test --filter WorkspaceAutomationsSurfaceBuilderTests`
- `swift test --filter ParityGateTests/testWorkspaceSurfaceDelegatesAutomationsSurfaceBuilding`
- `swift test --filter WorkspaceSurfaceTests`
- `swift test --filter QuillCodeSecondaryPaneSurfaceTests`
- `swift test`
- `git diff --check`