### PR TITLE
Split native sidebar thread list

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeSidebarThreadListView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarThreadListView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct QuillCodeSidebarThreadListView: View {
+    var sidebar: SidebarSurface
+    var onSelectThread: (UUID) -> Void
+    var onThreadAction: (SidebarItemActionSurface) -> Void
+    var onCommand: (WorkspaceCommandSurface) -> Void
+
+    var body: some View {
+        if sidebar.items.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    if !sidebar.pinnedItems.isEmpty {
+                        QuillCodeSidebarThreadSectionView(
+                            title: "Pinned",
+                            items: sidebar.pinnedItems,
+                            isSelectionMode: sidebar.isSelectionMode,
+                            onSelectThread: onSelectThread,
+                            onThreadAction: onThreadAction,
+                            onCommand: onCommand
+                        )
+                    }
+                    ForEach(sidebar.recentSections()) { section in
+                        QuillCodeSidebarThreadSectionView(
+                            title: section.title,
+                            items: section.items,
+                            isSelectionMode: sidebar.isSelectionMode,
+                            onSelectThread: onSelectThread,
+                            onThreadAction: onThreadAction,
+                            onCommand: onCommand
+                        )
+                    }
+                    if !sidebar.archivedItems.isEmpty {
+                        QuillCodeSidebarThreadSectionView(
+                            title: "Archived",
+                            items: sidebar.archivedItems,
+                            isSelectionMode: sidebar.isSelectionMode,
+                            onSelectThread: onSelectThread,
+                            onThreadAction: onThreadAction,
+                            onCommand: onCommand
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text(sidebar.emptyTitle)
+            .font(.callout)
+            .foregroundStyle(QuillCodePalette.muted)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct QuillCodeSidebarThreadSectionView: View {
+    var title: String
+    var items: [SidebarItemSurface]
+    var isSelectionMode: Bool
+    var onSelectThread: (UUID) -> Void
+    var onThreadAction: (SidebarItemActionSurface) -> Void
+    var onCommand: (WorkspaceCommandSurface) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(QuillCodePalette.muted)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.top, 4)
+            ForEach(items) { item in
+                QuillCodeSidebarThreadRowView(
+                    item: item,
+                    isSelectionMode: isSelectionMode,
+                    onSelectThread: onSelectThread,
+                    onThreadAction: onThreadAction,
+                    onCommand: onCommand
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct QuillCodeSidebarThreadRowView: View {
+    var item: SidebarItemSurface
+    var isSelectionMode: Bool
+    var onSelectThread: (UUID) -> Void
+    var onThreadAction: (SidebarItemActionSurface) -> Void
+    var onCommand: (WorkspaceCommandSurface) -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if isSelectionMode {
+                Button {
+                    toggleSelection()
+                } label: {
+                    Image(systemName: item.isBulkSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(item.isBulkSelected ? QuillCodePalette.blue : QuillCodePalette.muted)
+                        .frame(width: QuillCodeMetrics.minimumHitTarget, height: QuillCodeMetrics.minimumHitTarget)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(QuillCodePressableButtonStyle())
+                .accessibilityLabel(item.isBulkSelected ? "Deselect \(item.title)" : "Select \(item.title)")
+            }
+            Button {
+                if isSelectionMode {
+                    toggleSelection()
+                } else {
+                    onSelectThread(item.id)
+                }
+            } label: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.callout.weight(.semibold))
+                        .lineLimit(1)
+                    Text(item.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(QuillCodePalette.muted)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, minHeight: QuillCodeMetrics.minimumHitTarget, alignment: .leading)
+            }
+            .buttonStyle(QuillCodePressableButtonStyle())
+
+            Menu {
+                ForEach(item.actions) { action in
+                    Button(role: action.kind == .delete ? .destructive : nil) {
+                        onThreadAction(action)
+                    } label: {
+                        Text(action.kind.title)
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .frame(width: QuillCodeMetrics.minimumHitTarget, height: QuillCodeMetrics.minimumHitTarget)
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(QuillCodePressableButtonStyle())
+        }
+        .padding(10)
+        .background(item.isSelected ? QuillCodePalette.selection : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func toggleSelection() {
+        onCommand(QuillCodeSidebarCommandAdapter.toggleSelectionCommand(for: item))
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeSidebarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarView.swift
@@ -25,7 +25,12 @@ struct QuillCodeSidebarView: View {
                     )
                 }
             }
-            threadList
+            QuillCodeSidebarThreadListView(
+                sidebar: sidebar,
+                onSelectThread: onSelectThread,
+                onThreadAction: onThreadAction,
+                onCommand: onCommand
+            )
             Divider()
             QuillCodeProjectListView(
                 projects: projects,
@@ -64,50 +69,6 @@ struct QuillCodeSidebarView: View {
         }
     }
 
-    @ViewBuilder
-    private var threadList: some View {
-        if sidebar.items.isEmpty {
-            Text(sidebar.emptyTitle)
-                .font(.callout)
-                .foregroundStyle(QuillCodePalette.muted)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 8) {
-                    if !sidebar.pinnedItems.isEmpty {
-                        QuillCodeSidebarThreadSectionView(
-                            title: "Pinned",
-                            items: sidebar.pinnedItems,
-                            isSelectionMode: sidebar.isSelectionMode,
-                            onSelectThread: onSelectThread,
-                            onThreadAction: onThreadAction,
-                            onCommand: onCommand
-                        )
-                    }
-                    ForEach(sidebar.recentSections()) { section in
-                        QuillCodeSidebarThreadSectionView(
-                            title: section.title,
-                            items: section.items,
-                            isSelectionMode: sidebar.isSelectionMode,
-                            onSelectThread: onSelectThread,
-                            onThreadAction: onThreadAction,
-                            onCommand: onCommand
-                        )
-                    }
-                    if !sidebar.archivedItems.isEmpty {
-                        QuillCodeSidebarThreadSectionView(
-                            title: "Archived",
-                            items: sidebar.archivedItems,
-                            isSelectionMode: sidebar.isSelectionMode,
-                            onSelectThread: onSelectThread,
-                            onThreadAction: onThreadAction,
-                            onCommand: onCommand
-                        )
-                    }
-                }
-            }
-        }
-    }
 }
 
 private struct QuillCodeSidebarBulkActionsView: View {
@@ -141,104 +102,6 @@ private struct QuillCodeSidebarBulkActionsView: View {
         .padding(8)
         .background(QuillCodePalette.background.opacity(0.55))
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-    }
-}
-
-private struct QuillCodeSidebarThreadSectionView: View {
-    var title: String
-    var items: [SidebarItemSurface]
-    var isSelectionMode: Bool
-    var onSelectThread: (UUID) -> Void
-    var onThreadAction: (SidebarItemActionSurface) -> Void
-    var onCommand: (WorkspaceCommandSurface) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title.uppercased())
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(QuillCodePalette.muted)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .padding(.top, 4)
-            ForEach(items) { item in
-                QuillCodeSidebarThreadRowView(
-                    item: item,
-                    isSelectionMode: isSelectionMode,
-                    onSelectThread: onSelectThread,
-                    onThreadAction: onThreadAction,
-                    onCommand: onCommand
-                )
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-private struct QuillCodeSidebarThreadRowView: View {
-    var item: SidebarItemSurface
-    var isSelectionMode: Bool
-    var onSelectThread: (UUID) -> Void
-    var onThreadAction: (SidebarItemActionSurface) -> Void
-    var onCommand: (WorkspaceCommandSurface) -> Void
-
-    var body: some View {
-        HStack(spacing: 6) {
-            if isSelectionMode {
-                Button {
-                    toggleSelection()
-                } label: {
-                    Image(systemName: item.isBulkSelected ? "checkmark.circle.fill" : "circle")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(item.isBulkSelected ? QuillCodePalette.blue : QuillCodePalette.muted)
-                        .frame(width: QuillCodeMetrics.minimumHitTarget, height: QuillCodeMetrics.minimumHitTarget)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(QuillCodePressableButtonStyle())
-                .accessibilityLabel(item.isBulkSelected ? "Deselect \(item.title)" : "Select \(item.title)")
-            }
-            Button {
-                if isSelectionMode {
-                    toggleSelection()
-                } else {
-                    onSelectThread(item.id)
-                }
-            } label: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(item.title)
-                        .font(.callout.weight(.semibold))
-                        .lineLimit(1)
-                    Text(item.subtitle)
-                        .font(.caption)
-                        .foregroundStyle(QuillCodePalette.muted)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity, minHeight: QuillCodeMetrics.minimumHitTarget, alignment: .leading)
-            }
-            .buttonStyle(QuillCodePressableButtonStyle())
-
-            Menu {
-                ForEach(item.actions) { action in
-                    Button(role: action.kind == .delete ? .destructive : nil) {
-                        onThreadAction(action)
-                    } label: {
-                        Text(action.kind.title)
-                    }
-                }
-            } label: {
-                Image(systemName: "ellipsis")
-                    .frame(width: QuillCodeMetrics.minimumHitTarget, height: QuillCodeMetrics.minimumHitTarget)
-                    .foregroundStyle(QuillCodePalette.muted)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(QuillCodePressableButtonStyle())
-        }
-        .padding(10)
-        .background(item.isSelected ? QuillCodePalette.selection : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-    }
-
-    private func toggleSelection() {
-        onCommand(QuillCodeSidebarCommandAdapter.toggleSelectionCommand(for: item))
     }
 }
 

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -1519,6 +1519,7 @@ final class ParityGateTests: XCTestCase {
         let presentationText = try Self.appSourceText(named: "QuillCodeSidebarCommandPresentation.swift")
         let adapterText = try Self.appSourceText(named: "QuillCodeSidebarCommandAdapter.swift")
         let sidebarText = try Self.appSourceText(named: "QuillCodeSidebarView.swift")
+        let threadListText = try Self.appSourceText(named: "QuillCodeSidebarThreadListView.swift")
         let htmlSidebarText = try Self.appSourceText(named: "WorkspaceHTMLSidebarRenderer.swift")
 
         XCTAssertTrue(presentationText.contains("struct QuillCodeSidebarCommandPresentation"), "Sidebar command labels and icons should live in one focused presentation helper.")
@@ -1536,7 +1537,6 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(sidebarText.contains("QuillCodeSidebarCommandPresentation.systemImage"), "Native sidebar should consume shared SF Symbols.")
         XCTAssertTrue(adapterText.contains("enum QuillCodeSidebarCommandAdapter"), "Sidebar command payload construction should live in a focused adapter.")
         XCTAssertTrue(sidebarText.contains("QuillCodeSidebarCommandAdapter.workspaceCommand"), "Native sidebar should use the shared command adapter for bulk actions.")
-        XCTAssertTrue(sidebarText.contains("QuillCodeSidebarCommandAdapter.toggleSelectionCommand"), "Native sidebar should use the shared command adapter for selection toggles.")
         XCTAssertTrue(htmlSidebarText.contains("renderPrimaryActions"), "HTML sidebar renderer should build primary sidebar actions through a helper.")
         XCTAssertTrue(htmlSidebarText.contains("renderUtilityActions"), "HTML sidebar renderer should build utility menu actions through a helper.")
         XCTAssertTrue(htmlSidebarText.contains("QuillCodeSidebarCommandPresentation.primaryCommandIDs"), "HTML sidebar renderer should consume shared primary command ordering.")
@@ -1545,6 +1545,7 @@ final class ParityGateTests: XCTestCase {
         XCTAssertFalse(sidebarText.contains("private func displayTitle"), "Native sidebar should not maintain a second label map.")
         XCTAssertFalse(sidebarText.contains("private func systemImage"), "Native sidebar should not maintain a second icon map.")
         XCTAssertFalse(sidebarText.contains("WorkspaceCommandSurface("), "Native sidebar should not duplicate command payload construction.")
+        XCTAssertTrue(threadListText.contains("QuillCodeSidebarCommandAdapter.toggleSelectionCommand"), "Native sidebar thread rows should use the shared command adapter for selection toggles.")
         XCTAssertFalse(htmlSidebarText.contains(#"data-icon="plugins">Plugins"#), "HTML sidebar renderer should not hard-code sidebar plugin markup.")
     }
 
@@ -1558,6 +1559,19 @@ final class ParityGateTests: XCTestCase {
         XCTAssertTrue(projectListText.contains("maxProjectListHeight"), "Project rows should have an explicit scroll boundary so utility controls stay reachable.")
         XCTAssertFalse(sidebarText.contains("struct QuillCodeProjectRowView"), "Native sidebar should not own project-row rendering.")
         XCTAssertFalse(sidebarText.contains("maxProjectListHeight"), "Native sidebar should not own project-list sizing policy.")
+    }
+
+    func testNativeSidebarDelegatesThreadListRendering() throws {
+        let sidebarText = try Self.appSourceText(named: "QuillCodeSidebarView.swift")
+        let threadListText = try Self.appSourceText(named: "QuillCodeSidebarThreadListView.swift")
+
+        XCTAssertTrue(sidebarText.contains("QuillCodeSidebarThreadListView("), "Native sidebar should compose a focused thread-list view.")
+        XCTAssertTrue(threadListText.contains("struct QuillCodeSidebarThreadListView"), "Thread-list rendering should live in a focused file.")
+        XCTAssertTrue(threadListText.contains("struct QuillCodeSidebarThreadSectionView"), "Thread-section rendering should live beside the thread-list view.")
+        XCTAssertTrue(threadListText.contains("struct QuillCodeSidebarThreadRowView"), "Thread-row rendering should live beside the thread-list view.")
+        XCTAssertTrue(threadListText.contains("toggleSelectionCommand"), "Thread-row selection behavior should stay beside row rendering.")
+        XCTAssertFalse(sidebarText.contains("struct QuillCodeSidebarThreadRowView"), "Native sidebar should not own thread-row rendering.")
+        XCTAssertFalse(sidebarText.contains("sidebar.recentSections()"), "Native sidebar should not own thread sectioning presentation.")
     }
 
     func testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -3628,3 +3628,18 @@ What changed:
 
 Remaining risk:
 - `QuillCodeSidebarView.swift` still owns primary actions, bulk selection controls, thread sections, thread rows, and utility actions. Split thread rows next if the left rail gains more Codex parity controls such as per-thread status badges, drag ordering, or richer context menus.
+
+## 2026-06-24 Native Sidebar Thread List Split
+
+Overall grade after this slice: **A+ sidebar thread-list ownership, A+ left-rail composition boundary**.
+
+`QuillCodeSidebarView.swift` still owned empty thread copy, pinned/recent/archive rendering, thread section headers, row selection toggles, thread row menus, and selected-row chrome. Those rules are small individually, but together they are the highest-change part of Codex-style navigation: future status badges, drag ordering, richer row menus, and per-thread progress will all land there.
+
+What changed:
+- Added `QuillCodeSidebarThreadListView.swift` for native empty-state, thread-section, and thread-row rendering.
+- Kept selection hit targets and row menus beside row rendering so selection UX can evolve without touching the left-rail shell.
+- Reduced `QuillCodeSidebarView.swift` to left-rail composition for primary actions, thread header, thread list, project list, and utility actions.
+- Added a parity gate so thread-row rendering and recent-section presentation do not drift back into `QuillCodeSidebarView.swift`.
+
+Remaining risk:
+- `QuillCodeSidebarView.swift` still owns the thread header and bulk-selection control. That is acceptable while the header is compact, but split bulk action rendering if selection mode grows into a richer Codex-style batch toolbar.


### PR DESCRIPTION
## Summary
- move native sidebar thread-list, section, and row rendering out of QuillCodeSidebarView into QuillCodeSidebarThreadListView
- keep thread selection toggles and row menus beside thread-row rendering
- update sidebar parity gates so command adapter usage follows the new ownership boundary
- record the left-rail architecture pass in CODE_QUALITY_AUDIT

## Verification
- swift test --filter ParityGateTests/testSidebarCommandPresentationIsSharedByNativeAndHTMLSurfaces --filter ParityGateTests/testNativeSidebarDelegatesThreadListRendering
- swift test
- git diff --cached --check