### PR TITLE
Extract workspace agent send session factory

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
@@ -1,0 +1,63 @@
+import Foundation
+import QuillCodeAgent
+import QuillCodeCore
+import QuillCodeTools
+import QuillComputerUseKit
+
+struct WorkspaceAgentSendSessionFactory: Sendable {
+    private let selectedProject: ProjectRef?
+    private let browser: BrowserState
+    private let browserToolOverride: AgentToolExecutionOverride?
+    private let computerUseBackend: (any ComputerUseBackend)?
+    private let globalMemoryDirectory: URL?
+    private let mcpToolDefinitions: [ToolDefinition]
+    private let mcpToolExecutionOverride: AgentToolExecutionOverride?
+    private let sshRemoteShellExecutor: SSHRemoteShellExecutor
+
+    init(
+        selectedProject: ProjectRef?,
+        browser: BrowserState,
+        browserToolOverride: AgentToolExecutionOverride? = nil,
+        computerUseBackend: (any ComputerUseBackend)?,
+        globalMemoryDirectory: URL?,
+        mcpToolDefinitions: [ToolDefinition],
+        mcpToolExecutionOverride: AgentToolExecutionOverride?,
+        sshRemoteShellExecutor: SSHRemoteShellExecutor
+    ) {
+        self.selectedProject = selectedProject
+        self.browser = browser
+        self.browserToolOverride = browserToolOverride
+        self.computerUseBackend = computerUseBackend
+        self.globalMemoryDirectory = globalMemoryDirectory
+        self.mcpToolDefinitions = mcpToolDefinitions
+        self.mcpToolExecutionOverride = mcpToolExecutionOverride
+        self.sshRemoteShellExecutor = sshRemoteShellExecutor
+    }
+
+    func makeSession(
+        prompt: String,
+        thread: ChatThread,
+        runner: AgentRunner,
+        workspaceRoot: URL
+    ) -> WorkspaceAgentSendSession {
+        WorkspaceAgentSendSession(
+            prompt: prompt,
+            thread: thread,
+            runner: configuredRunner(from: runner),
+            workspaceRoot: workspaceRoot
+        )
+    }
+
+    private func configuredRunner(from runner: AgentRunner) -> AgentRunner {
+        WorkspaceAgentRunContextBuilder(
+            selectedProject: selectedProject,
+            browser: browser,
+            browserToolOverride: browserToolOverride,
+            computerUseBackend: computerUseBackend,
+            globalMemoryDirectory: globalMemoryDirectory,
+            mcpToolDefinitions: mcpToolDefinitions,
+            mcpToolExecutionOverride: mcpToolExecutionOverride,
+            sshRemoteShellExecutor: sshRemoteShellExecutor
+        ).configuredRunner(from: runner)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -766,7 +766,7 @@ public final class QuillCodeWorkspaceModel {
 
         do {
             try Task.checkCancellation()
-            let activeRunner = WorkspaceAgentRunContextBuilder(
+            let session = WorkspaceAgentSendSessionFactory(
                 selectedProject: selectedProject,
                 browser: browser,
                 browserToolOverride: WorkspaceBrowserAgentToolOverride.make { [weak self] call, workspaceRoot in
@@ -781,11 +781,10 @@ public final class QuillCodeWorkspaceModel {
                 ),
                 mcpToolExecutionOverride: mcpRuntime.executionOverride(extensions: extensions),
                 sshRemoteShellExecutor: sshRemoteShellExecutor
-            ).configuredRunner(from: runner)
-            let session = WorkspaceAgentSendSession(
+            ).makeSession(
                 prompt: prompt,
                 thread: thread,
-                runner: activeRunner,
+                runner: runner,
                 workspaceRoot: workspaceRoot
             )
             let result = try await session.run { [weak self] progressThread in

--- a/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionFactoryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionFactoryTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import QuillCodeAgent
+import QuillCodeCore
+import QuillCodeTools
+import QuillComputerUseKit
+@testable import QuillCodeApp
+
+final class WorkspaceAgentSendSessionFactoryTests: XCTestCase {
+    func testBuildsLocalSendSessionWithCoreToolContext() throws {
+        let workspaceRoot = try makeQuillCodeTestDirectory()
+        let thread = ChatThread(title: "Local")
+        let session = WorkspaceAgentSendSessionFactory(
+            selectedProject: nil,
+            browser: BrowserState(),
+            computerUseBackend: nil,
+            globalMemoryDirectory: nil,
+            mcpToolDefinitions: [],
+            mcpToolExecutionOverride: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor()
+        ).makeSession(
+            prompt: "run whoami",
+            thread: thread,
+            runner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
+            workspaceRoot: workspaceRoot
+        )
+
+        XCTAssertEqual(session.prompt, "run whoami")
+        XCTAssertEqual(session.threadID, thread.id)
+        XCTAssertEqual(session.workspaceRoot, workspaceRoot)
+        XCTAssertEqual(session.runner.baseToolDefinitions.map(\.name), ToolRouter.definitions.map(\.name))
+        XCTAssertEqual(session.runner.additionalToolDefinitions.map(\.name), [
+            ToolDefinition.planUpdate.name,
+            ToolDefinition.browserInspect.name,
+            ToolDefinition.browserOpen.name
+        ])
+    }
+
+    func testBuildsRemoteSendSessionWithRemoteToolContext() throws {
+        let remoteProject = ProjectRef(
+            name: "Feather",
+            path: "/Quill",
+            connection: .ssh(path: "/Quill", host: "quill-feather.local", user: "quill")
+        )
+
+        let session = WorkspaceAgentSendSessionFactory(
+            selectedProject: remoteProject,
+            browser: BrowserState(),
+            computerUseBackend: nil,
+            globalMemoryDirectory: nil,
+            mcpToolDefinitions: [],
+            mcpToolExecutionOverride: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor()
+        ).makeSession(
+            prompt: "git status",
+            thread: ChatThread(title: "Remote"),
+            runner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
+            workspaceRoot: try makeQuillCodeTestDirectory()
+        )
+
+        XCTAssertEqual(
+            session.runner.baseToolDefinitions.map(\.name),
+            WorkspaceRemoteProjectToolExecutor.toolDefinitions.map(\.name)
+        )
+    }
+
+    func testBuildsSendSessionWithOptionalComputerMemoryAndMCPContext() async throws {
+        let memoryDirectory = try makeQuillCodeTestDirectory()
+        let mcpTool = ToolDefinition(
+            name: "mcp.echo",
+            description: "Echo through MCP",
+            parametersJSON: #"{"type":"object","properties":{}}"#,
+            host: .mcp
+        )
+        let mcpOverride: AgentToolExecutionOverride = { call, _ in
+            call.name == "mcp.echo"
+                ? ToolResult(ok: true, stdout: "mcp echo")
+                : nil
+        }
+
+        let session = WorkspaceAgentSendSessionFactory(
+            selectedProject: nil,
+            browser: BrowserState(),
+            computerUseBackend: SendSessionFactoryStubComputerUseBackend(),
+            globalMemoryDirectory: memoryDirectory,
+            mcpToolDefinitions: [mcpTool],
+            mcpToolExecutionOverride: mcpOverride,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor()
+        ).makeSession(
+            prompt: "use tools",
+            thread: ChatThread(title: "Optional tools"),
+            runner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
+            workspaceRoot: try makeQuillCodeTestDirectory()
+        )
+
+        let expectedNames = [
+            ToolDefinition.planUpdate.name,
+            ToolDefinition.browserInspect.name,
+            ToolDefinition.browserOpen.name
+        ] + ToolDefinition.computerUseDefinitions.map(\.name)
+            + [ToolDefinition.memoryRemember.name, mcpTool.name]
+        XCTAssertEqual(session.runner.additionalToolDefinitions.map(\.name), expectedNames)
+
+        let override = try XCTUnwrap(session.runner.toolExecutionOverride)
+        let mcpResult = await override(ToolCall(name: "mcp.echo", argumentsJSON: "{}"), memoryDirectory)
+
+        XCTAssertEqual(mcpResult?.ok, true)
+        XCTAssertEqual(mcpResult?.stdout, "mcp echo")
+    }
+}
+
+private struct SendSessionFactoryStubComputerUseBackend: ComputerUseBackend {
+    var status: ComputerUseStatus {
+        .permissionStatus(screenRecordingGranted: true, accessibilityGranted: true)
+    }
+
+    func screenshot() async throws -> ComputerScreenshot {
+        ComputerScreenshot(width: 1, height: 1, pngBase64: "")
+    }
+
+    func leftClick(x: Int, y: Int) async throws {}
+
+    func type(_ text: String) async throws {}
+
+    func scroll(dx: Int, dy: Int) async throws {}
+
+    func moveCursor(x: Int, y: Int) async throws {}
+
+    func pressKey(_ key: String) async throws {}
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -38,14 +38,19 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesAgentSendSessionExecution() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
+        let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
 
         XCTAssertTrue(
             sessionText.contains("struct WorkspaceAgentSendSession"),
             "Agent send execution should live in a focused session object."
         )
         XCTAssertTrue(
-            modelText.contains("WorkspaceAgentSendSession("),
-            "WorkspaceModel should delegate runner execution to an agent send session."
+            factoryText.contains("WorkspaceAgentSendSession("),
+            "The send-session factory should own session construction."
+        )
+        XCTAssertTrue(
+            modelText.contains("WorkspaceAgentSendSessionFactory("),
+            "WorkspaceModel should delegate runner execution through the send-session factory."
         )
         XCTAssertFalse(
             modelText.contains("activeRunner.send("),
@@ -168,9 +173,10 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesAgentRunContextAssembly() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
+        let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
         let memoryExecutorText = try Self.appSourceText(named: "WorkspaceMemoryRememberToolExecutor.swift")
 
-        XCTAssertTrue(modelText.contains("WorkspaceAgentRunContextBuilder("), "WorkspaceModel should delegate per-run tool assembly.")
+        XCTAssertTrue(factoryText.contains("WorkspaceAgentRunContextBuilder("), "The send-session factory should delegate per-run tool assembly.")
         XCTAssertTrue(builderText.contains("configuredRunner(from runner: AgentRunner)"), "Agent run context builder should own runner configuration.")
         XCTAssertTrue(builderText.contains("ToolDefinition.planUpdate"), "Agent run context builder should attach the plan tool.")
         XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect"), "Agent run context builder should attach the browser tool.")
@@ -179,6 +185,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(builderText.contains("ToolDefinition.computerUseDefinitions"), "Agent run context builder should attach Computer Use tools only when available.")
         XCTAssertTrue(builderText.contains("WorkspaceMemoryRememberToolExecutor.executionOverride"), "Agent run context builder should delegate memory tool execution.")
         XCTAssertTrue(memoryExecutorText.contains("didSaveMemory(in thread: ChatThread)"), "Memory save detection should live beside memory tool execution.")
+        XCTAssertFalse(modelText.contains("WorkspaceAgentRunContextBuilder("), "WorkspaceModel should not own active runner context construction.")
         XCTAssertFalse(modelText.contains("activeRunner.additionalToolDefinitions"), "WorkspaceModel should not assemble per-run additional tool definitions inline.")
         XCTAssertFalse(modelText.contains("private func planToolExecutionOverride"), "WorkspaceModel should not own plan tool override assembly.")
         XCTAssertFalse(modelText.contains("private func browserToolExecutionOverride"), "WorkspaceModel should not own browser tool override assembly.")
@@ -189,12 +196,14 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesAgentSendSession() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
+        let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
 
         XCTAssertTrue(sessionText.contains("struct WorkspaceAgentSendSession"), "Agent send lifecycle should live in a focused session.")
         XCTAssertTrue(sessionText.contains("func run("), "Agent send lifecycle should be directly testable.")
         XCTAssertTrue(sessionText.contains("runner.send("), "The session should own the runner send call.")
         XCTAssertTrue(sessionText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory"), "The session should report whether the run saved memory.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSession("), "WorkspaceModel should delegate agent send execution.")
+        XCTAssertTrue(factoryText.contains("WorkspaceAgentSendSession("), "The send-session factory should own session construction.")
+        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel should delegate agent send execution.")
         XCTAssertFalse(modelText.contains("activeRunner.send("), "WorkspaceModel should not own the low-level send call.")
         XCTAssertFalse(modelText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory(in: thread)"), "WorkspaceModel should not inspect memory events after each send.")
     }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
@@ -53,6 +53,23 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(modelText.contains("public struct ActivityState"), "WorkspaceModel should not define activity-pane UI state contracts.")
     }
 
+    func testWorkspaceModelDelegatesAgentSendSessionConstruction() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
+        let factoryTestsText = try Self.appTestSourceText(named: "WorkspaceAgentSendSessionFactoryTests.swift")
+
+        XCTAssertTrue(factoryText.contains("struct WorkspaceAgentSendSessionFactory"), "Agent send-session construction should have a focused owner.")
+        XCTAssertTrue(factoryText.contains("func makeSession("), "The send-session factory should expose one construction boundary.")
+        XCTAssertTrue(factoryText.contains("WorkspaceAgentRunContextBuilder("), "Runner context wiring should live in the focused send-session factory.")
+        XCTAssertTrue(factoryText.contains("WorkspaceAgentSendSession("), "Session construction should live in the focused send-session factory.")
+        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel should delegate active runner/session construction.")
+        XCTAssertTrue(factoryTestsText.contains("testBuildsLocalSendSessionWithCoreToolContext"), "Local send-session wiring needs focused regression coverage.")
+        XCTAssertTrue(factoryTestsText.contains("testBuildsRemoteSendSessionWithRemoteToolContext"), "Remote send-session wiring needs focused regression coverage.")
+        XCTAssertTrue(factoryTestsText.contains("testBuildsSendSessionWithOptionalComputerMemoryAndMCPContext"), "Optional tool context wiring needs focused regression coverage.")
+        XCTAssertFalse(modelText.contains("WorkspaceAgentRunContextBuilder("), "WorkspaceModel should not own active runner context construction.")
+        XCTAssertFalse(modelText.contains("let activeRunner"), "WorkspaceModel should not keep inline active-runner wiring.")
+    }
+
     func testActionableReviewCardsStayWiredThroughSurfaces() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let toolCardSurfaceText = try Self.appSourceText(named: "QuillCodeToolCardSurface.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5774,3 +5774,23 @@ Current strict grades:
 
 Remaining risk:
 - Native packaged smoke should eventually drive the macOS menu-bar widget and SwiftUI top-bar directly; the current coverage proves the shared HTML harness contract.
+
+## 2026-06-25 Agent Send Session Factory
+
+Overall grade after this slice: **A send-session construction boundary, A context wiring coverage, A- WorkspaceModel send path**.
+
+`WorkspaceModel.submitComposer` still assembled the active `AgentRunner` inline: local-vs-remote tool definitions, browser overrides, Computer Use tools, memory tools, MCP tool definitions, MCP execution overrides, and SSH Remote execution. That wiring is core to Codex parity because every live send depends on the same local/remote/tool context, but it was mixed into UI send lifecycle and persistence handling.
+
+What changed:
+- Added `WorkspaceAgentSendSessionFactory` as the focused owner for active runner and send-session construction.
+- Kept `WorkspaceModel.submitComposer` responsible for orchestration, progress updates, persistence, and cancellation, while delegating tool-context wiring.
+- Added focused tests for local tool context, SSH Remote tool context, and optional Computer Use, memory, and MCP context.
+- Added a WorkspaceModel parity gate so future work keeps active runner/session construction outside the broad workspace coordinator.
+
+Current strict grades:
+- `WorkspaceAgentSendSessionFactory.swift`: **A**. It has one clear job: convert current workspace context into a configured send session.
+- `WorkspaceAgentSendSessionFactoryTests.swift`: **A**. It directly covers the tool-definition and override combinations that would otherwise only be seen indirectly through composer integration tests.
+- `WorkspaceModel.submitComposer`: **A-**. Runner/session wiring is extracted; result persistence and post-run memory refresh remain the next separable responsibilities.
+
+Remaining risk:
+- The send path still coordinates progress application, saved-memory refresh, thread upsert, persistence, and UI lifecycle in one method. The next architecture pass should extract the agent-run completion/persistence application boundary.


### PR DESCRIPTION
## Summary\n- Extract active runner and send-session construction from WorkspaceModel into WorkspaceAgentSendSessionFactory\n- Add focused coverage for local, SSH remote, Computer Use, memory, and MCP tool-context wiring\n- Update parity gates and code-quality audit to preserve the new boundary\n\n## Validation\n- swift test --filter WorkspaceAgentSendSessionFactoryTests\n- swift test --filter ParityWorkspaceExecutionGateTests\n- swift test --filter ParityWorkspaceModelGateTests\n- swift test\n- git diff --check