### PR TITLE
Split terminal Playwright flow

### DIFF
--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1594,66 +1594,6 @@ test('mock harness adds an SSH remote project from command palette and slash com
   await expect(page.getByText('Wrote `hello.txt` on feather.local · quill.')).toBeVisible();
 });
 
-test('mock harness runs a command in the integrated terminal', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await clickSidebarTool(page, 'terminal-button');
-  await expect(page.getByTestId('terminal-pane')).toBeVisible();
-  await expect(page.getByTestId('terminal-cwd')).toHaveText('/mock/QuillCode');
-  await expect(page.getByTestId('terminal-empty')).toBeVisible();
-
-  await page.getByLabel('Terminal command').fill('pwd');
-  await expect(page.getByTestId('terminal-run')).toBeEnabled();
-  await page.getByTestId('terminal-run').click();
-
-  await expect(page.getByTestId('terminal-entry')).toContainText('$ pwd');
-  await expect(page.getByTestId('terminal-status')).toHaveText('Running · running');
-  await expect(page.getByTestId('terminal-status')).toHaveText('Done · exit 0');
-  await expect(page.getByTestId('terminal-stdout')).toContainText('/mock/QuillCode');
-  await expect(page.getByLabel('Terminal command')).toHaveValue('');
-
-  await page.getByLabel('Terminal command').fill('stream-demo');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-status').last()).toHaveText('Running · running');
-  await expect(page.getByTestId('terminal-stdout').last()).toContainText('stream-start');
-  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
-  await expect(page.getByTestId('terminal-stdout').last()).toContainText('stream-end');
-
-  await page.getByLabel('Terminal command').fill('cd Packages');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
-  await expect(page.getByTestId('terminal-cwd')).toHaveText('/mock/QuillCode/Packages');
-  await page.getByLabel('Terminal command').fill('pwd');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-stdout').last()).toContainText('/mock/QuillCode/Packages');
-
-  await page.getByLabel('Terminal command').fill('export QUILL_TERMINAL_TEST=from-harness');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
-  await page.getByLabel('Terminal command').fill('printf \'%s\' "$QUILL_TERMINAL_TEST"');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-stdout').last()).toHaveText('from-harness');
-  await page.getByLabel('Terminal command').fill('unset QUILL_TERMINAL_TEST');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
-  await page.getByLabel('Terminal command').fill('printf \'%s\' "${QUILL_TERMINAL_TEST:-missing}"');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-stdout').last()).toHaveText('missing');
-
-  await page.getByLabel('Terminal command').fill('sleep 5');
-  await page.getByTestId('terminal-run').click();
-  await expect(page.getByTestId('terminal-status').last()).toHaveText('Running · running');
-  await page.getByTestId('terminal-stop').click();
-  await expect(page.getByTestId('terminal-status').last()).toHaveText('Stopped · stopped');
-  await expect(page.getByTestId('terminal-stderr').last()).toContainText('Command stopped.');
-
-  await expect(page.getByTestId('terminal-clear')).toBeEnabled();
-  await page.getByTestId('terminal-clear').click();
-  await expect(page.getByTestId('terminal-entry')).toHaveCount(0);
-  await expect(page.getByTestId('terminal-empty')).toBeVisible();
-  await expect(page.getByTestId('terminal-clear')).toBeDisabled();
-});
-
 test('mock harness shows project extension manifests from sidebar and command palette', async ({ page }) => {
   await page.goto('file://' + process.cwd() + '/../harness/index.html');
 

--- a/E2E/playwright/tests/terminal.spec.ts
+++ b/E2E/playwright/tests/terminal.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { clickSidebarTool, harnessURL } from './harness-helpers';
+
+test('mock harness runs a command in the integrated terminal', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await clickSidebarTool(page, 'terminal-button');
+  await expect(page.getByTestId('terminal-pane')).toBeVisible();
+  await expect(page.getByTestId('terminal-cwd')).toHaveText('/mock/QuillCode');
+  await expect(page.getByTestId('terminal-empty')).toBeVisible();
+
+  await page.getByLabel('Terminal command').fill('pwd');
+  await expect(page.getByTestId('terminal-run')).toBeEnabled();
+  await page.getByTestId('terminal-run').click();
+
+  await expect(page.getByTestId('terminal-entry')).toContainText('$ pwd');
+  await expect(page.getByTestId('terminal-status')).toHaveText('Running · running');
+  await expect(page.getByTestId('terminal-status')).toHaveText('Done · exit 0');
+  await expect(page.getByTestId('terminal-stdout')).toContainText('/mock/QuillCode');
+  await expect(page.getByLabel('Terminal command')).toHaveValue('');
+
+  await page.getByLabel('Terminal command').fill('stream-demo');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Running · running');
+  await expect(page.getByTestId('terminal-stdout').last()).toContainText('stream-start');
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
+  await expect(page.getByTestId('terminal-stdout').last()).toContainText('stream-end');
+
+  await page.getByLabel('Terminal command').fill('cd Packages');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
+  await expect(page.getByTestId('terminal-cwd')).toHaveText('/mock/QuillCode/Packages');
+  await page.getByLabel('Terminal command').fill('pwd');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-stdout').last()).toContainText('/mock/QuillCode/Packages');
+
+  await page.getByLabel('Terminal command').fill('export QUILL_TERMINAL_TEST=from-harness');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
+  await page.getByLabel('Terminal command').fill('printf \'%s\' "$QUILL_TERMINAL_TEST"');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-stdout').last()).toHaveText('from-harness');
+  await page.getByLabel('Terminal command').fill('unset QUILL_TERMINAL_TEST');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Done · exit 0');
+  await page.getByLabel('Terminal command').fill('printf \'%s\' "${QUILL_TERMINAL_TEST:-missing}"');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-stdout').last()).toHaveText('missing');
+
+  await page.getByLabel('Terminal command').fill('sleep 5');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Running · running');
+  await page.getByTestId('terminal-stop').click();
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Stopped · stopped');
+  await expect(page.getByTestId('terminal-stderr').last()).toContainText('Command stopped.');
+
+  await expect(page.getByTestId('terminal-clear')).toBeEnabled();
+  await page.getByTestId('terminal-clear').click();
+  await expect(page.getByTestId('terminal-entry')).toHaveCount(0);
+  await expect(page.getByTestId('terminal-empty')).toBeVisible();
+  await expect(page.getByTestId('terminal-clear')).toBeDisabled();
+});

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -25,6 +25,7 @@ struct ParityFocusedSuiteManifest {
         ]),
         Suite(fileName: "ParityWorkspaceSurfaceGateTests.swift", testNames: [
             "testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts",
+            "testPlaywrightTerminalFlowsStayInFocusedSpec",
             "testPlaywrightReviewFlowsStayInFocusedSpec"
         ]),
         Suite(fileName: "ParityBrowserGateTests.swift", testNames: [

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -167,6 +167,24 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(engineText.contains("environment(fromHex"), "Terminal engine should not own remote environment decoding.")
     }
 
+    func testPlaywrightTerminalFlowsStayInFocusedSpec() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let terminalSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("terminal.spec.ts"),
+            encoding: .utf8
+        )
+        let coreSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
+            encoding: .utf8
+        )
+        let terminalFlowName = "runs a command in the integrated terminal"
+
+        XCTAssertTrue(terminalSpecText.contains("harnessURL()"), "Focused terminal flows should reuse the shared harness URL helper.")
+        XCTAssertTrue(terminalSpecText.contains("clickSidebarTool"), "Focused terminal flows should reuse shared sidebar tool navigation.")
+        XCTAssertTrue(terminalSpecText.contains(terminalFlowName), "\(terminalFlowName) should live in terminal.spec.ts.")
+        XCTAssertFalse(coreSpecText.contains(terminalFlowName), "\(terminalFlowName) should not drift back into core.spec.ts.")
+    }
+
     func testWorkspaceSurfaceDelegatesReviewSurfaceContracts() throws {
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let reviewText = try Self.appSourceText(named: "QuillCodeReviewSurface.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5290,3 +5290,23 @@ Current strict grades:
 
 Remaining risk:
 - Continue splitting `WorkspaceSurfaceTests.swift` by feature family. Good next slices are command/sidebar search ownership and context banner ownership.
+
+## 2026-06-24 Playwright Terminal Spec Split
+
+Overall grade after this slice: **A terminal E2E ownership, A shared harness helper reuse, B+ broad Playwright core spec**.
+
+The integrated terminal flow exercises Codex-critical behavior: cwd display, command execution, streaming output, cwd persistence, environment persistence, cancellation, and clearing. It belonged in a terminal-specific E2E owner instead of the broad core smoke spec.
+
+What changed:
+- Added `terminal.spec.ts` for the integrated terminal execution flow.
+- Reused `harnessURL()` and `clickSidebarTool()` from the shared Playwright helper.
+- Removed the terminal-owned execution flow from `core.spec.ts` while leaving cross-feature terminal smoke paths in core.
+- Added a workspace surface parity gate that keeps the terminal execution flow out of `core.spec.ts` and registered it in the focused-suite manifest.
+
+Current strict grades:
+- `E2E/playwright/tests/terminal.spec.ts`: **A**. It owns the terminal lifecycle behavior and uses shared helpers.
+- `E2E/playwright/tests/core.spec.ts`: **B+**. Smaller again, but still owns unrelated extension/MCP, sidebar, settings, command palette, and slash/workflow coverage.
+- `ParityWorkspaceSurfaceGateTests.swift`: **A**. It guards native terminal architecture plus focused terminal E2E ownership.
+
+Remaining risk:
+- Continue splitting `core.spec.ts` by feature family. Good next slices are extension/MCP flows and command/sidebar search flows.


### PR DESCRIPTION
## Summary
- Move the integrated-terminal Playwright flow into terminal.spec.ts
- Keep core.spec.ts focused on broad/cross-feature smoke coverage
- Add a Swift parity gate and audit entry for terminal E2E ownership

## Validation
- npm test -- tests/terminal.spec.ts
- swift test --filter 'ParityWorkspaceSurfaceGateTests|ParityGateTests'
- swift test
- npm test
- git diff --check