### PR TITLE
Extract workspace retry planner

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -137,10 +137,10 @@ public final class QuillCodeWorkspaceModel {
     }
 
     public var canRetryLastUserTurn: Bool {
-        guard composer.isSending == false else { return false }
-        return selectedThread?.messages.contains {
-            $0.role == .user && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        } == true
+        WorkspaceRetryPlanner.canRetryLastUserTurn(
+            in: selectedThread,
+            isSending: composer.isSending
+        )
     }
 
     public func setDraft(_ draft: String) {
@@ -175,12 +175,10 @@ public final class QuillCodeWorkspaceModel {
 
     @discardableResult
     public func prepareRetryLastUserTurn() -> Bool {
-        guard let lastUserMessage = selectedThread?.messages.last(where: {
-            $0.role == .user && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }) else {
+        guard let draft = WorkspaceRetryPlanner.retryDraft(in: selectedThread) else {
             return false
         }
-        composer.draft = lastUserMessage.content
+        composer.draft = draft
         lastError = nil
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
         return true

--- a/Sources/QuillCodeApp/WorkspaceRetryPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceRetryPlanner.swift
@@ -1,0 +1,23 @@
+import Foundation
+import QuillCodeCore
+
+enum WorkspaceRetryPlanner {
+    static func canRetryLastUserTurn(
+        in thread: ChatThread?,
+        isSending: Bool
+    ) -> Bool {
+        guard !isSending else { return false }
+        return retryDraft(in: thread) != nil
+    }
+
+    static func retryDraft(in thread: ChatThread?) -> String? {
+        latestUserMessage(in: thread?.messages)?.content
+    }
+
+    private static func latestUserMessage(in messages: [ChatMessage]?) -> ChatMessage? {
+        messages?.last {
+            $0.role == .user
+                && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceRetryPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRetryPlannerTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceRetryPlannerTests: XCTestCase {
+    func testRetryDraftUsesLatestNonEmptyUserMessageAndPreservesOriginalText() {
+        let thread = ChatThread(messages: [
+            ChatMessage(role: .assistant, content: "Ready."),
+            ChatMessage(role: .user, content: "run whoami"),
+            ChatMessage(role: .user, content: "   "),
+            ChatMessage(role: .assistant, content: "Done."),
+            ChatMessage(role: .user, content: "  run pwd  ")
+        ])
+
+        XCTAssertEqual(WorkspaceRetryPlanner.retryDraft(in: thread), "  run pwd  ")
+    }
+
+    func testRetryRequiresUserMessageAndIdleComposer() {
+        let assistantOnly = ChatThread(messages: [
+            ChatMessage(role: .assistant, content: "I can help.")
+        ])
+        let retryable = ChatThread(messages: [
+            ChatMessage(role: .user, content: "run tests")
+        ])
+
+        XCTAssertFalse(WorkspaceRetryPlanner.canRetryLastUserTurn(in: nil, isSending: false))
+        XCTAssertFalse(WorkspaceRetryPlanner.canRetryLastUserTurn(in: assistantOnly, isSending: false))
+        XCTAssertFalse(WorkspaceRetryPlanner.canRetryLastUserTurn(in: retryable, isSending: true))
+        XCTAssertTrue(WorkspaceRetryPlanner.canRetryLastUserTurn(in: retryable, isSending: false))
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -356,6 +356,22 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(modelTests.contains("testBootstrapPersistsAndClearsTrustedRouterAPIKey"), "WorkspaceModelTests should not own TrustedRouter API key persistence integration.")
     }
 
+    func testWorkspaceModelDelegatesRetryPlanning() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let retryPlannerText = try Self.appSourceText(named: "WorkspaceRetryPlanner.swift")
+        let retryPlannerTests = try Self.appTestSourceText(named: "WorkspaceRetryPlannerTests.swift")
+
+        XCTAssertTrue(retryPlannerText.contains("enum WorkspaceRetryPlanner"), "Retry planning should live in a focused helper.")
+        XCTAssertTrue(retryPlannerText.contains("static func canRetryLastUserTurn"), "Retry availability should be directly testable.")
+        XCTAssertTrue(retryPlannerText.contains("static func retryDraft"), "Retry draft selection should be directly testable.")
+        XCTAssertTrue(modelText.contains("WorkspaceRetryPlanner.canRetryLastUserTurn"), "WorkspaceModel should delegate retry availability.")
+        XCTAssertTrue(modelText.contains("WorkspaceRetryPlanner.retryDraft"), "WorkspaceModel should delegate retry draft selection.")
+        XCTAssertTrue(retryPlannerTests.contains("testRetryDraftUsesLatestNonEmptyUserMessageAndPreservesOriginalText"), "Retry draft behavior should have focused coverage.")
+        XCTAssertTrue(retryPlannerTests.contains("testRetryRequiresUserMessageAndIdleComposer"), "Retry availability should have focused coverage.")
+        XCTAssertFalse(modelText.contains("messages.last(where:"), "WorkspaceModel should not scan transcript messages for retry drafts.")
+        XCTAssertFalse(modelText.contains("messages.contains {"), "WorkspaceModel should not own retry availability scans.")
+    }
+
     func testWorkspaceActivityIntegrationTestsOwnModelActivityFlows() throws {
         let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
         let activityIntegrationTests = try Self.appTestSourceText(named: "WorkspaceActivityIntegrationTests.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -3720,3 +3720,18 @@ What changed:
 
 Remaining risk:
 - `QuillCodeSidebarView.swift` still owns primary actions, bulk selection controls, thread sections, thread rows, and utility actions. Split thread rows next if the left rail gains more Codex parity controls such as per-thread status badges, drag ordering, or richer context menus.
+
+## 2026-06-24 Workspace Retry Planner Split
+
+Overall grade after this slice: **A retry ownership, A+ regression guard, A workspace-model boundary**.
+
+`WorkspaceModel.swift` still owned the transcript scan that decides whether the latest user turn can be retried and which exact draft should be restored. The behavior was small, but it is shared by runtime issue recovery, command enablement, and transcript retry affordances, so keeping it inline made the model responsible for another pure state query.
+
+What changed:
+- Added `WorkspaceRetryPlanner` for retry availability and retry draft selection.
+- Preserved exact draft text while ignoring empty/whitespace-only user messages.
+- Added focused retry planner tests for latest-user-message selection and send-state gating.
+- Tightened the parity gate so retry transcript scans do not drift back into `WorkspaceModel.swift`.
+
+Remaining risk:
+- `WorkspaceModel.swift` still owns the broader send lifecycle and cancellation side effects. Keep extracting pure send/session planning and small recovery policies before adding larger Codex-parity run controls.


### PR DESCRIPTION
## Summary
- move retry availability/draft selection out of WorkspaceModel into WorkspaceRetryPlanner
- add focused retry planner tests for latest user prompt selection and sending-state gating
- add a parity guard and code-quality audit note so retry transcript scans stay out of WorkspaceModel

## Validation
- swift test --filter WorkspaceRetryPlannerTests --filter WorkspaceRuntimeIssueIntegrationTests --filter ParityGateTests/testWorkspaceModelDelegatesRetryPlanning
- swift test