### PR TITLE
Canonicalize branded model aliases

### DIFF
--- a/Sources/QuillCodeCore/TrustedRouterDefaults.swift
+++ b/Sources/QuillCodeCore/TrustedRouterDefaults.swift
@@ -22,7 +22,13 @@ public enum TrustedRouterDefaults {
     public static let trustedRouterProviderAliases: [String: String] = ["tr": trustedRouterProvider]
     public static let recommendedModelIDs = [fastModel, synthModel, synthCodeModel]
     public static let modelIDAliases: [String: String] = [
+        "fast": fastModel,
+        "/fast": fastModel,
         "tr/fast": fastModel,
+        "nike": fastModel,
+        "/nike": fastModel,
+        "nike 1.0": fastModel,
+        "trustedrouter/nike": fastModel,
         "tr/synth": synthModel,
         "synth": synthModel,
         synthSlashAlias: synthModel,
@@ -33,6 +39,7 @@ public enum TrustedRouterDefaults {
         "trustedrouter/fusion": synthModel,
         "tr/synth-code": synthCodeModel,
         "synth-code": synthCodeModel,
+        "synth code": synthCodeModel,
         synthCodeSlashAlias: synthCodeModel,
         "trustedrouter/synth-code": synthCodeModel,
         "fusion-code": synthCodeModel,
@@ -60,7 +67,7 @@ public enum TrustedRouterDefaults {
 
     public static func canonicalProvider(_ provider: String) -> String {
         let normalized = provider.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trustedRouterProviderAliases[normalized] ?? normalized
+        return trustedRouterProviderAliases[normalized.lowercased()] ?? normalized
     }
 
     public static func canonicalModelID(_ id: String) -> String {

--- a/Tests/QuillCodeAppTests/WorkspaceConfigurationEngineTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfigurationEngineTests.swift
@@ -26,6 +26,18 @@ final class WorkspaceConfigurationEngineTests: XCTestCase {
         XCTAssertEqual(thread.model, TrustedRouterDefaults.synthModel)
     }
 
+    func testModelUpdatesNormalizeBrandedDefaultName() {
+        var config = AppConfig(defaultModel: TrustedRouterDefaults.synthModel)
+        var thread = ChatThread(model: TrustedRouterDefaults.synthModel)
+
+        let modelID = WorkspaceConfigurationEngine.setModel(" Nike 1.0 ", config: &config)
+        WorkspaceConfigurationEngine.setModelID(modelID, thread: &thread)
+
+        XCTAssertEqual(modelID, TrustedRouterDefaults.fastModel)
+        XCTAssertEqual(config.defaultModel, TrustedRouterDefaults.fastModel)
+        XCTAssertEqual(thread.model, TrustedRouterDefaults.fastModel)
+    }
+
     func testBlankModelFallsBackToDefault() {
         var config = AppConfig(defaultModel: TrustedRouterDefaults.synthModel)
         var thread = ChatThread(model: TrustedRouterDefaults.synthModel)

--- a/Tests/QuillCodeAppTests/WorkspaceSlashCommandTranscriptPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSlashCommandTranscriptPlannerTests.swift
@@ -42,6 +42,13 @@ final class WorkspaceSlashCommandTranscriptPlannerTests: XCTestCase {
         )
         XCTAssertEqual(
             WorkspaceSlashCommandTranscriptPlanner.model(
+                userText: "/model Nike 1.0",
+                model: "Nike 1.0"
+            ).assistantText,
+            "Model set to Nike 1.0 (trustedrouter/fast)."
+        )
+        XCTAssertEqual(
+            WorkspaceSlashCommandTranscriptPlanner.model(
                 userText: "/model z-ai/glm-5.2",
                 model: "z-ai/glm-5.2"
             ).assistantText,

--- a/Tests/QuillCodeCoreTests/CoreModelTests.swift
+++ b/Tests/QuillCodeCoreTests/CoreModelTests.swift
@@ -26,6 +26,9 @@ final class CoreModelTests: XCTestCase {
             ]
         )
         XCTAssertEqual(TrustedRouterDefaults.canonicalProvider("tr"), TrustedRouterDefaults.trustedRouterProvider)
+        XCTAssertEqual(TrustedRouterDefaults.canonicalProvider(" TR "), TrustedRouterDefaults.trustedRouterProvider)
+        XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("Nike 1.0"), TrustedRouterDefaults.fastModel)
+        XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("/fast"), TrustedRouterDefaults.fastModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("tr/synth"), TrustedRouterDefaults.synthModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("Synth"), TrustedRouterDefaults.synthModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("trustedrouter/synth"), TrustedRouterDefaults.synthModel)
@@ -36,6 +39,7 @@ final class CoreModelTests: XCTestCase {
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("trustedrouter/fusion"), TrustedRouterDefaults.synthModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("/fusion"), TrustedRouterDefaults.synthModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("tr/synth-code"), TrustedRouterDefaults.synthCodeModel)
+        XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("Synth Code"), TrustedRouterDefaults.synthCodeModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID("trustedrouter/synth-code"), TrustedRouterDefaults.synthCodeModel)
         XCTAssertEqual(TrustedRouterDefaults.canonicalModelID(TrustedRouterDefaults.synthCodeSlashAlias), TrustedRouterDefaults.synthCodeModel)
         XCTAssertEqual(TrustedRouterDefaults.provider(fromModelID: TrustedRouterDefaults.synthCodeSlashAlias), TrustedRouterDefaults.trustedRouterProvider)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -52,6 +52,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Promoted Synth Code (`/synth-code`, `tr/synth-code`) into the bundled Recommended catalog so the preferred code model is visible offline instead of only working as a hidden alias.
 - Added explicit catalog-normalization regression coverage so live or persisted legacy Fusion rows dedupe into Synth/Synth Code and do not reappear as user-facing picker rows.
 - Centralized the branded default names in `TrustedRouterDefaults`, with tests proving canonical IDs and display names separately.
+- Hardened the model alias boundary so branded `Nike 1.0`, `/fast`, and case-varied `TR` inputs normalize to canonical IDs instead of leaking display copy into persisted model settings.
 - Removed dead provider plumbing from model metadata summary generation.
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.
 - Updated the Playwright harness to preserve branded labels after model selection.


### PR DESCRIPTION
## Summary
- accept branded Nike 1.0, /fast, and /nike inputs as aliases for `trustedrouter/fast`
- keep Synth Code display input canonicalized to `tr/synth-code`
- make TrustedRouter provider alias normalization case-insensitive for `TR`/`tr`
- add focused core/config/transcript regressions and audit note

## Validation
- `swift test --filter 'CoreModelTests|WorkspaceConfigurationEngineTests|WorkspaceSlashCommandTranscriptPlannerTests|WorkspaceModelCatalogSurfaceBuilderTests|WorkspaceModelPickerSurfaceIntegrationTests|SlashModelCommandParserTests|ParityModelGateTests'`\n- `swift test`\n- `git diff --check`