### PR TITLE
Extract parity focused suite manifest

### DIFF
--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -1,0 +1,151 @@
+struct ParityFocusedSuiteManifest {
+    struct Suite {
+        let fileName: String
+        let testNames: [String]
+    }
+
+    static let supportFileName = "ParityTestSupport.swift"
+
+    static let suites: [Suite] = [
+        Suite(fileName: "ParityToolGateTests.swift", testNames: [
+            "testToolArgumentJSONSerializationLivesInCore"
+        ]),
+        Suite(fileName: "ParityDesktopGateTests.swift", testNames: [
+            "testDesktopDefinesNativeMenuBarWidget"
+        ]),
+        Suite(fileName: "ParityTopBarGateTests.swift", testNames: [
+            "testTopBarViewsDelegateStatusPresentationSemantics"
+        ]),
+        Suite(fileName: "ParitySlashGateTests.swift", testNames: [
+            "testSlashParserDelegatesPullRequestSubcommands"
+        ]),
+        Suite(fileName: "ParityModelGateTests.swift", testNames: [
+            "testTrustedRouterModelCatalogLivesOutsideGeneralDomainModels"
+        ]),
+        Suite(fileName: "ParityWorkspaceSurfaceGateTests.swift", testNames: [
+            "testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts"
+        ]),
+        Suite(fileName: "ParityWorkspaceModelGateTests.swift", testNames: [
+            "testWorkspaceModelDelegatesToolCardSurfaceTypes",
+            "testWorkspaceModelDelegatesProjectContextRefresh",
+            "testWorkspaceModelDelegatesThreadSeedBuilding",
+            "testWorkspaceModelDelegatesThreadCreationRecords",
+            "testWorkspaceModelDelegatesThreadLifecycleTransitions",
+            "testWorkspaceModelDelegatesConfigurationTransitions",
+            "testWorkspaceConfigurationIntegrationTestsOwnModelConfigurationFlows",
+            "testWorkspaceModelDelegatesRetryPlanning",
+            "testWorkspaceActivityIntegrationTestsOwnModelActivityFlows",
+            "testWorkspaceActivitySurfaceUsesFocusedBuilderAndSectionTypes",
+            "testWorkspaceToolCardIntegrationTestsOwnModelToolCardFlows",
+            "testWorkspaceModelTestsRemainRetired",
+            "testFocusedWorkspaceUnitSuitesUseSharedTemporaryDirectorySupport",
+            "testWorkspaceModelDelegatesStatusTextAndLabels",
+            "testWorkspaceModelDelegatesContextResolving",
+            "testWorkspaceModelDelegatesAgentProgressStatusCopy",
+            "testWorkspaceModelDelegatesThreadNoticeMutation",
+            "testWorkspaceModelUsesExplicitAgentRunThreadUpdates"
+        ]),
+        Suite(fileName: "ParityWorkspaceExecutionGateTests.swift", testNames: [
+            "testWorkspaceModelDelegatesComposerCancellationPlanning",
+            "testWorkspaceModelDelegatesComposerSubmissionPlanning",
+            "testWorkspaceModelDelegatesAgentSendSessionExecution",
+            "testWorkspaceModelDelegatesSlashCommandTranscriptPlanning",
+            "testWorkspaceModelDelegatesCommandActionPlanning",
+            "testWorkspaceModelDelegatesCommandPlanExecution",
+            "testWorkspaceModelDelegatesAgentRunContextAssembly",
+            "testWorkspaceModelDelegatesAgentSendSession",
+            "testWorkspaceModelDelegatesToolEventRecording",
+            "testWorkspaceModelDelegatesToolCallExecutionRouting",
+            "testWorkspaceModelDelegatesShellToolCallPlanning",
+            "testWorkspaceComposerIntegrationTestsOwnModelComposerFlows",
+            "testWorkspaceModelDelegatesSlashCommandDispatchPlanning",
+            "testWorkspaceModelDelegatesToolExecutionOverrideCombining"
+        ]),
+        Suite(fileName: "ParityWorkspaceProjectGateTests.swift", testNames: [
+            "testWorkspaceModelDelegatesProjectMetadataLoading",
+            "testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage",
+            "testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows",
+            "testWorkspaceProjectIntegrationTestsOwnModelProjectFlows",
+            "testWorkspaceRemoteProjectIntegrationTestsOwnModelRemoteProjectFlows",
+            "testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows",
+            "testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows",
+            "testWorkspaceModelDelegatesWorktreeOpenRecords"
+        ]),
+        Suite(fileName: "ParityWorkspaceMemoryGateTests.swift", testNames: [
+            "testWorkspaceModelDelegatesMemoryCommandOrchestration",
+            "testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows"
+        ]),
+        Suite(fileName: "ParityWorkspaceIntegrationGateTests.swift", testNames: [
+            "testWorkspaceMCPIntegrationTestsOwnModelMCPFlows",
+            "testWorkspaceReviewIntegrationTestsOwnModelReviewFlows",
+            "testFocusedFeedbackAndArtifactTestsOwnSurfaceSpecificFlows",
+            "testWorkspaceRuntimeIssueIntegrationTestsOwnModelRuntimeIssueFlows",
+            "testWorkspaceThreadLifecycleIntegrationTestsOwnModelLifecycleFlows",
+            "testWorkspaceSlashCommandIntegrationTestsOwnCoreSlashFlows",
+            "testWorkspaceLocalEnvironmentIntegrationTestsOwnModelLocalEnvironmentFlows",
+            "testWorkspaceAutomationIntegrationTestsOwnModelAutomationFlows",
+            "testWorkspaceTerminalIntegrationTestsOwnModelTerminalFlows",
+            "testWorkspaceModelTestsDoNotOwnRuntimeFactoryCoverage"
+        ]),
+        Suite(fileName: "ParityWorkspaceSidebarGateTests.swift", testNames: [
+            "testWorkspaceModelDelegatesSidebarSelectionTransitions",
+            "testSidebarRowActionsUseSharedPlannerAndExecutor",
+            "testSidebarCommandPresentationIsSharedByNativeAndHTMLSurfaces",
+            "testNativeSidebarDelegatesProjectListRendering",
+            "testWorkspaceSurfaceDelegatesSidebarSurfaceContracts",
+            "testWorkspaceSurfaceDelegatesNavigationSurfaceBuilding"
+        ]),
+        Suite(fileName: "ParityMCPGateTests.swift", testNames: [
+            "testWorkspaceModelDelegatesMCPSupportTypes",
+            "testMCPStdioProberDelegatesCodecAndResultMapping"
+        ]),
+        Suite(fileName: "ParityAutomationGateTests.swift", testNames: [
+            "testAutomationModelsLiveOutsideGeneralDomainModels",
+            "testWorkspaceModelDelegatesAutomationStateMutations",
+            "testWorkspaceSurfaceDelegatesAutomationsSurfaceBuilding"
+        ]),
+        Suite(fileName: "ParityWorkspaceRuntimeReviewGateTests.swift", testNames: [
+            "testNativeReviewPaneDelegatesFileHunkAndLineRendering",
+            "testWorkspaceSurfaceDelegatesRuntimeIssueBuilding",
+            "testWorkspaceSurfaceDelegatesRuntimeAndExecutionContextContracts",
+            "testWorkspaceViewDelegatesRuntimeIssueRecoveryPlanning"
+        ]),
+        Suite(fileName: "ParityWorkspaceCommandGateTests.swift", testNames: [
+            "testWorkspaceViewDelegatesCommandPlanning",
+            "testWorkspaceSurfaceDelegatesCommandSurfaceBuilding",
+            "testWorkspaceSurfaceDelegatesCommandPaletteContract"
+        ]),
+        Suite(fileName: "ParityWorkspaceSettingsSheetGateTests.swift", testNames: [
+            "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
+            "testNativeSettingsDelegatesFocusedViewsAndDraftState",
+            "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
+        ]),
+        Suite(fileName: "ParityWorkspaceTranscriptGateTests.swift", testNames: [
+            "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"
+        ]),
+        Suite(fileName: "ParityAgentGateTests.swift", testNames: [
+            "testAgentRunnerDelegatesFinalAnswerFormatting",
+            "testMockLLMClientLivesOutsideAgentRunnerFile",
+            "testAgentStreamingHelpersLiveOutsideAgentRunnerFile",
+            "testAgentToolStepRunnerLivesOutsideAgentRunnerFile"
+        ]),
+        Suite(fileName: "ParityTrustedRouterGateTests.swift", testNames: [
+            "testTrustedRouterActionParserLivesOutsideTransportClient",
+            "testTrustedRouterPromptBuilderLivesOutsideTransportClient",
+            "testTrustedRouterAPIKeyResolutionLivesInFocusedResolver",
+            "testTrustedRouterSafetyClientLivesOutsideActionTransportFile",
+            "testTrustedRouterChatParametersLiveOutsideTransportClients"
+        ]),
+        Suite(fileName: "ParitySafetyGateTests.swift", testNames: [
+            "testStaticSafetyPolicyLivesOutsideReviewerControlFlow"
+        ]),
+        Suite(fileName: "ParityCoreModelGateTests.swift", testNames: [
+            "testCoreToolModelsLiveOutsideGeneralDomainModels",
+            "testProjectModelsLiveOutsideGeneralDomainModels"
+        ])
+    ]
+
+    static var requiredFileNames: [String] {
+        [supportFileName] + suites.map(\.fileName)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -43,32 +43,7 @@ final class ParityGateTests: QuillCodeParityTestCase {
 
     func testParityGatesUseFocusedSuitesAndSharedSupport() throws {
         let root = Self.packageRoot().appendingPathComponent("Tests/QuillCodeParityTests")
-        let suiteFiles = [
-            "ParityTestSupport.swift",
-            "ParityToolGateTests.swift",
-            "ParityDesktopGateTests.swift",
-            "ParityTopBarGateTests.swift",
-            "ParitySlashGateTests.swift",
-            "ParityModelGateTests.swift",
-            "ParityWorkspaceSurfaceGateTests.swift",
-            "ParityWorkspaceModelGateTests.swift",
-            "ParityWorkspaceExecutionGateTests.swift",
-            "ParityWorkspaceProjectGateTests.swift",
-            "ParityWorkspaceMemoryGateTests.swift",
-            "ParityWorkspaceIntegrationGateTests.swift",
-            "ParityWorkspaceSidebarGateTests.swift",
-            "ParityMCPGateTests.swift",
-            "ParityAutomationGateTests.swift",
-            "ParityWorkspaceRuntimeReviewGateTests.swift",
-            "ParityWorkspaceCommandGateTests.swift",
-            "ParityWorkspaceSettingsSheetGateTests.swift",
-            "ParityWorkspaceTranscriptGateTests.swift",
-            "ParityAgentGateTests.swift",
-            "ParityTrustedRouterGateTests.swift",
-            "ParitySafetyGateTests.swift",
-            "ParityCoreModelGateTests.swift"
-        ]
-        for suiteFile in suiteFiles {
+        for suiteFile in ParityFocusedSuiteManifest.requiredFileNames {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(suiteFile).path), suiteFile)
         }
 
@@ -76,138 +51,11 @@ final class ParityGateTests: QuillCodeParityTestCase {
         let mainLines = Set(mainText.components(separatedBy: .newlines))
         XCTAssertFalse(mainLines.contains("    private static func packageRoot() -> URL {"), "Shared source-reading helpers should live in ParityTestSupport.")
 
-        let focusedSuiteTests: [(suiteName: String, testNames: [String])] = [
-            ("ParityToolGateTests", ["testToolArgumentJSONSerializationLivesInCore"]),
-            ("ParityDesktopGateTests", ["testDesktopDefinesNativeMenuBarWidget"]),
-            ("ParityTopBarGateTests", ["testTopBarViewsDelegateStatusPresentationSemantics"]),
-            ("ParitySlashGateTests", ["testSlashParserDelegatesPullRequestSubcommands"]),
-            ("ParityModelGateTests", ["testTrustedRouterModelCatalogLivesOutsideGeneralDomainModels"]),
-            ("ParityWorkspaceSurfaceGateTests", ["testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts"]),
-            ("ParityWorkspaceModelGateTests", [
-                "testWorkspaceModelDelegatesToolCardSurfaceTypes",
-                "testWorkspaceModelDelegatesProjectContextRefresh",
-                "testWorkspaceModelDelegatesThreadSeedBuilding",
-                "testWorkspaceModelDelegatesThreadCreationRecords",
-                "testWorkspaceModelDelegatesThreadLifecycleTransitions",
-                "testWorkspaceModelDelegatesConfigurationTransitions",
-                "testWorkspaceConfigurationIntegrationTestsOwnModelConfigurationFlows",
-                "testWorkspaceModelDelegatesRetryPlanning",
-                "testWorkspaceActivityIntegrationTestsOwnModelActivityFlows",
-                "testWorkspaceActivitySurfaceUsesFocusedBuilderAndSectionTypes",
-                "testWorkspaceToolCardIntegrationTestsOwnModelToolCardFlows",
-                "testWorkspaceModelTestsRemainRetired",
-                "testFocusedWorkspaceUnitSuitesUseSharedTemporaryDirectorySupport",
-                "testWorkspaceModelDelegatesStatusTextAndLabels",
-                "testWorkspaceModelDelegatesContextResolving",
-                "testWorkspaceModelDelegatesAgentProgressStatusCopy",
-                "testWorkspaceModelDelegatesThreadNoticeMutation",
-                "testWorkspaceModelUsesExplicitAgentRunThreadUpdates"
-            ]),
-            ("ParityWorkspaceExecutionGateTests", [
-                "testWorkspaceModelDelegatesComposerCancellationPlanning",
-                "testWorkspaceModelDelegatesComposerSubmissionPlanning",
-                "testWorkspaceModelDelegatesAgentSendSessionExecution",
-                "testWorkspaceModelDelegatesSlashCommandTranscriptPlanning",
-                "testWorkspaceModelDelegatesCommandActionPlanning",
-                "testWorkspaceModelDelegatesCommandPlanExecution",
-                "testWorkspaceModelDelegatesAgentRunContextAssembly",
-                "testWorkspaceModelDelegatesAgentSendSession",
-                "testWorkspaceModelDelegatesToolEventRecording",
-                "testWorkspaceModelDelegatesToolCallExecutionRouting",
-                "testWorkspaceModelDelegatesShellToolCallPlanning",
-                "testWorkspaceComposerIntegrationTestsOwnModelComposerFlows",
-                "testWorkspaceModelDelegatesSlashCommandDispatchPlanning",
-                "testWorkspaceModelDelegatesToolExecutionOverrideCombining"
-            ]),
-            ("ParityWorkspaceProjectGateTests", [
-                "testWorkspaceModelDelegatesProjectMetadataLoading",
-                "testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage",
-                "testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows",
-                "testWorkspaceProjectIntegrationTestsOwnModelProjectFlows",
-                "testWorkspaceRemoteProjectIntegrationTestsOwnModelRemoteProjectFlows",
-                "testWorkspacePullRequestIntegrationTestsOwnModelPullRequestFlows",
-                "testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows",
-                "testWorkspaceModelDelegatesWorktreeOpenRecords"
-            ]),
-            ("ParityWorkspaceMemoryGateTests", [
-                "testWorkspaceModelDelegatesMemoryCommandOrchestration",
-                "testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows"
-            ]),
-            ("ParityWorkspaceIntegrationGateTests", [
-                "testWorkspaceMCPIntegrationTestsOwnModelMCPFlows",
-                "testWorkspaceReviewIntegrationTestsOwnModelReviewFlows",
-                "testFocusedFeedbackAndArtifactTestsOwnSurfaceSpecificFlows",
-                "testWorkspaceRuntimeIssueIntegrationTestsOwnModelRuntimeIssueFlows",
-                "testWorkspaceThreadLifecycleIntegrationTestsOwnModelLifecycleFlows",
-                "testWorkspaceSlashCommandIntegrationTestsOwnCoreSlashFlows",
-                "testWorkspaceLocalEnvironmentIntegrationTestsOwnModelLocalEnvironmentFlows",
-                "testWorkspaceAutomationIntegrationTestsOwnModelAutomationFlows",
-                "testWorkspaceTerminalIntegrationTestsOwnModelTerminalFlows",
-                "testWorkspaceModelTestsDoNotOwnRuntimeFactoryCoverage"
-            ]),
-            ("ParityWorkspaceSidebarGateTests", [
-                "testWorkspaceModelDelegatesSidebarSelectionTransitions",
-                "testSidebarRowActionsUseSharedPlannerAndExecutor",
-                "testSidebarCommandPresentationIsSharedByNativeAndHTMLSurfaces",
-                "testNativeSidebarDelegatesProjectListRendering",
-                "testWorkspaceSurfaceDelegatesSidebarSurfaceContracts",
-                "testWorkspaceSurfaceDelegatesNavigationSurfaceBuilding"
-            ]),
-            ("ParityMCPGateTests", [
-                "testWorkspaceModelDelegatesMCPSupportTypes",
-                "testMCPStdioProberDelegatesCodecAndResultMapping"
-            ]),
-            ("ParityAutomationGateTests", [
-                "testAutomationModelsLiveOutsideGeneralDomainModels",
-                "testWorkspaceModelDelegatesAutomationStateMutations",
-                "testWorkspaceSurfaceDelegatesAutomationsSurfaceBuilding"
-            ]),
-            ("ParityWorkspaceRuntimeReviewGateTests", [
-                "testNativeReviewPaneDelegatesFileHunkAndLineRendering",
-                "testWorkspaceSurfaceDelegatesRuntimeIssueBuilding",
-                "testWorkspaceSurfaceDelegatesRuntimeAndExecutionContextContracts",
-                "testWorkspaceViewDelegatesRuntimeIssueRecoveryPlanning"
-            ]),
-            ("ParityWorkspaceCommandGateTests", [
-                "testWorkspaceViewDelegatesCommandPlanning",
-                "testWorkspaceSurfaceDelegatesCommandSurfaceBuilding",
-                "testWorkspaceSurfaceDelegatesCommandPaletteContract"
-            ]),
-            ("ParityWorkspaceSettingsSheetGateTests", [
-                "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
-                "testNativeSettingsDelegatesFocusedViewsAndDraftState",
-                "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
-            ]),
-            ("ParityWorkspaceTranscriptGateTests", [
-                "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"
-            ]),
-            ("ParityAgentGateTests", [
-                "testAgentRunnerDelegatesFinalAnswerFormatting",
-                "testMockLLMClientLivesOutsideAgentRunnerFile",
-                "testAgentStreamingHelpersLiveOutsideAgentRunnerFile",
-                "testAgentToolStepRunnerLivesOutsideAgentRunnerFile"
-            ]),
-            ("ParityTrustedRouterGateTests", [
-                "testTrustedRouterActionParserLivesOutsideTransportClient",
-                "testTrustedRouterPromptBuilderLivesOutsideTransportClient",
-                "testTrustedRouterAPIKeyResolutionLivesInFocusedResolver",
-                "testTrustedRouterSafetyClientLivesOutsideActionTransportFile",
-                "testTrustedRouterChatParametersLiveOutsideTransportClients"
-            ]),
-            ("ParitySafetyGateTests", [
-                "testStaticSafetyPolicyLivesOutsideReviewerControlFlow"
-            ]),
-            ("ParityCoreModelGateTests", [
-                "testCoreToolModelsLiveOutsideGeneralDomainModels",
-                "testProjectModelsLiveOutsideGeneralDomainModels"
-            ])
-        ]
-
-        for (suiteName, testNames) in focusedSuiteTests {
-            for testName in testNames {
+        for suite in ParityFocusedSuiteManifest.suites {
+            for testName in suite.testNames {
                 XCTAssertFalse(
                     mainLines.contains("    func \(testName)() throws {"),
-                    "\(testName) should live in \(suiteName)."
+                    "\(testName) should live in \(suite.fileName)."
                 )
             }
         }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5092,3 +5092,22 @@ Current strict grades:
 
 Remaining risk:
 - The focused-suite registry table is still hand-maintained. If it grows much further, move it into a data helper or manifest so the global gate stays declarative.
+
+## 2026-06-24 Focused Suite Manifest Split
+
+Overall grade after this slice: **A+ global parity gate, A focused-suite registry ownership, A merge-train friendliness**.
+
+The broad parity gate had been reduced to global hygiene and drift checks, but it still carried the full focused-suite registry inline. That made a small global test file visually noisy and kept creating conflict pressure whenever agents split another parity check into a focused suite.
+
+What changed:
+- Added `ParityFocusedSuiteManifest` as the single owner for focused parity suite file names and migrated test-name ownership checks.
+- Reduced `ParityGateTests.swift` to four global checks: platform conditionals, production force operations, required docs, and focused-suite registration.
+- Kept behavior identical while making future focused-suite additions a data-only change in one helper.
+
+Current strict grades:
+- `ParityGateTests.swift`: **A+**. It is now a true global hygiene gate with no embedded feature registry table.
+- `ParityFocusedSuiteManifest.swift`: **A**. It owns one explicit data contract and keeps feature-suite drift checks discoverable.
+- Parity gate architecture: **A+**. Feature ownership now lives in focused suites, with one manifest enforcing registration and no broad catch-all assertions.
+
+Remaining risk:
+- If the manifest grows beyond simple file/test ownership, split it into typed feature groups or generate it from a declarative test manifest. For now, keeping it as Swift data gives compile-time checks and low ceremony.


### PR DESCRIPTION
## Summary
- move the focused parity suite registry into ParityFocusedSuiteManifest
- reduce ParityGateTests to global hygiene/docs/registration checks
- record the A+ parity-gate audit slice

## Validation
- swift test --filter 'ParityGateTests/testParityGatesUseFocusedSuitesAndSharedSupport'
- swift test