### PR TITLE
Extract workspace project APIs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -235,118 +235,6 @@ public final class QuillCodeWorkspaceModel {
         }
     }
 
-    @discardableResult
-    public func addProject(path: URL, name: String? = nil) -> UUID {
-        let standardized = path.standardizedFileURL
-        let result = WorkspaceProjectEngine.upsertLocalProject(
-            path: standardized,
-            name: name,
-            metadata: WorkspaceProjectMetadataLoader.loadLocal(from: standardized),
-            projects: &root.projects
-        )
-        root.selectedProjectID = result.projectID
-        syncTerminalSessionToSelectedProject()
-        saveProjects()
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-        return result.projectID
-    }
-
-    @discardableResult
-    public func addSSHProject(_ address: String, name: String? = nil) -> UUID? {
-        switch WorkspaceProjectEngine.upsertSSHProject(address: address, name: name, projects: &root.projects) {
-        case .failure(let error):
-            lastError = error.message
-            return nil
-        case .success(let result):
-            root.selectedProjectID = result.projectID
-            syncTerminalSessionToSelectedProject()
-            saveProjects()
-            refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-            return result.projectID
-        }
-    }
-
-    public func selectProject(_ id: UUID?) {
-        guard let selection = WorkspaceProjectEngine.selectionAfterSelectingProject(
-            id,
-            projects: root.projects,
-            threads: root.threads
-        ) else { return }
-        root.selectedProjectID = selection.projectID
-        syncTerminalSessionToSelectedProject()
-        refreshProjectMetadata(selection.projectID)
-        touchProject(selection.projectID)
-        root.selectedThreadID = selection.threadID
-        saveProjects()
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-    }
-
-    @discardableResult
-    public func renameProject(_ id: UUID, to name: String) -> Bool {
-        guard WorkspaceProjectEngine.renameProject(id, to: name, projects: &root.projects) else {
-            return false
-        }
-        saveProjects()
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-        return true
-    }
-
-    @discardableResult
-    public func refreshProjectContext(_ id: UUID) -> Bool {
-        guard let project = root.projects.first(where: { $0.id == id }) else {
-            return false
-        }
-        if project.isRemote {
-            guard refreshRemoteProjectContext(id) else {
-                return false
-            }
-        } else {
-            refreshProjectMetadata(id)
-        }
-        if selectedThread?.projectID == id || root.selectedProjectID == id {
-            let refreshedContext = workspaceThreadContext(id)
-            mutateSelectedThread { thread in
-                guard thread.projectID == id else { return }
-                thread.instructions = refreshedContext.instructions
-                thread.memories = refreshedContext.memories
-                thread.events.append(ThreadEvent(
-                    kind: .notice,
-                    summary: "Refreshed project context",
-                    payloadJSON: id.uuidString
-                ))
-            }
-        }
-        touchProject(id)
-        saveProjects()
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-        return true
-    }
-
-    @discardableResult
-    public func removeProject(_ id: UUID) -> Bool {
-        var projects = root.projects
-        var threads = root.threads
-        guard let result = WorkspaceProjectEngine.removeProject(
-            id,
-            projects: &projects,
-            threads: &threads,
-            selectedProjectID: root.selectedProjectID
-        ) else {
-            return false
-        }
-        root.projects = projects
-        root.threads = threads
-        for threadID in result.changedThreadIDs {
-            guard let thread = root.threads.first(where: { $0.id == threadID }) else { continue }
-            threadPersistence.save(thread)
-        }
-        root.selectedProjectID = result.selectedProjectID
-        syncTerminalSessionToSelectedProject()
-        saveProjects()
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-        return true
-    }
-
     public func setMode(_ mode: AgentMode) {
         WorkspaceConfigurationEngine.setMode(mode, config: &root.config)
         mutateSelectedThread { thread in
@@ -1138,7 +1026,7 @@ public final class QuillCodeWorkspaceModel {
         ))
     }
 
-    private func mutateSelectedThread(_ update: (inout ChatThread) -> Void) {
+    func mutateSelectedThread(_ update: (inout ChatThread) -> Void) {
         guard let selectedThreadID = root.selectedThreadID,
               let index = mutateThread(selectedThreadID, update)
         else {

--- a/Sources/QuillCodeApp/WorkspaceModelProjects.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelProjects.swift
@@ -1,0 +1,117 @@
+import Foundation
+import QuillCodeCore
+
+@MainActor
+extension QuillCodeWorkspaceModel {
+    @discardableResult
+    public func addProject(path: URL, name: String? = nil) -> UUID {
+        let standardized = path.standardizedFileURL
+        let result = WorkspaceProjectEngine.upsertLocalProject(
+            path: standardized,
+            name: name,
+            metadata: WorkspaceProjectMetadataLoader.loadLocal(from: standardized),
+            projects: &root.projects
+        )
+        root.selectedProjectID = result.projectID
+        syncTerminalSessionToSelectedProject()
+        saveProjects()
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        return result.projectID
+    }
+
+    @discardableResult
+    public func addSSHProject(_ address: String, name: String? = nil) -> UUID? {
+        switch WorkspaceProjectEngine.upsertSSHProject(address: address, name: name, projects: &root.projects) {
+        case .failure(let error):
+            setLastError(error.message)
+            return nil
+        case .success(let result):
+            root.selectedProjectID = result.projectID
+            syncTerminalSessionToSelectedProject()
+            saveProjects()
+            refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+            return result.projectID
+        }
+    }
+
+    public func selectProject(_ id: UUID?) {
+        guard let selection = WorkspaceProjectEngine.selectionAfterSelectingProject(
+            id,
+            projects: root.projects,
+            threads: root.threads
+        ) else { return }
+        root.selectedProjectID = selection.projectID
+        syncTerminalSessionToSelectedProject()
+        refreshProjectMetadata(selection.projectID)
+        touchProject(selection.projectID)
+        root.selectedThreadID = selection.threadID
+        saveProjects()
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+    }
+
+    @discardableResult
+    public func renameProject(_ id: UUID, to name: String) -> Bool {
+        guard WorkspaceProjectEngine.renameProject(id, to: name, projects: &root.projects) else {
+            return false
+        }
+        saveProjects()
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        return true
+    }
+
+    @discardableResult
+    public func refreshProjectContext(_ id: UUID) -> Bool {
+        guard let project = root.projects.first(where: { $0.id == id }) else {
+            return false
+        }
+        if project.isRemote {
+            guard refreshRemoteProjectContext(id) else {
+                return false
+            }
+        } else {
+            refreshProjectMetadata(id)
+        }
+        if selectedThread?.projectID == id || root.selectedProjectID == id {
+            let refreshedContext = workspaceThreadContext(id)
+            mutateSelectedThread { thread in
+                guard thread.projectID == id else { return }
+                thread.instructions = refreshedContext.instructions
+                thread.memories = refreshedContext.memories
+                thread.events.append(ThreadEvent(
+                    kind: .notice,
+                    summary: "Refreshed project context",
+                    payloadJSON: id.uuidString
+                ))
+            }
+        }
+        touchProject(id)
+        saveProjects()
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        return true
+    }
+
+    @discardableResult
+    public func removeProject(_ id: UUID) -> Bool {
+        var projects = root.projects
+        var threads = root.threads
+        guard let result = WorkspaceProjectEngine.removeProject(
+            id,
+            projects: &projects,
+            threads: &threads,
+            selectedProjectID: root.selectedProjectID
+        ) else {
+            return false
+        }
+        root.projects = projects
+        root.threads = threads
+        for threadID in result.changedThreadIDs {
+            guard let thread = root.threads.first(where: { $0.id == threadID }) else { continue }
+            threadPersistence.save(thread)
+        }
+        root.selectedProjectID = result.selectedProjectID
+        syncTerminalSessionToSelectedProject()
+        saveProjects()
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        return true
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceProjectGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceProjectGateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 final class ParityWorkspaceProjectGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesProjectMetadataLoading() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let projectExtensionText = try Self.appSourceText(named: "WorkspaceModelProjects.swift")
         let loaderText = try Self.appSourceText(named: "WorkspaceProjectMetadataLoader.swift")
 
         XCTAssertTrue(loaderText.contains("enum WorkspaceProjectMetadataLoader"), "Project metadata loading should live in a focused loader.")
@@ -11,13 +12,37 @@ final class ParityWorkspaceProjectGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(loaderText.contains("ProjectExtensionManifestLoader.load"), "Project extension loading should stay with the metadata loader.")
         XCTAssertTrue(loaderText.contains("MemoryNoteLoader.loadProject"), "Project memory loading should stay with the metadata loader.")
         XCTAssertTrue(loaderText.contains("SSHRemoteProjectContextLoader.load"), "SSH Remote context loading should stay with the metadata loader.")
-        XCTAssertTrue(modelText.contains("WorkspaceProjectMetadataLoader.loadLocal"), "WorkspaceModel should delegate local project metadata loading.")
+        XCTAssertTrue(projectExtensionText.contains("WorkspaceProjectMetadataLoader.loadLocal"), "WorkspaceModel project APIs should delegate local project metadata loading.")
         XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshRemoteProjectContext"), "WorkspaceModel should delegate SSH Remote project metadata refresh.")
         XCTAssertFalse(modelText.contains("ProjectInstructionLoader.load"), "WorkspaceModel should not load instruction files directly.")
         XCTAssertFalse(modelText.contains("LocalEnvironmentActionLoader.load"), "WorkspaceModel should not load local environment actions directly.")
         XCTAssertFalse(modelText.contains("ProjectExtensionManifestLoader.load"), "WorkspaceModel should not load project extensions directly.")
         XCTAssertFalse(modelText.contains("MemoryNoteLoader.loadProject"), "WorkspaceModel should not load project memories directly.")
         XCTAssertFalse(modelText.contains("SSHRemoteProjectContextLoader.load"), "WorkspaceModel should not load SSH Remote context directly.")
+    }
+
+    func testWorkspaceModelProjectAPIsLiveInFocusedExtension() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let projectExtensionText = try Self.appSourceText(named: "WorkspaceModelProjects.swift")
+
+        XCTAssertTrue(projectExtensionText.contains("extension QuillCodeWorkspaceModel"), "Project APIs should live in a focused WorkspaceModel extension.")
+        XCTAssertTrue(projectExtensionText.contains("public func addProject"), "Project extension should own local project addition.")
+        XCTAssertTrue(projectExtensionText.contains("public func addSSHProject"), "Project extension should own SSH project addition.")
+        XCTAssertTrue(projectExtensionText.contains("public func selectProject"), "Project extension should own project selection.")
+        XCTAssertTrue(projectExtensionText.contains("public func renameProject"), "Project extension should own project rename.")
+        XCTAssertTrue(projectExtensionText.contains("public func refreshProjectContext"), "Project extension should own explicit project context refresh.")
+        XCTAssertTrue(projectExtensionText.contains("public func removeProject"), "Project extension should own project removal.")
+        XCTAssertTrue(projectExtensionText.contains("WorkspaceProjectEngine.upsertLocalProject"), "Project extension should delegate local project upserts.")
+        XCTAssertTrue(projectExtensionText.contains("WorkspaceProjectEngine.upsertSSHProject"), "Project extension should delegate SSH project upserts.")
+        XCTAssertTrue(projectExtensionText.contains("WorkspaceProjectEngine.selectionAfterSelectingProject"), "Project extension should delegate selected project/thread transitions.")
+        XCTAssertTrue(projectExtensionText.contains("WorkspaceProjectEngine.renameProject"), "Project extension should delegate project renames.")
+        XCTAssertTrue(projectExtensionText.contains("WorkspaceProjectEngine.removeProject"), "Project extension should delegate project removals.")
+        XCTAssertFalse(modelText.contains("public func addProject"), "WorkspaceModel.swift should not own local project addition API bodies.")
+        XCTAssertFalse(modelText.contains("public func addSSHProject"), "WorkspaceModel.swift should not own SSH project addition API bodies.")
+        XCTAssertFalse(modelText.contains("public func selectProject"), "WorkspaceModel.swift should not own project selection API bodies.")
+        XCTAssertFalse(modelText.contains("public func renameProject"), "WorkspaceModel.swift should not own project rename API bodies.")
+        XCTAssertFalse(modelText.contains("public func refreshProjectContext"), "WorkspaceModel.swift should not own project context refresh API bodies.")
+        XCTAssertFalse(modelText.contains("public func removeProject"), "WorkspaceModel.swift should not own project removal API bodies.")
     }
 
     func testWorkspaceModelTestsDoNotOwnPureProjectLoaderCoverage() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -6284,3 +6284,23 @@ Current strict grades:
 
 Remaining risk:
 - `WorkspaceModel.swift` is still the largest app file. The next high-leverage extraction should move another coherent same-actor API family, likely project APIs or terminal APIs, only if helper access can stay narrow and focused tests prove behavior did not change.
+
+## 2026-06-25 Workspace Project API Extension
+
+Overall grade after this slice: **A- project API ownership, A project parity gates, B+/A- central model size**.
+
+`WorkspaceModel.swift` still owned the public project API bodies even though the actual project registry policy already lived in `WorkspaceProjectEngine` and project context loading lived in the focused metadata/refresher helpers. Moving those public methods into a same-actor extension keeps the central model focused on shared storage, execution, persistence bridges, and actor-bound helper mutation.
+
+What changed:
+- Added `WorkspaceModelProjects.swift` for local project add, SSH project add, project selection, rename, explicit context refresh, and removal.
+- Kept project storage on `QuillCodeWorkspaceModel`, and reused existing helpers for terminal sync, context refresh, persistence, selected-thread mutation, and top-bar refresh.
+- Routed SSH project validation failures through the existing `setLastError` helper instead of widening `lastError` mutation.
+- Updated project parity gates to require project API bodies in the focused extension and prevent them from drifting back into `WorkspaceModel.swift`.
+
+Current strict grades:
+- `WorkspaceModelProjects.swift`: **A-**. It is cohesive and delegates registry policy to `WorkspaceProjectEngine`; it still necessarily coordinates persistence, thread context refresh, terminal sync, and top-bar refresh because those are actor-owned side effects.
+- `WorkspaceModel.swift`: **B+/A-**. It dropped another public API family, but remains the largest app file because send, tool, terminal, MCP, memory, automation, and shared persistence orchestration still live there.
+- `ParityWorkspaceProjectGateTests.swift`: **A**. It now checks both the project API extension boundary and the pure engine/loader ownership boundaries.
+
+Remaining risk:
+- The next central-model extraction should target terminal or tool-run APIs only if the resulting extension can preserve narrow helper access without broadening model storage setters.


### PR DESCRIPTION
## Summary
- move project-facing workspace APIs into a focused WorkspaceModelProjects extension
- keep project storage and shared actor helpers on QuillCodeWorkspaceModel while preserving behavior
- update project parity gates so API ownership stays out of WorkspaceModel.swift
- record the strict quality grade and remaining central-model risk in CODE_QUALITY_AUDIT

## Validation
- swift test --filter 'WorkspaceProjectIntegrationTests|WorkspaceRemoteProjectIntegrationTests|ParityWorkspaceProjectGateTests|ParityWorkspaceModelGateTests' (38 passed)
- swift test (1,160 passed)
- npm --prefix E2E/playwright test tests/sidebar.spec.ts tests/command-palette.spec.ts tests/core.spec.ts (18 passed)
- git diff --cached --check