### PR TITLE
Harden workspace agent send session factory

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
@@ -5,16 +5,40 @@ import QuillCodeTools
 import QuillComputerUseKit
 
 struct WorkspaceAgentSendSessionFactory: Sendable {
-    var baseRunner: AgentRunner
-    var selectedProject: ProjectRef?
-    var browser: BrowserState
-    var browserToolOverride: AgentToolExecutionOverride?
-    var computerUseBackend: (any ComputerUseBackend)?
-    var globalMemoryDirectory: URL?
-    var mcpToolDefinitions: [ToolDefinition]
-    var mcpToolExecutionOverride: AgentToolExecutionOverride?
-    var sshRemoteShellExecutor: SSHRemoteShellExecutor
-    var workspaceRoot: URL
+    private let baseRunner: AgentRunner
+    private let selectedProject: ProjectRef?
+    private let browser: BrowserState
+    private let browserToolOverride: AgentToolExecutionOverride?
+    private let computerUseBackend: (any ComputerUseBackend)?
+    private let globalMemoryDirectory: URL?
+    private let mcpToolDefinitions: [ToolDefinition]
+    private let mcpToolExecutionOverride: AgentToolExecutionOverride?
+    private let sshRemoteShellExecutor: SSHRemoteShellExecutor
+    private let workspaceRoot: URL
+
+    init(
+        baseRunner: AgentRunner,
+        selectedProject: ProjectRef?,
+        browser: BrowserState,
+        browserToolOverride: AgentToolExecutionOverride?,
+        computerUseBackend: (any ComputerUseBackend)?,
+        globalMemoryDirectory: URL?,
+        mcpToolDefinitions: [ToolDefinition],
+        mcpToolExecutionOverride: AgentToolExecutionOverride?,
+        sshRemoteShellExecutor: SSHRemoteShellExecutor,
+        workspaceRoot: URL
+    ) {
+        self.baseRunner = baseRunner
+        self.selectedProject = selectedProject
+        self.browser = browser
+        self.browserToolOverride = browserToolOverride
+        self.computerUseBackend = computerUseBackend
+        self.globalMemoryDirectory = globalMemoryDirectory
+        self.mcpToolDefinitions = mcpToolDefinitions
+        self.mcpToolExecutionOverride = mcpToolExecutionOverride
+        self.sshRemoteShellExecutor = sshRemoteShellExecutor
+        self.workspaceRoot = workspaceRoot
+    }
 
     func makeSession(prompt: String, thread: ChatThread) -> WorkspaceAgentSendSession {
         WorkspaceAgentSendSession(
@@ -25,7 +49,7 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
         )
     }
 
-    var configuredRunner: AgentRunner {
+    private var configuredRunner: AgentRunner {
         WorkspaceAgentRunContextBuilder(
             selectedProject: selectedProject,
             browser: browser,

--- a/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionFactoryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionFactoryTests.swift
@@ -46,7 +46,7 @@ final class WorkspaceAgentSendSessionFactoryTests: XCTestCase {
             path: "/Quill",
             connection: .ssh(path: "/Quill", host: "quill-feather.local", user: "quill")
         )
-        let runner = WorkspaceAgentSendSessionFactory(
+        let session = WorkspaceAgentSendSessionFactory(
             baseRunner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
             selectedProject: project,
             browser: BrowserState(),
@@ -57,17 +57,17 @@ final class WorkspaceAgentSendSessionFactoryTests: XCTestCase {
             mcpToolExecutionOverride: nil,
             sshRemoteShellExecutor: SSHRemoteShellExecutor(),
             workspaceRoot: URL(fileURLWithPath: "/tmp/quill")
-        ).configuredRunner
+        ).makeSession(prompt: "git status", thread: ChatThread(title: "Remote"))
 
         XCTAssertEqual(
-            runner.baseToolDefinitions.map(\.name),
+            session.runner.baseToolDefinitions.map(\.name),
             WorkspaceRemoteProjectToolExecutor.toolDefinitions.map(\.name)
         )
     }
 
     func testFactoryHonorsInjectedBrowserOverride() async throws {
         let workspaceRoot = try makeQuillCodeTestDirectory()
-        let runner = WorkspaceAgentSendSessionFactory(
+        let session = WorkspaceAgentSendSessionFactory(
             baseRunner: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []),
             selectedProject: nil,
             browser: BrowserState(),
@@ -81,8 +81,8 @@ final class WorkspaceAgentSendSessionFactoryTests: XCTestCase {
             mcpToolExecutionOverride: nil,
             sshRemoteShellExecutor: SSHRemoteShellExecutor(),
             workspaceRoot: workspaceRoot
-        ).configuredRunner
-        let override = try XCTUnwrap(runner.toolExecutionOverride)
+        ).makeSession(prompt: "inspect browser", thread: ChatThread(title: "Browser"))
+        let override = try XCTUnwrap(session.runner.toolExecutionOverride)
 
         let result = await override(
             ToolCall(name: ToolDefinition.browserInspect.name, argumentsJSON: "{}"),

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -5794,3 +5794,21 @@ Current strict grades:
 
 Remaining risk:
 - The next high-value extraction is a send-result/persistence coordinator that turns progress, memory refresh, final save, and cancellation transcript updates into typed effects. That should happen only after the factory boundary has stayed green across CI.
+
+## 2026-06-25 Send Session Factory Hardening
+
+Overall grade after this slice: **A immutable factory boundary, A black-box factory tests**.
+
+The send-session factory had the right responsibility after extraction, but its stored state was mutable and tests reached into `configuredRunner` directly. That made the helper feel more like a bag of fields than a narrow composition boundary.
+
+What changed:
+- Made `WorkspaceAgentSendSessionFactory` immutable with private stored state.
+- Kept configured-runner construction private so callers use one path: `makeSession`.
+- Updated factory tests to assert behavior through the returned `WorkspaceAgentSendSession`.
+
+Current strict grades:
+- `WorkspaceAgentSendSessionFactory.swift`: **A**. It now exposes one construction contract and hides implementation details.
+- `WorkspaceAgentSendSessionFactoryTests.swift`: **A**. Tests cover local, remote, memory, MCP, and browser override wiring through the public factory contract.
+
+Remaining risk:
+- `WorkspaceModel.submitComposer` still owns post-run completion, persistence, and memory-refresh coordination. That remains the next high-value extraction.


### PR DESCRIPTION
## Summary\n- Make WorkspaceAgentSendSessionFactory immutable with private stored state\n- Hide configured-runner construction behind makeSession\n- Update focused tests to assert behavior through the returned WorkspaceAgentSendSession\n- Record the quality pass in CODE_QUALITY_AUDIT\n\n## Validation\n- swift test --filter WorkspaceAgentSendSessionFactoryTests\n- swift test --filter ParityWorkspaceExecutionGateTests\n- swift test\n- git diff --check