### PR TITLE
Extract desktop active work coordinator

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopActiveWorkCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopActiveWorkCoordinator.swift
@@ -1,0 +1,37 @@
+import Foundation
+import QuillCodeApp
+
+@MainActor
+struct QuillCodeDesktopActiveWorkCoordinator {
+    func stopAll(
+        draft: inout String,
+        model: QuillCodeWorkspaceModel,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        cancelInteractiveTasks(tasks)
+        model.cancelActiveWork()
+        draft = ""
+        refresh()
+    }
+
+    func disconnectAll(
+        draft: inout String,
+        model: QuillCodeWorkspaceModel,
+        tasks: QuillCodeDesktopTaskCoordinator,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        cancelInteractiveTasks(tasks)
+        guard model.disconnectAll() else {
+            refresh()
+            return
+        }
+
+        draft = ""
+        refresh()
+    }
+
+    private func cancelInteractiveTasks(_ tasks: QuillCodeDesktopTaskCoordinator) {
+        tasks.cancel([.send, .terminal, .browserPreview])
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -19,6 +19,7 @@ final class QuillCodeDesktopController: ObservableObject {
     private let model: QuillCodeWorkspaceModel
     private let bootstrap: QuillCodeWorkspaceBootstrap
     private let computerUseBackend: MacComputerUseBackend
+    private let activeWorkCoordinator: QuillCodeDesktopActiveWorkCoordinator
     private let browserCoordinator: QuillCodeDesktopBrowserCoordinator
     private let automationCoordinator: QuillCodeDesktopAutomationCoordinator
     private let automationNotifier: any QuillCodeAutomationNotifying
@@ -42,6 +43,7 @@ final class QuillCodeDesktopController: ObservableObject {
     ) {
         self.bootstrap = bootstrap
         self.computerUseBackend = MacComputerUseBackend()
+        self.activeWorkCoordinator = QuillCodeDesktopActiveWorkCoordinator()
         self.browserCoordinator = QuillCodeDesktopBrowserCoordinator(
             pageFetcher: browserPageFetcher,
             liveDOMCapturer: browserLiveDOMCapturer,
@@ -407,20 +409,21 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func stopAll() {
-        tasks.cancel([.send, .terminal, .browserPreview])
-        model.cancelActiveWork()
-        draft = ""
-        refresh()
+        activeWorkCoordinator.stopAll(
+            draft: &draft,
+            model: model,
+            tasks: tasks,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     func disconnectAll() {
-        tasks.cancel([.send, .terminal, .browserPreview])
-        guard model.disconnectAll() else {
-            refresh()
-            return
-        }
-        draft = ""
-        refresh()
+        activeWorkCoordinator.disconnectAll(
+            draft: &draft,
+            model: model,
+            tasks: tasks,
+            refresh: { [weak self] in self?.refresh() }
+        )
     }
 
     private func completeTrustedRouterSignIn() async {

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -40,6 +40,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
     func testDesktopControllerDelegatesCancellableTaskSlots() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let activeWorkCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopActiveWorkCoordinator.swift")
         let automationCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopAutomationCoordinator.swift")
         let browserCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopBrowserCoordinator.swift")
         let composerCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopComposerCoordinator.swift")
@@ -53,6 +54,12 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(desktopTaskText.contains("QuillCodeTaskCoordinator<Slot>"), "Desktop task slots should delegate to the shared task coordinator.")
         XCTAssertTrue(sharedTaskText.contains("guard self?.finish(slot, id: id) == true else { return }"), "Cancelled or replaced tasks must not run stale finish callbacks.")
         XCTAssertTrue(sharedTaskTests.contains("testReplaceCancelsStaleTaskAndOnlyFinishesCurrentTask"), "Task replacement semantics need focused regression coverage.")
+        XCTAssertTrue(controllerText.contains("QuillCodeDesktopActiveWorkCoordinator"), "Desktop stop/disconnect workflow should be isolated behind a coordinator.")
+        XCTAssertTrue(controllerText.contains("activeWorkCoordinator.stopAll"), "Desktop controller should delegate Stop All.")
+        XCTAssertTrue(controllerText.contains("activeWorkCoordinator.disconnectAll"), "Desktop controller should delegate Disconnect All.")
+        XCTAssertTrue(activeWorkCoordinatorText.contains("tasks.cancel([.send, .terminal, .browserPreview])"), "Stop/disconnect should cancel interactive desktop task slots.")
+        XCTAssertTrue(activeWorkCoordinatorText.contains("model.cancelActiveWork()"), "Stop All should cancel active model work in the coordinator.")
+        XCTAssertTrue(activeWorkCoordinatorText.contains("model.disconnectAll()"), "Disconnect All should disconnect model state in the coordinator.")
         XCTAssertTrue(controllerText.contains("QuillCodeDesktopComposerCoordinator"), "Desktop composer send/retry workflow should be isolated behind a coordinator.")
         XCTAssertTrue(controllerText.contains("composerCoordinator.send"), "Desktop controller should delegate composer sends.")
         XCTAssertTrue(controllerText.contains("composerCoordinator.retryLastTurn"), "Desktop controller should delegate composer retries.")
@@ -80,6 +87,9 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(controllerText.contains("let command = terminalDraft.trimmingCharacters"), "Desktop controller should not own terminal command normalization.")
         XCTAssertFalse(controllerText.contains("tasks.replace(.automationTicker"), "Desktop controller should not own automation ticker task replacement.")
         XCTAssertFalse(controllerText.contains("30_000_000_000"), "Desktop controller should not own automation tick timing.")
+        XCTAssertFalse(controllerText.contains("tasks.cancel([.send, .terminal, .browserPreview])"), "Desktop controller should not own interactive task-slot cancellation.")
+        XCTAssertFalse(controllerText.contains("model.cancelActiveWork()"), "Desktop controller should not own Stop All model cancellation.")
+        XCTAssertFalse(controllerText.contains("model.disconnectAll()"), "Desktop controller should not own Disconnect All model mutation.")
     }
 
     func testDesktopBrowserLiveDOMCaptureUsesFocusedAdapter() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -36,7 +36,7 @@ The architecture is moving in the right direction: core state is value typed, pe
 | `Sources/QuillCodeApp/QuillCodeReviewFileRowView.swift` | A- | File rows, hunk rows, range-note controls, file/hunk actions, and hunk-to-line composition live together. Split hunk controls only if review workflows grow beyond compact stage/restore/comment actions. |
 | `Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift` | A | Line content, marker/background styling, inline comments, and line-note composer live together without expanding the review pane shell. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
-| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback, project-import resolution, terminal run/history, composer send/retry, and automation ticking/notification fan-out now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
+| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI/workspace routing. Pasteboard feedback, project-import resolution, terminal run/history, composer send/retry, automation ticking/notification fan-out, and stop/disconnect orchestration now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
 | `Sources/QuillCodeAgent/Agent.swift` | A- | Good test coverage; keep tool continuation limits and transcript filtering explicit. |
 | `Sources/QuillCodeCore/Models.swift` | A | General chat/thread/memory domain models only; app config, automation scheduling, project/workspace records, tool payloads, and TrustedRouter defaults/catalog records now live in focused core files. Watch for persistence, workflow, tool, or provider-specific behavior trying to drift back in. |
 | `Sources/QuillCodeCore/AppConfig.swift` | A | App settings, auth mode compatibility, signed-in account metadata, and favorite model normalization live together without pulling UI/runtime dependencies into core. |
@@ -93,6 +93,18 @@ Changes:
 - Added `QuillCodeWorktreeDialogCoordinator` as the single owner of worktree sheet selection, create/open/remove/prune draft state, choice loading, prune-preview loading, retry handling, and task cancellation.
 - Rewired `WorkspaceSwiftUIView` to delegate worktree presentation and retry behavior to the coordinator while keeping the root shell focused on command routing and layout.
 - Added coordinator tests proving successful loads apply to the intended draft, retries do not run against hidden sheets, and late async choice results do not overwrite the currently visible dialog after a sheet switch.
+
+## 2026-06-25 Desktop Active Work Coordinator Pass
+
+Overall grade after this slice: **A stop/disconnect routing, A task-slot reuse, A controller boundary**.
+
+`QuillCodeDesktopController.swift` still owned Stop All and Disconnect All orchestration: cancelling interactive desktop task slots, cancelling active model work, disconnecting model state, clearing the composer draft, and refreshing. That behavior is shared command execution policy, not view-state ownership, and it should stay coherent as Computer Use, browser, terminal, and agent work grow.
+
+Changes:
+
+- Added `QuillCodeDesktopActiveWorkCoordinator` for Stop All and Disconnect All behavior.
+- Rewired `QuillCodeDesktopController` to delegate stop/disconnect while keeping published draft and refresh ownership at the controller boundary.
+- Extended the desktop parity gate so interactive task-slot cancellation, active-work cancellation, and disconnect mutation stay in the focused coordinator.
 
 ## 2026-06-25 Desktop Automation Coordinator Pass
 


### PR DESCRIPTION
## Summary
- Move Stop All and Disconnect All orchestration into `QuillCodeDesktopActiveWorkCoordinator`
- Keep `QuillCodeDesktopController` focused on published UI state and refresh ownership
- Add parity coverage so interactive task cancellation, active-work cancellation, and disconnect mutation stay out of the controller

## Validation
- `swift test --filter 'ParityDesktopGateTests'`\n- `swift test --quiet`\n