### PR TITLE
Move browser surface tests to browser suite

### DIFF
--- a/Tests/QuillCodeAppTests/WorkspaceBrowserIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceBrowserIntegrationTests.swift
@@ -20,6 +20,36 @@ private struct FakeBrowserLiveDOMCapturer: BrowserLiveDOMCapturing {
 
 @MainActor
 final class WorkspaceBrowserIntegrationTests: XCTestCase {
+    func testBrowserSurfaceIncludesPreviewState() throws {
+        let root = try makeTempDirectory()
+        let model = QuillCodeWorkspaceModel()
+        model.toggleBrowser()
+        XCTAssertTrue(model.openBrowserPreview("example.com", workspaceRoot: root))
+        XCTAssertTrue(model.addBrowserComment("Looks aligned"))
+
+        let surface = model.surface()
+
+        XCTAssertTrue(surface.browser.isVisible)
+        XCTAssertEqual(surface.browser.currentURL, "https://example.com")
+        XCTAssertEqual(surface.browser.title, "example.com")
+        XCTAssertEqual(surface.browser.statusLabel, "Comment added")
+        XCTAssertEqual(surface.browser.snapshot?.sourceLabel, "Web page")
+        XCTAssertEqual(surface.browser.snapshot?.inspectionDepth, .metadataOnly)
+        XCTAssertEqual(surface.browser.snapshot?.inspectionDepthLabel, "Metadata only")
+        XCTAssertEqual(
+            surface.browser.snapshot?.summary,
+            "Live DOM capture is not attached yet; QuillCode has URL metadata for this web page."
+        )
+        XCTAssertEqual(surface.browser.snapshot?.details, [
+            "Host: example.com",
+            "Scheme: HTTPS",
+            "Path: /"
+        ])
+        XCTAssertEqual(surface.browser.comments.first?.text, "Looks aligned")
+        XCTAssertTrue(surface.browser.canOpen)
+        XCTAssertTrue(surface.commands.contains { $0.id == "toggle-browser" && $0.title == "Browser" })
+    }
+
     func testBrowserPreviewNormalizesURLsAndStoresComments() throws {
         let root = try makeTempDirectory()
         let previewFile = root.appendingPathComponent("preview.html")
@@ -318,6 +348,33 @@ final class WorkspaceBrowserIntegrationTests: XCTestCase {
         XCTAssertEqual(model.currentToolCards.last?.status, .done)
         XCTAssertTrue(thread.messages.last?.content.contains("Opened `Agent Opened Page`") == true)
         XCTAssertTrue(thread.messages.last?.content.contains("H1: Opened By Agent") == true)
+    }
+
+    func testHTMLRendererIncludesVisibleBrowserPane() throws {
+        let model = QuillCodeWorkspaceModel()
+        model.toggleBrowser()
+        XCTAssertTrue(model.openBrowserPreview("localhost:5173"))
+        XCTAssertTrue(model.addBrowserComment("Inspect responsive state"))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="browser-pane""#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-back" disabled"#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-forward" disabled"#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-reload" "#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-current-url""#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-snapshot""#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-source""#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-inspection-depth""#))
+        XCTAssertTrue(html.contains(#"data-depth="metadata_only""#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-snapshot-outline""#))
+        XCTAssertTrue(html.contains("Page: localhost"))
+        XCTAssertTrue(html.contains("Local web app"))
+        XCTAssertTrue(html.contains("Metadata only"))
+        XCTAssertTrue(html.contains("http://localhost:5173"))
+        XCTAssertTrue(html.contains(#"data-testid="browser-comment""#))
+        XCTAssertTrue(html.contains("Inspect responsive state"))
     }
 
 }

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -771,36 +771,6 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertEqual(command?.isEnabled, true)
     }
 
-    func testSurfaceIncludesBrowserPreviewState() throws {
-        let root = try makeTempDirectory()
-        let model = QuillCodeWorkspaceModel()
-        model.toggleBrowser()
-        XCTAssertTrue(model.openBrowserPreview("example.com", workspaceRoot: root))
-        XCTAssertTrue(model.addBrowserComment("Looks aligned"))
-
-        let surface = model.surface()
-
-        XCTAssertTrue(surface.browser.isVisible)
-        XCTAssertEqual(surface.browser.currentURL, "https://example.com")
-        XCTAssertEqual(surface.browser.title, "example.com")
-        XCTAssertEqual(surface.browser.statusLabel, "Comment added")
-        XCTAssertEqual(surface.browser.snapshot?.sourceLabel, "Web page")
-        XCTAssertEqual(surface.browser.snapshot?.inspectionDepth, .metadataOnly)
-        XCTAssertEqual(surface.browser.snapshot?.inspectionDepthLabel, "Metadata only")
-        XCTAssertEqual(
-            surface.browser.snapshot?.summary,
-            "Live DOM capture is not attached yet; QuillCode has URL metadata for this web page."
-        )
-        XCTAssertEqual(surface.browser.snapshot?.details, [
-            "Host: example.com",
-            "Scheme: HTTPS",
-            "Path: /"
-        ])
-        XCTAssertEqual(surface.browser.comments.first?.text, "Looks aligned")
-        XCTAssertTrue(surface.browser.canOpen)
-        XCTAssertTrue(surface.commands.contains { $0.id == "toggle-browser" && $0.title == "Browser" })
-    }
-
     func testEmptySurfaceShowsCodexLikeEmptyState() {
         let surface = QuillCodeWorkspaceModel().surface()
 
@@ -1009,33 +979,6 @@ final class WorkspaceSurfaceTests: XCTestCase {
         ))
 
         XCTAssertFalse(model.surface().review.isVisible)
-    }
-
-    func testHTMLRendererIncludesVisibleBrowserPane() throws {
-        let model = QuillCodeWorkspaceModel()
-        model.toggleBrowser()
-        XCTAssertTrue(model.openBrowserPreview("localhost:5173"))
-        XCTAssertTrue(model.addBrowserComment("Inspect responsive state"))
-
-        let html = WorkspaceHTMLRenderer.render(model.surface())
-
-        XCTAssertTrue(html.contains(#"data-testid="browser-pane""#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-preview""#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-back" disabled"#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-forward" disabled"#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-reload" "#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-current-url""#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-snapshot""#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-source""#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-inspection-depth""#))
-        XCTAssertTrue(html.contains(#"data-depth="metadata_only""#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-snapshot-outline""#))
-        XCTAssertTrue(html.contains("Page: localhost"))
-        XCTAssertTrue(html.contains("Local web app"))
-        XCTAssertTrue(html.contains("Metadata only"))
-        XCTAssertTrue(html.contains("http://localhost:5173"))
-        XCTAssertTrue(html.contains(#"data-testid="browser-comment""#))
-        XCTAssertTrue(html.contains("Inspect responsive state"))
     }
 
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5147,3 +5147,21 @@ Current strict grades:
 
 Remaining risk:
 - Continue splitting `WorkspaceSurfaceTests.swift` by feature family. Good next slices are browser/HTML preview ownership and settings/runtime issue surface ownership.
+
+## 2026-06-24 Browser Surface Test Ownership Split
+
+Overall grade after this slice: **A browser surface ownership, A HTML browser harness ownership, B+ broad workspace surface smoke**.
+
+Browser parity now includes URL normalization, local/web snapshots, comments, live-DOM snapshot fallbacks, agent browser tools, native surface state, and static HTML rendering. Two browser surface assertions still lived in `WorkspaceSurfaceTests.swift`, which made browser regressions look like generic workspace smoke failures.
+
+What changed:
+- Moved browser preview surface-state coverage into `WorkspaceBrowserIntegrationTests`.
+- Moved static HTML browser-pane renderer coverage into `WorkspaceBrowserIntegrationTests`.
+- Reduced `WorkspaceSurfaceTests.swift` below 1,000 lines while preserving the same assertions.
+
+Current strict grades:
+- `WorkspaceBrowserIntegrationTests.swift`: **A**. It owns browser workflow, agent browser tools, surface projection, and HTML harness checks in one cohesive browser parity suite.
+- `WorkspaceSurfaceTests.swift`: **B+**. It is now smaller broad smoke coverage, but still owns several unrelated surface families including settings, runtime issue decoding, memory, extensions/MCP, review, command palette, and sidebar search.
+
+Remaining risk:
+- Continue splitting `WorkspaceSurfaceTests.swift` by feature family. Good next slices are settings/runtime surface ownership and review surface ownership.


### PR DESCRIPTION
## Summary
- Move browser surface projection coverage from `WorkspaceSurfaceTests` into `WorkspaceBrowserIntegrationTests`
- Move static HTML browser-pane rendering coverage into the browser suite
- Record the strict ownership grades and remaining risks in `docs/CODE_QUALITY_AUDIT.md`

## Validation
- `swift test --filter 'WorkspaceBrowserIntegrationTests|WorkspaceSurfaceTests'`\n- `swift test` (1066 tests)\n- `git diff --check`