### PR TITLE
Extract workspace top-bar state builder

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -1788,17 +1788,7 @@ public final class QuillCodeWorkspaceModel {
     }
 
     private func refreshTopBar(agentStatus: String? = nil) {
-        let thread = selectedThread
-        let projectID = thread?.projectID ?? root.selectedProjectID
-        let project = projectID.flatMap { id in root.projects.first { $0.id == id } }
-        root.topBar = TopBarState(
-            projectName: project?.name,
-            threadTitle: thread?.title,
-            model: thread?.model ?? root.config.defaultModel,
-            mode: thread?.mode ?? root.config.mode,
-            agentStatus: agentStatus ?? root.topBar.agentStatus,
-            computerUseStatus: root.topBar.computerUseStatus
-        )
+        root.topBar = WorkspaceTopBarStateBuilder.state(from: root, agentStatus: agentStatus)
     }
 
     private func touchProject(_ id: UUID?) {

--- a/Sources/QuillCodeApp/WorkspaceTopBarStateBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarStateBuilder.swift
@@ -1,0 +1,24 @@
+import Foundation
+import QuillCodeCore
+
+enum WorkspaceTopBarStateBuilder {
+    static func state(from root: QuillCodeRootState, agentStatus: String? = nil) -> TopBarState {
+        let thread = root.selectedThreadID.flatMap { selectedThreadID in
+            root.threads.first { $0.id == selectedThreadID }
+        }
+        let projectID = thread?.projectID ?? root.selectedProjectID
+        let project = projectID.flatMap { selectedProjectID in
+            root.projects.first { $0.id == selectedProjectID }
+        }
+
+        return TopBarState(
+            appName: root.topBar.appName,
+            projectName: project?.name,
+            threadTitle: thread?.title,
+            model: thread?.model ?? root.config.defaultModel,
+            mode: thread?.mode ?? root.config.mode,
+            agentStatus: agentStatus ?? root.topBar.agentStatus,
+            computerUseStatus: root.topBar.computerUseStatus
+        )
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTopBarStateBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTopBarStateBuilderTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import QuillCodeCore
+import QuillComputerUseKit
+@testable import QuillCodeApp
+
+final class WorkspaceTopBarStateBuilderTests: XCTestCase {
+    func testSelectedThreadProjectAndThreadSettingsDriveTopBarState() {
+        let projectID = UUID()
+        let selectedProjectID = UUID()
+        let thread = ChatThread(
+            title: "Fix parser",
+            projectID: projectID,
+            mode: .review,
+            model: TrustedRouterDefaults.synthModel
+        )
+        let root = QuillCodeRootState(
+            config: AppConfig(defaultModel: TrustedRouterDefaults.defaultModel, mode: .auto),
+            projects: [
+                ProjectRef(id: selectedProjectID, name: "Selected Project", path: "/tmp/selected"),
+                ProjectRef(id: projectID, name: "Thread Project", path: "/tmp/thread")
+            ],
+            selectedProjectID: selectedProjectID,
+            threads: [thread],
+            selectedThreadID: thread.id,
+            topBar: TopBarState(
+                appName: "QuillCode",
+                agentStatus: TopBarAgentStatusLabel.streaming,
+                computerUseStatus: .permissionStatus(
+                    screenRecordingGranted: true,
+                    accessibilityGranted: true
+                )
+            )
+        )
+
+        let state = WorkspaceTopBarStateBuilder.state(from: root, agentStatus: TopBarAgentStatusLabel.running)
+
+        XCTAssertEqual(state.appName, "QuillCode")
+        XCTAssertEqual(state.projectName, "Thread Project")
+        XCTAssertEqual(state.threadTitle, "Fix parser")
+        XCTAssertEqual(state.model, TrustedRouterDefaults.synthModel)
+        XCTAssertEqual(state.mode, AgentMode.review)
+        XCTAssertEqual(state.agentStatus, TopBarAgentStatusLabel.running)
+        XCTAssertEqual(state.computerUseStatus.message, "Computer Use ready")
+    }
+
+    func testFallsBackToSelectedProjectAndConfigWhenNoThreadIsSelected() {
+        let selectedProjectID = UUID()
+        let root = QuillCodeRootState(
+            config: AppConfig(defaultModel: "z-ai/glm-5.2", mode: .readOnly),
+            projects: [
+                ProjectRef(id: selectedProjectID, name: "Selected Project", path: "/tmp/selected")
+            ],
+            selectedProjectID: selectedProjectID,
+            topBar: TopBarState(agentStatus: TopBarAgentStatusLabel.terminal)
+        )
+
+        let state = WorkspaceTopBarStateBuilder.state(from: root)
+
+        XCTAssertEqual(state.projectName, "Selected Project")
+        XCTAssertNil(state.threadTitle)
+        XCTAssertEqual(state.model, "z-ai/glm-5.2")
+        XCTAssertEqual(state.mode, AgentMode.readOnly)
+        XCTAssertEqual(state.agentStatus, TopBarAgentStatusLabel.terminal)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -391,6 +391,7 @@ final class ParityGateTests: XCTestCase {
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceStatusTextBuilder.swift")
         let topBarBuilderText = try Self.appSourceText(named: "WorkspaceTopBarSurfaceBuilder.swift")
+        let topBarStateBuilderText = try Self.appSourceText(named: "WorkspaceTopBarStateBuilder.swift")
         let slashTranscriptText = try Self.appSourceText(named: "WorkspaceSlashCommandTranscriptPlanner.swift")
 
         XCTAssertTrue(builderText.contains("struct WorkspaceStatusTextBuilder"), "Workspace status text and labels should live in a focused builder.")
@@ -404,6 +405,9 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.topBarSubtitle"), "Top-bar builder should delegate top-bar subtitles.")
         XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.instructionLabel"), "Top-bar builder should delegate instruction labels.")
         XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.memoryLabel"), "Top-bar builder should delegate memory labels.")
+        XCTAssertTrue(topBarStateBuilderText.contains("enum WorkspaceTopBarStateBuilder"), "Top-bar state assembly should live in a focused builder.")
+        XCTAssertTrue(modelText.contains("WorkspaceTopBarStateBuilder.state"), "WorkspaceModel should delegate top-bar state assembly.")
+        XCTAssertFalse(modelText.contains("root.topBar = TopBarState("), "WorkspaceModel should not assemble top-bar state inline.")
         XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.topBarSubtitle"), "WorkspaceSurface should not own top-bar subtitles.")
         XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.instructionLabel"), "WorkspaceSurface should not own instruction labels.")
         XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.memoryLabel"), "WorkspaceSurface should not own memory labels.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -23,7 +23,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 
 | File | Grade | Next Improvement |
 | --- | --- | --- |
-| `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, sidebar selection transitions, and sidebar bulk action planning now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
+| `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, sidebar selection transitions, sidebar bulk action planning, and top-bar state assembly now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
 | `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A- | The shell is now mostly chrome composition, state, and routing. Transcript layout and workspace sheet presentation live in focused files; keep future modal families and command workflow rules out of the root shell. |
 | `Sources/QuillCodeApp/QuillCodeToolCardView.swift` | A- | Native tool-card composition is now separate from reusable controls, artifact previews, and raw detail blocks. Keep future status/action chrome in `QuillCodeToolCardControls.swift` and artifact rendering in `QuillCodeToolArtifactViews.swift`. |
 | `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, active context-source selection, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, automation pane command wiring, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
@@ -48,6 +48,24 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
+
+## 2026-06-24 Top-Bar State Builder Pass
+
+Overall grade after this slice: **A top-bar state boundary, A behavior preservation, A regression guard**.
+
+`WorkspaceModel` was still assembling live top-bar state inline while also coordinating threads, projects, tools, automations, persistence, and runtime status. The logic was small, but selected-thread/project precedence is central to Codex parity and easy to regress when status or remote-context features grow.
+
+Code quality changes:
+
+- Added `WorkspaceTopBarStateBuilder` for top-bar state derivation from root state.
+- Preserved selected-thread model/mode/title precedence, selected-thread project precedence over selected project, and existing Computer Use status.
+- Simplified `WorkspaceModel.refreshTopBar` to delegate the state transition.
+- Added focused tests for thread-backed state and no-thread project/config fallback state.
+- Added a parity gate preventing inline `TopBarState` assembly from returning to `WorkspaceModel`.
+
+Remaining risk:
+
+- `WorkspaceModel` is still large because it is the app coordinator. The next A+ slices should keep extracting project/context refresh, slash-command dispatch, and tool-run orchestration into directly testable helpers.
 
 ## 2026-06-24 Sidebar Command Grouping Pass
 


### PR DESCRIPTION
## Summary\n- adds a focused WorkspaceTopBarStateBuilder for deriving live top-bar state from root state\n- keeps WorkspaceModel as coordinator only for top-bar refresh delegation\n- adds unit coverage for selected-thread precedence and config/project fallback\n- adds a parity gate preventing inline TopBarState assembly from returning to WorkspaceModel\n- updates the code-quality audit with the current grade and remaining WorkspaceModel risks\n\n## Validation\n- swift test --filter 'WorkspaceTopBarStateBuilderTests|WorkspaceProjectContextRefresherTests|ParityGateTests/testWorkspaceModelDelegatesStatusTextAndLabels|ParityGateTests/testWorkspaceModelDelegatesProjectContextRefresh'\n- ./scripts/smoke.sh (905 Swift tests, mock CLI checks, 61 Playwright tests)