### PR TITLE
Prefer Synth in model command feedback

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -981,12 +981,14 @@ public final class QuillCodeWorkspaceModel {
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
     }
 
-    public func setModel(_ model: String) {
+    @discardableResult
+    public func setModel(_ model: String) -> String {
         let modelID = WorkspaceConfigurationEngine.setModel(model, config: &root.config)
         mutateSelectedThread { thread in
             WorkspaceConfigurationEngine.setModelID(modelID, thread: &thread)
         }
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        return modelID
     }
 
     public func toggleModelFavorite(_ model: String) {
@@ -1503,10 +1505,10 @@ public final class QuillCodeWorkspaceModel {
                 mode: mode
             ))
         case .model(let model):
-            setModel(model)
+            let modelID = setModel(model)
             appendLocalCommandTranscript(WorkspaceSlashCommandTranscriptPlanner.model(
                 userText: originalPrompt,
-                model: model
+                model: modelID
             ))
         case .renameThread(let title):
             let succeeded = root.selectedThreadID.map { renameThread($0, to: title) } ?? false

--- a/Sources/QuillCodeApp/WorkspaceSlashCommandTranscriptPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceSlashCommandTranscriptPlanner.swift
@@ -35,7 +35,7 @@ struct WorkspaceSlashCommandTranscriptPlanner {
     static func model(userText: String, model: String) -> WorkspaceLocalCommandTranscript {
         transcript(
             userText: userText,
-            assistantText: "Model set to \(model).",
+            assistantText: "Model set to \(modelConfirmationLabel(for: model)).",
             title: "Set model"
         )
     }
@@ -162,6 +162,16 @@ struct WorkspaceSlashCommandTranscriptPlanner {
         let cwd = action.workingDirectory.map { " — cwd: \($0)" } ?? ""
         let timeout = action.timeoutSeconds.map { " — timeout: \($0)s" } ?? ""
         return "- `/env \(action.title)` — \(action.relativePath)\(cwd)\(timeout)\(detail)"
+    }
+
+    private static func modelConfirmationLabel(for model: String) -> String {
+        let modelID = TrustedRouterDefaults.canonicalModelID(model)
+        guard TrustedRouterDefaults.recommendedRank(for: modelID) != nil else {
+            return modelID
+        }
+        let displayName = TrustedRouterDefaults.displayName(fromModelID: modelID)
+        let preferredID = TrustedRouterDefaults.preferredDisplayModelID(modelID)
+        return "\(displayName) (\(preferredID))"
     }
 
     private static func transcript(userText: String, assistantText: String, title: String) -> WorkspaceLocalCommandTranscript {

--- a/Tests/QuillCodeAppTests/WorkspaceSlashCommandIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSlashCommandIntegrationTests.swift
@@ -140,6 +140,18 @@ final class WorkspaceSlashCommandIntegrationTests: XCTestCase {
         XCTAssertTrue(model.currentToolCards.isEmpty)
     }
 
+    func testSlashModelLegacyFusionAliasWritesPreferredSynthTranscript() async throws {
+        let model = QuillCodeWorkspaceModel()
+
+        model.setDraft("/model /fusion")
+        await model.submitComposer(workspaceRoot: try makeQuillCodeTestDirectory())
+
+        XCTAssertEqual(model.root.config.defaultModel, TrustedRouterDefaults.synthModel)
+        XCTAssertEqual(model.selectedThread?.model, TrustedRouterDefaults.synthModel)
+        XCTAssertEqual(model.selectedThread?.messages.last?.content, "Model set to Synth (/synth).")
+        XCTAssertTrue(model.currentToolCards.isEmpty)
+    }
+
     func testSlashCompactRoutesToContextCompaction() async throws {
         let source = ChatThread(title: "Long slash thread", messages: [
             .init(role: .user, content: "old question"),

--- a/Tests/QuillCodeAppTests/WorkspaceSlashCommandTranscriptPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSlashCommandTranscriptPlannerTests.swift
@@ -31,7 +31,21 @@ final class WorkspaceSlashCommandTranscriptPlannerTests: XCTestCase {
                 userText: "/model /synth",
                 model: TrustedRouterDefaults.synthModel
             ).assistantText,
-            "Model set to \(TrustedRouterDefaults.synthModel)."
+            "Model set to Synth (/synth)."
+        )
+        XCTAssertEqual(
+            WorkspaceSlashCommandTranscriptPlanner.model(
+                userText: "/model /fusion",
+                model: "trustedrouter/fusion"
+            ).assistantText,
+            "Model set to Synth (/synth)."
+        )
+        XCTAssertEqual(
+            WorkspaceSlashCommandTranscriptPlanner.model(
+                userText: "/model z-ai/glm-5.2",
+                model: "z-ai/glm-5.2"
+            ).assistantText,
+            "Model set to z-ai/glm-5.2."
         )
     }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -3798,3 +3798,18 @@ What changed:
 
 Remaining risk:
 - `SlashCommand.swift` still owns project, terminal, mode, model, and generic routing. That remains reasonable while those branches are small; split `SlashProjectCommandParser` only if project commands gain richer argument parsing or remote-project setup variants.
+
+## 2026-06-24 Synth Model Command Feedback
+
+Overall grade after this slice: **A+ model alias UX, A command transcript clarity, A+ regression coverage**.
+
+The TrustedRouter catalog correctly accepts legacy Fusion IDs as aliases for Synth, but the `/model` command acknowledgement still used the raw command argument. That could make a successful `/model /fusion` look like QuillCode still preferred Fusion terminology even though config, picker rows, and docs now prefer Synth.
+
+What changed:
+- `QuillCodeWorkspaceModel.setModel` now returns the canonical model ID it actually stored.
+- Slash-command model feedback is rendered from the canonical model ID instead of the raw user input.
+- Recommended models show user-facing brand plus preferred ID, such as `Synth (/synth)`, while arbitrary provider/model IDs stay literal.
+- Added focused planner and integration regressions proving `/model /fusion` stores Synth and confirms `Model set to Synth (/synth).`
+
+Remaining risk:
+- Other non-command surfaces should keep using `TrustedRouterDefaults.preferredDisplayModelID` rather than hand-formatting model IDs. If model picker subtitles or thread metadata gain richer copy, keep the branding policy centralized in `TrustedRouterDefaults` or a small display-label helper.


### PR DESCRIPTION
## Summary
- make /model command confirmations use the canonical model ID that was actually stored
- show recommended models with preferred branding, e.g. Synth (/synth), while arbitrary provider/model IDs stay literal
- add regressions proving legacy /fusion stores Synth and confirms Synth in chat

## Validation
- swift test --filter WorkspaceSlashCommandTranscriptPlannerTests
- swift test --filter WorkspaceSlashCommandIntegrationTests/testSlashModelLegacyFusionAliasWritesPreferredSynthTranscript
- swift test --filter WorkspaceSlashCommandIntegrationTests/testSlashModelChangesModelAndWritesLocalTranscript
- swift test --filter CoreModelTests/testTrustedRouterDefaults
- swift test
- git diff --check