### PR TITLE
[codex] Load worktree choices asynchronously

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -462,6 +462,26 @@
     .search-card header { display: flex; justify-content: space-between; gap: 16px; align-items: start; }
     .dialog-choice-list { display: grid; gap: 8px; }
     .dialog-choice-list .eyebrow { color: var(--muted); font-size: 11px; font-weight: 800; text-transform: uppercase; letter-spacing: .08em; }
+    .dialog-choice-status {
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 12px;
+      border: 1px solid rgba(255,255,255,.10);
+      border-radius: 14px;
+      background: rgba(255,255,255,.045);
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .dialog-choice-spinner {
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      border: 2px solid rgba(65,184,232,.22);
+      border-top-color: var(--accent);
+      animation: spin .85s linear infinite;
+    }
     .dialog-choice {
       min-height: 56px;
       display: grid;
@@ -476,6 +496,7 @@
     .dialog-choice:hover { border-color: rgba(65,184,232,.42); background: rgba(65,184,232,.10); }
     .dialog-choice span { color: var(--muted); font-size: 12px; }
     .dialog-choice code { display: block; color: rgba(231,238,241,.68); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    @keyframes spin { to { transform: rotate(360deg); } }
     .command-palette-input-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: center; }
     .command-scope-badge,
     .command-palette-legend {
@@ -2672,6 +2693,10 @@
         createBase: '',
         openPath: '',
         choices: [],
+        choicesLoading: false,
+        choicesLoaded: false,
+        choicesError: '',
+        choiceLoadToken: 0,
         removePath: '',
         removeForce: false
       },
@@ -7372,9 +7397,14 @@
           ...state.worktreeDialog,
           mode: 'open',
           openPath: '',
-          choices: availableWorktreeChoices()
+          choices: [],
+          choicesLoading: true,
+          choicesLoaded: false,
+          choicesError: '',
+          choiceLoadToken: state.worktreeDialog.choiceLoadToken + 1
         };
         render();
+        loadWorktreeChoicesForDialog('open', state.worktreeDialog.choiceLoadToken);
         return;
       }
       if (commandID === 'git-worktree-remove') {
@@ -7383,9 +7413,14 @@
           mode: 'remove',
           removePath: '',
           removeForce: false,
-          choices: availableWorktreeChoices()
+          choices: [],
+          choicesLoading: true,
+          choicesLoaded: false,
+          choicesError: '',
+          choiceLoadToken: state.worktreeDialog.choiceLoadToken + 1
         };
         render();
+        loadWorktreeChoicesForDialog('remove', state.worktreeDialog.choiceLoadToken);
         return;
       }
       if (commandID === 'git-worktree-prune') {
@@ -7969,18 +8004,7 @@
                 </div>
                 <button type="button" data-testid="worktree-dialog-close">Close</button>
               </header>
-              ${state.worktreeDialog.choices.length ? `
-                <div class="dialog-choice-list" aria-label="Known worktrees">
-                  <p class="eyebrow">Known worktrees</p>
-                  ${state.worktreeDialog.choices.map(choice => `
-                    <button type="button" class="dialog-choice" data-testid="worktree-choice" data-target="open" data-path="${escapeHTML(choice.path)}">
-                      <strong>${escapeHTML(choice.title)}</strong>
-                      <span>${escapeHTML(choice.detail)}</span>
-                      <code>${escapeHTML(choice.path)}</code>
-                    </button>
-                  `).join('')}
-                </div>
-              ` : ''}
+              ${renderWorktreeChoiceSection('open', 'No other registered worktrees found.')}
               <label>
                 Worktree folder
                 <input name="path" aria-label="Worktree folder" placeholder="quillcode-feature" value="${escapeHTML(state.worktreeDialog.openPath)}" autofocus>
@@ -8002,18 +8026,7 @@
               </div>
               <button type="button" data-testid="worktree-dialog-close">Close</button>
             </header>
-            ${state.worktreeDialog.choices.length ? `
-              <div class="dialog-choice-list" aria-label="Known worktrees">
-                <p class="eyebrow">Known worktrees</p>
-                ${state.worktreeDialog.choices.map(choice => `
-                  <button type="button" class="dialog-choice" data-testid="worktree-choice" data-target="remove" data-path="${escapeHTML(choice.path)}">
-                    <strong>${escapeHTML(choice.title)}</strong>
-                    <span>${escapeHTML(choice.detail)}</span>
-                    <code>${escapeHTML(choice.path)}</code>
-                  </button>
-                `).join('')}
-              </div>
-            ` : ''}
+            ${renderWorktreeChoiceSection('remove', 'No removable registered worktrees found.')}
             <label>
               Worktree folder
               <input name="path" aria-label="Worktree folder" placeholder="quillcode-feature" value="${escapeHTML(state.worktreeDialog.removePath)}" autofocus>
@@ -8029,6 +8042,49 @@
               <button type="submit" data-testid="worktree-remove-submit" ${state.worktreeDialog.removePath.trim() ? '' : 'disabled'}>Remove</button>
             </div>
           </form>
+        </div>`;
+    }
+
+    function loadWorktreeChoicesForDialog(mode, token) {
+      window.setTimeout(() => {
+        if (state.worktreeDialog.mode !== mode || state.worktreeDialog.choiceLoadToken !== token) {
+          return;
+        }
+        state.worktreeDialog = {
+          ...state.worktreeDialog,
+          choices: availableWorktreeChoices(),
+          choicesLoading: false,
+          choicesLoaded: true,
+          choicesError: ''
+        };
+        render();
+      }, 80);
+    }
+
+    function renderWorktreeChoiceSection(target, emptyMessage) {
+      const dialog = state.worktreeDialog;
+      const shouldRender = dialog.choicesLoading || dialog.choicesLoaded || dialog.choicesError || dialog.choices.length;
+      if (!shouldRender) {
+        return '';
+      }
+      const status = dialog.choicesLoading
+        ? '<div class="dialog-choice-status" data-testid="worktree-choices-loading"><span class="dialog-choice-spinner" aria-hidden="true"></span><span>Loading registered worktrees...</span></div>'
+        : dialog.choicesError
+          ? `<div class="dialog-choice-status" data-testid="worktree-choices-error">${escapeHTML(dialog.choicesError)} You can still paste a path.</div>`
+          : dialog.choicesLoaded && !dialog.choices.length
+            ? `<div class="dialog-choice-status" data-testid="worktree-choices-empty">${escapeHTML(emptyMessage)} You can still paste a path.</div>`
+            : '';
+      return `
+        <div class="dialog-choice-list" aria-label="Known worktrees">
+          <p class="eyebrow">Known worktrees</p>
+          ${status}
+          ${dialog.choices.map(choice => `
+            <button type="button" class="dialog-choice" data-testid="worktree-choice" data-target="${target}" data-path="${escapeHTML(choice.path)}">
+              <strong>${escapeHTML(choice.title)}</strong>
+              <span>${escapeHTML(choice.detail)}</span>
+              <code>${escapeHTML(choice.path)}</code>
+            </button>
+          `).join('')}
         </div>`;
     }
 

--- a/E2E/playwright/tests/command-palette.spec.ts
+++ b/E2E/playwright/tests/command-palette.spec.ts
@@ -195,7 +195,9 @@ test('mock harness creates and removes worktrees from dialogs', async ({ page })
   await clickCommandPaletteCommand(page, '>open worktree', 'git-worktree-open');
   await expect(page.getByTestId('worktree-open-panel')).toBeVisible();
   await expect(page.getByTestId('worktree-open-submit')).toBeDisabled();
+  await expect(page.getByTestId('worktree-choices-loading')).toBeVisible();
   await expect(page.getByTestId('worktree-choice')).toContainText(['QuillCode', 'quillcode-existing']);
+  await expect(page.getByTestId('worktree-choices-loading')).toHaveCount(0);
 
   await page.getByTestId('worktree-choice').filter({ hasText: 'quillcode-existing' }).click();
   await expect(page.getByLabel('Worktree folder')).toHaveValue('/mock/quillcode-existing');
@@ -210,7 +212,9 @@ test('mock harness creates and removes worktrees from dialogs', async ({ page })
   await clickSidebarTool(page, 'command-palette-button');
   await clickCommandPaletteCommand(page, '>remove worktree', 'git-worktree-remove');
   await expect(page.getByTestId('worktree-remove-panel')).toBeVisible();
+  await expect(page.getByTestId('worktree-choices-loading')).toBeVisible();
   await expect(page.getByTestId('worktree-choice')).toContainText(['QuillCode', 'quillcode-feature']);
+  await expect(page.getByTestId('worktree-choices-loading')).toHaveCount(0);
 
   await page.getByTestId('worktree-choice').filter({ hasText: 'quillcode-feature' }).click();
   await expect(page.getByLabel('Worktree folder')).toHaveValue('/mock/quillcode-feature');

--- a/Sources/QuillCodeApp/QuillCodeWorktreeDialogs.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorktreeDialogs.swift
@@ -27,9 +27,33 @@ struct QuillCodeWorktreeCreateDraft: Equatable {
     }
 }
 
+struct QuillCodeWorktreeChoiceLoadState: Equatable {
+    var choices: [WorkspaceWorktreeChoice] = []
+    var isLoading = false
+    var hasLoaded = false
+    var errorMessage: String?
+
+    static var loading: Self {
+        Self(isLoading: true)
+    }
+
+    static func loaded(_ load: WorkspaceWorktreeChoiceLoad) -> Self {
+        Self(
+            choices: load.choices,
+            hasLoaded: true,
+            errorMessage: load.errorMessage
+        )
+    }
+}
+
 struct QuillCodeWorktreeOpenDraft: Equatable {
     var path = ""
-    var choices: [WorkspaceWorktreeChoice] = []
+    var choiceLoad = QuillCodeWorktreeChoiceLoadState()
+
+    init(path: String = "", choiceLoad: QuillCodeWorktreeChoiceLoadState = QuillCodeWorktreeChoiceLoadState()) {
+        self.path = path
+        self.choiceLoad = choiceLoad
+    }
 
     var canOpen: Bool {
         !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -46,8 +70,18 @@ struct QuillCodeWorktreeOpenDraft: Equatable {
 
 struct QuillCodeWorktreeRemoveDraft: Equatable {
     var path = ""
-    var choices: [WorkspaceWorktreeChoice] = []
+    var choiceLoad = QuillCodeWorktreeChoiceLoadState()
     var force = false
+
+    init(
+        path: String = "",
+        choiceLoad: QuillCodeWorktreeChoiceLoadState = QuillCodeWorktreeChoiceLoadState(),
+        force: Bool = false
+    ) {
+        self.path = path
+        self.choiceLoad = choiceLoad
+        self.force = force
+    }
 
     var canRemove: Bool {
         !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -77,17 +111,16 @@ struct QuillCodeWorktreeOpenView: View {
             systemImage: "rectangle.on.rectangle",
             iconColor: QuillCodePalette.blue
         ) {
-            if !draft.choices.isEmpty {
-                QuillCodeWorktreeChoiceList(
-                    choices: draft.choices,
-                    selectedPath: draft.request.path,
-                    iconName: "arrow.turn.down.right",
-                    iconColor: QuillCodePalette.blue,
-                    onSelect: { choice in
-                        draft.select(choice)
-                    }
-                )
-            }
+            QuillCodeWorktreeChoiceSection(
+                state: draft.choiceLoad,
+                selectedPath: draft.request.path,
+                iconName: "arrow.turn.down.right",
+                iconColor: QuillCodePalette.blue,
+                emptyMessage: "No other registered worktrees found.",
+                onSelect: { choice in
+                    draft.select(choice)
+                }
+            )
 
             QuillCodeLabeledTextField(
                 title: "Worktree folder",
@@ -149,64 +182,59 @@ struct QuillCodeWorktreeCreateView: View {
     }
 }
 
-private struct QuillCodeWorktreeChoiceList: View {
-    var choices: [WorkspaceWorktreeChoice]
+private struct QuillCodeWorktreeChoiceSection: View {
+    var state: QuillCodeWorktreeChoiceLoadState
     var selectedPath: String
     var iconName: String
     var iconColor: Color
+    var emptyMessage: String
     var onSelect: (WorkspaceWorktreeChoice) -> Void
 
     var body: some View {
+        if shouldShowSection {
+            content
+        }
+    }
+
+    private var shouldShowSection: Bool {
+        state.isLoading || state.hasLoaded || state.errorMessage != nil || !state.choices.isEmpty
+    }
+
+    private var content: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Known Worktrees")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(QuillCodePalette.muted)
                 .textCase(.uppercase)
             VStack(spacing: 6) {
-                ForEach(choices) { choice in
-                    Button {
-                        onSelect(choice)
-                    } label: {
-                        HStack(spacing: 10) {
-                            Image(systemName: iconName)
-                                .foregroundStyle(iconColor)
-                                .accessibilityHidden(true)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(choice.title)
-                                    .font(.callout.weight(.semibold))
-                                    .lineLimit(1)
-                                Text(choice.detail)
-                                    .font(.caption)
-                                    .foregroundStyle(QuillCodePalette.muted)
-                                    .lineLimit(1)
-                                Text(choice.path)
-                                    .font(.caption2.monospaced())
-                                    .foregroundStyle(QuillCodePalette.muted.opacity(0.75))
-                                    .lineLimit(1)
-                            }
-                            Spacer(minLength: 8)
-                            if choice.path == selectedPath {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(QuillCodePalette.green)
-                                    .accessibilityLabel("Selected")
-                            }
-                        }
-                        .contentShape(Rectangle())
-                        .padding(10)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .fill(choice.path == selectedPath
-                                    ? QuillCodePalette.blue.opacity(0.14)
-                                    : QuillCodePalette.panel)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(choice.path == selectedPath
-                                    ? QuillCodePalette.blue.opacity(0.45)
-                                    : Color.white.opacity(0.08))
-                        )
-                    }
-                    .buttonStyle(.plain)
+                if state.isLoading {
+                    QuillCodeWorktreeChoiceStatusRow(
+                        systemImage: "clock.arrow.circlepath",
+                        message: "Loading registered worktrees...",
+                        color: QuillCodePalette.blue,
+                        showsSpinner: true
+                    )
+                } else if let errorMessage = state.errorMessage {
+                    QuillCodeWorktreeChoiceStatusRow(
+                        systemImage: "exclamationmark.triangle",
+                        message: "\(errorMessage) You can still paste a worktree path.",
+                        color: QuillCodePalette.yellow
+                    )
+                } else if state.hasLoaded && state.choices.isEmpty {
+                    QuillCodeWorktreeChoiceStatusRow(
+                        systemImage: "rectangle.stack.badge.questionmark",
+                        message: "\(emptyMessage) You can still paste a path.",
+                        color: QuillCodePalette.muted
+                    )
+                }
+                ForEach(state.choices) { choice in
+                    QuillCodeWorktreeChoiceRow(
+                        choice: choice,
+                        selectedPath: selectedPath,
+                        iconName: iconName,
+                        iconColor: iconColor,
+                        onSelect: onSelect
+                    )
                 }
             }
         }
@@ -225,17 +253,16 @@ struct QuillCodeWorktreeRemoveView: View {
             systemImage: "minus.rectangle",
             iconColor: QuillCodePalette.yellow
         ) {
-            if !draft.choices.isEmpty {
-                QuillCodeWorktreeChoiceList(
-                    choices: draft.choices,
-                    selectedPath: draft.request.path,
-                    iconName: "minus.circle",
-                    iconColor: QuillCodePalette.yellow,
-                    onSelect: { choice in
-                        draft.select(choice)
-                    }
-                )
-            }
+            QuillCodeWorktreeChoiceSection(
+                state: draft.choiceLoad,
+                selectedPath: draft.request.path,
+                iconName: "minus.circle",
+                iconColor: QuillCodePalette.yellow,
+                emptyMessage: "No removable registered worktrees found.",
+                onSelect: { choice in
+                    draft.select(choice)
+                }
+            )
 
             QuillCodeLabeledTextField(
                 title: "Worktree folder",
@@ -255,6 +282,95 @@ struct QuillCodeWorktreeRemoveView: View {
                     .disabled(!draft.canRemove)
             }
         }
+    }
+}
+
+private struct QuillCodeWorktreeChoiceStatusRow: View {
+    var systemImage: String
+    var message: String
+    var color: Color
+    var showsSpinner = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if showsSpinner {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Loading")
+            } else {
+                Image(systemName: systemImage)
+                    .foregroundStyle(color)
+                    .accessibilityHidden(true)
+            }
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(QuillCodePalette.muted)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(QuillCodePalette.panel)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.white.opacity(0.08))
+        )
+    }
+}
+
+private struct QuillCodeWorktreeChoiceRow: View {
+    var choice: WorkspaceWorktreeChoice
+    var selectedPath: String
+    var iconName: String
+    var iconColor: Color
+    var onSelect: (WorkspaceWorktreeChoice) -> Void
+
+    var body: some View {
+        Button {
+            onSelect(choice)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: iconName)
+                    .foregroundStyle(iconColor)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(choice.title)
+                        .font(.callout.weight(.semibold))
+                        .lineLimit(1)
+                    Text(choice.detail)
+                        .font(.caption)
+                        .foregroundStyle(QuillCodePalette.muted)
+                        .lineLimit(1)
+                    Text(choice.path)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(QuillCodePalette.muted.opacity(0.75))
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 8)
+                if choice.path == selectedPath {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(QuillCodePalette.green)
+                        .accessibilityLabel("Selected")
+                }
+            }
+            .contentShape(Rectangle())
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(choice.path == selectedPath
+                        ? QuillCodePalette.blue.opacity(0.14)
+                        : QuillCodePalette.panel)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(choice.path == selectedPath
+                        ? QuillCodePalette.blue.opacity(0.45)
+                        : Color.white.opacity(0.08))
+            )
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -964,14 +964,20 @@ public final class QuillCodeWorkspaceModel {
         }
     }
 
-    public func worktreeChoices(workspaceRoot: URL) -> [WorkspaceWorktreeChoice] {
-        let result = workspaceToolCallExecutor(router: ToolRouter(workspaceRoot: workspaceRoot))
-            .executePrimary(WorkspaceWorktreeToolCallPlanner.list())
-        guard result.ok else { return [] }
-        return WorkspaceWorktreeListSurfaceBuilder.choices(
-            fromPorcelain: result.stdout,
-            selectedProjectPath: selectedProject?.connection.path ?? selectedProject?.path ?? workspaceRoot.path
+    public func worktreeChoiceLoadRequest(workspaceRoot: URL) -> WorkspaceWorktreeChoiceLoadRequest {
+        WorkspaceWorktreeChoiceLoadRequest(
+            workspaceRoot: workspaceRoot,
+            selectedProject: selectedProject,
+            sshRemoteShellExecutor: sshRemoteShellExecutor
         )
+    }
+
+    public func worktreeChoiceLoad(workspaceRoot: URL) -> WorkspaceWorktreeChoiceLoad {
+        worktreeChoiceLoadRequest(workspaceRoot: workspaceRoot).load()
+    }
+
+    public func worktreeChoices(workspaceRoot: URL) -> [WorkspaceWorktreeChoice] {
+        worktreeChoiceLoad(workspaceRoot: workspaceRoot).choices
     }
 
     public func removeWorktree(_ request: WorkspaceWorktreeRemoveRequest, workspaceRoot: URL) {

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -32,7 +32,7 @@ public struct QuillCodeWorkspaceView: View {
     public var onToolCardAction: (ToolCardActionSurface) -> Void
     public var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     public var onCreateWorktree: (WorkspaceWorktreeCreateRequest) -> Void
-    public var onListWorktreeChoices: () -> [WorkspaceWorktreeChoice]
+    public var onListWorktreeChoices: () async -> WorkspaceWorktreeChoiceLoad
     public var onOpenWorktree: (WorkspaceWorktreeOpenRequest) -> Void
     public var onRemoveWorktree: (WorkspaceWorktreeRemoveRequest) -> Void
     public var onCopyTranscriptItem: (String, String) -> Void
@@ -51,6 +51,7 @@ public struct QuillCodeWorkspaceView: View {
     @State private var createWorktreeDraft = QuillCodeWorktreeCreateDraft()
     @State private var openWorktreeDraft = QuillCodeWorktreeOpenDraft()
     @State private var removeWorktreeDraft = QuillCodeWorktreeRemoveDraft()
+    @State private var worktreeChoiceLoadTask: Task<Void, Never>?
     @State private var renameThreadDraft: QuillCodeThreadRenameDraft?
     @State private var renameProjectDraft: QuillCodeProjectRenameDraft?
     @FocusState private var isComposerFocused: Bool
@@ -85,7 +86,7 @@ public struct QuillCodeWorkspaceView: View {
         onToolCardAction: @escaping (ToolCardActionSurface) -> Void = { _ in },
         onAddReviewComment: @escaping (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void,
         onCreateWorktree: @escaping (WorkspaceWorktreeCreateRequest) -> Void,
-        onListWorktreeChoices: @escaping () -> [WorkspaceWorktreeChoice] = { [] },
+        onListWorktreeChoices: @escaping () async -> WorkspaceWorktreeChoiceLoad = { WorkspaceWorktreeChoiceLoad() },
         onOpenWorktree: @escaping (WorkspaceWorktreeOpenRequest) -> Void,
         onRemoveWorktree: @escaping (WorkspaceWorktreeRemoveRequest) -> Void,
         onCopyTranscriptItem: @escaping (String, String) -> Void = { _, _ in },
@@ -270,14 +271,13 @@ public struct QuillCodeWorkspaceView: View {
         case let .renameProject(projectID, name):
             renameProjectDraft = QuillCodeProjectRenameDraft(projectID: projectID, name: name)
         case .presentCreateWorktree:
+            worktreeChoiceLoadTask?.cancel()
             createWorktreeDraft = QuillCodeWorktreeCreateDraft()
             worktreeSheet = .create
         case .presentOpenWorktree:
-            openWorktreeDraft = QuillCodeWorktreeOpenDraft(choices: onListWorktreeChoices())
-            worktreeSheet = .open
+            presentOpenWorktree()
         case .presentRemoveWorktree:
-            removeWorktreeDraft = QuillCodeWorktreeRemoveDraft(choices: onListWorktreeChoices())
-            worktreeSheet = .remove
+            presentRemoveWorktree()
         case .openBrowserSession:
             onOpenBrowserSession?()
         case let .dispatch(command, focusesComposer):
@@ -285,6 +285,37 @@ public struct QuillCodeWorkspaceView: View {
             if focusesComposer {
                 DispatchQueue.main.async {
                     isComposerFocused = true
+                }
+            }
+        }
+    }
+
+    private func presentOpenWorktree() {
+        openWorktreeDraft = QuillCodeWorktreeOpenDraft(choiceLoad: .loading)
+        worktreeSheet = .open
+        loadWorktreeChoices(for: .open)
+    }
+
+    private func presentRemoveWorktree() {
+        removeWorktreeDraft = QuillCodeWorktreeRemoveDraft(choiceLoad: .loading)
+        worktreeSheet = .remove
+        loadWorktreeChoices(for: .remove)
+    }
+
+    private func loadWorktreeChoices(for sheet: QuillCodeWorktreeSheet) {
+        worktreeChoiceLoadTask?.cancel()
+        worktreeChoiceLoadTask = Task {
+            let load = await onListWorktreeChoices()
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard worktreeSheet == sheet else { return }
+                switch sheet {
+                case .open:
+                    openWorktreeDraft.choiceLoad = .loaded(load)
+                case .remove:
+                    removeWorktreeDraft.choiceLoad = .loaded(load)
+                case .create:
+                    break
                 }
             }
         }

--- a/Sources/QuillCodeApp/WorkspaceWorktreeChoiceLoader.swift
+++ b/Sources/QuillCodeApp/WorkspaceWorktreeChoiceLoader.swift
@@ -1,0 +1,52 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+public struct WorkspaceWorktreeChoiceLoadRequest: Sendable {
+    public var workspaceRoot: URL
+    public var selectedProject: ProjectRef?
+    public var sshRemoteShellExecutor: SSHRemoteShellExecutor
+
+    public init(
+        workspaceRoot: URL,
+        selectedProject: ProjectRef?,
+        sshRemoteShellExecutor: SSHRemoteShellExecutor = SSHRemoteShellExecutor()
+    ) {
+        self.workspaceRoot = workspaceRoot
+        self.selectedProject = selectedProject
+        self.sshRemoteShellExecutor = sshRemoteShellExecutor
+    }
+
+    public func load() -> WorkspaceWorktreeChoiceLoad {
+        let call = WorkspaceWorktreeToolCallPlanner.list()
+        let result: ToolResult
+        if let selectedProject, selectedProject.isRemote {
+            result = WorkspaceRemoteProjectToolExecutor.execute(
+                call,
+                project: selectedProject,
+                executor: sshRemoteShellExecutor
+            )
+        } else {
+            result = ToolRouter(workspaceRoot: workspaceRoot).execute(call)
+        }
+        guard result.ok else {
+            return WorkspaceWorktreeChoiceLoad(errorMessage: Self.errorMessage(from: result))
+        }
+        return WorkspaceWorktreeChoiceLoad(
+            choices: WorkspaceWorktreeListSurfaceBuilder.choices(
+                fromPorcelain: result.stdout,
+                selectedProjectPath: selectedProject?.connection.path ?? selectedProject?.path ?? workspaceRoot.path
+            )
+        )
+    }
+
+    private static func errorMessage(from result: ToolResult) -> String {
+        let candidates = [result.error, result.stderr]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard let message = candidates.first else {
+            return "Could not load registered git worktrees."
+        }
+        return String(message.prefix(240))
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceWorktreeListSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceWorktreeListSurface.swift
@@ -14,6 +14,16 @@ public struct WorkspaceWorktreeChoice: Sendable, Hashable, Identifiable {
     }
 }
 
+public struct WorkspaceWorktreeChoiceLoad: Sendable, Hashable {
+    public var choices: [WorkspaceWorktreeChoice]
+    public var errorMessage: String?
+
+    public init(choices: [WorkspaceWorktreeChoice] = [], errorMessage: String? = nil) {
+        self.choices = choices
+        self.errorMessage = errorMessage
+    }
+}
+
 enum WorkspaceWorktreeListSurfaceBuilder {
     static func choices(fromPorcelain stdout: String, selectedProjectPath: String?) -> [WorkspaceWorktreeChoice] {
         let selectedPath = selectedProjectPath.map(normalizedPath)

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -74,7 +74,7 @@ private struct QuillCodeDesktopRootView: View {
             onToolCardAction: controller.runToolCardAction,
             onAddReviewComment: controller.addReviewComment,
             onCreateWorktree: controller.createWorktree,
-            onListWorktreeChoices: controller.worktreeChoices,
+            onListWorktreeChoices: controller.worktreeChoiceLoad,
             onOpenWorktree: controller.openWorktree,
             onRemoveWorktree: controller.removeWorktree,
             onCopyTranscriptItem: controller.copyTranscriptItem,

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -332,8 +332,11 @@ final class QuillCodeDesktopController: ObservableObject {
         refresh()
     }
 
-    func worktreeChoices() -> [WorkspaceWorktreeChoice] {
-        model.worktreeChoices(workspaceRoot: model.activeWorkspaceRoot ?? workspaceRoot)
+    func worktreeChoiceLoad() async -> WorkspaceWorktreeChoiceLoad {
+        let request = model.worktreeChoiceLoadRequest(workspaceRoot: model.activeWorkspaceRoot ?? workspaceRoot)
+        return await Task.detached(priority: .userInitiated) {
+            request.load()
+        }.value
     }
 
     func openWorktree(_ request: WorkspaceWorktreeOpenRequest) {

--- a/Tests/QuillCodeAppTests/WorkspaceWorktreeListSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceWorktreeListSurfaceBuilderTests.swift
@@ -2,6 +2,46 @@ import XCTest
 @testable import QuillCodeApp
 
 final class WorkspaceWorktreeListSurfaceBuilderTests: XCTestCase {
+    func testChoiceLoadStateTracksLoadingSuccessEmptyAndFailure() {
+        let choice = WorkspaceWorktreeChoice(
+            path: "/repo/quill-feature",
+            title: "quill-feature",
+            detail: "feature/picker"
+        )
+
+        XCTAssertTrue(QuillCodeWorktreeChoiceLoadState.loading.isLoading)
+
+        let loaded = QuillCodeWorktreeChoiceLoadState.loaded(.init(choices: [choice]))
+        XCTAssertFalse(loaded.isLoading)
+        XCTAssertTrue(loaded.hasLoaded)
+        XCTAssertEqual(loaded.choices, [choice])
+        XCTAssertNil(loaded.errorMessage)
+
+        let empty = QuillCodeWorktreeChoiceLoadState.loaded(.init())
+        XCTAssertFalse(empty.isLoading)
+        XCTAssertTrue(empty.hasLoaded)
+        XCTAssertEqual(empty.choices, [])
+        XCTAssertNil(empty.errorMessage)
+
+        let failed = QuillCodeWorktreeChoiceLoadState.loaded(.init(errorMessage: "not a git repo"))
+        XCTAssertFalse(failed.isLoading)
+        XCTAssertTrue(failed.hasLoaded)
+        XCTAssertEqual(failed.choices, [])
+        XCTAssertEqual(failed.errorMessage, "not a git repo")
+    }
+
+    func testChoiceLoadRequestReturnsVisibleErrorForNonGitDirectory() throws {
+        let directory = try makeQuillCodeTestDirectory()
+
+        let load = WorkspaceWorktreeChoiceLoadRequest(
+            workspaceRoot: directory,
+            selectedProject: nil
+        ).load()
+
+        XCTAssertEqual(load.choices, [])
+        XCTAssertTrue(load.errorMessage?.isEmpty == false)
+    }
+
     func testChoicesParsePorcelainBranchesAndSkipCurrentProject() {
         let stdout = """
         worktree /repo/quill


### PR DESCRIPTION
## Summary
- Present the open/remove worktree dialogs immediately with a loading state instead of blocking on git/SSH worktree discovery.
- Add a Sendable worktree-choice load request so the desktop controller can run slow local/remote listing work off the main actor.
- Surface empty and error states in the picker while still allowing users to paste a worktree path manually.
- Update the Playwright harness to exercise the loading state before known choices arrive.

## Validation
- `swift test --filter WorkspaceWorktree`
- `npm --prefix E2E/playwright test tests/command-palette.spec.ts`
- `swift test` (1,156 tests)
- `npm --prefix E2E/playwright test` (67 tests)
- `git diff --check`