### PR TITLE
Split safety model parity gates

### DIFF
--- a/Tests/QuillCodeParityTests/ParityCoreModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityCoreModelGateTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+final class ParityCoreModelGateTests: QuillCodeParityTestCase {
+    func testCoreToolModelsLiveOutsideGeneralDomainModels() throws {
+        let modelsText = try Self.coreSourceText(named: "Models.swift")
+        let toolModelsText = try Self.coreSourceText(named: "ToolModels.swift")
+
+        XCTAssertTrue(toolModelsText.contains("public struct ToolDefinition"), "Tool schema records should live in a focused core file.")
+        XCTAssertTrue(toolModelsText.contains("public struct ToolCall"), "Tool-call payload records should live beside tool schemas.")
+        XCTAssertTrue(toolModelsText.contains("public struct ToolResult"), "Tool-result payload records should live beside tool schemas.")
+        XCTAssertTrue(toolModelsText.contains("redactedForTranscript"), "Tool-call redaction belongs with tool-call payload records.")
+        XCTAssertTrue(toolModelsText.contains("public struct BrowserInspectionToolOutput"), "Tool-specific browser output compatibility belongs with tool models.")
+        XCTAssertTrue(toolModelsText.contains("public struct MemoryRememberToolOutput"), "Tool-specific memory output compatibility belongs with tool models.")
+        XCTAssertTrue(toolModelsText.contains("static let planUpdate"), "Built-in core tool definitions should live with tool schema records.")
+        XCTAssertFalse(modelsText.contains("public struct ToolDefinition"), "General domain models should not own tool schema records.")
+        XCTAssertFalse(modelsText.contains("public struct ToolCall"), "General domain models should not own tool-call payload records.")
+        XCTAssertFalse(modelsText.contains("public struct ToolResult"), "General domain models should not own tool-result payload records.")
+        XCTAssertFalse(modelsText.contains("redactedForTranscript"), "General domain models should not own tool-call redaction.")
+        XCTAssertFalse(modelsText.contains("public struct BrowserInspectionToolOutput"), "General domain models should not own tool-specific output compatibility.")
+        XCTAssertFalse(modelsText.contains("public struct MemoryRememberToolOutput"), "General domain models should not own tool-specific output compatibility.")
+    }
+
+    func testProjectModelsLiveOutsideGeneralDomainModels() throws {
+        let modelsText = try Self.coreSourceText(named: "Models.swift")
+        let projectText = try Self.coreSourceText(named: "ProjectModels.swift")
+
+        XCTAssertTrue(projectText.contains("public enum ProjectConnectionKind"), "Project connection kinds should live in a focused core file.")
+        XCTAssertTrue(projectText.contains("public struct ProjectConnection"), "Project connection parsing and display should live beside project records.")
+        XCTAssertTrue(projectText.contains("parseSSH"), "SSH project parsing should stay with project connection records.")
+        XCTAssertTrue(projectText.contains("public struct ProjectRef"), "Project references should live in the project model boundary.")
+        XCTAssertTrue(projectText.contains("public struct LocalEnvironmentAction"), "Local environment actions should live beside project records.")
+        XCTAssertTrue(projectText.contains("public struct ProjectExtensionManifest"), "Project extension manifests should live beside project records.")
+        XCTAssertFalse(modelsText.contains("public enum ProjectConnectionKind"), "General domain models should not own project connection kinds.")
+        XCTAssertFalse(modelsText.contains("public struct ProjectConnection"), "General domain models should not own project connection records.")
+        XCTAssertFalse(modelsText.contains("parseSSH"), "General domain models should not own SSH project parsing.")
+        XCTAssertFalse(modelsText.contains("public struct ProjectRef"), "General domain models should not own project references.")
+        XCTAssertFalse(modelsText.contains("public struct LocalEnvironmentAction"), "General domain models should not own local environment actions.")
+        XCTAssertFalse(modelsText.contains("public struct ProjectExtensionManifest"), "General domain models should not own project extension manifests.")
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -64,7 +64,9 @@ final class ParityGateTests: QuillCodeParityTestCase {
             "ParityWorkspaceSettingsSheetGateTests.swift",
             "ParityWorkspaceTranscriptGateTests.swift",
             "ParityAgentGateTests.swift",
-            "ParityTrustedRouterGateTests.swift"
+            "ParityTrustedRouterGateTests.swift",
+            "ParitySafetyGateTests.swift",
+            "ParityCoreModelGateTests.swift"
         ]
         for suiteFile in suiteFiles {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
@@ -191,6 +193,13 @@ final class ParityGateTests: QuillCodeParityTestCase {
                 "testTrustedRouterAPIKeyResolutionLivesInFocusedResolver",
                 "testTrustedRouterSafetyClientLivesOutsideActionTransportFile",
                 "testTrustedRouterChatParametersLiveOutsideTransportClients"
+            ]),
+            ("ParitySafetyGateTests", [
+                "testStaticSafetyPolicyLivesOutsideReviewerControlFlow"
+            ]),
+            ("ParityCoreModelGateTests", [
+                "testCoreToolModelsLiveOutsideGeneralDomainModels",
+                "testProjectModelsLiveOutsideGeneralDomainModels"
             ])
         ]
 
@@ -202,57 +211,6 @@ final class ParityGateTests: QuillCodeParityTestCase {
                 )
             }
         }
-    }
-
-    func testStaticSafetyPolicyLivesOutsideReviewerControlFlow() throws {
-        let reviewerText = try Self.safetySourceText(named: "Safety.swift")
-        let policyText = try Self.safetySourceText(named: "StaticSafetyPolicy.swift")
-
-        XCTAssertTrue(policyText.contains("struct StaticSafetyPolicy"), "Static safety intent policy should live in a focused policy file.")
-        XCTAssertTrue(policyText.contains("StaticSafetyHardDenyRule"), "Hard-deny patterns should be explicit policy table entries.")
-        XCTAssertTrue(policyText.contains("StaticSafetyIntentRule"), "Intent-to-tool matching should use table-driven rules.")
-        XCTAssertTrue(policyText.contains("StaticSafetyPullRequestPolicy"), "Pull request safety routing should live beside the static policy tables.")
-        XCTAssertTrue(reviewerText.contains("policy.hardDenyReason"), "StaticSafetyReviewer should delegate hard-deny checks to the policy.")
-        XCTAssertTrue(reviewerText.contains("policy.userIntentMatches"), "StaticSafetyReviewer should delegate intent matching to the policy.")
-        XCTAssertFalse(reviewerText.contains(#""rm -rf /""#), "StaticSafetyReviewer should not own raw hard-deny command patterns.")
-        XCTAssertFalse(reviewerText.contains("user.contains(\"pull request\")"), "StaticSafetyReviewer should not own raw pull-request intent chains.")
-    }
-
-    func testCoreToolModelsLiveOutsideGeneralDomainModels() throws {
-        let modelsText = try Self.coreSourceText(named: "Models.swift")
-        let toolModelsText = try Self.coreSourceText(named: "ToolModels.swift")
-
-        XCTAssertTrue(toolModelsText.contains("public struct ToolDefinition"), "Tool schema records should live in a focused core file.")
-        XCTAssertTrue(toolModelsText.contains("public struct ToolCall"), "Tool-call payload records should live beside tool schemas.")
-        XCTAssertTrue(toolModelsText.contains("public struct ToolResult"), "Tool-result payload records should live beside tool schemas.")
-        XCTAssertTrue(toolModelsText.contains("redactedForTranscript"), "Tool-call redaction belongs with tool-call payload records.")
-        XCTAssertTrue(toolModelsText.contains("public struct BrowserInspectionToolOutput"), "Tool-specific browser output compatibility belongs with tool models.")
-        XCTAssertTrue(toolModelsText.contains("public struct MemoryRememberToolOutput"), "Tool-specific memory output compatibility belongs with tool models.")
-        XCTAssertTrue(toolModelsText.contains("static let planUpdate"), "Built-in core tool definitions should live with tool schema records.")
-        XCTAssertFalse(modelsText.contains("public struct ToolDefinition"), "General domain models should not own tool schema records.")
-        XCTAssertFalse(modelsText.contains("public struct ToolCall"), "General domain models should not own tool-call payload records.")
-        XCTAssertFalse(modelsText.contains("public struct ToolResult"), "General domain models should not own tool-result payload records.")
-        XCTAssertFalse(modelsText.contains("redactedForTranscript"), "General domain models should not own tool-call redaction.")
-        XCTAssertFalse(modelsText.contains("public struct BrowserInspectionToolOutput"), "General domain models should not own tool-specific output compatibility.")
-        XCTAssertFalse(modelsText.contains("public struct MemoryRememberToolOutput"), "General domain models should not own tool-specific output compatibility.")
-    }
-
-    func testProjectModelsLiveOutsideGeneralDomainModels() throws {
-        let modelsText = try Self.coreSourceText(named: "Models.swift")
-        let projectText = try Self.coreSourceText(named: "ProjectModels.swift")
-
-        XCTAssertTrue(projectText.contains("public enum ProjectConnectionKind"), "Project connection kinds should live in a focused core file.")
-        XCTAssertTrue(projectText.contains("public struct ProjectConnection"), "Project connection parsing and display should live beside project records.")
-        XCTAssertTrue(projectText.contains("parseSSH"), "SSH project parsing should stay with project connection records.")
-        XCTAssertTrue(projectText.contains("public struct ProjectRef"), "Project references should live in the project model boundary.")
-        XCTAssertTrue(projectText.contains("public struct LocalEnvironmentAction"), "Local environment actions should live beside project records.")
-        XCTAssertTrue(projectText.contains("public struct ProjectExtensionManifest"), "Project extension manifests should live beside project records.")
-        XCTAssertFalse(modelsText.contains("public enum ProjectConnectionKind"), "General domain models should not own project connection kinds.")
-        XCTAssertFalse(modelsText.contains("public struct ProjectConnection"), "General domain models should not own project connection records.")
-        XCTAssertFalse(modelsText.contains("parseSSH"), "General domain models should not own SSH project parsing.")
-        XCTAssertFalse(modelsText.contains("public struct ProjectRef"), "General domain models should not own project references.")
-        XCTAssertFalse(modelsText.contains("public struct LocalEnvironmentAction"), "General domain models should not own local environment actions.")
-        XCTAssertFalse(modelsText.contains("public struct ProjectExtensionManifest"), "General domain models should not own project extension manifests.")
     }
 
 }

--- a/Tests/QuillCodeParityTests/ParitySafetyGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySafetyGateTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+
+final class ParitySafetyGateTests: QuillCodeParityTestCase {
+    func testStaticSafetyPolicyLivesOutsideReviewerControlFlow() throws {
+        let reviewerText = try Self.safetySourceText(named: "Safety.swift")
+        let policyText = try Self.safetySourceText(named: "StaticSafetyPolicy.swift")
+
+        XCTAssertTrue(policyText.contains("struct StaticSafetyPolicy"), "Static safety intent policy should live in a focused policy file.")
+        XCTAssertTrue(policyText.contains("StaticSafetyHardDenyRule"), "Hard-deny patterns should be explicit policy table entries.")
+        XCTAssertTrue(policyText.contains("StaticSafetyIntentRule"), "Intent-to-tool matching should use table-driven rules.")
+        XCTAssertTrue(policyText.contains("StaticSafetyPullRequestPolicy"), "Pull request safety routing should live beside the static policy tables.")
+        XCTAssertTrue(reviewerText.contains("policy.hardDenyReason"), "StaticSafetyReviewer should delegate hard-deny checks to the policy.")
+        XCTAssertTrue(reviewerText.contains("policy.userIntentMatches"), "StaticSafetyReviewer should delegate intent matching to the policy.")
+        XCTAssertFalse(reviewerText.contains(#""rm -rf /""#), "StaticSafetyReviewer should not own raw hard-deny command patterns.")
+        XCTAssertFalse(reviewerText.contains("user.contains(\"pull request\")"), "StaticSafetyReviewer should not own raw pull-request intent chains.")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5072,3 +5072,23 @@ Current strict grades:
 
 Remaining risk:
 - Optional final split for core/project model boundary checks; otherwise the broad suite is now appropriately small.
+
+## 2026-06-24 Safety And Core Model Parity Gate Split
+
+Overall grade after this slice: **A safety-boundary ownership, A core-model ownership, A global registry shape**.
+
+The last non-global checks in `ParityGateTests` covered static safety policy and core model decomposition. Those are separate architectural concerns: safety policy should guard the Auto-review fallback boundary, while core/project model checks should guard domain model ownership. Keeping them in focused suites makes the global parity suite a small registry plus hygiene gate instead of a mixed dumping ground.
+
+What changed:
+- Added `ParitySafetyGateTests` for static safety policy ownership and reviewer delegation.
+- Added `ParityCoreModelGateTests` for tool schema/model and project model decomposition.
+- Registered both suites in the parity drift guard.
+- Reduced `ParityGateTests.swift` to global hygiene, docs presence, and focused-suite registration checks.
+
+Current strict grades:
+- `ParitySafetyGateTests.swift`: **A**. It owns one safety policy boundary and directly guards the hard-deny and user-intent delegation points.
+- `ParityCoreModelGateTests.swift`: **A**. It keeps core tool models and project models in one focused domain-boundary suite.
+- `ParityGateTests.swift`: **A**. It is now an intentionally small global gate with no feature-specific architecture assertions.
+
+Remaining risk:
+- The focused-suite registry table is still hand-maintained. If it grows much further, move it into a data helper or manifest so the global gate stays declarative.


### PR DESCRIPTION
## Summary
- move static safety policy ownership checks into ParitySafetyGateTests
- move core tool/project model decomposition checks into ParityCoreModelGateTests
- register both suites in the parity drift guard and update the code quality audit

## Validation
- swift test --filter 'ParitySafetyGateTests|ParityCoreModelGateTests|ParityGateTests/testParityGatesUseFocusedSuitesAndSharedSupport'
- swift test
- git diff --check