### PR TITLE
[codex] Polish model picker recovery

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -355,6 +355,51 @@
       text-overflow: ellipsis;
     }
     .model-summary { color: var(--muted); }
+    .model-badges {
+      display: flex;
+      gap: 5px;
+      flex-wrap: wrap;
+      margin-top: 2px;
+    }
+    .model-badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 18px;
+      padding: 2px 6px;
+      border-radius: 999px;
+      color: var(--blue);
+      background: rgba(65,184,232,.12);
+      font-size: 10px;
+      font-weight: 700;
+      line-height: 1;
+    }
+    .model-badge.current {
+      color: var(--green);
+      background: rgba(88,214,141,.12);
+    }
+    .model-badge.favorite {
+      color: var(--yellow);
+      background: rgba(255,184,77,.12);
+    }
+    .model-result-summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .model-clear-search {
+      min-height: 40px;
+      padding: 0 8px;
+      border: 0;
+      color: var(--blue);
+      background: transparent;
+      box-shadow: none;
+      font-size: 12px;
+      font-weight: 700;
+    }
     .model-details {
       display: none;
     }
@@ -426,10 +471,15 @@
       font-variant-numeric: tabular-nums;
     }
     .model-empty {
+      display: grid;
+      gap: 8px;
       padding: 12px;
       border-radius: 10px;
       color: var(--muted);
       background: rgba(0,0,0,.22);
+    }
+    .model-empty strong {
+      color: var(--text);
     }
     .settings-panel,
     .search-panel {
@@ -4502,6 +4552,11 @@
         </div>
       ` : '';
       const filteredModelCategories = filterModelCategories(state.topBar.modelSearch);
+      const filteredModelCount = filteredModelCategories.reduce((count, category) => count + category.models.length, 0);
+      const modelSearchQuery = state.topBar.modelSearch.trim();
+      const modelResultSummary = modelSearchQuery
+        ? `${filteredModelCount} ${filteredModelCount === 1 ? 'model' : 'models'} for "${modelSearchQuery}"`
+        : `${filteredModelCount} ${filteredModelCount === 1 ? 'model' : 'models'} available`;
       const modelResults = filteredModelCategories.length ? `
         <div class="model-results" data-testid="model-results">
           ${filteredModelCategories.map(category => `
@@ -4512,6 +4567,7 @@
                   <button class="model-option ${model.id === state.topBar.selectedModelID ? 'selected' : ''}" type="button" data-testid="model-option" data-model-id="${escapeHTML(model.id)}">
                     <span class="model-title">${escapeHTML(modelDisplayLabel(model))}${model.id === state.topBar.selectedModelID ? ' ✓' : ''}</span>
                     <small class="model-summary" data-testid="model-option-summary">${escapeHTML(modelMetadataSummary(model, category.category))}</small>
+                    ${(model.badges || []).length ? `<span class="model-badges" data-testid="model-badges">${(model.badges || []).slice(0, 3).map(badge => `<span class="model-badge ${modelBadgeClass(badge)}" data-testid="model-badge">${escapeHTML(badge)}</span>`).join('')}</span>` : ''}
                   </button>
                   <div class="model-actions">
                     <button class="model-detail-toggle ${state.topBar.expandedModelID === model.id ? 'active' : ''}" type="button" data-testid="model-detail-button" data-model-id="${escapeHTML(model.id)}" aria-expanded="${state.topBar.expandedModelID === model.id ? 'true' : 'false'}" aria-label="${state.topBar.expandedModelID === model.id ? 'Hide model details' : 'Show model details'}">${state.topBar.expandedModelID === model.id ? 'i' : 'ⓘ'}</button>
@@ -4529,7 +4585,12 @@
                     </div>` : ''}
                 </div>`).join('')}
             </section>`).join('')}
-        </div>` : '<div class="model-empty" data-testid="model-empty">No models match. Try a provider, category, model name, or state.</div>';
+        </div>` : `
+        <div class="model-empty" data-testid="model-empty">
+          <strong>No models match</strong>
+          <span>Try a provider, category, model name, or state.</span>
+          ${modelSearchQuery ? '<button class="model-clear-search" type="button" data-testid="model-clear-search">Clear search</button>' : ''}
+        </div>`;
       const modelBrowser = state.topBar.modelPickerOpen ? `
         <section class="model-panel" data-testid="model-browser" aria-label="Model browser">
           <div>
@@ -4537,6 +4598,10 @@
             <p>Search provider, category, model, or state</p>
           </div>
           <input data-testid="model-search" aria-label="Search models" placeholder="Search models" value="${escapeHTML(state.topBar.modelSearch)}">
+          <div class="model-result-summary" data-testid="model-result-summary">
+            <span data-testid="model-result-count">${escapeHTML(modelResultSummary)}</span>
+            ${modelSearchQuery ? '<button class="model-clear-search" type="button" data-testid="model-clear-search">Clear</button>' : ''}
+          </div>
           ${modelResults}
         </section>` : '';
       const topBarOverflowCommandIDs = [
@@ -4767,6 +4832,13 @@
         state.topBar.modelSearch = event.target.value;
         render();
         document.querySelector('[data-testid="model-search"]')?.focus();
+      });
+      document.querySelectorAll('[data-testid="model-clear-search"]').forEach(button => {
+        button.addEventListener('click', () => {
+          state.topBar.modelSearch = '';
+          render();
+          document.querySelector('[data-testid="model-search"]')?.focus();
+        });
       });
       document.querySelectorAll('[data-testid="model-option"]').forEach(button => {
         button.addEventListener('click', event => {
@@ -5267,6 +5339,13 @@
       if (model.id === 'tr/synth-code') return 'Synth Code';
       if (model.provider === 'trustedrouter') return model.id;
       return `${model.provider}/${model.displayName}`;
+    }
+
+    function modelBadgeClass(badge) {
+      const normalized = String(badge || '').toLowerCase();
+      if (normalized === 'current') return 'current';
+      if (normalized === 'favorite') return 'favorite';
+      return '';
     }
 
     function toggleModelFavorite(modelID) {

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -188,7 +188,11 @@ test('mock harness searches and selects models from the composer', async ({ page
 
   await page.getByTestId('model-picker-button').click();
   await expect(page.getByTestId('model-browser')).toBeVisible();
+  await expect(page.getByTestId('model-result-count')).toHaveText('5 models available');
   await expect(page.getByTestId('model-option-summary').first()).toContainText('Fast everyday agent');
+  await expect(page.getByTestId('model-badge').nth(0)).toHaveText('Current');
+  await expect(page.getByTestId('model-badge').nth(1)).toHaveText('Default');
+  await expect(page.getByTestId('model-badge').nth(2)).toHaveText('Recommended');
   await expect(page.getByTestId('model-detail-button').first()).toHaveAttribute('aria-expanded', 'true');
   await expect(page.getByTestId('model-capability')).toContainText('Nike 1.0 is the fast default');
   await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'trustedrouter/fast' })).toBeVisible();
@@ -206,6 +210,7 @@ test('mock harness searches and selects models from the composer', async ({ page
   await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'tr/synth-code' })).toBeVisible();
 
   await page.getByTestId('model-search').fill('default model');
+  await expect(page.getByTestId('model-result-count')).toHaveText('1 model for "default model"');
   await expect(page.getByTestId('model-option')).toHaveCount(1);
   await expect(page.getByTestId('model-option')).toContainText('Nike 1.0');
   await page.getByTestId('model-search').fill('');
@@ -232,5 +237,10 @@ test('mock harness searches and selects models from the composer', async ({ page
 
   await page.getByTestId('model-picker-button').click();
   await page.getByTestId('model-search').fill('not-a-model');
+  await expect(page.getByTestId('model-result-count')).toHaveText('0 models for "not-a-model"');
   await expect(page.getByTestId('model-empty')).toBeVisible();
+  await page.getByTestId('model-clear-search').first().click();
+  await expect(page.getByTestId('model-search')).toBeFocused();
+  await expect(page.getByTestId('model-result-count')).toHaveText('6 models available');
+  await expect(page.getByTestId('model-option')).toHaveCount(6);
 });

--- a/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
@@ -16,6 +16,10 @@ struct QuillCodeModelPickerView: View {
         topBar.filteredModelCategories(matching: searchText)
     }
 
+    private var filteredModelCount: Int {
+        filteredCategories.reduce(0) { $0 + $1.models.count }
+    }
+
     private var currentModelID: String? {
         topBar.modelCategories
             .flatMap(\.models)
@@ -68,6 +72,7 @@ struct QuillCodeModelPickerView: View {
         VStack(alignment: .leading, spacing: 12) {
             header
             searchField
+            resultSummary
             modelList
         }
         .padding(14)
@@ -99,36 +104,88 @@ struct QuillCodeModelPickerView: View {
         if filteredCategories.isEmpty {
             emptyState
         } else {
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 9) {
-                    ForEach(filteredCategories) { category in
-                        QuillCodeModelCategorySection(
-                            category: category,
-                            expandedModelID: $expandedModelID,
-                            reduceMotion: reduceMotion,
-                            onSetModel: selectModel,
-                            onToggleModelFavorite: onToggleModelFavorite
-                        )
+            VStack(alignment: .leading, spacing: 8) {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 9) {
+                        ForEach(filteredCategories) { category in
+                            QuillCodeModelCategorySection(
+                                category: category,
+                                expandedModelID: $expandedModelID,
+                                reduceMotion: reduceMotion,
+                                onSetModel: selectModel,
+                                onToggleModelFavorite: onToggleModelFavorite
+                            )
+                        }
                     }
+                    .padding(.vertical, 2)
                 }
-                .padding(.vertical, 2)
             }
         }
     }
 
+    private var resultSummary: some View {
+        HStack(spacing: 8) {
+            Text(resultSummaryText)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(QuillCodePalette.muted)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            if !searchText.isEmpty {
+                Button("Clear") {
+                    clearSearch()
+                }
+                .font(.caption.weight(.semibold))
+                .buttonStyle(.plain)
+                .foregroundStyle(QuillCodePalette.blue)
+                .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .help("Clear model search")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var resultSummaryText: String {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let modelNoun = filteredModelCount == 1 ? "model" : "models"
+        if query.isEmpty {
+            return "\(filteredModelCount) \(modelNoun) available"
+        }
+        return "\(filteredModelCount) \(modelNoun) for \"\(query)\""
+    }
+
     private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 10) {
             Text("No models match")
                 .font(.headline)
             Text("Try a provider, model name, category, or state.")
                 .font(.caption)
                 .foregroundStyle(QuillCodePalette.muted)
                 .fixedSize(horizontal: false, vertical: true)
+            if !searchText.isEmpty {
+                Button("Clear search") {
+                    clearSearch()
+                }
+                .font(.caption.weight(.semibold))
+                .buttonStyle(QuillCodePressableButtonStyle())
+                .foregroundStyle(QuillCodePalette.blue)
+                .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
+                .padding(.top, 2)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(12)
         .background(QuillCodePalette.background.opacity(0.72))
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func clearSearch() {
+        searchText = ""
+        DispatchQueue.main.async {
+            isSearchFocused = true
+        }
     }
 
     private func selectModel(_ option: ModelOptionSurface) {
@@ -254,8 +311,43 @@ private struct QuillCodeModelRow: View {
                 .foregroundStyle(QuillCodePalette.muted)
                 .lineLimit(1)
                 .truncationMode(.middle)
+            if !option.badges.isEmpty {
+                badgeRow
+            }
         }
         .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var badgeRow: some View {
+        HStack(spacing: 5) {
+            ForEach(option.badges.prefix(3), id: \.self) { badge in
+                Text(badge)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(badgeForeground(for: badge))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(badgeBackground(for: badge))
+                    .clipShape(Capsule())
+            }
+        }
+        .lineLimit(1)
+    }
+
+    private func badgeForeground(for badge: String) -> Color {
+        switch badge {
+        case "Current":
+            return QuillCodePalette.green
+        case "Default", "Recommended":
+            return QuillCodePalette.blue
+        case "Favorite":
+            return QuillCodePalette.yellow
+        default:
+            return QuillCodePalette.muted
+        }
+    }
+
+    private func badgeBackground(for badge: String) -> Color {
+        badgeForeground(for: badge).opacity(0.12)
     }
 
     private func modelActionButton(


### PR DESCRIPTION
## Summary
- add a visible model result count and clear-search recovery path to the SwiftUI model picker
- surface compact model state chips for Current/Default/Recommended/Favorite metadata
- mirror the picker polish in the Playwright harness and cover count, badges, and clear-search focus recovery

## Validation
- swift test --filter WorkspaceModelPickerSurfaceIntegrationTests
- npm --prefix E2E/playwright test tests/composer.spec.ts
- swift test
- npm --prefix E2E/playwright test
- git diff --check