### PR TITLE
[codex] Extract workspace local environment APIs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -390,19 +390,6 @@ public final class QuillCodeWorkspaceModel {
     }
 
     @discardableResult
-    public func runLocalEnvironmentAction(_ actionID: String, workspaceRoot: URL) -> Bool {
-        refreshProjectMetadata(root.selectedProjectID)
-        guard let action = contextResolver.selectedLocalAction(withID: actionID) else {
-            return false
-        }
-        runToolCall(
-            WorkspaceShellToolCallPlanner.localEnvironmentAction(action),
-            workspaceRoot: workspaceRoot
-        )
-        return true
-    }
-
-    @discardableResult
     public func runProjectExtensionUpdate(id: String, workspaceRoot: URL) -> Bool {
         refreshProjectMetadata(root.selectedProjectID)
         guard let manifest = selectedProject?.extensionManifests.first(where: { $0.id == id }),
@@ -554,21 +541,6 @@ public final class QuillCodeWorkspaceModel {
             directory: globalMemoryDirectory
         )
         applyGlobalMemoryMutation(mutation)
-    }
-
-    func runEnvironmentSlashCommand(_ query: String?, originalPrompt: String, workspaceRoot: URL) {
-        refreshProjectMetadata(root.selectedProjectID)
-        let plan = WorkspaceEnvironmentSlashCommandPlanner.plan(
-            query: query,
-            userText: originalPrompt,
-            actions: selectedProject?.localActions ?? []
-        )
-        switch plan {
-        case .transcript(let transcript):
-            appendLocalCommandTranscript(transcript)
-        case .runAction(let actionID):
-            _ = runLocalEnvironmentAction(actionID, workspaceRoot: workspaceRoot)
-        }
     }
 
     func appendLocalCommandTranscript(_ transcript: WorkspaceLocalCommandTranscript) {

--- a/Sources/QuillCodeApp/WorkspaceModelLocalEnvironment.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelLocalEnvironment.swift
@@ -1,0 +1,36 @@
+import Foundation
+import QuillCodeCore
+
+extension QuillCodeWorkspaceModel {
+    @discardableResult
+    public func runLocalEnvironmentAction(_ actionID: String, workspaceRoot: URL) -> Bool {
+        refreshProjectMetadata(root.selectedProjectID)
+        guard let action = LocalEnvironmentActionMatcher.action(
+            withID: actionID,
+            in: selectedProject?.localActions ?? []
+        ) else {
+            return false
+        }
+
+        runToolCall(
+            WorkspaceShellToolCallPlanner.localEnvironmentAction(action),
+            workspaceRoot: workspaceRoot
+        )
+        return true
+    }
+
+    func runEnvironmentSlashCommand(_ query: String?, originalPrompt: String, workspaceRoot: URL) {
+        refreshProjectMetadata(root.selectedProjectID)
+        let plan = WorkspaceEnvironmentSlashCommandPlanner.plan(
+            query: query,
+            userText: originalPrompt,
+            actions: selectedProject?.localActions ?? []
+        )
+        switch plan {
+        case .transcript(let transcript):
+            appendLocalCommandTranscript(transcript)
+        case .runAction(let actionID):
+            _ = runLocalEnvironmentAction(actionID, workspaceRoot: workspaceRoot)
+        }
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -267,6 +267,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         let plannerText = try Self.appSourceText(named: "WorkspaceSlashCommandTranscriptPlanner.swift")
         let appenderText = try Self.appSourceText(named: "WorkspaceLocalCommandTranscriptAppender.swift")
         let environmentPlannerText = try Self.appSourceText(named: "WorkspaceEnvironmentSlashCommandPlanner.swift")
+        let localEnvironmentModelText = try Self.appSourceText(named: "WorkspaceModelLocalEnvironment.swift")
         let dispatchPlannerText = try Self.appSourceText(named: "WorkspaceSlashCommandDispatchPlanner.swift")
 
         XCTAssertTrue(plannerText.contains("struct WorkspaceLocalCommandTranscript"), "Local command transcript records should live beside the planner.")
@@ -282,7 +283,12 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(appenderText.contains("thread.messages.append(ChatMessage(role: .user"), "The transcript appender should own user-message insertion.")
         XCTAssertTrue(appenderText.contains("thread.messages.append(ChatMessage(role: .assistant"), "The transcript appender should own assistant-message insertion.")
         XCTAssertTrue(modelText.contains("WorkspaceLocalCommandTranscriptAppender.append"), "WorkspaceModel should delegate local command transcript mutation.")
-        XCTAssertTrue(modelText.contains("WorkspaceEnvironmentSlashCommandPlanner.plan"), "WorkspaceModel should delegate /env list/run/not-found planning.")
+        XCTAssertTrue(localEnvironmentModelText.contains("public func runLocalEnvironmentAction"), "Local environment action execution should live in the focused WorkspaceModelLocalEnvironment extension.")
+        XCTAssertTrue(localEnvironmentModelText.contains("func runEnvironmentSlashCommand"), "Local environment slash command dispatch should live in the focused WorkspaceModelLocalEnvironment extension.")
+        XCTAssertTrue(localEnvironmentModelText.contains("WorkspaceEnvironmentSlashCommandPlanner.plan"), "WorkspaceModelLocalEnvironment should delegate /env list/run/not-found planning.")
+        XCTAssertFalse(modelText.contains("public func runLocalEnvironmentAction"), "WorkspaceModel.swift should not own local environment action execution.")
+        XCTAssertFalse(modelText.contains("func runEnvironmentSlashCommand"), "WorkspaceModel.swift should not own local environment slash command dispatch.")
+        XCTAssertFalse(modelText.contains("WorkspaceEnvironmentSlashCommandPlanner.plan"), "WorkspaceModel.swift should not directly choose /env list/run/not-found planning.")
         XCTAssertTrue(plannerText.contains("static func sshProjectAdded"), "SSH success copy should be directly testable.")
         XCTAssertTrue(plannerText.contains("static func workspaceCommandFailed"), "Slash command failure copy should be directly testable.")
         XCTAssertTrue(plannerText.contains("SlashCommandCatalog.helpText()"), "Slash help text should stay catalog-backed.")
@@ -525,6 +531,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesShellToolCallPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let localEnvironmentModelText = try Self.appSourceText(named: "WorkspaceModelLocalEnvironment.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceShellToolCallPlanner.swift")
 
         XCTAssertTrue(plannerText.contains("enum WorkspaceShellToolCallPlanner"), "Local action shell tool-call planning should live in a focused planner.")
@@ -532,10 +539,11 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(plannerText.contains("static func projectExtensionUpdate"), "Extension update tool calls should be directly testable.")
         XCTAssertTrue(plannerText.contains("ToolDefinition.shellRun.name"), "The planner should own the canonical shell tool name.")
         XCTAssertTrue(plannerText.contains("ToolArguments.json(arguments)"), "The planner should own shell argument JSON construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceShellToolCallPlanner.localEnvironmentAction"), "WorkspaceModel should delegate local action shell call construction.")
+        XCTAssertTrue(localEnvironmentModelText.contains("WorkspaceShellToolCallPlanner.localEnvironmentAction"), "WorkspaceModelLocalEnvironment should delegate local action shell call construction.")
         XCTAssertTrue(modelText.contains("WorkspaceShellToolCallPlanner.projectExtensionUpdate"), "WorkspaceModel should delegate extension update shell call construction.")
         XCTAssertFalse(modelText.contains("arguments[\"environment\"] = environment"), "WorkspaceModel should not assemble local action environment arguments inline.")
         XCTAssertFalse(modelText.contains("arguments[\"timeoutSeconds\"] = timeoutSeconds"), "WorkspaceModel should not assemble local action timeout arguments inline.")
+        XCTAssertFalse(modelText.contains("WorkspaceShellToolCallPlanner.localEnvironmentAction"), "WorkspaceModel.swift should not own local action shell call execution.")
         XCTAssertFalse(modelText.contains("let command = manifest.updateCommand"), "WorkspaceModel should not parse extension update commands inline.")
     }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -48,6 +48,8 @@ The architecture is moving in the right direction: core state is value typed, pe
 
 ## Changes From This Pass
 
+- Extracted local environment action execution and `/env` slash-command dispatch from `WorkspaceModel.swift` into `WorkspaceModelLocalEnvironment.swift`.
+- Added a parity gate that requires local environment action execution to stay in the focused model extension and keeps `/env` transcript planning delegated to `WorkspaceEnvironmentSlashCommandPlanner`.
 - Added keyboard result highlighting to native and harness chat search so users can type, move with ArrowUp/ArrowDown, and press Enter to select a thread.
 - Added Playwright and parity-gate coverage for chat search keyboard selection.
 - Added keyboard result highlighting to the native and harness model picker so users can type, move with ArrowUp/ArrowDown, and press Enter to select a model without leaving the keyboard.
@@ -62,6 +64,23 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
+
+## 2026-06-25 Workspace Local Environment API Extension
+
+Overall grade after this slice: **A- local environment workflow ownership, A planner boundary, B+/A- central model size**.
+
+Local environment action metadata loading, matching, shell-call construction, transcript copy, and integration tests were already focused. The remaining issue was that the central workspace model still owned the public run path and `/env` slash-command dispatch body. That made `WorkspaceModel.swift` look like the owner of local environment workflow policy even though the actual decisions had already moved out.
+
+Code quality changes:
+
+- Added `WorkspaceModelLocalEnvironment.swift` for `runLocalEnvironmentAction` and `runEnvironmentSlashCommand`.
+- Kept action matching in `LocalEnvironmentActionMatcher`, command construction in `WorkspaceShellToolCallPlanner`, and `/env` list/run/not-found planning in `WorkspaceEnvironmentSlashCommandPlanner`.
+- Avoided widening the private `contextResolver` boundary; the extension reads selected project local actions directly and keeps actor-owned coordination explicit.
+- Strengthened the parity gate so local environment execution and slash dispatch cannot drift back into `WorkspaceModel.swift`.
+
+Remaining risk:
+
+- `WorkspaceModel.swift` still owns core tool-run execution and memory workflows. The next extraction should target memory command APIs or tool-run lifecycle ownership only if a cohesive helper boundary emerges.
 
 ## 2026-06-25 Terminal History Recall Pass
 


### PR DESCRIPTION
## Summary
- Move local environment action execution and `/env` slash-command dispatch out of `WorkspaceModel.swift` into `WorkspaceModelLocalEnvironment.swift`.
- Update parity gates so the local-environment workflow boundary stays focused.
- Record the architecture pass in `docs/CODE_QUALITY_AUDIT.md`.

## Validation
- `swift test --filter WorkspaceLocalEnvironmentIntegrationTests --filter WorkspaceEnvironmentSlashCommandPlannerTests --filter ParityWorkspaceExecutionGateTests`
- `git diff --check`
- `swift test` (1168 tests passed)
