### PR TITLE
Extract desktop browser workflow coordinator

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
@@ -1,0 +1,79 @@
+import Foundation
+import QuillCodeApp
+
+@MainActor
+struct QuillCodeDesktopBrowserCoordinator {
+    private let pageFetcher: any BrowserPageFetching
+    private let liveDOMCapturer: (any BrowserLiveDOMCapturing)?
+    private let sessionPresenter: any DesktopBrowserSessionPresenting
+
+    init(
+        pageFetcher: any BrowserPageFetching,
+        liveDOMCapturer: (any BrowserLiveDOMCapturing)?,
+        sessionPresenter: any DesktopBrowserSessionPresenting
+    ) {
+        self.pageFetcher = pageFetcher
+        self.liveDOMCapturer = liveDOMCapturer
+        self.sessionPresenter = sessionPresenter
+    }
+
+    func openPreview(
+        model: QuillCodeWorkspaceModel,
+        addressDraft: String,
+        workspaceRoot: URL,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        model.setBrowserAddressDraft(addressDraft)
+        _ = model.openBrowserPreview(workspaceRoot: activeWorkspaceRoot(for: model, fallback: workspaceRoot))
+        refresh()
+
+        tasks.replace(.browserPreview) {
+            _ = await model.refreshBrowserSnapshot(pageFetcher: pageFetcher)
+            if let liveDOMCapturer {
+                _ = await model.refreshRenderedBrowserSnapshot(capturer: liveDOMCapturer)
+            }
+        } onFinish: {
+            refresh()
+        }
+    }
+
+    func openSession(
+        model: QuillCodeWorkspaceModel,
+        addressDraft: String,
+        workspaceRoot: URL,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        let root = activeWorkspaceRoot(for: model, fallback: workspaceRoot)
+        let targetAddress = sessionTargetAddress(
+            addressDraft: addressDraft,
+            fallbackAddress: model.browser.currentURL ?? model.browser.addressDraft
+        )
+
+        guard let url = WorkspaceBrowserLocationResolver(workspaceRoot: root).resolve(targetAddress) else {
+            model.setBrowserAddressDraft(targetAddress)
+            _ = model.openBrowserPreview(workspaceRoot: root)
+            refresh()
+            return
+        }
+
+        sessionPresenter.openSession(url: url)
+        if model.browser.currentURL != url.absoluteString {
+            model.setBrowserAddressDraft(url.absoluteString)
+            _ = model.openBrowserPreview(workspaceRoot: root)
+        }
+        refresh()
+    }
+
+    private func activeWorkspaceRoot(
+        for model: QuillCodeWorkspaceModel,
+        fallback workspaceRoot: URL
+    ) -> URL {
+        model.activeWorkspaceRoot ?? workspaceRoot
+    }
+
+    private func sessionTargetAddress(addressDraft: String, fallbackAddress: String) -> String {
+        let rawAddress = addressDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return rawAddress.isEmpty ? fallbackAddress : rawAddress
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -19,9 +19,7 @@ final class QuillCodeDesktopController: ObservableObject {
     private let model: QuillCodeWorkspaceModel
     private let bootstrap: QuillCodeWorkspaceBootstrap
     private let computerUseBackend: MacComputerUseBackend
-    private let browserPageFetcher: any BrowserPageFetching
-    private let browserLiveDOMCapturer: (any BrowserLiveDOMCapturing)?
-    private let browserSessionPresenter: any DesktopBrowserSessionPresenting
+    private let browserCoordinator: QuillCodeDesktopBrowserCoordinator
     private let automationNotifier: any QuillCodeAutomationNotifying
     private let workspaceRoot: URL
     private let signInCoordinator: QuillCodeDesktopSignInCoordinator
@@ -41,9 +39,11 @@ final class QuillCodeDesktopController: ObservableObject {
     ) {
         self.bootstrap = bootstrap
         self.computerUseBackend = MacComputerUseBackend()
-        self.browserPageFetcher = browserPageFetcher
-        self.browserLiveDOMCapturer = browserLiveDOMCapturer
-        self.browserSessionPresenter = browserSessionPresenter
+        self.browserCoordinator = QuillCodeDesktopBrowserCoordinator(
+            pageFetcher: browserPageFetcher,
+            liveDOMCapturer: browserLiveDOMCapturer,
+            sessionPresenter: browserSessionPresenter
+        )
         self.automationNotifier = automationNotifier
         self.signInCoordinator = QuillCodeDesktopSignInCoordinator(bootstrap: bootstrap)
         self.settingsCoordinator = QuillCodeDesktopSettingsCoordinator(bootstrap: bootstrap)
@@ -245,38 +245,22 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func openBrowserPreview() {
-        model.setBrowserAddressDraft(browserAddressDraft)
-        _ = model.openBrowserPreview(workspaceRoot: model.activeWorkspaceRoot ?? workspaceRoot)
-        refresh()
-        tasks.replace(.browserPreview) { [weak self] in
-            guard let self else { return }
-            _ = await self.model.refreshBrowserSnapshot(pageFetcher: self.browserPageFetcher)
-            if let browserLiveDOMCapturer = self.browserLiveDOMCapturer {
-                _ = await self.model.refreshRenderedBrowserSnapshot(capturer: browserLiveDOMCapturer)
-            }
-        } onFinish: { [weak self] in
-            self?.refresh()
-        }
+        browserCoordinator.openPreview(
+            model: model,
+            addressDraft: browserAddressDraft,
+            workspaceRoot: workspaceRoot,
+            tasks: tasks,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     func openBrowserSession() {
-        let root = model.activeWorkspaceRoot ?? workspaceRoot
-        let rawAddress = browserAddressDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let fallbackAddress = model.browser.currentURL ?? model.browser.addressDraft
-        let targetAddress = rawAddress.isEmpty ? fallbackAddress : rawAddress
-        guard let url = WorkspaceBrowserLocationResolver(workspaceRoot: root).resolve(targetAddress) else {
-            model.setBrowserAddressDraft(targetAddress)
-            _ = model.openBrowserPreview(workspaceRoot: root)
-            refresh()
-            return
-        }
-
-        browserSessionPresenter.openSession(url: url)
-        if model.browser.currentURL != url.absoluteString {
-            model.setBrowserAddressDraft(url.absoluteString)
-            _ = model.openBrowserPreview(workspaceRoot: root)
-        }
-        refresh()
+        browserCoordinator.openSession(
+            model: model,
+            addressDraft: browserAddressDraft,
+            workspaceRoot: workspaceRoot,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     func addBrowserComment(_ comment: String) {

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -40,11 +40,12 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
     func testDesktopControllerDelegatesCancellableTaskSlots() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let browserCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopBrowserCoordinator.swift")
 
         XCTAssertTrue(text.contains("QuillCodeDesktopTaskCoordinator"), "Desktop cancellable tasks should be isolated behind a coordinator.")
         XCTAssertTrue(controllerText.contains("tasks.startIfIdle(.send"), "Composer sends should use the task coordinator.")
         XCTAssertTrue(controllerText.contains("tasks.startIfIdle(.terminal"), "Terminal runs should use the task coordinator.")
-        XCTAssertTrue(controllerText.contains("tasks.replace(.browserPreview"), "Browser previews should replace stale preview work.")
+        XCTAssertTrue(browserCoordinatorText.contains("tasks.replace(.browserPreview"), "Browser previews should replace stale preview work.")
         XCTAssertTrue(controllerText.contains("tasks.replace(.automationTicker"), "Automation ticks should use the task coordinator.")
         XCTAssertFalse(controllerText.contains("private var sendTask"), "Desktop controller should not own raw send task slots.")
         XCTAssertFalse(controllerText.contains("private var terminalTask"), "Desktop controller should not own raw terminal task slots.")
@@ -55,8 +56,10 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
     func testDesktopBrowserLiveDOMCaptureUsesFocusedAdapter() throws {
         let desktopText = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let browserCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopBrowserCoordinator.swift")
         let capturerText = try Self.desktopSourceText(named: "DesktopBrowserLiveDOMCapturer.swift")
 
+        XCTAssertTrue(desktopText.contains("QuillCodeDesktopBrowserCoordinator"), "Desktop browser preview workflow should be isolated behind a coordinator.")
         XCTAssertTrue(desktopText.contains("DesktopBrowserLiveDOMCapturer"), "Desktop should provide a native rendered-browser capture adapter.")
         XCTAssertTrue(capturerText.contains("BrowserLiveDOMCapturing"), "Desktop live DOM capture should implement the shared adapter protocol.")
         XCTAssertTrue(capturerText.contains("WKWebView"), "Desktop live DOM capture should render pages before inspecting DOM.")
@@ -68,9 +71,10 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(capturerText.contains("WKWebsiteDataStore"), "Desktop live DOM profile selection should be backed by WebKit data stores.")
         XCTAssertTrue(capturerText.contains("return .default()"), "Persistent desktop browser capture should reuse WebKit's default cookie/session store.")
         XCTAssertTrue(controllerText.contains("browserLiveDOMCapturer"), "Desktop controller should accept live DOM capture as an injectable dependency.")
+        XCTAssertTrue(controllerText.contains("browserCoordinator.openPreview"), "Desktop controller should delegate browser preview workflow.")
         XCTAssertTrue(
-            controllerText.contains("refreshRenderedBrowserSnapshot(capturer: browserLiveDOMCapturer)"),
-            "Desktop browser preview should upgrade fetched snapshots with rendered live DOM when available."
+            browserCoordinatorText.contains("refreshRenderedBrowserSnapshot(capturer: liveDOMCapturer)"),
+            "Desktop browser preview coordinator should upgrade fetched snapshots with rendered live DOM when available."
         )
         XCTAssertFalse(controllerText.contains("WKWebView"), "Desktop controller should not own WebKit rendering details.")
         XCTAssertFalse(controllerText.contains("evaluateJavaScript"), "Desktop controller should not own DOM capture details.")
@@ -81,6 +85,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
     func testDesktopBrowserVisibleSessionUsesFocusedAdapter() throws {
         let desktopText = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let browserCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopBrowserCoordinator.swift")
         let appText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
         let presenterText = try Self.desktopSourceText(named: "DesktopBrowserSessionPresenter.swift")
         let browserPaneText = try Self.appSourceText(named: "QuillCodeBrowserPaneView.swift")
@@ -97,7 +102,8 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(presenterText.contains("func present()"), "Visible browser session focus behavior should stay inside the presenter adapter.")
         XCTAssertFalse(presenterText.contains("sessions: [ObjectIdentifier"), "Visible browser sessions should not regress to one retained window per click.")
         XCTAssertTrue(controllerText.contains("browserSessionPresenter"), "Desktop controller should accept a visible browser session dependency.")
-        XCTAssertTrue(controllerText.contains("WorkspaceBrowserLocationResolver(workspaceRoot: root).resolve"), "Visible browser session URLs should share preview address resolution.")
+        XCTAssertTrue(controllerText.contains("browserCoordinator.openSession"), "Desktop controller should delegate visible browser session workflow.")
+        XCTAssertTrue(browserCoordinatorText.contains("WorkspaceBrowserLocationResolver(workspaceRoot: root).resolve"), "Visible browser session URLs should share preview address resolution.")
         XCTAssertTrue(controllerText.contains("func openBrowserSession()"), "Desktop controller should expose a visible browser session action.")
         XCTAssertTrue(appText.contains("onOpenBrowserSession: controller.openBrowserSession"), "Desktop app should wire visible browser sessions into shared UI.")
         XCTAssertTrue(browserPaneText.contains("var onOpenSession: (() -> Void)?"), "Shared browser pane should keep visible sessions optional for non-desktop platforms.")


### PR DESCRIPTION
## Summary
- move desktop browser preview/session workflow into a focused coordinator
- keep the desktop controller responsible for UI routing only
- update the desktop parity gate so preview task replacement, live DOM refresh, and visible session URL resolution stay outside the controller

## Tests
- swift test --filter ParityDesktopGateTests
- swift test