### PR TITLE
Split workspace project parity gates

### DIFF
--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -52,7 +52,8 @@ final class ParityGateTests: QuillCodeParityTestCase {
             "ParityModelGateTests.swift",
             "ParityWorkspaceSurfaceGateTests.swift",
             "ParityWorkspaceModelGateTests.swift",
-            "ParityWorkspaceExecutionGateTests.swift"
+            "ParityWorkspaceExecutionGateTests.swift",
+            "ParityWorkspaceProjectGateTests.swift"
         ]
         for suiteFile in suiteFiles {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
@@ -104,6 +105,16 @@ final class ParityGateTests: QuillCodeParityTestCase {
                 "testWorkspaceComposerIntegrationTestsOwnModelComposerFlows",
                 "testWorkspaceModelDelegatesSlashCommandDispatchPlanning",
                 "testWorkspaceModelDelegatesToolExecutionOverrideCombining"
+            ]),
+            ("ParityWorkspaceProjectGateTests", [
+                "testWorkspaceModelDelegatesProjectMetadataLoading",
+                "testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage",
+                "testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows",
+                "testWorkspaceProjectIntegrationTestsOwnModelProjectFlows",
+                "testWorkspaceRemoteProjectIntegrationTestsOwnModelRemoteProjectFlows",
+                "testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows",
+                "testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows",
+                "testWorkspaceModelDelegatesWorktreeOpenRecords"
             ])
         ]
 
@@ -371,42 +382,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(modelText.contains("payloadJSON: note.relativePath"), "WorkspaceModel should not build memory change events inline.")
     }
 
-    func testWorkspaceModelDelegatesProjectMetadataLoading() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let loaderText = try Self.appSourceText(named: "WorkspaceProjectMetadataLoader.swift")
-
-        XCTAssertTrue(loaderText.contains("enum WorkspaceProjectMetadataLoader"), "Project metadata loading should live in a focused loader.")
-        XCTAssertTrue(loaderText.contains("ProjectInstructionLoader.load"), "Project instruction loading should stay with the metadata loader.")
-        XCTAssertTrue(loaderText.contains("LocalEnvironmentActionLoader.load"), "Local environment action loading should stay with the metadata loader.")
-        XCTAssertTrue(loaderText.contains("ProjectExtensionManifestLoader.load"), "Project extension loading should stay with the metadata loader.")
-        XCTAssertTrue(loaderText.contains("MemoryNoteLoader.loadProject"), "Project memory loading should stay with the metadata loader.")
-        XCTAssertTrue(loaderText.contains("SSHRemoteProjectContextLoader.load"), "SSH Remote context loading should stay with the metadata loader.")
-        XCTAssertTrue(modelText.contains("WorkspaceProjectMetadataLoader.loadLocal"), "WorkspaceModel should delegate local project metadata loading.")
-        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshRemoteProjectContext"), "WorkspaceModel should delegate SSH Remote project metadata refresh.")
-        XCTAssertFalse(modelText.contains("ProjectInstructionLoader.load"), "WorkspaceModel should not load instruction files directly.")
-        XCTAssertFalse(modelText.contains("LocalEnvironmentActionLoader.load"), "WorkspaceModel should not load local environment actions directly.")
-        XCTAssertFalse(modelText.contains("ProjectExtensionManifestLoader.load"), "WorkspaceModel should not load project extensions directly.")
-        XCTAssertFalse(modelText.contains("MemoryNoteLoader.loadProject"), "WorkspaceModel should not load project memories directly.")
-        XCTAssertFalse(modelText.contains("SSHRemoteProjectContextLoader.load"), "WorkspaceModel should not load SSH Remote context directly.")
-    }
-
-    func testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage() throws {
-        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
-        let instructionTests = try Self.appTestSourceText(named: "ProjectInstructionLoaderTests.swift")
-        let actionTests = try Self.appTestSourceText(named: "LocalEnvironmentActionLoaderTests.swift")
-        let extensionTests = try Self.appTestSourceText(named: "ProjectExtensionManifestLoaderTests.swift")
-        let memoryTests = try Self.appTestSourceText(named: "MemoryNoteLoaderTests.swift")
-
-        XCTAssertTrue(instructionTests.contains("ProjectInstructionLoader.load"), "Project instruction loader coverage should live in its focused test file.")
-        XCTAssertTrue(actionTests.contains("LocalEnvironmentActionLoader.load"), "Local environment loader coverage should live in its focused test file.")
-        XCTAssertTrue(extensionTests.contains("ProjectExtensionManifestLoader.load"), "Project extension loader coverage should live in its focused test file.")
-        XCTAssertTrue(memoryTests.contains("MemoryNoteLoader.loadProject"), "Project memory loader coverage should live in its focused test file.")
-        XCTAssertFalse(modelTests.contains("ProjectInstructionLoader.load"), "WorkspaceModelTests should focus on model integration, not direct project instruction loader tests.")
-        XCTAssertFalse(modelTests.contains("LocalEnvironmentActionLoader.load"), "WorkspaceModelTests should focus on model integration, not direct local environment loader tests.")
-        XCTAssertFalse(modelTests.contains("ProjectExtensionManifestLoader.load"), "WorkspaceModelTests should focus on model integration, not direct extension loader tests.")
-        XCTAssertFalse(modelTests.contains("MemoryNoteLoader.loadProject"), "WorkspaceModelTests should focus on model integration, not direct memory loader tests.")
-    }
-
     func testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows() throws {
         let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
         let memoryIntegrationTests = try Self.appTestSourceText(named: "WorkspaceMemoryIntegrationTests.swift")
@@ -435,77 +410,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(modelTests.contains("testReadyMCPResourceCanBeReadFromAgentTurn"), "WorkspaceModelTests should not own MCP resource integration flows.")
         XCTAssertFalse(modelTests.contains("testReadyMCPPromptCanBeLoadedFromAgentTurn"), "WorkspaceModelTests should not own MCP prompt integration flows.")
         XCTAssertFalse(modelTests.contains("testMCPToolCallRejectsUnadvertisedTools"), "WorkspaceModelTests should not own MCP safety integration flows.")
-    }
-
-    func testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows() throws {
-        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
-        let extensionIntegrationTests = try Self.appTestSourceText(named: "WorkspaceProjectExtensionIntegrationTests.swift")
-
-        XCTAssertTrue(extensionIntegrationTests.contains("testProjectExtensionManifestsLoadIntoProjectSurface"), "Project extension manifest integration should live in focused extension integration tests.")
-        XCTAssertTrue(extensionIntegrationTests.contains("testProjectExtensionUpdateCommandRunsAndRefreshesProjectMetadata"), "Project extension update integration should live in focused extension integration tests.")
-        XCTAssertTrue(extensionIntegrationTests.contains("testProjectExtensionUpdateFailureKeepsManifestAndRecordsFailureNotice"), "Project extension update failure integration should live in focused extension integration tests.")
-        XCTAssertFalse(modelTests.contains("testProjectExtensionManifestsLoadIntoProjectSurface"), "WorkspaceModelTests should not own project extension manifest integration flows.")
-        XCTAssertFalse(modelTests.contains("testProjectExtensionUpdateCommandRunsAndRefreshesProjectMetadata"), "WorkspaceModelTests should not own project extension update integration flows.")
-    }
-
-    func testWorkspaceProjectIntegrationTestsOwnModelProjectFlows() throws {
-        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
-        let projectIntegrationTests = try Self.appTestSourceText(named: "WorkspaceProjectIntegrationTests.swift")
-
-        XCTAssertTrue(projectIntegrationTests.contains("testModelPersistsProjectRegistryChanges"), "Project registry persistence should live in focused project integration tests.")
-        XCTAssertTrue(projectIntegrationTests.contains("testSelectingProjectControlsNextChatAndWorkspaceRoot"), "Project selection workspace integration should live in focused project tests.")
-        XCTAssertTrue(projectIntegrationTests.contains("testProjectLifecycleActionsRenameRefreshNewChatAndRemove"), "Project lifecycle command integration should live in focused project tests.")
-        XCTAssertTrue(projectIntegrationTests.contains("testProjectInstructionsLoadIntoNewThreadsAndRefreshBeforeRun"), "Project instruction integration should live in focused project tests.")
-        XCTAssertFalse(modelTests.contains("testModelPersistsProjectRegistryChanges"), "WorkspaceModelTests should not own project registry persistence integration flows.")
-        XCTAssertFalse(modelTests.contains("testSelectingProjectControlsNextChatAndWorkspaceRoot"), "WorkspaceModelTests should not own project selection integration flows.")
-        XCTAssertFalse(modelTests.contains("testProjectLifecycleActionsRenameRefreshNewChatAndRemove"), "WorkspaceModelTests should not own project lifecycle command integration flows.")
-        XCTAssertFalse(modelTests.contains("testProjectInstructionsLoadIntoNewThreadsAndRefreshBeforeRun"), "WorkspaceModelTests should not own project instruction integration flows.")
-    }
-
-    func testWorkspaceRemoteProjectIntegrationTestsOwnModelRemoteProjectFlows() throws {
-        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
-        let remoteProjectIntegrationTests = try Self.appTestSourceText(named: "WorkspaceRemoteProjectIntegrationTests.swift")
-
-        XCTAssertTrue(remoteProjectIntegrationTests.contains("testSlashSSHAddsRemoteProjectAndEnablesRemoteGitActions"), "SSH project setup should live in focused remote project integration tests.")
-        XCTAssertTrue(remoteProjectIntegrationTests.contains("testRemoteProjectAgentRunsShellThroughSSH"), "Remote shell agent execution should live in focused remote project integration tests.")
-        XCTAssertTrue(remoteProjectIntegrationTests.contains("testRemoteProjectAgentCreatesPullRequestThroughSSH"), "Remote PR creation should live in focused remote project integration tests.")
-        XCTAssertTrue(remoteProjectIntegrationTests.contains("testRemoteProjectRejectsUnsafeWorktreePathBeforeSSH"), "Remote worktree safety coverage should live in focused remote project integration tests.")
-        XCTAssertFalse(modelTests.contains("testSlashSSHAddsRemoteProjectAndEnablesRemoteGitActions"), "WorkspaceModelTests should not own SSH project setup integration flows.")
-        XCTAssertFalse(modelTests.contains("testRemoteProjectAgentRunsShellThroughSSH"), "WorkspaceModelTests should not own remote shell agent integration flows.")
-        XCTAssertFalse(modelTests.contains("testRemoteProjectAgentCreatesPullRequestThroughSSH"), "WorkspaceModelTests should not own remote PR creation integration flows.")
-        XCTAssertFalse(modelTests.contains("testRemoteProjectRejectsUnsafeWorktreePathBeforeSSH"), "WorkspaceModelTests should not own remote worktree safety integration flows.")
-    }
-
-    func testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows() throws {
-        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
-        let pullRequestIntegrationTests = try Self.appTestSourceText(named: "WorkspacePullRequestIntegrationTests.swift")
-
-        XCTAssertTrue(pullRequestIntegrationTests.contains("testRemoteWorkspaceCommandsViewPullRequestAndChecksThroughSSH"), "Remote PR workspace commands should live in focused pull request integration tests.")
-        XCTAssertTrue(pullRequestIntegrationTests.contains("testPullRequestSlashCommandsDispatchStructuredGitHubToolsThroughSSH"), "PR slash command dispatch should live in focused pull request integration tests.")
-        XCTAssertTrue(pullRequestIntegrationTests.contains("testWorkspacePullRequestCommandsPrefillComposer"), "PR command prefills should live in focused pull request integration tests.")
-        XCTAssertTrue(pullRequestIntegrationTests.contains("makeRemotePullRequestFixture"), "Repeated fake GitHub CLI plus SSH setup should stay centralized in the PR integration suite.")
-
-        XCTAssertFalse(modelTests.contains("testRemoteWorkspaceCommandsViewPullRequestAndChecksThroughSSH"), "WorkspaceModelTests should not own remote PR workspace command integration.")
-        XCTAssertFalse(modelTests.contains("testPullRequestSlashCommandsDispatchStructuredGitHubToolsThroughSSH"), "WorkspaceModelTests should not own PR slash command integration.")
-        XCTAssertFalse(modelTests.contains("testWorkspacePullRequestCommandsPrefillComposer"), "WorkspaceModelTests should not own PR command prefill integration.")
-        XCTAssertFalse(modelTests.contains("makeRemotePullRequestFixture"), "WorkspaceModelTests should not own PR integration fixture setup.")
-    }
-
-    func testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows() throws {
-        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
-        let worktreeIntegrationTests = try Self.appTestSourceText(named: "WorkspaceWorktreeIntegrationTests.swift")
-
-        XCTAssertTrue(worktreeIntegrationTests.contains("testWorkspaceCommandListsGitWorktrees"), "Local worktree listing should live in focused worktree integration tests.")
-        XCTAssertTrue(worktreeIntegrationTests.contains("testRemoteWorkspaceCommandListsGitWorktreesThroughSSH"), "SSH Remote worktree listing should live in focused worktree integration tests.")
-        XCTAssertTrue(worktreeIntegrationTests.contains("testWorkspaceWorktreeCommandsPrefillComposer"), "Worktree command prefill should live in focused worktree integration tests.")
-        XCTAssertTrue(worktreeIntegrationTests.contains("testWorkspaceCreateWorktreeOpensFocusedThreadAndKeepsToolAudit"), "Local worktree create/open integration should live in focused worktree integration tests.")
-        XCTAssertTrue(worktreeIntegrationTests.contains("testRemoteWorkspaceCreateWorktreeOpensSSHProjectAndKeepsToolAudit"), "SSH Remote worktree create/open integration should live in focused worktree integration tests.")
-
-        XCTAssertFalse(modelTests.contains("testWorkspaceCommandListsGitWorktrees"), "WorkspaceModelTests should not own local worktree listing integration.")
-        XCTAssertFalse(modelTests.contains("testRemoteWorkspaceCommandListsGitWorktreesThroughSSH"), "WorkspaceModelTests should not own SSH Remote worktree listing integration.")
-        XCTAssertFalse(modelTests.contains("testWorkspaceWorktreeCommandsPrefillComposer"), "WorkspaceModelTests should not own worktree command prefill integration.")
-        XCTAssertFalse(modelTests.contains("testWorkspaceCreateWorktreeOpensFocusedThreadAndKeepsToolAudit"), "WorkspaceModelTests should not own local worktree create/open integration.")
-        XCTAssertFalse(modelTests.contains("testRemoteWorkspaceCreateWorktreeOpensSSHProjectAndKeepsToolAudit"), "WorkspaceModelTests should not own SSH Remote worktree create/open integration.")
     }
 
     func testWorkspaceReviewIntegrationTestsOwnModelReviewFlows() throws {
@@ -686,32 +590,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(surfaceText.contains("automationCreateWorkspaceSchedule"), "WorkspaceSurface should not build automation schedule commands inline.")
         XCTAssertFalse(surfaceText.contains("automationScheduleThreadFollowUpCommands"), "WorkspaceSurface should not build thread schedule command variants inline.")
         XCTAssertFalse(surfaceText.contains("automationScheduleWorkspaceScheduleCommands"), "WorkspaceSurface should not build workspace schedule command variants inline.")
-    }
-
-    func testWorkspaceModelDelegatesWorktreeOpenRecords() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let requestsText = try Self.appSourceText(named: "WorkspaceWorktreeRequests.swift")
-        let engineText = try Self.appSourceText(named: "WorkspaceWorktreeOpenEngine.swift")
-        let plannerText = try Self.appSourceText(named: "WorkspaceWorktreeToolCallPlanner.swift")
-
-        XCTAssertTrue(requestsText.contains("public struct WorkspaceWorktreeCreateRequest"), "Worktree create requests should live outside WorkspaceModel.")
-        XCTAssertTrue(requestsText.contains("public struct WorkspaceWorktreeRemoveRequest"), "Worktree remove requests should live outside WorkspaceModel.")
-        XCTAssertTrue(engineText.contains("struct WorkspaceWorktreeOpenEngine"), "Opened-worktree thread construction should live in a focused engine.")
-        XCTAssertTrue(engineText.contains("static func localThread"), "Local worktree handoff records should be directly testable.")
-        XCTAssertTrue(engineText.contains("static func remoteThread"), "SSH Remote worktree handoff records should be directly testable.")
-        XCTAssertTrue(plannerText.contains("enum WorkspaceWorktreeToolCallPlanner"), "Worktree tool-call JSON should live in a focused planner.")
-        XCTAssertTrue(plannerText.contains("static func create"), "Worktree create tool calls should be directly testable.")
-        XCTAssertTrue(plannerText.contains("static func remove"), "Worktree remove tool calls should be directly testable.")
-        XCTAssertTrue(modelText.contains("WorkspaceWorktreeToolCallPlanner.create"), "WorkspaceModel should delegate worktree create tool-call construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceWorktreeToolCallPlanner.remove"), "WorkspaceModel should delegate worktree remove tool-call construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceWorktreeOpenEngine.localThread"), "WorkspaceModel should delegate local worktree handoff records.")
-        XCTAssertTrue(modelText.contains("WorkspaceWorktreeOpenEngine.remoteThread"), "WorkspaceModel should delegate SSH Remote worktree handoff records.")
-        XCTAssertTrue(modelText.contains("openCreatedWorktreeThread"), "WorkspaceModel should share selected-thread persistence for local and remote worktrees.")
-        XCTAssertFalse(modelText.contains("ToolDefinition.gitWorktreeCreate.name"), "WorkspaceModel should not own worktree create tool-call details.")
-        XCTAssertFalse(modelText.contains("ToolDefinition.gitWorktreeRemove.name"), "WorkspaceModel should not own worktree remove tool-call details.")
-        XCTAssertFalse(modelText.contains("title: \"Worktree:"), "WorkspaceModel should not own worktree thread title copy.")
-        XCTAssertFalse(modelText.contains("Opened remote worktree `"), "WorkspaceModel should not own remote worktree transcript copy.")
-        XCTAssertFalse(modelText.contains("Opened worktree `"), "WorkspaceModel should not own local worktree transcript copy.")
     }
 
     func testWorkspaceModelDelegatesSidebarSelectionTransitions() throws {

--- a/Tests/QuillCodeParityTests/ParityWorkspaceProjectGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceProjectGateTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+final class ParityWorkspaceProjectGateTests: QuillCodeParityTestCase {
+    func testWorkspaceModelDelegatesProjectMetadataLoading() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let loaderText = try Self.appSourceText(named: "WorkspaceProjectMetadataLoader.swift")
+
+        XCTAssertTrue(loaderText.contains("enum WorkspaceProjectMetadataLoader"), "Project metadata loading should live in a focused loader.")
+        XCTAssertTrue(loaderText.contains("ProjectInstructionLoader.load"), "Project instruction loading should stay with the metadata loader.")
+        XCTAssertTrue(loaderText.contains("LocalEnvironmentActionLoader.load"), "Local environment action loading should stay with the metadata loader.")
+        XCTAssertTrue(loaderText.contains("ProjectExtensionManifestLoader.load"), "Project extension loading should stay with the metadata loader.")
+        XCTAssertTrue(loaderText.contains("MemoryNoteLoader.loadProject"), "Project memory loading should stay with the metadata loader.")
+        XCTAssertTrue(loaderText.contains("SSHRemoteProjectContextLoader.load"), "SSH Remote context loading should stay with the metadata loader.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectMetadataLoader.loadLocal"), "WorkspaceModel should delegate local project metadata loading.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshRemoteProjectContext"), "WorkspaceModel should delegate SSH Remote project metadata refresh.")
+        XCTAssertFalse(modelText.contains("ProjectInstructionLoader.load"), "WorkspaceModel should not load instruction files directly.")
+        XCTAssertFalse(modelText.contains("LocalEnvironmentActionLoader.load"), "WorkspaceModel should not load local environment actions directly.")
+        XCTAssertFalse(modelText.contains("ProjectExtensionManifestLoader.load"), "WorkspaceModel should not load project extensions directly.")
+        XCTAssertFalse(modelText.contains("MemoryNoteLoader.loadProject"), "WorkspaceModel should not load project memories directly.")
+        XCTAssertFalse(modelText.contains("SSHRemoteProjectContextLoader.load"), "WorkspaceModel should not load SSH Remote context directly.")
+    }
+
+    func testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage() throws {
+        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
+        let instructionTests = try Self.appTestSourceText(named: "ProjectInstructionLoaderTests.swift")
+        let actionTests = try Self.appTestSourceText(named: "LocalEnvironmentActionLoaderTests.swift")
+        let extensionTests = try Self.appTestSourceText(named: "ProjectExtensionManifestLoaderTests.swift")
+        let memoryTests = try Self.appTestSourceText(named: "MemoryNoteLoaderTests.swift")
+
+        XCTAssertTrue(instructionTests.contains("ProjectInstructionLoader.load"), "Project instruction loader coverage should live in its focused test file.")
+        XCTAssertTrue(actionTests.contains("LocalEnvironmentActionLoader.load"), "Local environment loader coverage should live in its focused test file.")
+        XCTAssertTrue(extensionTests.contains("ProjectExtensionManifestLoader.load"), "Project extension loader coverage should live in its focused test file.")
+        XCTAssertTrue(memoryTests.contains("MemoryNoteLoader.loadProject"), "Project memory loader coverage should live in its focused test file.")
+        XCTAssertFalse(modelTests.contains("ProjectInstructionLoader.load"), "WorkspaceModelTests should focus on model integration, not direct project instruction loader tests.")
+        XCTAssertFalse(modelTests.contains("LocalEnvironmentActionLoader.load"), "WorkspaceModelTests should focus on model integration, not direct local environment loader tests.")
+        XCTAssertFalse(modelTests.contains("ProjectExtensionManifestLoader.load"), "WorkspaceModelTests should focus on model integration, not direct extension loader tests.")
+        XCTAssertFalse(modelTests.contains("MemoryNoteLoader.loadProject"), "WorkspaceModelTests should focus on model integration, not direct memory loader tests.")
+    }
+
+    func testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows() throws {
+        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
+        let extensionIntegrationTests = try Self.appTestSourceText(named: "WorkspaceProjectExtensionIntegrationTests.swift")
+
+        XCTAssertTrue(extensionIntegrationTests.contains("testProjectExtensionManifestsLoadIntoProjectSurface"), "Project extension manifest integration should live in focused extension integration tests.")
+        XCTAssertTrue(extensionIntegrationTests.contains("testProjectExtensionUpdateCommandRunsAndRefreshesProjectMetadata"), "Project extension update integration should live in focused extension integration tests.")
+        XCTAssertTrue(extensionIntegrationTests.contains("testProjectExtensionUpdateFailureKeepsManifestAndRecordsFailureNotice"), "Project extension update failure integration should live in focused extension integration tests.")
+        XCTAssertFalse(modelTests.contains("testProjectExtensionManifestsLoadIntoProjectSurface"), "WorkspaceModelTests should not own project extension manifest integration flows.")
+        XCTAssertFalse(modelTests.contains("testProjectExtensionUpdateCommandRunsAndRefreshesProjectMetadata"), "WorkspaceModelTests should not own project extension update integration flows.")
+    }
+
+    func testWorkspaceProjectIntegrationTestsOwnModelProjectFlows() throws {
+        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
+        let projectIntegrationTests = try Self.appTestSourceText(named: "WorkspaceProjectIntegrationTests.swift")
+
+        XCTAssertTrue(projectIntegrationTests.contains("testModelPersistsProjectRegistryChanges"), "Project registry persistence should live in focused project integration tests.")
+        XCTAssertTrue(projectIntegrationTests.contains("testSelectingProjectControlsNextChatAndWorkspaceRoot"), "Project selection workspace integration should live in focused project tests.")
+        XCTAssertTrue(projectIntegrationTests.contains("testProjectLifecycleActionsRenameRefreshNewChatAndRemove"), "Project lifecycle command integration should live in focused project tests.")
+        XCTAssertTrue(projectIntegrationTests.contains("testProjectInstructionsLoadIntoNewThreadsAndRefreshBeforeRun"), "Project instruction integration should live in focused project tests.")
+        XCTAssertFalse(modelTests.contains("testModelPersistsProjectRegistryChanges"), "WorkspaceModelTests should not own project registry persistence integration flows.")
+        XCTAssertFalse(modelTests.contains("testSelectingProjectControlsNextChatAndWorkspaceRoot"), "WorkspaceModelTests should not own project selection integration flows.")
+        XCTAssertFalse(modelTests.contains("testProjectLifecycleActionsRenameRefreshNewChatAndRemove"), "WorkspaceModelTests should not own project lifecycle command integration flows.")
+        XCTAssertFalse(modelTests.contains("testProjectInstructionsLoadIntoNewThreadsAndRefreshBeforeRun"), "WorkspaceModelTests should not own project instruction integration flows.")
+    }
+
+    func testWorkspaceRemoteProjectIntegrationTestsOwnModelRemoteProjectFlows() throws {
+        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
+        let remoteProjectIntegrationTests = try Self.appTestSourceText(named: "WorkspaceRemoteProjectIntegrationTests.swift")
+
+        XCTAssertTrue(remoteProjectIntegrationTests.contains("testSlashSSHAddsRemoteProjectAndEnablesRemoteGitActions"), "SSH project setup should live in focused remote project integration tests.")
+        XCTAssertTrue(remoteProjectIntegrationTests.contains("testRemoteProjectAgentRunsShellThroughSSH"), "Remote shell agent execution should live in focused remote project integration tests.")
+        XCTAssertTrue(remoteProjectIntegrationTests.contains("testRemoteProjectAgentCreatesPullRequestThroughSSH"), "Remote PR creation should live in focused remote project integration tests.")
+        XCTAssertTrue(remoteProjectIntegrationTests.contains("testRemoteProjectRejectsUnsafeWorktreePathBeforeSSH"), "Remote worktree safety coverage should live in focused remote project integration tests.")
+        XCTAssertFalse(modelTests.contains("testSlashSSHAddsRemoteProjectAndEnablesRemoteGitActions"), "WorkspaceModelTests should not own SSH project setup integration flows.")
+        XCTAssertFalse(modelTests.contains("testRemoteProjectAgentRunsShellThroughSSH"), "WorkspaceModelTests should not own remote shell agent integration flows.")
+        XCTAssertFalse(modelTests.contains("testRemoteProjectAgentCreatesPullRequestThroughSSH"), "WorkspaceModelTests should not own remote PR creation integration flows.")
+        XCTAssertFalse(modelTests.contains("testRemoteProjectRejectsUnsafeWorktreePathBeforeSSH"), "WorkspaceModelTests should not own remote worktree safety integration flows.")
+    }
+
+    func testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows() throws {
+        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
+        let pullRequestIntegrationTests = try Self.appTestSourceText(named: "WorkspacePullRequestIntegrationTests.swift")
+
+        XCTAssertTrue(pullRequestIntegrationTests.contains("testRemoteWorkspaceCommandsViewPullRequestAndChecksThroughSSH"), "Remote PR workspace commands should live in focused pull request integration tests.")
+        XCTAssertTrue(pullRequestIntegrationTests.contains("testPullRequestSlashCommandsDispatchStructuredGitHubToolsThroughSSH"), "PR slash command dispatch should live in focused pull request integration tests.")
+        XCTAssertTrue(pullRequestIntegrationTests.contains("testWorkspacePullRequestCommandsPrefillComposer"), "PR command prefills should live in focused pull request integration tests.")
+        XCTAssertTrue(pullRequestIntegrationTests.contains("makeRemotePullRequestFixture"), "Repeated fake GitHub CLI plus SSH setup should stay centralized in the PR integration suite.")
+
+        XCTAssertFalse(modelTests.contains("testRemoteWorkspaceCommandsViewPullRequestAndChecksThroughSSH"), "WorkspaceModelTests should not own remote PR workspace command integration.")
+        XCTAssertFalse(modelTests.contains("testPullRequestSlashCommandsDispatchStructuredGitHubToolsThroughSSH"), "WorkspaceModelTests should not own PR slash command integration.")
+        XCTAssertFalse(modelTests.contains("testWorkspacePullRequestCommandsPrefillComposer"), "WorkspaceModelTests should not own PR command prefill integration.")
+        XCTAssertFalse(modelTests.contains("makeRemotePullRequestFixture"), "WorkspaceModelTests should not own PR integration fixture setup.")
+    }
+
+    func testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows() throws {
+        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
+        let worktreeIntegrationTests = try Self.appTestSourceText(named: "WorkspaceWorktreeIntegrationTests.swift")
+
+        XCTAssertTrue(worktreeIntegrationTests.contains("testWorkspaceCommandListsGitWorktrees"), "Local worktree listing should live in focused worktree integration tests.")
+        XCTAssertTrue(worktreeIntegrationTests.contains("testRemoteWorkspaceCommandListsGitWorktreesThroughSSH"), "SSH Remote worktree listing should live in focused worktree integration tests.")
+        XCTAssertTrue(worktreeIntegrationTests.contains("testWorkspaceWorktreeCommandsPrefillComposer"), "Worktree command prefill should live in focused worktree integration tests.")
+        XCTAssertTrue(worktreeIntegrationTests.contains("testWorkspaceCreateWorktreeOpensFocusedThreadAndKeepsToolAudit"), "Local worktree create/open integration should live in focused worktree integration tests.")
+        XCTAssertTrue(worktreeIntegrationTests.contains("testRemoteWorkspaceCreateWorktreeOpensSSHProjectAndKeepsToolAudit"), "SSH Remote worktree create/open integration should live in focused worktree integration tests.")
+
+        XCTAssertFalse(modelTests.contains("testWorkspaceCommandListsGitWorktrees"), "WorkspaceModelTests should not own local worktree listing integration.")
+        XCTAssertFalse(modelTests.contains("testRemoteWorkspaceCommandListsGitWorktreesThroughSSH"), "WorkspaceModelTests should not own SSH Remote worktree listing integration.")
+        XCTAssertFalse(modelTests.contains("testWorkspaceWorktreeCommandsPrefillComposer"), "WorkspaceModelTests should not own worktree command prefill integration.")
+        XCTAssertFalse(modelTests.contains("testWorkspaceCreateWorktreeOpensFocusedThreadAndKeepsToolAudit"), "WorkspaceModelTests should not own local worktree create/open integration.")
+        XCTAssertFalse(modelTests.contains("testRemoteWorkspaceCreateWorktreeOpensSSHProjectAndKeepsToolAudit"), "WorkspaceModelTests should not own SSH Remote worktree create/open integration.")
+    }
+
+    func testWorkspaceModelDelegatesWorktreeOpenRecords() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let requestsText = try Self.appSourceText(named: "WorkspaceWorktreeRequests.swift")
+        let engineText = try Self.appSourceText(named: "WorkspaceWorktreeOpenEngine.swift")
+        let plannerText = try Self.appSourceText(named: "WorkspaceWorktreeToolCallPlanner.swift")
+
+        XCTAssertTrue(requestsText.contains("public struct WorkspaceWorktreeCreateRequest"), "Worktree create requests should live outside WorkspaceModel.")
+        XCTAssertTrue(requestsText.contains("public struct WorkspaceWorktreeRemoveRequest"), "Worktree remove requests should live outside WorkspaceModel.")
+        XCTAssertTrue(engineText.contains("struct WorkspaceWorktreeOpenEngine"), "Opened-worktree thread construction should live in a focused engine.")
+        XCTAssertTrue(engineText.contains("static func localThread"), "Local worktree handoff records should be directly testable.")
+        XCTAssertTrue(engineText.contains("static func remoteThread"), "SSH Remote worktree handoff records should be directly testable.")
+        XCTAssertTrue(plannerText.contains("enum WorkspaceWorktreeToolCallPlanner"), "Worktree tool-call JSON should live in a focused planner.")
+        XCTAssertTrue(plannerText.contains("static func create"), "Worktree create tool calls should be directly testable.")
+        XCTAssertTrue(plannerText.contains("static func remove"), "Worktree remove tool calls should be directly testable.")
+        XCTAssertTrue(modelText.contains("WorkspaceWorktreeToolCallPlanner.create"), "WorkspaceModel should delegate worktree create tool-call construction.")
+        XCTAssertTrue(modelText.contains("WorkspaceWorktreeToolCallPlanner.remove"), "WorkspaceModel should delegate worktree remove tool-call construction.")
+        XCTAssertTrue(modelText.contains("WorkspaceWorktreeOpenEngine.localThread"), "WorkspaceModel should delegate local worktree handoff records.")
+        XCTAssertTrue(modelText.contains("WorkspaceWorktreeOpenEngine.remoteThread"), "WorkspaceModel should delegate SSH Remote worktree handoff records.")
+        XCTAssertTrue(modelText.contains("openCreatedWorktreeThread"), "WorkspaceModel should share selected-thread persistence for local and remote worktrees.")
+        XCTAssertFalse(modelText.contains("ToolDefinition.gitWorktreeCreate.name"), "WorkspaceModel should not own worktree create tool-call details.")
+        XCTAssertFalse(modelText.contains("ToolDefinition.gitWorktreeRemove.name"), "WorkspaceModel should not own worktree remove tool-call details.")
+        XCTAssertFalse(modelText.contains("title: \"Worktree:"), "WorkspaceModel should not own worktree thread title copy.")
+        XCTAssertFalse(modelText.contains("Opened remote worktree `"), "WorkspaceModel should not own remote worktree transcript copy.")
+        XCTAssertFalse(modelText.contains("Opened worktree `"), "WorkspaceModel should not own local worktree transcript copy.")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -4855,3 +4855,21 @@ Current strict grades:
 
 Remaining risk:
 - Memory, project metadata, local environment, automation, worktree, MCP, remote project, and review-runtime gates still live in the catch-all. Continue extracting by domain before adding more Codex-parity gates.
+
+## 2026-06-24 Workspace Project Gate Split
+
+Overall grade after this slice: **A focused project-boundary ownership, A merge-risk reduction, B+ catch-all size**.
+
+After the execution split, the catch-all parity suite still mixed project metadata loading, project loader ownership, project extension integration, local/remote project flows, pull-request flows, and worktree handoff gates with unrelated memory, MCP, automation, sidebar, and surface checks. Those gates all protect project and remote-project ownership boundaries, so they now have a focused suite.
+
+What changed:
+- Added `ParityWorkspaceProjectGateTests` for project metadata, project loader ownership, project extension, project registry, remote project, pull request, and worktree gates.
+- Moved the project-family gates out of `ParityGateTests.swift`.
+- Extended the focused-suite guard so project-family gates cannot drift back into the catch-all.
+
+Current strict grades:
+- `ParityWorkspaceProjectGateTests.swift`: **A**. The suite is coherent, small, and directly tied to project/remote-project ownership boundaries.
+- `ParityGateTests.swift`: **B+**. The file is smaller again, but still owns memory, MCP, automation, terminal, sidebar, and remaining surface-boundary gates.
+
+Remaining risk:
+- Continue splitting the broad parity file by remaining domains: memory, MCP, automation/terminal, sidebar, and final workspace-surface contracts.


### PR DESCRIPTION
## Summary
- Add `ParityWorkspaceProjectGateTests` for project metadata, project loader ownership, extension/project/remote/pull-request integration gates, and worktree handoff gates.
- Register the project suite in the parity meta-gate so those checks cannot drift back into `ParityGateTests`.
- Update the code-quality audit with strict grades and the remaining broad-suite risks.

## Validation
- `swift test --filter ParityWorkspaceProjectGateTests`
- `swift test --filter ParityGateTests/testParityGatesUseFocusedSuitesAndSharedSupport`
- `git diff --check`
- `swift test` (1066 tests)
