### PR TITLE
Route memory mutations through workflow

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceMemoryWorkflow.swift
+++ b/Sources/QuillCodeApp/WorkspaceMemoryWorkflow.swift
@@ -1,0 +1,102 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+struct WorkspaceMemoryWorkflowContext: Sendable {
+    var globalMemoryDirectory: URL?
+    var editableProject: ProjectRef?
+    var editableProjectRoot: URL?
+    var sshRemoteShellExecutor: SSHRemoteShellExecutor
+}
+
+enum WorkspaceMemoryWorkflow {
+    static func scope(for id: String) -> MemoryScope {
+        id.hasPrefix("\(MemoryScope.project.rawValue):") ? .project : .global
+    }
+
+    static func editableNote(
+        id: String,
+        globalMemories: [MemoryNote],
+        project: ProjectRef?
+    ) -> MemoryNote? {
+        switch scope(for: id) {
+        case .global:
+            return globalMemories.first { $0.id == id && $0.scope == .global }
+        case .project:
+            return project?.memories.first { $0.id == id && $0.scope == .project }
+        }
+    }
+
+    static func delete(
+        id: String,
+        context: WorkspaceMemoryWorkflowContext
+    ) -> WorkspaceMemoryMutation? {
+        switch scope(for: id) {
+        case .global:
+            return WorkspaceMemoryEngine.deleteGlobal(
+                id: id,
+                directory: context.globalMemoryDirectory
+            )
+        case .project:
+            return projectMutation(context: context) { project in
+                WorkspaceMemoryEngine.deleteRemoteProject(
+                    id: id,
+                    project: project,
+                    executor: context.sshRemoteShellExecutor
+                )
+            } local: {
+                WorkspaceMemoryEngine.deleteProject(
+                    id: id,
+                    projectRoot: context.editableProjectRoot
+                )
+            }
+        }
+    }
+
+    static func update(
+        id: String,
+        content: String,
+        userText: String,
+        context: WorkspaceMemoryWorkflowContext
+    ) -> WorkspaceMemoryMutation {
+        switch scope(for: id) {
+        case .global:
+            return WorkspaceMemoryEngine.updateGlobal(
+                id: id,
+                content: content,
+                userText: userText,
+                directory: context.globalMemoryDirectory
+            )
+        case .project:
+            return projectMutation(context: context) { project in
+                WorkspaceMemoryEngine.updateRemoteProject(
+                    id: id,
+                    content: content,
+                    userText: userText,
+                    project: project,
+                    executor: context.sshRemoteShellExecutor
+                )
+            } local: {
+                WorkspaceMemoryEngine.updateProject(
+                    id: id,
+                    content: content,
+                    userText: userText,
+                    projectRoot: context.editableProjectRoot
+                )
+            }
+        }
+    }
+
+    private static func projectMutation(
+        context: WorkspaceMemoryWorkflowContext,
+        remote: (ProjectRef) -> WorkspaceMemoryMutation,
+        local: () -> WorkspaceMemoryMutation
+    ) -> WorkspaceMemoryMutation {
+        guard context.editableProject?.isRemote == true,
+              let project = context.editableProject
+        else {
+            return local()
+        }
+        return remote(project)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModelMemory.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelMemory.swift
@@ -4,37 +4,19 @@ import QuillCodeCore
 extension QuillCodeWorkspaceModel {
     @discardableResult
     func deleteGlobalMemory(id: String) -> Bool {
-        guard let mutation = WorkspaceMemoryEngine.deleteGlobal(id: id, directory: globalMemoryDirectory) else {
-            return false
-        }
-        applyMemoryMutation(mutation)
-        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
-        return true
+        guard WorkspaceMemoryWorkflow.scope(for: id) == .global else { return false }
+        return deleteMemory(id: id)
     }
 
     @discardableResult
     func deleteMemory(id: String) -> Bool {
-        if id.hasPrefix("project:") {
-            let project = editableProjectMemory()
-            let mutation = if project?.isRemote == true {
-                WorkspaceMemoryEngine.deleteRemoteProject(
-                    id: id,
-                    project: project,
-                    executor: sshRemoteShellExecutor
-                )
-            } else {
-                WorkspaceMemoryEngine.deleteProject(
-                    id: id,
-                    projectRoot: editableProjectMemoryRoot()
-                )
-            }
-            applyProjectMemoryMutation(mutation)
-        } else {
-            guard let mutation = WorkspaceMemoryEngine.deleteGlobal(id: id, directory: globalMemoryDirectory) else {
-                return false
-            }
-            applyMemoryMutation(mutation)
+        guard let mutation = WorkspaceMemoryWorkflow.delete(
+            id: id,
+            context: memoryWorkflowContext()
+        ) else {
+            return false
         }
+        applyMemoryMutation(mutation, for: id)
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
         return true
     }
@@ -50,60 +32,33 @@ extension QuillCodeWorkspaceModel {
 
     @discardableResult
     func prepareEditMemory(id: String) -> Bool {
-        if let note = editableMemoryNote(id: id) {
+        if let note = WorkspaceMemoryWorkflow.editableNote(
+            id: id,
+            globalMemories: root.globalMemories,
+            project: editableProjectMemory()
+        ) {
             setDraft("/remember-edit \(note.id)\n\(note.content)")
             return true
         }
 
-        if id.hasPrefix("project:") {
-            let mutation = WorkspaceMemoryEngine.updateProject(
-                id: id,
-                content: "",
-                userText: "Edit memory",
-                projectRoot: editableProjectMemoryRoot()
-            )
-            applyProjectMemoryMutation(mutation)
-        } else {
-            let mutation = WorkspaceMemoryEngine.updateGlobal(
-                id: id,
-                content: "",
-                userText: "Edit memory",
-                directory: globalMemoryDirectory
-            )
-            applyMemoryMutation(mutation)
-        }
+        let mutation = WorkspaceMemoryWorkflow.update(
+            id: id,
+            content: "",
+            userText: "Edit memory",
+            context: memoryWorkflowContext()
+        )
+        applyMemoryMutation(mutation, for: id)
         return true
     }
 
     func runEditMemorySlashCommand(id: String, content: String, originalPrompt: String) {
-        if id.hasPrefix("project:") {
-            let project = editableProjectMemory()
-            let mutation = if project?.isRemote == true {
-                WorkspaceMemoryEngine.updateRemoteProject(
-                    id: id,
-                    content: content,
-                    userText: originalPrompt,
-                    project: project,
-                    executor: sshRemoteShellExecutor
-                )
-            } else {
-                WorkspaceMemoryEngine.updateProject(
-                    id: id,
-                    content: content,
-                    userText: originalPrompt,
-                    projectRoot: editableProjectMemoryRoot()
-                )
-            }
-            applyProjectMemoryMutation(mutation)
-        } else {
-            let mutation = WorkspaceMemoryEngine.updateGlobal(
-                id: id,
-                content: content,
-                userText: originalPrompt,
-                directory: globalMemoryDirectory
-            )
-            applyMemoryMutation(mutation)
-        }
+        let mutation = WorkspaceMemoryWorkflow.update(
+            id: id,
+            content: content,
+            userText: originalPrompt,
+            context: memoryWorkflowContext()
+        )
+        applyMemoryMutation(mutation, for: id)
     }
 
     func refreshGlobalMemories() {
@@ -147,11 +102,13 @@ extension QuillCodeWorkspaceModel {
         }
     }
 
-    private func editableMemoryNote(id: String) -> MemoryNote? {
-        if id.hasPrefix("project:") {
-            return editableProjectMemory()?.memories.first { $0.id == id && $0.scope == .project }
+    private func applyMemoryMutation(_ mutation: WorkspaceMemoryMutation, for id: String) {
+        switch WorkspaceMemoryWorkflow.scope(for: id) {
+        case .global:
+            applyMemoryMutation(mutation)
+        case .project:
+            applyProjectMemoryMutation(mutation)
         }
-        return root.globalMemories.first { $0.id == id && $0.scope == .global }
     }
 
     private func editableProjectMemory() -> ProjectRef? {
@@ -166,6 +123,15 @@ extension QuillCodeWorkspaceModel {
     private func editableProjectMemoryRoot() -> URL? {
         guard let project = editableProjectMemory(), !project.isRemote else { return nil }
         return URL(fileURLWithPath: project.path)
+    }
+
+    private func memoryWorkflowContext() -> WorkspaceMemoryWorkflowContext {
+        WorkspaceMemoryWorkflowContext(
+            globalMemoryDirectory: globalMemoryDirectory,
+            editableProject: editableProjectMemory(),
+            editableProjectRoot: editableProjectMemoryRoot(),
+            sshRemoteShellExecutor: sshRemoteShellExecutor
+        )
     }
 
     func refreshThreadMemoryContext(_ thread: inout ChatThread) {

--- a/Tests/QuillCodeAppTests/WorkspaceMemoryWorkflowTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceMemoryWorkflowTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeApp
+
+final class WorkspaceMemoryWorkflowTests: XCTestCase {
+    func testScopeAndEditableNoteRespectMemoryIDPrefix() {
+        let global = MemoryNote(
+            id: "global:preferences.md",
+            scope: .global,
+            title: "Preferences",
+            content: "Prefer concise answers.",
+            relativePath: "memories/preferences.md",
+            byteCount: 23
+        )
+        let project = MemoryNote(
+            id: "project:.quillcode/memories/project.md",
+            scope: .project,
+            title: "Project",
+            content: "Use SwiftUI.",
+            relativePath: ".quillcode/memories/project.md",
+            byteCount: 12
+        )
+        let projectRef = ProjectRef(name: "App", path: "/tmp/app", memories: [project])
+
+        XCTAssertEqual(WorkspaceMemoryWorkflow.scope(for: global.id), .global)
+        XCTAssertEqual(WorkspaceMemoryWorkflow.scope(for: project.id), .project)
+        XCTAssertEqual(
+            WorkspaceMemoryWorkflow.editableNote(id: global.id, globalMemories: [global], project: projectRef),
+            global
+        )
+        XCTAssertEqual(
+            WorkspaceMemoryWorkflow.editableNote(id: project.id, globalMemories: [global], project: projectRef),
+            project
+        )
+    }
+
+    func testDeleteRoutesGlobalMemoryThroughGlobalDirectory() throws {
+        let globalDirectory = try makeQuillCodeTestDirectory()
+        let note = try MemoryNoteLoader.saveGlobal(content: "Prefer small PRs.", to: globalDirectory)
+        let context = WorkspaceMemoryWorkflowContext(
+            globalMemoryDirectory: globalDirectory,
+            editableProject: nil,
+            editableProjectRoot: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor()
+        )
+
+        let mutation = try XCTUnwrap(WorkspaceMemoryWorkflow.delete(id: note.id, context: context))
+
+        XCTAssertEqual(mutation.updatedGlobalMemories, [])
+        XCTAssertNil(mutation.updatedProjectMemories)
+        XCTAssertEqual(mutation.noticeSummary, "Forgot memory: \(note.title)")
+        XCTAssertEqual(MemoryNoteLoader.loadGlobal(from: globalDirectory), [])
+    }
+
+    func testUpdateRoutesLocalProjectMemoryThroughProjectRoot() throws {
+        let projectRoot = try makeQuillCodeTestDirectory()
+        let memoryDirectory = projectRoot.appendingPathComponent(".quillcode/memories")
+        try FileManager.default.createDirectory(at: memoryDirectory, withIntermediateDirectories: true)
+        let memoryURL = memoryDirectory.appendingPathComponent("project.md")
+        try "Use SwiftPM.\n".write(to: memoryURL, atomically: true, encoding: .utf8)
+        let note = try XCTUnwrap(MemoryNoteLoader.loadProject(from: projectRoot).first)
+        let context = WorkspaceMemoryWorkflowContext(
+            globalMemoryDirectory: nil,
+            editableProject: ProjectRef(name: "App", path: projectRoot.path, memories: [note]),
+            editableProjectRoot: projectRoot,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor()
+        )
+
+        let mutation = WorkspaceMemoryWorkflow.update(
+            id: note.id,
+            content: "Use SwiftPM and small reviewable changes.",
+            userText: "/remember-edit \(note.id)\nUse SwiftPM and small reviewable changes.",
+            context: context
+        )
+
+        XCTAssertNil(mutation.updatedGlobalMemories)
+        XCTAssertEqual(mutation.updatedProjectMemories?.first?.content, "Use SwiftPM and small reviewable changes.")
+        XCTAssertEqual(
+            try String(contentsOf: memoryURL, encoding: .utf8),
+            "Use SwiftPM and small reviewable changes.\n"
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceMemoryGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceMemoryGateTests.swift
@@ -4,6 +4,7 @@ final class ParityWorkspaceMemoryGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesMemoryCommandOrchestration() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let memoryModelText = try Self.appSourceText(named: "WorkspaceModelMemory.swift")
+        let workflowText = try Self.appSourceText(named: "WorkspaceMemoryWorkflow.swift")
         let engineText = try Self.appSourceText(named: "WorkspaceMemoryEngine.swift")
         let loaderText = try Self.appSourceText(named: "MemoryNoteLoader.swift")
         let contentPolicyText = try Self.appSourceText(named: "MemoryNoteContentPolicy.swift")
@@ -22,6 +23,8 @@ final class ParityWorkspaceMemoryGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(loaderText.contains("MemoryNotePathResolver.globalMemoryFileURL"), "MemoryNoteLoader should delegate global file resolution.")
         XCTAssertFalse(loaderText.contains("private static func looksSensitive"), "MemoryNoteLoader should not own sensitive-content detection.")
         XCTAssertFalse(loaderText.contains("private static func projectMemoryFileURL"), "MemoryNoteLoader should not own project memory file path resolution.")
+        XCTAssertTrue(workflowText.contains("enum WorkspaceMemoryWorkflow"), "Memory command routing should live in a focused workflow boundary.")
+        XCTAssertTrue(workflowText.contains("struct WorkspaceMemoryWorkflowContext"), "Memory workflow should receive a typed context instead of reading model state directly.")
         XCTAssertTrue(remoteUpdaterText.contains("enum WorkspaceRemoteProjectMemoryUpdater"), "SSH Remote memory writes should live in a focused remote updater.")
         XCTAssertTrue(remoteUpdaterText.contains("enum WorkspaceRemoteProjectMemoryDeleter"), "SSH Remote memory deletion should stay with the focused remote memory mutation helpers.")
         XCTAssertTrue(remoteUpdaterText.contains("MemoryNoteLoader.validatedUpdateContent"), "Remote project memory edits should share local memory validation.")
@@ -32,14 +35,19 @@ final class ParityWorkspaceMemoryGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(memoryModelText.contains("func deleteGlobalMemory"), "Memory deletion execution should live in the focused WorkspaceModelMemory extension.")
         XCTAssertTrue(memoryModelText.contains("func refreshThreadMemoryContext"), "Thread memory refresh should live in the focused WorkspaceModelMemory extension.")
         XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.saveGlobal"), "WorkspaceModelMemory should delegate global memory saves.")
-        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.updateGlobal"), "WorkspaceModelMemory should delegate global memory updates.")
-        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.updateProject"), "WorkspaceModelMemory should delegate project memory updates.")
-        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.updateRemoteProject"), "WorkspaceModelMemory should delegate SSH Remote project memory updates.")
-        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.deleteGlobal"), "WorkspaceModelMemory should delegate global memory deletion.")
-        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.deleteProject"), "WorkspaceModelMemory should delegate local project memory deletion.")
-        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.deleteRemoteProject"), "WorkspaceModelMemory should delegate SSH Remote project memory deletion.")
+        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryWorkflow.update"), "WorkspaceModelMemory should delegate memory update routing to the workflow boundary.")
+        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryWorkflow.delete"), "WorkspaceModelMemory should delegate memory delete routing to the workflow boundary.")
+        XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryWorkflow.editableNote"), "WorkspaceModelMemory should delegate scoped editable-note lookup to the workflow boundary.")
         XCTAssertTrue(memoryModelText.contains("WorkspaceProjectContextRefresher.globalMemories"), "WorkspaceModelMemory should delegate global memory reloads through the project context refresher.")
         XCTAssertTrue(memoryModelText.contains("WorkspaceMemoryEngine.contextUpdate"), "WorkspaceModelMemory should delegate memory context update construction.")
+        XCTAssertFalse(memoryModelText.contains("project?.isRemote == true"), "WorkspaceModelMemory should not own local-vs-remote memory routing.")
+        XCTAssertFalse(memoryModelText.contains("id.hasPrefix(\"project:\")"), "WorkspaceModelMemory should not parse memory scope IDs directly.")
+        XCTAssertFalse(memoryModelText.contains("WorkspaceMemoryEngine.updateGlobal"), "WorkspaceModelMemory should not bypass the memory workflow for updates.")
+        XCTAssertFalse(memoryModelText.contains("WorkspaceMemoryEngine.updateProject"), "WorkspaceModelMemory should not bypass the memory workflow for project updates.")
+        XCTAssertFalse(memoryModelText.contains("WorkspaceMemoryEngine.updateRemoteProject"), "WorkspaceModelMemory should not bypass the memory workflow for remote project updates.")
+        XCTAssertFalse(memoryModelText.contains("WorkspaceMemoryEngine.deleteGlobal"), "WorkspaceModelMemory should not bypass the memory workflow for deletes.")
+        XCTAssertFalse(memoryModelText.contains("WorkspaceMemoryEngine.deleteProject"), "WorkspaceModelMemory should not bypass the memory workflow for project deletes.")
+        XCTAssertFalse(memoryModelText.contains("WorkspaceMemoryEngine.deleteRemoteProject"), "WorkspaceModelMemory should not bypass the memory workflow for remote project deletes.")
         XCTAssertFalse(modelText.contains("func runRememberSlashCommand"), "WorkspaceModel.swift should not own memory slash-command execution.")
         XCTAssertFalse(modelText.contains("func runEditMemorySlashCommand"), "WorkspaceModel.swift should not own memory edit slash-command execution.")
         XCTAssertFalse(modelText.contains("func deleteGlobalMemory"), "WorkspaceModel.swift should not own memory deletion execution.")
@@ -55,8 +63,6 @@ final class ParityWorkspaceMemoryGateTests: QuillCodeParityTestCase {
             "WorkspaceMemoryCommandTranscriptPlanner.memoryUpdated",
             "WorkspaceMemoryCommandTranscriptPlanner.memoryNotUpdated",
             "WorkspaceMemoryCommandTranscriptPlanner.memoryUpdatedSummary",
-            "WorkspaceRemoteProjectMemoryUpdater.update",
-            "WorkspaceRemoteProjectMemoryDeleter.delete",
             "WorkspaceMemoryCommandTranscriptPlanner.memoryForgotten",
             "WorkspaceMemoryCommandTranscriptPlanner.memoryNotDeleted",
             "WorkspaceMemoryCommandTranscriptPlanner.memoryForgottenSummary",
@@ -65,6 +71,18 @@ final class ParityWorkspaceMemoryGateTests: QuillCodeParityTestCase {
         ] {
             XCTAssertTrue(engineText.contains(delegatedCall), "WorkspaceMemoryEngine should delegate \(delegatedCall).")
         }
+        for routedCall in [
+            "WorkspaceMemoryEngine.updateGlobal",
+            "WorkspaceMemoryEngine.updateProject",
+            "WorkspaceMemoryEngine.updateRemoteProject",
+            "WorkspaceMemoryEngine.deleteGlobal",
+            "WorkspaceMemoryEngine.deleteProject",
+            "WorkspaceMemoryEngine.deleteRemoteProject"
+        ] {
+            XCTAssertTrue(workflowText.contains(routedCall), "WorkspaceMemoryWorkflow should route \(routedCall).")
+        }
+        XCTAssertTrue(engineText.contains("WorkspaceRemoteProjectMemoryUpdater.update"), "WorkspaceMemoryEngine should delegate remote memory edits.")
+        XCTAssertTrue(engineText.contains("WorkspaceRemoteProjectMemoryDeleter.delete"), "WorkspaceMemoryEngine should delegate remote memory deletes.")
         XCTAssertFalse(modelText.contains("It will be included as background context in future turns."), "WorkspaceModel should not own memory save success copy.")
         XCTAssertFalse(modelText.contains("Memory not saved"), "WorkspaceModel should not own memory save failure title copy.")
         XCTAssertFalse(modelText.contains("It will no longer be included as background context."), "WorkspaceModel should not own memory delete success copy.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -6764,3 +6764,28 @@ Strict grades:
 Remaining parity risk:
 
 - Project memory review/conflict UI, redaction review, idle Chronicle jobs, and autonomous memory inference remain pending.
+
+## 2026-06-25 Memory Workflow Boundary Slice
+
+Overall grade after this slice: **A memory routing boundary, A- model thinness, B+/A- Chronicle parity**.
+
+The Project Memory Forget slice made global, local project, and SSH Remote project memory mutations symmetric, but `WorkspaceModelMemory` still owned too much routing policy: it parsed memory IDs, selected local vs remote project mutation paths, and applied the resulting model state. That was acceptable while there were only explicit user commands, but conflict review, redaction previews, and autonomous Chronicle inference would have made the model extension a policy magnet.
+
+Code quality changes:
+
+- Added `WorkspaceMemoryWorkflow` and `WorkspaceMemoryWorkflowContext` as the focused boundary for memory ID scope, editable-note lookup, and global/local/SSH Remote update-delete routing.
+- Kept `WorkspaceMemoryEngine` as the mutation-result builder and storage adapter coordinator, so transcript copy, refresh payloads, and remote helpers stay in their existing tested locations.
+- Reduced `WorkspaceModelMemory` to actor-owned state application: build context from selected project state, call the workflow, apply global/project memory mutations, and refresh the top bar.
+- Added focused workflow unit tests for scope lookup, editable-note resolution, global deletion routing, and local project update routing.
+- Tightened the parity gate so `WorkspaceModelMemory` cannot regain direct memory ID parsing or local-vs-remote routing.
+
+Strict grades:
+
+- `WorkspaceMemoryWorkflow.swift`: **A**. It is deliberately small and has one job: route memory commands based on typed context. It does not mutate workspace state, touch files directly, or know UI details.
+- `WorkspaceModelMemory.swift`: **A-**. The extension is now thinner and keeps the necessary actor mutation boundary. It still applies context notices because selected-thread mutation is actor-owned model state.
+- `WorkspaceMemoryEngine.swift`: **A-**. The engine remains the right place for mutation outcome construction. The next Chronicle feature can now add review/conflict state without forcing another routing branch into the model.
+- `WorkspaceMemoryWorkflowTests.swift`: **A**. It directly guards the new seam with cheap unit tests and leaves expensive remote shell behavior in the existing fake-SSH integration tests.
+
+Remaining parity risk:
+
+- Project memory review/conflict UI, redaction review, idle Chronicle jobs, and autonomous memory inference remain pending, but they now have a better architecture boundary to land behind.


### PR DESCRIPTION
## Summary
- Add `WorkspaceMemoryWorkflow` as the routing boundary for memory scope, editable-note lookup, and global/local/SSH Remote update-delete paths
- Thin `WorkspaceModelMemory` so it applies workflow mutations instead of parsing memory IDs or choosing remote/local paths
- Add focused workflow unit tests and stricter parity guards for the memory architecture boundary
- Record the code-quality grade in the audit log

## Validation
- `git diff --check`
- `swift test --filter 'WorkspaceMemoryWorkflowTests|WorkspaceMemoryIntegrationTests|WorkspaceMemoryEngineTests|ParityWorkspaceMemoryGateTests'` (29 passed)\n- `swift test` (1195 passed)