### PR TITLE
Cover top-bar chrome actions

### DIFF
--- a/E2E/playwright/tests/workspace-chrome.spec.ts
+++ b/E2E/playwright/tests/workspace-chrome.spec.ts
@@ -36,6 +36,38 @@ test('mock harness opens utilities from the top-bar overflow', async ({ page }) 
   await expect(page.getByTestId('top-bar-stop-button')).toHaveCount(0);
 });
 
+test('mock harness opens Computer Use setup from the top-bar overflow', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-computer-use').click();
+
+  const settingsPanel = page.getByTestId('settings-panel');
+  await expect(settingsPanel).toBeVisible();
+  await expect(settingsPanel.getByTestId('computer-use-settings')).toBeVisible();
+  await expect(settingsPanel.getByTestId('computer-use-settings-status')).toHaveText('Setup needed');
+  await expect(settingsPanel.getByTestId('computer-use-next-action')).toContainText('Open Screen Recording first');
+
+  await settingsPanel.getByTestId('computer-use-permission-open').first().click();
+  await expect(settingsPanel.getByTestId('computer-use-last-opened')).toContainText('Privacy_ScreenCapture');
+});
+
+test('mock harness disconnects remote project connections from the top-bar overflow', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('/ssh quill@feather.local:/srv/quill');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('top-bar-subtitle')).toContainText('feather.local · quill');
+
+  await openTopBarOverflow(page);
+  await expect(page.getByTestId('top-bar-overflow-disconnect-all')).toBeVisible();
+  await page.getByTestId('top-bar-overflow-disconnect-all').click();
+
+  await expect(page.getByTestId('top-bar-subtitle')).toContainText('No project');
+  await openTopBarOverflow(page);
+  await expect(page.getByTestId('top-bar-overflow-disconnect-all')).toHaveCount(0);
+});
+
 test('mock harness avoids horizontal clipping in key desktop and mobile flows', async ({ browser }) => {
   const viewports = [
     { name: 'desktop', width: 1440, height: 1000 },

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -293,6 +293,8 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         )
         let chromeFlowNames = [
             "opens utilities from the top-bar overflow",
+            "opens Computer Use setup from the top-bar overflow",
+            "disconnects remote project connections from the top-bar overflow",
             "avoids horizontal clipping in key desktop and mobile flows",
             "applies interface polish primitives",
             "keeps quiet top bar stable under long status metadata"

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5756,3 +5756,21 @@ Current strict grades:
 
 Remaining risk:
 - `WorkspaceModel.submitComposer` remains a high-value extraction target. The next architectural slice should separate runner context creation and result persistence from the UI-facing send orchestration.
+
+## 2026-06-25 Workspace Chrome Action Coverage
+
+Overall grade after this slice: **A workspace chrome action coverage, A focused parity guard, A harness behavior confidence**.
+
+The chrome spec already checked that top-bar utility buttons existed and that a few panels opened, but two user-critical actions were under-covered: Computer Use setup from the top-bar overflow and Disconnect All for remote project sessions. Both are the kind of "button looks present but does nothing useful" regression users feel immediately.
+
+What changed:
+- Added a top-bar overflow Computer Use setup flow that verifies the Settings sheet opens directly to the Computer Use card and routes the Screen Recording permission action.
+- Added a top-bar Disconnect All flow that creates an SSH Remote project through the public `/ssh` path, invokes Disconnect All from the overflow menu, verifies the workspace detaches to `No project`, and verifies the command hides when there is nothing left to disconnect.
+- Expanded the workspace chrome parity gate so these action semantics stay in `workspace-chrome.spec.ts`.
+
+Current strict grades:
+- `E2E/playwright/tests/workspace-chrome.spec.ts`: **A**. The file now owns both visual chrome stability and the critical top-bar action semantics users touch first.
+- `ParityWorkspaceSurfaceGateTests.swift`: **A**. It guards focused ownership without tying the test to implementation details.
+
+Remaining risk:
+- Native packaged smoke should eventually drive the macOS menu-bar widget and SwiftUI top-bar directly; the current coverage proves the shared HTML harness contract.


### PR DESCRIPTION
## Summary\n- Add Playwright coverage for launching Computer Use setup from the top-bar overflow\n- Add Playwright coverage for Disconnect All detaching an SSH Remote project from the top-bar overflow\n- Extend the workspace chrome parity gate and code-quality audit notes\n\n## Validation\n- npm test -- --workers=2 tests/workspace-chrome.spec.ts\n- npm test -- --workers=2\n- swift test --filter ParityWorkspaceSurfaceGateTests\n- swift test\n- git diff --check