### PR TITLE
Extract desktop automation coordinator

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopAutomationCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAutomationCoordinator.swift
@@ -1,0 +1,38 @@
+import Foundation
+import QuillCodeApp
+
+@MainActor
+struct QuillCodeDesktopAutomationCoordinator {
+    private let tickIntervalNanoseconds: UInt64
+
+    init(tickIntervalNanoseconds: UInt64 = 30_000_000_000) {
+        self.tickIntervalNanoseconds = tickIntervalNanoseconds
+    }
+
+    func startTicker(
+        model: QuillCodeWorkspaceModel,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        notifier: any QuillCodeAutomationNotifying,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        tasks.replace(.automationTicker) {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: tickIntervalNanoseconds)
+                guard !Task.isCancelled else { return }
+                runDueAutomations(model: model, notifier: notifier, refresh: refresh)
+            }
+        }
+    }
+
+    func runDueAutomations(
+        model: QuillCodeWorkspaceModel,
+        notifier: any QuillCodeAutomationNotifying,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        let reports = model.runDueAutomationReports()
+        guard !reports.isEmpty else { return }
+
+        reports.forEach(notifier.deliver)
+        refresh()
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -20,6 +20,7 @@ final class QuillCodeDesktopController: ObservableObject {
     private let bootstrap: QuillCodeWorkspaceBootstrap
     private let computerUseBackend: MacComputerUseBackend
     private let browserCoordinator: QuillCodeDesktopBrowserCoordinator
+    private let automationCoordinator: QuillCodeDesktopAutomationCoordinator
     private let automationNotifier: any QuillCodeAutomationNotifying
     private let workspaceRoot: URL
     private let signInCoordinator: QuillCodeDesktopSignInCoordinator
@@ -46,6 +47,7 @@ final class QuillCodeDesktopController: ObservableObject {
             liveDOMCapturer: browserLiveDOMCapturer,
             sessionPresenter: browserSessionPresenter
         )
+        self.automationCoordinator = QuillCodeDesktopAutomationCoordinator()
         self.automationNotifier = automationNotifier
         self.signInCoordinator = QuillCodeDesktopSignInCoordinator(bootstrap: bootstrap)
         self.settingsCoordinator = QuillCodeDesktopSettingsCoordinator(bootstrap: bootstrap)
@@ -68,8 +70,17 @@ final class QuillCodeDesktopController: ObservableObject {
         self.draft = model.composer.draft
         self.terminalDraft = model.terminal.draft
         self.browserAddressDraft = model.browser.addressDraft
-        runDueAutomations()
-        startAutomationTicker()
+        automationCoordinator.runDueAutomations(
+            model: model,
+            notifier: automationNotifier,
+            refresh: { [weak self] in self?.refresh() }
+        )
+        automationCoordinator.startTicker(
+            model: model,
+            tasks: tasks,
+            notifier: automationNotifier,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     func newChat() {
@@ -435,25 +446,6 @@ final class QuillCodeDesktopController: ObservableObject {
             )
             refresh()
         }
-    }
-
-    private func startAutomationTicker() {
-        tasks.replace(.automationTicker) { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 30_000_000_000)
-                guard let self, !Task.isCancelled else {
-                    return
-                }
-                self.runDueAutomations()
-            }
-        }
-    }
-
-    private func runDueAutomations() {
-        let reports = model.runDueAutomationReports()
-        guard !reports.isEmpty else { return }
-        reports.forEach(automationNotifier.deliver)
-        refresh()
     }
 
     private func refresh() {

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -40,6 +40,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
     func testDesktopControllerDelegatesCancellableTaskSlots() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let automationCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopAutomationCoordinator.swift")
         let browserCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopBrowserCoordinator.swift")
         let composerCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopComposerCoordinator.swift")
         let terminalCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopTerminalCoordinator.swift")
@@ -65,7 +66,10 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(terminalCoordinatorText.contains("draft.trimmingCharacters(in: .whitespacesAndNewlines)"), "Terminal coordinator should normalize submitted commands.")
         XCTAssertTrue(terminalCoordinatorText.contains("model.setTerminalDraft(draft)"), "Terminal history recall should sync unsent UI draft before moving through history.")
         XCTAssertTrue(browserCoordinatorText.contains("tasks.replace(.browserPreview"), "Browser previews should replace stale preview work.")
-        XCTAssertTrue(controllerText.contains("tasks.replace(.automationTicker"), "Automation ticks should use the task coordinator.")
+        XCTAssertTrue(controllerText.contains("QuillCodeDesktopAutomationCoordinator"), "Desktop automation ticking should be isolated behind a coordinator.")
+        XCTAssertTrue(controllerText.contains("automationCoordinator.startTicker"), "Desktop controller should delegate automation ticking.")
+        XCTAssertTrue(automationCoordinatorText.contains("tasks.replace(.automationTicker"), "Automation ticks should use the task coordinator.")
+        XCTAssertTrue(automationCoordinatorText.contains("Task.sleep(nanoseconds: tickIntervalNanoseconds)"), "Automation tick timing should live in the automation coordinator.")
         XCTAssertFalse(desktopTaskText.contains("private var tasks"), "Desktop wrapper should not own raw task storage.")
         XCTAssertFalse(controllerText.contains("private var sendTask"), "Desktop controller should not own raw send task slots.")
         XCTAssertFalse(controllerText.contains("private var terminalTask"), "Desktop controller should not own raw terminal task slots.")
@@ -74,6 +78,8 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(controllerText.contains("let prompt = draft.trimmingCharacters"), "Desktop controller should not own composer prompt normalization.")
         XCTAssertFalse(controllerText.contains("model.prepareRetryLastUserTurn()"), "Desktop controller should not own retry preparation.")
         XCTAssertFalse(controllerText.contains("let command = terminalDraft.trimmingCharacters"), "Desktop controller should not own terminal command normalization.")
+        XCTAssertFalse(controllerText.contains("tasks.replace(.automationTicker"), "Desktop controller should not own automation ticker task replacement.")
+        XCTAssertFalse(controllerText.contains("30_000_000_000"), "Desktop controller should not own automation tick timing.")
     }
 
     func testDesktopBrowserLiveDOMCaptureUsesFocusedAdapter() throws {
@@ -210,10 +216,17 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
 
     func testDesktopNotifiesWhenDueAutomationsRun() throws {
         let text = try Self.desktopSourceText()
+        let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let automationCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopAutomationCoordinator.swift")
 
         XCTAssertTrue(text.contains("UNUserNotificationCenter"), "Desktop app should use native notifications for due automations.")
         XCTAssertTrue(text.contains("MacAutomationNotifier"), "Desktop app should isolate notification delivery behind an adapter.")
-        XCTAssertTrue(text.contains("runDueAutomationReports"), "Desktop app should consume structured automation run reports.")
-        XCTAssertTrue(text.contains("automationNotifier.deliver"), "Desktop app should deliver a notification for each due automation report.")
+        XCTAssertTrue(text.contains("QuillCodeDesktopAutomationCoordinator"), "Desktop automation ticking should be isolated from UI routing.")
+        XCTAssertTrue(controllerText.contains("automationCoordinator.runDueAutomations"), "Desktop controller should delegate startup due-automation runs.")
+        XCTAssertTrue(controllerText.contains("automationCoordinator.startTicker"), "Desktop controller should delegate recurring automation ticks.")
+        XCTAssertTrue(automationCoordinatorText.contains("runDueAutomationReports"), "Desktop automation coordinator should consume structured automation run reports.")
+        XCTAssertTrue(automationCoordinatorText.contains("reports.forEach(notifier.deliver)"), "Desktop automation coordinator should deliver a notification for each due automation report.")
+        XCTAssertFalse(controllerText.contains("let reports = model.runDueAutomationReports()"), "Desktop controller should not query due automations directly.")
+        XCTAssertFalse(controllerText.contains("reports.forEach(automationNotifier.deliver)"), "Desktop controller should not fan out automation notifications directly.")
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -36,7 +36,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `Sources/QuillCodeApp/QuillCodeReviewFileRowView.swift` | A- | File rows, hunk rows, range-note controls, file/hunk actions, and hunk-to-line composition live together. Split hunk controls only if review workflows grow beyond compact stage/restore/comment actions. |
 | `Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift` | A | Line content, marker/background styling, inline comments, and line-note composer live together without expanding the review pane shell. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
-| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback, project-import resolution, terminal run/history, and composer send/retry workflows now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
+| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback, project-import resolution, terminal run/history, composer send/retry, and automation ticking/notification fan-out now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
 | `Sources/QuillCodeAgent/Agent.swift` | A- | Good test coverage; keep tool continuation limits and transcript filtering explicit. |
 | `Sources/QuillCodeCore/Models.swift` | A | General chat/thread/memory domain models only; app config, automation scheduling, project/workspace records, tool payloads, and TrustedRouter defaults/catalog records now live in focused core files. Watch for persistence, workflow, tool, or provider-specific behavior trying to drift back in. |
 | `Sources/QuillCodeCore/AppConfig.swift` | A | App settings, auth mode compatibility, signed-in account metadata, and favorite model normalization live together without pulling UI/runtime dependencies into core. |
@@ -93,6 +93,18 @@ Changes:
 - Added `QuillCodeWorktreeDialogCoordinator` as the single owner of worktree sheet selection, create/open/remove/prune draft state, choice loading, prune-preview loading, retry handling, and task cancellation.
 - Rewired `WorkspaceSwiftUIView` to delegate worktree presentation and retry behavior to the coordinator while keeping the root shell focused on command routing and layout.
 - Added coordinator tests proving successful loads apply to the intended draft, retries do not run against hidden sheets, and late async choice results do not overwrite the currently visible dialog after a sheet switch.
+
+## 2026-06-25 Desktop Automation Coordinator Pass
+
+Overall grade after this slice: **A desktop automation routing, A task-slot reuse, A controller boundary**.
+
+`QuillCodeDesktopController.swift` still owned the startup due-automation run, recurring ticker loop, tick interval, report query, and notification fan-out. That behavior is desktop runtime orchestration, not view-state routing, and it should be reviewable beside the notification adapter and task-slot use.
+
+Changes:
+
+- Added `QuillCodeDesktopAutomationCoordinator` for startup due-automation execution and recurring automation ticks.
+- Rewired `QuillCodeDesktopController` to delegate startup and recurring automation behavior while keeping the controller responsible for refresh state.
+- Extended the desktop parity gate so ticker task replacement, tick timing, due-report queries, and notification fan-out stay in the focused coordinator instead of drifting back into the controller.
 
 ## 2026-06-25 Desktop Composer Coordinator Pass
 


### PR DESCRIPTION
## Summary
- Move desktop due-automation startup and recurring ticker behavior into `QuillCodeDesktopAutomationCoordinator`
- Keep `QuillCodeDesktopController` focused on UI state/routing and refresh ownership
- Add parity coverage so automation ticker task use, tick timing, due-report queries, and notification fan-out stay out of the controller

## Validation
- `swift test --filter 'ParityDesktopGateTests'`\n- `swift test --quiet`\n