### PR TITLE
Add agent cancellation telemetry

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -101,74 +101,80 @@ public struct AgentRunner: Sendable {
         }
         await onProgress?(next)
 
-        try Task.checkCancellation()
-        let tools = Self.mergedToolDefinitions(baseToolDefinitions, additionalToolDefinitions)
-        var toolResults: [ToolResult] = []
-        var lastExecutedCall: ToolCall?
-        var lastCompletion: AgentToolStepCompletion?
-        let limit = max(1, maxToolSteps)
-
-        for _ in 0..<limit {
-            let action = try await nextAction(
-                thread: &next,
-                userMessage: userMessage,
-                tools: tools,
-                onProgress: onProgress
-            )
+        do {
             try Task.checkCancellation()
-            switch action {
-            case .say(let text):
-                appendAssistantMessage(text, to: &next)
-                await onProgress?(next)
-                return AgentRunResult(thread: next, toolResults: toolResults)
-            case .tool(let call):
-                if let lastExecutedCall,
-                   lastExecutedCall.name == call.name,
-                   lastExecutedCall.argumentsJSON == call.argumentsJSON,
-                   let lastCompletion {
-                    appendAssistantMessage(Self.finalAnswer(
-                        for: lastCompletion.call,
-                        result: lastCompletion.result,
-                        followUpReviewResult: lastCompletion.followUpReviewResult
-                    ), to: &next)
-                    await onProgress?(next)
-                    return AgentRunResult(thread: next, toolResults: toolResults)
-                }
+            let tools = Self.mergedToolDefinitions(baseToolDefinitions, additionalToolDefinitions)
+            var toolResults: [ToolResult] = []
+            var lastExecutedCall: ToolCall?
+            var lastCompletion: AgentToolStepCompletion?
+            let limit = max(1, maxToolSteps)
 
-                let step = try await runToolStep(
-                    call,
-                    userMessage: userMessage,
+            for _ in 0..<limit {
+                let action = try await nextAction(
                     thread: &next,
-                    workspaceRoot: workspaceRoot,
-                    toolDefinitions: tools,
+                    userMessage: userMessage,
+                    tools: tools,
                     onProgress: onProgress
                 )
-                switch step {
-                case .blocked:
+                try Task.checkCancellation()
+                switch action {
+                case .say(let text):
+                    appendAssistantMessage(text, to: &next)
+                    await onProgress?(next)
                     return AgentRunResult(thread: next, toolResults: toolResults)
-                case .completed(let completion):
-                    toolResults.append(contentsOf: completion.toolResults)
-                    lastExecutedCall = call
-                    lastCompletion = completion
-                    appendToolFeedback(completion, to: &next)
+                case .tool(let call):
+                    if let lastExecutedCall,
+                       lastExecutedCall.name == call.name,
+                       lastExecutedCall.argumentsJSON == call.argumentsJSON,
+                       let lastCompletion {
+                        appendAssistantMessage(Self.finalAnswer(
+                            for: lastCompletion.call,
+                            result: lastCompletion.result,
+                            followUpReviewResult: lastCompletion.followUpReviewResult
+                        ), to: &next)
+                        await onProgress?(next)
+                        return AgentRunResult(thread: next, toolResults: toolResults)
+                    }
+
+                    let step = try await runToolStep(
+                        call,
+                        userMessage: userMessage,
+                        thread: &next,
+                        workspaceRoot: workspaceRoot,
+                        toolDefinitions: tools,
+                        onProgress: onProgress
+                    )
+                    switch step {
+                    case .blocked:
+                        return AgentRunResult(thread: next, toolResults: toolResults)
+                    case .completed(let completion):
+                        toolResults.append(contentsOf: completion.toolResults)
+                        lastExecutedCall = call
+                        lastCompletion = completion
+                        appendToolFeedback(completion, to: &next)
+                    }
                 }
             }
-        }
 
-        if let lastCompletion {
-            appendAssistantMessage(Self.finalAnswer(
-                for: lastCompletion.call,
-                result: lastCompletion.result,
-                followUpReviewResult: lastCompletion.followUpReviewResult
-            ), to: &next)
-        } else {
-            let message = AgentError.tooManyToolSteps(limit).description
-            next.messages.append(.init(role: .assistant, content: message))
-            next.events.append(.init(kind: .message, summary: message))
-            next.updatedAt = Date()
+            if let lastCompletion {
+                appendAssistantMessage(Self.finalAnswer(
+                    for: lastCompletion.call,
+                    result: lastCompletion.result,
+                    followUpReviewResult: lastCompletion.followUpReviewResult
+                ), to: &next)
+            } else {
+                let message = AgentError.tooManyToolSteps(limit).description
+                next.messages.append(.init(role: .assistant, content: message))
+                next.events.append(.init(kind: .message, summary: message))
+                next.updatedAt = Date()
+            }
+            await onProgress?(next)
+            return AgentRunResult(thread: next, toolResults: toolResults)
+        } catch is CancellationError {
+            AgentCancellationRecorder.recordCancelledRun(in: &next)
+            await onProgress?(next)
+            throw CancellationError()
         }
-        await onProgress?(next)
-        return AgentRunResult(thread: next, toolResults: toolResults)
     }
 
     private func nextAction(

--- a/Sources/QuillCodeAgent/AgentCancellationRecorder.swift
+++ b/Sources/QuillCodeAgent/AgentCancellationRecorder.swift
@@ -1,0 +1,29 @@
+import Foundation
+import QuillCodeCore
+
+enum AgentCancellationRecorder {
+    static let stoppedSummary = "Stopped by user"
+    static let stoppedPayloadJSON = #"{"ok":false,"error":"Stopped by user"}"#
+
+    static func recordCancelledRun(in thread: inout ChatThread) {
+        if shouldMarkActiveToolStopped(thread.events.last) {
+            thread.events.append(ThreadEvent(
+                kind: .toolFailed,
+                summary: stoppedSummary,
+                payloadJSON: stoppedPayloadJSON
+            ))
+        }
+        if shouldAppendStoppedNotice(thread.events.last) {
+            thread.events.append(ThreadEvent(kind: .notice, summary: stoppedSummary))
+        }
+        thread.updatedAt = Date()
+    }
+
+    private static func shouldMarkActiveToolStopped(_ event: ThreadEvent?) -> Bool {
+        event?.kind == .toolQueued || event?.kind == .toolRunning
+    }
+
+    private static func shouldAppendStoppedNotice(_ event: ThreadEvent?) -> Bool {
+        event?.kind != .notice || event?.summary != stoppedSummary
+    }
+}

--- a/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
@@ -3,6 +3,81 @@ import QuillCodeCore
 @testable import QuillCodeAgent
 
 final class AgentStreamingTests: XCTestCase {
+    func testCancellingBeforeModelActionPublishesStoppedNotice() async throws {
+        let root = try makeTempDirectory()
+        let recorder = ProgressRecorder()
+        let runner = AgentRunner(llm: NeverReturningLLMClient())
+
+        let task = Task {
+            try await runner.send(
+                "run a long task",
+                in: ChatThread(mode: .auto),
+                workspaceRoot: root,
+                onProgress: { thread in
+                    await recorder.record(thread)
+                }
+            )
+        }
+        try await waitUntil(timeoutSeconds: 1) {
+            await recorder.eventKinds() == [.message]
+        }
+
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation.")
+        } catch is CancellationError {
+            let snapshots = await recorder.eventSnapshots()
+            XCTAssertEqual(snapshots.last?.map(\.kind), [.message, .notice])
+            XCTAssertEqual(snapshots.last?.last?.summary, AgentCancellationRecorder.stoppedSummary)
+        }
+    }
+
+    func testCancellingRunningToolPublishesStoppedToolFailure() async throws {
+        let root = try makeTempDirectory()
+        let recorder = ProgressRecorder()
+        let call = ToolCall(
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "sleep 5"])
+        )
+        let runner = AgentRunner(
+            llm: FixedToolLLMClient(call: call),
+            toolExecutionOverride: { _, _ in
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 5_000_000)
+                }
+                return ToolResult(ok: false, error: "Override noticed cancellation.")
+            }
+        )
+
+        let task = Task {
+            try await runner.send(
+                "run a long shell command",
+                in: ChatThread(mode: .auto),
+                workspaceRoot: root,
+                onProgress: { thread in
+                    await recorder.record(thread)
+                }
+            )
+        }
+        try await waitUntil(timeoutSeconds: 1) {
+            await recorder.eventKinds().contains(.toolRunning)
+        }
+
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation.")
+        } catch is CancellationError {
+            let snapshots = await recorder.eventSnapshots()
+            let snapshot = try XCTUnwrap(snapshots.last)
+            XCTAssertEqual(snapshot.map(\.kind), [.message, .toolQueued, .toolRunning, .toolFailed, .notice])
+            XCTAssertEqual(snapshot[snapshot.count - 2].summary, AgentCancellationRecorder.stoppedSummary)
+            XCTAssertEqual(snapshot[snapshot.count - 2].payloadJSON, AgentCancellationRecorder.stoppedPayloadJSON)
+            XCTAssertEqual(snapshot.last?.summary, AgentCancellationRecorder.stoppedSummary)
+        }
+    }
+
     func testSendReportsIncrementalToolProgress() async throws {
         let root = try makeTempDirectory()
         let recorder = ProgressRecorder()
@@ -85,5 +160,28 @@ final class AgentStreamingTests: XCTestCase {
         let progressMessages = await recorder.messageContents()
         XCTAssertTrue(progressMessages.contains(["say hello", "hello"]))
         XCTAssertTrue(progressMessages.contains(["say hello", "hello world"]))
+    }
+
+    private func waitUntil(
+        timeoutSeconds: TimeInterval,
+        condition: @escaping () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if await condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("Timed out waiting for condition.")
+    }
+}
+
+private struct NeverReturningLLMClient: LLMClient {
+    func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+        while true {
+            try Task.checkCancellation()
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
     }
 }

--- a/Tests/QuillCodeAgentTests/AgentTestSupport.swift
+++ b/Tests/QuillCodeAgentTests/AgentTestSupport.swift
@@ -22,11 +22,13 @@ func initializeGitRepo(at root: URL) throws {
 actor ProgressRecorder {
     private var kinds: [ThreadEventKind] = []
     private var contents: [[String]] = []
+    private var snapshots: [[ThreadEvent]] = []
 
     func record(_ thread: ChatThread) {
         guard let kind = thread.events.last?.kind else { return }
         kinds.append(kind)
         contents.append(thread.messages.map(\.content))
+        snapshots.append(thread.events)
     }
 
     func eventKinds() -> [ThreadEventKind] {
@@ -35,6 +37,10 @@ actor ProgressRecorder {
 
     func messageContents() -> [[String]] {
         contents
+    }
+
+    func eventSnapshots() -> [[ThreadEvent]] {
+        snapshots
     }
 }
 

--- a/Tests/QuillCodeParityTests/ParityAgentGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAgentGateTests.swift
@@ -63,6 +63,19 @@ final class ParityAgentGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(agentText.contains("Tool is not available in this workspace"), "Agent.swift should not own unavailable-tool result copy.")
     }
 
+    func testAgentCancellationTelemetryLivesInFocusedRecorder() throws {
+        let agentText = try Self.agentSourceText(named: "Agent.swift")
+        let recorderText = try Self.agentSourceText(named: "AgentCancellationRecorder.swift")
+        let streamingTests = try Self.agentTestSourceText(named: "AgentStreamingTests.swift")
+
+        XCTAssertTrue(recorderText.contains("enum AgentCancellationRecorder"), "Agent cancellation transcript mutation should live in a focused recorder.")
+        XCTAssertTrue(recorderText.contains("Stopped by user"), "Stopped-run copy should be centralized in the recorder.")
+        XCTAssertTrue(agentText.contains("AgentCancellationRecorder.recordCancelledRun"), "AgentRunner should delegate cancellation transcript mutation.")
+        XCTAssertFalse(agentText.contains(#""Stopped by user""#), "Agent.swift should not own stopped-run copy inline.")
+        XCTAssertTrue(streamingTests.contains("testCancellingBeforeModelActionPublishesStoppedNotice"), "Agent tests should cover cancellation before a model action arrives.")
+        XCTAssertTrue(streamingTests.contains("testCancellingRunningToolPublishesStoppedToolFailure"), "Agent tests should cover cancellation while a tool is active.")
+    }
+
     func testAgentBehaviorTestsUseFocusedSuites() throws {
         let immediateTests = try Self.agentTestSourceText(named: "AgentImmediateActionTests.swift")
         let toolLoopTests = try Self.agentTestSourceText(named: "AgentToolLoopTests.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -58,6 +58,25 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
 
+## 2026-06-25 Agent Cancellation Telemetry Pass
+
+Overall grade after this slice: **A agent cancellation telemetry, A focused transcript boundary, A regression coverage**.
+
+`AgentRunner.send` already checked cancellation, and the workspace layer repaired cancelled transcripts for the visible app. The agent boundary itself still threw cancellation without publishing a final stopped state, which meant standalone callers and future CLI/remote send sessions could leave the last progress snapshot as queued or running.
+
+Code quality changes:
+
+- Added `AgentCancellationRecorder` as the single owner of agent-level stopped-run transcript mutation.
+- Cancellation before the model returns now publishes a stopped notice after the user message.
+- Cancellation while a tool is queued or running now publishes a stopped `toolFailed` event plus the stopped notice before rethrowing `CancellationError`.
+- Kept `AgentRunner.send` focused on the orchestration loop by delegating stopped-copy and payload JSON to the recorder.
+- Added focused async tests for pre-action cancellation and active-tool cancellation.
+- Added a parity gate so stopped-run copy and mutation rules do not drift back into `Agent.swift`.
+
+Remaining risk:
+
+- The workspace send lifecycle still owns UI state, persistence timing, and top-bar recovery. That is correct while the app coordinator controls visible selection, but a future session coordinator should own richer retry telemetry if background runs gain more states.
+
 ## 2026-06-24 Top-Bar State Builder Pass
 
 Overall grade after this slice: **A top-bar state boundary, A behavior preservation, A regression guard**.


### PR DESCRIPTION
## Summary
- add a focused AgentCancellationRecorder for stopped-run transcript mutation
- publish stopped notices for cancellation before model action, and stopped tool-failure events for cancellation while a tool is queued/running
- add async agent cancellation tests, a parity gate, and audit notes

## Validation
- swift test --filter 'AgentStreamingTests|ParityAgentGateTests'\n- swift test\n- npm --prefix E2E/playwright test\n- git diff --check