### PR TITLE
Split review card Playwright flows

### DIFF
--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1,14 +1,10 @@
 import { test, expect } from '@playwright/test';
 import {
+  elementRect,
   harnessURL,
   openSidebarTools,
   openTopBarOverflow
 } from './harness-helpers';
-
-function expectPresent<T>(value: T | null, label: string): T {
-  expect(value, label).not.toBeNull();
-  return value as T;
-}
 
 test('mock harness executes simple command flow', async ({ page }) => {
   await page.goto(harnessURL());
@@ -29,11 +25,9 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
   await expect(page.locator('[data-testid="mode-picker-button"] .mode-dot')).toHaveCount(1);
   await expect(page.getByTestId('composer-agent-status')).toHaveCount(0);
-  const modelButtonBox = await page.getByTestId('model-picker-button').boundingBox();
-  const modeButtonBox = await page.getByTestId('mode-picker-button').boundingBox();
-  const modelButtonBounds = expectPresent(modelButtonBox, 'model picker button should have bounds');
-  const modeButtonBounds = expectPresent(modeButtonBox, 'mode picker button should have bounds');
-  expect(modeButtonBounds.x - (modelButtonBounds.x + modelButtonBounds.width)).toBeGreaterThanOrEqual(8);
+  const modelButtonBounds = await elementRect(page, '[data-testid="model-picker-button"]');
+  const modeButtonBounds = await elementRect(page, '[data-testid="mode-picker-button"]');
+  expect(modeButtonBounds.left - modelButtonBounds.right).toBeGreaterThanOrEqual(8);
   await page.getByTestId('model-picker-button').click();
   await expect(page.getByTestId('model-category')).toHaveCount(2);
   await page.getByTestId('model-picker-button').click();
@@ -128,94 +122,4 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('message').filter({ hasText: 'You are `mock-user` in this workspace.' })).toHaveCount(2);
   await expect(page.getByTestId('message-retry')).toHaveCount(1);
   await expect(page.getByTestId('message-use-as-draft')).toHaveCount(2);
-});
-
-test('mock harness exposes actionable approval buttons on review cards', async ({ page }) => {
-  await page.goto(harnessURL());
-
-  await page.evaluate(() => {
-    const harness = window as typeof window & {
-      addToolCard: (card: Record<string, unknown>) => void;
-      render: () => void;
-    };
-    harness.addToolCard({
-      id: 'shell-review',
-      title: 'host.shell.run',
-      subtitle: 'Ready to run · whoami',
-      status: 'review',
-      reviewState: 'ready',
-      density: 'expanded',
-      inputJSON: JSON.stringify({ cmd: 'whoami' }, null, 2),
-      isExpanded: true,
-      actions: [
-        {
-          id: 'tool-card-action-approve-approval-1',
-          title: 'Run',
-          kind: 'approve',
-          requestID: 'approval-1',
-          style: 'primary'
-        },
-        {
-          id: 'tool-card-action-deny-approval-1',
-          title: 'Skip',
-          kind: 'deny',
-          requestID: 'approval-1',
-          style: 'secondary'
-        }
-      ]
-    });
-    harness.render();
-  });
-
-  await expect(page.getByTestId('tool-card')).toHaveCount(1);
-  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'review');
-  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-review-state', 'ready');
-  await expect(page.getByTestId('tool-card-status')).toHaveText('Ready');
-  await expect(page.getByTestId('tool-card-actions')).toBeVisible();
-  await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Run' })).toBeVisible();
-  await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Skip' })).toBeVisible();
-  const runBox = await page.getByTestId('tool-card-action').filter({ hasText: 'Run' }).boundingBox();
-  const skipBox = await page.getByTestId('tool-card-action').filter({ hasText: 'Skip' }).boundingBox();
-  const runBounds = expectPresent(runBox, 'run approval action should have bounds');
-  const skipBounds = expectPresent(skipBox, 'skip approval action should have bounds');
-  expect(runBounds.width).toBeGreaterThan(skipBounds.width);
-
-  await page.getByTestId('tool-card-action').filter({ hasText: 'Run' }).click();
-
-  await expect(page.getByTestId('tool-card')).toHaveCount(2);
-  await expect(page.getByTestId('tool-card').first()).toHaveAttribute('data-status', 'done');
-  await expect(page.getByTestId('tool-card-subtitle').first()).toHaveText('Approved · whoami');
-  await expect(page.getByTestId('tool-card-actions')).toHaveCount(0);
-  await expect(page.getByTestId('tool-card').nth(1)).toHaveAttribute('data-status', 'done');
-  await expect(page.getByTestId('tool-card-output').last()).toContainText('mock-user');
-  await expect(page.getByTestId('message').last()).toContainText('Approved and ran the tool.');
-});
-
-test('mock harness shows denied review cards as needs review without actions', async ({ page }) => {
-  await page.goto(harnessURL());
-
-  await page.evaluate(() => {
-    const harness = window as typeof window & {
-      addToolCard: (card: Record<string, unknown>) => void;
-      render: () => void;
-    };
-    harness.addToolCard({
-      id: 'shell-blocked-review',
-      title: 'host.shell.run',
-      subtitle: 'Blocked · rm -rf /',
-      status: 'review',
-      reviewState: 'needsReview',
-      density: 'expanded',
-      inputJSON: JSON.stringify({ cmd: 'rm -rf /' }, null, 2),
-      isExpanded: true,
-      actions: []
-    });
-    harness.render();
-  });
-
-  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'review');
-  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-review-state', 'needsReview');
-  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status-label', 'Needs review');
-  await expect(page.getByTestId('tool-card-status')).toHaveText('Needs review');
-  await expect(page.getByTestId('tool-card-action')).toHaveCount(0);
 });

--- a/E2E/playwright/tests/review.spec.ts
+++ b/E2E/playwright/tests/review.spec.ts
@@ -1,5 +1,93 @@
 import { test, expect } from '@playwright/test';
-import { harnessURL } from './harness-helpers';
+import { elementRect, harnessURL } from './harness-helpers';
+
+test('mock harness exposes actionable approval buttons on review cards', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.evaluate(() => {
+    const harness = window as typeof window & {
+      addToolCard: (card: Record<string, unknown>) => void;
+      render: () => void;
+    };
+    harness.addToolCard({
+      id: 'shell-review',
+      title: 'host.shell.run',
+      subtitle: 'Ready to run · whoami',
+      status: 'review',
+      reviewState: 'ready',
+      density: 'expanded',
+      inputJSON: JSON.stringify({ cmd: 'whoami' }, null, 2),
+      isExpanded: true,
+      actions: [
+        {
+          id: 'tool-card-action-approve-approval-1',
+          title: 'Run',
+          kind: 'approve',
+          requestID: 'approval-1',
+          style: 'primary'
+        },
+        {
+          id: 'tool-card-action-deny-approval-1',
+          title: 'Skip',
+          kind: 'deny',
+          requestID: 'approval-1',
+          style: 'secondary'
+        }
+      ]
+    });
+    harness.render();
+  });
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(1);
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'review');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-review-state', 'ready');
+  await expect(page.getByTestId('tool-card-status')).toHaveText('Ready');
+  await expect(page.getByTestId('tool-card-actions')).toBeVisible();
+  await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Run' })).toBeVisible();
+  await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Skip' })).toBeVisible();
+  const runBounds = await elementRect(page, '[data-testid="tool-card-action"]:has-text("Run")');
+  const skipBounds = await elementRect(page, '[data-testid="tool-card-action"]:has-text("Skip")');
+  expect(runBounds.width).toBeGreaterThan(skipBounds.width);
+
+  await page.getByTestId('tool-card-action').filter({ hasText: 'Run' }).click();
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(2);
+  await expect(page.getByTestId('tool-card').first()).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-subtitle').first()).toHaveText('Approved · whoami');
+  await expect(page.getByTestId('tool-card-actions')).toHaveCount(0);
+  await expect(page.getByTestId('tool-card').nth(1)).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-output').last()).toContainText('mock-user');
+  await expect(page.getByTestId('message').last()).toContainText('Approved and ran the tool.');
+});
+
+test('mock harness shows denied review cards as needs review without actions', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.evaluate(() => {
+    const harness = window as typeof window & {
+      addToolCard: (card: Record<string, unknown>) => void;
+      render: () => void;
+    };
+    harness.addToolCard({
+      id: 'shell-blocked-review',
+      title: 'host.shell.run',
+      subtitle: 'Blocked · rm -rf /',
+      status: 'review',
+      reviewState: 'needsReview',
+      density: 'expanded',
+      inputJSON: JSON.stringify({ cmd: 'rm -rf /' }, null, 2),
+      isExpanded: true,
+      actions: []
+    });
+    harness.render();
+  });
+
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'review');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-review-state', 'needsReview');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status-label', 'Needs review');
+  await expect(page.getByTestId('tool-card-status')).toHaveText('Needs review');
+  await expect(page.getByTestId('tool-card-action')).toHaveCount(0);
+});
 
 test('mock harness shows git review summary for diff flow', async ({ page }) => {
   await page.goto(harnessURL());

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -461,6 +461,8 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
             encoding: .utf8
         )
         let reviewFlowNames = [
+            "exposes actionable approval buttons on review cards",
+            "shows denied review cards as needs review without actions",
             "shows git review summary for diff flow",
             "flows apply patch into review diff",
             "stages a changed file from the review pane",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5716,3 +5716,23 @@ Current strict grades:
 
 Remaining risk:
 - `core.spec.ts` still includes both the full first-run command smoke and review-card smoke. That is acceptable for now, but the next quality slice could move review-card approval/denial smoke into `review.spec.ts` if core should become a single first-run scenario.
+
+## 2026-06-25 Playwright Review Card Spec Split
+
+Overall grade after this slice: **A review-card E2E ownership, A shared Playwright geometry helpers, A core smoke spec**.
+
+`core.spec.ts` still owned the approval-card and denied-review-card smoke flows. Those checks validate review-card interaction semantics, not first-run workspace setup, so they belong beside the review pane, stage, hunk, and commit flows.
+
+What changed:
+- Moved actionable approval-card and denied-review-card flows into `review.spec.ts`.
+- Reused the shared Playwright `elementRect()` helper for action button geometry instead of keeping local bounding-box unwrap helpers in `core.spec.ts`.
+- Removed the local `expectPresent` helper from `core.spec.ts`, leaving it focused on the first-run command smoke path.
+- Expanded the review Playwright parity gate so approval-card and denied-review-card flows must stay in `review.spec.ts`.
+
+Current strict grades:
+- `E2E/playwright/tests/core.spec.ts`: **A**. It now acts as a true first-run command smoke test.
+- `E2E/playwright/tests/review.spec.ts`: **A**. It owns review-card actions, blocked-review presentation, diff review, staging, hunk staging, and commit flows.
+- `ParityWorkspaceSurfaceGateTests.swift`: **A**. It now guards focused ownership for all review Playwright flow families.
+
+Remaining risk:
+- Good next slices should move beyond E2E suite shape and target deeper Codex parity: richer review diff interactions, worktree lifecycle polish, and real app-shell smoke around browser/Computer Use.


### PR DESCRIPTION
## Summary
- move actionable approval-card and denied-review-card Playwright flows from `core.spec.ts` into `review.spec.ts`
- replace core's local bounding-box helper with the shared `elementRect()` helper
- extend the review parity gate and audit log so review-card flows stay in the focused review suite

## Validation
- `swift test`
- `swift test --filter ParityWorkspaceSurfaceGateTests`
- `npm test -- --workers=2`
- `npm test -- --workers=2 tests/core.spec.ts tests/review.spec.ts`
- `git diff --check`