### PR TITLE
Split settings Playwright flows

### DIFF
--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1,19 +1,9 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
-import { clickSidebarTool, openSidebarTools } from './harness-helpers';
+import { clickSidebarTool, openSettings, openSidebarTools, openTopBarOverflow } from './harness-helpers';
 
 async function clickProjectAction(row: Locator, name: string) {
   await row.getByLabel(/^Actions for project /).click();
   await row.getByRole('button', { name }).click();
-}
-
-async function openTopBarOverflow(page: Page) {
-  await page.getByTestId('top-bar-overflow-button').click();
-  await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');
-}
-
-async function openSettings(page: Page) {
-  await openTopBarOverflow(page);
-  await page.getByTestId('top-bar-overflow-settings').click();
 }
 
 async function replaceFocusedText(page: Page, text: string) {
@@ -258,25 +248,6 @@ test('mock harness opens utilities from the top-bar overflow', async ({ page }) 
   await openTopBarOverflow(page);
   await expect(page.getByTestId('top-bar-overflow-stop-all')).toHaveCount(0);
   await expect(page.getByTestId('top-bar-stop-button')).toHaveCount(0);
-});
-
-test('mock harness shows actionable Computer Use setup in settings', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await openSettings(page);
-  const settingsPanel = page.getByTestId('settings-panel');
-  await expect(settingsPanel).toBeVisible();
-  await expect(settingsPanel.getByTestId('computer-use-settings')).toBeVisible();
-  await expect(settingsPanel.getByTestId('computer-use-settings-status')).toHaveText('Setup needed');
-  await expect(settingsPanel.getByTestId('computer-use-permission')).toHaveCount(2);
-  await expect(settingsPanel.getByTestId('computer-use-permission').nth(0)).toContainText('Screen Recording');
-  await expect(settingsPanel.getByTestId('computer-use-permission').nth(1)).toContainText('Accessibility');
-
-  await settingsPanel.getByTestId('computer-use-permission-open').first().click();
-  await expect(settingsPanel.getByTestId('computer-use-last-opened')).toContainText('Privacy_ScreenCapture');
-
-  await settingsPanel.getByTestId('computer-use-refresh').click();
-  await expect(page.getByTestId('computer-use-status')).toHaveText('Needs Screen Recording + Accessibility');
 });
 
 test('mock harness composer supports multiline editing and Enter-to-send', async ({ page }) => {
@@ -566,111 +537,6 @@ test('mock harness stops an active composer run from the composer', async ({ pag
   await page.waitForTimeout(2200);
   await expect(page.getByText('Long-running task completed.')).toHaveCount(0);
   await expect(page.getByTestId('agent-status')).toHaveText('Stopped');
-});
-
-test('mock harness shows actionable TrustedRouter runtime issue', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await openSettings(page);
-  await expect(page.getByTestId('settings-panel')).toBeVisible();
-  await page.getByTestId('settings-save').click();
-
-  await expect(page.getByTestId('settings-panel')).toBeHidden();
-  await expect(page.getByTestId('runtime-issue-pill')).toHaveText('TrustedRouter sign-in needed');
-  await expect(page.getByTestId('runtime-issue')).toBeVisible();
-  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter sign-in needed');
-  await expect(page.getByTestId('runtime-issue-message')).toContainText('Sign in with TrustedRouter');
-  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Open Settings');
-
-  await page.getByTestId('runtime-issue-action').click();
-  const settingsPanel = page.getByTestId('settings-panel');
-  await expect(settingsPanel.getByTestId('runtime-issue')).toBeVisible();
-  await expect(settingsPanel.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter sign-in needed');
-});
-
-test('mock harness retries the last user turn from a runtime issue', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await page.getByLabel('Message').fill('trigger network failure');
-  await page.getByRole('button', { name: 'Send' }).click();
-
-  await expect(page.getByTestId('runtime-issue')).toBeVisible();
-  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter network issue');
-  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Retry');
-
-  await page.getByTestId('runtime-issue-action').click();
-
-  await expect(page.getByTestId('runtime-issue')).toHaveCount(0);
-  await expect(page.getByText('Retry completed after reconnecting to TrustedRouter.')).toBeVisible();
-  await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
-  await expect(page.getByTestId('tool-card-input')).toContainText('whoami');
-  await expect(page.getByTestId('message').filter({ hasText: 'trigger network failure' })).toHaveCount(2);
-});
-
-test('mock harness shows runtime diagnostics in settings', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await page.getByLabel('Message').fill('trigger network failure');
-  await page.getByRole('button', { name: 'Send' }).click();
-  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter network issue');
-
-  await openSettings(page);
-  const settingsPanel = page.getByTestId('settings-panel');
-
-  await expect(settingsPanel.getByTestId('runtime-diagnostics')).toBeVisible();
-  await expect(settingsPanel.getByTestId('runtime-diagnostic')).toHaveCount(6);
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(0)).toContainText('API base URL');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(0)).toContainText('https://api.trustedrouter.com/v1');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(1)).toContainText('TrustedRouter login');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(2)).toContainText('Missing');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(3)).toContainText('trustedrouter/fast');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(4)).toContainText('Failed');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(5)).toContainText('Bearer ...redacted');
-  await expect(settingsPanel).not.toContainText('secretDiagnosticToken');
-});
-
-test('mock harness opens model picker from malformed model issue', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await page.getByLabel('Message').fill('trigger malformed model action');
-  await page.getByRole('button', { name: 'Send' }).click();
-
-  await expect(page.getByTestId('runtime-issue')).toBeVisible();
-  await expect(page.getByTestId('runtime-issue-title')).toHaveText('Model response was malformed');
-  await expect(page.getByTestId('runtime-issue-message')).toContainText('Try Nike 1.0');
-  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Switch model');
-
-  await page.getByTestId('runtime-issue-action').click();
-
-  await expect(page.getByTestId('model-browser')).toBeVisible();
-  await expect(page.getByTestId('model-search')).toBeFocused();
-  await page.getByTestId('model-search').fill('synth');
-  await expect(page.getByTestId('model-option')).toHaveCount(2);
-  await expect(page.getByTestId('model-option').nth(0)).toContainText('Synth');
-  await expect(page.getByTestId('model-option').nth(1)).toContainText('Synth Code');
-});
-
-test('mock harness surfaces rate limits with model-switch recovery and diagnostics', async ({ page }) => {
-  await page.goto('file://' + process.cwd() + '/../harness/index.html');
-
-  await page.getByLabel('Message').fill('trigger rate limit');
-  await page.getByRole('button', { name: 'Send' }).click();
-
-  await expect(page.getByTestId('runtime-issue')).toBeVisible();
-  await expect(page.getByTestId('runtime-issue')).toHaveAttribute('data-severity', 'warning');
-  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter rate limit reached');
-  await expect(page.getByTestId('runtime-issue-message')).toContainText('switch models');
-  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Switch model');
-
-  await page.getByTestId('runtime-issue-action').click();
-  await expect(page.getByTestId('model-browser')).toBeVisible();
-  await expect(page.getByTestId('model-search')).toBeFocused();
-
-  await openSettings(page);
-  const settingsPanel = page.getByTestId('settings-panel');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').filter({ hasText: 'Provider status' })).toContainText('Rate limited');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').filter({ hasText: 'Retry after' })).toContainText('120s');
-  await expect(settingsPanel.getByTestId('runtime-diagnostic').filter({ hasText: 'Rate limit remaining' })).toContainText('0');
 });
 
 test('mock harness surfaces file artifacts from tool cards', async ({ page }) => {

--- a/E2E/playwright/tests/extensions.spec.ts
+++ b/E2E/playwright/tests/extensions.spec.ts
@@ -44,11 +44,12 @@ test('mock harness shows project extension manifests from sidebar and command pa
   await expect(page.getByTestId('extensions-pane')).toHaveCount(0);
 
   await clickSidebarTool(page, 'command-palette-button');
-  await page.getByLabel('Search commands').fill('>update github');
-  await expect(page.getByTestId('command-palette-group')).toContainText('Extensions');
-  await expect(page.getByTestId('command-palette-result')).toContainText('Update GitHub');
-  await page.getByLabel('Search commands').fill('>manifest');
-  await expect(page.getByTestId('command-palette-group')).toContainText('Extensions');
-  await page.getByTestId('command-palette-result').click();
+  const commandSearch = page.getByLabel('Search commands');
+  await expect(page.getByTestId('command-palette-panel')).toBeVisible();
+  await expect(commandSearch).toBeFocused();
+  await commandSearch.fill('>update github');
+  await expect(page.locator('[data-testid="command-palette-result"][data-command-id="extension-update:plugin:github"]')).toContainText('Update GitHub');
+  await commandSearch.fill('>extensions');
+  await page.locator('[data-testid="command-palette-result"][data-command-id="toggle-extensions"]').click();
   await expect(page.getByTestId('extensions-pane')).toBeVisible();
 });

--- a/E2E/playwright/tests/harness-helpers.ts
+++ b/E2E/playwright/tests/harness-helpers.ts
@@ -13,3 +13,13 @@ export async function clickSidebarTool(page: Page, testID: string) {
   await openSidebarTools(page);
   await page.getByTestId(testID).click();
 }
+
+export async function openTopBarOverflow(page: Page) {
+  await page.getByTestId('top-bar-overflow-button').click();
+  await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');
+}
+
+export async function openSettings(page: Page) {
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-settings').click();
+}

--- a/E2E/playwright/tests/settings.spec.ts
+++ b/E2E/playwright/tests/settings.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test';
+import { harnessURL, openSettings } from './harness-helpers';
+
+test('mock harness shows actionable Computer Use setup in settings', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await openSettings(page);
+  const settingsPanel = page.getByTestId('settings-panel');
+  await expect(settingsPanel).toBeVisible();
+  await expect(settingsPanel.getByTestId('computer-use-settings')).toBeVisible();
+  await expect(settingsPanel.getByTestId('computer-use-settings-status')).toHaveText('Setup needed');
+  await expect(settingsPanel.getByTestId('computer-use-permission')).toHaveCount(2);
+  await expect(settingsPanel.getByTestId('computer-use-permission').nth(0)).toContainText('Screen Recording');
+  await expect(settingsPanel.getByTestId('computer-use-permission').nth(1)).toContainText('Accessibility');
+
+  await settingsPanel.getByTestId('computer-use-permission-open').first().click();
+  await expect(settingsPanel.getByTestId('computer-use-last-opened')).toContainText('Privacy_ScreenCapture');
+
+  await settingsPanel.getByTestId('computer-use-refresh').click();
+  await expect(page.getByTestId('computer-use-status')).toHaveText('Needs Screen Recording + Accessibility');
+});
+
+test('mock harness shows actionable TrustedRouter runtime issue', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await openSettings(page);
+  await expect(page.getByTestId('settings-panel')).toBeVisible();
+  await page.getByTestId('settings-save').click();
+
+  await expect(page.getByTestId('settings-panel')).toBeHidden();
+  await expect(page.getByTestId('runtime-issue-pill')).toHaveText('TrustedRouter sign-in needed');
+  await expect(page.getByTestId('runtime-issue')).toBeVisible();
+  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter sign-in needed');
+  await expect(page.getByTestId('runtime-issue-message')).toContainText('Sign in with TrustedRouter');
+  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Open Settings');
+
+  await page.getByTestId('runtime-issue-action').click();
+  const settingsPanel = page.getByTestId('settings-panel');
+  await expect(settingsPanel.getByTestId('runtime-issue')).toBeVisible();
+  await expect(settingsPanel.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter sign-in needed');
+});
+
+test('mock harness retries the last user turn from a runtime issue', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('trigger network failure');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('runtime-issue')).toBeVisible();
+  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter network issue');
+  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Retry');
+
+  await page.getByTestId('runtime-issue-action').click();
+
+  await expect(page.getByTestId('runtime-issue')).toHaveCount(0);
+  await expect(page.getByText('Retry completed after reconnecting to TrustedRouter.')).toBeVisible();
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
+  await expect(page.getByTestId('tool-card-input')).toContainText('whoami');
+  await expect(page.getByTestId('message').filter({ hasText: 'trigger network failure' })).toHaveCount(2);
+});
+
+test('mock harness shows runtime diagnostics in settings', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('trigger network failure');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter network issue');
+
+  await openSettings(page);
+  const settingsPanel = page.getByTestId('settings-panel');
+
+  await expect(settingsPanel.getByTestId('runtime-diagnostics')).toBeVisible();
+  await expect(settingsPanel.getByTestId('runtime-diagnostic')).toHaveCount(6);
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(0)).toContainText('API base URL');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(0)).toContainText('https://api.trustedrouter.com/v1');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(1)).toContainText('TrustedRouter login');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(2)).toContainText('Missing');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(3)).toContainText('trustedrouter/fast');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(4)).toContainText('Failed');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').nth(5)).toContainText('Bearer ...redacted');
+  await expect(settingsPanel).not.toContainText('secretDiagnosticToken');
+});
+
+test('mock harness opens model picker from malformed model issue', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('trigger malformed model action');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('runtime-issue')).toBeVisible();
+  await expect(page.getByTestId('runtime-issue-title')).toHaveText('Model response was malformed');
+  await expect(page.getByTestId('runtime-issue-message')).toContainText('Try Nike 1.0');
+  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Switch model');
+
+  await page.getByTestId('runtime-issue-action').click();
+
+  await expect(page.getByTestId('model-browser')).toBeVisible();
+  await expect(page.getByTestId('model-search')).toBeFocused();
+  await page.getByTestId('model-search').fill('synth');
+  await expect(page.getByTestId('model-option')).toHaveCount(2);
+  await expect(page.getByTestId('model-option').nth(0)).toContainText('Synth');
+  await expect(page.getByTestId('model-option').nth(1)).toContainText('Synth Code');
+});
+
+test('mock harness surfaces rate limits with model-switch recovery and diagnostics', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('trigger rate limit');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('runtime-issue')).toBeVisible();
+  await expect(page.getByTestId('runtime-issue')).toHaveAttribute('data-severity', 'warning');
+  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter rate limit reached');
+  await expect(page.getByTestId('runtime-issue-message')).toContainText('switch models');
+  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Switch model');
+
+  await page.getByTestId('runtime-issue-action').click();
+  await expect(page.getByTestId('model-browser')).toBeVisible();
+  await expect(page.getByTestId('model-search')).toBeFocused();
+
+  await openSettings(page);
+  const settingsPanel = page.getByTestId('settings-panel');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').filter({ hasText: 'Provider status' })).toContainText('Rate limited');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').filter({ hasText: 'Retry after' })).toContainText('120s');
+  await expect(settingsPanel.getByTestId('runtime-diagnostic').filter({ hasText: 'Rate limit remaining' })).toContainText('0');
+});

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -137,7 +137,8 @@ struct ParityFocusedSuiteManifest {
             "testWorkspaceSwiftUIViewDelegatesSheetPresentation",
             "testNativeSettingsDelegatesFocusedViewsAndDraftState",
             "testNativeSearchDialogsKeepLocalTypingState",
-            "testWorkspaceSurfaceDelegatesSettingsSurfaceContract"
+            "testWorkspaceSurfaceDelegatesSettingsSurfaceContract",
+            "testPlaywrightSettingsAndRuntimeFlowsStayInFocusedSpec"
         ]),
         Suite(fileName: "ParityWorkspaceTranscriptGateTests.swift", testNames: [
             "testWorkspaceSwiftUIViewDelegatesTranscriptFindAndContextBanner"

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -91,4 +91,34 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(surfaceText.contains("private static func computerUseStatusLabel"), "WorkspaceSurface should not own Computer Use settings copy.")
         XCTAssertFalse(surfaceText.contains("TrustedRouterDefaults.loopbackCallbackURL"), "WorkspaceSurface should not own TrustedRouter sign-in copy.")
     }
+
+    func testPlaywrightSettingsAndRuntimeFlowsStayInFocusedSpec() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let settingsSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("settings.spec.ts"),
+            encoding: .utf8
+        )
+        let coreSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
+            encoding: .utf8
+        )
+        let settingsFlowNames = [
+            "shows actionable Computer Use setup in settings",
+            "shows actionable TrustedRouter runtime issue",
+            "retries the last user turn from a runtime issue",
+            "shows runtime diagnostics in settings",
+            "opens model picker from malformed model issue",
+            "surfaces rate limits with model-switch recovery and diagnostics"
+        ]
+
+        XCTAssertTrue(settingsSpecText.contains("harnessURL()"), "Focused settings/runtime flows should reuse the shared harness URL helper.")
+        XCTAssertTrue(settingsSpecText.contains("openSettings"), "Focused settings/runtime flows should reuse shared top-bar settings navigation.")
+        XCTAssertTrue(settingsSpecText.contains("computer-use-settings"), "Focused settings flows should cover Computer Use onboarding.")
+        XCTAssertTrue(settingsSpecText.contains("runtime-diagnostics"), "Focused runtime flows should cover diagnostic redaction.")
+        XCTAssertTrue(settingsSpecText.contains("TrustedRouter rate limit reached"), "Focused runtime flows should cover rate-limit recovery.")
+        for flowName in settingsFlowNames {
+            XCTAssertTrue(settingsSpecText.contains(flowName), "\(flowName) should live in settings.spec.ts.")
+            XCTAssertFalse(coreSpecText.contains(flowName), "\(flowName) should not drift back into core.spec.ts.")
+        }
+    }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5451,3 +5451,24 @@ Current strict grades:
 
 Remaining risk:
 - `TrustedRouterAdapterTests.swift` is now the largest agent test hotspot. Split parser, prompt-builder, streaming, model-catalog, and key-resolution coverage when it is next touched.
+
+## 2026-06-25 Playwright Settings And Runtime Spec Split
+
+Overall grade after this slice: **A settings/runtime E2E ownership, A shared top-bar settings helper reuse, A- broad Playwright core spec**.
+
+Settings and runtime recovery are their own Codex parity surface: TrustedRouter sign-in, runtime issue callouts, retry recovery, malformed model recovery, rate-limit diagnostics, and Computer Use permission setup. Keeping those in `core.spec.ts` made broad smoke changes touch unrelated auth/runtime behavior.
+
+What changed:
+- Added `settings.spec.ts` for Computer Use setup, TrustedRouter sign-in-needed recovery, network retry recovery, runtime diagnostics/redaction, malformed model recovery, and rate-limit recovery.
+- Promoted `openTopBarOverflow()` and `openSettings()` into `harness-helpers.ts` so focused specs reuse the same top-bar navigation path.
+- Removed settings/runtime-owned flows from `core.spec.ts`.
+- Added a settings parity gate that keeps these flows in the focused spec and registered it in the focused-suite manifest.
+
+Current strict grades:
+- `E2E/playwright/tests/settings.spec.ts`: **A**. It owns runtime recovery and settings behavior with a cohesive feature boundary.
+- `E2E/playwright/tests/harness-helpers.ts`: **A**. Shared top-bar and sidebar navigation helpers now keep focused specs DRY.
+- `E2E/playwright/tests/core.spec.ts`: **A-**. It is smaller, but still owns broad workspace smoke plus command palette, worktrees, projects, and remote-project flows.
+- `ParityWorkspaceSettingsSheetGateTests.swift`: **A**. It now guards native settings structure, local dialog typing, settings surface contracts, and focused Playwright ownership.
+
+Remaining risk:
+- Continue splitting `core.spec.ts` by feature family. Good next slices are command-palette/git/worktree flows and sidebar/project lifecycle flows.


### PR DESCRIPTION
## Summary
- Move Computer Use setup, TrustedRouter runtime recovery, diagnostics, malformed-model recovery, and rate-limit Playwright flows out of `core.spec.ts` into `settings.spec.ts`.
- Promote shared top-bar overflow/settings helpers so focused specs reuse the same navigation path.
- Add a parity gate and audit entry so settings/runtime flows do not drift back into the broad core spec.
- Harden the focused extension command-palette flow by targeting stable command IDs after CI exposed a broad-locator race.

## Validation
- `swift test --filter 'ParityWorkspaceSettingsSheetGateTests|ParityGateTests'`\n- `cd E2E/playwright && npm test -- tests/settings.spec.ts`\n- `cd E2E/playwright && npm test -- tests/core.spec.ts`\n- `swift test`\n- `cd E2E/playwright && npm test`\n- `cd E2E/playwright && npm test -- tests/extensions.spec.ts --workers=2` repeated 10x\n- `swift test --filter 'ParityWorkspaceSettingsSheetGateTests|ParityWorkspaceSurfaceGateTests|ParityGateTests'`\n- `cd E2E/playwright && npm test -- --workers=2`\n- `git diff --check`