### PR TITLE
Extract workspace terminal APIs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -9,7 +9,7 @@ import QuillComputerUseKit
 public final class QuillCodeWorkspaceModel {
     public internal(set) var root: QuillCodeRootState
     public private(set) var composer: ComposerState
-    public private(set) var terminal: TerminalState
+    public internal(set) var terminal: TerminalState
     public private(set) var browser: BrowserState
     public private(set) var extensions: ExtensionsState
     public private(set) var memories: MemoriesState
@@ -24,7 +24,7 @@ public final class QuillCodeWorkspaceModel {
     private let automationStore: JSONAutomationStore?
     private let globalMemoryDirectory: URL?
     private var computerUseBackend: (any ComputerUseBackend)?
-    private let sshRemoteShellExecutor: SSHRemoteShellExecutor
+    let sshRemoteShellExecutor: SSHRemoteShellExecutor
     private let mcpRuntime: WorkspaceMCPRuntime
 
     public init(
@@ -187,26 +187,6 @@ public final class QuillCodeWorkspaceModel {
         composer.draft = draft
         lastError = nil
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-        return true
-    }
-
-    public func setTerminalDraft(_ draft: String) {
-        terminal.draft = draft
-    }
-
-    public func setTerminalVisible(_ isVisible: Bool) {
-        terminal.isVisible = isVisible
-    }
-
-    public func toggleTerminal() {
-        terminal.isVisible.toggle()
-    }
-
-    @discardableResult
-    public func clearTerminalHistory() -> Bool {
-        guard WorkspaceTerminalEngine.clearHistory(terminal: &terminal) else { return false }
-        terminal.isVisible = true
-        lastError = nil
         return true
     }
 
@@ -700,75 +680,6 @@ public final class QuillCodeWorkspaceModel {
         }
         refreshTopBar(agentStatus: finishPlan.agentStatus)
         return finishPlan.result
-    }
-
-    public func runTerminalCommand(workspaceRoot: URL) async {
-        await runTerminalCommand(terminal.draft, workspaceRoot: workspaceRoot)
-    }
-
-    public func runTerminalCommand(_ input: String, workspaceRoot: URL) async {
-        let command = WorkspaceTerminalEngine.normalizedCommand(input)
-        guard WorkspaceTerminalEngine.canBeginRun(command: command, terminal: terminal) else { return }
-        syncTerminalSessionToSelectedProject()
-
-        let entryID = WorkspaceTerminalEngine.beginRun(command: command, terminal: &terminal)
-        applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.started())
-
-        guard let executionContext = WorkspaceTerminalEngine.executionContext(
-            command: command,
-            selectedProject: selectedProject,
-            terminalCurrentDirectoryURL: terminalCurrentDirectoryURL,
-            terminal: terminal,
-            workspaceRoot: workspaceRoot,
-            sshRemoteShellExecutor: sshRemoteShellExecutor
-        ) else {
-            WorkspaceTerminalEngine.failMissingExecutionContext(id: entryID, terminal: &terminal)
-            applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.missingExecutionContext())
-            return
-        }
-        WorkspaceTerminalEngine.updateExecutionContext(
-            id: entryID,
-            executionContext: executionContext.surface,
-            terminal: &terminal
-        )
-
-        var finalResult: ToolResult?
-        for await event in ShellToolExecutor().runStreaming(executionContext.request) {
-            if Task.isCancelled || WorkspaceTerminalEngine.entryIsStopped(id: entryID, terminal: terminal) {
-                break
-            }
-            if let result = WorkspaceTerminalEngine.applyStreamingEvent(event, id: entryID, terminal: &terminal) {
-                finalResult = result
-            }
-        }
-
-        if WorkspaceTerminalEngine.entryIsStopped(id: entryID, terminal: terminal) {
-            WorkspaceTerminalEngine.finishStoppedRun(executionContext: executionContext, terminal: &terminal)
-            applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.stopped())
-            return
-        }
-        guard !Task.isCancelled, let result = finalResult else {
-            WorkspaceTerminalEngine.finishCancelledRun(
-                id: entryID,
-                executionContext: executionContext,
-                terminal: &terminal
-            )
-            applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.cancelled())
-            return
-        }
-
-        WorkspaceTerminalEngine.finishCompletedRun(
-            id: entryID,
-            executionContext: executionContext,
-            result: result,
-            terminal: &terminal
-        )
-        applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.finished(result: result))
-    }
-
-    private func applyTerminalLifecyclePlan(_ plan: WorkspaceTerminalLifecyclePlan) {
-        lastError = plan.lastError
-        refreshTopBar(agentStatus: plan.agentStatus)
     }
 
     public func cancelActiveWork() {

--- a/Sources/QuillCodeApp/WorkspaceModelTerminal.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelTerminal.swift
@@ -1,0 +1,95 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+@MainActor
+extension QuillCodeWorkspaceModel {
+    public func setTerminalDraft(_ draft: String) {
+        terminal.draft = draft
+    }
+
+    public func setTerminalVisible(_ isVisible: Bool) {
+        terminal.isVisible = isVisible
+    }
+
+    public func toggleTerminal() {
+        terminal.isVisible.toggle()
+    }
+
+    @discardableResult
+    public func clearTerminalHistory() -> Bool {
+        guard WorkspaceTerminalEngine.clearHistory(terminal: &terminal) else { return false }
+        terminal.isVisible = true
+        setLastError(nil)
+        return true
+    }
+
+    public func runTerminalCommand(workspaceRoot: URL) async {
+        await runTerminalCommand(terminal.draft, workspaceRoot: workspaceRoot)
+    }
+
+    public func runTerminalCommand(_ input: String, workspaceRoot: URL) async {
+        let command = WorkspaceTerminalEngine.normalizedCommand(input)
+        guard WorkspaceTerminalEngine.canBeginRun(command: command, terminal: terminal) else { return }
+        syncTerminalSessionToSelectedProject()
+
+        let entryID = WorkspaceTerminalEngine.beginRun(command: command, terminal: &terminal)
+        applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.started())
+
+        guard let executionContext = WorkspaceTerminalEngine.executionContext(
+            command: command,
+            selectedProject: selectedProject,
+            terminalCurrentDirectoryURL: terminalCurrentDirectoryURL,
+            terminal: terminal,
+            workspaceRoot: workspaceRoot,
+            sshRemoteShellExecutor: sshRemoteShellExecutor
+        ) else {
+            WorkspaceTerminalEngine.failMissingExecutionContext(id: entryID, terminal: &terminal)
+            applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.missingExecutionContext())
+            return
+        }
+        WorkspaceTerminalEngine.updateExecutionContext(
+            id: entryID,
+            executionContext: executionContext.surface,
+            terminal: &terminal
+        )
+
+        var finalResult: ToolResult?
+        for await event in ShellToolExecutor().runStreaming(executionContext.request) {
+            if Task.isCancelled || WorkspaceTerminalEngine.entryIsStopped(id: entryID, terminal: terminal) {
+                break
+            }
+            if let result = WorkspaceTerminalEngine.applyStreamingEvent(event, id: entryID, terminal: &terminal) {
+                finalResult = result
+            }
+        }
+
+        if WorkspaceTerminalEngine.entryIsStopped(id: entryID, terminal: terminal) {
+            WorkspaceTerminalEngine.finishStoppedRun(executionContext: executionContext, terminal: &terminal)
+            applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.stopped())
+            return
+        }
+        guard !Task.isCancelled, let result = finalResult else {
+            WorkspaceTerminalEngine.finishCancelledRun(
+                id: entryID,
+                executionContext: executionContext,
+                terminal: &terminal
+            )
+            applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.cancelled())
+            return
+        }
+
+        WorkspaceTerminalEngine.finishCompletedRun(
+            id: entryID,
+            executionContext: executionContext,
+            result: result,
+            terminal: &terminal
+        )
+        applyTerminalLifecyclePlan(WorkspaceTerminalLifecyclePlanner.finished(result: result))
+    }
+
+    private func applyTerminalLifecyclePlan(_ plan: WorkspaceTerminalLifecyclePlan) {
+        setLastError(plan.lastError)
+        refreshTopBar(agentStatus: plan.agentStatus)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -447,7 +447,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         let preparerText = try Self.appSourceText(named: "WorkspaceToolRunPreparer.swift")
         let runToolCallStart = try XCTUnwrap(modelText.range(of: "public func runToolCall"))
         let runToolCallEnd = try XCTUnwrap(modelText.range(
-            of: "public func runTerminalCommand",
+            of: "public func cancelActiveWork",
             range: runToolCallStart.upperBound..<modelText.endIndex
         ))
         let runToolCallBody = String(modelText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
@@ -467,7 +467,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         let lifecycleText = try Self.appSourceText(named: "WorkspaceToolRunLifecyclePlanner.swift")
         let runToolCallStart = try XCTUnwrap(modelText.range(of: "public func runToolCall"))
         let runToolCallEnd = try XCTUnwrap(modelText.range(
-            of: "public func runTerminalCommand",
+            of: "public func cancelActiveWork",
             range: runToolCallStart.upperBound..<modelText.endIndex
         ))
         let runToolCallBody = String(modelText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
@@ -483,26 +483,24 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesTerminalLifecyclePlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let terminalText = try Self.appSourceText(named: "WorkspaceModelTerminal.swift")
         let lifecycleText = try Self.appSourceText(named: "WorkspaceTerminalLifecyclePlanner.swift")
-        let terminalStart = try XCTUnwrap(modelText.range(of: "public func runTerminalCommand(_ input"))
-        let terminalEnd = try XCTUnwrap(modelText.range(
-            of: "public func cancelActiveWork",
-            range: terminalStart.upperBound..<modelText.endIndex
-        ))
-        let terminalBody = String(modelText[terminalStart.lowerBound..<terminalEnd.lowerBound])
 
+        XCTAssertTrue(terminalText.contains("extension QuillCodeWorkspaceModel"), "Terminal workspace APIs should live in a focused model extension.")
         XCTAssertTrue(lifecycleText.contains("enum WorkspaceTerminalLifecyclePlanner"), "Terminal lifecycle status should live in a focused planner.")
         XCTAssertTrue(lifecycleText.contains("static func started"), "Terminal start lifecycle should be directly testable.")
         XCTAssertTrue(lifecycleText.contains("static func missingExecutionContext"), "Terminal missing-context lifecycle should be directly testable.")
         XCTAssertTrue(lifecycleText.contains("static func finished"), "Terminal finish lifecycle should be directly testable.")
-        XCTAssertTrue(terminalBody.contains("WorkspaceTerminalLifecyclePlanner.started"), "WorkspaceModel should delegate terminal start lifecycle.")
-        XCTAssertTrue(terminalBody.contains("WorkspaceTerminalLifecyclePlanner.missingExecutionContext"), "WorkspaceModel should delegate terminal missing-context lifecycle.")
-        XCTAssertTrue(terminalBody.contains("WorkspaceTerminalLifecyclePlanner.stopped"), "WorkspaceModel should delegate terminal stopped lifecycle.")
-        XCTAssertTrue(terminalBody.contains("WorkspaceTerminalLifecyclePlanner.cancelled"), "WorkspaceModel should delegate terminal cancelled lifecycle.")
-        XCTAssertTrue(terminalBody.contains("WorkspaceTerminalLifecyclePlanner.finished"), "WorkspaceModel should delegate terminal finish lifecycle.")
-        XCTAssertFalse(terminalBody.contains("TopBarAgentStatusLabel.terminal"), "runTerminalCommand should not choose started status inline.")
-        XCTAssertFalse(terminalBody.contains("TopBarAgentStatusLabel.stopped"), "runTerminalCommand should not choose stopped status inline.")
-        XCTAssertFalse(terminalBody.contains("result.ok ?"), "runTerminalCommand should not choose final status inline.")
+        XCTAssertTrue(terminalText.contains("WorkspaceTerminalLifecyclePlanner.started"), "Terminal API extension should delegate terminal start lifecycle.")
+        XCTAssertTrue(terminalText.contains("WorkspaceTerminalLifecyclePlanner.missingExecutionContext"), "Terminal API extension should delegate terminal missing-context lifecycle.")
+        XCTAssertTrue(terminalText.contains("WorkspaceTerminalLifecyclePlanner.stopped"), "Terminal API extension should delegate terminal stopped lifecycle.")
+        XCTAssertTrue(terminalText.contains("WorkspaceTerminalLifecyclePlanner.cancelled"), "Terminal API extension should delegate terminal cancelled lifecycle.")
+        XCTAssertTrue(terminalText.contains("WorkspaceTerminalLifecyclePlanner.finished"), "Terminal API extension should delegate terminal finish lifecycle.")
+        XCTAssertFalse(modelText.contains("public func runTerminalCommand"), "WorkspaceModel.swift should not own terminal run APIs.")
+        XCTAssertFalse(modelText.contains("public func clearTerminalHistory"), "WorkspaceModel.swift should not own terminal history APIs.")
+        XCTAssertFalse(terminalText.contains("TopBarAgentStatusLabel.terminal"), "runTerminalCommand should not choose started status inline.")
+        XCTAssertFalse(terminalText.contains("TopBarAgentStatusLabel.stopped"), "runTerminalCommand should not choose stopped status inline.")
+        XCTAssertFalse(terminalText.contains("result.ok ?"), "runTerminalCommand should not choose final status inline.")
     }
 
     func testWorkspaceModelDelegatesActiveWorkStopPlanning() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -6327,3 +6327,24 @@ Current strict grades:
 
 Remaining risk:
 - The preview currently displays the first 20 non-empty Git output lines as records. That is robust for current `git worktree prune --dry-run --verbose` output, but a future richer UI could classify messages by stale administrative path, missing checkout, or reason when Git exposes more structured detail.
+
+## 2026-06-25 Workspace Terminal API Extension
+
+Overall grade after this slice: **A- terminal API ownership, A terminal parity gates, B+/A- central model size**.
+
+`WorkspaceModel.swift` still owned the public terminal draft, visibility, history, and command-run API bodies even though terminal state transitions already lived in `WorkspaceTerminalEngine` and lifecycle status decisions lived in `WorkspaceTerminalLifecyclePlanner`. Moving the API body to a same-actor extension keeps terminal orchestration discoverable without making the central model carry every workspace surface.
+
+What changed:
+- Added `WorkspaceModelTerminal.swift` for terminal draft mutation, visibility toggles, history clearing, and async command execution.
+- Kept the actor-owned terminal state on `QuillCodeWorkspaceModel`, but narrowed external exposure with `public internal(set)` so same-module extensions can mutate terminal state without making it writable to package users.
+- Widened the immutable SSH executor from file-private to module-internal so terminal, project, and worktree helpers use the same collaborator without a callback bridge.
+- Routed terminal error clearing and lifecycle error writes through the existing `setLastError` helper.
+- Updated parity gates to require terminal lifecycle delegation in the focused extension and prevent terminal run/history APIs from drifting back into `WorkspaceModel.swift`.
+
+Current strict grades:
+- `WorkspaceModelTerminal.swift`: **A-**. It is cohesive and delegates the command/session mechanics to focused helpers; the async streaming loop remains actor-owned because it mutates terminal entries in order.
+- `WorkspaceModel.swift`: **B+/A-**. It dropped another public API family, but still owns send, tool-run, MCP, memory, automation, and shared persistence orchestration.
+- `ParityWorkspaceExecutionGateTests.swift`: **A-**. It now tests the terminal extension boundary directly and catches regression back into the central model.
+
+Remaining risk:
+- The terminal extension still sequences execution-context lookup, streaming events, stop/cancel detection, and finish mutation. A future extraction could introduce a terminal run coordinator, but only if it keeps actor mutation order explicit and avoids callback-heavy indirection.


### PR DESCRIPTION
## Summary
- move terminal draft, visibility, history, and command-run APIs into `WorkspaceModelTerminal.swift`
- keep terminal lifecycle/status decisions delegated to `WorkspaceTerminalLifecyclePlanner`
- update parity gates and code-quality audit for the new ownership boundary

## Validation
- `swift test --filter 'WorkspaceTerminalIntegrationTests|WorkspaceTerminalEngineTests|WorkspaceTerminalLifecyclePlannerTests|ParityWorkspaceExecutionGateTests|ParityWorkspaceModelGateTests'`\n- `swift test`\n- `npm --prefix E2E/playwright test tests/terminal.spec.ts tests/core.spec.ts`\n- `git diff --check`