### PR TITLE
Extract workspace UI state contracts

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -5,40 +5,6 @@ import QuillCodePersistence
 import QuillCodeTools
 import QuillComputerUseKit
 
-public struct ComposerState: Sendable, Hashable {
-    public var draft: String
-    public var isSending: Bool
-    public var placeholder: String
-
-    public init(
-        draft: String = "",
-        isSending: Bool = false,
-        placeholder: String = "Message QuillCode"
-    ) {
-        self.draft = draft
-        self.isSending = isSending
-        self.placeholder = placeholder
-    }
-}
-
-public struct MemoriesState: Sendable, Hashable {
-    public var isVisible: Bool
-
-    public init(isVisible: Bool = false) {
-        self.isVisible = isVisible
-    }
-}
-
-public struct ActivityState: Sendable, Hashable {
-    public var isVisible: Bool
-    public var collapsedSectionIDs: Set<ActivitySectionKind>
-
-    public init(isVisible: Bool = false, collapsedSectionIDs: Set<ActivitySectionKind> = []) {
-        self.isVisible = isVisible
-        self.collapsedSectionIDs = collapsedSectionIDs
-    }
-}
-
 @MainActor
 public final class QuillCodeWorkspaceModel {
     public private(set) var root: QuillCodeRootState

--- a/Sources/QuillCodeApp/WorkspaceUIState.swift
+++ b/Sources/QuillCodeApp/WorkspaceUIState.swift
@@ -1,0 +1,33 @@
+public struct ComposerState: Sendable, Hashable {
+    public var draft: String
+    public var isSending: Bool
+    public var placeholder: String
+
+    public init(
+        draft: String = "",
+        isSending: Bool = false,
+        placeholder: String = "Message QuillCode"
+    ) {
+        self.draft = draft
+        self.isSending = isSending
+        self.placeholder = placeholder
+    }
+}
+
+public struct MemoriesState: Sendable, Hashable {
+    public var isVisible: Bool
+
+    public init(isVisible: Bool = false) {
+        self.isVisible = isVisible
+    }
+}
+
+public struct ActivityState: Sendable, Hashable {
+    public var isVisible: Bool
+    public var collapsedSectionIDs: Set<ActivitySectionKind>
+
+    public init(isVisible: Bool = false, collapsedSectionIDs: Set<ActivitySectionKind> = []) {
+        self.isVisible = isVisible
+        self.collapsedSectionIDs = collapsedSectionIDs
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceUIStateTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceUIStateTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class WorkspaceUIStateTests: XCTestCase {
+    func testComposerDefaultsMatchPrimaryChatEntryPoint() {
+        let state = ComposerState()
+
+        XCTAssertEqual(state.draft, "")
+        XCTAssertFalse(state.isSending)
+        XCTAssertEqual(state.placeholder, "Message QuillCode")
+    }
+
+    func testVisibilityStatesDefaultClosedAndPreserveCollapsedActivitySections() {
+        XCTAssertFalse(MemoriesState().isVisible)
+
+        let activity = ActivityState(
+            isVisible: true,
+            collapsedSectionIDs: [.tools, .sources]
+        )
+
+        XCTAssertTrue(activity.isVisible)
+        XCTAssertEqual(activity.collapsedSectionIDs, [.tools, .sources])
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -74,6 +74,19 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(toolCardSurfaceText.contains("public enum ToolArtifactDocumentKind"), "Tool-card state should not own artifact document metadata.")
     }
 
+    func testWorkspaceModelDelegatesUIStateContracts() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let stateText = try Self.appSourceText(named: "WorkspaceUIState.swift")
+
+        XCTAssertTrue(stateText.contains("public struct ComposerState"), "Composer UI state should live in a focused state contract file.")
+        XCTAssertTrue(stateText.contains("public struct MemoriesState"), "Memory-pane UI state should live in a focused state contract file.")
+        XCTAssertTrue(stateText.contains("public struct ActivityState"), "Activity-pane UI state should live in a focused state contract file.")
+        XCTAssertTrue(modelText.contains("public private(set) var composer: ComposerState"), "WorkspaceModel should still own live composer state.")
+        XCTAssertFalse(modelText.contains("public struct ComposerState"), "WorkspaceModel should not define composer UI state contracts.")
+        XCTAssertFalse(modelText.contains("public struct MemoriesState"), "WorkspaceModel should not define memory-pane UI state contracts.")
+        XCTAssertFalse(modelText.contains("public struct ActivityState"), "WorkspaceModel should not define activity-pane UI state contracts.")
+    }
+
     func testActionableReviewCardsStayWiredThroughSurfaces() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let toolCardSurfaceText = try Self.appSourceText(named: "QuillCodeToolCardSurface.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -3581,3 +3581,17 @@ What changed:
 
 Remaining risk:
 - `WorkspaceMemoriesSurface` still computes memory count labels inline, and `WorkspaceAutomationsSurface` still computes aggregate status labels inline. That is appropriate while the aggregate labels remain compact and directly tested; split them only if secondary-pane aggregate state grows beyond count/status projection.
+
+## 2026-06-24 Workspace UI State Contract Split
+
+Overall grade after this slice: **A+ UI state ownership, A workspace-model boundary**.
+
+`WorkspaceModel.swift` still orchestrates live workspace behavior, but it no longer defines the reusable UI state contracts for the composer, Memories pane, and Activity pane. Those DTOs are shared by the native UI, surface builders, and focused tests, so keeping them in the model file made the model look like the owner of presentation contracts that are not actor-bound behavior.
+
+What changed:
+- Added `WorkspaceUIState.swift` for `ComposerState`, `MemoriesState`, and `ActivityState`.
+- Added direct default-state coverage in `WorkspaceUIStateTests`.
+- Added a parity gate so the state contracts do not drift back into `WorkspaceModel.swift`.
+
+Remaining risk:
+- `WorkspaceModel.swift` is still the largest app source file because it owns actor-bound orchestration for sends, tools, terminal, projects, memory, automations, and MCP lifecycle. Continue extracting pure state transitions and copy into focused helpers before adding larger Codex-parity features.


### PR DESCRIPTION
## Summary
- move ComposerState, MemoriesState, and ActivityState out of WorkspaceModel into WorkspaceUIState
- add focused default-state coverage
- add a parity gate so WorkspaceModel does not absorb UI state contracts again
- record the architecture pass in CODE_QUALITY_AUDIT

## Verification
- swift test --filter WorkspaceUIStateTests --filter ParityGateTests/testWorkspaceModelDelegatesUIStateContracts
- swift test
- git diff --cached --check