### PR TITLE
Refine parity focused suite manifest

### DIFF
--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -1,39 +1,32 @@
-enum ParityFocusedSuiteRegistry {
-    static let requiredTestFiles = [
-        "ParityTestSupport.swift",
-        "ParityFocusedSuiteRegistry.swift",
-        "ParityToolGateTests.swift",
-        "ParityDesktopGateTests.swift",
-        "ParityTopBarGateTests.swift",
-        "ParitySlashGateTests.swift",
-        "ParityModelGateTests.swift",
-        "ParityWorkspaceSurfaceGateTests.swift",
-        "ParityWorkspaceModelGateTests.swift",
-        "ParityWorkspaceExecutionGateTests.swift",
-        "ParityWorkspaceProjectGateTests.swift",
-        "ParityWorkspaceMemoryGateTests.swift",
-        "ParityWorkspaceIntegrationGateTests.swift",
-        "ParityWorkspaceSidebarGateTests.swift",
-        "ParityMCPGateTests.swift",
-        "ParityAutomationGateTests.swift",
-        "ParityWorkspaceRuntimeReviewGateTests.swift",
-        "ParityWorkspaceCommandGateTests.swift",
-        "ParityWorkspaceSettingsSheetGateTests.swift",
-        "ParityWorkspaceTranscriptGateTests.swift",
-        "ParityAgentGateTests.swift",
-        "ParityTrustedRouterGateTests.swift",
-        "ParitySafetyGateTests.swift",
-        "ParityCoreModelGateTests.swift"
-    ]
+struct ParityFocusedSuiteManifest {
+    struct Suite {
+        let fileName: String
+        let testNames: [String]
+    }
 
-    static let focusedSuiteTests: [(suiteName: String, testNames: [String])] = [
-        ("ParityToolGateTests", ["testToolArgumentJSONSerializationLivesInCore"]),
-        ("ParityDesktopGateTests", ["testDesktopDefinesNativeMenuBarWidget"]),
-        ("ParityTopBarGateTests", ["testTopBarViewsDelegateStatusPresentationSemantics"]),
-        ("ParitySlashGateTests", ["testSlashParserDelegatesPullRequestSubcommands"]),
-        ("ParityModelGateTests", ["testTrustedRouterModelCatalogLivesOutsideGeneralDomainModels"]),
-        ("ParityWorkspaceSurfaceGateTests", ["testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts"]),
-        ("ParityWorkspaceModelGateTests", [
+    static let supportFileName = "ParityTestSupport.swift"
+    static let manifestFileName = "ParityFocusedSuiteManifest.swift"
+
+    static let suites: [Suite] = [
+        Suite(fileName: "ParityToolGateTests.swift", testNames: [
+            "testToolArgumentJSONSerializationLivesInCore"
+        ]),
+        Suite(fileName: "ParityDesktopGateTests.swift", testNames: [
+            "testDesktopDefinesNativeMenuBarWidget"
+        ]),
+        Suite(fileName: "ParityTopBarGateTests.swift", testNames: [
+            "testTopBarViewsDelegateStatusPresentationSemantics"
+        ]),
+        Suite(fileName: "ParitySlashGateTests.swift", testNames: [
+            "testSlashParserDelegatesPullRequestSubcommands"
+        ]),
+        Suite(fileName: "ParityModelGateTests.swift", testNames: [
+            "testTrustedRouterModelCatalogLivesOutsideGeneralDomainModels"
+        ]),
+        Suite(fileName: "ParityWorkspaceSurfaceGateTests.swift", testNames: [
+            "testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts"
+        ]),
+        Suite(fileName: "ParityWorkspaceModelGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesToolCardSurfaceTypes",
             "testWorkspaceModelDelegatesProjectContextRefresh",
             "testWorkspaceModelDelegatesThreadSeedBuilding",
@@ -53,7 +46,7 @@ enum ParityFocusedSuiteRegistry {
             "testWorkspaceModelDelegatesThreadNoticeMutation",
             "testWorkspaceModelUsesExplicitAgentRunThreadUpdates"
         ]),
-        ("ParityWorkspaceExecutionGateTests", [
+        Suite(fileName: "ParityWorkspaceExecutionGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesComposerCancellationPlanning",
             "testWorkspaceModelDelegatesComposerSubmissionPlanning",
             "testWorkspaceModelDelegatesAgentSendSessionExecution",
@@ -69,7 +62,7 @@ enum ParityFocusedSuiteRegistry {
             "testWorkspaceModelDelegatesSlashCommandDispatchPlanning",
             "testWorkspaceModelDelegatesToolExecutionOverrideCombining"
         ]),
-        ("ParityWorkspaceProjectGateTests", [
+        Suite(fileName: "ParityWorkspaceProjectGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesProjectMetadataLoading",
             "testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage",
             "testWorkspaceProjectExtensionIntegrationTestsOwnModelExtensionFlows",
@@ -79,11 +72,11 @@ enum ParityFocusedSuiteRegistry {
             "testWorkspaceWorktreeIntegrationTestsOwnModelWorktreeFlows",
             "testWorkspaceModelDelegatesWorktreeOpenRecords"
         ]),
-        ("ParityWorkspaceMemoryGateTests", [
+        Suite(fileName: "ParityWorkspaceMemoryGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesMemoryCommandOrchestration",
             "testWorkspaceMemoryIntegrationTestsOwnModelMemoryFlows"
         ]),
-        ("ParityWorkspaceIntegrationGateTests", [
+        Suite(fileName: "ParityWorkspaceIntegrationGateTests.swift", testNames: [
             "testWorkspaceMCPIntegrationTestsOwnModelMCPFlows",
             "testWorkspaceReviewIntegrationTestsOwnModelReviewFlows",
             "testFocusedFeedbackAndArtifactTestsOwnSurfaceSpecificFlows",
@@ -95,7 +88,7 @@ enum ParityFocusedSuiteRegistry {
             "testWorkspaceTerminalIntegrationTestsOwnModelTerminalFlows",
             "testWorkspaceModelTestsDoNotOwnRuntimeFactoryCoverage"
         ]),
-        ("ParityWorkspaceSidebarGateTests", [
+        Suite(fileName: "ParityWorkspaceSidebarGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesSidebarSelectionTransitions",
             "testSidebarRowActionsUseSharedPlannerAndExecutor",
             "testSidebarCommandPresentationIsSharedByNativeAndHTMLSurfaces",
@@ -103,53 +96,57 @@ enum ParityFocusedSuiteRegistry {
             "testWorkspaceSurfaceDelegatesSidebarSurfaceContracts",
             "testWorkspaceSurfaceDelegatesNavigationSurfaceBuilding"
         ]),
-        ("ParityMCPGateTests", [
+        Suite(fileName: "ParityMCPGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesMCPSupportTypes",
             "testMCPStdioProberDelegatesCodecAndResultMapping"
         ]),
-        ("ParityAutomationGateTests", [
+        Suite(fileName: "ParityAutomationGateTests.swift", testNames: [
             "testAutomationModelsLiveOutsideGeneralDomainModels",
             "testWorkspaceModelDelegatesAutomationStateMutations",
             "testWorkspaceSurfaceDelegatesAutomationsSurfaceBuilding"
         ]),
-        ("ParityWorkspaceRuntimeReviewGateTests", [
+        Suite(fileName: "ParityWorkspaceRuntimeReviewGateTests.swift", testNames: [
             "testNativeReviewPaneDelegatesFileHunkAndLineRendering",
             "testWorkspaceSurfaceDelegatesRuntimeIssueBuilding",
             "testWorkspaceSurfaceDelegatesRuntimeAndExecutionContextContracts",
             "testWorkspaceViewDelegatesRuntimeIssueRecoveryPlanning"
         ]),
-        ("ParityWorkspaceCommandGateTests", [
+        Suite(fileName: "ParityWorkspaceCommandGateTests.swift", testNames: [
             "testWorkspaceViewDelegatesCommandPlanning",
             "testWorkspaceSurfaceDelegatesCommandSurfaceBuilding",
             "testWorkspaceSurfaceDelegatesCommandPaletteContract"
         ]),
-        ("ParityWorkspaceSettingsSheetGateTests", [
+        Suite(fileName: "ParityWorkspaceSettingsSheetGateTests.swift", testNames: [
             "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
             "testNativeSettingsDelegatesFocusedViewsAndDraftState",
             "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
         ]),
-        ("ParityWorkspaceTranscriptGateTests", [
+        Suite(fileName: "ParityWorkspaceTranscriptGateTests.swift", testNames: [
             "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"
         ]),
-        ("ParityAgentGateTests", [
+        Suite(fileName: "ParityAgentGateTests.swift", testNames: [
             "testAgentRunnerDelegatesFinalAnswerFormatting",
             "testMockLLMClientLivesOutsideAgentRunnerFile",
             "testAgentStreamingHelpersLiveOutsideAgentRunnerFile",
             "testAgentToolStepRunnerLivesOutsideAgentRunnerFile"
         ]),
-        ("ParityTrustedRouterGateTests", [
+        Suite(fileName: "ParityTrustedRouterGateTests.swift", testNames: [
             "testTrustedRouterActionParserLivesOutsideTransportClient",
             "testTrustedRouterPromptBuilderLivesOutsideTransportClient",
             "testTrustedRouterAPIKeyResolutionLivesInFocusedResolver",
             "testTrustedRouterSafetyClientLivesOutsideActionTransportFile",
             "testTrustedRouterChatParametersLiveOutsideTransportClients"
         ]),
-        ("ParitySafetyGateTests", [
+        Suite(fileName: "ParitySafetyGateTests.swift", testNames: [
             "testStaticSafetyPolicyLivesOutsideReviewerControlFlow"
         ]),
-        ("ParityCoreModelGateTests", [
+        Suite(fileName: "ParityCoreModelGateTests.swift", testNames: [
             "testCoreToolModelsLiveOutsideGeneralDomainModels",
             "testProjectModelsLiveOutsideGeneralDomainModels"
         ])
     ]
+
+    static var requiredFileNames: [String] {
+        [supportFileName, manifestFileName] + suites.map(\.fileName)
+    }
 }

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -43,21 +43,21 @@ final class ParityGateTests: QuillCodeParityTestCase {
 
     func testParityGatesUseFocusedSuitesAndSharedSupport() throws {
         let root = Self.packageRoot().appendingPathComponent("Tests/QuillCodeParityTests")
-        for testFile in ParityFocusedSuiteRegistry.requiredTestFiles {
+        for testFile in ParityFocusedSuiteManifest.requiredFileNames {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(testFile).path), testFile)
         }
 
         let mainText = try String(contentsOf: root.appendingPathComponent("ParityGateTests.swift"), encoding: .utf8)
         let mainLines = Set(mainText.components(separatedBy: .newlines))
         XCTAssertFalse(mainLines.contains("    private static func packageRoot() -> URL {"), "Shared source-reading helpers should live in ParityTestSupport.")
-        let inlineRegistryNeedle = "static " + "let " + "focusedSuiteTests"
-        XCTAssertFalse(mainText.contains(inlineRegistryNeedle), "Focused-suite registry data should live in ParityFocusedSuiteRegistry.")
+        let inlineRegistryNeedle = "static " + "let " + "suites"
+        XCTAssertFalse(mainText.contains(inlineRegistryNeedle), "Focused-suite manifest data should live in ParityFocusedSuiteManifest.")
 
-        for (suiteName, testNames) in ParityFocusedSuiteRegistry.focusedSuiteTests {
-            for testName in testNames {
+        for suite in ParityFocusedSuiteManifest.suites {
+            for testName in suite.testNames {
                 XCTAssertFalse(
                     mainLines.contains("    func \(testName)() throws {"),
-                    "\(testName) should live in \(suiteName)."
+                    "\(testName) should live in \(suite.fileName)."
                 )
             }
         }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5110,3 +5110,21 @@ Current strict grades:
 
 Remaining risk:
 - If the registry grows substantially again, the next step is a generated or declarative manifest file; for now a typed Swift helper is simple and keeps CI fast.
+
+## 2026-06-24 Typed Focused Suite Manifest
+
+Overall grade after this slice: **A+ manifest clarity, A+ Swift ergonomics, A global gate readability**.
+
+The focused-suite helper removed the broad registry from `ParityGateTests`, but its tuple-shaped API still exposed file and test names as loosely related values. A tiny typed manifest makes the contract clearer: each focused parity suite has one file name and the tests it owns.
+
+What changed:
+- Replaced `ParityFocusedSuiteRegistry` with `ParityFocusedSuiteManifest`.
+- Added a `Suite` value type so each parity suite's file name and test ownership stay together.
+- Updated the global parity gate to iterate typed suite records while keeping required support and manifest files explicit.
+
+Current strict grades:
+- `ParityFocusedSuiteManifest.swift`: **A+**. It is structured, readable Swift data with one responsibility.
+- `ParityGateTests.swift`: **A+**. It stays compact and reads as global hygiene plus manifest enforcement.
+
+Remaining risk:
+- The manifest is still maintained by hand, which is acceptable at this size. If parity suites continue to grow rapidly, move to a generated manifest with a validation script.


### PR DESCRIPTION
## Summary
- replace the tuple-based parity focused suite registry with a typed `ParityFocusedSuiteManifest.Suite` value
- keep required support/manifest file names explicit
- keep `ParityGateTests` compact and focused on global hygiene plus manifest enforcement

## Validation
- swift test --filter ParityGateTests
- swift test