### PR TITLE
Wire new chat command execution

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
@@ -17,6 +17,9 @@ extension QuillCodeWorkspaceModel {
     @discardableResult
     func runWorkspaceCommandActionEffect(_ effect: WorkspaceCommandActionEffect) -> Bool {
         switch effect {
+        case .newChat:
+            _ = newChat()
+            return true
         case .toggleTerminal:
             toggleTerminal()
             return true

--- a/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
@@ -2,6 +2,7 @@ import Foundation
 import QuillCodeCore
 
 enum WorkspaceCommandActionEffect: Sendable, Hashable {
+    case newChat
     case toggleTerminal
     case clearTerminal
     case toggleBrowser
@@ -39,6 +40,8 @@ struct WorkspaceCommandActionPlanner: Sendable, Hashable {
 
     func effect(for action: WorkspaceCommandAction) -> WorkspaceCommandActionEffect? {
         switch action {
+        case .newChat:
+            return .newChat
         case .toggleTerminal:
             return .toggleTerminal
         case .clearTerminal:

--- a/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
@@ -137,6 +137,7 @@ enum WorkspaceCommandPlan: Equatable {
 }
 
 enum WorkspaceCommandAction: String, Equatable {
+    case newChat = "new-chat"
     case toggleTerminal = "toggle-terminal"
     case clearTerminal = "terminal-clear"
     case toggleBrowser = "toggle-browser"

--- a/Tests/QuillCodeAppTests/WorkspaceCommandActionPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandActionPlannerTests.swift
@@ -6,6 +6,7 @@ final class WorkspaceCommandActionPlannerTests: XCTestCase {
     func testContextFreeActionsMapToEffects() {
         let planner = WorkspaceCommandActionPlanner()
 
+        XCTAssertEqual(planner.effect(for: .newChat), .newChat)
         XCTAssertEqual(planner.effect(for: .toggleTerminal), .toggleTerminal)
         XCTAssertEqual(planner.effect(for: .clearTerminal), .clearTerminal)
         XCTAssertEqual(planner.effect(for: .toggleBrowser), .toggleBrowser)

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPlanExecutorTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPlanExecutorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import QuillCodeCore
 @testable import QuillCodeApp
 
 @MainActor
@@ -17,6 +18,18 @@ final class WorkspaceCommandPlanExecutorTests: XCTestCase {
         XCTAssertFalse(model.terminal.isVisible)
         XCTAssertTrue(model.runWorkspaceCommandPlan(.action(.toggleTerminal), workspaceRoot: try makeTempDirectory()))
         XCTAssertTrue(model.terminal.isVisible)
+    }
+
+    func testExecutorRunsNewChatCommandPlan() throws {
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [ChatThread(title: "Existing")],
+            selectedThreadID: nil
+        ))
+
+        XCTAssertTrue(model.runWorkspaceCommand("new-chat", workspaceRoot: try makeTempDirectory()))
+
+        XCTAssertEqual(model.root.threads.count, 2)
+        XCTAssertEqual(model.selectedThread?.title, "New chat")
     }
 
 }

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPlanTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPlanTests.swift
@@ -124,6 +124,10 @@ final class WorkspaceCommandPlanTests: XCTestCase {
 
     func testStaticCommandsMapToActions() {
         XCTAssertEqual(
+            WorkspaceCommandPlan(commandID: "new-chat"),
+            .action(.newChat)
+        )
+        XCTAssertEqual(
             WorkspaceCommandPlan(commandID: "toggle-terminal"),
             .action(.toggleTerminal)
         )
@@ -159,7 +163,6 @@ final class WorkspaceCommandPlanTests: XCTestCase {
 
     func testInvalidCommandsReturnNil() {
         XCTAssertNil(WorkspaceCommandPlan(commandID: "unknown-command"))
-        XCTAssertNil(WorkspaceCommandPlan(commandID: "new-chat"))
         XCTAssertNil(WorkspaceCommandPlan(commandID: "automation-pause:not-a-uuid"))
         XCTAssertNil(WorkspaceCommandPlan(commandID: "automation-create-thread-follow-up-after:soon"))
         XCTAssertNil(WorkspaceCommandPlan(commandID: "automation-create-workspace-schedule-every:yearly"))

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5497,3 +5497,23 @@ Current strict grades:
 
 Remaining risk:
 - The production TrustedRouter adapter boundaries are now well guarded. The next quality slices should target `WorkspaceAutomationIntegrationTests.swift`, remaining broad Playwright `core.spec.ts` flows, or another focused `WorkspaceModel` workflow extraction.
+
+## 2026-06-25 New Chat Command Execution Boundary
+
+Overall grade after this slice: **A command-plan completeness, A action-executor wiring, A regression coverage**.
+
+`new-chat` was exposed through the sidebar command catalog and context warning banner, but it was explicitly invalid in `WorkspaceCommandPlan`. Native SwiftUI command handling sends most ordinary command IDs through the model command executor, so a surfaced `new-chat` button could silently no-op depending on which surface emitted it.
+
+What changed:
+- Added `WorkspaceCommandAction.newChat` so the command ID parses through the same command-plan path as other visible workspace actions.
+- Added `WorkspaceCommandActionEffect.newChat` and executor handling that calls the existing `newChat()` model path, preserving selected-project/default mode/model behavior.
+- Added focused tests for command parsing, action planning, and model execution.
+
+Current strict grades:
+- `WorkspaceCommandPlan.swift`: **A**. Static command IDs that are visible in UI now include the global new-chat action instead of requiring a special missing-command exception.
+- `WorkspaceCommandActionPlanner.swift`: **A**. Context-free workspace actions include new-chat alongside terminal/browser/activity toggles.
+- `WorkspaceCommandActionExecutor.swift`: **A**. New-chat uses the existing model lifecycle API rather than duplicating thread construction.
+- `WorkspaceCommandPlanExecutorTests.swift`: **A**. It now catches visible command IDs that parse but fail to mutate model state.
+
+Remaining risk:
+- Continue auditing command IDs emitted by native-only surfaces. Any command that appears in a `WorkspaceCommandSurface` should either have an explicit view-planner presentation route or a model command plan with an execution test.


### PR DESCRIPTION
## Summary
- routes the visible `new-chat` command through `WorkspaceCommandPlan` instead of treating it as invalid
- adds a new action effect/executor path that calls the existing `newChat()` model lifecycle
- covers parsing, planning, and execution so native command surfaces cannot silently no-op

## Validation
- `swift test --filter 'WorkspaceCommandPlanTests|WorkspaceCommandActionPlannerTests|WorkspaceCommandPlanExecutorTests|WorkspaceProjectIntegrationTests|WorkspaceThreadLifecycleIntegrationTests'`\n- `git diff --check`\n- `swift test`\n- `cd E2E/playwright && npm test -- --workers=2`