### PR TITLE
Stabilize search dialog typing

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3828,11 +3828,16 @@
     }
 
     function focusInputByTestID(testID) {
-      requestAnimationFrame(() => {
+      const focus = () => {
         const input = document.querySelector(`[data-testid="${testID}"]`);
         if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return;
         input.focus();
         input.setSelectionRange(input.value.length, input.value.length);
+      };
+      requestAnimationFrame(() => {
+        focus();
+        setTimeout(focus, 0);
+        setTimeout(focus, 50);
       });
     }
 
@@ -7022,8 +7027,8 @@
         return;
       }
       if (commandID === 'search') {
-        state.search.isOpen = true;
-        state.search.query = '';
+        openSearchPanel();
+        return;
       }
       if (commandID === 'find-in-chat') {
         openFindInChat();

--- a/E2E/playwright/tests/search.spec.ts
+++ b/E2E/playwright/tests/search.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect, type Page } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+async function openTopBarOverflow(page: Page) {
+  await page.getByTestId('top-bar-overflow-button').click();
+  await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');
+}
+
+test('mock harness keeps chat search typeable from sidebar and top bar entry points', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('run whoami');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('sidebar-item')).toContainText('run whoami');
+
+  await page.getByTestId('sidebar-search-button').click();
+  await expect(page.getByTestId('search-panel')).toBeVisible();
+  await expect(page.getByTestId('search-input')).toBeFocused();
+  await page.keyboard.type('whoami');
+  await expect(page.getByTestId('search-input')).toHaveValue('whoami');
+  await expect(page.getByTestId('search-result')).toContainText('run whoami');
+  await page.getByTestId('search-close').click();
+
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-search').click();
+  await expect(page.getByTestId('search-panel')).toBeVisible();
+  await expect(page.getByTestId('search-input')).toBeFocused();
+  await page.keyboard.type('mock-user');
+  await expect(page.getByTestId('search-input')).toHaveValue('mock-user');
+  await expect(page.getByTestId('search-result')).toContainText('run whoami');
+});
+
+test('mock harness keeps command palette search typeable from top bar entry point', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-command-palette').click();
+  await expect(page.getByTestId('command-palette-panel')).toBeVisible();
+  await expect(page.getByTestId('command-palette-input')).toBeFocused();
+
+  await page.keyboard.type('>terminal');
+
+  await expect(page.getByTestId('command-palette-input')).toHaveValue('>terminal');
+  await expect(page.getByTestId('command-palette-result').first()).toContainText('Terminal');
+});

--- a/Sources/QuillCodeApp/QuillCodeCommandPaletteDialog.swift
+++ b/Sources/QuillCodeApp/QuillCodeCommandPaletteDialog.swift
@@ -7,15 +7,29 @@ struct QuillCodeCommandPaletteView: View {
     var onSelectCommand: (WorkspaceCommandSurface) -> Void
     var onClose: () -> Void
 
+    @State private var localQuery: String
     @State private var selectedCommandID: String?
     @FocusState private var isSearchFocused: Bool
 
+    init(
+        commands: [WorkspaceCommandSurface],
+        query: Binding<String>,
+        onSelectCommand: @escaping (WorkspaceCommandSurface) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.commands = commands
+        self._query = query
+        self.onSelectCommand = onSelectCommand
+        self.onClose = onClose
+        self._localQuery = State(initialValue: query.wrappedValue)
+    }
+
     private var results: [WorkspaceCommandSurface] {
-        WorkspaceCommandPalette.rankedCommands(commands, matching: query)
+        WorkspaceCommandPalette.rankedCommands(commands, matching: localQuery)
     }
 
     private var groups: [WorkspaceCommandGroupSurface] {
-        WorkspaceCommandPalette.groupedCommands(commands, matching: query)
+        WorkspaceCommandPalette.groupedCommands(commands, matching: localQuery)
     }
 
     private var enabledResults: [WorkspaceCommandSurface] {
@@ -32,9 +46,10 @@ struct QuillCodeCommandPaletteView: View {
             )
 
             HStack(spacing: 10) {
-                TextField("Search commands, > actions, / slash", text: $query)
+                TextField("Search commands, > actions, / slash", text: $localQuery)
                     .textFieldStyle(.roundedBorder)
                     .focused($isSearchFocused)
+                    .accessibilityIdentifier("quillcode-command-palette-input")
                     .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
                     .onSubmit(selectHighlightedCommand)
                 if let label = activeScopeLabel {
@@ -73,15 +88,21 @@ struct QuillCodeCommandPaletteView: View {
         .background(QuillCodePalette.background)
         .onAppear {
             ensureSelection()
-            DispatchQueue.main.async {
-                isSearchFocused = true
-            }
+            focusSearchField()
         }
         .onDisappear {
             isSearchFocused = false
         }
-        .onChange(of: query) { _, _ in
+        .onChange(of: localQuery) { _, newValue in
+            if query != newValue {
+                query = newValue
+            }
             ensureSelection()
+        }
+        .onChange(of: query) { _, newValue in
+            if localQuery != newValue {
+                localQuery = newValue
+            }
         }
         .onMoveCommand { direction in
             switch direction {
@@ -96,7 +117,7 @@ struct QuillCodeCommandPaletteView: View {
     }
 
     private var activeScopeLabel: String? {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = localQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("/") {
             return "Slash"
         }
@@ -104,6 +125,15 @@ struct QuillCodeCommandPaletteView: View {
             return "Actions"
         }
         return nil
+    }
+
+    private func focusSearchField() {
+        DispatchQueue.main.async {
+            isSearchFocused = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            isSearchFocused = true
+        }
     }
 
     private func ensureSelection() {

--- a/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
+++ b/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
@@ -47,10 +47,24 @@ struct QuillCodeSearchView: View {
     var onSelectThread: (UUID) -> Void
     var onClose: () -> Void
 
+    @State private var localQuery: String
     @FocusState private var isSearchFocused: Bool
 
+    init(
+        sidebar: SidebarSurface,
+        query: Binding<String>,
+        onSelectThread: @escaping (UUID) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.sidebar = sidebar
+        self._query = query
+        self.onSelectThread = onSelectThread
+        self.onClose = onClose
+        self._localQuery = State(initialValue: query.wrappedValue)
+    }
+
     private var results: [SidebarItemSurface] {
-        sidebar.filteredItems(matching: query)
+        sidebar.filteredItems(matching: localQuery)
     }
 
     var body: some View {
@@ -62,9 +76,10 @@ struct QuillCodeSearchView: View {
                 onClose: onClose
             )
 
-            TextField("Search chats", text: $query)
+            TextField("Search chats", text: $localQuery)
                 .textFieldStyle(.roundedBorder)
                 .focused($isSearchFocused)
+                .accessibilityIdentifier("quillcode-search-input")
                 .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
                 .onSubmit {
                     if let firstResult = results.first {
@@ -92,12 +107,29 @@ struct QuillCodeSearchView: View {
         .frame(width: 560, height: 520)
         .background(QuillCodePalette.background)
         .onAppear {
-            DispatchQueue.main.async {
-                isSearchFocused = true
+            focusSearchField()
+        }
+        .onChange(of: localQuery) { _, newValue in
+            if query != newValue {
+                query = newValue
+            }
+        }
+        .onChange(of: query) { _, newValue in
+            if localQuery != newValue {
+                localQuery = newValue
             }
         }
         .onDisappear {
             isSearchFocused = false
+        }
+    }
+
+    private func focusSearchField() {
+        DispatchQueue.main.async {
+            isSearchFocused = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            isSearchFocused = true
         }
     }
 }

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -26,6 +26,7 @@ struct ParityFocusedSuiteManifest {
         Suite(fileName: "ParityWorkspaceSurfaceGateTests.swift", testNames: [
             "testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts",
             "testPlaywrightTerminalFlowsStayInFocusedSpec",
+            "testPlaywrightSearchFlowsStayInFocusedSpec",
             "testPlaywrightReviewFlowsStayInFocusedSpec"
         ]),
         Suite(fileName: "ParityBrowserGateTests.swift", testNames: [
@@ -133,6 +134,7 @@ struct ParityFocusedSuiteManifest {
         Suite(fileName: "ParityWorkspaceSettingsSheetGateTests.swift", testNames: [
             "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
             "testNativeSettingsDelegatesFocusedViewsAndDraftState",
+            "testNativeSearchDialogsKeepLocalTypingState",
             "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
         ]),
         Suite(fileName: "ParityWorkspaceTranscriptGateTests.swift", testNames: [

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -62,6 +62,20 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(settingsText.contains("struct QuillCodeSettingsDraft"), "Settings shell should not own settings draft state.")
     }
 
+    func testNativeSearchDialogsKeepLocalTypingState() throws {
+        let searchShortcutText = try Self.appSourceText(named: "QuillCodeSearchAndShortcutDialogs.swift")
+        let commandPaletteText = try Self.appSourceText(named: "QuillCodeCommandPaletteDialog.swift")
+
+        XCTAssertTrue(searchShortcutText.contains("@State private var localQuery"), "Chat search should keep keystrokes in local dialog state while the sheet is active.")
+        XCTAssertTrue(searchShortcutText.contains("TextField(\"Search chats\", text: $localQuery)"), "Chat search text entry should not be wired directly to root workspace state.")
+        XCTAssertTrue(searchShortcutText.contains(".accessibilityIdentifier(\"quillcode-search-input\")"), "Chat search needs a stable native UI automation identifier.")
+        XCTAssertTrue(searchShortcutText.contains("private func focusSearchField()"), "Chat search should refocus after sheet presentation settles.")
+        XCTAssertTrue(commandPaletteText.contains("@State private var localQuery"), "Command palette should keep keystrokes in local dialog state while the sheet is active.")
+        XCTAssertTrue(commandPaletteText.contains("TextField(\"Search commands, > actions, / slash\", text: $localQuery)"), "Command palette text entry should not be wired directly to root workspace state.")
+        XCTAssertTrue(commandPaletteText.contains(".accessibilityIdentifier(\"quillcode-command-palette-input\")"), "Command palette needs a stable native UI automation identifier.")
+        XCTAssertTrue(commandPaletteText.contains("private func focusSearchField()"), "Command palette should refocus after sheet presentation settles.")
+    }
+
     func testWorkspaceSurfaceDelegatesSettingsSurfaceContract() throws {
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let settingsText = try Self.appSourceText(named: "QuillCodeSettingsSurface.swift")

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -185,6 +185,25 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(coreSpecText.contains(terminalFlowName), "\(terminalFlowName) should not drift back into core.spec.ts.")
     }
 
+    func testPlaywrightSearchFlowsStayInFocusedSpec() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let searchSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("search.spec.ts"),
+            encoding: .utf8
+        )
+        let coreSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
+            encoding: .utf8
+        )
+        let searchFlowName = "keeps chat search typeable from sidebar and top bar entry points"
+
+        XCTAssertTrue(searchSpecText.contains("harnessURL()"), "Focused search flows should reuse the shared harness URL helper.")
+        XCTAssertTrue(searchSpecText.contains("top-bar-overflow-search"), "Focused search flows should cover the top-bar search entry point.")
+        XCTAssertTrue(searchSpecText.contains("sidebar-search-button"), "Focused search flows should cover the sidebar search entry point.")
+        XCTAssertTrue(searchSpecText.contains(searchFlowName), "\(searchFlowName) should live in search.spec.ts.")
+        XCTAssertFalse(coreSpecText.contains(searchFlowName), "\(searchFlowName) should not drift back into core.spec.ts.")
+    }
+
     func testWorkspaceSurfaceDelegatesReviewSurfaceContracts() throws {
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let reviewText = try Self.appSourceText(named: "QuillCodeReviewSurface.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5337,3 +5337,26 @@ Current strict grades:
 
 Remaining risk:
 - Continue reducing the largest integration files. Good next slices are `WorkspaceRemoteProjectIntegrationTests.swift`, `AgentTests.swift`, and the remaining broad Playwright `core.spec.ts` flows.
+
+## 2026-06-24 Search Input Stability
+
+Overall grade after this slice: **A- native dialog typing stability, A focused search E2E coverage, B+ broad Playwright core spec**.
+
+User-facing search and command-palette entry need to behave like Codex: open from visible chrome, take focus immediately, and keep accepting text while the workspace surface continues to update. The previous SwiftUI dialogs bound each keystroke directly to workspace-level sheet state, which was unnecessarily fragile because it let root surface churn participate in every input edit.
+
+What changed:
+- Search and command-palette dialogs now keep active keystrokes in local dialog state and sync outward only as a side effect.
+- Native dialog focus now gets a second post-presentation tick so fields are still focused after sheet/menu animation settles.
+- Both native fields expose stable accessibility identifiers for future native UI automation.
+- Added `search.spec.ts` for chat-search typing from sidebar and top-bar entry points plus command-palette typing from the top-bar entry point.
+- Hardened the HTML harness focus helper so menu-launched search/palette fields receive focus across the next frame and short timeout.
+- Fixed the HTML harness generic `search` command path to call the same focused `openSearchPanel()` helper as the sidebar button instead of falling through to a plain render.
+- Added parity guards for local native dialog typing state and focused Playwright search ownership.
+
+Current strict grades:
+- `QuillCodeSearchAndShortcutDialogs.swift`: **A-**. Search keeps local typing state and stable focus, but the search result row UI still shares the broad shortcut/dialog file.
+- `QuillCodeCommandPaletteDialog.swift`: **A-**. Palette search keeps local typing state and stable focus; richer native keyboard regression tests are still pending.
+- `E2E/playwright/tests/search.spec.ts`: **A**. It owns the user-visible search typing regression directly.
+
+Remaining risk:
+- Add packaged native UI smoke tests that drive `quillcode-search-input` and `quillcode-command-palette-input` directly once the desktop app has a stable automation harness.


### PR DESCRIPTION
## Summary
- keep native chat search and command palette keystrokes in local dialog state while syncing outward
- route the harness generic search command through the focused open-search helper
- add focused Playwright coverage for sidebar/top-bar search typing and top-bar command-palette typing
- document the input-stability slice in the code quality audit

## Validation
- swift test --filter 'ParityWorkspaceSettingsSheetGateTests|ParityWorkspaceSurfaceGateTests|ParityGateTests'
- npm test -- tests/search.spec.ts
- swift test
- npm test
- git diff --check