### PR TITLE
Extract composer send lifecycle reducer

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceComposerSendLifecycle.swift
+++ b/Sources/QuillCodeApp/WorkspaceComposerSendLifecycle.swift
@@ -1,0 +1,48 @@
+struct WorkspaceComposerSendLifecyclePlan: Equatable {
+    var composer: ComposerState
+    var lastError: String?
+    var agentStatus: String
+}
+
+enum WorkspaceComposerSendLifecycle {
+    static func started(from composer: ComposerState) -> WorkspaceComposerSendLifecyclePlan {
+        var nextComposer = composer
+        nextComposer.draft = ""
+        nextComposer.isSending = true
+        return WorkspaceComposerSendLifecyclePlan(
+            composer: nextComposer,
+            lastError: nil,
+            agentStatus: TopBarAgentStatusLabel.running
+        )
+    }
+
+    static func completed(from composer: ComposerState) -> WorkspaceComposerSendLifecyclePlan {
+        var nextComposer = composer
+        nextComposer.isSending = false
+        return WorkspaceComposerSendLifecyclePlan(
+            composer: nextComposer,
+            lastError: nil,
+            agentStatus: TopBarAgentStatusLabel.idle
+        )
+    }
+
+    static func cancelled(from composer: ComposerState) -> WorkspaceComposerSendLifecyclePlan {
+        var nextComposer = composer
+        nextComposer.isSending = false
+        return WorkspaceComposerSendLifecyclePlan(
+            composer: nextComposer,
+            lastError: nil,
+            agentStatus: TopBarAgentStatusLabel.stopped
+        )
+    }
+
+    static func failed(_ error: any Error, from composer: ComposerState) -> WorkspaceComposerSendLifecyclePlan {
+        var nextComposer = composer
+        nextComposer.isSending = false
+        return WorkspaceComposerSendLifecyclePlan(
+            composer: nextComposer,
+            lastError: String(describing: error),
+            agentStatus: TopBarAgentStatusLabel.failed
+        )
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -762,10 +762,7 @@ public final class QuillCodeWorkspaceModel {
         syncThreadContext(into: &thread)
         let threadID = thread.id
 
-        composer.draft = ""
-        composer.isSending = true
-        lastError = nil
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.running)
+        applyComposerSendLifecycle(WorkspaceComposerSendLifecycle.started(from: composer))
 
         do {
             try Task.checkCancellation()
@@ -800,14 +797,11 @@ public final class QuillCodeWorkspaceModel {
             }
             updateThreadFromAgentRun(thread)
             try threadPersistence.saveOrThrow(thread)
-            composer.isSending = false
-            refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+            applyComposerSendLifecycle(WorkspaceComposerSendLifecycle.completed(from: composer))
         } catch is CancellationError {
             finishCancelledSend(userPrompt: prompt, threadID: threadID)
         } catch {
-            composer.isSending = false
-            lastError = String(describing: error)
-            refreshTopBar(agentStatus: TopBarAgentStatusLabel.failed)
+            applyComposerSendLifecycle(WorkspaceComposerSendLifecycle.failed(error, from: composer))
         }
     }
 
@@ -1349,12 +1343,16 @@ public final class QuillCodeWorkspaceModel {
     }
 
     private func finishCancelledSend(userPrompt: String, threadID: UUID) {
-        composer.isSending = false
-        lastError = nil
         mutateThread(threadID) { thread in
             WorkspaceComposerCancellationPlanner.applyCancelledSend(userPrompt: userPrompt, to: &thread)
         }
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.stopped)
+        applyComposerSendLifecycle(WorkspaceComposerSendLifecycle.cancelled(from: composer))
+    }
+
+    private func applyComposerSendLifecycle(_ plan: WorkspaceComposerSendLifecyclePlan) {
+        composer = plan.composer
+        lastError = plan.lastError
+        refreshTopBar(agentStatus: plan.agentStatus)
     }
 
     private func statusText() -> String {

--- a/Tests/QuillCodeAppTests/WorkspaceComposerSendLifecycleTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerSendLifecycleTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class WorkspaceComposerSendLifecycleTests: XCTestCase {
+    func testStartedClearsDraftAndMarksSendRunning() {
+        let plan = WorkspaceComposerSendLifecycle.started(from: ComposerState(
+            draft: "run tests",
+            isSending: false,
+            placeholder: "Message"
+        ))
+
+        XCTAssertEqual(plan.composer.draft, "")
+        XCTAssertTrue(plan.composer.isSending)
+        XCTAssertEqual(plan.composer.placeholder, "Message")
+        XCTAssertNil(plan.lastError)
+        XCTAssertEqual(plan.agentStatus, TopBarAgentStatusLabel.running)
+    }
+
+    func testCompletedPreservesDraftAndClearsSendingState() {
+        let plan = WorkspaceComposerSendLifecycle.completed(from: ComposerState(
+            draft: "",
+            isSending: true
+        ))
+
+        XCTAssertEqual(plan.composer.draft, "")
+        XCTAssertFalse(plan.composer.isSending)
+        XCTAssertNil(plan.lastError)
+        XCTAssertEqual(plan.agentStatus, TopBarAgentStatusLabel.idle)
+    }
+
+    func testCancelledClearsSendingStateWithoutShowingError() {
+        let plan = WorkspaceComposerSendLifecycle.cancelled(from: ComposerState(
+            draft: "",
+            isSending: true
+        ))
+
+        XCTAssertFalse(plan.composer.isSending)
+        XCTAssertNil(plan.lastError)
+        XCTAssertEqual(plan.agentStatus, TopBarAgentStatusLabel.stopped)
+    }
+
+    func testFailedClearsSendingStateAndReportsDescribedError() {
+        let plan = WorkspaceComposerSendLifecycle.failed(SampleError.nope, from: ComposerState(
+            draft: "",
+            isSending: true
+        ))
+
+        XCTAssertFalse(plan.composer.isSending)
+        XCTAssertEqual(plan.lastError, "nope")
+        XCTAssertEqual(plan.agentStatus, TopBarAgentStatusLabel.failed)
+    }
+}
+
+private enum SampleError: Error, CustomStringConvertible {
+    case nope
+
+    var description: String {
+        "nope"
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
@@ -37,10 +37,16 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesUIStateContracts() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let stateText = try Self.appSourceText(named: "WorkspaceUIState.swift")
+        let sendLifecycleText = try Self.appSourceText(named: "WorkspaceComposerSendLifecycle.swift")
 
         XCTAssertTrue(stateText.contains("public struct ComposerState"), "Composer UI state should live in a focused state contract file.")
         XCTAssertTrue(stateText.contains("public struct MemoriesState"), "Memory-pane UI state should live in a focused state contract file.")
         XCTAssertTrue(stateText.contains("public struct ActivityState"), "Activity-pane UI state should live in a focused state contract file.")
+        XCTAssertTrue(sendLifecycleText.contains("enum WorkspaceComposerSendLifecycle"), "Composer send lifecycle transitions should live in a focused helper.")
+        XCTAssertTrue(modelText.contains("WorkspaceComposerSendLifecycle.started"), "WorkspaceModel should delegate composer send start transitions.")
+        XCTAssertTrue(modelText.contains("WorkspaceComposerSendLifecycle.completed"), "WorkspaceModel should delegate composer send completion transitions.")
+        XCTAssertTrue(modelText.contains("WorkspaceComposerSendLifecycle.cancelled"), "WorkspaceModel should delegate composer send cancellation transitions.")
+        XCTAssertTrue(modelText.contains("WorkspaceComposerSendLifecycle.failed"), "WorkspaceModel should delegate composer send failure transitions.")
         XCTAssertTrue(modelText.contains("public private(set) var composer: ComposerState"), "WorkspaceModel should still own live composer state.")
         XCTAssertFalse(modelText.contains("public struct ComposerState"), "WorkspaceModel should not define composer UI state contracts.")
         XCTAssertFalse(modelText.contains("public struct MemoriesState"), "WorkspaceModel should not define memory-pane UI state contracts.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5736,3 +5736,23 @@ Current strict grades:
 
 Remaining risk:
 - Good next slices should move beyond E2E suite shape and target deeper Codex parity: richer review diff interactions, worktree lifecycle polish, and real app-shell smoke around browser/Computer Use.
+
+## 2026-06-25 Composer Send Lifecycle Reducer
+
+Overall grade after this slice: **A composer lifecycle ownership, A cancellation/error state coverage, A- WorkspaceModel send path**.
+
+`WorkspaceModel.submitComposer` still owned low-level composer send state transitions inline: clearing the draft, flipping `isSending`, clearing/reporting `lastError`, and choosing the top-bar status for started, completed, cancelled, and failed sends. That made the agent send path harder to audit because UI state mutation sat beside runner construction, progress application, persistence, and memory refresh.
+
+What changed:
+- Added `WorkspaceComposerSendLifecycle` as a focused reducer for composer send start, completion, cancellation, and failure state.
+- Replaced direct inline composer/top-bar send-state mutations in `WorkspaceModel.submitComposer` and `finishCancelledSend`.
+- Added focused reducer tests for draft clearing, sending flags, stopped status, idle status, and described failure errors.
+- Added a WorkspaceModel parity gate so future refactors keep send lifecycle transitions outside the broad workspace model.
+
+Current strict grades:
+- `WorkspaceComposerSendLifecycle.swift`: **A**. The reducer is small, value-oriented, and directly testable without runner, persistence, or thread dependencies.
+- `WorkspaceModel.submitComposer`: **A-**. It still coordinates runner context, memory refresh, thread persistence, and progress updates, but the repeated composer state transitions are now delegated.
+- `WorkspaceComposerSendLifecycleTests.swift`: **A**. It covers every lifecycle branch and keeps the state contract explicit.
+
+Remaining risk:
+- `WorkspaceModel.submitComposer` remains a high-value extraction target. The next architectural slice should separate runner context creation and result persistence from the UI-facing send orchestration.


### PR DESCRIPTION
## Summary
- Add a focused WorkspaceComposerSendLifecycle reducer for composer send start/completion/cancel/failure state
- Delegate WorkspaceModel composer/top-bar send-state transitions to the reducer
- Add lifecycle tests, a WorkspaceModel parity gate, and a code-quality audit note

## Validation
- swift test --filter 'WorkspaceComposerSendLifecycleTests|WorkspaceComposerIntegrationTests|WorkspaceComposerCancellationPlannerTests|ParityWorkspaceModelGateTests'
- swift test
- npm --prefix E2E/playwright test
- git diff --check