### PR TITLE
Split transcript surface parity gates

### DIFF
--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -61,7 +61,8 @@ final class ParityGateTests: QuillCodeParityTestCase {
             "ParityAutomationGateTests.swift",
             "ParityWorkspaceRuntimeReviewGateTests.swift",
             "ParityWorkspaceCommandGateTests.swift",
-            "ParityWorkspaceSettingsSheetGateTests.swift"
+            "ParityWorkspaceSettingsSheetGateTests.swift",
+            "ParityWorkspaceTranscriptGateTests.swift"
         ]
         for suiteFile in suiteFiles {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
@@ -172,6 +173,9 @@ final class ParityGateTests: QuillCodeParityTestCase {
                 "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
                 "testNativeSettingsDelegatesFocusedViewsAndDraftState",
                 "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
+            ]),
+            ("ParityWorkspaceTranscriptGateTests", [
+                "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"
             ])
         ]
 
@@ -380,34 +384,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(agentText.contains("private func runToolStep"), "Agent.swift should not own individual tool-step execution.")
         XCTAssertFalse(agentText.contains("kind: .toolQueued"), "Agent.swift should not own tool lifecycle event emission.")
         XCTAssertFalse(agentText.contains("Tool is not available in this workspace"), "Agent.swift should not own unavailable-tool result copy.")
-    }
-
-    func testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner() throws {
-        let shellText = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
-        let mainPaneText = try Self.appSourceText(named: "QuillCodeWorkspaceMainPaneView.swift")
-        let transcriptText = try Self.appSourceText(named: "QuillCodeTranscriptView.swift")
-        let findText = try Self.appSourceText(named: "QuillCodeTranscriptFindView.swift")
-        let contextBannerText = try Self.appSourceText(named: "QuillCodeContextBannerView.swift")
-
-        XCTAssertTrue(mainPaneText.contains("struct QuillCodeWorkspaceMainPaneView"), "Workspace center-pane layout should live in a focused view file.")
-        XCTAssertTrue(transcriptText.contains("struct QuillCodeTranscriptView"), "Transcript layout should live in a focused view file.")
-        XCTAssertTrue(transcriptText.contains("QuillCodeTranscriptFindBar"), "Transcript layout should compose the focused Find bar.")
-        XCTAssertTrue(transcriptText.contains("QuillCodeContextBannerView"), "Transcript layout should compose the focused context banner.")
-        XCTAssertTrue(transcriptText.contains("QuillCodeRuntimeIssueView"), "Transcript layout should own runtime issue placement.")
-        XCTAssertTrue(transcriptText.contains("QuillCodeReviewPaneView"), "Transcript layout should own review placement.")
-        XCTAssertTrue(transcriptText.contains("QuillCodeToolCardView"), "Transcript layout should own tool-card timeline placement.")
-        XCTAssertTrue(findText.contains("struct QuillCodeTranscriptFindMatch"), "Transcript Find matching should live in a focused Find file.")
-        XCTAssertTrue(findText.contains("struct QuillCodeTranscriptFindBar"), "Transcript Find bar should live in a focused Find file.")
-        XCTAssertTrue(contextBannerText.contains("struct QuillCodeContextBannerView"), "Context banner rendering should live in a focused banner file.")
-        XCTAssertTrue(shellText.contains("QuillCodeWorkspaceMainPaneView"), "Workspace shell should compose the extracted center-pane view.")
-        XCTAssertTrue(mainPaneText.contains("QuillCodeTranscriptView"), "Workspace center pane should compose the extracted transcript view.")
-        XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptView"), "Workspace shell should not own transcript layout.")
-        XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptFindMatch"), "Workspace shell should not own transcript Find matching.")
-        XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptFindBar"), "Workspace shell should not own transcript Find UI.")
-        XCTAssertFalse(shellText.contains("struct QuillCodeContextBannerView"), "Workspace shell should not own context banner UI.")
-        XCTAssertFalse(shellText.contains("QuillCodeRuntimeIssueView"), "Workspace shell should not own runtime issue transcript placement.")
-        XCTAssertFalse(shellText.contains("QuillCodeReviewPaneView"), "Workspace shell should not own review transcript placement.")
-        XCTAssertFalse(shellText.contains("QuillCodeToolCardView"), "Workspace shell should not own tool-card timeline placement.")
     }
 
 }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceTranscriptGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceTranscriptGateTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+final class ParityWorkspaceTranscriptGateTests: QuillCodeParityTestCase {
+    func testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner() throws {
+        let shellText = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
+        let mainPaneText = try Self.appSourceText(named: "QuillCodeWorkspaceMainPaneView.swift")
+        let transcriptText = try Self.appSourceText(named: "QuillCodeTranscriptView.swift")
+        let findText = try Self.appSourceText(named: "QuillCodeTranscriptFindView.swift")
+        let contextBannerText = try Self.appSourceText(named: "QuillCodeContextBannerView.swift")
+
+        XCTAssertTrue(mainPaneText.contains("struct QuillCodeWorkspaceMainPaneView"), "Workspace center-pane layout should live in a focused view file.")
+        XCTAssertTrue(transcriptText.contains("struct QuillCodeTranscriptView"), "Transcript layout should live in a focused view file.")
+        XCTAssertTrue(transcriptText.contains("QuillCodeTranscriptFindBar"), "Transcript layout should compose the focused Find bar.")
+        XCTAssertTrue(transcriptText.contains("QuillCodeContextBannerView"), "Transcript layout should compose the focused context banner.")
+        XCTAssertTrue(transcriptText.contains("QuillCodeRuntimeIssueView"), "Transcript layout should own runtime issue placement.")
+        XCTAssertTrue(transcriptText.contains("QuillCodeReviewPaneView"), "Transcript layout should own review placement.")
+        XCTAssertTrue(transcriptText.contains("QuillCodeToolCardView"), "Transcript layout should own tool-card timeline placement.")
+        XCTAssertTrue(findText.contains("struct QuillCodeTranscriptFindMatch"), "Transcript Find matching should live in a focused Find file.")
+        XCTAssertTrue(findText.contains("struct QuillCodeTranscriptFindBar"), "Transcript Find bar should live in a focused Find file.")
+        XCTAssertTrue(contextBannerText.contains("struct QuillCodeContextBannerView"), "Context banner rendering should live in a focused banner file.")
+        XCTAssertTrue(shellText.contains("QuillCodeWorkspaceMainPaneView"), "Workspace shell should compose the extracted center-pane view.")
+        XCTAssertTrue(mainPaneText.contains("QuillCodeTranscriptView"), "Workspace center pane should compose the extracted transcript view.")
+        XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptView"), "Workspace shell should not own transcript layout.")
+        XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptFindMatch"), "Workspace shell should not own transcript Find matching.")
+        XCTAssertFalse(shellText.contains("struct QuillCodeTranscriptFindBar"), "Workspace shell should not own transcript Find UI.")
+        XCTAssertFalse(shellText.contains("struct QuillCodeContextBannerView"), "Workspace shell should not own context banner UI.")
+        XCTAssertFalse(shellText.contains("QuillCodeRuntimeIssueView"), "Workspace shell should not own runtime issue transcript placement.")
+        XCTAssertFalse(shellText.contains("QuillCodeReviewPaneView"), "Workspace shell should not own review transcript placement.")
+        XCTAssertFalse(shellText.contains("QuillCodeToolCardView"), "Workspace shell should not own tool-card timeline placement.")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5017,3 +5017,21 @@ Current strict grades:
 
 Remaining risk:
 - Continue draining `ParityGateTests.swift` by feature family. Good next splits: agent/TrustedRouter gates and transcript/context-banner gates.
+
+## 2026-06-24 Transcript Surface Parity Gate Split
+
+Overall grade after this slice: **A transcript-surface ownership, A drift protection, B+ catch-all size**.
+
+Transcript layout, transcript Find, and context banner ownership were the last workspace UI surface gates in the broad parity registry. Those checks protect center-pane composition, not settings or command routing, so they now have their own focused suite.
+
+What changed:
+- Added `ParityWorkspaceTranscriptGateTests` for workspace center-pane, transcript Find, context banner, runtime issue, review, and tool-card placement boundaries.
+- Registered the transcript suite in the parity drift guard.
+- Reduced `ParityGateTests.swift` again without changing product behavior.
+
+Current strict grades:
+- `ParityWorkspaceTranscriptGateTests.swift`: **A**. It owns one center-pane transcript boundary and keeps transcript layout assertions away from settings and command suites.
+- `ParityGateTests.swift`: **B+**. Smaller, but still owns TrustedRouter, agent-runner, core/project model boundaries, and global hygiene gates.
+
+Remaining risk:
+- Continue draining `ParityGateTests.swift` by feature family. Good next split: agent/TrustedRouter gates.


### PR DESCRIPTION
## Summary
- move transcript/find/context-banner architecture checks into ParityWorkspaceTranscriptGateTests
- register the transcript suite in the parity drift guard
- update the code quality audit and supersede the transcript portion of dirty PR #318

## Validation
- swift test --filter 'ParityWorkspaceTranscriptGateTests|ParityGateTests'
- swift test