### PR TITLE
Split project context refresh helper

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -1349,11 +1349,14 @@ public final class QuillCodeWorkspaceModel {
         }
         let contextProjectID = selectedThread?.projectID ?? root.selectedProjectID
         refreshProjectMetadata(contextProjectID)
-        let refreshedMemories = contextResolver.memoryNotes(for: contextProjectID)
-        let refreshedInstructions = contextResolver.instructions(for: contextProjectID)
+        let refreshedContext = WorkspaceProjectContextRefresher.threadContext(
+            projectID: contextProjectID,
+            projects: root.projects,
+            globalMemories: root.globalMemories
+        )
         mutateSelectedThread { thread in
-            thread.memories = refreshedMemories
-            thread.instructions = refreshedInstructions
+            thread.instructions = refreshedContext.instructions
+            thread.memories = refreshedContext.memories
         }
         lastError = nil
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.running)
@@ -1776,13 +1779,15 @@ public final class QuillCodeWorkspaceModel {
 
     public func refreshSelectedProjectContext() {
         let projectID = selectedThread?.projectID ?? root.selectedProjectID
-        refreshGlobalMemories()
         refreshProjectMetadata(projectID)
-        let refreshedInstructions = contextResolver.instructions(for: projectID)
-        let refreshedMemories = contextResolver.memoryNotes(for: projectID)
+        let refreshedContext = WorkspaceProjectContextRefresher.threadContext(
+            projectID: projectID,
+            projects: root.projects,
+            globalMemories: root.globalMemories
+        )
         mutateSelectedThread { thread in
-            thread.instructions = refreshedInstructions
-            thread.memories = refreshedMemories
+            thread.instructions = refreshedContext.instructions
+            thread.memories = refreshedContext.memories
         }
         saveProjects()
     }
@@ -1807,33 +1812,24 @@ public final class QuillCodeWorkspaceModel {
 
     private func refreshProjectMetadata(_ id: UUID?) {
         refreshGlobalMemories()
-        guard let id, let index = root.projects.firstIndex(where: { $0.id == id }) else { return }
-        guard !root.projects[index].isRemote else { return }
-        let rootURL = URL(fileURLWithPath: root.projects[index].path)
-        WorkspaceProjectEngine.applyMetadata(
-            WorkspaceProjectMetadataLoader.loadLocal(from: rootURL),
-            to: id,
-            projects: &root.projects,
-            includeLocalExtensions: true
+        WorkspaceProjectContextRefresher.refreshLocalProjectMetadata(
+            projectID: id,
+            projects: &root.projects
         )
     }
 
     private func refreshRemoteProjectContext(_ id: UUID) -> Bool {
         refreshGlobalMemories()
-        guard let index = root.projects.firstIndex(where: { $0.id == id }),
-              root.projects[index].isRemote
-        else {
-            return false
-        }
-
         do {
-            let metadata = try WorkspaceProjectMetadataLoader.loadRemote(
-                connection: root.projects[index].connection,
+            let didRefresh = try WorkspaceProjectContextRefresher.refreshRemoteProjectContext(
+                projectID: id,
+                projects: &root.projects,
                 executor: sshRemoteShellExecutor
             )
-            WorkspaceProjectEngine.applyMetadata(metadata, to: id, projects: &root.projects, includeLocalExtensions: false)
-            lastError = nil
-            return true
+            if didRefresh {
+                lastError = nil
+            }
+            return didRefresh
         } catch {
             lastError = error.localizedDescription
             return false
@@ -1841,7 +1837,7 @@ public final class QuillCodeWorkspaceModel {
     }
 
     private func refreshGlobalMemories() {
-        root.globalMemories = WorkspaceMemoryEngine.loadGlobal(from: globalMemoryDirectory)
+        root.globalMemories = WorkspaceProjectContextRefresher.globalMemories(directory: globalMemoryDirectory)
     }
 
     private func applyGlobalMemoryMutation(_ mutation: WorkspaceMemoryMutation) {
@@ -1869,14 +1865,23 @@ public final class QuillCodeWorkspaceModel {
     private func syncThreadContext(into thread: inout ChatThread) {
         let projectID = thread.projectID ?? root.selectedProjectID
         refreshProjectMetadata(projectID)
-        thread.instructions = contextResolver.instructions(for: projectID)
-        thread.memories = contextResolver.memoryNotes(for: projectID)
+        WorkspaceProjectContextRefresher.syncThreadContext(
+            &thread,
+            fallbackProjectID: root.selectedProjectID,
+            projects: root.projects,
+            globalMemories: root.globalMemories
+        )
     }
 
     private func refreshThreadMemoryContext(_ thread: inout ChatThread) {
         let projectID = thread.projectID ?? root.selectedProjectID
         refreshProjectMetadata(projectID)
-        thread.memories = contextResolver.memoryNotes(for: projectID)
+        WorkspaceProjectContextRefresher.syncThreadMemories(
+            &thread,
+            fallbackProjectID: root.selectedProjectID,
+            projects: root.projects,
+            globalMemories: root.globalMemories
+        )
     }
 
     private func knownProjectID(_ id: UUID?) -> UUID? {

--- a/Sources/QuillCodeApp/WorkspaceProjectContextRefresher.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectContextRefresher.swift
@@ -1,0 +1,98 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+struct WorkspaceThreadContextSnapshot: Equatable, Sendable {
+    var instructions: [ProjectInstruction]
+    var memories: [MemoryNote]
+}
+
+enum WorkspaceProjectContextRefresher {
+    static func refreshLocalProjectMetadata(
+        projectID: UUID?,
+        projects: inout [ProjectRef]
+    ) {
+        guard let projectID,
+              let index = projects.firstIndex(where: { $0.id == projectID }),
+              !projects[index].isRemote
+        else {
+            return
+        }
+
+        let rootURL = URL(fileURLWithPath: projects[index].path)
+        WorkspaceProjectEngine.applyMetadata(
+            WorkspaceProjectMetadataLoader.loadLocal(from: rootURL),
+            to: projectID,
+            projects: &projects,
+            includeLocalExtensions: true
+        )
+    }
+
+    static func refreshRemoteProjectContext(
+        projectID: UUID,
+        projects: inout [ProjectRef],
+        executor: SSHRemoteShellExecutor
+    ) throws -> Bool {
+        guard let index = projects.firstIndex(where: { $0.id == projectID }),
+              projects[index].isRemote
+        else {
+            return false
+        }
+
+        let metadata = try WorkspaceProjectMetadataLoader.loadRemote(
+            connection: projects[index].connection,
+            executor: executor
+        )
+        WorkspaceProjectEngine.applyMetadata(metadata, to: projectID, projects: &projects, includeLocalExtensions: false)
+        return true
+    }
+
+    static func threadContext(
+        projectID: UUID?,
+        projects: [ProjectRef],
+        globalMemories: [MemoryNote]
+    ) -> WorkspaceThreadContextSnapshot {
+        let resolver = WorkspaceContextResolver(
+            projects: projects,
+            globalMemories: globalMemories,
+            selectedProject: nil
+        )
+        return WorkspaceThreadContextSnapshot(
+            instructions: resolver.instructions(for: projectID),
+            memories: resolver.memoryNotes(for: projectID)
+        )
+    }
+
+    static func syncThreadContext(
+        _ thread: inout ChatThread,
+        fallbackProjectID: UUID?,
+        projects: [ProjectRef],
+        globalMemories: [MemoryNote]
+    ) {
+        let snapshot = threadContext(
+            projectID: thread.projectID ?? fallbackProjectID,
+            projects: projects,
+            globalMemories: globalMemories
+        )
+        thread.instructions = snapshot.instructions
+        thread.memories = snapshot.memories
+    }
+
+    static func syncThreadMemories(
+        _ thread: inout ChatThread,
+        fallbackProjectID: UUID?,
+        projects: [ProjectRef],
+        globalMemories: [MemoryNote]
+    ) {
+        let snapshot = threadContext(
+            projectID: thread.projectID ?? fallbackProjectID,
+            projects: projects,
+            globalMemories: globalMemories
+        )
+        thread.memories = snapshot.memories
+    }
+
+    static func globalMemories(directory: URL?) -> [MemoryNote] {
+        WorkspaceMemoryEngine.loadGlobal(from: directory)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceProjectContextRefresherTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProjectContextRefresherTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceProjectContextRefresherTests: XCTestCase {
+    func testRefreshLocalProjectMetadataReloadsGlobalAndProjectContext() throws {
+        let projectRoot = try makeQuillCodeTestDirectory()
+        let globalMemoryDirectory = projectRoot.appendingPathComponent("global-memories")
+        let projectMemoryDirectory = projectRoot.appendingPathComponent(".quillcode/memories")
+        try FileManager.default.createDirectory(at: globalMemoryDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: projectMemoryDirectory, withIntermediateDirectories: true)
+        try "Prefer focused Swift tests.\n".write(
+            to: projectRoot.appendingPathComponent("AGENTS.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "Global preference.\n".write(
+            to: globalMemoryDirectory.appendingPathComponent("global.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "Project preference.\n".write(
+            to: projectMemoryDirectory.appendingPathComponent("project.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let projectID = UUID()
+        var projects = [
+            ProjectRef(id: projectID, name: "Project", path: projectRoot.path)
+        ]
+        let globalMemories = WorkspaceProjectContextRefresher.globalMemories(directory: globalMemoryDirectory)
+
+        WorkspaceProjectContextRefresher.refreshLocalProjectMetadata(
+            projectID: projectID,
+            projects: &projects
+        )
+
+        XCTAssertEqual(globalMemories.map(\.title), ["Global"])
+        XCTAssertEqual(projects.first?.instructions.map(\.path), ["AGENTS.md"])
+        XCTAssertEqual(projects.first?.memories.map(\.title), ["Project"])
+
+        let snapshot = WorkspaceProjectContextRefresher.threadContext(
+            projectID: projectID,
+            projects: projects,
+            globalMemories: globalMemories
+        )
+        XCTAssertEqual(snapshot.instructions.map(\.title), ["Project AGENTS.md"])
+        XCTAssertEqual(snapshot.memories.map(\.title), ["Global", "Project"])
+    }
+
+    func testThreadContextSyncUsesThreadProjectBeforeFallback() {
+        let fallbackProjectID = UUID()
+        let threadProjectID = UUID()
+        let projects = [
+            Self.project(id: fallbackProjectID, instructionTitle: "Fallback instruction", memoryTitle: "Fallback memory"),
+            Self.project(id: threadProjectID, instructionTitle: "Thread instruction", memoryTitle: "Thread memory")
+        ]
+        let globalMemories = [
+            Self.memory(id: "global", scope: .global, title: "Global memory")
+        ]
+        var thread = ChatThread(title: "Thread", projectID: threadProjectID)
+
+        WorkspaceProjectContextRefresher.syncThreadContext(
+            &thread,
+            fallbackProjectID: fallbackProjectID,
+            projects: projects,
+            globalMemories: globalMemories
+        )
+
+        XCTAssertEqual(thread.instructions.map(\.title), ["Thread instruction"])
+        XCTAssertEqual(thread.memories.map(\.title), ["Global memory", "Thread memory"])
+
+        WorkspaceProjectContextRefresher.syncThreadMemories(
+            &thread,
+            fallbackProjectID: fallbackProjectID,
+            projects: projects,
+            globalMemories: []
+        )
+        XCTAssertEqual(thread.instructions.map(\.title), ["Thread instruction"])
+        XCTAssertEqual(thread.memories.map(\.title), ["Thread memory"])
+    }
+
+    private static func project(id: UUID, instructionTitle: String, memoryTitle: String) -> ProjectRef {
+        ProjectRef(
+            id: id,
+            name: instructionTitle,
+            path: "/tmp/\(id.uuidString)",
+            instructions: [
+                ProjectInstruction(
+                    path: "\(instructionTitle).md",
+                    title: instructionTitle,
+                    content: instructionTitle,
+                    byteCount: instructionTitle.utf8.count
+                )
+            ],
+            memories: [
+                memory(id: memoryTitle, scope: .project, title: memoryTitle)
+            ]
+        )
+    }
+
+    private static func memory(id: String, scope: MemoryScope, title: String) -> MemoryNote {
+        MemoryNote(
+            id: id,
+            scope: scope,
+            title: title,
+            content: title,
+            relativePath: "\(scope.rawValue)/\(id).md",
+            byteCount: title.utf8.count
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -196,6 +196,26 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(modelText.contains("private static func projectFileBrowserURL"), "WorkspaceModel should not own project file URL resolution.")
     }
 
+    func testWorkspaceModelDelegatesProjectContextRefresh() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let refresherText = try Self.appSourceText(named: "WorkspaceProjectContextRefresher.swift")
+
+        XCTAssertTrue(refresherText.contains("enum WorkspaceProjectContextRefresher"), "Project context refresh should have a focused owner.")
+        XCTAssertTrue(refresherText.contains("refreshLocalProjectMetadata"), "Local project metadata refresh should be directly testable.")
+        XCTAssertTrue(refresherText.contains("refreshRemoteProjectContext"), "Remote project metadata refresh should be directly testable.")
+        XCTAssertTrue(refresherText.contains("syncThreadContext"), "Thread instruction and memory sync should be directly testable.")
+        XCTAssertTrue(refresherText.contains("syncThreadMemories"), "Saved-memory refresh should be directly testable.")
+        XCTAssertTrue(refresherText.contains("static func globalMemories"), "Global memory loading should be directly testable.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshLocalProjectMetadata"), "WorkspaceModel should delegate local project metadata refresh.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshRemoteProjectContext"), "WorkspaceModel should delegate remote project metadata refresh.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.syncThreadContext"), "WorkspaceModel should delegate thread context sync.")
+        XCTAssertFalse(modelText.contains("WorkspaceProjectMetadataLoader.loadLocal(from: rootURL)"), "WorkspaceModel should not own refresh-time local project metadata loading.")
+        XCTAssertFalse(modelText.contains("WorkspaceProjectMetadataLoader.loadRemote"), "WorkspaceModel should not own remote project metadata loading.")
+        XCTAssertFalse(modelText.contains("WorkspaceMemoryEngine.loadGlobal(from:"), "WorkspaceModel should not own global memory loading.")
+        XCTAssertFalse(modelText.contains("thread.instructions = contextResolver.instructions"), "WorkspaceModel should not directly sync thread instructions from the resolver.")
+        XCTAssertFalse(modelText.contains("thread.memories = contextResolver.memoryNotes"), "WorkspaceModel should not directly sync thread memories from the resolver.")
+    }
+
     func testWorkspaceModelDelegatesThreadSeedBuilding() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let seedBuilderText = try Self.appSourceText(named: "WorkspaceThreadSeedBuilder.swift")
@@ -796,7 +816,7 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(engineText.contains("struct WorkspaceMemoryMutation"), "Memory command outcomes should use a typed mutation value.")
         XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.saveGlobal"), "WorkspaceModel should delegate global memory saves.")
         XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.deleteGlobal"), "WorkspaceModel should delegate global memory deletion.")
-        XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.loadGlobal"), "WorkspaceModel should delegate global memory reloads.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.globalMemories"), "WorkspaceModel should delegate global memory reloads through the project context refresher.")
         XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.contextUpdate"), "WorkspaceModel should delegate memory context update construction.")
         XCTAssertTrue(plannerText.contains("struct WorkspaceMemoryCommandTranscriptPlanner"), "Memory command transcript copy should live in a focused planner.")
         XCTAssertTrue(errorText.contains("enum WorkspaceMemoryErrorMessageBuilder"), "Memory write and delete errors should share one user-facing formatter.")
@@ -1024,7 +1044,7 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(loaderText.contains("MemoryNoteLoader.loadProject"), "Project memory loading should stay with the metadata loader.")
         XCTAssertTrue(loaderText.contains("SSHRemoteProjectContextLoader.load"), "SSH Remote context loading should stay with the metadata loader.")
         XCTAssertTrue(modelText.contains("WorkspaceProjectMetadataLoader.loadLocal"), "WorkspaceModel should delegate local project metadata loading.")
-        XCTAssertTrue(modelText.contains("WorkspaceProjectMetadataLoader.loadRemote"), "WorkspaceModel should delegate SSH Remote project metadata loading.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshRemoteProjectContext"), "WorkspaceModel should delegate SSH Remote project metadata refresh.")
         XCTAssertFalse(modelText.contains("ProjectInstructionLoader.load"), "WorkspaceModel should not load instruction files directly.")
         XCTAssertFalse(modelText.contains("LocalEnvironmentActionLoader.load"), "WorkspaceModel should not load local environment actions directly.")
         XCTAssertFalse(modelText.contains("ProjectExtensionManifestLoader.load"), "WorkspaceModel should not load project extensions directly.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -3407,3 +3407,21 @@ Code quality changes:
 Remaining risk:
 
 - Project row menu actions still route directly through typed row actions, which is appropriate for now because they do not need command-palette payloads. Revisit only if project row actions become workspace commands.
+
+## 2026-06-24 Project Context Refresh Split
+
+Overall grade after this slice: **A+ context refresh boundary, A thread-context sync guard, A metadata loading ownership**.
+
+`WorkspaceModel.swift` still owned local metadata reloads, remote metadata reloads, global memory reloads, and repeated instruction/memory snapshot assignment for selected threads. The behavior was correct, but the model was becoming the implicit owner of project context refresh policy.
+
+Code quality changes:
+
+- Added `WorkspaceProjectContextRefresher` for local project metadata refresh, SSH Remote project context refresh, global-memory reloads, and thread context snapshots.
+- Added `WorkspaceThreadContextSnapshot` so instruction/memory refresh has a named value boundary instead of repeated local variables.
+- Updated `WorkspaceModel` to delegate refresh and thread sync while keeping orchestration, persistence, and top-bar status updates in the model.
+- Added focused tests for local project/global memory reloads, project plus global memory merge order, thread-project precedence over fallback project, and memory-only refresh.
+- Added a parity gate so metadata loaders, global-memory loads, and direct thread instruction/memory sync do not drift back into `WorkspaceModel`.
+
+Remaining risk:
+
+- `WorkspaceModel` still calls context snapshots for new threads, worktrees, automations, and status copy. Those reads are acceptable because they assemble different workflows; if those workflows start mutating project context directly, move them through this refresher instead of adding more inline refresh logic.


### PR DESCRIPTION
## Summary
- add `WorkspaceProjectContextRefresher` for local/remote project metadata refresh, global-memory reloads, and thread context snapshots
- delegate `WorkspaceModel` refresh/sync paths to the helper while keeping orchestration and persistence in the model
- add focused refresher tests plus parity gates preventing metadata/global-memory/thread-context logic from drifting back into `WorkspaceModel`

## Validation
- `swift test --filter ParityGateTests/testWorkspaceModelDelegatesMemoryCommandOrchestration`
- `swift test --filter ParityGateTests/testWorkspaceModelDelegatesProjectMetadataLoading`
- `swift test --filter ParityGateTests/testWorkspaceModelDelegatesProjectContextRefresh`
- `swift test`
- `git diff --check`