### PR TITLE
Harden Playwright DOM style queries

### DIFF
--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clickSidebarTool, harnessURL } from './harness-helpers';
+import { clickSidebarTool, computedStyleProperties, harnessURL } from './harness-helpers';
 
 test('mock harness surfaces file artifacts from tool cards', async ({ page }) => {
   await page.goto(harnessURL());
@@ -76,17 +76,22 @@ test('mock harness renders image artifact previews from tool cards', async ({ pa
   await expect(page.getByTestId('tool-card-image-preview-label')).toHaveText('screenshot.png');
   await expect(page.getByTestId('tool-card-image-preview-detail')).toHaveText('/mock/QuillCode/screenshots');
   await expect(page.getByTestId('tool-card-image-preview').locator('img')).toHaveAttribute('src', 'file:///mock/QuillCode/screenshots/screenshot.png');
-  const imageSurface = await page.getByTestId('tool-card-image-preview').evaluate((element) => {
-    const cardStyle = getComputedStyle(element);
-    const imageStyle = getComputedStyle(element.querySelector('img')!);
-    return {
-      cardRadius: cardStyle.borderRadius,
-      imageRadius: imageStyle.borderRadius,
-      imageOutlineColor: imageStyle.outlineColor,
-      imageOutlineWidth: imageStyle.outlineWidth,
-      imageOutlineOffset: imageStyle.outlineOffset
-    };
-  });
+  const [imageCardStyle, imageStyle] = await Promise.all([
+    computedStyleProperties(page, '[data-testid="tool-card-image-preview"]', ['border-radius']),
+    computedStyleProperties(page, '[data-testid="tool-card-image-preview"] img', [
+      'border-radius',
+      'outline-color',
+      'outline-width',
+      'outline-offset'
+    ])
+  ]);
+  const imageSurface = {
+    cardRadius: imageCardStyle['border-radius'],
+    imageRadius: imageStyle['border-radius'],
+    imageOutlineColor: imageStyle['outline-color'],
+    imageOutlineWidth: imageStyle['outline-width'],
+    imageOutlineOffset: imageStyle['outline-offset']
+  };
   expect(imageSurface.cardRadius).toBe('18px');
   expect(imageSurface.imageRadius).toBe('10px');
   expect(imageSurface.imageOutlineColor).toBe('rgba(255, 255, 255, 0.1)');
@@ -110,16 +115,20 @@ test('mock harness renders document artifact previews from tool cards', async ({
   await expect(page.getByTestId('tool-card-document-preview-label')).toHaveText('briefing.pdf');
   await expect(page.getByTestId('tool-card-document-preview-detail')).toHaveText('/mock/QuillCode/reports');
   await expect(page.getByTestId('tool-card-document-preview-open')).toHaveAttribute('href', 'file:///mock/QuillCode/reports/briefing.pdf');
-  const documentSurface = await page.getByTestId('tool-card-document-preview').evaluate((element) => {
-    const cardStyle = getComputedStyle(element);
-    const iconStyle = getComputedStyle(element.querySelector('.artifact-document-icon')!);
-    return {
-      cardRadius: cardStyle.borderRadius,
-      cardMinHeight: cardStyle.minHeight,
-      iconRadius: iconStyle.borderRadius,
-      transitionProperty: cardStyle.transitionProperty
-    };
-  });
+  const [documentCardStyle, documentIconStyle] = await Promise.all([
+    computedStyleProperties(page, '[data-testid="tool-card-document-preview"]', [
+      'border-radius',
+      'min-height',
+      'transition-property'
+    ]),
+    computedStyleProperties(page, '[data-testid="tool-card-document-preview"] .artifact-document-icon', ['border-radius'])
+  ]);
+  const documentSurface = {
+    cardRadius: documentCardStyle['border-radius'],
+    cardMinHeight: documentCardStyle['min-height'],
+    iconRadius: documentIconStyle['border-radius'],
+    transitionProperty: documentCardStyle['transition-property']
+  };
   expect(documentSurface.cardRadius).toBe('18px');
   expect(documentSurface.cardMinHeight).toBe('74px');
   expect(documentSurface.iconRadius).toBe('10px');

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1,5 +1,17 @@
 import { test, expect, type Page } from '@playwright/test';
-import { clickSidebarTool, openSettings, openSidebarTools, openTopBarOverflow } from './harness-helpers';
+import {
+  clickSidebarTool,
+  computedStyleProperties,
+  elementRect,
+  openSettings,
+  openSidebarTools,
+  openTopBarOverflow
+} from './harness-helpers';
+
+function expectPresent<T>(value: T | null, label: string): T {
+  expect(value, label).not.toBeNull();
+  return value as T;
+}
 
 test('mock harness executes simple command flow', async ({ page }) => {
   await page.goto('file://' + process.cwd() + '/../harness/index.html');
@@ -22,9 +34,9 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('composer-agent-status')).toHaveCount(0);
   const modelButtonBox = await page.getByTestId('model-picker-button').boundingBox();
   const modeButtonBox = await page.getByTestId('mode-picker-button').boundingBox();
-  expect(modelButtonBox).not.toBeNull();
-  expect(modeButtonBox).not.toBeNull();
-  expect(modeButtonBox!.x - (modelButtonBox!.x + modelButtonBox!.width)).toBeGreaterThanOrEqual(8);
+  const modelButtonBounds = expectPresent(modelButtonBox, 'model picker button should have bounds');
+  const modeButtonBounds = expectPresent(modeButtonBox, 'mode picker button should have bounds');
+  expect(modeButtonBounds.x - (modelButtonBounds.x + modelButtonBounds.width)).toBeGreaterThanOrEqual(8);
   await page.getByTestId('model-picker-button').click();
   await expect(page.getByTestId('model-category')).toHaveCount(2);
   await page.getByTestId('model-picker-button').click();
@@ -167,9 +179,9 @@ test('mock harness exposes actionable approval buttons on review cards', async (
   await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Skip' })).toBeVisible();
   const runBox = await page.getByTestId('tool-card-action').filter({ hasText: 'Run' }).boundingBox();
   const skipBox = await page.getByTestId('tool-card-action').filter({ hasText: 'Skip' }).boundingBox();
-  expect(runBox).not.toBeNull();
-  expect(skipBox).not.toBeNull();
-  expect(runBox!.width).toBeGreaterThan(skipBox!.width);
+  const runBounds = expectPresent(runBox, 'run approval action should have bounds');
+  const skipBounds = expectPresent(skipBox, 'skip approval action should have bounds');
+  expect(runBounds.width).toBeGreaterThan(skipBounds.width);
 
   await page.getByTestId('tool-card-action').filter({ hasText: 'Run' }).click();
 
@@ -292,39 +304,51 @@ test('mock harness avoids horizontal clipping in key desktop and mobile flows', 
 test('mock harness applies interface polish primitives', async ({ page }) => {
   await page.goto('file://' + process.cwd() + '/../harness/index.html');
 
-  const polish = await page.evaluate(() => {
-    const styleFor = (selector: string) => getComputedStyle(document.querySelector(selector)!);
-    const sendButton = styleFor('[data-testid="send-button"]');
-    const addProjectButton = styleFor('[data-testid="add-project-button"]');
-    const sidebarAction = styleFor('[data-testid="new-chat-button"]');
-    const messageInput = styleFor('#message');
-    const title = styleFor('[data-testid="top-bar-title"]');
-    const agentStatus = styleFor('[data-testid="agent-status"]');
-    const sidebar = styleFor('[data-testid="sidebar"]');
-    const sidebarToolsButton = styleFor('[data-testid="sidebar-tools-button"]');
-    const sidebarToolAction = styleFor('[data-testid="sidebar-search-button"]');
-    const sidebarSettingsButton = styleFor('[data-testid="settings-button"]');
+  const [
+    rootStyle,
+    sendButtonStyle,
+    addProjectButtonStyle,
+    sidebarActionStyle,
+    messageInputStyle,
+    titleStyle,
+    agentStatusStyle,
+    sidebarStyle,
+    sidebarToolsButtonStyle,
+    sidebarToolActionStyle,
+    sidebarSettingsButtonStyle
+  ] = await Promise.all([
+    computedStyleProperties(page, 'html', ['-webkit-font-smoothing']),
+    computedStyleProperties(page, '[data-testid="send-button"]', ['min-height', 'transition-property']),
+    computedStyleProperties(page, '[data-testid="add-project-button"]', ['width', 'height']),
+    computedStyleProperties(page, '[data-testid="new-chat-button"]', ['min-height', 'transition-property']),
+    computedStyleProperties(page, '#message', ['transition-property']),
+    computedStyleProperties(page, '[data-testid="top-bar-title"]', ['text-wrap']),
+    computedStyleProperties(page, '[data-testid="agent-status"]', ['font-variant-numeric']),
+    computedStyleProperties(page, '[data-testid="sidebar"]', ['border-radius']),
+    computedStyleProperties(page, '[data-testid="sidebar-tools-button"]', ['min-height', 'transition-property']),
+    computedStyleProperties(page, '[data-testid="sidebar-search-button"]', ['min-height', 'transition-property']),
+    computedStyleProperties(page, '[data-testid="settings-button"]', ['width', 'min-height'])
+  ]);
 
-    return {
-      rootFontSmoothing: getComputedStyle(document.documentElement).webkitFontSmoothing,
-      sendMinHeight: parseFloat(sendButton.minHeight),
-      sendTransitionProperty: sendButton.transitionProperty,
-      inputTransitionProperty: messageInput.transitionProperty,
-      sidebarActionTransitionProperty: sidebarAction.transitionProperty,
-      sidebarActionMinHeight: parseFloat(sidebarAction.minHeight),
-      titleTextWrap: title.getPropertyValue('text-wrap'),
-      agentStatusNumbers: agentStatus.fontVariantNumeric,
-      addProjectWidth: parseFloat(addProjectButton.width),
-      addProjectHeight: parseFloat(addProjectButton.height),
-      sidebarToolsMinHeight: parseFloat(sidebarToolsButton.minHeight),
-      sidebarToolsTransitionProperty: sidebarToolsButton.transitionProperty,
-      sidebarToolActionMinHeight: parseFloat(sidebarToolAction.minHeight),
-      sidebarToolActionTransitionProperty: sidebarToolAction.transitionProperty,
-      sidebarSettingsWidth: parseFloat(sidebarSettingsButton.width),
-      sidebarSettingsMinHeight: parseFloat(sidebarSettingsButton.minHeight),
-      sidebarRadius: parseFloat(sidebar.borderRadius)
-    };
-  });
+  const polish = {
+    rootFontSmoothing: rootStyle['-webkit-font-smoothing'],
+    sendMinHeight: parseFloat(sendButtonStyle['min-height']),
+    sendTransitionProperty: sendButtonStyle['transition-property'],
+    inputTransitionProperty: messageInputStyle['transition-property'],
+    sidebarActionTransitionProperty: sidebarActionStyle['transition-property'],
+    sidebarActionMinHeight: parseFloat(sidebarActionStyle['min-height']),
+    titleTextWrap: titleStyle['text-wrap'],
+    agentStatusNumbers: agentStatusStyle['font-variant-numeric'],
+    addProjectWidth: parseFloat(addProjectButtonStyle.width),
+    addProjectHeight: parseFloat(addProjectButtonStyle.height),
+    sidebarToolsMinHeight: parseFloat(sidebarToolsButtonStyle['min-height']),
+    sidebarToolsTransitionProperty: sidebarToolsButtonStyle['transition-property'],
+    sidebarToolActionMinHeight: parseFloat(sidebarToolActionStyle['min-height']),
+    sidebarToolActionTransitionProperty: sidebarToolActionStyle['transition-property'],
+    sidebarSettingsWidth: parseFloat(sidebarSettingsButtonStyle.width),
+    sidebarSettingsMinHeight: parseFloat(sidebarSettingsButtonStyle['min-height']),
+    sidebarRadius: parseFloat(sidebarStyle['border-radius'])
+  };
 
   expect(polish.rootFontSmoothing).toBe('antialiased');
   expect(polish.sendMinHeight).toBeGreaterThanOrEqual(40);
@@ -354,25 +378,31 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
   await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
   await expect(page.getByTestId('tool-card')).toHaveAttribute('data-density', 'collapsed');
 
-  const transcriptPolish = await page.evaluate(() => {
-    const styleFor = (selector: string) => getComputedStyle(document.querySelector(selector)!);
-    const toolCard = styleFor('[data-testid="tool-card"]');
-    const toolCardRect = document.querySelector('[data-testid="tool-card"]')!.getBoundingClientRect();
-    const toolStatus = styleFor('[data-testid="tool-card-status"]');
-    const toolCopyButton = styleFor('[data-testid="tool-card-copy"]');
-    const messageCopyButton = styleFor('[data-testid="message-copy"]');
-    const sidebarMenuRect = document.querySelector('[data-testid="sidebar-item-actions"] summary')!.getBoundingClientRect();
+  const [
+    toolCardStyle,
+    toolCardRect,
+    toolStatusStyle,
+    toolCopyButtonStyle,
+    messageCopyButtonStyle,
+    sidebarMenuRect
+  ] = await Promise.all([
+    computedStyleProperties(page, '[data-testid="tool-card"]', ['min-height']),
+    elementRect(page, '[data-testid="tool-card"]'),
+    computedStyleProperties(page, '[data-testid="tool-card-status"]', ['font-variant-numeric']),
+    computedStyleProperties(page, '[data-testid="tool-card-copy"]', ['min-height']),
+    computedStyleProperties(page, '[data-testid="message-copy"]', ['min-height']),
+    elementRect(page, '[data-testid="sidebar-item-actions"] summary')
+  ]);
 
-    return {
-      toolCardMinHeight: parseFloat(toolCard.minHeight),
-      toolCardRenderedHeight: toolCardRect.height,
-      toolStatusNumbers: toolStatus.fontVariantNumeric,
-      toolCopyMinHeight: parseFloat(toolCopyButton.minHeight),
-      messageCopyMinHeight: parseFloat(messageCopyButton.minHeight),
-      sidebarMenuWidth: sidebarMenuRect.width,
-      sidebarMenuHeight: sidebarMenuRect.height
-    };
-  });
+  const transcriptPolish = {
+    toolCardMinHeight: parseFloat(toolCardStyle['min-height']),
+    toolCardRenderedHeight: toolCardRect.height,
+    toolStatusNumbers: toolStatusStyle['font-variant-numeric'],
+    toolCopyMinHeight: parseFloat(toolCopyButtonStyle['min-height']),
+    messageCopyMinHeight: parseFloat(messageCopyButtonStyle['min-height']),
+    sidebarMenuWidth: sidebarMenuRect.width,
+    sidebarMenuHeight: sidebarMenuRect.height
+  };
 
   expect(transcriptPolish.toolCardMinHeight).toBeGreaterThanOrEqual(58);
   expect(transcriptPolish.toolCardRenderedHeight).toBeGreaterThanOrEqual(58);
@@ -400,26 +430,38 @@ test('mock harness keeps quiet top bar stable under long status metadata', async
     element.textContent = 'Idle';
   });
 
-  const metrics = await page.evaluate(() => {
-    const styleFor = (selector: string) => getComputedStyle(document.querySelector(selector)!);
-    const rectFor = (selector: string) => document.querySelector(selector)!.getBoundingClientRect();
-    const topBarRect = rectFor('[data-testid="top-bar"]');
-    const actionRect = rectFor('[data-testid="top-bar-action-cluster"]');
-    const metadataRect = rectFor('[data-testid="top-bar-status-metadata"]');
-    return {
-      viewportWidth: document.documentElement.clientWidth,
+  const [
+    viewportMetrics,
+    clustersStyle,
+    contextStyle,
+    metadataRect,
+    topBarRect,
+    actionRect
+  ] = await Promise.all([
+    page.evaluate(() => ({
       scrollWidth: document.documentElement.scrollWidth,
-      clustersDisplay: styleFor('[data-testid="top-bar-clusters"]').display,
-      clustersColumns: styleFor('[data-testid="top-bar-clusters"]').gridTemplateColumns,
-      contextOverflow: styleFor('[data-testid="top-bar-subtitle"]').overflow,
-      contextTextOverflow: styleFor('[data-testid="top-bar-subtitle"]').textOverflow,
-      metadataWidth: metadataRect.width,
-      metadataHeight: metadataRect.height,
-      topBarHeight: topBarRect.height,
-      actionRight: actionRect.right,
-      topBarRight: topBarRect.right
-    };
-  });
+      viewportWidth: document.documentElement.clientWidth
+    })),
+    computedStyleProperties(page, '[data-testid="top-bar-clusters"]', ['display', 'grid-template-columns']),
+    computedStyleProperties(page, '[data-testid="top-bar-subtitle"]', ['overflow', 'text-overflow']),
+    elementRect(page, '[data-testid="top-bar-status-metadata"]'),
+    elementRect(page, '[data-testid="top-bar"]'),
+    elementRect(page, '[data-testid="top-bar-action-cluster"]')
+  ]);
+
+  const metrics = {
+    viewportWidth: viewportMetrics.viewportWidth,
+    scrollWidth: viewportMetrics.scrollWidth,
+    clustersDisplay: clustersStyle.display,
+    clustersColumns: clustersStyle['grid-template-columns'],
+    contextOverflow: contextStyle.overflow,
+    contextTextOverflow: contextStyle['text-overflow'],
+    metadataWidth: metadataRect.width,
+    metadataHeight: metadataRect.height,
+    topBarHeight: topBarRect.height,
+    actionRight: actionRect.right,
+    topBarRight: topBarRect.right
+  };
 
   await expect(page.getByTestId('top-bar-status-button')).toHaveCount(0);
   await expect(page.getByTestId('top-bar-status-menu')).toHaveCount(0);

--- a/E2E/playwright/tests/harness-helpers.ts
+++ b/E2E/playwright/tests/harness-helpers.ts
@@ -1,7 +1,37 @@
 import { expect, type Page } from '@playwright/test';
 
+export type ElementRect = {
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+};
+
 export function harnessURL(): string {
   return 'file://' + process.cwd() + '/../harness/index.html';
+}
+
+export async function computedStyleProperties(page: Page, selector: string, properties: string[]) {
+  return page.locator(selector).first().evaluate((element, styleProperties) => {
+    const style = getComputedStyle(element);
+    return Object.fromEntries(
+      styleProperties.map(property => [property, style.getPropertyValue(property)])
+    );
+  }, properties);
+}
+
+export async function elementRect(page: Page, selector: string): Promise<ElementRect> {
+  return page.locator(selector).first().evaluate(element => {
+    const rect = element.getBoundingClientRect();
+    return {
+      height: rect.height,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      width: rect.width
+    };
+  });
 }
 
 export async function openSidebarTools(page: Page) {

--- a/Tests/QuillCodeParityTests/ParityGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityGateTests.swift
@@ -34,6 +34,34 @@ final class ParityGateTests: QuillCodeParityTestCase {
         }
     }
 
+    func testPlaywrightTestsAvoidDomForceUnwraps() throws {
+        let testsRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        guard let enumerator = FileManager.default.enumerator(
+            at: testsRoot,
+            includingPropertiesForKeys: nil
+        ) else {
+            XCTFail("Expected Playwright tests at \(testsRoot.path)")
+            return
+        }
+
+        let testFiles = enumerator
+            .compactMap { $0 as? URL }
+            .filter { $0.pathExtension == "ts" }
+            .sorted { $0.path < $1.path }
+
+        for file in testFiles {
+            let text = try String(contentsOf: file, encoding: .utf8)
+            XCTAssertFalse(
+                text.range(of: #"querySelector\([^\n]+\)!"#, options: .regularExpression) != nil,
+                "\(file.path) should use locators or explicit guards instead of querySelector(...)!."
+            )
+            XCTAssertFalse(
+                text.range(of: #"[A-Za-z0-9_\)\]]!\s*(\.|\)|,|\]|$)"#, options: .regularExpression) != nil,
+                "\(file.path) should avoid non-null assertions in Playwright tests."
+            )
+        }
+    }
+
     func testParityDocsExist() {
         let root = Self.packageRoot()
         for name in ["DECISIONS.md", "CODEX_RESEARCH.md", "CODEX_PARITY_MATRIX.md", "ROADMAP.md", "TEST_PLAN.md"] {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5615,3 +5615,24 @@ Current strict grades:
 
 Remaining risk:
 - Continue splitting `core.spec.ts` by feature family. Good next slices are top-bar/polish flows, shortcut flows, and memory/context/activity flows.
+
+## 2026-06-25 Playwright DOM Query Hardening
+
+Overall grade after this slice: **A E2E DOM assertion hygiene, A shared Playwright metric helpers, A- broad Playwright core spec**.
+
+The Playwright suite had useful visual-polish checks, but a few still used TypeScript non-null assertions such as `boundingBox()!` and `querySelector(...)!`. Those are acceptable for quick prototypes, but they produce poor diagnostics in CI and encourage fragile browser-side selector probing as the harness grows.
+
+What changed:
+- Added shared Playwright helpers for computed style reads and element rectangle reads.
+- Replaced `core.spec.ts` bounding-box non-null assertions with labeled `expectPresent(...)` checks.
+- Moved style and rect probes out of ad hoc `page.evaluate()` scripts and onto locator-backed helpers.
+- Replaced nested artifact-preview `querySelector(...)!` probes with locator-backed style helper calls.
+- Added a parity gate that scans Playwright tests for DOM force unwraps and TypeScript non-null assertions.
+
+Current strict grades:
+- `E2E/playwright/tests/harness-helpers.ts`: **A**. Shared E2E helpers now cover command palette, sidebar, settings, computed styles, and element rects.
+- `E2E/playwright/tests/core.spec.ts`: **A-**. The broad spec still needs more feature-family splits, but its remaining style and layout checks now fail with better selector diagnostics.
+- `ParityGateTests.swift`: **A**. It now guards both production Swift crash patterns and Playwright DOM assertion hygiene.
+
+Remaining risk:
+- Continue splitting `core.spec.ts` by feature family. Composer/model-picker, shortcut/slash, and memory/context flows are still the highest-value next splits.


### PR DESCRIPTION
## Summary
- add shared Playwright helpers for computed style and element rect reads
- replace non-null DOM assertions in core/artifact E2E style checks with locator-backed helpers
- add parity coverage to prevent Playwright DOM force unwraps from returning

## Validation
- swift test
- npm test -- --workers=2
- npm test -- --workers=2 tests/core.spec.ts tests/artifacts.spec.ts
- swift test --filter ParityGateTests
- git diff --check --cached