### PR TITLE
Split browser Playwright flows

### DIFF
--- a/E2E/playwright/tests/browser.spec.ts
+++ b/E2E/playwright/tests/browser.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test';
+import { clickSidebarTool, harnessURL } from './harness-helpers';
+
+test('mock harness opens browser preview and records comments', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await clickSidebarTool(page, 'command-palette-button');
+  await page.getByLabel('Search commands').fill('>browser');
+  await page.getByTestId('command-palette-result').first().click();
+
+  await expect(page.getByTestId('browser-pane')).toBeVisible();
+  await expect(page.getByTestId('browser-empty')).toBeVisible();
+  await expect(page.getByTestId('browser-session')).toBeDisabled();
+
+  await page.getByLabel('Browser address').fill('localhost:5173');
+  await expect(page.getByTestId('browser-open')).toBeEnabled();
+  await expect(page.getByTestId('browser-session')).toBeEnabled();
+  await page.getByTestId('browser-session').click();
+
+  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
+  await expect(page.getByTestId('browser-status-label')).toHaveText('Session open');
+  await expect(page.getByTestId('browser-session-status')).toContainText('Visible session 1:');
+  await expect(page.getByTestId('browser-session-url')).toHaveText('http://localhost:5173');
+
+  await page.getByTestId('browser-open').click();
+
+  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
+  await expect(page.getByTestId('browser-status-label')).toHaveText('Preview ready');
+  await expect(page.getByTestId('browser-back')).toBeDisabled();
+  await expect(page.getByTestId('browser-forward')).toBeDisabled();
+  await expect(page.getByTestId('browser-reload')).toBeEnabled();
+  await expect(page.getByTestId('browser-source')).toHaveText('Local web app');
+  await expect(page.getByTestId('browser-inspection-depth')).toHaveText('Network HTML snapshot');
+  await expect(page.getByTestId('browser-inspection-depth')).toHaveAttribute('data-depth', 'network_html_snapshot');
+  await expect(page.getByTestId('browser-snapshot-summary')).toHaveText(
+    'Fetched a network HTML snapshot for this local page.'
+  );
+  await expect(page.getByTestId('browser-snapshot-detail')).toContainText([
+    'Host: localhost',
+    'Scheme: HTTP',
+    'Path: /',
+    'HTTP: 200',
+    'Title: Vite Preview',
+    'Heading: QuillCode Browser Preview'
+  ]);
+  await expect(page.getByTestId('browser-snapshot-outline-item')).toContainText([
+    'H1: QuillCode Browser Preview',
+    'Link: Dashboard -> /dashboard',
+    'Button: Launch',
+    'Input: Search workspace'
+  ]);
+  const outlineStyle = await page.getByTestId('browser-snapshot-outline-item').first().evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      borderRadius: style.borderRadius
+    };
+  });
+  expect(outlineStyle.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+  expect(outlineStyle.borderRadius).toBe('0px');
+
+  await page.getByLabel('Browser address').fill('example.com/docs');
+  await page.getByTestId('browser-open').click();
+  await expect(page.getByTestId('browser-current-url')).toHaveText('https://example.com/docs');
+  await expect(page.getByTestId('browser-back')).toBeEnabled();
+  await expect(page.getByTestId('browser-forward')).toBeDisabled();
+
+  await page.getByLabel('Browser address').fill('localhost:5173/dashboard');
+  await clickSidebarTool(page, 'command-palette-button');
+  await page.getByLabel('Search commands').fill('>session');
+  await page.locator('[data-testid="command-palette-result"][data-command-id="open-browser-session"]').click();
+  await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
+  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173/dashboard');
+  await expect(page.getByTestId('browser-status-label')).toHaveText('Session open');
+  await expect(page.getByTestId('browser-session-status')).toContainText('Visible session 2:');
+  await expect(page.getByTestId('browser-session-url')).toHaveText('http://localhost:5173/dashboard');
+
+  await page.getByTestId('browser-back').click();
+  await expect(page.getByTestId('browser-current-url')).toHaveText('https://example.com/docs');
+  await page.getByTestId('browser-back').click();
+  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
+  await expect(page.getByTestId('browser-back')).toBeDisabled();
+  await expect(page.getByTestId('browser-forward')).toBeEnabled();
+
+  await page.getByTestId('browser-forward').click();
+  await expect(page.getByTestId('browser-current-url')).toHaveText('https://example.com/docs');
+  await page.getByTestId('browser-reload').click();
+  await expect(page.getByTestId('browser-status-label')).toHaveText('Reloaded');
+
+  await page.getByLabel('Browser comment').fill('Check hero spacing');
+  await expect(page.getByTestId('browser-add-comment')).toBeEnabled();
+  await page.getByTestId('browser-add-comment').click();
+
+  await expect(page.getByTestId('browser-comment')).toContainText('Check hero spacing');
+  await expect(page.getByTestId('browser-status-label')).toHaveText('Comment added');
+});
+
+test('mock harness opens browser preview from chat', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('open localhost:5173 in the browser');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.browser.open');
+  await expect(page.getByTestId('tool-card-input').last()).toContainText('localhost:5173');
+  await expect(page.getByText('Opened `Vite Preview` at http://localhost:5173.')).toBeVisible();
+  await expect(page.getByTestId('browser-pane')).toBeVisible();
+  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
+  await expect(page.getByTestId('browser-inspection-depth')).toHaveText('Network HTML snapshot');
+});

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
+import { clickSidebarTool, openSidebarTools } from './harness-helpers';
 
 async function clickProjectAction(row: Locator, name: string) {
   await row.getByLabel(/^Actions for project /).click();
@@ -8,16 +9,6 @@ async function clickProjectAction(row: Locator, name: string) {
 async function openTopBarOverflow(page: Page) {
   await page.getByTestId('top-bar-overflow-button').click();
   await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');
-}
-
-async function openSidebarTools(page: Page) {
-  await page.getByTestId('sidebar-tools-button').click();
-  await expect(page.getByTestId('sidebar-tools-menu')).toHaveAttribute('open', '');
-}
-
-async function clickSidebarTool(page: Page, testID: string) {
-  await openSidebarTools(page);
-  await page.getByTestId(testID).click();
 }
 
 async function openSettings(page: Page) {
@@ -1661,114 +1652,6 @@ test('mock harness runs a command in the integrated terminal', async ({ page }) 
   await expect(page.getByTestId('terminal-entry')).toHaveCount(0);
   await expect(page.getByTestId('terminal-empty')).toBeVisible();
   await expect(page.getByTestId('terminal-clear')).toBeDisabled();
-});
-
-test('mock harness opens browser preview and records comments', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await clickSidebarTool(page, 'command-palette-button');
-  await page.getByLabel('Search commands').fill('>browser');
-  await page.getByTestId('command-palette-result').first().click();
-
-  await expect(page.getByTestId('browser-pane')).toBeVisible();
-  await expect(page.getByTestId('browser-empty')).toBeVisible();
-  await expect(page.getByTestId('browser-session')).toBeDisabled();
-
-  await page.getByLabel('Browser address').fill('localhost:5173');
-  await expect(page.getByTestId('browser-open')).toBeEnabled();
-  await expect(page.getByTestId('browser-session')).toBeEnabled();
-  await page.getByTestId('browser-session').click();
-
-  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
-  await expect(page.getByTestId('browser-status-label')).toHaveText('Session open');
-  await expect(page.getByTestId('browser-session-status')).toContainText('Visible session 1:');
-  await expect(page.getByTestId('browser-session-url')).toHaveText('http://localhost:5173');
-
-  await page.getByTestId('browser-open').click();
-
-  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
-  await expect(page.getByTestId('browser-status-label')).toHaveText('Preview ready');
-  await expect(page.getByTestId('browser-back')).toBeDisabled();
-  await expect(page.getByTestId('browser-forward')).toBeDisabled();
-  await expect(page.getByTestId('browser-reload')).toBeEnabled();
-  await expect(page.getByTestId('browser-source')).toHaveText('Local web app');
-  await expect(page.getByTestId('browser-inspection-depth')).toHaveText('Network HTML snapshot');
-  await expect(page.getByTestId('browser-inspection-depth')).toHaveAttribute('data-depth', 'network_html_snapshot');
-  await expect(page.getByTestId('browser-snapshot-summary')).toHaveText(
-    'Fetched a network HTML snapshot for this local page.'
-  );
-  await expect(page.getByTestId('browser-snapshot-detail')).toContainText([
-    'Host: localhost',
-    'Scheme: HTTP',
-    'Path: /',
-    'HTTP: 200',
-    'Title: Vite Preview',
-    'Heading: QuillCode Browser Preview'
-  ]);
-  await expect(page.getByTestId('browser-snapshot-outline-item')).toContainText([
-    'H1: QuillCode Browser Preview',
-    'Link: Dashboard -> /dashboard',
-    'Button: Launch',
-    'Input: Search workspace'
-  ]);
-  const outlineStyle = await page.getByTestId('browser-snapshot-outline-item').first().evaluate((element) => {
-    const style = getComputedStyle(element);
-    return {
-      backgroundColor: style.backgroundColor,
-      borderRadius: style.borderRadius
-    };
-  });
-  expect(outlineStyle.backgroundColor).toBe('rgba(0, 0, 0, 0)');
-  expect(outlineStyle.borderRadius).toBe('0px');
-
-  await page.getByLabel('Browser address').fill('example.com/docs');
-  await page.getByTestId('browser-open').click();
-  await expect(page.getByTestId('browser-current-url')).toHaveText('https://example.com/docs');
-  await expect(page.getByTestId('browser-back')).toBeEnabled();
-  await expect(page.getByTestId('browser-forward')).toBeDisabled();
-
-  await page.getByLabel('Browser address').fill('localhost:5173/dashboard');
-  await clickSidebarTool(page, 'command-palette-button');
-  await page.getByLabel('Search commands').fill('>session');
-  await page.locator('[data-testid="command-palette-result"][data-command-id="open-browser-session"]').click();
-  await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
-  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173/dashboard');
-  await expect(page.getByTestId('browser-status-label')).toHaveText('Session open');
-  await expect(page.getByTestId('browser-session-status')).toContainText('Visible session 2:');
-  await expect(page.getByTestId('browser-session-url')).toHaveText('http://localhost:5173/dashboard');
-
-  await page.getByTestId('browser-back').click();
-  await expect(page.getByTestId('browser-current-url')).toHaveText('https://example.com/docs');
-  await page.getByTestId('browser-back').click();
-  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
-  await expect(page.getByTestId('browser-back')).toBeDisabled();
-  await expect(page.getByTestId('browser-forward')).toBeEnabled();
-
-  await page.getByTestId('browser-forward').click();
-  await expect(page.getByTestId('browser-current-url')).toHaveText('https://example.com/docs');
-  await page.getByTestId('browser-reload').click();
-  await expect(page.getByTestId('browser-status-label')).toHaveText('Reloaded');
-
-  await page.getByLabel('Browser comment').fill('Check hero spacing');
-  await expect(page.getByTestId('browser-add-comment')).toBeEnabled();
-  await page.getByTestId('browser-add-comment').click();
-
-  await expect(page.getByTestId('browser-comment')).toContainText('Check hero spacing');
-  await expect(page.getByTestId('browser-status-label')).toHaveText('Comment added');
-});
-
-test('mock harness opens browser preview from chat', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await page.getByLabel('Message').fill('open localhost:5173 in the browser');
-  await page.getByRole('button', { name: 'Send' }).click();
-
-  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.browser.open');
-  await expect(page.getByTestId('tool-card-input').last()).toContainText('localhost:5173');
-  await expect(page.getByText('Opened `Vite Preview` at http://localhost:5173.')).toBeVisible();
-  await expect(page.getByTestId('browser-pane')).toBeVisible();
-  await expect(page.getByTestId('browser-current-url')).toHaveText('http://localhost:5173');
-  await expect(page.getByTestId('browser-inspection-depth')).toHaveText('Network HTML snapshot');
 });
 
 test('mock harness shows project extension manifests from sidebar and command palette', async ({ page }) => {

--- a/E2E/playwright/tests/harness-helpers.ts
+++ b/E2E/playwright/tests/harness-helpers.ts
@@ -1,0 +1,15 @@
+import { expect, type Page } from '@playwright/test';
+
+export function harnessURL(): string {
+  return 'file://' + process.cwd() + '/../harness/index.html';
+}
+
+export async function openSidebarTools(page: Page) {
+  await page.getByTestId('sidebar-tools-button').click();
+  await expect(page.getByTestId('sidebar-tools-menu')).toHaveAttribute('open', '');
+}
+
+export async function clickSidebarTool(page: Page, testID: string) {
+  await openSidebarTools(page);
+  await page.getByTestId(testID).click();
+}

--- a/Tests/QuillCodeParityTests/ParityBrowserGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityBrowserGateTests.swift
@@ -192,4 +192,19 @@ final class ParityBrowserGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(broadSuiteText.contains("testWorkspaceBrowserIntegrationTestsOwnModelBrowserFlows"), "Browser integration ownership gates should stay in ParityBrowserGateTests.")
         XCTAssertFalse(broadSuiteText.contains("testWorkspaceHTMLRendererDelegatesBrowserRendering"), "Browser renderer gates should stay in ParityBrowserGateTests.")
     }
+
+    func testPlaywrightBrowserFlowsStayInFocusedSpec() throws {
+        let root = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let browserSpecText = try String(contentsOf: root.appendingPathComponent("browser.spec.ts"), encoding: .utf8)
+        let coreSpecText = try String(contentsOf: root.appendingPathComponent("core.spec.ts"), encoding: .utf8)
+        let helperText = try String(contentsOf: root.appendingPathComponent("harness-helpers.ts"), encoding: .utf8)
+
+        XCTAssertTrue(browserSpecText.contains("opens browser preview and records comments"), "Browser E2E preview/comment flow should live in browser.spec.ts.")
+        XCTAssertTrue(browserSpecText.contains("opens browser preview from chat"), "Browser chat-open flow should live in browser.spec.ts.")
+        XCTAssertTrue(browserSpecText.contains("harnessURL()"), "Focused Playwright specs should share the harness URL helper.")
+        XCTAssertTrue(helperText.contains("export function harnessURL"), "Shared Playwright harness URL helper should be available to focused specs.")
+        XCTAssertTrue(helperText.contains("export async function clickSidebarTool"), "Shared sidebar tool navigation should avoid duplicated focused-spec helpers.")
+        XCTAssertFalse(coreSpecText.contains("opens browser preview and records comments"), "The broad core Playwright spec should not own browser-specific E2E flows.")
+        XCTAssertFalse(coreSpecText.contains("opens browser preview from chat"), "The broad core Playwright spec should not own chat-to-browser E2E flows.")
+    }
 }

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -26,6 +26,18 @@ struct ParityFocusedSuiteManifest {
         Suite(fileName: "ParityWorkspaceSurfaceGateTests.swift", testNames: [
             "testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts"
         ]),
+        Suite(fileName: "ParityBrowserGateTests.swift", testNames: [
+            "testWorkspaceModelDelegatesBrowserSurfaceTypes",
+            "testBrowserInspectorDelegatesStaticHTMLSnapshotExtraction",
+            "testBrowserLiveDOMCaptureStaysBehindAdapterContract",
+            "testWorkspaceModelDelegatesBrowserStateTransitions",
+            "testWorkspaceModelDelegatesBrowserLocationResolving",
+            "testWorkspaceBrowserIntegrationTestsOwnModelBrowserFlows",
+            "testBrowserAgentToolsShareFocusedExecutor",
+            "testWorkspaceHTMLRendererDelegatesBrowserRendering",
+            "testBrowserArchitectureGatesStayOutOfBroadSuite",
+            "testPlaywrightBrowserFlowsStayInFocusedSpec"
+        ]),
         Suite(fileName: "ParityWorkspaceModelGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesToolCardSurfaceTypes",
             "testWorkspaceModelDelegatesProjectContextRefresh",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5211,3 +5211,23 @@ Current strict grades:
 
 Remaining risk:
 - Continue splitting `WorkspaceSurfaceTests.swift` by feature family. Good next slices are review surface ownership and memory/extensions surface ownership.
+
+## 2026-06-24 Playwright Browser Spec Split
+
+Overall grade after this slice: **A browser E2E ownership, A shared harness helper boundary, B+ broad Playwright core spec**.
+
+The mock Playwright suite is valuable because it catches Codex-like UI regressions quickly, but `core.spec.ts` was still the owner for browser preview flows. That made browser failures look like global core failures and kept the largest spec file harder for parallel agents to edit safely.
+
+What changed:
+- Added `browser.spec.ts` for browser preview, session, navigation, comments, and chat-to-browser flows.
+- Added `harness-helpers.ts` for shared harness URL and sidebar tool navigation helpers.
+- Removed browser-specific E2E flows from `core.spec.ts` while keeping broad smoke and cross-feature flows there.
+- Added a browser parity gate that enforces focused browser E2E ownership and registered `ParityBrowserGateTests` in the focused-suite manifest.
+
+Current strict grades:
+- `E2E/playwright/tests/browser.spec.ts`: **A**. It owns one browser surface area and keeps browser expectations reviewable.
+- `E2E/playwright/tests/harness-helpers.ts`: **A**. It is tiny, typed, and avoids helper drift between focused specs.
+- `E2E/playwright/tests/core.spec.ts`: **B+**. Smaller and healthier, but still owns many unrelated UI families. Continue splitting settings/runtime, review, terminal, extensions, and sidebar flows into focused specs.
+
+Remaining risk:
+- `E2E/harness/index.html` is still a single large static harness. Once the spec files are split by feature, the next larger A+ step is modularizing the harness state/render/event handlers by pane.


### PR DESCRIPTION
## Summary
- move browser preview/session/comment Playwright coverage into `browser.spec.ts`
- add shared Playwright harness helpers for harness URL and sidebar tool navigation
- register browser parity gates in the focused-suite manifest and document the code-quality slice

## Validation
- `swift test --filter ParityBrowserGateTests`
- `swift test --filter 'ParityGateTests|ParityBrowserGateTests'`\n- `swift test` (1067 tests)\n- `npm test -- tests/browser.spec.ts`\n- `npm test` in `E2E/playwright` (62 tests)\n- `git diff --check`