### PR TITLE
Extract workspace composer APIs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -23,7 +23,7 @@ public final class QuillCodeWorkspaceModel {
     private let projectStore: JSONProjectStore?
     private let automationStore: JSONAutomationStore?
     let globalMemoryDirectory: URL?
-    private var computerUseBackend: (any ComputerUseBackend)?
+    var computerUseBackend: (any ComputerUseBackend)?
     let sshRemoteShellExecutor: SSHRemoteShellExecutor
     let mcpRuntime: WorkspaceMCPRuntime
 
@@ -142,17 +142,6 @@ public final class QuillCodeWorkspaceModel {
         root.projects.first { $0.id == id }
     }
 
-    public var canRetryLastUserTurn: Bool {
-        WorkspaceRetryPlanner.canRetryLastUserTurn(
-            in: selectedThread,
-            isSending: composer.isSending
-        )
-    }
-
-    public func setDraft(_ draft: String) {
-        composer.draft = draft
-    }
-
     @discardableResult
     public func setMessageFeedback(messageID: UUID, value: MessageFeedbackValue) -> Bool {
         guard selectedThread?.messages.contains(where: { $0.id == messageID && $0.role == .assistant }) == true else {
@@ -179,17 +168,6 @@ public final class QuillCodeWorkspaceModel {
         return true
     }
 
-    @discardableResult
-    public func prepareRetryLastUserTurn() -> Bool {
-        guard let draft = WorkspaceRetryPlanner.retryDraft(in: selectedThread) else {
-            return false
-        }
-        composer.draft = draft
-        lastError = nil
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-        return true
-    }
-
     public func toggleExtensions() {
         extensions.isVisible.toggle()
     }
@@ -213,114 +191,6 @@ public final class QuillCodeWorkspaceModel {
         } else {
             activity.collapsedSectionIDs.insert(section)
         }
-    }
-
-    public func submitComposer(workspaceRoot: URL) async {
-        let submissionPlan = WorkspaceComposerSubmissionPlanner.plan(draft: composer.draft)
-        let prompt: String
-        switch submissionPlan {
-        case .ignore:
-            return
-        case .slash(let command, let originalPrompt):
-            composer.draft = ""
-            lastError = nil
-            handleSlashCommand(command, originalPrompt: originalPrompt, workspaceRoot: workspaceRoot)
-            return
-        case .agent(let plannedPrompt):
-            prompt = plannedPrompt
-        }
-
-        guard let thread = prepareAgentSendThread() else { return }
-        let sendStart = WorkspaceAgentSendStartPlanner.started(
-            prompt: prompt,
-            thread: thread,
-            composer: composer
-        )
-        applyComposerSendLifecycle(sendStart.lifecycle)
-
-        let session = agentSendSessionFactory(workspaceRoot: workspaceRoot)
-            .makeSession(prompt: sendStart.prompt, thread: sendStart.thread)
-        let outcome = await WorkspaceAgentSendTaskCoordinator(
-            start: sendStart,
-            session: session
-        ).run { [weak self] progressThread in
-            await self?.applyAgentProgress(progressThread, expectedThreadID: sendStart.threadID)
-        }
-        finishAgentSend(outcome)
-    }
-
-    private func prepareAgentSendThread() -> ChatThread? {
-        if selectedThread == nil {
-            _ = newChat()
-        }
-        guard var thread = selectedThread else { return nil }
-        syncThreadContext(into: &thread)
-        return thread
-    }
-
-    private func agentSendSessionFactory(workspaceRoot: URL) -> WorkspaceAgentSendSessionFactory {
-        WorkspaceAgentSendSessionFactory(
-            baseRunner: runner,
-            selectedProject: selectedProject,
-            browser: browser,
-            browserToolOverride: WorkspaceBrowserAgentToolOverride.make { [weak self] call, workspaceRoot in
-                guard let self else { return nil }
-                return self.executeBrowserToolForAgent(call, workspaceRoot: workspaceRoot)
-            },
-            computerUseBackend: computerUseBackend,
-            globalMemoryDirectory: globalMemoryDirectory,
-            mcpToolDefinitions: mcpRuntime.toolDefinitions(
-                manifests: selectedProject?.extensionManifests ?? [],
-                extensions: extensions
-            ),
-            mcpToolExecutionOverride: mcpRuntime.executionOverride(extensions: extensions),
-            sshRemoteShellExecutor: sshRemoteShellExecutor,
-            workspaceRoot: workspaceRoot
-        )
-    }
-
-    private func finishCompletedSend(_ result: WorkspaceAgentSendSessionResult) throws {
-        let completion = WorkspaceAgentSendTerminalPlanner.completed(
-            result: result,
-            composer: composer
-        )
-        var thread = completion.thread
-        if completion.shouldRefreshMemoryContext {
-            refreshThreadMemoryContext(&thread)
-        }
-        updateThreadFromAgentRun(thread)
-        try threadPersistence.saveOrThrow(thread)
-        applyComposerSendLifecycle(completion.lifecycle)
-    }
-
-    private func finishAgentSend(_ outcome: WorkspaceAgentSendTaskOutcome) {
-        switch outcome {
-        case .completed(let result):
-            do {
-                try finishCompletedSend(result)
-            } catch {
-                finishFailedSend(error)
-            }
-        case .cancelled(let cancellation):
-            finishCancelledSend(
-                userPrompt: cancellation.userPrompt,
-                threadID: cancellation.threadID
-            )
-        case .failed(let error):
-            finishFailedSend(error)
-        }
-    }
-
-    private func applyAgentProgress(_ thread: ChatThread, expectedThreadID: UUID) {
-        guard let progress = WorkspaceAgentSendProgressPlanner.progress(
-            thread: thread,
-            expectedThreadID: expectedThreadID,
-            composer: composer
-        ) else { return }
-        updateThreadFromAgentRun(progress.thread)
-        composer = progress.composer
-        lastError = progress.lastError
-        refreshTopBar(agentStatus: progress.agentStatus)
     }
 
     func appendNotice(_ summary: String) {
@@ -350,112 +220,6 @@ public final class QuillCodeWorkspaceModel {
         return result.ok
     }
 
-    private func executeBrowserToolForAgent(_ call: ToolCall, workspaceRoot: URL) -> ToolResult? {
-        let result = WorkspaceBrowserToolExecutor.execute(
-            call,
-            workspaceRoot: workspaceRoot,
-            browser: &browser,
-            lastError: &lastError
-        )
-        refreshTopBar(agentStatus: root.topBar.agentStatus)
-        return result
-    }
-
-    private func handleSlashCommand(_ command: SlashCommand, originalPrompt: String, workspaceRoot: URL) {
-        let action = WorkspaceSlashCommandDispatchPlanner.action(
-            for: command,
-            userText: originalPrompt,
-            statusText: statusText()
-        )
-        runSlashCommandDispatchAction(action, workspaceRoot: workspaceRoot)
-        composer.isSending = false
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-    }
-
-    func runThreadFollowUpSlashCommand(_ scheduleText: String, originalPrompt: String) {
-        appendScheduledAutomationTranscript(
-            createThreadFollowUpAutomation(matching: scheduleText),
-            success: {
-                WorkspaceSlashCommandTranscriptPlanner.threadFollowUpScheduled(
-                    userText: originalPrompt,
-                    scheduleDescription: $0
-                )
-            },
-            failure: {
-                WorkspaceSlashCommandTranscriptPlanner.threadFollowUpFailed(
-                    userText: originalPrompt,
-                    message: $0
-                )
-            }
-        )
-    }
-
-    func runWorkspaceScheduleSlashCommand(_ scheduleText: String, originalPrompt: String) {
-        appendScheduledAutomationTranscript(
-            createWorkspaceScheduleAutomation(matching: scheduleText),
-            success: {
-                WorkspaceSlashCommandTranscriptPlanner.workspaceScheduleScheduled(
-                    userText: originalPrompt,
-                    scheduleDescription: $0
-                )
-            },
-            failure: {
-                WorkspaceSlashCommandTranscriptPlanner.workspaceScheduleFailed(
-                    userText: originalPrompt,
-                    message: $0
-                )
-            }
-        )
-    }
-
-    private func appendScheduledAutomationTranscript(
-        _ automation: QuillAutomation?,
-        success: (String) -> WorkspaceLocalCommandTranscript,
-        failure: (String?) -> WorkspaceLocalCommandTranscript
-    ) {
-        let transcript = automation
-            .map { success($0.scheduleDescription) }
-            ?? failure(lastError)
-        appendLocalCommandTranscript(transcript)
-    }
-
-    func appendLocalCommandTranscript(_ transcript: WorkspaceLocalCommandTranscript) {
-        if selectedThread == nil {
-            _ = newChat()
-        }
-        mutateSelectedThread { thread in
-            WorkspaceLocalCommandTranscriptAppender.append(transcript, to: &thread)
-        }
-    }
-
-    private func finishCancelledSend(userPrompt: String, threadID: UUID) {
-        let terminal = WorkspaceAgentSendTerminalPlanner.cancelled(composer: composer)
-        mutateThread(threadID) { thread in
-            WorkspaceComposerCancellationPlanner.applyCancelledSend(userPrompt: userPrompt, to: &thread)
-        }
-        applyComposerSendLifecycle(terminal.lifecycle)
-    }
-
-    private func finishFailedSend(_ error: any Error) {
-        let terminal = WorkspaceAgentSendTerminalPlanner.failed(error, composer: composer)
-        applyComposerSendLifecycle(terminal.lifecycle)
-    }
-
-    private func applyComposerSendLifecycle(_ plan: WorkspaceComposerSendLifecyclePlan) {
-        composer = plan.composer
-        lastError = plan.lastError
-        refreshTopBar(agentStatus: plan.agentStatus)
-    }
-
-    private func statusText() -> String {
-        WorkspaceStatusTextBuilder.statusText(for: WorkspaceStatusContextBuilder.context(
-            root: root,
-            selectedProject: selectedProject,
-            selectedThread: selectedThread,
-            fallbackThreadContext: workspaceThreadContext(root.selectedProjectID)
-        ))
-    }
-
     func mutateSelectedThread(_ update: (inout ChatThread) -> Void) {
         guard let selectedThreadID = root.selectedThreadID,
               let index = mutateThread(selectedThreadID, update)
@@ -481,13 +245,13 @@ public final class QuillCodeWorkspaceModel {
     }
 
     @discardableResult
-    private func mutateThread(_ id: UUID, _ update: (inout ChatThread) -> Void) -> Int? {
+    func mutateThread(_ id: UUID, _ update: (inout ChatThread) -> Void) -> Int? {
         guard let index = threadPersistence.mutate(id, threads: &root.threads, update: update) else { return nil }
         refreshTopBar(agentStatus: root.topBar.agentStatus)
         return index
     }
 
-    private func updateThreadFromAgentRun(_ thread: ChatThread) {
+    func updateThreadFromAgentRun(_ thread: ChatThread) {
         let result = WorkspaceThreadLifecycleEngine.applyAgentRunThreadUpdate(
             thread,
             threads: &root.threads,
@@ -569,17 +333,6 @@ public final class QuillCodeWorkspaceModel {
             lastError = error.localizedDescription
             return false
         }
-    }
-
-    private func syncThreadContext(into thread: inout ChatThread) {
-        let projectID = thread.projectID ?? root.selectedProjectID
-        refreshProjectMetadata(projectID)
-        WorkspaceProjectContextRefresher.syncThreadContext(
-            &thread,
-            fallbackProjectID: root.selectedProjectID,
-            projects: root.projects,
-            globalMemories: root.globalMemories
-        )
     }
 
     func knownProjectID(_ id: UUID?) -> UUID? {

--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -1,0 +1,255 @@
+import Foundation
+import QuillCodeAgent
+import QuillCodeCore
+
+@MainActor
+extension QuillCodeWorkspaceModel {
+    public var canRetryLastUserTurn: Bool {
+        WorkspaceRetryPlanner.canRetryLastUserTurn(
+            in: selectedThread,
+            isSending: composer.isSending
+        )
+    }
+
+    public func setDraft(_ draft: String) {
+        composer.draft = draft
+    }
+
+    @discardableResult
+    public func prepareRetryLastUserTurn() -> Bool {
+        guard let draft = WorkspaceRetryPlanner.retryDraft(in: selectedThread) else {
+            return false
+        }
+        composer.draft = draft
+        setLastError(nil)
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        return true
+    }
+
+    public func submitComposer(workspaceRoot: URL) async {
+        let submissionPlan = WorkspaceComposerSubmissionPlanner.plan(draft: composer.draft)
+        let prompt: String
+        switch submissionPlan {
+        case .ignore:
+            return
+        case .slash(let command, let originalPrompt):
+            composer.draft = ""
+            setLastError(nil)
+            handleSlashCommand(command, originalPrompt: originalPrompt, workspaceRoot: workspaceRoot)
+            return
+        case .agent(let plannedPrompt):
+            prompt = plannedPrompt
+        }
+
+        guard let thread = prepareAgentSendThread() else { return }
+        let sendStart = WorkspaceAgentSendStartPlanner.started(
+            prompt: prompt,
+            thread: thread,
+            composer: composer
+        )
+        applyComposerSendLifecycle(sendStart.lifecycle)
+
+        let session = agentSendSessionFactory(workspaceRoot: workspaceRoot)
+            .makeSession(prompt: sendStart.prompt, thread: sendStart.thread)
+        let outcome = await WorkspaceAgentSendTaskCoordinator(
+            start: sendStart,
+            session: session
+        ).run { [weak self] progressThread in
+            await self?.applyAgentProgress(progressThread, expectedThreadID: sendStart.threadID)
+        }
+        finishAgentSend(outcome)
+    }
+
+    private func prepareAgentSendThread() -> ChatThread? {
+        if selectedThread == nil {
+            _ = newChat()
+        }
+        guard var thread = selectedThread else { return nil }
+        syncThreadContext(into: &thread)
+        return thread
+    }
+
+    private func agentSendSessionFactory(workspaceRoot: URL) -> WorkspaceAgentSendSessionFactory {
+        WorkspaceAgentSendSessionFactory(
+            baseRunner: runner,
+            selectedProject: selectedProject,
+            browser: browser,
+            browserToolOverride: WorkspaceBrowserAgentToolOverride.make { [weak self] call, workspaceRoot in
+                guard let self else { return nil }
+                return self.executeBrowserToolForAgent(call, workspaceRoot: workspaceRoot)
+            },
+            computerUseBackend: computerUseBackend,
+            globalMemoryDirectory: globalMemoryDirectory,
+            mcpToolDefinitions: mcpRuntime.toolDefinitions(
+                manifests: selectedProject?.extensionManifests ?? [],
+                extensions: extensions
+            ),
+            mcpToolExecutionOverride: mcpRuntime.executionOverride(extensions: extensions),
+            sshRemoteShellExecutor: sshRemoteShellExecutor,
+            workspaceRoot: workspaceRoot
+        )
+    }
+
+    private func finishCompletedSend(_ result: WorkspaceAgentSendSessionResult) throws {
+        let completion = WorkspaceAgentSendTerminalPlanner.completed(
+            result: result,
+            composer: composer
+        )
+        var thread = completion.thread
+        if completion.shouldRefreshMemoryContext {
+            refreshThreadMemoryContext(&thread)
+        }
+        updateThreadFromAgentRun(thread)
+        try threadPersistence.saveOrThrow(thread)
+        applyComposerSendLifecycle(completion.lifecycle)
+    }
+
+    private func finishAgentSend(_ outcome: WorkspaceAgentSendTaskOutcome) {
+        switch outcome {
+        case .completed(let result):
+            do {
+                try finishCompletedSend(result)
+            } catch {
+                finishFailedSend(error)
+            }
+        case .cancelled(let cancellation):
+            finishCancelledSend(
+                userPrompt: cancellation.userPrompt,
+                threadID: cancellation.threadID
+            )
+        case .failed(let error):
+            finishFailedSend(error)
+        }
+    }
+
+    private func applyAgentProgress(_ thread: ChatThread, expectedThreadID: UUID) {
+        guard let progress = WorkspaceAgentSendProgressPlanner.progress(
+            thread: thread,
+            expectedThreadID: expectedThreadID,
+            composer: composer
+        ) else { return }
+        updateThreadFromAgentRun(progress.thread)
+        composer = progress.composer
+        setLastError(progress.lastError)
+        refreshTopBar(agentStatus: progress.agentStatus)
+    }
+
+    private func executeBrowserToolForAgent(_ call: ToolCall, workspaceRoot: URL) -> ToolResult? {
+        let result = mutateBrowserState { browser, lastError in
+            WorkspaceBrowserToolExecutor.execute(
+                call,
+                workspaceRoot: workspaceRoot,
+                browser: &browser,
+                lastError: &lastError
+            )
+        }
+        refreshTopBar(agentStatus: root.topBar.agentStatus)
+        return result
+    }
+
+    private func handleSlashCommand(_ command: SlashCommand, originalPrompt: String, workspaceRoot: URL) {
+        let action = WorkspaceSlashCommandDispatchPlanner.action(
+            for: command,
+            userText: originalPrompt,
+            statusText: statusText()
+        )
+        runSlashCommandDispatchAction(action, workspaceRoot: workspaceRoot)
+        composer.isSending = false
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+    }
+
+    func runThreadFollowUpSlashCommand(_ scheduleText: String, originalPrompt: String) {
+        appendScheduledAutomationTranscript(
+            createThreadFollowUpAutomation(matching: scheduleText),
+            success: {
+                WorkspaceSlashCommandTranscriptPlanner.threadFollowUpScheduled(
+                    userText: originalPrompt,
+                    scheduleDescription: $0
+                )
+            },
+            failure: {
+                WorkspaceSlashCommandTranscriptPlanner.threadFollowUpFailed(
+                    userText: originalPrompt,
+                    message: $0
+                )
+            }
+        )
+    }
+
+    func runWorkspaceScheduleSlashCommand(_ scheduleText: String, originalPrompt: String) {
+        appendScheduledAutomationTranscript(
+            createWorkspaceScheduleAutomation(matching: scheduleText),
+            success: {
+                WorkspaceSlashCommandTranscriptPlanner.workspaceScheduleScheduled(
+                    userText: originalPrompt,
+                    scheduleDescription: $0
+                )
+            },
+            failure: {
+                WorkspaceSlashCommandTranscriptPlanner.workspaceScheduleFailed(
+                    userText: originalPrompt,
+                    message: $0
+                )
+            }
+        )
+    }
+
+    private func appendScheduledAutomationTranscript(
+        _ automation: QuillAutomation?,
+        success: (String) -> WorkspaceLocalCommandTranscript,
+        failure: (String?) -> WorkspaceLocalCommandTranscript
+    ) {
+        let transcript = automation
+            .map { success($0.scheduleDescription) }
+            ?? failure(lastError)
+        appendLocalCommandTranscript(transcript)
+    }
+
+    func appendLocalCommandTranscript(_ transcript: WorkspaceLocalCommandTranscript) {
+        if selectedThread == nil {
+            _ = newChat()
+        }
+        mutateSelectedThread { thread in
+            WorkspaceLocalCommandTranscriptAppender.append(transcript, to: &thread)
+        }
+    }
+
+    private func finishCancelledSend(userPrompt: String, threadID: UUID) {
+        let terminal = WorkspaceAgentSendTerminalPlanner.cancelled(composer: composer)
+        mutateThread(threadID) { thread in
+            WorkspaceComposerCancellationPlanner.applyCancelledSend(userPrompt: userPrompt, to: &thread)
+        }
+        applyComposerSendLifecycle(terminal.lifecycle)
+    }
+
+    private func finishFailedSend(_ error: any Error) {
+        let terminal = WorkspaceAgentSendTerminalPlanner.failed(error, composer: composer)
+        applyComposerSendLifecycle(terminal.lifecycle)
+    }
+
+    private func applyComposerSendLifecycle(_ plan: WorkspaceComposerSendLifecyclePlan) {
+        composer = plan.composer
+        setLastError(plan.lastError)
+        refreshTopBar(agentStatus: plan.agentStatus)
+    }
+
+    private func statusText() -> String {
+        WorkspaceStatusTextBuilder.statusText(for: WorkspaceStatusContextBuilder.context(
+            root: root,
+            selectedProject: selectedProject,
+            selectedThread: selectedThread,
+            fallbackThreadContext: workspaceThreadContext(root.selectedProjectID)
+        ))
+    }
+
+    private func syncThreadContext(into thread: inout ChatThread) {
+        let projectID = thread.projectID ?? root.selectedProjectID
+        refreshProjectMetadata(projectID)
+        WorkspaceProjectContextRefresher.syncThreadContext(
+            &thread,
+            fallbackProjectID: root.selectedProjectID,
+            projects: root.projects,
+            globalMemories: root.globalMemories
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -3,18 +3,21 @@ import XCTest
 final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesComposerCancellationPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceComposerCancellationPlanner.swift")
 
         XCTAssertTrue(plannerText.contains("struct WorkspaceComposerCancellationPlanner"), "Composer cancellation mutation should live in a focused planner.")
         XCTAssertTrue(plannerText.contains("static func applyCancelledSend"), "Cancelled-send thread mutation should be directly testable.")
         XCTAssertTrue(plannerText.contains("static let stoppedSummary"), "Cancelled-send copy should be shared through the planner.")
-        XCTAssertTrue(modelText.contains("WorkspaceComposerCancellationPlanner.applyCancelledSend"), "WorkspaceModel should delegate cancelled-send transcript mutation.")
+        XCTAssertTrue(composerText.contains("WorkspaceComposerCancellationPlanner.applyCancelledSend"), "WorkspaceModel composer APIs should delegate cancelled-send transcript mutation.")
+        XCTAssertFalse(modelText.contains("WorkspaceComposerCancellationPlanner.applyCancelledSend"), "WorkspaceModel.swift should not own cancelled-send transcript mutation.")
         XCTAssertFalse(modelText.contains(#""Stopped by user""#), "WorkspaceModel should not own cancelled-send copy.")
         XCTAssertFalse(modelText.contains(#"{"ok":false,"error":"Stopped by user"}"#), "WorkspaceModel should not own cancelled-send result payload copy.")
     }
 
     func testWorkspaceModelDelegatesComposerSubmissionPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceComposerSubmissionPlanner.swift")
 
         XCTAssertTrue(
@@ -22,21 +25,23 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
             "Composer submission planning should live in a focused pure planner."
         )
         XCTAssertTrue(
-            modelText.contains("WorkspaceComposerSubmissionPlanner.plan"),
-            "WorkspaceModel should delegate prompt trimming and slash-command classification."
+            composerText.contains("WorkspaceComposerSubmissionPlanner.plan"),
+            "WorkspaceModel composer APIs should delegate prompt trimming and slash-command classification."
         )
         XCTAssertFalse(
-            modelText.contains("composer.draft.trimmingCharacters"),
-            "WorkspaceModel should not own raw composer prompt normalization."
+            composerText.contains("composer.draft.trimmingCharacters"),
+            "WorkspaceModel composer APIs should not own raw composer prompt normalization."
         )
         XCTAssertFalse(
-            modelText.contains("SlashCommandParser.parse(prompt)"),
+            composerText.contains("SlashCommandParser.parse(prompt)"),
             "WorkspaceModel should not classify slash commands inline."
         )
+        XCTAssertFalse(modelText.contains("public func submitComposer"), "WorkspaceModel.swift should not own composer submission APIs.")
     }
 
     func testWorkspaceModelDelegatesAgentSendSessionExecution() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
         let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
         let coordinatorText = try Self.appSourceText(named: "WorkspaceAgentSendTaskCoordinator.swift")
@@ -83,15 +88,15 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
             "Focused coordinator tests should cover runtime failure classification."
         )
         XCTAssertTrue(
-            modelText.contains("WorkspaceAgentSendSessionFactory("),
-            "WorkspaceModel should delegate runner execution setup to the send-session factory."
+            composerText.contains("WorkspaceAgentSendSessionFactory("),
+            "WorkspaceModel composer APIs should delegate runner execution setup to the send-session factory."
         )
         XCTAssertTrue(
-            modelText.contains("WorkspaceAgentSendTaskCoordinator("),
-            "WorkspaceModel should delegate active send task execution to the focused coordinator."
+            composerText.contains("WorkspaceAgentSendTaskCoordinator("),
+            "WorkspaceModel composer APIs should delegate active send task execution to the focused coordinator."
         )
         XCTAssertFalse(
-            modelText.contains("WorkspaceAgentSendSession("),
+            composerText.contains("WorkspaceAgentSendSession("),
             "WorkspaceModel should not construct agent send sessions inline."
         )
         XCTAssertFalse(
@@ -105,11 +110,11 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
     }
 
     func testWorkspaceModelDelegatesAgentSendStartPlanning() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceAgentSendStartPlanner.swift")
-        let submitStart = try XCTUnwrap(modelText.range(of: "public func submitComposer"))
-        let submitEnd = try XCTUnwrap(modelText.range(of: "private func prepareAgentSendThread"))
-        let submitBody = String(modelText[submitStart.lowerBound..<submitEnd.lowerBound])
+        let submitStart = try XCTUnwrap(composerText.range(of: "public func submitComposer"))
+        let submitEnd = try XCTUnwrap(composerText.range(of: "private func prepareAgentSendThread"))
+        let submitBody = String(composerText[submitStart.lowerBound..<submitEnd.lowerBound])
 
         XCTAssertTrue(
             plannerText.contains("struct WorkspaceAgentSendStartPlan"),
@@ -130,12 +135,12 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
     }
 
     func testWorkspaceModelDelegatesAgentSendThreadPreparation() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
-        let submitStart = try XCTUnwrap(modelText.range(of: "public func submitComposer"))
-        let prepareStart = try XCTUnwrap(modelText.range(of: "private func prepareAgentSendThread"))
-        let prepareEnd = try XCTUnwrap(modelText.range(of: "private func agentSendSessionFactory"))
-        let submitBody = String(modelText[submitStart.lowerBound..<prepareStart.lowerBound])
-        let prepareBody = String(modelText[prepareStart.lowerBound..<prepareEnd.lowerBound])
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
+        let submitStart = try XCTUnwrap(composerText.range(of: "public func submitComposer"))
+        let prepareStart = try XCTUnwrap(composerText.range(of: "private func prepareAgentSendThread"))
+        let prepareEnd = try XCTUnwrap(composerText.range(of: "private func agentSendSessionFactory"))
+        let submitBody = String(composerText[submitStart.lowerBound..<prepareStart.lowerBound])
+        let prepareBody = String(composerText[prepareStart.lowerBound..<prepareEnd.lowerBound])
 
         XCTAssertTrue(
             submitBody.contains("prepareAgentSendThread()"),
@@ -161,10 +166,11 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesAgentSendProgressPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceAgentSendProgressPlanner.swift")
-        let progressStart = try XCTUnwrap(modelText.range(of: "private func applyAgentProgress"))
-        let progressEnd = try XCTUnwrap(modelText.range(of: "func appendNotice"))
-        let progressBody = String(modelText[progressStart.lowerBound..<progressEnd.lowerBound])
+        let progressStart = try XCTUnwrap(composerText.range(of: "private func applyAgentProgress"))
+        let progressEnd = try XCTUnwrap(composerText.range(of: "private func executeBrowserToolForAgent"))
+        let progressBody = String(composerText[progressStart.lowerBound..<progressEnd.lowerBound])
 
         XCTAssertTrue(
             plannerText.contains("struct WorkspaceAgentSendProgressPlan"),
@@ -190,14 +196,15 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
             progressBody.contains("lastError = nil"),
             "WorkspaceModel should not clear progress errors inline."
         )
+        XCTAssertFalse(modelText.contains("private func applyAgentProgress"), "WorkspaceModel.swift should not own agent-send progress APIs.")
     }
 
     func testWorkspaceModelDelegatesAgentSendTerminalPlanning() throws {
-        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceAgentSendTerminalPlanner.swift")
-        let submitStart = try XCTUnwrap(modelText.range(of: "public func submitComposer"))
-        let submitEnd = try XCTUnwrap(modelText.range(of: "private func prepareAgentSendThread"))
-        let submitBody = String(modelText[submitStart.lowerBound..<submitEnd.lowerBound])
+        let submitStart = try XCTUnwrap(composerText.range(of: "public func submitComposer"))
+        let submitEnd = try XCTUnwrap(composerText.range(of: "private func prepareAgentSendThread"))
+        let submitBody = String(composerText[submitStart.lowerBound..<submitEnd.lowerBound])
 
         XCTAssertTrue(
             plannerText.contains("struct WorkspaceAgentSendCompletionPlan"),
@@ -208,27 +215,27 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
             "Agent send terminal planning should live in a focused planner."
         )
         XCTAssertTrue(
-            modelText.contains("private func finishCompletedSend"),
-            "WorkspaceModel should route successful send completion through a named helper."
+            composerText.contains("private func finishCompletedSend"),
+            "WorkspaceModel composer APIs should route successful send completion through a named helper."
         )
         XCTAssertTrue(
-            modelText.contains("private func finishFailedSend"),
-            "WorkspaceModel should route failed send completion through a named helper."
+            composerText.contains("private func finishFailedSend"),
+            "WorkspaceModel composer APIs should route failed send completion through a named helper."
         )
         XCTAssertTrue(
-            modelText.contains("private func finishAgentSend"),
-            "WorkspaceModel should route typed send outcomes through a named terminal helper."
+            composerText.contains("private func finishAgentSend"),
+            "WorkspaceModel composer APIs should route typed send outcomes through a named terminal helper."
         )
         XCTAssertTrue(
             submitBody.contains("finishAgentSend(outcome)"),
             "submitComposer should delegate typed send outcome handling."
         )
         XCTAssertTrue(
-            modelText.contains("try finishCompletedSend(result)"),
+            composerText.contains("try finishCompletedSend(result)"),
             "The terminal helper should delegate successful send completion."
         )
         XCTAssertTrue(
-            modelText.contains("finishFailedSend(error)"),
+            composerText.contains("finishFailedSend(error)"),
             "The terminal helper should delegate failed send completion."
         )
         XCTAssertFalse(
@@ -263,6 +270,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesSlashCommandTranscriptPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let actionExecutorText = try Self.appSourceText(named: "WorkspaceSlashCommandActionExecutor.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceSlashCommandTranscriptPlanner.swift")
         let appenderText = try Self.appSourceText(named: "WorkspaceLocalCommandTranscriptAppender.swift")
@@ -282,12 +290,13 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(dispatchPlannerText.contains("WorkspaceSlashCommandTranscriptPlanner.unknown"), "Unknown-command transcripts should be selected by slash dispatch planning.")
         XCTAssertTrue(appenderText.contains("thread.messages.append(ChatMessage(role: .user"), "The transcript appender should own user-message insertion.")
         XCTAssertTrue(appenderText.contains("thread.messages.append(ChatMessage(role: .assistant"), "The transcript appender should own assistant-message insertion.")
-        XCTAssertTrue(modelText.contains("WorkspaceLocalCommandTranscriptAppender.append"), "WorkspaceModel should delegate local command transcript mutation.")
+        XCTAssertTrue(composerText.contains("WorkspaceLocalCommandTranscriptAppender.append"), "WorkspaceModel composer APIs should delegate local command transcript mutation.")
         XCTAssertTrue(localEnvironmentModelText.contains("public func runLocalEnvironmentAction"), "Local environment action execution should live in the focused WorkspaceModelLocalEnvironment extension.")
         XCTAssertTrue(localEnvironmentModelText.contains("func runEnvironmentSlashCommand"), "Local environment slash command dispatch should live in the focused WorkspaceModelLocalEnvironment extension.")
         XCTAssertTrue(localEnvironmentModelText.contains("WorkspaceEnvironmentSlashCommandPlanner.plan"), "WorkspaceModelLocalEnvironment should delegate /env list/run/not-found planning.")
         XCTAssertFalse(modelText.contains("public func runLocalEnvironmentAction"), "WorkspaceModel.swift should not own local environment action execution.")
         XCTAssertFalse(modelText.contains("func runEnvironmentSlashCommand"), "WorkspaceModel.swift should not own local environment slash command dispatch.")
+        XCTAssertFalse(modelText.contains("WorkspaceLocalCommandTranscriptAppender.append"), "WorkspaceModel.swift should not own local command transcript mutation.")
         XCTAssertFalse(modelText.contains("WorkspaceEnvironmentSlashCommandPlanner.plan"), "WorkspaceModel.swift should not directly choose /env list/run/not-found planning.")
         XCTAssertTrue(plannerText.contains("static func sshProjectAdded"), "SSH success copy should be directly testable.")
         XCTAssertTrue(plannerText.contains("static func workspaceCommandFailed"), "Slash command failure copy should be directly testable.")
@@ -307,7 +316,8 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
             "WorkspaceSlashCommandTranscriptPlanner.threadFollowUpScheduled",
             "WorkspaceSlashCommandTranscriptPlanner.workspaceScheduleScheduled"
         ] {
-            XCTAssertTrue(modelText.contains(modelOwnedScheduledCall), "WorkspaceModel should keep schedule transcript delegation beside schedule persistence.")
+            XCTAssertTrue(composerText.contains(modelOwnedScheduledCall), "WorkspaceModel composer APIs should keep schedule transcript delegation beside schedule persistence.")
+            XCTAssertFalse(modelText.contains(modelOwnedScheduledCall), "WorkspaceModel.swift should not own schedule transcript delegation.")
         }
         for dispatchOwnedCall in [
             "WorkspaceSlashCommandTranscriptPlanner.help",
@@ -377,12 +387,13 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesAgentRunContextAssembly() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceAgentRunContextBuilder.swift")
         let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
         let memoryExecutorText = try Self.appSourceText(named: "WorkspaceMemoryRememberToolExecutor.swift")
 
         XCTAssertTrue(factoryText.contains("WorkspaceAgentRunContextBuilder("), "The send-session factory should delegate per-run tool assembly.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel should delegate per-run session assembly.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel composer APIs should delegate per-run session assembly.")
         XCTAssertTrue(builderText.contains("configuredRunner(from runner: AgentRunner)"), "Agent run context builder should own runner configuration.")
         XCTAssertTrue(builderText.contains("ToolDefinition.planUpdate"), "Agent run context builder should attach the plan tool.")
         XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect"), "Agent run context builder should attach the browser tool.")
@@ -401,6 +412,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesAgentSendSession() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let factoryText = try Self.appSourceText(named: "WorkspaceAgentSendSessionFactory.swift")
         let sessionText = try Self.appSourceText(named: "WorkspaceAgentSendSession.swift")
 
@@ -409,7 +421,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(sessionText.contains("runner.send("), "The session should own the runner send call.")
         XCTAssertTrue(sessionText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory"), "The session should report whether the run saved memory.")
         XCTAssertTrue(factoryText.contains("WorkspaceAgentSendSession("), "The factory should own agent send session construction.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel should delegate agent send execution setup.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendSessionFactory("), "WorkspaceModel composer APIs should delegate agent send execution setup.")
         XCTAssertFalse(modelText.contains("WorkspaceAgentSendSession("), "WorkspaceModel should not construct agent send sessions inline.")
         XCTAssertFalse(modelText.contains("activeRunner.send("), "WorkspaceModel should not own the low-level send call.")
         XCTAssertFalse(modelText.contains("WorkspaceMemoryRememberToolExecutor.didSaveMemory(in: thread)"), "WorkspaceModel should not inspect memory events after each send.")
@@ -575,6 +587,7 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesSlashCommandDispatchPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let plannerText = try Self.appSourceText(named: "WorkspaceSlashCommandDispatchPlanner.swift")
         let actionExecutorText = try Self.appSourceText(named: "WorkspaceSlashCommandActionExecutor.swift")
         let plannerTests = try Self.appTestSourceText(named: "WorkspaceSlashCommandDispatchPlannerTests.swift")
@@ -587,9 +600,10 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(actionExecutorText.contains("extension QuillCodeWorkspaceModel"), "Slash action execution should live in a focused model extension.")
         XCTAssertTrue(actionExecutorText.contains("func runSlashCommandDispatchAction"), "Typed slash action application should live outside the main model file.")
         XCTAssertTrue(actionExecutorText.contains("switch action"), "The slash action executor should own the typed action switch.")
-        XCTAssertTrue(modelText.contains("WorkspaceSlashCommandDispatchPlanner.action("), "WorkspaceModel should consume the slash dispatch planner.")
-        XCTAssertTrue(modelText.contains("runSlashCommandDispatchAction(action, workspaceRoot: workspaceRoot)"), "WorkspaceModel should delegate typed slash action application.")
+        XCTAssertTrue(composerText.contains("WorkspaceSlashCommandDispatchPlanner.action("), "WorkspaceModel composer APIs should consume the slash dispatch planner.")
+        XCTAssertTrue(composerText.contains("runSlashCommandDispatchAction(action, workspaceRoot: workspaceRoot)"), "WorkspaceModel composer APIs should delegate typed slash action application.")
         XCTAssertTrue(plannerTests.contains("testExternalCommandFamiliesMapToTypedActions"), "Slash dispatch families should have focused planner coverage.")
+        XCTAssertFalse(modelText.contains("WorkspaceSlashCommandDispatchPlanner.action("), "WorkspaceModel.swift should not own slash dispatch planning.")
         XCTAssertFalse(modelText.contains("switch command {\n        case .help:"), "WorkspaceModel should not switch directly over parsed slash commands.")
         XCTAssertFalse(modelText.contains("switch action {"), "WorkspaceModel should not own typed slash action application.")
         XCTAssertFalse(modelText.contains("case .appendTranscript"), "WorkspaceModel should not own typed slash transcript actions.")

--- a/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
@@ -36,6 +36,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesUIStateContracts() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let stateText = try Self.appSourceText(named: "WorkspaceUIState.swift")
         let sendLifecycleText = try Self.appSourceText(named: "WorkspaceComposerSendLifecycle.swift")
         let sendStartText = try Self.appSourceText(named: "WorkspaceAgentSendStartPlanner.swift")
@@ -48,14 +49,14 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(sendLifecycleText.contains("enum WorkspaceComposerSendLifecycle"), "Composer send lifecycle transitions should live in a focused helper.")
         XCTAssertTrue(sendStartText.contains("WorkspaceComposerSendLifecycle.started"), "Agent send start should choose started lifecycle through the start planner.")
         XCTAssertTrue(sendProgressText.contains("WorkspaceAgentStatusBuilder.status"), "Agent send progress should choose progress status through the progress planner.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendStartPlanner.started"), "WorkspaceModel should delegate composer send start transitions.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendProgressPlanner.progress"), "WorkspaceModel should delegate composer send progress transitions.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendStartPlanner.started"), "WorkspaceModel composer APIs should delegate composer send start transitions.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendProgressPlanner.progress"), "WorkspaceModel composer APIs should delegate composer send progress transitions.")
         XCTAssertTrue(sendTerminalText.contains("WorkspaceComposerSendLifecycle.completed"), "Successful send completion should choose completed lifecycle through the terminal planner.")
         XCTAssertTrue(sendTerminalText.contains("WorkspaceComposerSendLifecycle.cancelled"), "Cancelled send completion should choose cancelled lifecycle through the terminal planner.")
         XCTAssertTrue(sendTerminalText.contains("WorkspaceComposerSendLifecycle.failed"), "Failed send completion should choose failed lifecycle through the terminal planner.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendTerminalPlanner.completed"), "WorkspaceModel should delegate composer send completion transitions.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendTerminalPlanner.cancelled"), "WorkspaceModel should delegate composer send cancellation transitions.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendTerminalPlanner.failed"), "WorkspaceModel should delegate composer send failure transitions.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendTerminalPlanner.completed"), "WorkspaceModel composer APIs should delegate composer send completion transitions.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendTerminalPlanner.cancelled"), "WorkspaceModel composer APIs should delegate composer send cancellation transitions.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendTerminalPlanner.failed"), "WorkspaceModel composer APIs should delegate composer send failure transitions.")
         XCTAssertTrue(modelText.contains("public internal(set) var composer: ComposerState"), "WorkspaceModel should own live composer state while focused same-module extensions may apply state transitions.")
         XCTAssertFalse(modelText.contains("public struct ComposerState"), "WorkspaceModel should not define composer UI state contracts.")
         XCTAssertFalse(modelText.contains("public struct MemoriesState"), "WorkspaceModel should not define memory-pane UI state contracts.")
@@ -133,6 +134,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesProjectContextRefresh() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let threadExtensionText = try Self.appSourceText(named: "WorkspaceModelThreads.swift")
         let worktreeExtensionText = try Self.appSourceText(named: "WorkspaceModelWorktrees.swift")
         let refresherText = try Self.appSourceText(named: "WorkspaceProjectContextRefresher.swift")
@@ -147,9 +149,10 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(refresherText.contains("static func globalMemories"), "Global memory loading should be directly testable.")
         XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshLocalProjectMetadata"), "WorkspaceModel should delegate local project metadata refresh.")
         XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.refreshRemoteProjectContext"), "WorkspaceModel should delegate remote project metadata refresh.")
-        XCTAssertTrue(modelText.contains("WorkspaceProjectContextRefresher.syncThreadContext"), "WorkspaceModel should delegate thread context sync.")
+        XCTAssertTrue(composerText.contains("WorkspaceProjectContextRefresher.syncThreadContext"), "WorkspaceModel composer APIs should delegate thread context sync.")
         XCTAssertTrue(threadExtensionText.contains("WorkspaceProjectContextRefresher.threadCreationContext"), "WorkspaceModel thread APIs should delegate thread creation context assembly.")
         XCTAssertTrue(worktreeExtensionText.contains("WorkspaceProjectContextRefresher.worktreeOpenContext"), "WorkspaceModel worktree APIs should delegate worktree open context assembly.")
+        XCTAssertFalse(modelText.contains("WorkspaceProjectContextRefresher.syncThreadContext"), "WorkspaceModel.swift should not own agent-send thread context sync.")
         XCTAssertFalse(modelText.contains("WorkspaceProjectContextRefresher.worktreeOpenContext"), "WorkspaceModel.swift should not own worktree open context assembly.")
         XCTAssertFalse(modelText.contains("WorkspaceProjectMetadataLoader.loadLocal(from: rootURL)"), "WorkspaceModel should not own refresh-time local project metadata loading.")
         XCTAssertFalse(modelText.contains("WorkspaceProjectMetadataLoader.loadRemote"), "WorkspaceModel should not own remote project metadata loading.")
@@ -291,18 +294,20 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesRetryPlanning() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let retryPlannerText = try Self.appSourceText(named: "WorkspaceRetryPlanner.swift")
         let retryPlannerTests = try Self.appTestSourceText(named: "WorkspaceRetryPlannerTests.swift")
 
         XCTAssertTrue(retryPlannerText.contains("enum WorkspaceRetryPlanner"), "Retry planning should live in a focused helper.")
         XCTAssertTrue(retryPlannerText.contains("static func canRetryLastUserTurn"), "Retry availability should be directly testable.")
         XCTAssertTrue(retryPlannerText.contains("static func retryDraft"), "Retry draft selection should be directly testable.")
-        XCTAssertTrue(modelText.contains("WorkspaceRetryPlanner.canRetryLastUserTurn"), "WorkspaceModel should delegate retry availability.")
-        XCTAssertTrue(modelText.contains("WorkspaceRetryPlanner.retryDraft"), "WorkspaceModel should delegate retry draft selection.")
+        XCTAssertTrue(composerText.contains("WorkspaceRetryPlanner.canRetryLastUserTurn"), "WorkspaceModel composer APIs should delegate retry availability.")
+        XCTAssertTrue(composerText.contains("WorkspaceRetryPlanner.retryDraft"), "WorkspaceModel composer APIs should delegate retry draft selection.")
         XCTAssertTrue(retryPlannerTests.contains("testRetryDraftUsesLatestNonEmptyUserMessageAndPreservesOriginalText"), "Retry draft behavior should have focused coverage.")
         XCTAssertTrue(retryPlannerTests.contains("testRetryRequiresUserMessageAndIdleComposer"), "Retry availability should have focused coverage.")
         XCTAssertFalse(modelText.contains("messages.last(where:"), "WorkspaceModel should not scan transcript messages for retry drafts.")
         XCTAssertFalse(modelText.contains("messages.contains {"), "WorkspaceModel should not own retry availability scans.")
+        XCTAssertFalse(modelText.contains("WorkspaceRetryPlanner.canRetryLastUserTurn"), "WorkspaceModel.swift should not own retry availability APIs.")
     }
 
     func testWorkspaceActivityIntegrationTestsOwnModelActivityFlows() throws {
@@ -432,6 +437,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesStatusTextAndLabels() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceStatusTextBuilder.swift")
         let contextBuilderText = try Self.appSourceText(named: "WorkspaceStatusContextBuilder.swift")
@@ -447,8 +453,8 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(builderText.contains("static func instructionLabel"), "Instruction status labels should be directly testable.")
         XCTAssertTrue(builderText.contains("static func memoryLabel"), "Memory status labels should be directly testable.")
         XCTAssertTrue(builderText.contains("static func modeLabel"), "Mode labels should be shared by status and UI surfaces.")
-        XCTAssertTrue(modelText.contains("WorkspaceStatusTextBuilder.statusText"), "WorkspaceModel should delegate /status copy.")
-        XCTAssertTrue(modelText.contains("WorkspaceStatusContextBuilder.context"), "WorkspaceModel should delegate /status context assembly.")
+        XCTAssertTrue(composerText.contains("WorkspaceStatusTextBuilder.statusText"), "WorkspaceModel composer APIs should delegate /status copy.")
+        XCTAssertTrue(composerText.contains("WorkspaceStatusContextBuilder.context"), "WorkspaceModel composer APIs should delegate /status context assembly.")
         XCTAssertTrue(slashTranscriptText.contains("WorkspaceStatusTextBuilder.modeLabel"), "Slash mode transcript copy should delegate shared mode labels.")
         XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.topBarSubtitle"), "Top-bar builder should delegate top-bar subtitles.")
         XCTAssertTrue(topBarBuilderText.contains("WorkspaceStatusTextBuilder.instructionLabel"), "Top-bar builder should delegate instruction labels.")
@@ -457,6 +463,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(modelText.contains("WorkspaceTopBarStateBuilder.state"), "WorkspaceModel should delegate top-bar state assembly.")
         XCTAssertFalse(modelText.contains("root.topBar = TopBarState("), "WorkspaceModel should not assemble top-bar state inline.")
         XCTAssertFalse(modelText.contains("WorkspaceStatusContext("), "WorkspaceModel should not assemble /status context inline.")
+        XCTAssertFalse(modelText.contains("WorkspaceStatusTextBuilder.statusText"), "WorkspaceModel.swift should not own slash status text assembly.")
         XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.topBarSubtitle"), "WorkspaceSurface should not own top-bar subtitles.")
         XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.instructionLabel"), "WorkspaceSurface should not own instruction labels.")
         XCTAssertFalse(surfaceText.contains("WorkspaceStatusTextBuilder.memoryLabel"), "WorkspaceSurface should not own memory labels.")
@@ -498,6 +505,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelDelegatesAgentProgressStatusCopy() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
         let builderText = try Self.appSourceText(named: "WorkspaceAgentStatusBuilder.swift")
         let progressPlannerText = try Self.appSourceText(named: "WorkspaceAgentSendProgressPlanner.swift")
 
@@ -508,7 +516,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(progressPlannerText.contains("struct WorkspaceAgentSendProgressPlan"), "Live agent progress should have a typed plan.")
         XCTAssertTrue(progressPlannerText.contains("enum WorkspaceAgentSendProgressPlanner"), "Live agent progress planning should live in a focused planner.")
         XCTAssertTrue(progressPlannerText.contains("WorkspaceAgentStatusBuilder.status(for: thread)"), "Progress planning should delegate status copy to the focused status builder.")
-        XCTAssertTrue(modelText.contains("WorkspaceAgentSendProgressPlanner.progress"), "WorkspaceModel should delegate live send progress planning.")
+        XCTAssertTrue(composerText.contains("WorkspaceAgentSendProgressPlanner.progress"), "WorkspaceModel composer APIs should delegate live send progress planning.")
         XCTAssertFalse(modelText.contains("private func agentStatus"), "WorkspaceModel should not own agent progress status copy.")
         XCTAssertFalse(modelText.contains("WorkspaceAgentStatusBuilder.status(for: thread)"), "WorkspaceModel should not choose live progress status inline.")
         XCTAssertFalse(modelText.contains("case .toolQueued:"), "WorkspaceModel should not switch over progress event kinds for top-bar status.")
@@ -533,9 +541,10 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
 
     func testWorkspaceModelUsesExplicitAgentRunThreadUpdates() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let composerText = try Self.appSourceText(named: "WorkspaceModelComposer.swift")
 
-        XCTAssertTrue(modelText.contains("private func updateThreadFromAgentRun"), "Agent-run thread updates should use a named helper that documents focus preservation.")
-        XCTAssertTrue(modelText.contains("updateThreadFromAgentRun(thread)"), "Agent progress and completion should route through the explicit async-update helper.")
+        XCTAssertTrue(modelText.contains("func updateThreadFromAgentRun"), "Agent-run thread updates should use a named helper that documents focus preservation.")
+        XCTAssertTrue(composerText.contains("updateThreadFromAgentRun(thread)"), "Agent progress and completion should route through the explicit async-update helper.")
         XCTAssertFalse(modelText.contains("preservingSelection"), "WorkspaceModel should not hide async navigation behavior behind a boolean flag.")
         XCTAssertFalse(modelText.contains("replaceThread("), "WorkspaceModel should not route async run updates through an ambiguous generic replacement helper.")
     }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -48,6 +48,8 @@ The architecture is moving in the right direction: core state is value typed, pe
 
 ## Changes From This Pass
 
+- Extracted composer retry, submit, slash-dispatch, agent-send session construction, progress application, and terminal outcome handling from `WorkspaceModel.swift` into `WorkspaceModelComposer.swift`.
+- Added parity gates that require composer orchestration to stay in the focused extension while keeping send planning/session execution in their existing focused helpers.
 - Extracted mode/model/favorite/catalog/settings/runtime/status APIs from `WorkspaceModel.swift` into `WorkspaceModelConfiguration.swift`.
 - Added a configuration parity gate that requires configuration/runtime APIs to stay in the focused model extension while keeping normalization and settings policy in `WorkspaceConfigurationEngine`.
 - Extracted global memory save/delete, mutation application, global reload, and thread memory refresh from `WorkspaceModel.swift` into `WorkspaceModelMemory.swift`.
@@ -68,6 +70,24 @@ The architecture is moving in the right direction: core state is value typed, pe
 - Refactored model-category construction to compute favorite IDs once and pass a `Set` through option building instead of recomputing favorites for every model.
 - Updated the Playwright harness to preserve branded labels after model selection.
 - Fixed stale decisions documentation that still described recurring automation as deferred.
+
+## 2026-06-25 Workspace Composer API Extension
+
+Overall grade after this slice: **A- composer workflow ownership, A send-planner/session boundaries, A- central model size**.
+
+Composer submission is a cohesive workflow family: retry availability, draft mutation, slash-command dispatch, thread preparation, agent-send session construction, live progress application, cancellation, failure, and successful completion all coordinate the same visible send lifecycle. The detailed policies already lived in focused planners and session objects; the central model no longer needs to own the public API body.
+
+Code quality changes:
+
+- Added `WorkspaceModelComposer.swift` for retry/draft APIs, `submitComposer`, slash dispatch, agent-send thread preparation, send-session factory creation, progress application, terminal outcome handling, and agent-send thread context sync.
+- Kept prompt/slash classification in `WorkspaceComposerSubmissionPlanner`, send-start state in `WorkspaceAgentSendStartPlanner`, live progress state in `WorkspaceAgentSendProgressPlanner`, terminal lifecycle state in `WorkspaceAgentSendTerminalPlanner`, and async send execution in `WorkspaceAgentSendTaskCoordinator`.
+- Moved browser tool mutation for agent sends through `mutateBrowserState` so the composer extension does not need direct write access to `browser` or `lastError`.
+- Kept generic thread mutation and agent-run thread replacement as same-module helpers on the central model because they are shared actor-owned state primitives, not composer policy.
+- Strengthened parity gates so composer submission, slash dispatch consumption, schedule transcripts, session factory usage, and agent-send progress cannot drift back into `WorkspaceModel.swift`.
+
+Remaining risk:
+
+- `WorkspaceModel.swift` still owns message feedback, pane visibility, project-extension update orchestration, project-context refresh primitives, and persistence helpers. Those are smaller than the previous agent-send block, but the next pass should look for another cohesive ownership group rather than moving mixed utilities.
 
 ## 2026-06-25 Workspace Configuration API Extension
 


### PR DESCRIPTION
## Summary
- move composer retry/draft submission, slash dispatch, agent-send session construction, progress, and terminal outcome handling into `WorkspaceModelComposer`
- keep browser mutation and error updates behind existing actor-owned helpers
- retarget parity gates so composer orchestration cannot drift back into `WorkspaceModel.swift`
- document the code-quality pass in `docs/CODE_QUALITY_AUDIT.md`

## Validation
- `swift test --filter 'WorkspaceComposerIntegrationTests|WorkspaceAgentSendStartPlannerTests|WorkspaceAgentSendProgressPlannerTests|WorkspaceAgentSendTerminalPlannerTests|WorkspaceAgentSendSessionFactoryTests|WorkspaceAgentSendTaskCoordinatorTests|WorkspaceSlashCommandIntegrationTests|WorkspaceRetryPlannerTests|WorkspaceRuntimeIssueIntegrationTests|ParityWorkspaceExecutionGateTests|ParityWorkspaceModelGateTests'`\n- `swift test`\n- `git diff --check`