### PR TITLE
Extract workspace tool-run APIs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -410,61 +410,6 @@ public final class QuillCodeWorkspaceModel {
         return result.ok
     }
 
-    @discardableResult
-    public func runToolCall(_ call: ToolCall, workspaceRoot: URL) -> ToolResult {
-        if selectedThread == nil {
-            _ = newChat()
-        }
-        guard selectedThread != nil else {
-            return ToolResult(ok: false, error: "No active thread")
-        }
-        let contextProjectID = WorkspaceToolRunPreparer.effectiveProjectID(
-            thread: selectedThread,
-            fallbackProjectID: root.selectedProjectID
-        )
-        refreshProjectMetadata(contextProjectID)
-        let fallbackProjectID = root.selectedProjectID
-        let projects = root.projects
-        let globalMemories = root.globalMemories
-        mutateSelectedThread { thread in
-            _ = WorkspaceToolRunPreparer.syncThreadContext(
-                &thread,
-                fallbackProjectID: fallbackProjectID,
-                projects: projects,
-                globalMemories: globalMemories
-            )
-        }
-        let startPlan = WorkspaceToolRunLifecyclePlanner.started()
-        lastError = startPlan.lastError
-        refreshTopBar(agentStatus: startPlan.agentStatus)
-
-        let router = ToolRouter(workspaceRoot: workspaceRoot)
-        let execution = workspaceToolCallExecutor(router: router).execute(
-            call,
-            browser: &browser,
-            lastError: &lastError
-        )
-        let finishPlan = WorkspaceToolRunLifecyclePlanner.finished(execution: execution)
-        mutateSelectedThread { thread in
-            WorkspaceToolEventRecorder.append(execution: execution, to: &thread)
-        }
-
-        if let thread = selectedThread {
-            threadPersistence.save(thread)
-        }
-        refreshTopBar(agentStatus: finishPlan.agentStatus)
-        return finishPlan.result
-    }
-
-    func workspaceToolCallExecutor(router: ToolRouter) -> WorkspaceToolCallExecutor {
-        WorkspaceToolCallExecutor(
-            selectedProject: selectedProject,
-            browser: browser,
-            router: router,
-            sshRemoteShellExecutor: sshRemoteShellExecutor
-        )
-    }
-
     private func executeBrowserToolForAgent(_ call: ToolCall, workspaceRoot: URL) -> ToolResult? {
         let result = WorkspaceBrowserToolExecutor.execute(
             call,

--- a/Sources/QuillCodeApp/WorkspaceModelToolRuns.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelToolRuns.swift
@@ -1,0 +1,76 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+@MainActor
+public extension QuillCodeWorkspaceModel {
+    @discardableResult
+    func runToolCall(_ call: ToolCall, workspaceRoot: URL) -> ToolResult {
+        if selectedThread == nil {
+            _ = newChat()
+        }
+        guard selectedThread != nil else {
+            return ToolResult(ok: false, error: "No active thread")
+        }
+
+        let contextProjectID = WorkspaceToolRunPreparer.effectiveProjectID(
+            thread: selectedThread,
+            fallbackProjectID: root.selectedProjectID
+        )
+        refreshProjectMetadata(contextProjectID)
+        syncSelectedThreadContextForToolRun()
+
+        let startPlan = WorkspaceToolRunLifecyclePlanner.started()
+        setLastError(startPlan.lastError)
+        refreshTopBar(agentStatus: startPlan.agentStatus)
+
+        let router = ToolRouter(workspaceRoot: workspaceRoot)
+        let executor = workspaceToolCallExecutor(router: router)
+        let execution = mutateBrowserState { browser, lastError in
+            executor.execute(call, browser: &browser, lastError: &lastError)
+        }
+        let finishPlan = WorkspaceToolRunLifecyclePlanner.finished(execution: execution)
+        recordToolRun(execution)
+
+        if let thread = selectedThread {
+            threadPersistence.save(thread)
+        }
+        refreshTopBar(agentStatus: finishPlan.agentStatus)
+        return finishPlan.result
+    }
+}
+
+@MainActor
+extension QuillCodeWorkspaceModel {
+    func workspaceToolCallExecutor(router: ToolRouter) -> WorkspaceToolCallExecutor {
+        WorkspaceToolCallExecutor(
+            selectedProject: selectedProject,
+            browser: browser,
+            router: router,
+            sshRemoteShellExecutor: sshRemoteShellExecutor
+        )
+    }
+}
+
+@MainActor
+private extension QuillCodeWorkspaceModel {
+    func syncSelectedThreadContextForToolRun() {
+        let fallbackProjectID = root.selectedProjectID
+        let projects = root.projects
+        let globalMemories = root.globalMemories
+        mutateSelectedThread { thread in
+            _ = WorkspaceToolRunPreparer.syncThreadContext(
+                &thread,
+                fallbackProjectID: fallbackProjectID,
+                projects: projects,
+                globalMemories: globalMemories
+            )
+        }
+    }
+
+    func recordToolRun(_ execution: WorkspaceToolCallExecution) {
+        mutateSelectedThread { thread in
+            WorkspaceToolEventRecorder.append(execution: execution, to: &thread)
+        }
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityToolGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityToolGateTests.swift
@@ -64,6 +64,7 @@ final class ParityToolGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesRemoteProjectToolExecution() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let toolRunsText = try Self.appSourceText(named: "WorkspaceModelToolRuns.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
         let executorText = try Self.appSourceText(named: "WorkspaceRemoteProjectToolExecutor.swift")
         let gitPlannerText = try Self.appSourceText(named: "WorkspaceRemoteGitToolRequestPlanner.swift")
@@ -102,7 +103,8 @@ final class ParityToolGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(executorText.contains("WorkspaceRemoteProjectPath.relativePath"), "Remote executor should delegate file path normalization.")
         XCTAssertTrue(builderText.contains("WorkspaceRemoteProjectToolExecutor.toolDefinitions"), "Agent run context builder should delegate remote base tool definitions.")
         XCTAssertTrue(builderText.contains("WorkspaceRemoteProjectToolExecutor.executionOverride"), "Agent run context builder should delegate remote override creation.")
-        XCTAssertTrue(modelText.contains("workspaceToolCallExecutor(router:"), "WorkspaceModel should delegate manual/review tool execution through the shared workspace executor.")
+        XCTAssertTrue(toolRunsText.contains("workspaceToolCallExecutor(router:"), "Generic tool runs should delegate manual tool execution through the shared workspace executor.")
+        XCTAssertFalse(modelText.contains("func workspaceToolCallExecutor"), "WorkspaceModel.swift should not own the shared workspace executor factory.")
         XCTAssertTrue(try Self.appSourceText(named: "WorkspaceToolCallExecutor.swift").contains("WorkspaceRemoteProjectToolExecutor.execute"), "WorkspaceToolCallExecutor should own remote project routing.")
         XCTAssertFalse(modelText.contains("WorkspaceRemoteProjectToolExecutor.toolDefinitions"), "WorkspaceModel should not choose remote base tool definitions inline.")
         XCTAssertFalse(modelText.contains("WorkspaceRemoteProjectToolExecutor.executionOverride"), "WorkspaceModel should not create remote agent overrides inline.")

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -417,6 +417,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesToolEventRecording() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let toolRunsText = try Self.appSourceText(named: "WorkspaceModelToolRuns.swift")
         let recorderText = try Self.appSourceText(named: "WorkspaceToolEventRecorder.swift")
 
         XCTAssertTrue(recorderText.contains("struct WorkspaceToolEventRecorder"), "Tool audit event construction should live in a focused recorder.")
@@ -424,7 +425,8 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(recorderText.contains("static func append"), "Thread mutation should be a thin append helper.")
         XCTAssertTrue(recorderText.contains("call.redactedForTranscript()"), "Tool call redaction should live beside queued-event construction.")
         XCTAssertTrue(recorderText.contains("result.ok ? .toolCompleted : .toolFailed"), "Completion/failure classification should live beside tool event construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceToolEventRecorder.append"), "WorkspaceModel should delegate tool audit event recording.")
+        XCTAssertTrue(toolRunsText.contains("WorkspaceToolEventRecorder.append"), "The tool-run extension should delegate tool audit event recording.")
+        XCTAssertFalse(modelText.contains("WorkspaceToolEventRecorder.append(execution:"), "WorkspaceModel.swift should not own generic tool audit event recording.")
         XCTAssertFalse(modelText.contains("call.redactedForTranscript()"), "WorkspaceModel should not own tool call redaction for transcript events.")
         XCTAssertFalse(modelText.contains("let resultJSON ="), "WorkspaceModel should not own tool result JSON payload construction.")
         XCTAssertFalse(modelText.contains("summary: \"\\(call.name) queued\""), "WorkspaceModel should not construct queued tool summaries directly.")
@@ -433,6 +435,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesToolCallExecutionRouting() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let toolRunsText = try Self.appSourceText(named: "WorkspaceModelToolRuns.swift")
         let executorText = try Self.appSourceText(named: "WorkspaceToolCallExecutor.swift")
 
         XCTAssertTrue(executorText.contains("struct WorkspaceToolCallExecutor"), "Tool-call routing should live in a focused executor.")
@@ -440,7 +443,8 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(executorText.contains("PlanUpdateToolExecutor.execute"), "The executor should own plan update routing.")
         XCTAssertTrue(executorText.contains("WorkspaceRemoteProjectToolExecutor.execute"), "The executor should own remote project routing.")
         XCTAssertTrue(executorText.contains("ToolDefinition.applyPatch.name"), "The executor should own apply-patch follow-up routing.")
-        XCTAssertTrue(modelText.contains("workspaceToolCallExecutor(router:"), "WorkspaceModel should delegate tool execution routing.")
+        XCTAssertTrue(toolRunsText.contains("workspaceToolCallExecutor(router:"), "The tool-run extension should delegate tool execution routing.")
+        XCTAssertFalse(modelText.contains("func workspaceToolCallExecutor"), "WorkspaceModel.swift should not own tool execution routing.")
         XCTAssertFalse(modelText.contains("call.name == ToolDefinition.browserInspect.name"), "WorkspaceModel should not branch on browser inspect tool execution.")
         XCTAssertFalse(modelText.contains("call.name == ToolDefinition.browserOpen.name"), "WorkspaceModel should not branch on browser open tool execution.")
         XCTAssertFalse(modelText.contains("call.name == ToolDefinition.planUpdate.name"), "WorkspaceModel should not branch on plan update tool execution.")
@@ -450,33 +454,37 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesToolRunPreparation() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let toolRunsText = try Self.appSourceText(named: "WorkspaceModelToolRuns.swift")
         let preparerText = try Self.appSourceText(named: "WorkspaceToolRunPreparer.swift")
-        let runToolCallStart = try XCTUnwrap(modelText.range(of: "public func runToolCall"))
-        let runToolCallEnd = try XCTUnwrap(modelText.range(
+        let runToolCallStart = try XCTUnwrap(toolRunsText.range(of: "func runToolCall"))
+        let runToolCallEnd = try XCTUnwrap(toolRunsText.range(
             of: "func workspaceToolCallExecutor",
-            range: runToolCallStart.upperBound..<modelText.endIndex
+            range: runToolCallStart.upperBound..<toolRunsText.endIndex
         ))
-        let runToolCallBody = String(modelText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
+        let runToolCallBody = String(toolRunsText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
 
+        XCTAssertTrue(toolRunsText.contains("extension QuillCodeWorkspaceModel"), "Generic tool-run APIs should live in a focused model extension.")
+        XCTAssertFalse(modelText.contains("public func runToolCall"), "WorkspaceModel.swift should not own the generic tool-run API body.")
         XCTAssertTrue(preparerText.contains("enum WorkspaceToolRunPreparer"), "Tool-run context preparation should live in a focused helper.")
         XCTAssertTrue(preparerText.contains("static func effectiveProjectID"), "Effective tool-run project selection should be directly testable.")
         XCTAssertTrue(preparerText.contains("static func syncThreadContext"), "Tool-run thread context sync should be directly testable.")
         XCTAssertTrue(runToolCallBody.contains("WorkspaceToolRunPreparer.effectiveProjectID"), "WorkspaceModel should delegate tool-run project selection.")
-        XCTAssertTrue(runToolCallBody.contains("WorkspaceToolRunPreparer.syncThreadContext"), "WorkspaceModel should delegate tool-run thread context sync.")
+        XCTAssertTrue(runToolCallBody.contains("syncSelectedThreadContextForToolRun"), "runToolCall should delegate selected-thread context sync to a named helper.")
+        XCTAssertTrue(toolRunsText.contains("WorkspaceToolRunPreparer.syncThreadContext"), "The tool-run extension should delegate tool-run thread context sync.")
         XCTAssertFalse(runToolCallBody.contains("workspaceThreadContext("), "runToolCall should not rebuild thread context inline.")
         XCTAssertFalse(runToolCallBody.contains("thread.instructions ="), "runToolCall should not assign instruction snapshots inline.")
         XCTAssertFalse(runToolCallBody.contains("thread.memories ="), "runToolCall should not assign memory snapshots inline.")
     }
 
     func testWorkspaceModelDelegatesToolRunLifecyclePlanning() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let toolRunsText = try Self.appSourceText(named: "WorkspaceModelToolRuns.swift")
         let lifecycleText = try Self.appSourceText(named: "WorkspaceToolRunLifecyclePlanner.swift")
-        let runToolCallStart = try XCTUnwrap(modelText.range(of: "public func runToolCall"))
-        let runToolCallEnd = try XCTUnwrap(modelText.range(
+        let runToolCallStart = try XCTUnwrap(toolRunsText.range(of: "func runToolCall"))
+        let runToolCallEnd = try XCTUnwrap(toolRunsText.range(
             of: "func workspaceToolCallExecutor",
-            range: runToolCallStart.upperBound..<modelText.endIndex
+            range: runToolCallStart.upperBound..<toolRunsText.endIndex
         ))
-        let runToolCallBody = String(modelText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
+        let runToolCallBody = String(toolRunsText[runToolCallStart.lowerBound..<runToolCallEnd.lowerBound])
 
         XCTAssertTrue(lifecycleText.contains("enum WorkspaceToolRunLifecyclePlanner"), "Tool-run lifecycle status should live in a focused planner.")
         XCTAssertTrue(lifecycleText.contains("static func started"), "Tool-run start lifecycle should be directly testable.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -148,6 +148,30 @@ Remaining risk:
 
 - The next best central-model extraction is probably review/action APIs or local environment action APIs. Tool-run execution is still central by necessity, but its helper boundary is a candidate for a focused extension once review and local-action calls are outside the main file.
 
+## 2026-06-25 Workspace Tool-Run API Extension
+
+Overall grade after this slice: **A- tool-run API boundary, A executor/planner reuse, B+/A- central model size**.
+
+Manual and review-triggered tool runs are a shared workflow family: they make sure a thread exists, refresh project context, start visible agent status, route the tool through the shared workspace executor, record transcript events, persist the thread, and return the final tool result. Keeping that public API body in `WorkspaceModel.swift` made the central coordinator look like the owner of generic tool execution, even though project selection, lifecycle planning, routing, and transcript event construction already lived in focused helpers.
+
+What changed:
+
+- Added `WorkspaceModelToolRuns.swift` for `runToolCall`, selected-thread context sync, shared workspace executor construction, and tool-run event recording.
+- Kept effective project selection in `WorkspaceToolRunPreparer`, lifecycle status in `WorkspaceToolRunLifecyclePlanner`, routing in `WorkspaceToolCallExecutor`, and queued/completed transcript event construction in `WorkspaceToolEventRecorder`.
+- Left browser mutation, last-error mutation, selected-thread persistence, and top-bar refresh on the app actor where visible workspace state still lives.
+- Updated parity gates so generic tool-run APIs and executor construction are required to live in the focused extension and cannot drift back into `WorkspaceModel.swift`.
+
+Current strict grades:
+
+- `WorkspaceModelToolRuns.swift`: **A-**. Cohesive, short, and deliberately thin around already-tested helpers; remaining complexity is necessary app-actor coordination across selected thread, browser state, persistence, and top-bar status.
+- `WorkspaceToolCallExecutor.swift`: **A**. Centralized tool routing remains directly tested and reusable by manual, review, and future workflow calls.
+- `WorkspaceToolRunPreparer.swift`: **A**. Effective project selection and context sync stay pure enough for focused regression coverage.
+- `WorkspaceModel.swift`: **B+/A-**. It dropped another public workflow family, but still owns agent-send, local environment, memory, and shared persistence orchestration.
+
+Remaining risk:
+
+- The central model still coordinates too many public workflow surfaces. The next high-value extraction should target local environment action APIs or memory APIs, because both are cohesive enough to move without weakening actor-owned state safety.
+
 ## 2026-06-25 Agent Send Progress Planner Pass
 
 Overall grade after this slice: **A live-progress boundary, A async-thread safety, A regression coverage**.


### PR DESCRIPTION
## Summary
- move generic workspace tool-run execution into `WorkspaceModelToolRuns.swift`
- keep project preparation, lifecycle planning, routing, and transcript recording delegated to focused helpers
- update parity gates and code-quality audit so the boundary stays enforced

## Validation
- `swift test --filter 'WorkspaceToolCallExecutorTests|WorkspaceToolRunPreparerTests|WorkspaceToolRunLifecyclePlannerTests|WorkspaceToolCardIntegrationTests|WorkspaceComposerIntegrationTests|WorkspaceReviewIntegrationTests|ParityWorkspaceExecutionGateTests|ParityToolGateTests|ParityWorkspaceModelGateTests'`\n- `git diff --check`