### PR TITLE
Split workspace memory parity gates

### DIFF
--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -53,7 +53,8 @@ final class ParityGateTests: QuillCodeParityTestCase {
             "ParityWorkspaceSurfaceGateTests.swift",
             "ParityWorkspaceModelGateTests.swift",
             "ParityWorkspaceExecutionGateTests.swift",
-            "ParityWorkspaceProjectGateTests.swift"
+            "ParityWorkspaceProjectGateTests.swift",
+            "ParityWorkspaceMemoryGateTests.swift"
         ]
         for suiteFile in suiteFiles {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
@@ -115,6 +116,10 @@ final class ParityGateTests: QuillCodeParityTestCase {
                 "testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows",
                 "testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows",
                 "testWorkspaceModelDelegatesWorktreeOpenRecords"
+            ]),
+            ("ParityWorkspaceMemoryGateTests", [
+                "testWorkspaceModelDelegatesMemoryCommandOrchestration",
+                "testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows"
             ])
         ]
 
@@ -340,60 +345,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(agentText.contains("private func runToolStep"), "Agent.swift should not own individual tool-step execution.")
         XCTAssertFalse(agentText.contains("kind: .toolQueued"), "Agent.swift should not own tool lifecycle event emission.")
         XCTAssertFalse(agentText.contains("Tool is not available in this workspace"), "Agent.swift should not own unavailable-tool result copy.")
-    }
-
-    func testWorkspaceModelDelegatesMemoryCommandOrchestration() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let engineText = try Self.appSourceText(named: "WorkspaceMemoryEngine.swift")
-        let plannerText = try Self.appSourceText(named: "WorkspaceMemoryCommandTranscriptPlanner.swift")
-        let errorText = try Self.appSourceText(named: "WorkspaceMemoryErrorMessageBuilder.swift")
-        let contextUpdateText = try Self.appSourceText(named: "WorkspaceMemoryContextUpdatePlanner.swift")
-
-        XCTAssertTrue(engineText.contains("enum WorkspaceMemoryEngine"), "Memory command orchestration should live in a focused engine.")
-        XCTAssertTrue(engineText.contains("struct WorkspaceMemoryMutation"), "Memory command outcomes should use a typed mutation value.")
-        XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.saveGlobal"), "WorkspaceModel should delegate global memory saves.")
-        XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.deleteGlobal"), "WorkspaceModel should delegate global memory deletion.")
-        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.globalMemories"), "WorkspaceModel should delegate global memory reloads through the project context refresher.")
-        XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.contextUpdate"), "WorkspaceModel should delegate memory context update construction.")
-        XCTAssertTrue(plannerText.contains("struct WorkspaceMemoryCommandTranscriptPlanner"), "Memory command transcript copy should live in a focused planner.")
-        XCTAssertTrue(errorText.contains("enum WorkspaceMemoryErrorMessageBuilder"), "Memory write and delete errors should share one user-facing formatter.")
-        XCTAssertTrue(contextUpdateText.contains("struct WorkspaceMemoryContextUpdatePlanner"), "Memory thread context updates should live in a focused planner.")
-        for delegatedCall in [
-            "WorkspaceMemoryCommandTranscriptPlanner.memorySaved",
-            "WorkspaceMemoryCommandTranscriptPlanner.memoryNotSaved",
-            "WorkspaceMemoryCommandTranscriptPlanner.memorySavedSummary",
-            "WorkspaceMemoryCommandTranscriptPlanner.memoryForgotten",
-            "WorkspaceMemoryCommandTranscriptPlanner.memoryNotDeleted",
-            "WorkspaceMemoryCommandTranscriptPlanner.memoryForgottenSummary",
-            "WorkspaceMemoryErrorMessageBuilder.userFacingMessage",
-            "WorkspaceMemoryContextUpdatePlanner.globalMemoryChanged"
-        ] {
-            XCTAssertTrue(engineText.contains(delegatedCall), "WorkspaceMemoryEngine should delegate \(delegatedCall).")
-        }
-        XCTAssertFalse(modelText.contains("It will be included as background context in future turns."), "WorkspaceModel should not own memory save success copy.")
-        XCTAssertFalse(modelText.contains("Memory not saved"), "WorkspaceModel should not own memory save failure title copy.")
-        XCTAssertFalse(modelText.contains("It will no longer be included as background context."), "WorkspaceModel should not own memory delete success copy.")
-        XCTAssertFalse(modelText.contains("Memory not deleted"), "WorkspaceModel should not own memory delete failure title copy.")
-        XCTAssertFalse(modelText.contains("Forgot memory:"), "WorkspaceModel should not own memory delete summary copy.")
-        XCTAssertFalse(modelText.contains("MemoryNoteLoader.saveGlobal"), "WorkspaceModel should not write memory files directly.")
-        XCTAssertFalse(modelText.contains("MemoryNoteLoader.deleteGlobal"), "WorkspaceModel should not delete memory files directly.")
-        XCTAssertFalse(modelText.contains("MemoryNoteLoader.loadGlobal"), "WorkspaceModel should not reload global memories directly.")
-        XCTAssertFalse(modelText.contains("MemoryNoteDeleteError.deleteFailed.localizedDescription"), "WorkspaceModel should not format memory delete errors directly.")
-        XCTAssertFalse(modelText.contains("payloadJSON: note.relativePath"), "WorkspaceModel should not build memory change events inline.")
-    }
-
-    func testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows() throws {
-        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
-        let memoryIntegrationTests = try Self.appTestSourceText(named: "WorkspaceMemoryIntegrationTests.swift")
-
-        XCTAssertTrue(memoryIntegrationTests.contains("testMemoryNotesLoadGlobalAndProjectIntoThreadAndSurface"), "Workspace memory integration should live in a focused test file.")
-        XCTAssertTrue(memoryIntegrationTests.contains("testSlashRememberWritesGlobalMemoryAndRefreshesThreadSurface"), "Slash remember integration should live in focused memory tests.")
-        XCTAssertTrue(memoryIntegrationTests.contains("testAgentRememberToolWritesGlobalMemoryAndRefreshesThreadSurface"), "Agent memory tool integration should live in focused memory tests.")
-        XCTAssertTrue(memoryIntegrationTests.contains("testMemoryDeleteWorkspaceCommandRemovesGlobalMemoryAndRefreshesThreadSurface"), "Memory delete integration should live in focused memory tests.")
-        XCTAssertFalse(modelTests.contains("testMemoryNotesLoadGlobalAndProjectIntoThreadAndSurface"), "WorkspaceModelTests should not own memory integration flows.")
-        XCTAssertFalse(modelTests.contains("testSlashRememberWritesGlobalMemoryAndRefreshesThreadSurface"), "WorkspaceModelTests should not own slash memory integration flows.")
-        XCTAssertFalse(modelTests.contains("testAgentRememberToolWritesGlobalMemoryAndRefreshesThreadSurface"), "WorkspaceModelTests should not own agent memory integration flows.")
-        XCTAssertFalse(modelTests.contains("testMemoryDeleteWorkspaceCommandRemovesGlobalMemoryAndRefreshesThreadSurface"), "WorkspaceModelTests should not own memory delete integration flows.")
     }
 
     func testWorkspaceMCPIntegrationTestsOwnModelMCPFlows() throws {

--- a/Tests/QuillCodeParityTests/ParityWorkspaceMemoryGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceMemoryGateTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+final class ParityWorkspaceMemoryGateTests: QuillCodeParityTestCase {
+    func testWorkspaceModelDelegatesMemoryCommandOrchestration() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let engineText = try Self.appSourceText(named: "WorkspaceMemoryEngine.swift")
+        let plannerText = try Self.appSourceText(named: "WorkspaceMemoryCommandTranscriptPlanner.swift")
+        let errorText = try Self.appSourceText(named: "WorkspaceMemoryErrorMessageBuilder.swift")
+        let contextUpdateText = try Self.appSourceText(named: "WorkspaceMemoryContextUpdatePlanner.swift")
+
+        XCTAssertTrue(engineText.contains("enum WorkspaceMemoryEngine"), "Memory command orchestration should live in a focused engine.")
+        XCTAssertTrue(engineText.contains("struct WorkspaceMemoryMutation"), "Memory command outcomes should use a typed mutation value.")
+        XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.saveGlobal"), "WorkspaceModel should delegate global memory saves.")
+        XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.deleteGlobal"), "WorkspaceModel should delegate global memory deletion.")
+        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.globalMemories"), "WorkspaceModel should delegate global memory reloads through the project context refresher.")
+        XCTAssertTrue(modelText.contains("WorkspaceMemoryEngine.contextUpdate"), "WorkspaceModel should delegate memory context update construction.")
+        XCTAssertTrue(plannerText.contains("struct WorkspaceMemoryCommandTranscriptPlanner"), "Memory command transcript copy should live in a focused planner.")
+        XCTAssertTrue(errorText.contains("enum WorkspaceMemoryErrorMessageBuilder"), "Memory write and delete errors should share one user-facing formatter.")
+        XCTAssertTrue(contextUpdateText.contains("struct WorkspaceMemoryContextUpdatePlanner"), "Memory thread context updates should live in a focused planner.")
+        for delegatedCall in [
+            "WorkspaceMemoryCommandTranscriptPlanner.memorySaved",
+            "WorkspaceMemoryCommandTranscriptPlanner.memoryNotSaved",
+            "WorkspaceMemoryCommandTranscriptPlanner.memorySavedSummary",
+            "WorkspaceMemoryCommandTranscriptPlanner.memoryForgotten",
+            "WorkspaceMemoryCommandTranscriptPlanner.memoryNotDeleted",
+            "WorkspaceMemoryCommandTranscriptPlanner.memoryForgottenSummary",
+            "WorkspaceMemoryErrorMessageBuilder.userFacingMessage",
+            "WorkspaceMemoryContextUpdatePlanner.globalMemoryChanged"
+        ] {
+            XCTAssertTrue(engineText.contains(delegatedCall), "WorkspaceMemoryEngine should delegate \(delegatedCall).")
+        }
+        XCTAssertFalse(modelText.contains("It will be included as background context in future turns."), "WorkspaceModel should not own memory save success copy.")
+        XCTAssertFalse(modelText.contains("Memory not saved"), "WorkspaceModel should not own memory save failure title copy.")
+        XCTAssertFalse(modelText.contains("It will no longer be included as background context."), "WorkspaceModel should not own memory delete success copy.")
+        XCTAssertFalse(modelText.contains("Memory not deleted"), "WorkspaceModel should not own memory delete failure title copy.")
+        XCTAssertFalse(modelText.contains("Forgot memory:"), "WorkspaceModel should not own memory delete summary copy.")
+        XCTAssertFalse(modelText.contains("MemoryNoteLoader.saveGlobal"), "WorkspaceModel should not write memory files directly.")
+        XCTAssertFalse(modelText.contains("MemoryNoteLoader.deleteGlobal"), "WorkspaceModel should not delete memory files directly.")
+        XCTAssertFalse(modelText.contains("MemoryNoteLoader.loadGlobal"), "WorkspaceModel should not reload global memories directly.")
+        XCTAssertFalse(modelText.contains("MemoryNoteDeleteError.deleteFailed.localizedDescription"), "WorkspaceModel should not format memory delete errors directly.")
+        XCTAssertFalse(modelText.contains("payloadJSON: note.relativePath"), "WorkspaceModel should not build memory change events inline.")
+    }
+
+    func testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows() throws {
+        let modelTests = try Self.appTestSourceText(named: "WorkspaceModelTests.swift")
+        let memoryIntegrationTests = try Self.appTestSourceText(named: "WorkspaceMemoryIntegrationTests.swift")
+
+        XCTAssertTrue(memoryIntegrationTests.contains("testMemoryNotesLoadGlobalAndProjectIntoThreadAndSurface"), "Workspace memory integration should live in a focused test file.")
+        XCTAssertTrue(memoryIntegrationTests.contains("testSlashRememberWritesGlobalMemoryAndRefreshesThreadSurface"), "Slash remember integration should live in focused memory tests.")
+        XCTAssertTrue(memoryIntegrationTests.contains("testAgentRememberToolWritesGlobalMemoryAndRefreshesThreadSurface"), "Agent memory tool integration should live in focused memory tests.")
+        XCTAssertTrue(memoryIntegrationTests.contains("testMemoryDeleteWorkspaceCommandRemovesGlobalMemoryAndRefreshesThreadSurface"), "Memory delete integration should live in focused memory tests.")
+        XCTAssertFalse(modelTests.contains("testMemoryNotesLoadGlobalAndProjectIntoThreadAndSurface"), "WorkspaceModelTests should not own memory integration flows.")
+        XCTAssertFalse(modelTests.contains("testSlashRememberWritesGlobalMemoryAndRefreshesThreadSurface"), "WorkspaceModelTests should not own slash memory integration flows.")
+        XCTAssertFalse(modelTests.contains("testAgentRememberToolWritesGlobalMemoryAndRefreshesThreadSurface"), "WorkspaceModelTests should not own agent memory integration flows.")
+        XCTAssertFalse(modelTests.contains("testMemoryDeleteWorkspaceCommandRemovesGlobalMemoryAndRefreshesThreadSurface"), "WorkspaceModelTests should not own memory delete integration flows.")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -4873,3 +4873,21 @@ Current strict grades:
 
 Remaining risk:
 - Continue splitting the broad parity file by remaining domains: memory, MCP, automation/terminal, sidebar, and final workspace-surface contracts.
+
+## 2026-06-24 Workspace Memory Gate Split
+
+Overall grade after this slice: **A memory-gate ownership, A drift protection, B+ catch-all size**.
+
+After the project split, memory command orchestration and memory integration ownership still lived in the broad parity file. Those checks protect a user-visible behavior: memories should be persisted, summarized, deleted, and refreshed through focused engines rather than leaking file and transcript details back into `WorkspaceModel`.
+
+What changed:
+- Added `ParityWorkspaceMemoryGateTests` for memory orchestration and memory integration ownership gates.
+- Registered the memory suite in the top-level parity guard so moved memory gates cannot drift back to the catch-all.
+- Reduced the catch-all parity file again while leaving behavior unchanged.
+
+Current strict grades:
+- `ParityWorkspaceMemoryGateTests.swift`: **A**. Memory persistence, copy, and context-refresh boundaries now have a focused parity owner.
+- `ParityGateTests.swift`: **B+**. Smaller, but still owns MCP, automation, terminal, sidebar, review/runtime, and remaining surface-boundary gates.
+
+Remaining risk:
+- Continue draining `ParityGateTests.swift` by feature family. Good next splits: MCP gates, automation/terminal gates, sidebar gates, and final workspace-surface gates.


### PR DESCRIPTION
## Summary
- add ParityWorkspaceMemoryGateTests for memory orchestration and memory integration ownership gates
- register the new focused suite in the parity drift guard
- update the code quality audit with memory-gate grades and remaining risks

## Validation
- swift test --filter 'ParityWorkspaceMemoryGateTests|ParityGateTests'\n- swift test