### PR TITLE
Split workspace execution parity gates

### DIFF
--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -51,7 +51,8 @@ final class ParityGateTests: QuillCodeParityTestCase {
             "ParitySlashGateTests.swift",
             "ParityModelGateTests.swift",
             "ParityWorkspaceSurfaceGateTests.swift",
-            "ParityWorkspaceModelGateTests.swift"
+            "ParityWorkspaceModelGateTests.swift",
+            "ParityWorkspaceExecutionGateTests.swift"
         ]
         for suiteFile in suiteFiles {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
@@ -87,6 +88,17 @@ final class ParityGateTests: QuillCodeParityTestCase {
                 "testWorkspaceModelDelegatesAgentProgressStatusCopy",
                 "testWorkspaceModelDelegatesThreadNoticeMutation",
                 "testWorkspaceModelUsesExplicitAgentRunThreadUpdates"
+            ]),
+            ("ParityWorkspaceExecutionGateTests", [
+                "testWorkspaceModelDelegatesComposerCancellationPlanning",
+                "testWorkspaceModelDelegatesComposerSubmissionPlanning",
+                "testWorkspaceModelDelegatesAgentSendSessionExecution",
+                "testWorkspaceModelDelegatesAgentRunContextAssembly",
+                "testWorkspaceModelDelegatesAgentSendSession",
+                "testWorkspaceModelDelegatesToolEventRecording",
+                "testWorkspaceModelDelegatesToolCallExecutionRouting",
+                "testWorkspaceModelDelegatesShellToolCallPlanning",
+                "testWorkspaceModelDelegatesToolExecutionOverrideCombining"
             ])
         ]
 
@@ -314,62 +326,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(agentText.contains("Tool is not available in this workspace"), "Agent.swift should not own unavailable-tool result copy.")
     }
 
-    func testWorkspaceModelDelegatesComposerCancellationPlanning() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let plannerText = try Self.appSourceText(named: "WorkspaceComposerCancellationPlanner.swift")
-
-        XCTAssertTrue(plannerText.contains("struct WorkspaceComposerCancellationPlanner"), "Composer cancellation mutation should live in a focused planner.")
-        XCTAssertTrue(plannerText.contains("static func applyCancelledSend"), "Cancelled-send thread mutation should be directly testable.")
-        XCTAssertTrue(plannerText.contains("static let stoppedSummary"), "Cancelled-send copy should be shared through the planner.")
-        XCTAssertTrue(modelText.contains("WorkspaceComposerCancellationPlanner.applyCancelledSend"), "WorkspaceModel should delegate cancelled-send transcript mutation.")
-        XCTAssertFalse(modelText.contains(#""Stopped by user""#), "WorkspaceModel should not own cancelled-send copy.")
-        XCTAssertFalse(modelText.contains(#"{"ok":false,"error":"Stopped by user"}"#), "WorkspaceModel should not own cancelled-send result payload copy.")
-    }
-
-    func testWorkspaceModelDelegatesComposerSubmissionPlanning() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let plannerText = try Self.appSourceText(named: "WorkspaceComposerSubmissionPlanner.swift")
-
-        XCTAssertTrue(
-            plannerText.contains("struct WorkspaceComposerSubmissionPlanner"),
-            "Composer submission planning should live in a focused pure planner."
-        )
-        XCTAssertTrue(
-            modelText.contains("WorkspaceComposerSubmissionPlanner.plan"),
-            "WorkspaceModel should delegate prompt trimming and slash-command classification."
-        )
-        XCTAssertFalse(
-            modelText.contains("composer.draft.trimmingCharacters"),
-            "WorkspaceModel should not own raw composer prompt normalization."
-        )
-        XCTAssertFalse(
-            modelText.contains("SlashCommandParser.parse(prompt)"),
-            "WorkspaceModel should not classify slash commands inline."
-        )
-    }
-
-    func testWorkspaceModelDelegatesAgentSendSessionExecution() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
-
-        XCTAssertTrue(
-            sessionText.contains("struct WorkspaceAgentSendSession"),
-            "Agent send execution should live in a focused session object."
-        )
-        XCTAssertTrue(
-            modelText.contains("WorkspaceAgentSendSession("),
-            "WorkspaceModel should delegate runner execution to an agent send session."
-        )
-        XCTAssertFalse(
-            modelText.contains("activeRunner.send("),
-            "WorkspaceModel should not call the runner directly from submitComposer."
-        )
-        XCTAssertFalse(
-            modelText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory(in: thread)"),
-            "WorkspaceModel should not inspect completed run memory events inline."
-        )
-    }
-
     func testWorkspaceModelDelegatesSlashCommandTranscriptPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let actionExecutorText = try Self.appSourceText(named: "WorkspaceSlashCommandActionExecutor.swift")
@@ -516,89 +472,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(modelText.contains("case .localEnvironmentAction"), "WorkspaceModel should not own command-plan execution switching.")
         XCTAssertFalse(modelText.contains("case .startMCPServer"), "WorkspaceModel should not own MCP command-plan routing.")
         XCTAssertFalse(modelText.contains("case .runTool"), "WorkspaceModel should not own tool command-plan routing.")
-    }
-
-    func testWorkspaceModelDelegatesAgentRunContextAssembly() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
-        let memoryExecutorText = try Self.appSourceText(named: "WorkspaceMemoryRememberToolExecutor.swift")
-
-        XCTAssertTrue(modelText.contains("WorkspaceAgentRunContextBuilder("), "WorkspaceModel should delegate per-run tool assembly.")
-        XCTAssertTrue(builderText.contains("configuredRunner(from runner: AgentRunner)"), "Agent run context builder should own runner configuration.")
-        XCTAssertTrue(builderText.contains("ToolDefinition.planUpdate"), "Agent run context builder should attach the plan tool.")
-        XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect"), "Agent run context builder should attach the browser tool.")
-        XCTAssertTrue(builderText.contains("ToolDefinition.browserOpen"), "Agent run context builder should attach browser navigation.")
-        XCTAssertTrue(builderText.contains("WorkspaceBrowserToolExecutor.execute"), "Browser tool execution should stay in the focused browser executor.")
-        XCTAssertTrue(builderText.contains("ToolDefinition.computerUseDefinitions"), "Agent run context builder should attach Computer Use tools only when available.")
-        XCTAssertTrue(builderText.contains("WorkspaceMemoryRememberToolExecutor.executionOverride"), "Agent run context builder should delegate memory tool execution.")
-        XCTAssertTrue(memoryExecutorText.contains("didSaveMemory(in thread: ChatThread)"), "Memory save detection should live beside memory tool execution.")
-        XCTAssertFalse(modelText.contains("activeRunner.additionalToolDefinitions"), "WorkspaceModel should not assemble per-run additional tool definitions inline.")
-        XCTAssertFalse(modelText.contains("private func planToolExecutionOverride"), "WorkspaceModel should not own plan tool override assembly.")
-        XCTAssertFalse(modelText.contains("private func browserToolExecutionOverride"), "WorkspaceModel should not own browser tool override assembly.")
-        XCTAssertFalse(modelText.contains("private func memoryToolExecutionOverride"), "WorkspaceModel should not own memory tool override assembly.")
-        XCTAssertFalse(modelText.contains("private nonisolated static func didSaveMemory"), "WorkspaceModel should not own memory-save event parsing.")
-    }
-
-    func testWorkspaceModelDelegatesAgentSendSession() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
-
-        XCTAssertTrue(sessionText.contains("struct WorkspaceAgentSendSession"), "Agent send lifecycle should live in a focused session.")
-        XCTAssertTrue(sessionText.contains("func run("), "Agent send lifecycle should be directly testable.")
-        XCTAssertTrue(sessionText.contains("runner.send("), "The session should own the runner send call.")
-        XCTAssertTrue(sessionText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory"), "The session should report whether the run saved memory.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSession("), "WorkspaceModel should delegate agent send execution.")
-        XCTAssertFalse(modelText.contains("activeRunner.send("), "WorkspaceModel should not own the low-level send call.")
-        XCTAssertFalse(modelText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory(in: thread)"), "WorkspaceModel should not inspect memory events after each send.")
-    }
-
-    func testWorkspaceModelDelegatesToolEventRecording() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let recorderText = try Self.appSourceText(named: "WorkspaceToolEventRecorder.swift")
-
-        XCTAssertTrue(recorderText.contains("struct WorkspaceToolEventRecorder"), "Tool audit event construction should live in a focused recorder.")
-        XCTAssertTrue(recorderText.contains("static func events"), "Tool event construction should be directly testable.")
-        XCTAssertTrue(recorderText.contains("static func append"), "Thread mutation should be a thin append helper.")
-        XCTAssertTrue(recorderText.contains("call.redactedForTranscript()"), "Tool call redaction should live beside queued-event construction.")
-        XCTAssertTrue(recorderText.contains("result.ok ? .toolCompleted : .toolFailed"), "Completion/failure classification should live beside tool event construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceToolEventRecorder.append"), "WorkspaceModel should delegate tool audit event recording.")
-        XCTAssertFalse(modelText.contains("call.redactedForTranscript()"), "WorkspaceModel should not own tool call redaction for transcript events.")
-        XCTAssertFalse(modelText.contains("let resultJSON ="), "WorkspaceModel should not own tool result JSON payload construction.")
-        XCTAssertFalse(modelText.contains("summary: \"\\(call.name) queued\""), "WorkspaceModel should not construct queued tool summaries directly.")
-        XCTAssertFalse(modelText.contains("summary: \"\\(call.name) running\""), "WorkspaceModel should not construct running tool summaries directly.")
-    }
-
-    func testWorkspaceModelDelegatesToolCallExecutionRouting() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let executorText = try Self.appSourceText(named: "WorkspaceToolCallExecutor.swift")
-
-        XCTAssertTrue(executorText.contains("struct WorkspaceToolCallExecutor"), "Tool-call routing should live in a focused executor.")
-        XCTAssertTrue(executorText.contains("WorkspaceBrowserToolExecutor.execute"), "The executor should own browser tool routing.")
-        XCTAssertTrue(executorText.contains("PlanUpdateToolExecutor.execute"), "The executor should own plan update routing.")
-        XCTAssertTrue(executorText.contains("WorkspaceRemoteProjectToolExecutor.execute"), "The executor should own remote project routing.")
-        XCTAssertTrue(executorText.contains("ToolDefinition.applyPatch.name"), "The executor should own apply-patch follow-up routing.")
-        XCTAssertTrue(modelText.contains("workspaceToolCallExecutor(router:"), "WorkspaceModel should delegate tool execution routing.")
-        XCTAssertFalse(modelText.contains("call.name == ToolDefinition.browserInspect.name"), "WorkspaceModel should not branch on browser inspect tool execution.")
-        XCTAssertFalse(modelText.contains("call.name == ToolDefinition.browserOpen.name"), "WorkspaceModel should not branch on browser open tool execution.")
-        XCTAssertFalse(modelText.contains("call.name == ToolDefinition.planUpdate.name"), "WorkspaceModel should not branch on plan update tool execution.")
-        XCTAssertFalse(modelText.contains("private func appendReviewDiffAfterPatchIfNeeded"), "WorkspaceModel should not own apply-patch review diff follow-up routing.")
-        XCTAssertFalse(modelText.contains("private func executeReviewGitToolCall"), "WorkspaceModel should not own parallel review git routing.")
-    }
-
-    func testWorkspaceModelDelegatesShellToolCallPlanning() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let plannerText = try Self.appSourceText(named: "WorkspaceShellToolCallPlanner.swift")
-
-        XCTAssertTrue(plannerText.contains("enum WorkspaceShellToolCallPlanner"), "Local action shell tool-call planning should live in a focused planner.")
-        XCTAssertTrue(plannerText.contains("static func localEnvironmentAction"), "Local environment action tool calls should be directly testable.")
-        XCTAssertTrue(plannerText.contains("static func projectExtensionUpdate"), "Extension update tool calls should be directly testable.")
-        XCTAssertTrue(plannerText.contains("ToolDefinition.shellRun.name"), "The planner should own the canonical shell tool name.")
-        XCTAssertTrue(plannerText.contains("ToolArguments.json(arguments)"), "The planner should own shell argument JSON construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceShellToolCallPlanner.localEnvironmentAction"), "WorkspaceModel should delegate local action shell call construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceShellToolCallPlanner.projectExtensionUpdate"), "WorkspaceModel should delegate extension update shell call construction.")
-        XCTAssertFalse(modelText.contains("arguments[\"environment\"] = environment"), "WorkspaceModel should not assemble local action environment arguments inline.")
-        XCTAssertFalse(modelText.contains("arguments[\"timeoutSeconds\"] = timeoutSeconds"), "WorkspaceModel should not assemble local action timeout arguments inline.")
-        XCTAssertFalse(modelText.contains("let command = manifest.updateCommand"), "WorkspaceModel should not parse extension update commands inline.")
     }
 
     func testWorkspaceModelDelegatesProjectMetadataLoading() throws {
@@ -1481,19 +1354,4 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(surfaceText.contains("TrustedRouterDefaults.loopbackCallbackURL"), "WorkspaceSurface should not own TrustedRouter sign-in copy.")
     }
 
-    func testWorkspaceModelDelegatesToolExecutionOverrideCombining() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
-        let combinerText = try Self.appSourceText(named: "WorkspaceToolExecutionOverrideCombiner.swift")
-
-        XCTAssertTrue(combinerText.contains("struct WorkspaceToolExecutionOverrideCombiner"), "Tool override composition should live in a focused helper.")
-        XCTAssertTrue(combinerText.contains("static func combine"), "Tool override composition should expose a directly testable combine function.")
-        XCTAssertTrue(combinerText.contains("plan?(call, workspaceRoot)"), "Plan override should keep first dispatch priority.")
-        XCTAssertTrue(combinerText.contains("remoteProject?(call, workspaceRoot)"), "Remote-project override should stay before local browser/computer/memory/MCP overrides.")
-        XCTAssertTrue(combinerText.contains("mcp?(call, workspaceRoot)"), "MCP override should keep final fallback priority.")
-        XCTAssertTrue(builderText.contains("WorkspaceToolExecutionOverrideCombiner.combine"), "Agent run context builder should delegate override composition.")
-        XCTAssertFalse(modelText.contains("WorkspaceToolExecutionOverrideCombiner.combine"), "WorkspaceModel should not compose per-run overrides directly.")
-        XCTAssertFalse(modelText.contains("private func combinedToolExecutionOverride"), "WorkspaceModel should not own override composition.")
-        XCTAssertFalse(modelText.contains("if let result = await plan?(call, workspaceRoot)"), "WorkspaceModel should not inline override precedence.")
-    }
 }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+
+final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
+    func testWorkspaceModelDelegatesComposerCancellationPlanning() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let plannerText = try Self.appSourceText(named: "WorkspaceComposerCancellationPlanner.swift")
+
+        XCTAssertTrue(plannerText.contains("struct WorkspaceComposerCancellationPlanner"), "Composer cancellation mutation should live in a focused planner.")
+        XCTAssertTrue(plannerText.contains("static func applyCancelledSend"), "Cancelled-send thread mutation should be directly testable.")
+        XCTAssertTrue(plannerText.contains("static let stoppedSummary"), "Cancelled-send copy should be shared through the planner.")
+        XCTAssertTrue(modelText.contains("WorkspaceComposerCancellationPlanner.applyCancelledSend"), "WorkspaceModel should delegate cancelled-send transcript mutation.")
+        XCTAssertFalse(modelText.contains(#""Stopped by user""#), "WorkspaceModel should not own cancelled-send copy.")
+        XCTAssertFalse(modelText.contains(#"{"ok":false,"error":"Stopped by user"}"#), "WorkspaceModel should not own cancelled-send result payload copy.")
+    }
+
+    func testWorkspaceModelDelegatesComposerSubmissionPlanning() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let plannerText = try Self.appSourceText(named: "WorkspaceComposerSubmissionPlanner.swift")
+
+        XCTAssertTrue(
+            plannerText.contains("struct WorkspaceComposerSubmissionPlanner"),
+            "Composer submission planning should live in a focused pure planner."
+        )
+        XCTAssertTrue(
+            modelText.contains("WorkspaceComposerSubmissionPlanner.plan"),
+            "WorkspaceModel should delegate prompt trimming and slash-command classification."
+        )
+        XCTAssertFalse(
+            modelText.contains("composer.draft.trimmingCharacters"),
+            "WorkspaceModel should not own raw composer prompt normalization."
+        )
+        XCTAssertFalse(
+            modelText.contains("SlashCommandParser.parse(prompt)"),
+            "WorkspaceModel should not classify slash commands inline."
+        )
+    }
+
+    func testWorkspaceModelDelegatesAgentSendSessionExecution() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
+
+        XCTAssertTrue(
+            sessionText.contains("struct WorkspaceAgentSendSession"),
+            "Agent send execution should live in a focused session object."
+        )
+        XCTAssertTrue(
+            modelText.contains("WorkspaceAgentSendSession("),
+            "WorkspaceModel should delegate runner execution to an agent send session."
+        )
+        XCTAssertFalse(
+            modelText.contains("activeRunner.send("),
+            "WorkspaceModel should not call the runner directly from submitComposer."
+        )
+        XCTAssertFalse(
+            modelText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory(in: thread)"),
+            "WorkspaceModel should not inspect completed run memory events inline."
+        )
+    }
+
+    func testWorkspaceModelDelegatesAgentRunContextAssembly() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
+        let memoryExecutorText = try Self.appSourceText(named: "WorkspaceMemoryRememberToolExecutor.swift")
+
+        XCTAssertTrue(modelText.contains("WorkspaceAgentRunContextBuilder("), "WorkspaceModel should delegate per-run tool assembly.")
+        XCTAssertTrue(builderText.contains("configuredRunner(from runner: AgentRunner)"), "Agent run context builder should own runner configuration.")
+        XCTAssertTrue(builderText.contains("ToolDefinition.planUpdate"), "Agent run context builder should attach the plan tool.")
+        XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect"), "Agent run context builder should attach the browser tool.")
+        XCTAssertTrue(builderText.contains("ToolDefinition.browserOpen"), "Agent run context builder should attach browser navigation.")
+        XCTAssertTrue(builderText.contains("WorkspaceBrowserToolExecutor.execute"), "Browser tool execution should stay in the focused browser executor.")
+        XCTAssertTrue(builderText.contains("ToolDefinition.computerUseDefinitions"), "Agent run context builder should attach Computer Use tools only when available.")
+        XCTAssertTrue(builderText.contains("WorkspaceMemoryRememberToolExecutor.executionOverride"), "Agent run context builder should delegate memory tool execution.")
+        XCTAssertTrue(memoryExecutorText.contains("didSaveMemory(in thread: ChatThread)"), "Memory save detection should live beside memory tool execution.")
+        XCTAssertFalse(modelText.contains("activeRunner.additionalToolDefinitions"), "WorkspaceModel should not assemble per-run additional tool definitions inline.")
+        XCTAssertFalse(modelText.contains("private func planToolExecutionOverride"), "WorkspaceModel should not own plan tool override assembly.")
+        XCTAssertFalse(modelText.contains("private func browserToolExecutionOverride"), "WorkspaceModel should not own browser tool override assembly.")
+        XCTAssertFalse(modelText.contains("private func memoryToolExecutionOverride"), "WorkspaceModel should not own memory tool override assembly.")
+        XCTAssertFalse(modelText.contains("private nonisolated static func didSaveMemory"), "WorkspaceModel should not own memory-save event parsing.")
+    }
+
+    func testWorkspaceModelDelegatesAgentSendSession() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
+
+        XCTAssertTrue(sessionText.contains("struct WorkspaceAgentSendSession"), "Agent send lifecycle should live in a focused session.")
+        XCTAssertTrue(sessionText.contains("func run("), "Agent send lifecycle should be directly testable.")
+        XCTAssertTrue(sessionText.contains("runner.send("), "The session should own the runner send call.")
+        XCTAssertTrue(sessionText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory"), "The session should report whether the run saved memory.")
+        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSession("), "WorkspaceModel should delegate agent send execution.")
+        XCTAssertFalse(modelText.contains("activeRunner.send("), "WorkspaceModel should not own the low-level send call.")
+        XCTAssertFalse(modelText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory(in: thread)"), "WorkspaceModel should not inspect memory events after each send.")
+    }
+
+    func testWorkspaceModelDelegatesToolEventRecording() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let recorderText = try Self.appSourceText(named: "WorkspaceToolEventRecorder.swift")
+
+        XCTAssertTrue(recorderText.contains("struct WorkspaceToolEventRecorder"), "Tool audit event construction should live in a focused recorder.")
+        XCTAssertTrue(recorderText.contains("static func events"), "Tool event construction should be directly testable.")
+        XCTAssertTrue(recorderText.contains("static func append"), "Thread mutation should be a thin append helper.")
+        XCTAssertTrue(recorderText.contains("call.redactedForTranscript()"), "Tool call redaction should live beside queued-event construction.")
+        XCTAssertTrue(recorderText.contains("result.ok ? .toolCompleted : .toolFailed"), "Completion/failure classification should live beside tool event construction.")
+        XCTAssertTrue(modelText.contains("WorkspaceToolEventRecorder.append"), "WorkspaceModel should delegate tool audit event recording.")
+        XCTAssertFalse(modelText.contains("call.redactedForTranscript()"), "WorkspaceModel should not own tool call redaction for transcript events.")
+        XCTAssertFalse(modelText.contains("let resultJSON ="), "WorkspaceModel should not own tool result JSON payload construction.")
+        XCTAssertFalse(modelText.contains("summary: \"\\(call.name) queued\""), "WorkspaceModel should not construct queued tool summaries directly.")
+        XCTAssertFalse(modelText.contains("summary: \"\\(call.name) running\""), "WorkspaceModel should not construct running tool summaries directly.")
+    }
+
+    func testWorkspaceModelDelegatesToolCallExecutionRouting() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let executorText = try Self.appSourceText(named: "WorkspaceToolCallExecutor.swift")
+
+        XCTAssertTrue(executorText.contains("struct WorkspaceToolCallExecutor"), "Tool-call routing should live in a focused executor.")
+        XCTAssertTrue(executorText.contains("WorkspaceBrowserToolExecutor.execute"), "The executor should own browser tool routing.")
+        XCTAssertTrue(executorText.contains("PlanUpdateToolExecutor.execute"), "The executor should own plan update routing.")
+        XCTAssertTrue(executorText.contains("WorkspaceRemoteProjectToolExecutor.execute"), "The executor should own remote project routing.")
+        XCTAssertTrue(executorText.contains("ToolDefinition.applyPatch.name"), "The executor should own apply-patch follow-up routing.")
+        XCTAssertTrue(modelText.contains("workspaceToolCallExecutor(router:"), "WorkspaceModel should delegate tool execution routing.")
+        XCTAssertFalse(modelText.contains("call.name == ToolDefinition.browserInspect.name"), "WorkspaceModel should not branch on browser inspect tool execution.")
+        XCTAssertFalse(modelText.contains("call.name == ToolDefinition.browserOpen.name"), "WorkspaceModel should not branch on browser open tool execution.")
+        XCTAssertFalse(modelText.contains("call.name == ToolDefinition.planUpdate.name"), "WorkspaceModel should not branch on plan update tool execution.")
+        XCTAssertFalse(modelText.contains("private func appendReviewDiffAfterPatchIfNeeded"), "WorkspaceModel should not own apply-patch review diff follow-up routing.")
+        XCTAssertFalse(modelText.contains("private func executeReviewGitToolCall"), "WorkspaceModel should not own parallel review git routing.")
+    }
+
+    func testWorkspaceModelDelegatesShellToolCallPlanning() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let plannerText = try Self.appSourceText(named: "WorkspaceShellToolCallPlanner.swift")
+
+        XCTAssertTrue(plannerText.contains("enum WorkspaceShellToolCallPlanner"), "Local action shell tool-call planning should live in a focused planner.")
+        XCTAssertTrue(plannerText.contains("static func localEnvironmentAction"), "Local environment action tool calls should be directly testable.")
+        XCTAssertTrue(plannerText.contains("static func projectExtensionUpdate"), "Extension update tool calls should be directly testable.")
+        XCTAssertTrue(plannerText.contains("ToolDefinition.shellRun.name"), "The planner should own the canonical shell tool name.")
+        XCTAssertTrue(plannerText.contains("ToolArguments.json(arguments)"), "The planner should own shell argument JSON construction.")
+        XCTAssertTrue(modelText.contains("WorkspaceShellToolCallPlanner.localEnvironmentAction"), "WorkspaceModel should delegate local action shell call construction.")
+        XCTAssertTrue(modelText.contains("WorkspaceShellToolCallPlanner.projectExtensionUpdate"), "WorkspaceModel should delegate extension update shell call construction.")
+        XCTAssertFalse(modelText.contains("arguments[\"environment\"] = environment"), "WorkspaceModel should not assemble local action environment arguments inline.")
+        XCTAssertFalse(modelText.contains("arguments[\"timeoutSeconds\"] = timeoutSeconds"), "WorkspaceModel should not assemble local action timeout arguments inline.")
+        XCTAssertFalse(modelText.contains("let command = manifest.updateCommand"), "WorkspaceModel should not parse extension update commands inline.")
+    }
+
+    func testWorkspaceModelDelegatesToolExecutionOverrideCombining() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
+        let combinerText = try Self.appSourceText(named: "WorkspaceToolExecutionOverrideCombiner.swift")
+
+        XCTAssertTrue(combinerText.contains("struct WorkspaceToolExecutionOverrideCombiner"), "Tool override composition should live in a focused helper.")
+        XCTAssertTrue(combinerText.contains("static func combine"), "Tool override composition should expose a directly testable combine function.")
+        XCTAssertTrue(combinerText.contains("plan?(call, workspaceRoot)"), "Plan override should keep first dispatch priority.")
+        XCTAssertTrue(combinerText.contains("remoteProject?(call, workspaceRoot)"), "Remote-project override should stay before local browser/computer/memory/MCP overrides.")
+        XCTAssertTrue(combinerText.contains("mcp?(call, workspaceRoot)"), "MCP override should keep final fallback priority.")
+        XCTAssertTrue(builderText.contains("WorkspaceToolExecutionOverrideCombiner.combine"), "Agent run context builder should delegate override composition.")
+        XCTAssertFalse(modelText.contains("WorkspaceToolExecutionOverrideCombiner.combine"), "WorkspaceModel should not compose per-run overrides directly.")
+        XCTAssertFalse(modelText.contains("private func combinedToolExecutionOverride"), "WorkspaceModel should not own override composition.")
+        XCTAssertFalse(modelText.contains("if let result = await plan?(call, workspaceRoot)"), "WorkspaceModel should not inline override precedence.")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -4837,3 +4837,22 @@ Current strict grades:
 
 Remaining risk:
 - Continue draining `ParityGateTests.swift` by feature family. The next clean split should move composer/send-session/tool-execution gates to a dedicated workspace execution gate suite.
+
+## 2026-06-24 Workspace Execution Gate Split
+
+Overall grade after this slice: **A execution-gate ownership, A drift protection, B+ catch-all size**.
+
+After the workspace-model gate drain, execution-specific boundaries still lived in the broad parity file: composer cancellation/submission, agent send sessions, run-context assembly, tool event recording, tool-call routing, shell call planning, and tool override composition. Those checks all protect the same high-risk behavior: turning a user prompt into safe, auditable, executable work without letting `WorkspaceModel` absorb tool orchestration again.
+
+What changed:
+- Added `ParityWorkspaceExecutionGateTests` for composer, agent-send, and tool-execution boundary gates.
+- Registered the suite in the top-level parity guard and moved the execution gate names into the table-driven drift check.
+- Reduced the catch-all parity file again while leaving behavior unchanged.
+
+Current strict grades:
+- `ParityWorkspaceExecutionGateTests.swift`: **A**. It gives execution reliability and tool-routing boundaries a focused owner.
+- `ParityWorkspaceModelGateTests.swift`: **A-**. It no longer needs to absorb execution-specific gates while it grows model-boundary coverage.
+- `ParityGateTests.swift`: **B+**. Smaller and more DRY, but it still owns later slash-command, memory, automation, worktree, MCP, and command-plan gates.
+
+Remaining risk:
+- Continue draining `ParityGateTests.swift` by feature family. The next clean splits are slash/memory command gates and MCP/worktree/automation gates.


### PR DESCRIPTION
## Summary
- add ParityWorkspaceExecutionGateTests for composer, agent-send, and tool-execution boundary gates
- register the new focused suite in the table-driven parity drift guard
- update the code quality audit with execution-gate grades and remaining risks

## Validation
- swift test --filter 'ParityWorkspaceExecutionGateTests|ParityWorkspaceModelGateTests|ParityGateTests'
- swift test