### PR TITLE
Split extensions Playwright flow

### DIFF
--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1594,58 +1594,6 @@ test('mock harness adds an SSH remote project from command palette and slash com
   await expect(page.getByText('Wrote `hello.txt` on feather.local · quill.')).toBeVisible();
 });
 
-test('mock harness shows project extension manifests from sidebar and command palette', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await clickSidebarTool(page, 'extensions-button');
-
-  await expect(page.getByTestId('extensions-pane')).toBeVisible();
-  await expect(page.getByTestId('extensions-subtitle')).toHaveText('1 plugin · 1 skill · 1 MCP server');
-  await expect(page.getByTestId('extensions-count')).toContainText(['1 plugin', '1 skill', '1 MCP server']);
-  await expect(page.getByTestId('extension-item')).toHaveCount(3);
-  await expect(page.getByTestId('extension-item').first()).toContainText('GitHub');
-  await expect(page.getByTestId('extension-version')).toHaveText('v1.2.0');
-  await expect(page.getByTestId('extension-source')).toHaveText('https://github.com/Lore-Hex/quillcode-github');
-  await expect(page.getByTestId('extension-update-command')).toHaveText('git -C .quillcode/plugins/github pull --ff-only');
-  await expect(page.getByTestId('extension-update')).toBeVisible();
-  await page.getByTestId('extension-update').click();
-  await expect(page.getByTestId('message').last()).toContainText('GitHub update finished.');
-  await expect(page.getByTestId('extension-item').nth(1)).toContainText('Code Review');
-  await expect(page.getByTestId('extension-item').nth(2)).toContainText('Stopped');
-  await expect(page.getByTestId('extension-transport')).toHaveText('STDIO');
-  await expect(page.getByTestId('extension-command')).toHaveText('quill-mcp-filesystem --root .');
-  await expect(page.getByTestId('extension-start')).toBeVisible();
-  await page.getByTestId('extension-start').click();
-  await expect(page.getByTestId('extension-item').nth(2)).toContainText('Ready');
-  await expect(page.getByTestId('extension-mcp-server')).toHaveText('Fixture MCP 1.0.0');
-  await expect(page.getByTestId('extension-mcp-tools-count')).toHaveText('2 tools');
-  await expect(page.getByTestId('extension-mcp-group-label')).toContainText(['Tools', 'Resources', 'Prompts']);
-  await expect(page.getByTestId('extension-mcp-tool')).toContainText(['read_file', 'write_file']);
-  await expect(page.getByTestId('extension-mcp-tool-schema')).toContainText([
-    'required: path:string',
-    'required: content:string, path:string; optional: overwrite:boolean'
-  ]);
-  await expect(page.getByTestId('extension-mcp-resources-count')).toHaveText('2 resources');
-  await expect(page.getByTestId('extension-mcp-resource')).toContainText(['README', 'Project config']);
-  await expect(page.getByTestId('extension-mcp-prompts-count')).toHaveText('1 prompt');
-  await expect(page.getByTestId('extension-mcp-prompt')).toContainText(['summarize_project']);
-  await expect(page.getByTestId('extension-stop')).toBeVisible();
-  await page.getByTestId('extension-stop').click();
-  await expect(page.getByTestId('extension-item').nth(2)).toContainText('Stopped');
-
-  await clickSidebarTool(page, 'extensions-button');
-  await expect(page.getByTestId('extensions-pane')).toHaveCount(0);
-
-  await clickSidebarTool(page, 'command-palette-button');
-  await page.getByLabel('Search commands').fill('>update github');
-  await expect(page.getByTestId('command-palette-group')).toContainText('Extensions');
-  await expect(page.getByTestId('command-palette-result')).toContainText('Update GitHub');
-  await page.getByLabel('Search commands').fill('>manifest');
-  await expect(page.getByTestId('command-palette-group')).toContainText('Extensions');
-  await page.getByTestId('command-palette-result').click();
-  await expect(page.getByTestId('extensions-pane')).toBeVisible();
-});
-
 test('mock harness handles slash mode locally', async ({ page }) => {
   await page.goto('file://' + process.cwd() + '/../harness/index.html');
 

--- a/E2E/playwright/tests/extensions.spec.ts
+++ b/E2E/playwright/tests/extensions.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { clickSidebarTool, harnessURL } from './harness-helpers';
+
+test('mock harness shows project extension manifests from sidebar and command palette', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await clickSidebarTool(page, 'extensions-button');
+
+  await expect(page.getByTestId('extensions-pane')).toBeVisible();
+  await expect(page.getByTestId('extensions-subtitle')).toHaveText('1 plugin · 1 skill · 1 MCP server');
+  await expect(page.getByTestId('extensions-count')).toContainText(['1 plugin', '1 skill', '1 MCP server']);
+  await expect(page.getByTestId('extension-item')).toHaveCount(3);
+  await expect(page.getByTestId('extension-item').first()).toContainText('GitHub');
+  await expect(page.getByTestId('extension-version')).toHaveText('v1.2.0');
+  await expect(page.getByTestId('extension-source')).toHaveText('https://github.com/Lore-Hex/quillcode-github');
+  await expect(page.getByTestId('extension-update-command')).toHaveText('git -C .quillcode/plugins/github pull --ff-only');
+  await expect(page.getByTestId('extension-update')).toBeVisible();
+  await page.getByTestId('extension-update').click();
+  await expect(page.getByTestId('message').last()).toContainText('GitHub update finished.');
+  await expect(page.getByTestId('extension-item').nth(1)).toContainText('Code Review');
+  await expect(page.getByTestId('extension-item').nth(2)).toContainText('Stopped');
+  await expect(page.getByTestId('extension-transport')).toHaveText('STDIO');
+  await expect(page.getByTestId('extension-command')).toHaveText('quill-mcp-filesystem --root .');
+  await expect(page.getByTestId('extension-start')).toBeVisible();
+  await page.getByTestId('extension-start').click();
+  await expect(page.getByTestId('extension-item').nth(2)).toContainText('Ready');
+  await expect(page.getByTestId('extension-mcp-server')).toHaveText('Fixture MCP 1.0.0');
+  await expect(page.getByTestId('extension-mcp-tools-count')).toHaveText('2 tools');
+  await expect(page.getByTestId('extension-mcp-group-label')).toContainText(['Tools', 'Resources', 'Prompts']);
+  await expect(page.getByTestId('extension-mcp-tool')).toContainText(['read_file', 'write_file']);
+  await expect(page.getByTestId('extension-mcp-tool-schema')).toContainText([
+    'required: path:string',
+    'required: content:string, path:string; optional: overwrite:boolean'
+  ]);
+  await expect(page.getByTestId('extension-mcp-resources-count')).toHaveText('2 resources');
+  await expect(page.getByTestId('extension-mcp-resource')).toContainText(['README', 'Project config']);
+  await expect(page.getByTestId('extension-mcp-prompts-count')).toHaveText('1 prompt');
+  await expect(page.getByTestId('extension-mcp-prompt')).toContainText(['summarize_project']);
+  await expect(page.getByTestId('extension-stop')).toBeVisible();
+  await page.getByTestId('extension-stop').click();
+  await expect(page.getByTestId('extension-item').nth(2)).toContainText('Stopped');
+
+  await clickSidebarTool(page, 'extensions-button');
+  await expect(page.getByTestId('extensions-pane')).toHaveCount(0);
+
+  await clickSidebarTool(page, 'command-palette-button');
+  await page.getByLabel('Search commands').fill('>update github');
+  await expect(page.getByTestId('command-palette-group')).toContainText('Extensions');
+  await expect(page.getByTestId('command-palette-result')).toContainText('Update GitHub');
+  await page.getByLabel('Search commands').fill('>manifest');
+  await expect(page.getByTestId('command-palette-group')).toContainText('Extensions');
+  await page.getByTestId('command-palette-result').click();
+  await expect(page.getByTestId('extensions-pane')).toBeVisible();
+});

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -27,6 +27,7 @@ struct ParityFocusedSuiteManifest {
             "testWorkspaceSurfaceDelegatesSecondaryPaneSurfaceContracts",
             "testPlaywrightTerminalFlowsStayInFocusedSpec",
             "testPlaywrightSearchFlowsStayInFocusedSpec",
+            "testPlaywrightExtensionsFlowsStayInFocusedSpec",
             "testPlaywrightReviewFlowsStayInFocusedSpec"
         ]),
         Suite(fileName: "ParityBrowserGateTests.swift", testNames: [

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -204,6 +204,25 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(coreSpecText.contains(searchFlowName), "\(searchFlowName) should not drift back into core.spec.ts.")
     }
 
+    func testPlaywrightExtensionsFlowsStayInFocusedSpec() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let extensionsSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("extensions.spec.ts"),
+            encoding: .utf8
+        )
+        let coreSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
+            encoding: .utf8
+        )
+        let extensionsFlowName = "shows project extension manifests from sidebar and command palette"
+
+        XCTAssertTrue(extensionsSpecText.contains("harnessURL()"), "Focused extension flows should reuse the shared harness URL helper.")
+        XCTAssertTrue(extensionsSpecText.contains("extensions-button"), "Focused extension flows should cover the sidebar Extensions entry point.")
+        XCTAssertTrue(extensionsSpecText.contains("extension-mcp-tool-schema"), "Focused extension flows should cover MCP tool schema display.")
+        XCTAssertTrue(extensionsSpecText.contains(extensionsFlowName), "\(extensionsFlowName) should live in extensions.spec.ts.")
+        XCTAssertFalse(coreSpecText.contains(extensionsFlowName), "\(extensionsFlowName) should not drift back into core.spec.ts.")
+    }
+
     func testWorkspaceSurfaceDelegatesReviewSurfaceContracts() throws {
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let reviewText = try Self.appSourceText(named: "QuillCodeReviewSurface.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5385,3 +5385,23 @@ Current strict grades:
 
 Remaining risk:
 - Continue reducing the largest broad files. Good next slices are `AgentTests.swift`, `TrustedRouterAdapterTests.swift`, and the remaining broad Playwright `core.spec.ts` flows.
+
+## 2026-06-24 Playwright Extensions Spec Split
+
+Overall grade after this slice: **A extension/MCP E2E ownership, A shared harness helper reuse, A- broad Playwright core spec**.
+
+The project extension and MCP manifest flow exercises a full Codex extension surface: sidebar entry, plugin update commands, skill rows, MCP process start/stop, advertised tools, resources, prompts, and command-palette discovery. Keeping that in `core.spec.ts` made the broad smoke own too many unrelated feature families.
+
+What changed:
+- Added `extensions.spec.ts` for project extension manifests and MCP probe display.
+- Reused `harnessURL()` and `clickSidebarTool()` from the shared Playwright helper.
+- Removed the extension/MCP-owned flow from `core.spec.ts`.
+- Added a workspace surface parity gate that keeps the extension flow out of `core.spec.ts` and registered it in the focused-suite manifest.
+
+Current strict grades:
+- `E2E/playwright/tests/extensions.spec.ts`: **A**. It owns extension and MCP manifest behavior with one cohesive flow.
+- `E2E/playwright/tests/core.spec.ts`: **A-**. It is smaller, but still owns broad workspace smoke plus several feature families such as settings, composer, runtime issue recovery, automations, remote projects, and worktrees.
+- `ParityWorkspaceSurfaceGateTests.swift`: **A**. It now guards review, terminal, search, and extension E2E ownership.
+
+Remaining risk:
+- Continue splitting `core.spec.ts` by feature family. Good next slices are settings/runtime issue flows and automation flows.


### PR DESCRIPTION
## Summary
- move the extension/MCP manifest Playwright flow from core.spec.ts into a focused extensions.spec.ts
- add a parity gate so the flow stays out of the broad core smoke
- record the code-quality audit for this E2E ownership split

## Validation
- swift test --filter 'ParityWorkspaceSurfaceGateTests|ParityGateTests'
- npm test -- tests/extensions.spec.ts
- npm test -- tests/core.spec.ts
- swift test
- npm test
- git diff --check