### PR TITLE
Extract workspace main pane view

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import QuillCodeCore
+
+struct QuillCodeWorkspaceMainPaneView: View {
+    var surface: WorkspaceSurface
+    @Binding var draft: String
+    @Binding var terminalDraft: String
+    @Binding var browserAddressDraft: String
+    @Binding var isModelPickerPresented: Bool
+    @Binding var isFindPresented: Bool
+    @Binding var findQuery: String
+    @Binding var activeFindIndex: Int
+    var isComposerFocused: FocusState<Bool>.Binding
+    var copiedTranscriptItemID: String?
+    var onSetMode: (AgentMode) -> Void
+    var onSetModel: (String) -> Void
+    var onToggleModelFavorite: (String) -> Void
+    var onSend: () -> Void
+    var onRunTerminalCommand: () -> Void
+    var onOpenBrowserPreview: () -> Void
+    var onAddBrowserComment: (String) -> Void
+    var onReviewAction: (WorkspaceReviewActionSurface) -> Void
+    var onToolCardAction: (ToolCardActionSurface) -> Void
+    var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
+    var onCopyTranscriptItem: (String, String) -> Void
+    var onMessageFeedback: (UUID, MessageFeedbackValue) -> Void
+    var onCommand: (WorkspaceCommandSurface) -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                if surface.automations.isVisible {
+                    QuillCodeAutomationsPaneView(
+                        automations: surface.automations,
+                        onCommand: onCommand
+                    )
+                    Divider()
+                }
+                if !surface.automations.isVisible || !surface.transcript.timelineItems.isEmpty {
+                    QuillCodeTranscriptView(
+                        transcript: surface.transcript,
+                        contextBanner: surface.contextBanner,
+                        runtimeIssue: surface.runtimeIssue,
+                        review: surface.review,
+                        retryLastTurnCommand: surface.commands.first { $0.id == "retry-last-turn" && $0.isEnabled },
+                        isFindPresented: $isFindPresented,
+                        findQuery: $findQuery,
+                        activeFindIndex: $activeFindIndex,
+                        copiedTranscriptItemID: copiedTranscriptItemID,
+                        onContextCommand: onCommand,
+                        onRuntimeIssueAction: runtimeIssueAction(for: surface.runtimeIssue),
+                        onReviewAction: onReviewAction,
+                        onToolCardAction: onToolCardAction,
+                        onAddReviewComment: onAddReviewComment,
+                        onCopyTranscriptItem: onCopyTranscriptItem,
+                        onUseMessageAsDraft: useMessageAsDraft,
+                        onMessageFeedback: onMessageFeedback
+                    )
+                } else {
+                    Spacer(minLength: 0)
+                }
+                if surface.browser.isVisible {
+                    Divider()
+                    QuillCodeBrowserPaneView(
+                        browser: surface.browser,
+                        addressDraft: $browserAddressDraft,
+                        onOpen: onOpenBrowserPreview,
+                        onAddComment: onAddBrowserComment,
+                        onCommand: runCommand(id:)
+                    )
+                }
+                if surface.extensions.isVisible {
+                    Divider()
+                    QuillCodeExtensionsPaneView(
+                        extensions: surface.extensions,
+                        onCommand: onCommand
+                    )
+                }
+                if surface.memories.isVisible {
+                    Divider()
+                    QuillCodeMemoriesPaneView(memories: surface.memories) { commandID in
+                        if let command = surface.commands.first(where: { $0.id == commandID }) {
+                            onCommand(command)
+                        } else if commandID.hasPrefix("memory-delete:") {
+                            onCommand(WorkspaceCommandSurface(
+                                id: commandID,
+                                title: "Forget memory",
+                                category: WorkspaceCommandPalette.memoriesCategory,
+                                keywords: ["memory", "forget", "delete"]
+                            ))
+                        }
+                    }
+                }
+                if surface.terminal.isVisible {
+                    Divider()
+                    QuillCodeTerminalPaneView(
+                        terminal: surface.terminal,
+                        draft: $terminalDraft,
+                        onRun: onRunTerminalCommand,
+                        onStop: stopActiveRun,
+                        onClear: { runCommand(id: "terminal-clear") }
+                    )
+                }
+                Divider()
+                QuillCodeComposerView(
+                    composer: surface.composer,
+                    topBar: surface.topBar,
+                    draft: $draft,
+                    isModelPickerPresented: $isModelPickerPresented,
+                    isFocused: isComposerFocused,
+                    onSetMode: onSetMode,
+                    onSetModel: onSetModel,
+                    onToggleModelFavorite: onToggleModelFavorite,
+                    onSend: onSend,
+                    onStop: stopActiveRun
+                )
+            }
+            if surface.activity.isVisible {
+                Divider()
+                QuillCodeActivityPaneView(activity: surface.activity) { commandID in
+                    onCommand(WorkspaceCommandSurface(
+                        id: commandID,
+                        title: "Toggle activity section",
+                        category: WorkspaceCommandPalette.workspaceCategory,
+                        keywords: ["activity", "task", "collapse", "expand"]
+                    ))
+                }
+                    .frame(width: 320)
+            }
+        }
+    }
+
+    private func runCommand(id: String) {
+        guard let command = surface.commands.first(where: { $0.id == id }) else { return }
+        onCommand(command)
+    }
+
+    private func stopActiveRun() {
+        if let command = surface.commands.first(where: { $0.id == "stop-all" }) {
+            onCommand(command)
+        } else {
+            onCommand(WorkspaceCommandSurface(
+                id: "stop-all",
+                title: "Stop all",
+                category: WorkspaceCommandPalette.controlCategory,
+                keywords: ["cancel", "abort", "halt"]
+            ))
+        }
+    }
+
+    private func useMessageAsDraft(_ text: String) {
+        draft = text
+        DispatchQueue.main.async {
+            isComposerFocused.wrappedValue = true
+        }
+    }
+
+    private func runtimeIssueAction(for issue: RuntimeIssueSurface?) -> (() -> Void)? {
+        guard let action = RuntimeIssueRecoveryPlanner(commands: surface.commands).action(for: issue) else {
+            return nil
+        }
+        switch action {
+        case .presentModelPicker:
+            return {
+                isModelPickerPresented = true
+            }
+        case let .command(command):
+            return {
+                onCommand(command)
+            }
+        }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -141,107 +141,31 @@ public struct QuillCodeWorkspaceView: View {
                 )
                     .frame(width: 280)
                 Divider()
-                HStack(spacing: 0) {
-                    VStack(spacing: 0) {
-                        if surface.automations.isVisible {
-                            QuillCodeAutomationsPaneView(
-                                automations: surface.automations,
-                                onCommand: handleCommand
-                            )
-                            Divider()
-                        }
-                        if !surface.automations.isVisible || !surface.transcript.timelineItems.isEmpty {
-                            QuillCodeTranscriptView(
-                                transcript: surface.transcript,
-                                contextBanner: surface.contextBanner,
-                                runtimeIssue: surface.runtimeIssue,
-                                review: surface.review,
-                                retryLastTurnCommand: surface.commands.first { $0.id == "retry-last-turn" && $0.isEnabled },
-                                isFindPresented: $isFindPresented,
-                                findQuery: $findQuery,
-                                activeFindIndex: $activeFindIndex,
-                                copiedTranscriptItemID: copiedTranscriptItemID,
-                                onContextCommand: handleCommand,
-                                onRuntimeIssueAction: runtimeIssueAction(for: surface.runtimeIssue),
-                                onReviewAction: onReviewAction,
-                                onToolCardAction: onToolCardAction,
-                                onAddReviewComment: onAddReviewComment,
-                                onCopyTranscriptItem: onCopyTranscriptItem,
-                                onUseMessageAsDraft: useMessageAsDraft,
-                                onMessageFeedback: onMessageFeedback
-                            )
-                        } else {
-                            Spacer(minLength: 0)
-                        }
-                        if surface.browser.isVisible {
-                            Divider()
-                            QuillCodeBrowserPaneView(
-                                browser: surface.browser,
-                                addressDraft: $browserAddressDraft,
-                                onOpen: onOpenBrowserPreview,
-                                onAddComment: onAddBrowserComment,
-                                onCommand: runCommand(id:)
-                            )
-                        }
-                        if surface.extensions.isVisible {
-                            Divider()
-                            QuillCodeExtensionsPaneView(
-                                extensions: surface.extensions,
-                                onCommand: handleCommand
-                            )
-                        }
-                        if surface.memories.isVisible {
-                            Divider()
-                            QuillCodeMemoriesPaneView(memories: surface.memories) { commandID in
-                                if let command = surface.commands.first(where: { $0.id == commandID }) {
-                                    handleCommand(command)
-                                } else if commandID.hasPrefix("memory-delete:") {
-                                    handleCommand(WorkspaceCommandSurface(
-                                        id: commandID,
-                                        title: "Forget memory",
-                                        category: WorkspaceCommandPalette.memoriesCategory,
-                                        keywords: ["memory", "forget", "delete"]
-                                    ))
-                                }
-                            }
-                        }
-                        if surface.terminal.isVisible {
-                            Divider()
-                            QuillCodeTerminalPaneView(
-                                terminal: surface.terminal,
-                                draft: $terminalDraft,
-                                onRun: onRunTerminalCommand,
-                                onStop: stopActiveRun,
-                                onClear: { runCommand(id: "terminal-clear") }
-                            )
-                        }
-                        Divider()
-                        QuillCodeComposerView(
-                            composer: surface.composer,
-                            topBar: surface.topBar,
-                            draft: $draft,
-                            isModelPickerPresented: $isModelPickerPresented,
-                            isFocused: $isComposerFocused,
-                            onSetMode: onSetMode,
-                            onSetModel: onSetModel,
-                            onToggleModelFavorite: onToggleModelFavorite,
-                            onSend: onSend,
-                            onStop: stopActiveRun
-                        )
-                    }
-                    if surface.activity.isVisible {
-                        Divider()
-                        QuillCodeActivityPaneView(activity: surface.activity) { commandID in
-                            handleCommand(WorkspaceCommandSurface(
-                                id: commandID,
-                                title: "Toggle activity section",
-                                category: WorkspaceCommandPalette.workspaceCategory,
-                                keywords: ["activity", "task", "collapse", "expand"]
-                            ))
-                        }
-                            .frame(width: 320)
-                    }
-                }
+                QuillCodeWorkspaceMainPaneView(
+                    surface: surface,
+                    draft: $draft,
+                    terminalDraft: $terminalDraft,
+                    browserAddressDraft: $browserAddressDraft,
+                    isModelPickerPresented: $isModelPickerPresented,
+                    isFindPresented: $isFindPresented,
+                    findQuery: $findQuery,
+                    activeFindIndex: $activeFindIndex,
+                    isComposerFocused: $isComposerFocused,
+                    copiedTranscriptItemID: copiedTranscriptItemID,
+                    onSetMode: onSetMode,
+                    onSetModel: onSetModel,
+                    onToggleModelFavorite: onToggleModelFavorite,
+                    onSend: onSend,
+                    onRunTerminalCommand: onRunTerminalCommand,
+                    onOpenBrowserPreview: onOpenBrowserPreview,
+                    onAddBrowserComment: onAddBrowserComment,
+                    onReviewAction: onReviewAction,
+                    onToolCardAction: onToolCardAction,
+                    onAddReviewComment: onAddReviewComment,
+                    onCopyTranscriptItem: onCopyTranscriptItem,
+                    onMessageFeedback: onMessageFeedback,
+                    onCommand: handleCommand
+                )
             }
         }
         .frame(minWidth: 980, minHeight: 640)
@@ -348,46 +272,6 @@ public struct QuillCodeWorkspaceView: View {
         }
     }
 
-    private func runCommand(id: String) {
-        guard let command = surface.commands.first(where: { $0.id == id }) else { return }
-        handleCommand(command)
-    }
-
-    private func stopActiveRun() {
-        if let command = surface.commands.first(where: { $0.id == "stop-all" }) {
-            onCommand(command)
-        } else {
-            onCommand(WorkspaceCommandSurface(
-                id: "stop-all",
-                title: "Stop all",
-                category: WorkspaceCommandPalette.controlCategory,
-                keywords: ["cancel", "abort", "halt"]
-            ))
-        }
-    }
-
-    private func useMessageAsDraft(_ text: String) {
-        draft = text
-        DispatchQueue.main.async {
-            isComposerFocused = true
-        }
-    }
-
-    private func runtimeIssueAction(for issue: RuntimeIssueSurface?) -> (() -> Void)? {
-        guard let action = RuntimeIssueRecoveryPlanner(commands: surface.commands).action(for: issue) else {
-            return nil
-        }
-        switch action {
-        case .presentModelPicker:
-            return {
-                isModelPickerPresented = true
-            }
-        case let .command(command):
-            return {
-                handleCommand(command)
-            }
-        }
-    }
 }
 
 extension AgentMode {

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1550,10 +1550,12 @@ final class ParityGateTests: XCTestCase {
 
     func testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner() throws {
         let shellText = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
+        let mainPaneText = try Self.appSourceText(named: "QuillCodeWorkspaceMainPaneView.swift")
         let transcriptText = try Self.appSourceText(named: "QuillCodeTranscriptView.swift")
         let findText = try Self.appSourceText(named: "QuillCodeTranscriptFindView.swift")
         let contextBannerText = try Self.appSourceText(named: "QuillCodeContextBannerView.swift")
 
+        XCTAssertTrue(mainPaneText.contains("struct QuillCodeWorkspaceMainPaneView"), "Workspace center-pane layout should live in a focused view file.")
         XCTAssertTrue(transcriptText.contains("struct QuillCodeTranscriptView"), "Transcript layout should live in a focused view file.")
         XCTAssertTrue(transcriptText.contains("QuillCodeTranscriptFindBar"), "Transcript layout should compose the focused Find bar.")
         XCTAssertTrue(transcriptText.contains("QuillCodeContextBannerView"), "Transcript layout should compose the focused context banner.")
@@ -1563,7 +1565,8 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(findText.contains("struct QuillCodeTranscriptFindMatch"), "Transcript Find matching should live in a focused Find file.")
         XCTAssertTrue(findText.contains("struct QuillCodeTranscriptFindBar"), "Transcript Find bar should live in a focused Find file.")
         XCTAssertTrue(contextBannerText.contains("struct QuillCodeContextBannerView"), "Context banner rendering should live in a focused banner file.")
-        XCTAssertTrue(shellText.contains("QuillCodeTranscriptView"), "Workspace shell should compose the extracted transcript view.")
+        XCTAssertTrue(shellText.contains("QuillCodeWorkspaceMainPaneView"), "Workspace shell should compose the extracted center-pane view.")
+        XCTAssertTrue(mainPaneText.contains("QuillCodeTranscriptView"), "Workspace center pane should compose the extracted transcript view.")
         XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptView"), "Workspace shell should not own transcript layout.")
         XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptFindMatch"), "Workspace shell should not own transcript Find matching.")
         XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptFindBar"), "Workspace shell should not own transcript Find UI.")
@@ -1720,6 +1723,7 @@ final class ParityGateTests: XCTestCase {
 
     func testWorkspaceViewDelegatesRuntimeIssueRecoveryPlanning() throws {
         let viewText = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
+        let mainPaneText = try Self.appSourceText(named: "QuillCodeWorkspaceMainPaneView.swift")
         let plannerText = try Self.appSourceText(named: "QuillCodeRuntimeIssueRecoveryPlanner.swift")
 
         XCTAssertTrue(plannerText.contains("struct RuntimeIssueRecoveryPlanner"), "Runtime issue recovery routing should live in a focused planner.")
@@ -1727,7 +1731,8 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(plannerText.contains("case \"Open Settings\", \"Add key\", \"Fix key\""), "Settings recovery labels should be directly testable.")
         XCTAssertTrue(plannerText.contains("case \"Retry\""), "Retry recovery routing should be directly testable.")
         XCTAssertTrue(plannerText.contains("case \"Switch model\""), "Model-switch recovery routing should be directly testable.")
-        XCTAssertTrue(viewText.contains("RuntimeIssueRecoveryPlanner(commands:"), "WorkspaceSwiftUIView should delegate runtime issue recovery planning.")
+        XCTAssertTrue(viewText.contains("QuillCodeWorkspaceMainPaneView"), "WorkspaceSwiftUIView should delegate center-pane layout and recovery wiring.")
+        XCTAssertTrue(mainPaneText.contains("RuntimeIssueRecoveryPlanner(commands:"), "Workspace main pane should delegate runtime issue recovery planning.")
         XCTAssertFalse(viewText.contains("[\"Open Settings\", \"Add key\", \"Fix key\"]"), "WorkspaceSwiftUIView should not own settings recovery labels.")
         XCTAssertFalse(viewText.contains("actionLabel == \"Retry\""), "WorkspaceSwiftUIView should not own retry recovery labels.")
         XCTAssertFalse(viewText.contains("actionLabel == \"Switch model\""), "WorkspaceSwiftUIView should not own model-picker recovery labels.")
@@ -1948,20 +1953,25 @@ final class ParityGateTests: XCTestCase {
 
     func testNativeSecondaryPanesUseFocusedViewFiles() throws {
         let workspaceText = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
+        let mainPaneText = try Self.appSourceText(named: "QuillCodeWorkspaceMainPaneView.swift")
         let chromeText = try Self.appSourceText(named: "QuillCodeSecondaryPanesView.swift")
         let extensionsText = try Self.appSourceText(named: "QuillCodeExtensionsPaneView.swift")
         let memoriesText = try Self.appSourceText(named: "QuillCodeMemoriesPaneView.swift")
         let automationsText = try Self.appSourceText(named: "QuillCodeAutomationsPaneView.swift")
 
+        XCTAssertTrue(workspaceText.contains("QuillCodeWorkspaceMainPaneView"), "Workspace shell should delegate center-pane placement.")
         XCTAssertTrue(chromeText.contains("struct QuillCodePaneCountPill"), "Secondary pane count pills should remain shared native chrome.")
         XCTAssertTrue(chromeText.contains("struct QuillCodePaneEmptyStateView"), "Secondary pane empty states should remain shared native chrome.")
         XCTAssertTrue(extensionsText.contains("struct QuillCodeExtensionsPaneView"), "Extensions native UI should live in its own focused file.")
         XCTAssertTrue(extensionsText.contains("ProjectExtensionManifestSurface"), "MCP extension metadata display should stay with the Extensions native pane.")
         XCTAssertTrue(memoriesText.contains("struct QuillCodeMemoriesPaneView"), "Memories native UI should live in its own focused file.")
         XCTAssertTrue(automationsText.contains("struct QuillCodeAutomationsPaneView"), "Automations native UI should live in its own focused file.")
-        XCTAssertTrue(workspaceText.contains("QuillCodeExtensionsPaneView"), "Workspace shell should route Extensions pane placement.")
-        XCTAssertTrue(workspaceText.contains("QuillCodeMemoriesPaneView"), "Workspace shell should route Memories pane placement.")
-        XCTAssertTrue(workspaceText.contains("QuillCodeAutomationsPaneView"), "Workspace shell should route Automations pane placement.")
+        XCTAssertTrue(mainPaneText.contains("QuillCodeExtensionsPaneView"), "Workspace main pane should route Extensions pane placement.")
+        XCTAssertTrue(mainPaneText.contains("QuillCodeMemoriesPaneView"), "Workspace main pane should route Memories pane placement.")
+        XCTAssertTrue(mainPaneText.contains("QuillCodeAutomationsPaneView"), "Workspace main pane should route Automations pane placement.")
+        XCTAssertFalse(workspaceText.contains("QuillCodeExtensionsPaneView"), "Workspace shell should not own Extensions pane placement.")
+        XCTAssertFalse(workspaceText.contains("QuillCodeMemoriesPaneView"), "Workspace shell should not own Memories pane placement.")
+        XCTAssertFalse(workspaceText.contains("QuillCodeAutomationsPaneView"), "Workspace shell should not own Automations pane placement.")
         XCTAssertFalse(chromeText.contains("struct QuillCodeExtensionsPaneView"), "Shared secondary chrome should not own Extensions pane content.")
         XCTAssertFalse(chromeText.contains("struct QuillCodeMemoriesPaneView"), "Shared secondary chrome should not own Memories pane content.")
         XCTAssertFalse(chromeText.contains("struct QuillCodeAutomationsPaneView"), "Shared secondary chrome should not own Automations pane content.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -24,7 +24,8 @@ The architecture is moving in the right direction: core state is value typed, pe
 | File | Grade | Next Improvement |
 | --- | --- | --- |
 | `Sources/QuillCodeApp/WorkspaceModel.swift` | A- | Command parsing, automation records/run drafts, terminal session construction, project registry transitions, context/action lookup, review-comment planning, tool override composition, SSH Remote tool execution, browser location/state transitions, MCP surface state, MCP request parsing, MCP runtime/catalog/launch work, tool-card surface types, execution-context enrichment, thread seeding, thread lifecycle transitions, thread persistence, local command transcript mutation, thread notice mutation, sidebar selection transitions, sidebar bulk action planning, project context refresh, `/status` context assembly, and top-bar state assembly now live in focused helpers; keep extracting pure surface/workflow builders before adding more parity commands. |
-| `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A- | The shell is now mostly chrome composition, state, and routing. Transcript layout and workspace sheet presentation live in focused files; keep future modal families and command workflow rules out of the root shell. |
+| `Sources/QuillCodeApp/WorkspaceSwiftUIView.swift` | A | The shell is now top-bar/sidebar chrome, state, and routing; center-pane layout and workspace sheet presentation live in focused files. Keep future modal families and command workflow rules out of the root shell. |
+| `Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift` | A- | Center-pane layout owns transcript/browser/extensions/memories/terminal/composer/activity composition and runtime issue recovery wiring. Keep workflow decisions in planners and avoid growing this into a second root shell. |
 | `Sources/QuillCodeApp/QuillCodeToolCardView.swift` | A- | Native tool-card composition is now separate from reusable controls, artifact previews, and raw detail blocks. Keep future status/action chrome in `QuillCodeToolCardControls.swift` and artifact rendering in `QuillCodeToolArtifactViews.swift`. |
 | `Sources/QuillCodeApp/WorkspaceSurface.swift` | A- | Surface assembly is now mostly aggregate payload plus runtime/execution context records. Settings copy/compatibility, runtime issue classification, active context-source selection, model catalog presentation, top-bar/model presentation contracts, project/sidebar navigation assembly, sidebar/project contracts, browser state/presentation contracts, terminal presentation contracts, review presentation contracts, transcript/composer/context presentation contracts, secondary-pane presentation contracts, automation pane command wiring, command construction, command palette ranking, review diff construction, context banner estimation, and transcript message projection are extracted into focused files. Next step is extracting runtime/execution context contracts if their presentation behavior grows. |
 | `Sources/QuillCodeApp/WorkspaceHTMLRenderer.swift` | A- | Static HTML harness rendering is still broad, but top-bar HTML delegates to `WorkspaceHTMLTopBarRenderer`, sidebar HTML delegates to `WorkspaceHTMLSidebarRenderer`, tool-card/artifact preview HTML delegates to `WorkspaceHTMLToolCardRenderer`, review pane HTML delegates to `WorkspaceHTMLReviewRenderer`, secondary pane HTML delegates to `WorkspaceHTMLSecondaryPaneRenderer`, browser pane HTML delegates to `WorkspaceHTMLBrowserRenderer`, terminal pane HTML delegates to `WorkspaceHTMLTerminalRenderer`, and shared escaping/context chips live in `WorkspaceHTMLPrimitives`. Next step is extracting another transcript/composer family only when renderer drift appears. |
@@ -136,6 +137,23 @@ Code quality changes:
 Remaining risk:
 
 - Slash-command dispatch still chooses when `/status` runs inside `WorkspaceModel`. That is acceptable while command branches mostly delegate to focused planners; extract command-effect dispatch only when shared command workflow mechanics grow.
+
+## 2026-06-24 Workspace Main Pane Split
+
+Overall grade after this slice: **A root-shell boundary, A center-pane composition, A regression guard**.
+
+`WorkspaceSwiftUIView` still owned the entire center-pane layout: transcript, browser, extensions, memories, terminal, composer, activity, stop fallback, message-as-draft focus, and runtime issue recovery wiring. That made the root shell harder to scan because it mixed app chrome, sheet state, sidebar row routing, and the live workspace pane stack.
+
+Code quality changes:
+
+- Added `QuillCodeWorkspaceMainPaneView` for transcript/browser/extensions/memories/terminal/composer/activity composition.
+- Reduced `WorkspaceSwiftUIView` from 404 lines to 288 lines so it primarily owns top-bar/sidebar chrome, state, sheets, and routing.
+- Moved stop fallback, message-as-draft focus, command-ID lookup, and runtime issue recovery wiring into the center-pane view where those controls are rendered.
+- Updated parity gates so root shell composition, transcript placement, and runtime issue recovery boundaries stay explicit.
+
+Remaining risk:
+
+- `QuillCodeWorkspaceMainPaneView` is intentionally a composition view. If pane-specific behavior grows, split those rules into focused planners or pane views instead of adding more branching to the main pane.
 
 ## 2026-06-24 Sidebar Command Grouping Pass
 


### PR DESCRIPTION
## Summary
- extract center-pane layout from `WorkspaceSwiftUIView` into `QuillCodeWorkspaceMainPaneView`
- keep the root shell focused on chrome, state, sheets, sidebar routing, and command planning
- move runtime issue recovery wiring, stop fallback, message-as-draft focus, and command-ID lookup beside the controls that render them
- update parity gates and code-quality audit for the new root-shell boundary

## Validation
- `swift test --filter 'ParityGateTests/testNativeSecondaryPanesUseFocusedViewFiles|ParityGateTests/testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner|ParityGateTests/testWorkspaceViewDelegatesRuntimeIssueRecoveryPlanning'`\n- `./scripts/smoke.sh` (926 Swift tests, CLI checks, 61 Playwright tests)