### PR TITLE
Extract desktop terminal coordinator

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -27,6 +27,7 @@ final class QuillCodeDesktopController: ObservableObject {
     private let systemSettingsOpener: MacSystemSettingsOpener
     private let copyCoordinator: QuillCodeDesktopCopyCoordinator
     private let projectImportCoordinator: QuillCodeDesktopProjectImportCoordinator
+    private let terminalCoordinator: QuillCodeDesktopTerminalCoordinator
     private let tasks = QuillCodeDesktopTaskCoordinator()
 
     init(
@@ -50,6 +51,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.systemSettingsOpener = MacSystemSettingsOpener()
         self.copyCoordinator = QuillCodeDesktopCopyCoordinator()
         self.projectImportCoordinator = QuillCodeDesktopProjectImportCoordinator()
+        self.terminalCoordinator = QuillCodeDesktopTerminalCoordinator()
         do {
             self.model = try bootstrap.makeModel()
         } catch {
@@ -274,39 +276,31 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func runTerminalCommand() {
-        let command = terminalDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !command.isEmpty, !tasks.isRunning(.terminal) else { return }
-        terminalDraft = ""
-        refresh()
-        tasks.startIfIdle(.terminal) { [weak self] in
-            guard let self else { return }
-            await self.model.runTerminalCommand(
-                command,
-                workspaceRoot: self.model.activeWorkspaceRoot ?? self.workspaceRoot
-            )
-        } onFinish: { [weak self] in
-            self?.refresh()
-        }
+        terminalCoordinator.runCommand(
+            draft: &terminalDraft,
+            model: model,
+            fallbackWorkspaceRoot: workspaceRoot,
+            tasks: tasks,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     func recallPreviousTerminalCommand() {
-        guard !tasks.isRunning(.terminal) else { return }
-        if terminalDraft != model.terminal.draft {
-            model.setTerminalDraft(terminalDraft)
-        }
-        guard model.recallPreviousTerminalCommand() else { return }
-        terminalDraft = model.terminal.draft
-        refresh()
+        terminalCoordinator.recallPreviousCommand(
+            draft: &terminalDraft,
+            model: model,
+            tasks: tasks,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     func recallNextTerminalCommand() {
-        guard !tasks.isRunning(.terminal) else { return }
-        if terminalDraft != model.terminal.draft {
-            model.setTerminalDraft(terminalDraft)
-        }
-        guard model.recallNextTerminalCommand() else { return }
-        terminalDraft = model.terminal.draft
-        refresh()
+        terminalCoordinator.recallNextCommand(
+            draft: &terminalDraft,
+            model: model,
+            tasks: tasks,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     func runReviewAction(_ action: WorkspaceReviewActionSurface) {

--- a/Sources/quill-code-desktop/QuillCodeDesktopTerminalCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopTerminalCoordinator.swift
@@ -1,0 +1,74 @@
+import Foundation
+import QuillCodeApp
+
+@MainActor
+struct QuillCodeDesktopTerminalCoordinator {
+    func runCommand(
+        draft: inout String,
+        model: QuillCodeWorkspaceModel,
+        fallbackWorkspaceRoot: URL,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        let command = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !command.isEmpty, !tasks.isRunning(.terminal) else { return }
+
+        draft = ""
+        refresh()
+        tasks.startIfIdle(.terminal) { [weak model] in
+            guard let model else { return }
+            await model.runTerminalCommand(
+                command,
+                workspaceRoot: model.activeWorkspaceRoot ?? fallbackWorkspaceRoot
+            )
+        } onFinish: {
+            refresh()
+        }
+    }
+
+    func recallPreviousCommand(
+        draft: inout String,
+        model: QuillCodeWorkspaceModel,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        recallCommand(
+            draft: &draft,
+            model: model,
+            tasks: tasks,
+            refresh: refresh,
+            recall: { $0.recallPreviousTerminalCommand() }
+        )
+    }
+
+    func recallNextCommand(
+        draft: inout String,
+        model: QuillCodeWorkspaceModel,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        recallCommand(
+            draft: &draft,
+            model: model,
+            tasks: tasks,
+            refresh: refresh,
+            recall: { $0.recallNextTerminalCommand() }
+        )
+    }
+
+    private func recallCommand(
+        draft: inout String,
+        model: QuillCodeWorkspaceModel,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        refresh: @escaping @MainActor () -> Void,
+        recall: (QuillCodeWorkspaceModel) -> Bool
+    ) {
+        guard !tasks.isRunning(.terminal) else { return }
+        if draft != model.terminal.draft {
+            model.setTerminalDraft(draft)
+        }
+        guard recall(model) else { return }
+        draft = model.terminal.draft
+        refresh()
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -41,6 +41,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
         let browserCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopBrowserCoordinator.swift")
+        let terminalCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopTerminalCoordinator.swift")
         let desktopTaskText = try Self.desktopSourceText(named: "QuillCodeDesktopTaskCoordinator.swift")
         let sharedTaskText = try Self.appSourceText(named: "QuillCodeTaskCoordinator.swift")
         let sharedTaskTests = try Self.appTestSourceText(named: "QuillCodeTaskCoordinatorTests.swift")
@@ -51,7 +52,12 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(sharedTaskText.contains("guard self?.finish(slot, id: id) == true else { return }"), "Cancelled or replaced tasks must not run stale finish callbacks.")
         XCTAssertTrue(sharedTaskTests.contains("testReplaceCancelsStaleTaskAndOnlyFinishesCurrentTask"), "Task replacement semantics need focused regression coverage.")
         XCTAssertTrue(controllerText.contains("tasks.startIfIdle(.send"), "Composer sends should use the task coordinator.")
-        XCTAssertTrue(controllerText.contains("tasks.startIfIdle(.terminal"), "Terminal runs should use the task coordinator.")
+        XCTAssertTrue(controllerText.contains("QuillCodeDesktopTerminalCoordinator"), "Desktop terminal workflow should be isolated behind a coordinator.")
+        XCTAssertTrue(controllerText.contains("terminalCoordinator.runCommand"), "Desktop controller should delegate terminal command execution.")
+        XCTAssertTrue(controllerText.contains("terminalCoordinator.recallPreviousCommand"), "Desktop controller should delegate terminal history recall.")
+        XCTAssertTrue(terminalCoordinatorText.contains("tasks.startIfIdle(.terminal"), "Terminal runs should use the task coordinator.")
+        XCTAssertTrue(terminalCoordinatorText.contains("draft.trimmingCharacters(in: .whitespacesAndNewlines)"), "Terminal coordinator should normalize submitted commands.")
+        XCTAssertTrue(terminalCoordinatorText.contains("model.setTerminalDraft(draft)"), "Terminal history recall should sync unsent UI draft before moving through history.")
         XCTAssertTrue(browserCoordinatorText.contains("tasks.replace(.browserPreview"), "Browser previews should replace stale preview work.")
         XCTAssertTrue(controllerText.contains("tasks.replace(.automationTicker"), "Automation ticks should use the task coordinator.")
         XCTAssertFalse(desktopTaskText.contains("private var tasks"), "Desktop wrapper should not own raw task storage.")
@@ -59,6 +65,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(controllerText.contains("private var terminalTask"), "Desktop controller should not own raw terminal task slots.")
         XCTAssertFalse(controllerText.contains("private var browserPreviewTask"), "Desktop controller should not own raw browser-preview task slots.")
         XCTAssertFalse(controllerText.contains("sendTaskID"), "Desktop controller should not own manual task identity bookkeeping.")
+        XCTAssertFalse(controllerText.contains("let command = terminalDraft.trimmingCharacters"), "Desktop controller should not own terminal command normalization.")
     }
 
     func testDesktopBrowserLiveDOMCaptureUsesFocusedAdapter() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -36,7 +36,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `Sources/QuillCodeApp/QuillCodeReviewFileRowView.swift` | A- | File rows, hunk rows, range-note controls, file/hunk actions, and hunk-to-line composition live together. Split hunk controls only if review workflows grow beyond compact stage/restore/comment actions. |
 | `Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift` | A | Line content, marker/background styling, inline comments, and line-note composer live together without expanding the review pane shell. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
-| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback and project-import resolution now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
+| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback, project-import resolution, and terminal run/history workflows now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
 | `Sources/QuillCodeAgent/Agent.swift` | A- | Good test coverage; keep tool continuation limits and transcript filtering explicit. |
 | `Sources/QuillCodeCore/Models.swift` | A | General chat/thread/memory domain models only; app config, automation scheduling, project/workspace records, tool payloads, and TrustedRouter defaults/catalog records now live in focused core files. Watch for persistence, workflow, tool, or provider-specific behavior trying to drift back in. |
 | `Sources/QuillCodeCore/AppConfig.swift` | A | App settings, auth mode compatibility, signed-in account metadata, and favorite model normalization live together without pulling UI/runtime dependencies into core. |
@@ -93,6 +93,18 @@ Changes:
 - Added `QuillCodeWorktreeDialogCoordinator` as the single owner of worktree sheet selection, create/open/remove/prune draft state, choice loading, prune-preview loading, retry handling, and task cancellation.
 - Rewired `WorkspaceSwiftUIView` to delegate worktree presentation and retry behavior to the coordinator while keeping the root shell focused on command routing and layout.
 - Added coordinator tests proving successful loads apply to the intended draft, retries do not run against hidden sheets, and late async choice results do not overwrite the currently visible dialog after a sheet switch.
+
+## 2026-06-25 Desktop Terminal Coordinator Pass
+
+Overall grade after this slice: **A desktop terminal routing, A task-slot reuse, A controller boundary**.
+
+`QuillCodeDesktopController.swift` still owned terminal command trimming, run-task startup, UI draft clearing, history-draft synchronization, and previous/next recall. Those rules are small but important for a fast native app: terminal commands should not double-run, stale UI drafts should be preserved correctly when browsing history, and the controller should not become the owner of every desktop workflow.
+
+Changes:
+
+- Added `QuillCodeDesktopTerminalCoordinator` for terminal command execution and history recall wiring.
+- Rewired `QuillCodeDesktopController` to delegate terminal run/previous/next behavior while keeping the controller responsible for published UI state and refresh.
+- Extended the desktop parity gate so terminal task-slot use, command normalization, and draft-history synchronization stay in the focused coordinator instead of drifting back into the controller.
 
 ## 2026-06-25 Shared Task Coordinator Pass
 


### PR DESCRIPTION
## Summary
- move desktop terminal command execution and history recall wiring into QuillCodeDesktopTerminalCoordinator
- keep QuillCodeDesktopController focused on published UI state, routing, and refresh
- add parity coverage that terminal task-slot use, command normalization, and draft-history sync stay outside the controller
- document the code-quality boundary in CODE_QUALITY_AUDIT

## Validation
- swift test --filter 'ParityDesktopGateTests'
- swift test --quiet