### PR TITLE
Split agent and TrustedRouter parity gates

### DIFF
--- a/Tests/QuillCodeParityTests/ParityAgentGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAgentGateTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+final class ParityAgentGateTests: QuillCodeParityTestCase {
+    func testAgentRunnerDelegatesFinalAnswerFormatting() throws {
+        let agentText = try Self.agentSourceText(named: "Agent.swift")
+        let builderText = try Self.agentSourceText(named: "AgentFinalAnswerBuilder.swift")
+
+        XCTAssertTrue(builderText.contains("enum AgentFinalAnswerBuilder"), "Tool-result final answer copy should live in a focused builder.")
+        XCTAssertTrue(builderText.contains("static func finalAnswer"), "Final answer formatting should be directly testable.")
+        XCTAssertTrue(builderText.contains("ToolDefinition.shellRun.name"), "Shell final-answer special cases should live in the builder.")
+        XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect.name"), "Browser final-answer special cases should live in the builder.")
+        XCTAssertTrue(agentText.contains("AgentFinalAnswerBuilder.finalAnswer"), "AgentRunner should delegate final-answer formatting.")
+        XCTAssertFalse(agentText.contains("private static func shellAnswer"), "AgentRunner should not own shell final-answer formatting.")
+        XCTAssertFalse(agentText.contains("private static func browserInspectionAnswer"), "AgentRunner should not own browser final-answer formatting.")
+    }
+
+    func testMockLLMClientLivesOutsideAgentRunnerFile() throws {
+        let agentText = try Self.agentSourceText(named: "Agent.swift")
+        let mockText = try Self.agentSourceText(named: "MockLLMClient.swift")
+        let pullRequestPlannerText = try Self.agentSourceText(named: "MockPullRequestIntentPlanner.swift")
+        let pullRequestExtractorText = try Self.agentSourceText(named: "MockPullRequestArgumentExtractor.swift")
+
+        XCTAssertTrue(mockText.contains("public struct MockLLMClient"), "The deterministic mock LLM client should live in its own file.")
+        XCTAssertTrue(mockText.contains("MockPullRequestIntentPlanner.toolCall"), "The mock LLM client should delegate PR-specific planning.")
+        XCTAssertTrue(mockText.contains("AgentRunner.finalAnswer"), "Mock tool feedback should still reuse the production final-answer contract.")
+        XCTAssertTrue(pullRequestPlannerText.contains("enum MockPullRequestIntentPlanner"), "Mock PR intent detection should live in a focused planner.")
+        XCTAssertTrue(pullRequestPlannerText.contains("MockPullRequestArgumentExtractor.createArguments"), "Mock PR planner should delegate payload construction.")
+        XCTAssertTrue(pullRequestExtractorText.contains("enum MockPullRequestArgumentExtractor"), "Mock PR payload construction should live in a focused extractor.")
+        XCTAssertTrue(pullRequestExtractorText.contains("static func createArguments"), "Mock PR create argument extraction should stay out of intent routing.")
+        XCTAssertFalse(agentText.contains("public struct MockLLMClient"), "Agent.swift should not own mock LLM planning.")
+        XCTAssertFalse(agentText.contains("extractPullRequestArguments"), "Agent.swift should not own mock PR parsing heuristics.")
+        XCTAssertFalse(mockText.contains("extractPullRequestArguments"), "MockLLMClient.swift should not own PR parsing heuristics.")
+        XCTAssertFalse(mockText.contains("isPullRequestRequest"), "MockLLMClient.swift should not own PR intent detection.")
+        XCTAssertFalse(pullRequestPlannerText.contains("static func createArguments"), "Mock PR planner should not own argument extraction.")
+    }
+
+    func testAgentStreamingHelpersLiveOutsideAgentRunnerFile() throws {
+        let agentText = try Self.agentSourceText(named: "Agent.swift")
+        let streamingText = try Self.agentSourceText(named: "AgentActionStreaming.swift")
+
+        XCTAssertTrue(streamingText.contains("public enum AgentActionStreamCollector"), "Streaming action collection should live in a focused helper.")
+        XCTAssertTrue(streamingText.contains("public enum AgentActionStreamPreview"), "Partial assistant preview parsing should live with streaming helpers.")
+        XCTAssertTrue(streamingText.contains("var rawActionText"), "Progressive stream accumulation should live with the stream collector.")
+        XCTAssertTrue(streamingText.contains("AgentActionStreamPreview.visibleAssistantText"), "Stream collector should own draft-preview extraction.")
+        XCTAssertTrue(agentText.contains("AgentActionStreamCollector.collect"), "AgentRunner should delegate streaming collection.")
+        XCTAssertFalse(agentText.contains("public enum AgentActionStreamCollector"), "Agent.swift should not own streaming collection details.")
+        XCTAssertFalse(agentText.contains("private static func partialJSONStringValue"), "Agent.swift should not own partial JSON preview parsing.")
+        XCTAssertFalse(agentText.contains("AgentActionStreamPreview.visibleAssistantText"), "Agent.swift should not own streaming preview parsing.")
+        XCTAssertFalse(agentText.contains("var rawActionText"), "Agent.swift should not own raw streaming accumulation.")
+    }
+
+    func testAgentToolStepRunnerLivesOutsideAgentRunnerFile() throws {
+        let agentText = try Self.agentSourceText(named: "Agent.swift")
+        let runnerText = try Self.agentSourceText(named: "AgentToolStepRunner.swift")
+
+        XCTAssertTrue(runnerText.contains("enum AgentToolStep"), "Tool-step state should live beside the extracted runner.")
+        XCTAssertTrue(runnerText.contains("func runToolStep"), "Tool-step execution should live in a focused runner extension.")
+        XCTAssertTrue(runnerText.contains("appendQueuedEvent"), "Tool lifecycle transcript events should be owned by the tool-step runner.")
+        XCTAssertTrue(runnerText.contains("SafetyReview"), "Safety-review blocking copy should stay with tool-step execution.")
+        XCTAssertTrue(agentText.contains("runToolStep("), "AgentRunner should delegate individual tool-step execution.")
+        XCTAssertFalse(agentText.contains("private func runToolStep"), "Agent.swift should not own individual tool-step execution.")
+        XCTAssertFalse(agentText.contains("kind: .toolQueued"), "Agent.swift should not own tool lifecycle event emission.")
+        XCTAssertFalse(agentText.contains("Tool is not available in this workspace"), "Agent.swift should not own unavailable-tool result copy.")
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -63,7 +63,8 @@ final class ParityGateTests: QuillCodeParityTestCase {
             "ParityWorkspaceCommandGateTests.swift",
             "ParityWorkspaceSettingsSheetGateTests.swift",
             "ParityWorkspaceTranscriptGateTests.swift",
-            "ParityAgentRouterGateTests.swift"
+            "ParityAgentGateTests.swift",
+            "ParityTrustedRouterGateTests.swift"
         ]
         for suiteFile in suiteFiles {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
@@ -178,16 +179,18 @@ final class ParityGateTests: QuillCodeParityTestCase {
             ("ParityWorkspaceTranscriptGateTests", [
                 "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"
             ]),
-            ("ParityAgentRouterGateTests", [
+            ("ParityAgentGateTests", [
                 "testAgentRunnerDelegatesFinalAnswerFormatting",
                 "testMockLLMClientLivesOutsideAgentRunnerFile",
                 "testAgentStreamingHelpersLiveOutsideAgentRunnerFile",
+                "testAgentToolStepRunnerLivesOutsideAgentRunnerFile"
+            ]),
+            ("ParityTrustedRouterGateTests", [
                 "testTrustedRouterActionParserLivesOutsideTransportClient",
                 "testTrustedRouterPromptBuilderLivesOutsideTransportClient",
                 "testTrustedRouterAPIKeyResolutionLivesInFocusedResolver",
                 "testTrustedRouterSafetyClientLivesOutsideActionTransportFile",
-                "testTrustedRouterChatParametersLiveOutsideTransportClients",
-                "testAgentToolStepRunnerLivesOutsideAgentRunnerFile"
+                "testTrustedRouterChatParametersLiveOutsideTransportClients"
             ])
         ]
 

--- a/Tests/QuillCodeParityTests/ParityTrustedRouterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTrustedRouterGateTests.swift
@@ -1,54 +1,6 @@
 import XCTest
 
-final class ParityAgentRouterGateTests: QuillCodeParityTestCase {
-    func testAgentRunnerDelegatesFinalAnswerFormatting() throws {
-        let agentText = try Self.agentSourceText(named: "Agent.swift")
-        let builderText = try Self.agentSourceText(named: "AgentFinalAnswerBuilder.swift")
-
-        XCTAssertTrue(builderText.contains("enum AgentFinalAnswerBuilder"), "Tool-result final answer copy should live in a focused builder.")
-        XCTAssertTrue(builderText.contains("static func finalAnswer"), "Final answer formatting should be directly testable.")
-        XCTAssertTrue(builderText.contains("ToolDefinition.shellRun.name"), "Shell final-answer special cases should live in the builder.")
-        XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect.name"), "Browser final-answer special cases should live in the builder.")
-        XCTAssertTrue(agentText.contains("AgentFinalAnswerBuilder.finalAnswer"), "AgentRunner should delegate final-answer formatting.")
-        XCTAssertFalse(agentText.contains("private static func shellAnswer"), "AgentRunner should not own shell final-answer formatting.")
-        XCTAssertFalse(agentText.contains("private static func browserInspectionAnswer"), "AgentRunner should not own browser final-answer formatting.")
-    }
-
-    func testMockLLMClientLivesOutsideAgentRunnerFile() throws {
-        let agentText = try Self.agentSourceText(named: "Agent.swift")
-        let mockText = try Self.agentSourceText(named: "MockLLMClient.swift")
-        let pullRequestPlannerText = try Self.agentSourceText(named: "MockPullRequestIntentPlanner.swift")
-        let pullRequestExtractorText = try Self.agentSourceText(named: "MockPullRequestArgumentExtractor.swift")
-
-        XCTAssertTrue(mockText.contains("public struct MockLLMClient"), "The deterministic mock LLM client should live in its own file.")
-        XCTAssertTrue(mockText.contains("MockPullRequestIntentPlanner.toolCall"), "The mock LLM client should delegate PR-specific planning.")
-        XCTAssertTrue(mockText.contains("AgentRunner.finalAnswer"), "Mock tool feedback should still reuse the production final-answer contract.")
-        XCTAssertTrue(pullRequestPlannerText.contains("enum MockPullRequestIntentPlanner"), "Mock PR intent detection should live in a focused planner.")
-        XCTAssertTrue(pullRequestPlannerText.contains("MockPullRequestArgumentExtractor.createArguments"), "Mock PR planner should delegate payload construction.")
-        XCTAssertTrue(pullRequestExtractorText.contains("enum MockPullRequestArgumentExtractor"), "Mock PR payload construction should live in a focused extractor.")
-        XCTAssertTrue(pullRequestExtractorText.contains("static func createArguments"), "Mock PR create argument extraction should stay out of intent routing.")
-        XCTAssertFalse(agentText.contains("public struct MockLLMClient"), "Agent.swift should not own mock LLM planning.")
-        XCTAssertFalse(agentText.contains("extractPullRequestArguments"), "Agent.swift should not own mock PR parsing heuristics.")
-        XCTAssertFalse(mockText.contains("extractPullRequestArguments"), "MockLLMClient.swift should not own PR parsing heuristics.")
-        XCTAssertFalse(mockText.contains("isPullRequestRequest"), "MockLLMClient.swift should not own PR intent detection.")
-        XCTAssertFalse(pullRequestPlannerText.contains("static func createArguments"), "Mock PR planner should not own argument extraction.")
-    }
-
-    func testAgentStreamingHelpersLiveOutsideAgentRunnerFile() throws {
-        let agentText = try Self.agentSourceText(named: "Agent.swift")
-        let streamingText = try Self.agentSourceText(named: "AgentActionStreaming.swift")
-
-        XCTAssertTrue(streamingText.contains("public enum AgentActionStreamCollector"), "Streaming action collection should live in a focused helper.")
-        XCTAssertTrue(streamingText.contains("public enum AgentActionStreamPreview"), "Partial assistant preview parsing should live with streaming helpers.")
-        XCTAssertTrue(streamingText.contains("var rawActionText"), "Progressive stream accumulation should live with the stream collector.")
-        XCTAssertTrue(streamingText.contains("AgentActionStreamPreview.visibleAssistantText"), "Stream collector should own draft-preview extraction.")
-        XCTAssertTrue(agentText.contains("AgentActionStreamCollector.collect"), "AgentRunner should delegate streaming collection.")
-        XCTAssertFalse(agentText.contains("public enum AgentActionStreamCollector"), "Agent.swift should not own streaming collection details.")
-        XCTAssertFalse(agentText.contains("private static func partialJSONStringValue"), "Agent.swift should not own partial JSON preview parsing.")
-        XCTAssertFalse(agentText.contains("AgentActionStreamPreview.visibleAssistantText"), "Agent.swift should not own streaming preview parsing.")
-        XCTAssertFalse(agentText.contains("var rawActionText"), "Agent.swift should not own raw streaming accumulation.")
-    }
-
+final class ParityTrustedRouterGateTests: QuillCodeParityTestCase {
     func testTrustedRouterActionParserLivesOutsideTransportClient() throws {
         let clientText = try Self.agentSourceText(named: "TrustedRouterLLMClient.swift")
         let parserText = try Self.agentSourceText(named: "AgentActionJSONParser.swift")
@@ -131,19 +83,5 @@ final class ParityAgentRouterGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(clientText.contains("\"response_format\""), "Action transport should not own raw response-format payloads.")
         XCTAssertFalse(safetyClientText.contains("\"response_format\""), "Safety transport should not own raw response-format payloads.")
         XCTAssertFalse(safetyClientText.contains("TrustedRouterLLMClient."), "Safety transport should not depend on the action transport type.")
-    }
-
-    func testAgentToolStepRunnerLivesOutsideAgentRunnerFile() throws {
-        let agentText = try Self.agentSourceText(named: "Agent.swift")
-        let runnerText = try Self.agentSourceText(named: "AgentToolStepRunner.swift")
-
-        XCTAssertTrue(runnerText.contains("enum AgentToolStep"), "Tool-step state should live beside the extracted runner.")
-        XCTAssertTrue(runnerText.contains("func runToolStep"), "Tool-step execution should live in a focused runner extension.")
-        XCTAssertTrue(runnerText.contains("appendQueuedEvent"), "Tool lifecycle transcript events should be owned by the tool-step runner.")
-        XCTAssertTrue(runnerText.contains("SafetyReview"), "Safety-review blocking copy should stay with tool-step execution.")
-        XCTAssertTrue(agentText.contains("runToolStep("), "AgentRunner should delegate individual tool-step execution.")
-        XCTAssertFalse(agentText.contains("private func runToolStep"), "Agent.swift should not own individual tool-step execution.")
-        XCTAssertFalse(agentText.contains("kind: .toolQueued"), "Agent.swift should not own tool lifecycle event emission.")
-        XCTAssertFalse(agentText.contains("Tool is not available in this workspace"), "Agent.swift should not own unavailable-tool result copy.")
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5053,3 +5053,22 @@ Current strict grades:
 
 Remaining risk:
 - Consider one final split for core/project model boundary checks, but the broad suite is now small enough to act as the global parity registry.
+
+## 2026-06-24 Agent And TrustedRouter Parity Gate Split
+
+Overall grade after this slice: **A agent ownership, A TrustedRouter ownership, A drift protection**.
+
+The combined agent/router suite was a good step down from the broad parity registry, but it still coupled local agent-runner decomposition to TrustedRouter transport responsibilities. Splitting those domains makes ownership clearer for future runtime and provider work.
+
+What changed:
+- Replaced `ParityAgentRouterGateTests` with `ParityAgentGateTests` for agent runner, mock LLM, streaming, and tool-step boundaries.
+- Added `ParityTrustedRouterGateTests` for action parsing, prompt building, API-key resolution, safety transport, and shared chat parameters.
+- Updated the parity drift guard so the two domains cannot collapse back together.
+
+Current strict grades:
+- `ParityAgentGateTests.swift`: **A**. It owns local agent-runner decomposition without provider transport concerns.
+- `ParityTrustedRouterGateTests.swift`: **A**. It owns provider transport, parsing, prompt, key, and safety-client boundaries.
+- `ParityGateTests.swift`: **A-**. It remains a small global registry plus global hygiene and core model-boundary checks.
+
+Remaining risk:
+- Optional final split for core/project model boundary checks; otherwise the broad suite is now appropriately small.


### PR DESCRIPTION
## Summary
- split the combined agent/router parity suite into focused Agent and TrustedRouter gate suites
- update the parity drift registry to require both suites
- record the ownership split in the code quality audit

## Validation
- swift test --filter 'ParityAgentGateTests|ParityTrustedRouterGateTests|ParityGateTests'
- swift test