### PR TITLE
Extract workspace active-work APIs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -8,7 +8,7 @@ import QuillComputerUseKit
 @MainActor
 public final class QuillCodeWorkspaceModel {
     public internal(set) var root: QuillCodeRootState
-    public private(set) var composer: ComposerState
+    public internal(set) var composer: ComposerState
     public internal(set) var terminal: TerminalState
     public private(set) var browser: BrowserState
     public internal(set) var extensions: ExtensionsState
@@ -624,58 +624,6 @@ public final class QuillCodeWorkspaceModel {
         }
         refreshTopBar(agentStatus: finishPlan.agentStatus)
         return finishPlan.result
-    }
-
-    public func cancelActiveWork() {
-        applyActiveWorkStopPlan(
-            WorkspaceActiveWorkStopPlanner.cancel(stoppedWork: stopActiveWorkspaceWork())
-        )
-    }
-
-    @discardableResult
-    public func disconnectAll() -> Bool {
-        let stoppedWork = stopActiveWorkspaceWork()
-        let shouldDetachRemoteProject = selectedProject?.isRemote == true
-
-        guard let plan = WorkspaceActiveWorkStopPlanner.disconnectAll(
-            stoppedWork: stoppedWork,
-            shouldDetachRemoteProject: shouldDetachRemoteProject
-        ) else {
-            return false
-        }
-
-        if shouldDetachRemoteProject,
-           let selection = WorkspaceProjectEngine.selectionAfterSelectingProject(
-            nil,
-            projects: root.projects,
-            threads: root.threads
-           ) {
-            root.selectedProjectID = selection.projectID
-            root.selectedThreadID = selection.threadID
-            syncTerminalSessionToSelectedProject()
-        }
-
-        applyActiveWorkStopPlan(plan)
-        return true
-    }
-
-    private func stopActiveWorkspaceWork() -> WorkspaceStoppedActiveWork {
-        let hadRunningMCPServers = mcpRuntime.cancelAll(extensions: &extensions)
-        let hadActiveWork = composer.isSending || terminal.isRunning
-        composer.isSending = false
-        terminal.isRunning = false
-        WorkspaceTerminalEngine.stopRunningEntries(terminal: &terminal)
-        return WorkspaceStoppedActiveWork(
-            hadRunningMCPServers: hadRunningMCPServers,
-            hadActiveWork: hadActiveWork
-        )
-    }
-
-    private func applyActiveWorkStopPlan(_ plan: WorkspaceActiveWorkStopPlan) {
-        lastError = plan.lastError
-        if let agentStatus = plan.agentStatus {
-            refreshTopBar(agentStatus: agentStatus)
-        }
     }
 
     private func appendToolRun(call: ToolCall, result: ToolResult) {

--- a/Sources/QuillCodeApp/WorkspaceModelActiveWork.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelActiveWork.swift
@@ -1,0 +1,54 @@
+@MainActor
+extension QuillCodeWorkspaceModel {
+    public func cancelActiveWork() {
+        applyActiveWorkStopPlan(
+            WorkspaceActiveWorkStopPlanner.cancel(stoppedWork: stopActiveWorkspaceWork())
+        )
+    }
+
+    @discardableResult
+    public func disconnectAll() -> Bool {
+        let stoppedWork = stopActiveWorkspaceWork()
+        let shouldDetachRemoteProject = selectedProject?.isRemote == true
+
+        guard let plan = WorkspaceActiveWorkStopPlanner.disconnectAll(
+            stoppedWork: stoppedWork,
+            shouldDetachRemoteProject: shouldDetachRemoteProject
+        ) else {
+            return false
+        }
+
+        if shouldDetachRemoteProject,
+           let selection = WorkspaceProjectEngine.selectionAfterSelectingProject(
+            nil,
+            projects: root.projects,
+            threads: root.threads
+           ) {
+            root.selectedProjectID = selection.projectID
+            root.selectedThreadID = selection.threadID
+            syncTerminalSessionToSelectedProject()
+        }
+
+        applyActiveWorkStopPlan(plan)
+        return true
+    }
+
+    private func stopActiveWorkspaceWork() -> WorkspaceStoppedActiveWork {
+        let hadRunningMCPServers = mcpRuntime.cancelAll(extensions: &extensions)
+        let hadActiveWork = composer.isSending || terminal.isRunning
+        composer.isSending = false
+        terminal.isRunning = false
+        WorkspaceTerminalEngine.stopRunningEntries(terminal: &terminal)
+        return WorkspaceStoppedActiveWork(
+            hadRunningMCPServers: hadRunningMCPServers,
+            hadActiveWork: hadActiveWork
+        )
+    }
+
+    private func applyActiveWorkStopPlan(_ plan: WorkspaceActiveWorkStopPlan) {
+        setLastError(plan.lastError)
+        if let agentStatus = plan.agentStatus {
+            refreshTopBar(agentStatus: agentStatus)
+        }
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -447,7 +447,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         let preparerText = try Self.appSourceText(named: "WorkspaceToolRunPreparer.swift")
         let runToolCallStart = try XCTUnwrap(modelText.range(of: "public func runToolCall"))
         let runToolCallEnd = try XCTUnwrap(modelText.range(
-            of: "public func cancelActiveWork",
+            of: "private func appendToolRun",
             range: runToolCallStart.upperBound..<modelText.endIndex
         ))
         let runToolCallBody = String(modelText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
@@ -467,7 +467,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         let lifecycleText = try Self.appSourceText(named: "WorkspaceToolRunLifecyclePlanner.swift")
         let runToolCallStart = try XCTUnwrap(modelText.range(of: "public func runToolCall"))
         let runToolCallEnd = try XCTUnwrap(modelText.range(
-            of: "public func cancelActiveWork",
+            of: "private func appendToolRun",
             range: runToolCallStart.upperBound..<modelText.endIndex
         ))
         let runToolCallBody = String(modelText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
@@ -505,23 +505,22 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesActiveWorkStopPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let activeWorkText = try Self.appSourceText(named: "WorkspaceModelActiveWork.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceActiveWorkStopPlanner.swift")
-        let cancelStart = try XCTUnwrap(modelText.range(of: "public func cancelActiveWork"))
-        let cancelEnd = try XCTUnwrap(modelText.range(
-            of: "private func appendToolRun",
-            range: cancelStart.upperBound..<modelText.endIndex
-        ))
-        let cancelAndDisconnectBody = String(modelText[cancelStart.lowerBound..<cancelEnd.lowerBound])
 
+        XCTAssertTrue(activeWorkText.contains("extension QuillCodeWorkspaceModel"), "Active-work APIs should live in a focused model extension.")
         XCTAssertTrue(plannerText.contains("enum WorkspaceActiveWorkStopPlanner"), "Stop/disconnect lifecycle status should live in a focused planner.")
         XCTAssertTrue(plannerText.contains("static func cancel"), "Cancel lifecycle should be directly testable.")
         XCTAssertTrue(plannerText.contains("static func disconnectAll"), "Disconnect lifecycle should be directly testable.")
-        XCTAssertTrue(cancelAndDisconnectBody.contains("WorkspaceActiveWorkStopPlanner.cancel"), "WorkspaceModel should delegate cancel lifecycle.")
-        XCTAssertTrue(cancelAndDisconnectBody.contains("WorkspaceActiveWorkStopPlanner.disconnectAll"), "WorkspaceModel should delegate disconnect lifecycle.")
-        XCTAssertTrue(cancelAndDisconnectBody.contains("applyActiveWorkStopPlan"), "WorkspaceModel should share active-work stop plan application.")
-        XCTAssertFalse(cancelAndDisconnectBody.contains("TopBarAgentStatusLabel.stopped"), "WorkspaceModel should not choose stopped status inline for active-work cancellation.")
-        XCTAssertFalse(cancelAndDisconnectBody.contains("TopBarAgentStatusLabel.idle"), "WorkspaceModel should not choose idle status inline for disconnect.")
-        XCTAssertFalse(cancelAndDisconnectBody.contains("? TopBarAgentStatusLabel"), "WorkspaceModel should not choose active-work stop status with inline ternaries.")
+        XCTAssertTrue(activeWorkText.contains("WorkspaceActiveWorkStopPlanner.cancel"), "Active-work extension should delegate cancel lifecycle.")
+        XCTAssertTrue(activeWorkText.contains("WorkspaceActiveWorkStopPlanner.disconnectAll"), "Active-work extension should delegate disconnect lifecycle.")
+        XCTAssertTrue(activeWorkText.contains("applyActiveWorkStopPlan"), "Active-work extension should share active-work stop plan application.")
+        XCTAssertFalse(modelText.contains("public func cancelActiveWork"), "WorkspaceModel.swift should not own active-work cancel APIs.")
+        XCTAssertFalse(modelText.contains("public func disconnectAll"), "WorkspaceModel.swift should not own active-work disconnect APIs.")
+        XCTAssertFalse(modelText.contains("stopActiveWorkspaceWork"), "WorkspaceModel.swift should not own active-work stop aggregation.")
+        XCTAssertFalse(activeWorkText.contains("TopBarAgentStatusLabel.stopped"), "Active-work extension should not choose stopped status inline for cancellation.")
+        XCTAssertFalse(activeWorkText.contains("TopBarAgentStatusLabel.idle"), "Active-work extension should not choose idle status inline for disconnect.")
+        XCTAssertFalse(activeWorkText.contains("? TopBarAgentStatusLabel"), "Active-work extension should not choose stop status with inline ternaries.")
     }
 
     func testWorkspaceModelDelegatesShellToolCallPlanning() throws {

--- a/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
@@ -56,7 +56,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(modelText.contains("WorkspaceAgentSendTerminalPlanner.completed"), "WorkspaceModel should delegate composer send completion transitions.")
         XCTAssertTrue(modelText.contains("WorkspaceAgentSendTerminalPlanner.cancelled"), "WorkspaceModel should delegate composer send cancellation transitions.")
         XCTAssertTrue(modelText.contains("WorkspaceAgentSendTerminalPlanner.failed"), "WorkspaceModel should delegate composer send failure transitions.")
-        XCTAssertTrue(modelText.contains("public private(set) var composer: ComposerState"), "WorkspaceModel should still own live composer state.")
+        XCTAssertTrue(modelText.contains("public internal(set) var composer: ComposerState"), "WorkspaceModel should own live composer state while focused same-module extensions may apply state transitions.")
         XCTAssertFalse(modelText.contains("public struct ComposerState"), "WorkspaceModel should not define composer UI state contracts.")
         XCTAssertFalse(modelText.contains("public struct MemoriesState"), "WorkspaceModel should not define memory-pane UI state contracts.")
         XCTAssertFalse(modelText.contains("public struct ActivityState"), "WorkspaceModel should not define activity-pane UI state contracts.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -76,6 +76,30 @@ Remaining risk:
 
 - This is still line-oriented terminal history, not full interactive PTY parity. Job control, stdin during long-running commands, and curses-style TUI handling remain the larger terminal product gap.
 
+## 2026-06-25 Workspace Active-Work API Extension
+
+Overall grade after this slice: **A- Stop/Disconnect ownership, A planner boundary, B+/A- central model size**.
+
+`WorkspaceModel.swift` still owned the public Stop All and Disconnect All API bodies even though the user-visible lifecycle decisions already lived in `WorkspaceActiveWorkStopPlanner`. Those commands cut across composer sends, terminal runs, MCP processes, and SSH Remote project detachment, so the app actor still needs to coordinate state mutation, but that coordination no longer needs to sit in the central model file.
+
+What changed:
+
+- Added `WorkspaceModelActiveWork.swift` for `cancelActiveWork`, `disconnectAll`, active-work aggregation, and stop-plan application.
+- Kept stop/disconnect status policy in `WorkspaceActiveWorkStopPlanner`; the extension only applies actor-owned state, selected project/thread detachment, terminal state cleanup, and top-bar refresh.
+- Narrowly changed `composer` to same-module writable so the focused model extension can clear send state while external package users still observe read-only state.
+- Updated parity gates to require active-work APIs in the focused extension and prevent cancel/disconnect aggregation from drifting back into `WorkspaceModel.swift`.
+
+Current strict grades:
+
+- `WorkspaceModelActiveWork.swift`: **A-**. It is cohesive and deliberately small; its remaining complexity is the necessary cross-surface cleanup between composer, terminal, MCP, and remote project selection.
+- `WorkspaceActiveWorkStopPlanner.swift`: **A**. Status/last-error choices remain pure and directly tested.
+- `WorkspaceModel.swift`: **B+/A-**. It dropped another cross-surface command group, but still owns send, tool-run, memory, local environment, worktree, review, and shared persistence orchestration.
+- `ParityWorkspaceExecutionGateTests.swift`: **A-**. It now enforces the active-work extension boundary and the planner/status boundary.
+
+Remaining risk:
+
+- `WorkspaceModel.swift` still contains multiple public workflow API families. The next central-model extraction should target a cohesive group such as worktree APIs or review/comment APIs rather than a mixed utility sweep.
+
 ## 2026-06-25 Agent Send Progress Planner Pass
 
 Overall grade after this slice: **A live-progress boundary, A async-thread safety, A regression coverage**.


### PR DESCRIPTION
## Summary
- move Stop All / Disconnect All workspace APIs into a focused WorkspaceModelActiveWork extension
- keep stop/disconnect lifecycle policy delegated to WorkspaceActiveWorkStopPlanner
- update parity gates and the code-quality audit for the new boundary

## Validation
- swift test --filter 'WorkspaceActiveWorkStopPlannerTests|WorkspaceMCPIntegrationTests|WorkspaceTerminalIntegrationTests|WorkspaceCommandPlanExecutorTests|ParityWorkspaceExecutionGateTests|ParityWorkspaceModelGateTests|ParityDesktopGateTests'
- swift test
- npm --prefix E2E/playwright test tests/core.spec.ts
- git diff --check