### PR TITLE
Guard Synth model aliases

### DIFF
--- a/Tests/QuillCodeAgentTests/TrustedRouterAdapterTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterAdapterTests.swift
@@ -479,15 +479,20 @@ final class TrustedRouterAdapterTests: XCTestCase {
         let catalog = TrustedRouterModelCatalog(models: [
             .init(id: "acme/code-pro", provider: "acme", displayName: "Code Pro", category: "Coding"),
             .init(id: TrustedRouterDefaults.fastModel, provider: "trustedrouter", displayName: "Fast Duplicate", category: "Recommended"),
-            .init(id: "/synth", provider: "trustedrouter", displayName: "Synth Alias", category: "Recommended")
+            .init(id: "/synth", provider: "trustedrouter", displayName: "Synth Alias", category: "Recommended"),
+            .init(id: "tr/fusion", provider: "trustedrouter", displayName: "Legacy Fusion", category: "Recommended"),
+            .init(id: "/fusion-code", provider: "trustedrouter", displayName: "Legacy Fusion Code", category: "Recommended")
         ])
 
         XCTAssertEqual(catalog.models.prefix(3).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
         XCTAssertEqual(Array(catalog.categories().prefix(3)), ["Recommended", "Safety", "Coding"])
         XCTAssertEqual(catalog.models.filter { $0.id == TrustedRouterDefaults.fastModel }.count, 1)
         XCTAssertEqual(catalog.models.filter { $0.id == TrustedRouterDefaults.synthModel }.count, 1)
+        XCTAssertEqual(catalog.models.filter { $0.id == TrustedRouterDefaults.synthCodeModel }.count, 1)
         XCTAssertFalse(catalog.models.contains { $0.id == "/synth" })
+        XCTAssertFalse(catalog.models.contains { $0.id.contains("fusion") })
         XCTAssertFalse(catalog.models.contains { $0.displayName.contains("Alias") })
+        XCTAssertFalse(catalog.models.contains { $0.displayName.contains("Fusion") })
         XCTAssertTrue(catalog.models.contains { $0.id == "acme/code-pro" })
     }
 

--- a/Tests/QuillCodeCoreTests/CoreModelTests.swift
+++ b/Tests/QuillCodeCoreTests/CoreModelTests.swift
@@ -158,7 +158,9 @@ final class CoreModelTests: XCTestCase {
         let catalog = TrustedRouterDefaults.normalizedModelCatalog([
             .init(id: "acme/code-pro", provider: "acme", displayName: "Code Pro", category: "Coding"),
             .init(id: "/synth", provider: "trustedrouter", displayName: "Synth Alias", category: "Recommended"),
+            .init(id: "trustedrouter/fusion", provider: "trustedrouter", displayName: "Legacy Fusion", category: "Recommended"),
             .init(id: "/synth-code", provider: "trustedrouter", displayName: "Synth Code Alias", category: "Recommended"),
+            .init(id: "/fusion-code", provider: "trustedrouter", displayName: "Legacy Fusion Code", category: "Recommended"),
             .init(id: "tr/fast", provider: "tr", displayName: "Fast Alias", category: "Recommended")
         ])
 
@@ -166,6 +168,8 @@ final class CoreModelTests: XCTestCase {
         XCTAssertEqual(catalog.filter { $0.id == TrustedRouterDefaults.fastModel }.count, 1)
         XCTAssertEqual(catalog.filter { $0.id == TrustedRouterDefaults.synthModel }.count, 1)
         XCTAssertEqual(catalog.filter { $0.id == TrustedRouterDefaults.synthCodeModel }.count, 1)
+        XCTAssertFalse(catalog.contains { $0.id.contains("fusion") })
+        XCTAssertFalse(catalog.contains { $0.displayName.contains("Fusion") })
         XCTAssertTrue(catalog.contains { $0.id == "acme/code-pro" })
     }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -47,6 +47,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 
 - Kept `trustedrouter/fast` stable and moved the fallback model to preferred `/synth`/`tr/synth` while preserving `trustedrouter/fusion`, `tr/fusion`, `/fusion`, `fusion-code`, and `/fusion-code` legacy aliases. User-facing model surfaces brand the defaults as **Nike 1.0** and **Synth**.
 - Promoted Synth Code (`/synth-code`, `tr/synth-code`) into the bundled Recommended catalog so the preferred code model is visible offline instead of only working as a hidden alias.
+- Added explicit catalog-normalization regression coverage so live or persisted legacy Fusion rows dedupe into Synth/Synth Code and do not reappear as user-facing picker rows.
 - Centralized the branded default names in `TrustedRouterDefaults`, with tests proving canonical IDs and display names separately.
 - Removed dead provider plumbing from model metadata summary generation.
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.


### PR DESCRIPTION
## Summary
- verify legacy Fusion catalog rows normalize into Synth and Synth Code
- ensure live/catalog fallback surfaces do not re-expose Fusion IDs or display names
- record the Synth alias regression guard in the code-quality audit

## Notes
- Product code on main already prefers `/synth`, `/synth-code`, `tr/synth`, and `tr/synth-code` while preserving `trustedrouter/fusion`, `tr/fusion`, `/fusion`, `fusion-code`, and `/fusion-code` as aliases.

## Verification
- swift test --filter CoreModelTests/testModelCatalogNormalizationDeduplicatesAliasesAndSortsDefaultsFirst --filter TrustedRouterAdapterTests/testModelCatalogAlwaysIncludesRankedRecommendedFallbacks
- swift test
- git diff --check