### PR TITLE
Move parity focused suite registry to helper

### DIFF
--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteRegistry.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteRegistry.swift
@@ -1,0 +1,155 @@
+enum ParityFocusedSuiteRegistry {
+    static let requiredTestFiles = [
+        "ParityTestSupport.swift",
+        "ParityFocusedSuiteRegistry.swift",
+        "ParityToolGateTests.swift",
+        "ParityDesktopGateTests.swift",
+        "ParityTopBarGateTests.swift",
+        "ParitySlashGateTests.swift",
+        "ParityModelGateTests.swift",
+        "ParityWorkspaceSurfaceGateTests.swift",
+        "ParityWorkspaceModelGateTests.swift",
+        "ParityWorkspaceExecutionGateTests.swift",
+        "ParityWorkspaceProjectGateTests.swift",
+        "ParityWorkspaceMemoryGateTests.swift",
+        "ParityWorkspaceIntegrationGateTests.swift",
+        "ParityWorkspaceSidebarGateTests.swift",
+        "ParityMCPGateTests.swift",
+        "ParityAutomationGateTests.swift",
+        "ParityWorkspaceRuntimeReviewGateTests.swift",
+        "ParityWorkspaceCommandGateTests.swift",
+        "ParityWorkspaceSettingsSheetGateTests.swift",
+        "ParityWorkspaceTranscriptGateTests.swift",
+        "ParityAgentGateTests.swift",
+        "ParityTrustedRouterGateTests.swift",
+        "ParitySafetyGateTests.swift",
+        "ParityCoreModelGateTests.swift"
+    ]
+
+    static let focusedSuiteTests: [(suiteName: String, testNames: [String])] = [
+        ("ParityToolGateTests", ["testToolArgumentJSONSerializationLivesInCore"]),
+        ("ParityDesktopGateTests", ["testDesktopDefinesNativeMenuBarWidget"]),
+        ("ParityTopBarGateTests", ["testTopBarViewsDelegateStatusPresentationSemantics"]),
+        ("ParitySlashGateTests", ["testSlashParserDelegatesPullRequestSubcommands"]),
+        ("ParityModelGateTests", ["testTrustedRouterModelCatalogLivesOutsideGeneralDomainModels"]),
+        ("ParityWorkspaceSurfaceGateTests", ["testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts"]),
+        ("ParityWorkspaceModelGateTests", [
+            "testWorkspaceModelDelegatesToolCardSurfaceTypes",
+            "testWorkspaceModelDelegatesProjectContextRefresh",
+            "testWorkspaceModelDelegatesThreadSeedBuilding",
+            "testWorkspaceModelDelegatesThreadCreationRecords",
+            "testWorkspaceModelDelegatesThreadLifecycleTransitions",
+            "testWorkspaceModelDelegatesConfigurationTransitions",
+            "testWorkspaceConfigurationIntegrationTestsOwnModelConfigurationFlows",
+            "testWorkspaceModelDelegatesRetryPlanning",
+            "testWorkspaceActivityIntegrationTestsOwnModelActivityFlows",
+            "testWorkspaceActivitySurfaceUsesFocusedBuilderAndSectionTypes",
+            "testWorkspaceToolCardIntegrationTestsOwnModelToolCardFlows",
+            "testWorkspaceModelTestsRemainRetired",
+            "testFocusedWorkspaceUnitSuitesUseSharedTemporaryDirectorySupport",
+            "testWorkspaceModelDelegatesStatusTextAndLabels",
+            "testWorkspaceModelDelegatesContextResolving",
+            "testWorkspaceModelDelegatesAgentProgressStatusCopy",
+            "testWorkspaceModelDelegatesThreadNoticeMutation",
+            "testWorkspaceModelUsesExplicitAgentRunThreadUpdates"
+        ]),
+        ("ParityWorkspaceExecutionGateTests", [
+            "testWorkspaceModelDelegatesComposerCancellationPlanning",
+            "testWorkspaceModelDelegatesComposerSubmissionPlanning",
+            "testWorkspaceModelDelegatesAgentSendSessionExecution",
+            "testWorkspaceModelDelegatesSlashCommandTranscriptPlanning",
+            "testWorkspaceModelDelegatesCommandActionPlanning",
+            "testWorkspaceModelDelegatesCommandPlanExecution",
+            "testWorkspaceModelDelegatesAgentRunContextAssembly",
+            "testWorkspaceModelDelegatesAgentSendSession",
+            "testWorkspaceModelDelegatesToolEventRecording",
+            "testWorkspaceModelDelegatesToolCallExecutionRouting",
+            "testWorkspaceModelDelegatesShellToolCallPlanning",
+            "testWorkspaceComposerIntegrationTestsOwnModelComposerFlows",
+            "testWorkspaceModelDelegatesSlashCommandDispatchPlanning",
+            "testWorkspaceModelDelegatesToolExecutionOverrideCombining"
+        ]),
+        ("ParityWorkspaceProjectGateTests", [
+            "testWorkspaceModelDelegatesProjectMetadataLoading",
+            "testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage",
+            "testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows",
+            "testWorkspaceProjectIntegrationTestsOwnModelProjectFlows",
+            "testWorkspaceRemoteProjectIntegrationTestsOwnModelRemoteProjectFlows",
+            "testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows",
+            "testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows",
+            "testWorkspaceModelDelegatesWorktreeOpenRecords"
+        ]),
+        ("ParityWorkspaceMemoryGateTests", [
+            "testWorkspaceModelDelegatesMemoryCommandOrchestration",
+            "testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows"
+        ]),
+        ("ParityWorkspaceIntegrationGateTests", [
+            "testWorkspaceMCPIntegrationTestsOwnModelMCPFlows",
+            "testWorkspaceReviewIntegrationTestsOwnModelReviewFlows",
+            "testFocusedFeedbackAndArtifactTestsOwnSurfaceSpecificFlows",
+            "testWorkspaceRuntimeIssueIntegrationTestsOwnModelRuntimeIssueFlows",
+            "testWorkspaceThreadLifecycleIntegrationTestsOwnModelLifecycleFlows",
+            "testWorkspaceSlashCommandIntegrationTestsOwnCoreSlashFlows",
+            "testWorkspaceLocalEnvironmentIntegrationTestsOwnModelLocalEnvironmentFlows",
+            "testWorkspaceAutomationIntegrationTestsOwnModelAutomationFlows",
+            "testWorkspaceTerminalIntegrationTestsOwnModelTerminalFlows",
+            "testWorkspaceModelTestsDoNotOwnRuntimeFactoryCoverage"
+        ]),
+        ("ParityWorkspaceSidebarGateTests", [
+            "testWorkspaceModelDelegatesSidebarSelectionTransitions",
+            "testSidebarRowActionsUseSharedPlannerAndExecutor",
+            "testSidebarCommandPresentationIsSharedByNativeAndHTMLSurfaces",
+            "testNativeSidebarDelegatesProjectListRendering",
+            "testWorkspaceSurfaceDelegatesSidebarSurfaceContracts",
+            "testWorkspaceSurfaceDelegatesNavigationSurfaceBuilding"
+        ]),
+        ("ParityMCPGateTests", [
+            "testWorkspaceModelDelegatesMCPSupportTypes",
+            "testMCPStdioProberDelegatesCodecAndResultMapping"
+        ]),
+        ("ParityAutomationGateTests", [
+            "testAutomationModelsLiveOutsideGeneralDomainModels",
+            "testWorkspaceModelDelegatesAutomationStateMutations",
+            "testWorkspaceSurfaceDelegatesAutomationsSurfaceBuilding"
+        ]),
+        ("ParityWorkspaceRuntimeReviewGateTests", [
+            "testNativeReviewPaneDelegatesFileHunkAndLineRendering",
+            "testWorkspaceSurfaceDelegatesRuntimeIssueBuilding",
+            "testWorkspaceSurfaceDelegatesRuntimeAndExecutionContextContracts",
+            "testWorkspaceViewDelegatesRuntimeIssueRecoveryPlanning"
+        ]),
+        ("ParityWorkspaceCommandGateTests", [
+            "testWorkspaceViewDelegatesCommandPlanning",
+            "testWorkspaceSurfaceDelegatesCommandSurfaceBuilding",
+            "testWorkspaceSurfaceDelegatesCommandPaletteContract"
+        ]),
+        ("ParityWorkspaceSettingsSheetGateTests", [
+            "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
+            "testNativeSettingsDelegatesFocusedViewsAndDraftState",
+            "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
+        ]),
+        ("ParityWorkspaceTranscriptGateTests", [
+            "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"
+        ]),
+        ("ParityAgentGateTests", [
+            "testAgentRunnerDelegatesFinalAnswerFormatting",
+            "testMockLLMClientLivesOutsideAgentRunnerFile",
+            "testAgentStreamingHelpersLiveOutsideAgentRunnerFile",
+            "testAgentToolStepRunnerLivesOutsideAgentRunnerFile"
+        ]),
+        ("ParityTrustedRouterGateTests", [
+            "testTrustedRouterActionParserLivesOutsideTransportClient",
+            "testTrustedRouterPromptBuilderLivesOutsideTransportClient",
+            "testTrustedRouterAPIKeyResolutionLivesInFocusedResolver",
+            "testTrustedRouterSafetyClientLivesOutsideActionTransportFile",
+            "testTrustedRouterChatParametersLiveOutsideTransportClients"
+        ]),
+        ("ParitySafetyGateTests", [
+            "testStaticSafetyPolicyLivesOutsideReviewerControlFlow"
+        ]),
+        ("ParityCoreModelGateTests", [
+            "testCoreToolModelsLiveOutsideGeneralDomainModels",
+            "testProjectModelsLiveOutsideGeneralDomainModels"
+        ])
+    ]
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -43,167 +43,17 @@ final class ParityGateTests: QuillCodeParityTestCase {
 
     func testParityGatesUseFocusedSuitesAndSharedSupport() throws {
         let root = Self.packageRoot().appendingPathComponent("Tests/QuillCodeParityTests")
-        let suiteFiles = [
-            "ParityTestSupport.swift",
-            "ParityToolGateTests.swift",
-            "ParityDesktopGateTests.swift",
-            "ParityTopBarGateTests.swift",
-            "ParitySlashGateTests.swift",
-            "ParityModelGateTests.swift",
-            "ParityWorkspaceSurfaceGateTests.swift",
-            "ParityWorkspaceModelGateTests.swift",
-            "ParityWorkspaceExecutionGateTests.swift",
-            "ParityWorkspaceProjectGateTests.swift",
-            "ParityWorkspaceMemoryGateTests.swift",
-            "ParityWorkspaceIntegrationGateTests.swift",
-            "ParityWorkspaceSidebarGateTests.swift",
-            "ParityMCPGateTests.swift",
-            "ParityAutomationGateTests.swift",
-            "ParityWorkspaceRuntimeReviewGateTests.swift",
-            "ParityWorkspaceCommandGateTests.swift",
-            "ParityWorkspaceSettingsSheetGateTests.swift",
-            "ParityWorkspaceTranscriptGateTests.swift",
-            "ParityAgentGateTests.swift",
-            "ParityTrustedRouterGateTests.swift",
-            "ParitySafetyGateTests.swift",
-            "ParityCoreModelGateTests.swift"
-        ]
-        for suiteFile in suiteFiles {
-            XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
+        for testFile in ParityFocusedSuiteRegistry.requiredTestFiles {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(testFile).path), testFile)
         }
 
         let mainText = try String(contentsOf: root.appendingPathComponent("ParityGateTests.swift"), encoding: .utf8)
         let mainLines = Set(mainText.components(separatedBy: .newlines))
         XCTAssertFalse(mainLines.contains("    private static func packageRoot() -> URL {"), "Shared source-reading helpers should live in ParityTestSupport.")
+        let inlineRegistryNeedle = "static " + "let " + "focusedSuiteTests"
+        XCTAssertFalse(mainText.contains(inlineRegistryNeedle), "Focused-suite registry data should live in ParityFocusedSuiteRegistry.")
 
-        let focusedSuiteTests: [(suiteName: String, testNames: [String])] = [
-            ("ParityToolGateTests", ["testToolArgumentJSONSerializationLivesInCore"]),
-            ("ParityDesktopGateTests", ["testDesktopDefinesNativeMenuBarWidget"]),
-            ("ParityTopBarGateTests", ["testTopBarViewsDelegateStatusPresentationSemantics"]),
-            ("ParitySlashGateTests", ["testSlashParserDelegatesPullRequestSubcommands"]),
-            ("ParityModelGateTests", ["testTrustedRouterModelCatalogLivesOutsideGeneralDomainModels"]),
-            ("ParityWorkspaceSurfaceGateTests", ["testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts"]),
-            ("ParityWorkspaceModelGateTests", [
-                "testWorkspaceModelDelegatesToolCardSurfaceTypes",
-                "testWorkspaceModelDelegatesProjectContextRefresh",
-                "testWorkspaceModelDelegatesThreadSeedBuilding",
-                "testWorkspaceModelDelegatesThreadCreationRecords",
-                "testWorkspaceModelDelegatesThreadLifecycleTransitions",
-                "testWorkspaceModelDelegatesConfigurationTransitions",
-                "testWorkspaceConfigurationIntegrationTestsOwnModelConfigurationFlows",
-                "testWorkspaceModelDelegatesRetryPlanning",
-                "testWorkspaceActivityIntegrationTestsOwnModelActivityFlows",
-                "testWorkspaceActivitySurfaceUsesFocusedBuilderAndSectionTypes",
-                "testWorkspaceToolCardIntegrationTestsOwnModelToolCardFlows",
-                "testWorkspaceModelTestsRemainRetired",
-                "testFocusedWorkspaceUnitSuitesUseSharedTemporaryDirectorySupport",
-                "testWorkspaceModelDelegatesStatusTextAndLabels",
-                "testWorkspaceModelDelegatesContextResolving",
-                "testWorkspaceModelDelegatesAgentProgressStatusCopy",
-                "testWorkspaceModelDelegatesThreadNoticeMutation",
-                "testWorkspaceModelUsesExplicitAgentRunThreadUpdates"
-            ]),
-            ("ParityWorkspaceExecutionGateTests", [
-                "testWorkspaceModelDelegatesComposerCancellationPlanning",
-                "testWorkspaceModelDelegatesComposerSubmissionPlanning",
-                "testWorkspaceModelDelegatesAgentSendSessionExecution",
-                "testWorkspaceModelDelegatesSlashCommandTranscriptPlanning",
-                "testWorkspaceModelDelegatesCommandActionPlanning",
-                "testWorkspaceModelDelegatesCommandPlanExecution",
-                "testWorkspaceModelDelegatesAgentRunContextAssembly",
-                "testWorkspaceModelDelegatesAgentSendSession",
-                "testWorkspaceModelDelegatesToolEventRecording",
-                "testWorkspaceModelDelegatesToolCallExecutionRouting",
-                "testWorkspaceModelDelegatesShellToolCallPlanning",
-                "testWorkspaceComposerIntegrationTestsOwnModelComposerFlows",
-                "testWorkspaceModelDelegatesSlashCommandDispatchPlanning",
-                "testWorkspaceModelDelegatesToolExecutionOverrideCombining"
-            ]),
-            ("ParityWorkspaceProjectGateTests", [
-                "testWorkspaceModelDelegatesProjectMetadataLoading",
-                "testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage",
-                "testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows",
-                "testWorkspaceProjectIntegrationTestsOwnModelProjectFlows",
-                "testWorkspaceRemoteProjectIntegrationTestsOwnModelRemoteProjectFlows",
-                "testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows",
-                "testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows",
-                "testWorkspaceModelDelegatesWorktreeOpenRecords"
-            ]),
-            ("ParityWorkspaceMemoryGateTests", [
-                "testWorkspaceModelDelegatesMemoryCommandOrchestration",
-                "testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows"
-            ]),
-            ("ParityWorkspaceIntegrationGateTests", [
-                "testWorkspaceMCPIntegrationTestsOwnModelMCPFlows",
-                "testWorkspaceReviewIntegrationTestsOwnModelReviewFlows",
-                "testFocusedFeedbackAndArtifactTestsOwnSurfaceSpecificFlows",
-                "testWorkspaceRuntimeIssueIntegrationTestsOwnModelRuntimeIssueFlows",
-                "testWorkspaceThreadLifecycleIntegrationTestsOwnModelLifecycleFlows",
-                "testWorkspaceSlashCommandIntegrationTestsOwnCoreSlashFlows",
-                "testWorkspaceLocalEnvironmentIntegrationTestsOwnModelLocalEnvironmentFlows",
-                "testWorkspaceAutomationIntegrationTestsOwnModelAutomationFlows",
-                "testWorkspaceTerminalIntegrationTestsOwnModelTerminalFlows",
-                "testWorkspaceModelTestsDoNotOwnRuntimeFactoryCoverage"
-            ]),
-            ("ParityWorkspaceSidebarGateTests", [
-                "testWorkspaceModelDelegatesSidebarSelectionTransitions",
-                "testSidebarRowActionsUseSharedPlannerAndExecutor",
-                "testSidebarCommandPresentationIsSharedByNativeAndHTMLSurfaces",
-                "testNativeSidebarDelegatesProjectListRendering",
-                "testWorkspaceSurfaceDelegatesSidebarSurfaceContracts",
-                "testWorkspaceSurfaceDelegatesNavigationSurfaceBuilding"
-            ]),
-            ("ParityMCPGateTests", [
-                "testWorkspaceModelDelegatesMCPSupportTypes",
-                "testMCPStdioProberDelegatesCodecAndResultMapping"
-            ]),
-            ("ParityAutomationGateTests", [
-                "testAutomationModelsLiveOutsideGeneralDomainModels",
-                "testWorkspaceModelDelegatesAutomationStateMutations",
-                "testWorkspaceSurfaceDelegatesAutomationsSurfaceBuilding"
-            ]),
-            ("ParityWorkspaceRuntimeReviewGateTests", [
-                "testNativeReviewPaneDelegatesFileHunkAndLineRendering",
-                "testWorkspaceSurfaceDelegatesRuntimeIssueBuilding",
-                "testWorkspaceSurfaceDelegatesRuntimeAndExecutionContextContracts",
-                "testWorkspaceViewDelegatesRuntimeIssueRecoveryPlanning"
-            ]),
-            ("ParityWorkspaceCommandGateTests", [
-                "testWorkspaceViewDelegatesCommandPlanning",
-                "testWorkspaceSurfaceDelegatesCommandSurfaceBuilding",
-                "testWorkspaceSurfaceDelegatesCommandPaletteContract"
-            ]),
-            ("ParityWorkspaceSettingsSheetGateTests", [
-                "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
-                "testNativeSettingsDelegatesFocusedViewsAndDraftState",
-                "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
-            ]),
-            ("ParityWorkspaceTranscriptGateTests", [
-                "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"
-            ]),
-            ("ParityAgentGateTests", [
-                "testAgentRunnerDelegatesFinalAnswerFormatting",
-                "testMockLLMClientLivesOutsideAgentRunnerFile",
-                "testAgentStreamingHelpersLiveOutsideAgentRunnerFile",
-                "testAgentToolStepRunnerLivesOutsideAgentRunnerFile"
-            ]),
-            ("ParityTrustedRouterGateTests", [
-                "testTrustedRouterActionParserLivesOutsideTransportClient",
-                "testTrustedRouterPromptBuilderLivesOutsideTransportClient",
-                "testTrustedRouterAPIKeyResolutionLivesInFocusedResolver",
-                "testTrustedRouterSafetyClientLivesOutsideActionTransportFile",
-                "testTrustedRouterChatParametersLiveOutsideTransportClients"
-            ]),
-            ("ParitySafetyGateTests", [
-                "testStaticSafetyPolicyLivesOutsideReviewerControlFlow"
-            ]),
-            ("ParityCoreModelGateTests", [
-                "testCoreToolModelsLiveOutsideGeneralDomainModels",
-                "testProjectModelsLiveOutsideGeneralDomainModels"
-            ])
-        ]
-
-        for (suiteName, testNames) in focusedSuiteTests {
+        for (suiteName, testNames) in ParityFocusedSuiteRegistry.focusedSuiteTests {
             for testName in testNames {
                 XCTAssertFalse(
                     mainLines.contains("    func \(testName)() throws {"),

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5092,3 +5092,21 @@ Current strict grades:
 
 Remaining risk:
 - The focused-suite registry table is still hand-maintained. If it grows much further, move it into a data helper or manifest so the global gate stays declarative.
+
+## 2026-06-24 Focused Suite Registry Helper
+
+Overall grade after this slice: **A parity registry shape, A merge ergonomics, A global gate readability**.
+
+After the safety/core split, `ParityGateTests` no longer owned feature-specific assertions, but it still carried the full focused-suite manifest inline. That made the global gate look heavier than its actual responsibility and created an easy merge hotspot for agents adding new parity slices.
+
+What changed:
+- Added `ParityFocusedSuiteRegistry` to own required parity test files and focused-suite test names.
+- Updated `ParityGateTests` to consume the registry helper instead of carrying manifest data inline.
+- Added a guard so the focused-suite registry data does not drift back into the global gate.
+
+Current strict grades:
+- `ParityFocusedSuiteRegistry.swift`: **A**. It has one data-manifest responsibility and no test execution logic.
+- `ParityGateTests.swift`: **A**. It now reads as global hygiene plus registry enforcement, not a mixed feature/assertion dump.
+
+Remaining risk:
+- If the registry grows substantially again, the next step is a generated or declarative manifest file; for now a typed Swift helper is simple and keeps CI fast.


### PR DESCRIPTION
## Summary
- move focused parity suite file/test-name registry data into `ParityFocusedSuiteRegistry`
- keep `ParityGateTests` focused on global hygiene and registry enforcement
- document the cleanup in the code quality audit

## Validation
- swift test --filter ParityGateTests
- swift test