### PR TITLE
Cover visible browser sessions in E2E

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -1140,7 +1140,7 @@
     }
     .browser-nav-controls {
       display: grid;
-      grid-template-columns: repeat(3, 40px);
+      grid-template-columns: repeat(3, 40px) minmax(72px, auto);
       gap: 6px;
       align-items: center;
     }
@@ -1156,8 +1156,18 @@
     .browser-nav-button:not(:disabled):hover {
       background: rgba(255,255,255,.12);
     }
+    [data-testid="browser-session"].browser-nav-button {
+      width: auto;
+      min-width: 72px;
+      padding: 0 10px;
+    }
     .browser-open-button {
       min-width: 78px;
+    }
+    .browser-session-status {
+      margin: 0;
+      color: var(--muted);
+      font-size: 12px;
     }
     .browser-comment-form { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
     .browser-preview,
@@ -2675,6 +2685,7 @@
         { id: 'browser-back', title: 'Browser: Back', shortcut: '', category: 'Workspace', keywords: ['preview', 'web', 'history', 'back'], isEnabled: false },
         { id: 'browser-forward', title: 'Browser: Forward', shortcut: '', category: 'Workspace', keywords: ['preview', 'web', 'history', 'forward'], isEnabled: false },
         { id: 'browser-reload', title: 'Browser: Reload', shortcut: '', category: 'Workspace', keywords: ['preview', 'web', 'refresh', 'reload'], isEnabled: false },
+        { id: 'open-browser-session', title: 'Browser: Open session', shortcut: '', category: 'Workspace', keywords: ['preview', 'web', 'session', 'login', 'cookies', 'sign in'], isEnabled: false },
         { id: 'toggle-activity', title: 'Activity', shortcut: '', category: 'Workspace', keywords: ['task', 'summary', 'sources', 'artifacts', 'tools'], isEnabled: true },
         { id: 'toggle-automations', title: 'Automations', shortcut: '', category: 'Workspace', keywords: ['automation', 'schedule', 'recurring', 'monitor', 'follow-up', 'heartbeat'], isEnabled: true },
         { id: 'automation-create-thread-follow-up', title: 'Create thread follow-up', shortcut: '', category: 'Automations', keywords: ['automation', 'follow-up', 'thread', 'heartbeat', 'schedule'], isEnabled: false },
@@ -2729,6 +2740,8 @@
         historyIndex: null,
         title: 'Browser preview',
         statusLabel: 'Ready',
+        sessionURL: null,
+        sessionOpenCount: 0,
         snapshot: null,
         comments: []
       },
@@ -4931,9 +4944,14 @@
 	      document.querySelector('[data-testid="browser-reload"]')?.addEventListener('click', () => {
 	        browserReload();
 	      });
+	      document.querySelector('[data-testid="browser-session"]')?.addEventListener('click', () => {
+	        openBrowserSession();
+	      });
 	      document.querySelector('[data-testid="browser-address"]')?.addEventListener('input', event => {
 	        state.browser.addressDraft = event.target.value;
 	        document.querySelector('[data-testid="browser-open"]').disabled = !state.browser.addressDraft.trim();
+	        document.querySelector('[data-testid="browser-session"]').disabled = !browserCanOpenSession();
+          syncBrowserCommandStates();
 	      });
 	      document.querySelector('[data-testid="browser-form"]')?.addEventListener('submit', event => {
 	        event.preventDefault();
@@ -5908,10 +5926,12 @@
               <button class="browser-nav-button" type="button" data-testid="browser-back" aria-label="Back" ${browserCanGoBack() ? '' : 'disabled'}>&lt;</button>
               <button class="browser-nav-button" type="button" data-testid="browser-forward" aria-label="Forward" ${browserCanGoForward() ? '' : 'disabled'}>&gt;</button>
               <button class="browser-nav-button" type="button" data-testid="browser-reload" aria-label="Reload" ${browserCanReload() ? '' : 'disabled'}>R</button>
+              <button class="browser-nav-button" type="button" data-testid="browser-session" aria-label="Open visible browser session" ${browserCanOpenSession() ? '' : 'disabled'}>Session</button>
             </div>
 	            <input data-testid="browser-address" aria-label="Browser address" placeholder="localhost:3000 or https://example.com" value="${escapeHTML(state.browser.addressDraft)}">
 	            <button class="browser-open-button" type="submit" data-testid="browser-open" ${state.browser.addressDraft.trim() ? '' : 'disabled'}>Open</button>
 	          </form>
+            ${state.browser.sessionURL ? `<p class="browser-session-status" data-testid="browser-session-status">Visible session ${state.browser.sessionOpenCount}: <code data-testid="browser-session-url">${escapeHTML(state.browser.sessionURL)}</code></p>` : ''}
 	          ${preview}
 	          <form class="browser-comment-form" data-testid="browser-comment-form">
 	            <input data-testid="browser-comment-input" aria-label="Browser comment" placeholder="Add browser comment">
@@ -7076,6 +7096,10 @@
         browserReload();
         return;
       }
+      if (commandID === 'open-browser-session') {
+        openBrowserSession();
+        return;
+      }
       if (commandID === 'toggle-activity') {
         state.activity.isVisible = !state.activity.isVisible;
       }
@@ -7487,11 +7511,21 @@
       return Boolean(state.browser.currentURL);
     }
 
+    function browserSessionTargetURL() {
+      const rawDraft = state.browser.addressDraft.trim();
+      return normalizeBrowserURL(rawDraft || state.browser.currentURL || '');
+    }
+
+    function browserCanOpenSession() {
+      return Boolean(browserSessionTargetURL());
+    }
+
     function syncBrowserCommandStates() {
       const enabled = new Map([
         ['browser-back', browserCanGoBack()],
         ['browser-forward', browserCanGoForward()],
-        ['browser-reload', browserCanReload()]
+        ['browser-reload', browserCanReload()],
+        ['open-browser-session', browserCanOpenSession()]
       ]);
       state.commands = state.commands.map(command => (
         enabled.has(command.id) ? { ...command, isEnabled: enabled.get(command.id) } : command
@@ -7546,6 +7580,25 @@
     function browserReload() {
       if (!browserCanReload()) return;
       setBrowserPage(state.browser.currentURL, { updateHistory: false, statusLabel: 'Reloaded' });
+      render();
+    }
+
+    function openBrowserSession() {
+      const url = browserSessionTargetURL();
+      state.browser.isVisible = true;
+      if (!url) {
+        state.browser.statusLabel = 'Invalid session address';
+        syncBrowserCommandStates();
+        render();
+        return;
+      }
+      if (state.browser.currentURL !== url) {
+        setBrowserPage(url);
+      }
+      state.browser.sessionURL = url;
+      state.browser.sessionOpenCount += 1;
+      state.browser.statusLabel = 'Session open';
+      syncBrowserCommandStates();
       render();
     }
 

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1670,9 +1670,18 @@ test('mock harness opens browser preview and records comments', async ({ page })
 
   await expect(page.getByTestId('browser-pane')).toBeVisible();
   await expect(page.getByTestId('browser-empty')).toBeVisible();
+  await expect(page.getByTestId('browser-session')).toBeDisabled();
 
   await page.getByLabel('Browser address').fill('localhost:5173');
   await expect(page.getByTestId('browser-open')).toBeEnabled();
+  await expect(page.getByTestId('browser-session')).toBeEnabled();
+  await page.getByTestId('browser-session').click();
+
+  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
+  await expect(page.getByTestId('browser-status-label')).toHaveText('Session open');
+  await expect(page.getByTestId('browser-session-status')).toContainText('Visible session 1:');
+  await expect(page.getByTestId('browser-session-url')).toHaveText('http://localhost:5173');
+
   await page.getByTestId('browser-open').click();
 
   await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
@@ -1716,6 +1725,18 @@ test('mock harness opens browser preview and records comments', async ({ page })
   await expect(page.getByTestId('browser-back')).toBeEnabled();
   await expect(page.getByTestId('browser-forward')).toBeDisabled();
 
+  await page.getByLabel('Browser address').fill('localhost:5173/dashboard');
+  await clickSidebarTool(page, 'command-palette-button');
+  await page.getByLabel('Search commands').fill('>session');
+  await page.locator('[data-testid="command-palette-result"][data-command-id="open-browser-session"]').click();
+  await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
+  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173/dashboard');
+  await expect(page.getByTestId('browser-status-label')).toHaveText('Session open');
+  await expect(page.getByTestId('browser-session-status')).toContainText('Visible session 2:');
+  await expect(page.getByTestId('browser-session-url')).toHaveText('http://localhost:5173/dashboard');
+
+  await page.getByTestId('browser-back').click();
+  await expect(page.getByTestId('browser-current-url')).toHaveText('https://example.com/docs');
   await page.getByTestId('browser-back').click();
   await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
   await expect(page.getByTestId('browser-back')).toBeDisabled();

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -4786,3 +4786,18 @@ Current strict grades:
 
 Remaining risk:
 - More workspace-model gates still live in the catch-all. Continue moving them by domain, especially project/thread lifecycle and MCP/tool execution boundaries, before adding new Codex-parity gates.
+
+## 2026-06-24 Browser Session E2E Harness Pass
+
+Overall grade after this slice: **A- browser-session harness coverage, A command parity guard, B+ browser product completeness**.
+
+The native browser pane and desktop presenter exposed a visible persistent browser session, but the Playwright harness still tested only static browser preview/navigation. That left a gap where the pane Session button or `Browser: Open session` command could become disabled or no-op without the UI smoke suite noticing.
+
+What changed:
+- Added `Browser: Open session` to the Playwright harness command catalog with dynamic enablement.
+- Added a visible Session control to the harness browser pane and matched native semantics: a typed address or current page can open a session.
+- Recorded the resolved session URL and open count in the harness so tests can assert real state changes instead of only checking that a button exists.
+- Extended the browser Playwright flow to open a session from the pane and from the command palette.
+
+Remaining risk:
+- This is still a deterministic HTML harness, not a packaged native WebKit smoke test. The next product-grade browser slice should automate a native app smoke run that opens a visible session, reuses its cookie profile, and verifies the same window is focused/navigated instead of duplicated.


### PR DESCRIPTION
## Summary\n- add the visible Browser Session control to the Playwright harness\n- wire Browser: Open session through harness command enablement and execution\n- extend the browser Playwright flow to verify pane and command-palette session opens\n- record the code-quality audit entry for this coverage pass\n\n## Validation\n- npm test -- --grep "mock harness opens browser preview and records comments"\n- npm test\n- swift test