### PR TITLE
Extract thread notice appender

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -1271,10 +1271,7 @@ public final class QuillCodeWorkspaceModel {
 
     private func appendNotice(_ summary: String) {
         mutateSelectedThread { thread in
-            thread.events.append(.init(kind: .notice, summary: summary))
-        }
-        if let thread = selectedThread {
-            threadPersistence.save(thread)
+            WorkspaceThreadNoticeAppender.appendNotice(summary, to: &thread)
         }
     }
 
@@ -1869,8 +1866,7 @@ public final class QuillCodeWorkspaceModel {
 
     private func appendAssistantNotice(_ text: String) {
         mutateSelectedThread { thread in
-            thread.messages.append(.init(role: .assistant, content: text))
-            thread.events.append(.init(kind: .message, summary: text))
+            WorkspaceThreadNoticeAppender.appendAssistantNotice(text, to: &thread)
         }
     }
 

--- a/Sources/QuillCodeApp/WorkspaceThreadNoticeAppender.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadNoticeAppender.swift
@@ -1,0 +1,12 @@
+import QuillCodeCore
+
+enum WorkspaceThreadNoticeAppender {
+    static func appendNotice(_ summary: String, to thread: inout ChatThread) {
+        thread.events.append(ThreadEvent(kind: .notice, summary: summary))
+    }
+
+    static func appendAssistantNotice(_ text: String, to thread: inout ChatThread) {
+        thread.messages.append(ChatMessage(role: .assistant, content: text))
+        thread.events.append(ThreadEvent(kind: .message, summary: text))
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceThreadNoticeAppenderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceThreadNoticeAppenderTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceThreadNoticeAppenderTests: XCTestCase {
+    func testAppendNoticeAddsNoticeEventOnly() {
+        var thread = ChatThread(title: "Thread")
+
+        WorkspaceThreadNoticeAppender.appendNotice("Refreshed project context", to: &thread)
+
+        XCTAssertTrue(thread.messages.isEmpty)
+        XCTAssertEqual(thread.events.map(\.kind), [.notice])
+        XCTAssertEqual(thread.events.map(\.summary), ["Refreshed project context"])
+    }
+
+    func testAppendAssistantNoticeAddsMessageAndEvent() {
+        var thread = ChatThread(title: "Thread")
+
+        WorkspaceThreadNoticeAppender.appendAssistantNotice("Ready.", to: &thread)
+
+        XCTAssertEqual(thread.messages.map(\.role), [.assistant])
+        XCTAssertEqual(thread.messages.map(\.content), ["Ready."])
+        XCTAssertEqual(thread.events.map(\.kind), [.message])
+        XCTAssertEqual(thread.events.map(\.summary), ["Ready."])
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -491,6 +491,20 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(modelText.contains("AgentRunner.streamingNotice"), "WorkspaceModel should not know the streaming notice string.")
     }
 
+    func testWorkspaceModelDelegatesThreadNoticeMutation() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let appenderText = try Self.appSourceText(named: "WorkspaceThreadNoticeAppender.swift")
+
+        XCTAssertTrue(appenderText.contains("enum WorkspaceThreadNoticeAppender"), "Thread notice mutation should live in a focused helper.")
+        XCTAssertTrue(appenderText.contains("static func appendNotice"), "Notice event mutation should be directly testable.")
+        XCTAssertTrue(appenderText.contains("static func appendAssistantNotice"), "Assistant notice mutation should be directly testable.")
+        XCTAssertTrue(modelText.contains("WorkspaceThreadNoticeAppender.appendNotice"), "WorkspaceModel should delegate notice event mutation.")
+        XCTAssertTrue(modelText.contains("WorkspaceThreadNoticeAppender.appendAssistantNotice"), "WorkspaceModel should delegate assistant notice mutation.")
+        XCTAssertFalse(modelText.contains("thread.events.append(.init(kind: .notice"), "WorkspaceModel should not append notice events inline.")
+        XCTAssertFalse(modelText.contains("thread.events.append(.init(kind: .message"), "WorkspaceModel should not append message events inline.")
+        XCTAssertFalse(modelText.contains("thread.messages.append(.init(role: .assistant"), "WorkspaceModel should not append assistant notice messages inline.")
+    }
+
     func testWorkspaceModelUsesExplicitAgentRunThreadUpdates() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -23,7 +23,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 
 | File | Grade | Next Improvement |
 | --- | --- | --- |
-| `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, thread persistence, local command transcript mutation, sidebar selection transitions, sidebar bulk action planning, project context refresh, and top-bar state assembly now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
+| `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, thread persistence, local command transcript mutation, thread notice mutation, sidebar selection transitions, sidebar bulk action planning, project context refresh, and top-bar state assembly now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
 | `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A- | The shell is now mostly chrome composition, state, and routing. Transcript layout and workspace sheet presentation live in focused files; keep future modal families and command workflow rules out of the root shell. |
 | `Sources/QuillCodeApp/QuillCodeToolCardView.swift` | A- | Native tool-card composition is now separate from reusable controls, artifact previews, and raw detail blocks. Keep future status/action chrome in `QuillCodeToolCardControls.swift` and artifact rendering in `QuillCodeToolArtifactViews.swift`. |
 | `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, active context-source selection, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, automation pane command wiring, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
@@ -101,6 +101,23 @@ Code quality changes:
 Remaining risk:
 
 - Slash-command dispatch itself is still a switch in `WorkspaceModel`. That is acceptable while the branches mostly call focused planners/engines, but a future slice should extract the command-effect dispatcher once more slash commands share workflow mechanics.
+
+## 2026-06-24 Thread Notice Appender Pass
+
+Overall grade after this slice: **A notice mutation boundary, A transcript event coverage, A regression guard**.
+
+`WorkspaceModel` still directly appended lightweight notice events and assistant notice messages. These are small operations, but they affect transcript rendering, activity state, and persistence through `mutateSelectedThread`, so keeping the mutation shape outside the coordinator reduces drift.
+
+Code quality changes:
+
+- Added `WorkspaceThreadNoticeAppender` for notice-only events and assistant notice message/event pairs.
+- Simplified `WorkspaceModel.appendNotice` and `appendAssistantNotice` to delegate thread mutation.
+- Added focused tests proving notice-only events do not create messages and assistant notices create both message and event records.
+- Added a parity gate preventing inline notice/message event mutation from returning to `WorkspaceModel`.
+
+Remaining risk:
+
+- Some specialized event appends still belong to their domain planners (`WorkspaceComposerCancellationPlanner`, memory context updates, tool events). Keep them there; only shared primitive transcript mutation should use this appender.
 
 ## 2026-06-24 Sidebar Command Grouping Pass
 


### PR DESCRIPTION
## Summary
- extract thread notice and assistant notice mutations from `WorkspaceModel` into `WorkspaceThreadNoticeAppender`
- keep coordinator timing unchanged while making notice/message event shape directly testable
- add focused notice appender tests and a parity gate against inline notice mutation in the coordinator
- update the code-quality audit with the new grade and remaining event ownership guidance

## Validation
- `swift test --filter 'WorkspaceThreadNoticeAppenderTests|WorkspaceProjectExtensionIntegrationTests|WorkspaceMCPIntegrationTests/testStartAndStopMCPServerUpdatesExtensionState|WorkspaceLocalEnvironmentIntegrationTests/testRunLocalEnvironmentActionRecordsNotice|ParityGateTests/testWorkspaceModelDelegatesThreadNoticeMutation'`\n- `./scripts/smoke.sh` (922 Swift tests, CLI checks, 61 Playwright tests)