### PR TITLE
Extract agent send session factory

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
@@ -1,0 +1,40 @@
+import Foundation
+import QuillCodeAgent
+import QuillCodeCore
+import QuillCodeTools
+import QuillComputerUseKit
+
+struct WorkspaceAgentSendSessionFactory: Sendable {
+    var baseRunner: AgentRunner
+    var selectedProject: ProjectRef?
+    var browser: BrowserState
+    var browserToolOverride: AgentToolExecutionOverride?
+    var computerUseBackend: (any ComputerUseBackend)?
+    var globalMemoryDirectory: URL?
+    var mcpToolDefinitions: [ToolDefinition]
+    var mcpToolExecutionOverride: AgentToolExecutionOverride?
+    var sshRemoteShellExecutor: SSHRemoteShellExecutor
+    var workspaceRoot: URL
+
+    func makeSession(prompt: String, thread: ChatThread) -> WorkspaceAgentSendSession {
+        WorkspaceAgentSendSession(
+            prompt: prompt,
+            thread: thread,
+            runner: configuredRunner,
+            workspaceRoot: workspaceRoot
+        )
+    }
+
+    var configuredRunner: AgentRunner {
+        WorkspaceAgentRunContextBuilder(
+            selectedProject: selectedProject,
+            browser: browser,
+            browserToolOverride: browserToolOverride,
+            computerUseBackend: computerUseBackend,
+            globalMemoryDirectory: globalMemoryDirectory,
+            mcpToolDefinitions: mcpToolDefinitions,
+            mcpToolExecutionOverride: mcpToolExecutionOverride,
+            sshRemoteShellExecutor: sshRemoteShellExecutor
+        ).configuredRunner(from: baseRunner)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -766,28 +766,8 @@ public final class QuillCodeWorkspaceModel {
 
         do {
             try Task.checkCancellation()
-            let activeRunner = WorkspaceAgentRunContextBuilder(
-                selectedProject: selectedProject,
-                browser: browser,
-                browserToolOverride: WorkspaceBrowserAgentToolOverride.make { [weak self] call, workspaceRoot in
-                    guard let self else { return nil }
-                    return self.executeBrowserToolForAgent(call, workspaceRoot: workspaceRoot)
-                },
-                computerUseBackend: computerUseBackend,
-                globalMemoryDirectory: globalMemoryDirectory,
-                mcpToolDefinitions: mcpRuntime.toolDefinitions(
-                    manifests: selectedProject?.extensionManifests ?? [],
-                    extensions: extensions
-                ),
-                mcpToolExecutionOverride: mcpRuntime.executionOverride(extensions: extensions),
-                sshRemoteShellExecutor: sshRemoteShellExecutor
-            ).configuredRunner(from: runner)
-            let session = WorkspaceAgentSendSession(
-                prompt: prompt,
-                thread: thread,
-                runner: activeRunner,
-                workspaceRoot: workspaceRoot
-            )
+            let session = agentSendSessionFactory(workspaceRoot: workspaceRoot)
+                .makeSession(prompt: prompt, thread: thread)
             let result = try await session.run { [weak self] progressThread in
                 await self?.applyAgentProgress(progressThread, expectedThreadID: threadID)
             }
@@ -803,6 +783,27 @@ public final class QuillCodeWorkspaceModel {
         } catch {
             applyComposerSendLifecycle(WorkspaceComposerSendLifecycle.failed(error, from: composer))
         }
+    }
+
+    private func agentSendSessionFactory(workspaceRoot: URL) -> WorkspaceAgentSendSessionFactory {
+        WorkspaceAgentSendSessionFactory(
+            baseRunner: runner,
+            selectedProject: selectedProject,
+            browser: browser,
+            browserToolOverride: WorkspaceBrowserAgentToolOverride.make { [weak self] call, workspaceRoot in
+                guard let self else { return nil }
+                return self.executeBrowserToolForAgent(call, workspaceRoot: workspaceRoot)
+            },
+            computerUseBackend: computerUseBackend,
+            globalMemoryDirectory: globalMemoryDirectory,
+            mcpToolDefinitions: mcpRuntime.toolDefinitions(
+                manifests: selectedProject?.extensionManifests ?? [],
+                extensions: extensions
+            ),
+            mcpToolExecutionOverride: mcpRuntime.executionOverride(extensions: extensions),
+            sshRemoteShellExecutor: sshRemoteShellExecutor,
+            workspaceRoot: workspaceRoot
+        )
     }
 
     private func applyAgentProgress(_ thread: ChatThread, expectedThreadID: UUID) {

--- a/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionFactoryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionFactoryTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import QuillCodeAgent
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeApp
+
+final class WorkspaceAgentSendSessionFactoryTests: XCTestCase {
+    func testMakeSessionPreservesThreadWorkspaceAndConfiguredTools() throws {
+        let workspaceRoot = try makeQuillCodeTestDirectory()
+        let memoryRoot = try makeQuillCodeTestDirectory()
+        let mcpTool = ToolDefinition(
+            name: "mcp.echo",
+            description: "Echo through MCP",
+            parametersJSON: #"{"type":"object","properties":{}}"#,
+            host: .mcp
+        )
+        let thread = ChatThread(title: "Agent")
+        let session = WorkspaceAgentSendSessionFactory(
+            baseRunner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
+            selectedProject: nil,
+            browser: BrowserState(),
+            browserToolOverride: nil,
+            computerUseBackend: nil,
+            globalMemoryDirectory: memoryRoot,
+            mcpToolDefinitions: [mcpTool],
+            mcpToolExecutionOverride: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor(),
+            workspaceRoot: workspaceRoot
+        ).makeSession(prompt: "hello", thread: thread)
+
+        XCTAssertEqual(session.threadID, thread.id)
+        XCTAssertEqual(session.workspaceRoot, workspaceRoot)
+        XCTAssertEqual(session.runner.baseToolDefinitions.map(\.name), ToolRouter.definitions.map(\.name))
+        XCTAssertEqual(session.runner.additionalToolDefinitions.map(\.name), [
+            ToolDefinition.planUpdate.name,
+            ToolDefinition.browserInspect.name,
+            ToolDefinition.browserOpen.name,
+            ToolDefinition.memoryRemember.name,
+            mcpTool.name
+        ])
+    }
+
+    func testFactoryUsesRemoteProjectToolDefinitions() {
+        let project = ProjectRef(
+            name: "Feather",
+            path: "/Quill",
+            connection: .ssh(path: "/Quill", host: "quill-feather.local", user: "quill")
+        )
+        let runner = WorkspaceAgentSendSessionFactory(
+            baseRunner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
+            selectedProject: project,
+            browser: BrowserState(),
+            browserToolOverride: nil,
+            computerUseBackend: nil,
+            globalMemoryDirectory: nil,
+            mcpToolDefinitions: [],
+            mcpToolExecutionOverride: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor(),
+            workspaceRoot: URL(fileURLWithPath: "/tmp/quill")
+        ).configuredRunner
+
+        XCTAssertEqual(
+            runner.baseToolDefinitions.map(\.name),
+            WorkspaceRemoteProjectToolExecutor.toolDefinitions.map(\.name)
+        )
+    }
+
+    func testFactoryHonorsInjectedBrowserOverride() async throws {
+        let workspaceRoot = try makeQuillCodeTestDirectory()
+        let runner = WorkspaceAgentSendSessionFactory(
+            baseRunner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
+            selectedProject: nil,
+            browser: BrowserState(),
+            browserToolOverride: { call, _ in
+                guard call.name == ToolDefinition.browserInspect.name else { return nil }
+                return ToolResult(ok: true, stdout: "custom browser snapshot")
+            },
+            computerUseBackend: nil,
+            globalMemoryDirectory: nil,
+            mcpToolDefinitions: [],
+            mcpToolExecutionOverride: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor(),
+            workspaceRoot: workspaceRoot
+        ).configuredRunner
+        let override = try XCTUnwrap(runner.toolExecutionOverride)
+
+        let result = await override(
+            ToolCall(name: ToolDefinition.browserInspect.name, argumentsJSON: "{}"),
+            workspaceRoot
+        )
+
+        XCTAssertEqual(result?.ok, true)
+        XCTAssertEqual(result?.stdout, "custom browser snapshot")
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -37,6 +37,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesAgentSendSessionExecution() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
         let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
 
         XCTAssertTrue(
@@ -44,8 +45,16 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
             "Agent send execution should live in a focused session object."
         )
         XCTAssertTrue(
+            factoryText.contains("WorkspaceAgentSendSession("),
+            "Agent send session construction should live in the send-session factory."
+        )
+        XCTAssertTrue(
+            modelText.contains("WorkspaceAgentSendSessionFactory("),
+            "WorkspaceModel should delegate runner execution setup to the send-session factory."
+        )
+        XCTAssertFalse(
             modelText.contains("WorkspaceAgentSendSession("),
-            "WorkspaceModel should delegate runner execution to an agent send session."
+            "WorkspaceModel should not construct agent send sessions inline."
         )
         XCTAssertFalse(
             modelText.contains("activeRunner.send("),
@@ -168,9 +177,11 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesAgentRunContextAssembly() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
+        let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
         let memoryExecutorText = try Self.appSourceText(named: "WorkspaceMemoryRememberToolExecutor.swift")
 
-        XCTAssertTrue(modelText.contains("WorkspaceAgentRunContextBuilder("), "WorkspaceModel should delegate per-run tool assembly.")
+        XCTAssertTrue(factoryText.contains("WorkspaceAgentRunContextBuilder("), "The send-session factory should delegate per-run tool assembly.")
+        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel should delegate per-run session assembly.")
         XCTAssertTrue(builderText.contains("configuredRunner(from runner: AgentRunner)"), "Agent run context builder should own runner configuration.")
         XCTAssertTrue(builderText.contains("ToolDefinition.planUpdate"), "Agent run context builder should attach the plan tool.")
         XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect"), "Agent run context builder should attach the browser tool.")
@@ -179,6 +190,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(builderText.contains("ToolDefinition.computerUseDefinitions"), "Agent run context builder should attach Computer Use tools only when available.")
         XCTAssertTrue(builderText.contains("WorkspaceMemoryRememberToolExecutor.executionOverride"), "Agent run context builder should delegate memory tool execution.")
         XCTAssertTrue(memoryExecutorText.contains("didSaveMemory(in thread: ChatThread)"), "Memory save detection should live beside memory tool execution.")
+        XCTAssertFalse(modelText.contains("WorkspaceAgentRunContextBuilder("), "WorkspaceModel should not construct the run-context builder inline.")
         XCTAssertFalse(modelText.contains("activeRunner.additionalToolDefinitions"), "WorkspaceModel should not assemble per-run additional tool definitions inline.")
         XCTAssertFalse(modelText.contains("private func planToolExecutionOverride"), "WorkspaceModel should not own plan tool override assembly.")
         XCTAssertFalse(modelText.contains("private func browserToolExecutionOverride"), "WorkspaceModel should not own browser tool override assembly.")
@@ -188,13 +200,16 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesAgentSendSession() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
         let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
 
         XCTAssertTrue(sessionText.contains("struct WorkspaceAgentSendSession"), "Agent send lifecycle should live in a focused session.")
         XCTAssertTrue(sessionText.contains("func run("), "Agent send lifecycle should be directly testable.")
         XCTAssertTrue(sessionText.contains("runner.send("), "The session should own the runner send call.")
         XCTAssertTrue(sessionText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory"), "The session should report whether the run saved memory.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSession("), "WorkspaceModel should delegate agent send execution.")
+        XCTAssertTrue(factoryText.contains("WorkspaceAgentSendSession("), "The factory should own agent send session construction.")
+        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel should delegate agent send execution setup.")
+        XCTAssertFalse(modelText.contains("WorkspaceAgentSendSession("), "WorkspaceModel should not construct agent send sessions inline.")
         XCTAssertFalse(modelText.contains("activeRunner.send("), "WorkspaceModel should not own the low-level send call.")
         XCTAssertFalse(modelText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory(in: thread)"), "WorkspaceModel should not inspect memory events after each send.")
     }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
@@ -342,6 +342,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
 
         let suiteNames = [
             "WorkspaceAgentRunContextBuilderTests.swift",
+            "WorkspaceAgentSendSessionFactoryTests.swift",
             "WorkspaceAgentSendSessionTests.swift",
             "WorkspaceMemoryEngineTests.swift",
             "WorkspaceTerminalEngineTests.swift",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5774,3 +5774,23 @@ Current strict grades:
 
 Remaining risk:
 - Native packaged smoke should eventually drive the macOS menu-bar widget and SwiftUI top-bar directly; the current coverage proves the shared HTML harness contract.
+
+## 2026-06-25 Agent Send Session Factory
+
+Overall grade after this slice: **A runner/session composition ownership, A factory coverage, A- WorkspaceModel send path**.
+
+`WorkspaceModel.submitComposer` still assembled the per-turn `AgentRunner` and constructed `WorkspaceAgentSendSession` inline. That kept browser override wiring, MCP tool resolution, memory directory selection, SSH remote executor selection, and workspace-root capture in the same method as composer state, progress updates, memory refresh, persistence, and error handling.
+
+What changed:
+- Added `WorkspaceAgentSendSessionFactory` as the focused composition boundary for current workspace state, configured runner creation, and send-session construction.
+- Simplified `WorkspaceModel.submitComposer` so it asks the factory for a session and then only owns actor-bound UI/persistence side effects.
+- Added focused factory tests for local tool composition, remote project tool composition, workspace/thread capture, memory/MCP tool propagation, and injected browser override behavior.
+- Updated architectural parity gates so `WorkspaceModel` cannot reintroduce inline run-context builder or send-session construction.
+
+Current strict grades:
+- `WorkspaceAgentSendSessionFactory.swift`: **A**. It is a small value boundary that cleanly composes existing runner-context and send-session types without adding new policy.
+- `WorkspaceModel.submitComposer`: **A-**. Runner/session setup is now delegated, but the method still owns progress application, memory refresh, thread persistence, cancellation, and final UI status.
+- `WorkspaceAgentSendSessionFactoryTests.swift`: **A**. It directly checks the factory’s local, remote, and override contracts.
+
+Remaining risk:
+- The next high-value extraction is a send-result/persistence coordinator that turns progress, memory refresh, final save, and cancellation transcript updates into typed effects. That should happen only after the factory boundary has stayed green across CI.


### PR DESCRIPTION
## Summary
- add WorkspaceAgentSendSessionFactory as the composition boundary for per-turn runner setup and send-session construction
- simplify WorkspaceModel.submitComposer so it delegates runner/session assembly and keeps actor-bound UI/persistence work
- add focused factory tests and parity gates that prevent inline run-context/session construction from returning to WorkspaceModel
- document the slice in docs/CODE_QUALITY_AUDIT.md

## Validation
- swift test --filter WorkspaceAgentSendSessionFactoryTests|WorkspaceAgentRunContextBuilderTests|WorkspaceAgentSendSessionTests|WorkspaceComposerIntegrationTests|ParityWorkspaceExecutionGateTests|ParityWorkspaceModelGateTests
- swift test
- npm --prefix E2E/playwright test
- git diff --check
