### PR TITLE
Clarify worktree prune final answers

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8347,9 +8347,7 @@
       ensureThread('Prune worktrees');
       const dryRun = values.dryRun === true;
       const verbose = values.verbose === true;
-      const stdout = dryRun
-        ? 'Checking stale worktree administrative records.\n'
-        : 'Pruned stale worktree administrative records.\n';
+      const stdout = '';
       addToolCard({
         title: 'host.git.worktree.prune',
         subtitle: dryRun ? 'Completed · dry run' : 'Completed',
@@ -8358,8 +8356,8 @@
         outputJSON: JSON.stringify({ ok: true, stdout }, null, 2)
       });
       addMessage('assistant', dryRun
-        ? 'Checked for stale worktree records.'
-        : 'Pruned stale worktree records.');
+        ? 'No stale worktree records found.'
+        : 'Pruned stale worktree records. Git did not report any entries.');
       syncSelectedThreadSearchText();
       render();
     }

--- a/E2E/playwright/tests/command-palette.spec.ts
+++ b/E2E/playwright/tests/command-palette.spec.ts
@@ -102,7 +102,7 @@ test('mock harness prunes worktrees from the command palette', async ({ page }) 
   await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
   await expect(page.getByTestId('tool-card-title')).toHaveText('host.git.worktree.prune');
   await expect(page.getByTestId('tool-card-input')).toContainText('"dryRun": true');
-  await expect(page.getByTestId('message').last()).toContainText('Checked for stale worktree records.');
+  await expect(page.getByTestId('message').last()).toContainText('No stale worktree records found.');
 });
 
 test('mock harness prepares pull request creation from the command palette', async ({ page }) => {

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -121,7 +121,7 @@ test('mock harness routes slash commands to workspace actions', async ({ page })
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.worktree.prune');
   await expect(page.getByTestId('tool-card-input').last()).toContainText('"dryRun": true');
-  await expect(page.getByTestId('message').last()).toContainText('Checked for stale worktree records.');
+  await expect(page.getByTestId('message').last()).toContainText('No stale worktree records found.');
 
   await page.getByLabel('Message').fill('/pr');
   await page.getByRole('button', { name: 'Send' }).click();

--- a/Sources/QuillCodeAgent/AgentFinalAnswerBuilder.swift
+++ b/Sources/QuillCodeAgent/AgentFinalAnswerBuilder.swift
@@ -44,6 +44,10 @@ enum AgentFinalAnswerBuilder {
                 : "Patch applied. Review the resulting diff below."
         }
 
+        if call.name == ToolDefinition.gitWorktreePrune.name {
+            return gitWorktreePruneAnswer(call: call, result: result)
+        }
+
         if call.name == ToolDefinition.planUpdate.name {
             return "Updated the task plan."
         }
@@ -163,6 +167,43 @@ enum AgentFinalAnswerBuilder {
         return nil
     }
 
+    private static func gitWorktreePruneAnswer(call: ToolCall, result: ToolResult) -> String {
+        let dryRun = boolArgument("dryRun", in: call) ?? false
+        let output = [result.stdout, result.stderr]
+            .compactMap(\.trimmedNonEmpty)
+            .joined(separator: "\n")
+        let lines = output
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        if dryRun {
+            guard !lines.isEmpty else {
+                return "No stale worktree records found."
+            }
+            let count = staleWorktreeRecordCount(in: lines)
+            return [
+                "Found \(count) stale worktree \(count == 1 ? "record" : "records").",
+                "Run `/worktree prune` to remove \(count == 1 ? "it" : "them").",
+                truncated(output)
+            ].joined(separator: "\n")
+        }
+
+        guard !lines.isEmpty else {
+            return "Pruned stale worktree records. Git did not report any entries."
+        }
+        let count = staleWorktreeRecordCount(in: lines)
+        return "Pruned \(count) stale worktree \(count == 1 ? "record" : "records").\n\(truncated(output))"
+    }
+
+    private static func staleWorktreeRecordCount(in lines: [String]) -> Int {
+        let removingLines = lines.filter { line in
+            let lower = line.lowercased()
+            return lower.hasPrefix("removing ") || lower.contains(": gitdir file points")
+        }
+        return removingLines.isEmpty ? lines.count : removingLines.count
+    }
+
     private static func argument(_ key: String, in call: ToolCall) -> String? {
         guard let data = call.argumentsJSON.data(using: .utf8),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -172,6 +213,29 @@ enum AgentFinalAnswerBuilder {
         }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func boolArgument(_ key: String, in call: ToolCall) -> Bool? {
+        guard let data = call.argumentsJSON.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let value = object[key]
+        else {
+            return nil
+        }
+        if let bool = value as? Bool {
+            return bool
+        }
+        if let string = value as? String {
+            switch string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "true":
+                return true
+            case "false":
+                return false
+            default:
+                return nil
+            }
+        }
+        return nil
     }
 
     private static func firstLine(_ text: String) -> String {

--- a/Tests/QuillCodeAgentTests/AgentFinalAnswerBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentFinalAnswerBuilderTests.swift
@@ -30,6 +30,55 @@ final class AgentFinalAnswerBuilderTests: XCTestCase {
         XCTAssertEqual(answer, "openclaw is not installed or is not on PATH.")
     }
 
+    func testWorktreePruneDryRunReportsNoStaleRecords() {
+        let answer = AgentFinalAnswerBuilder.finalAnswer(
+            for: ToolCall(
+                name: ToolDefinition.gitWorktreePrune.name,
+                argumentsJSON: ToolArguments.json(["dryRun": true, "verbose": true])
+            ),
+            result: ToolResult(ok: true)
+        )
+
+        XCTAssertEqual(answer, "No stale worktree records found.")
+    }
+
+    func testWorktreePruneDryRunReportsStaleRecordsAndCleanupCommand() {
+        let answer = AgentFinalAnswerBuilder.finalAnswer(
+            for: ToolCall(
+                name: ToolDefinition.gitWorktreePrune.name,
+                argumentsJSON: ToolArguments.json(["dryRun": true, "verbose": true])
+            ),
+            result: ToolResult(
+                ok: true,
+                stdout: "Removing ../quillcode-old: gitdir file points to non-existent location\n"
+            )
+        )
+
+        XCTAssertTrue(answer.contains("Found 1 stale worktree record."))
+        XCTAssertTrue(answer.contains("Run `/worktree prune` to remove it."))
+        XCTAssertTrue(answer.contains("../quillcode-old"))
+    }
+
+    func testWorktreePruneReportsRemovedRecords() {
+        let answer = AgentFinalAnswerBuilder.finalAnswer(
+            for: ToolCall(
+                name: ToolDefinition.gitWorktreePrune.name,
+                argumentsJSON: ToolArguments.json(["dryRun": false, "verbose": true])
+            ),
+            result: ToolResult(
+                ok: true,
+                stdout: """
+                Removing ../quillcode-old: gitdir file points to non-existent location
+                Removing ../quillcode-older: gitdir file points to non-existent location
+                """
+            )
+        )
+
+        XCTAssertTrue(answer.contains("Pruned 2 stale worktree records."))
+        XCTAssertTrue(answer.contains("../quillcode-old"))
+        XCTAssertTrue(answer.contains("../quillcode-older"))
+    }
+
     func testLongOutputIsTruncatedWithToolCardHint() {
         let answer = AgentFinalAnswerBuilder.finalAnswer(
             for: ToolCall(


### PR DESCRIPTION
## Summary
- Add native final-answer handling for `host.git.worktree.prune` dry-run and prune results.
- Report empty dry-runs as `No stale worktree records found.` instead of generic checked copy.
- Align the mock E2E harness and command-palette/composer expectations with the native answer text.

## Validation
- `swift test --filter AgentFinalAnswerBuilderTests`
- `npm --prefix E2E/playwright test tests/command-palette.spec.ts tests/composer.spec.ts`
- `swift test` (1,159 passed)
- `npm --prefix E2E/playwright test` (68 passed)
- `git diff --check`