### PR TITLE
Harden command palette Playwright interactions

### DIFF
--- a/E2E/playwright/tests/extensions.spec.ts
+++ b/E2E/playwright/tests/extensions.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { clickSidebarTool, harnessURL } from './harness-helpers';
+import {
+  clickCommandPaletteCommand,
+  clickSidebarTool,
+  commandPaletteResult,
+  fillCommandPalette,
+  harnessURL
+} from './harness-helpers';
 
 test('mock harness shows project extension manifests from sidebar and command palette', async ({ page }) => {
   await page.goto(harnessURL());
@@ -44,12 +50,10 @@ test('mock harness shows project extension manifests from sidebar and command pa
   await expect(page.getByTestId('extensions-pane')).toHaveCount(0);
 
   await clickSidebarTool(page, 'command-palette-button');
-  const commandSearch = page.getByLabel('Search commands');
   await expect(page.getByTestId('command-palette-panel')).toBeVisible();
-  await expect(commandSearch).toBeFocused();
-  await commandSearch.fill('>update github');
-  await expect(page.locator('[data-testid="command-palette-result"][data-command-id="extension-update:plugin:github"]')).toContainText('Update GitHub');
-  await commandSearch.fill('>extensions');
-  await page.locator('[data-testid="command-palette-result"][data-command-id="toggle-extensions"]').click();
+  await expect(page.getByTestId('command-palette-input')).toBeFocused();
+  await fillCommandPalette(page, '>update github');
+  await expect(commandPaletteResult(page, 'extension-update:plugin:github')).toContainText('Update GitHub');
+  await clickCommandPaletteCommand(page, '>extensions', 'toggle-extensions');
   await expect(page.getByTestId('extensions-pane')).toBeVisible();
 });

--- a/E2E/playwright/tests/harness-helpers.ts
+++ b/E2E/playwright/tests/harness-helpers.ts
@@ -14,6 +14,24 @@ export async function clickSidebarTool(page: Page, testID: string) {
   await page.getByTestId(testID).click();
 }
 
+export function commandPaletteResult(page: Page, commandID: string) {
+  return page.locator(`[data-testid="command-palette-result"][data-command-id="${commandID}"]`);
+}
+
+export async function fillCommandPalette(page: Page, query: string) {
+  const input = page.getByTestId('command-palette-input');
+  await expect(input).toBeVisible();
+  await input.fill(query);
+  await expect(input).toHaveValue(query);
+}
+
+export async function clickCommandPaletteCommand(page: Page, query: string, commandID: string) {
+  await fillCommandPalette(page, query);
+  const result = commandPaletteResult(page, commandID);
+  await expect(result).toBeVisible();
+  await result.click();
+}
+
 export async function openTopBarOverflow(page: Page) {
   await page.getByTestId('top-bar-overflow-button').click();
   await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5518,6 +5518,23 @@ Current strict grades:
 Remaining risk:
 - Continue auditing command IDs emitted by native-only surfaces. Any command that appears in a `WorkspaceCommandSurface` should either have an explicit view-planner presentation route or a model command plan with an execution test.
 
+## 2026-06-25 Command Palette Playwright Locator Boundary
+
+Overall grade after this slice: **A E2E interaction determinism, A shared command-palette helper reuse**.
+
+The HTML mock harness intentionally re-renders the command palette as the query changes so it can model SwiftUI-style derived state. A focused extensions E2E test reused a command-palette input locator across two filters, which passed locally but exposed a CI race after main merged: the second query could miss the expected `toggle-extensions` row before the click wait timed out.
+
+What changed:
+- Added shared Playwright helpers that reacquire the current command-palette input, assert the entered query, and wait for an exact command row before clicking.
+- Updated the extensions parity test to use those helpers for both the `>update github` discovery check and the `>extensions` navigation action.
+
+Current strict grades:
+- `E2E/playwright/tests/harness-helpers.ts`: **A**. Command-palette tests now have one deterministic query/click path.
+- `E2E/playwright/tests/extensions.spec.ts`: **A**. The test still owns extension sidebar and command-palette parity without relying on stale input element handles.
+
+Remaining risk:
+- Migrate other command-palette specs to the shared helpers opportunistically as they are touched, especially broad `core.spec.ts` command-palette flows.
+
 ## 2026-06-25 Playwright Sidebar And Project Spec Split
 
 Overall grade after this slice: **A sidebar/project E2E ownership, A focused helper locality, A- broad Playwright core spec**.


### PR DESCRIPTION
## Summary
- adds shared Playwright helpers for command-palette query/result interactions
- makes the extensions command-palette flow reacquire the input and assert the query before clicking
- documents the CI flake root cause and follow-up boundary in the quality audit

## Validation
- `git diff --check`
- `cd E2E/playwright && npm test -- tests/extensions.spec.ts --repeat-each=10 --workers=2`
- `cd E2E/playwright && npm test -- --workers=2`
- `swift test --filter ParityWorkspaceSurfaceGateTests`