### PR TITLE
Show user turns before agent progress

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -90,14 +90,17 @@ public struct AgentRunner: Sendable {
         _ userMessage: String,
         in thread: ChatThread,
         workspaceRoot: URL,
+        recordUserMessage: Bool = true,
         onProgress: AgentRunProgressHandler? = nil
     ) async throws -> AgentRunResult {
         var next = thread
-        next.messages.append(.init(role: .user, content: userMessage))
-        next.events.append(.init(kind: .message, summary: userMessage))
-        next.updatedAt = Date()
-        if next.title == "New chat" {
-            next.title = Self.title(from: userMessage)
+        if recordUserMessage {
+            next.messages.append(.init(role: .user, content: userMessage))
+            next.events.append(.init(kind: .message, summary: userMessage))
+            next.updatedAt = Date()
+            if next.title == "New chat" {
+                next.title = Self.title(from: userMessage)
+            }
         }
         await onProgress?(next)
 

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -5,6 +5,7 @@ public struct TranscriptSurface: Codable, Sendable, Hashable {
     public var messages: [MessageSurface]
     public var toolCards: [ToolCardState]
     public var timelineItems: [TranscriptTimelineItemSurface]
+    public var thinking: TranscriptThinkingSurface?
     public var emptyTitle: String
     public var emptySubtitle: String
 
@@ -12,6 +13,7 @@ public struct TranscriptSurface: Codable, Sendable, Hashable {
         messages: [MessageSurface],
         toolCards: [ToolCardState],
         timelineItems: [TranscriptTimelineItemSurface]? = nil,
+        thinking: TranscriptThinkingSurface? = nil,
         emptyTitle: String = "Ask QuillCode to inspect, edit, or run this project.",
         emptySubtitle: String = "Use Auto for normal coding work, Review for manual gates, or Read-only for exploration."
     ) {
@@ -19,8 +21,31 @@ public struct TranscriptSurface: Codable, Sendable, Hashable {
         self.toolCards = toolCards
         self.timelineItems = timelineItems ?? messages.map(TranscriptTimelineItemSurface.message)
             + toolCards.map(TranscriptTimelineItemSurface.toolCard)
+        self.thinking = thinking
         self.emptyTitle = emptyTitle
         self.emptySubtitle = emptySubtitle
+    }
+}
+
+public struct TranscriptThinkingSurface: Codable, Sendable, Hashable, Identifiable {
+    public var id: String
+    public var title: String
+    public var subtitle: String
+    public var traceTitle: String
+    public var traceLines: [String]
+
+    public init(
+        id: String,
+        title: String,
+        subtitle: String,
+        traceTitle: String = "Trace",
+        traceLines: [String] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.traceTitle = traceTitle
+        self.traceLines = traceLines
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -43,6 +43,10 @@ struct QuillCodeTranscriptView: View {
         transcript.timelineItems.isEmpty && !review.isVisible && contextBanner == nil && runtimeIssue == nil
     }
 
+    private var scrollAnchorID: String? {
+        transcript.thinking?.id ?? transcript.timelineItems.last?.id
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if isFindPresented {
@@ -85,9 +89,16 @@ struct QuillCodeTranscriptView: View {
                                 )
                             }
                             timelineItems
+                            if let thinking = transcript.thinking {
+                                QuillCodeThinkingView(thinking: thinking)
+                                    .id(thinking.id)
+                            }
                         }
                         .frame(maxWidth: .infinity)
                         .padding(22)
+                    }
+                    .onChange(of: scrollAnchorID) { _, id in
+                        scrollToTranscriptEnd(proxy, id: id)
                     }
                     .onChange(of: activeFindIndex) { _, _ in
                         scrollToActiveFindMatch(proxy)
@@ -217,5 +228,92 @@ struct QuillCodeTranscriptView: View {
                 proxy.scrollTo(activeFindMatch.timelineItemID, anchor: .center)
             }
         }
+    }
+
+    private func scrollToTranscriptEnd(_ proxy: ScrollViewProxy, id: String?) {
+        guard let id, !isFindPresented else { return }
+        DispatchQueue.main.async {
+            quillCodeWithAnimation(.easeOut(duration: 0.18), reduceMotion: reduceMotion) {
+                proxy.scrollTo(id, anchor: .bottom)
+            }
+        }
+    }
+}
+
+private struct QuillCodeThinkingView: View {
+    var thinking: TranscriptThinkingSurface
+
+    @State private var isTraceExpanded = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    Text(thinking.title)
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(QuillCodePalette.text)
+                    QuillCodeThinkingDots(reduceMotion: reduceMotion)
+                }
+                Text(thinking.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(QuillCodePalette.muted)
+                if !thinking.traceLines.isEmpty {
+                    DisclosureGroup(isExpanded: $isTraceExpanded) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            ForEach(thinking.traceLines, id: \.self) { line in
+                                Text(line)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(QuillCodePalette.muted)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                        .padding(.top, 4)
+                    } label: {
+                        Text(thinking.traceTitle)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(QuillCodePalette.blue)
+                    }
+                    .tint(QuillCodePalette.blue)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .background(QuillCodePalette.panel.opacity(0.82))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            Spacer(minLength: 80)
+        }
+        .frame(maxWidth: 760, alignment: .leading)
+        .accessibilityIdentifier("thinking-indicator")
+        .accessibilityLabel("\(thinking.title): \(thinking.subtitle)")
+    }
+}
+
+private struct QuillCodeThinkingDots: View {
+    var reduceMotion: Bool
+
+    @ViewBuilder
+    var body: some View {
+        if reduceMotion {
+            dots(activeIndex: 2)
+        } else {
+            TimelineView(.animation) { context in
+                dots(activeIndex: Int(context.date.timeIntervalSinceReferenceDate * 2.8) % 3)
+            }
+        }
+    }
+
+    private func dots(activeIndex: Int) -> some View {
+        HStack(spacing: 4) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(QuillCodePalette.blue)
+                    .frame(width: 5, height: 5)
+                    .scaleEffect(index == activeIndex ? 1 : 0.72)
+                    .opacity(index == activeIndex ? 1 : 0.42)
+            }
+        }
+        .frame(width: 28, height: 12)
+        .accessibilityHidden(true)
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceAgentSendSession.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSession.swift
@@ -13,18 +13,21 @@ struct WorkspaceAgentSendSession: Sendable {
     var threadID: UUID
     var runner: AgentRunner
     var workspaceRoot: URL
+    var recordsUserMessage: Bool
 
     init(
         prompt: String,
         thread: ChatThread,
         runner: AgentRunner,
-        workspaceRoot: URL
+        workspaceRoot: URL,
+        recordsUserMessage: Bool = true
     ) {
         self.prompt = prompt
         self.thread = thread
         self.threadID = thread.id
         self.runner = runner
         self.workspaceRoot = workspaceRoot
+        self.recordsUserMessage = recordsUserMessage
     }
 
     func run(onProgress: AgentRunProgressHandler? = nil) async throws -> WorkspaceAgentSendSessionResult {
@@ -33,6 +36,7 @@ struct WorkspaceAgentSendSession: Sendable {
             prompt,
             in: thread,
             workspaceRoot: workspaceRoot,
+            recordUserMessage: recordsUserMessage,
             onProgress: onProgress
         )
         try Task.checkCancellation()

--- a/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
@@ -40,12 +40,17 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
         self.workspaceRoot = workspaceRoot
     }
 
-    func makeSession(prompt: String, thread: ChatThread) -> WorkspaceAgentSendSession {
+    func makeSession(
+        prompt: String,
+        thread: ChatThread,
+        recordsUserMessage: Bool = true
+    ) -> WorkspaceAgentSendSession {
         WorkspaceAgentSendSession(
             prompt: prompt,
             thread: thread,
             runner: configuredRunner,
-            workspaceRoot: workspaceRoot
+            workspaceRoot: workspaceRoot,
+            recordsUserMessage: recordsUserMessage
         )
     }
 

--- a/Sources/QuillCodeApp/WorkspaceAgentSendStartPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendStartPlanner.swift
@@ -14,11 +14,22 @@ enum WorkspaceAgentSendStartPlanner {
         thread: ChatThread,
         composer: ComposerState
     ) -> WorkspaceAgentSendStartPlan {
-        WorkspaceAgentSendStartPlan(
+        var startedThread = thread
+        appendUserTurn(prompt, to: &startedThread)
+        return WorkspaceAgentSendStartPlan(
             prompt: prompt,
-            thread: thread,
-            threadID: thread.id,
+            thread: startedThread,
+            threadID: startedThread.id,
             lifecycle: WorkspaceComposerSendLifecycle.started(from: composer)
         )
+    }
+
+    private static func appendUserTurn(_ prompt: String, to thread: inout ChatThread) {
+        thread.messages.append(ChatMessage(role: .user, content: prompt))
+        thread.events.append(ThreadEvent(kind: .message, summary: prompt))
+        thread.updatedAt = Date()
+        if thread.title == "New chat" {
+            thread.title = WorkspaceThreadSeedBuilder.title(fromUserPrompt: prompt)
+        }
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -22,7 +22,8 @@ enum WorkspaceHTMLTranscriptRenderer {
                 retryLastTurnCommand: retryLastTurnCommand
             )
         }.joined(separator: "\n")
-        if context.isEmpty && issue.isEmpty && timeline.isEmpty && !review.isVisible {
+        let thinking = renderThinking(transcript.thinking)
+        if context.isEmpty && issue.isEmpty && timeline.isEmpty && thinking.isEmpty && !review.isVisible {
             return """
             <section class="empty" data-testid="transcript-empty">
               <h1>\(escape(transcript.emptyTitle))</h1>
@@ -30,7 +31,7 @@ enum WorkspaceHTMLTranscriptRenderer {
             </section>
             """
         }
-        return context + "\n" + issue + "\n" + reviewPane + "\n" + timeline
+        return context + "\n" + issue + "\n" + reviewPane + "\n" + timeline + "\n" + thinking
     }
 
     static func renderComposer(_ composer: ComposerSurface, topBar: TopBarSurface) -> String {
@@ -87,6 +88,28 @@ enum WorkspaceHTMLTranscriptRenderer {
           \(issue.actionLabel.map { #"<button type="button" data-testid="runtime-issue-action">\#(escape($0))</button>"# } ?? "")
           \(diagnostics)
         </section>
+        """
+    }
+
+    private static func renderThinking(_ thinking: TranscriptThinkingSurface?) -> String {
+        guard let thinking else { return "" }
+        let trace = thinking.traceLines.isEmpty ? "" : """
+          <details data-testid="thinking-trace">
+            <summary>\(escape(thinking.traceTitle))</summary>
+            <ul>
+              \(thinking.traceLines.map { #"<li>\#(escape($0))</li>"# }.joined(separator: "\n"))
+            </ul>
+          </details>
+        """
+        return """
+        <article class="thinking" data-testid="thinking-indicator" data-thinking-id="\(escape(thinking.id))" aria-label="\(escape(thinking.title)): \(escape(thinking.subtitle))">
+          <header>
+            <strong data-testid="thinking-title">\(escape(thinking.title))</strong>
+            <span aria-hidden="true">...</span>
+          </header>
+          <p data-testid="thinking-subtitle">\(escape(thinking.subtitle))</p>
+          \(trace)
+        </article>
         """
     }
 

--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -26,7 +26,11 @@ extension QuillCodeWorkspaceModel {
         return true
     }
 
-    public func submitComposer(workspaceRoot: URL) async {
+    public func submitComposer(
+        workspaceRoot: URL,
+        onStarted: (@MainActor @Sendable () -> Void)? = nil,
+        onProgressUpdated: (@MainActor @Sendable () -> Void)? = nil
+    ) async {
         let submissionPlan = WorkspaceComposerSubmissionPlanner.plan(draft: composer.draft)
         let prompt: String
         switch submissionPlan {
@@ -47,15 +51,23 @@ extension QuillCodeWorkspaceModel {
             thread: thread,
             composer: composer
         )
+        updateThreadFromAgentRun(sendStart.thread)
+        threadPersistence.save(sendStart.thread)
         applyComposerSendLifecycle(sendStart.lifecycle)
+        onStarted?()
 
         let session = agentSendSessionFactory(workspaceRoot: workspaceRoot)
-            .makeSession(prompt: sendStart.prompt, thread: sendStart.thread)
+            .makeSession(
+                prompt: sendStart.prompt,
+                thread: sendStart.thread,
+                recordsUserMessage: false
+            )
         let outcome = await WorkspaceAgentSendTaskCoordinator(
             start: sendStart,
             session: session
         ).run { [weak self] progressThread in
             await self?.applyAgentProgress(progressThread, expectedThreadID: sendStart.threadID)
+            await onProgressUpdated?()
         }
         finishAgentSend(outcome)
     }

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -108,7 +108,12 @@ public extension QuillCodeWorkspaceModel {
             transcript: TranscriptSurface(
                 messages: thread.map { WorkspaceTranscriptSurfaceBuilder(thread: $0).messageSurfaces() } ?? [],
                 toolCards: toolCards,
-                timelineItems: thread == nil ? nil : currentTimelineItems
+                timelineItems: thread == nil ? nil : currentTimelineItems,
+                thinking: WorkspaceTranscriptThinkingSurfaceBuilder(
+                    thread: thread,
+                    composer: composer,
+                    agentStatus: topBarState.agentStatus
+                ).surface()
             ),
             contextBanner: WorkspaceContextBannerBuilder(thread: thread).banner(),
             review: WorkspaceReviewSurfaceBuilder(

--- a/Sources/QuillCodeApp/WorkspaceTranscriptThinkingSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptThinkingSurfaceBuilder.swift
@@ -1,0 +1,66 @@
+import Foundation
+import QuillCodeCore
+
+struct WorkspaceTranscriptThinkingSurfaceBuilder: Sendable, Hashable {
+    var thread: ChatThread?
+    var composer: ComposerState
+    var agentStatus: String
+
+    func surface() -> TranscriptThinkingSurface? {
+        guard composer.isSending, let thread else { return nil }
+        if thread.messages.last(where: { $0.role != .tool })?.role == .assistant {
+            return nil
+        }
+        let traceLines = Self.traceLines(from: thread.events)
+        return TranscriptThinkingSurface(
+            id: "thinking-\(thread.id.uuidString)",
+            title: title,
+            subtitle: subtitle(traceLines: traceLines),
+            traceLines: traceLines
+        )
+    }
+
+    private var title: String {
+        switch agentStatus {
+        case TopBarAgentStatusLabel.queued:
+            return "Queued"
+        case TopBarAgentStatusLabel.streaming:
+            return "Streaming"
+        case TopBarAgentStatusLabel.review:
+            return "Reviewing"
+        case TopBarAgentStatusLabel.finishing:
+            return "Finishing"
+        default:
+            return "Thinking"
+        }
+    }
+
+    private func subtitle(traceLines: [String]) -> String {
+        traceLines.last ?? "Preparing the next step"
+    }
+
+    private static func traceLines(from events: [ThreadEvent]) -> [String] {
+        events.compactMap(traceLine).suffix(6).map { $0 }
+    }
+
+    private static func traceLine(for event: ThreadEvent) -> String? {
+        switch event.kind {
+        case .message, .messageFeedback, .reviewComment:
+            return nil
+        case .notice:
+            return event.summary
+        case .toolQueued:
+            return "Queued: \(event.summary)"
+        case .toolRunning:
+            return "Running: \(event.summary)"
+        case .toolCompleted:
+            return "Completed: \(event.summary)"
+        case .toolFailed:
+            return "Failed: \(event.summary)"
+        case .approvalRequested:
+            return "Safety check: \(event.summary)"
+        case .approvalDecided:
+            return "Safety decision: \(event.summary)"
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopComposerCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComposerCoordinator.swift
@@ -51,7 +51,11 @@ struct QuillCodeDesktopComposerCoordinator {
     ) {
         tasks.startIfIdle(.send) { [weak model] in
             guard let model else { return }
-            await model.submitComposer(workspaceRoot: model.activeWorkspaceRoot ?? fallbackWorkspaceRoot)
+            await model.submitComposer(
+                workspaceRoot: model.activeWorkspaceRoot ?? fallbackWorkspaceRoot,
+                onStarted: refresh,
+                onProgressUpdated: refresh
+            )
         } onFinish: {
             refresh()
         }

--- a/Tests/QuillCodeAppTests/QuillCodeTranscriptSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeTranscriptSurfaceTests.swift
@@ -22,6 +22,7 @@ final class QuillCodeTranscriptSurfaceTests: XCTestCase {
 
         XCTAssertEqual(transcript.emptyTitle, "Ask QuillCode to inspect, edit, or run this project.")
         XCTAssertEqual(transcript.emptySubtitle, "Use Auto for normal coding work, Review for manual gates, or Read-only for exploration.")
+        XCTAssertNil(transcript.thinking)
         XCTAssertEqual(transcript.timelineItems.map(\.kind), [.message, .toolCard])
         XCTAssertEqual(transcript.timelineItems.map(\.id), [
             "message-00000000-0000-0000-0000-000000000401",

--- a/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentSendSessionTests.swift
@@ -44,6 +44,41 @@ final class WorkspaceAgentSendSessionTests: XCTestCase {
         XCTAssertEqual(Set(ids), [session.threadID])
     }
 
+    func testRunCanUsePreRecordedUserMessageWithoutDuplicatingIt() async throws {
+        let workspaceRoot = try makeQuillCodeTestDirectory()
+        var thread = ChatThread(title: "New chat")
+        thread.messages.append(ChatMessage(role: .user, content: "say hello"))
+        thread.events.append(ThreadEvent(kind: .message, summary: "say hello"))
+        thread.title = "say hello"
+        let session = WorkspaceAgentSendSession(
+            prompt: "say hello",
+            thread: thread,
+            runner: AgentRunner(llm: SequenceLLMClient(actions: [.say("hello")])),
+            workspaceRoot: workspaceRoot,
+            recordsUserMessage: false
+        )
+
+        let result = try await session.run()
+
+        XCTAssertEqual(result.thread.messages.map(\.role), [.user, .assistant])
+        XCTAssertEqual(result.thread.messages.map(\.content), ["say hello", "hello"])
+        XCTAssertEqual(result.thread.events.filter { $0.kind == .message }.map(\.summary), ["say hello", "hello"])
+    }
+
+    func testRunDefaultsToRecordingUserMessage() async throws {
+        let workspaceRoot = try makeQuillCodeTestDirectory()
+        let session = WorkspaceAgentSendSession(
+            prompt: "say hello",
+            thread: ChatThread(title: "New chat"),
+            runner: AgentRunner(llm: SequenceLLMClient(actions: [.say("hello")])),
+            workspaceRoot: workspaceRoot
+        )
+
+        let result = try await session.run()
+
+        XCTAssertEqual(result.thread.messages.map(\.content), ["say hello", "hello"])
+    }
+
     func testRunReportsSavedMemoryWhenMemoryToolCompletes() async throws {
         let workspaceRoot = try makeQuillCodeTestDirectory()
         let memoryRoot = try makeQuillCodeTestDirectory()

--- a/Tests/QuillCodeAppTests/WorkspaceAgentSendTaskCoordinatorTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentSendTaskCoordinatorTests.swift
@@ -89,7 +89,8 @@ final class WorkspaceAgentSendTaskCoordinatorTests: XCTestCase {
             prompt: start.prompt,
             thread: start.thread,
             runner: runner,
-            workspaceRoot: try makeQuillCodeTestDirectory()
+            workspaceRoot: try makeQuillCodeTestDirectory(),
+            recordsUserMessage: false
         )
         return WorkspaceAgentSendTaskCoordinator(start: start, session: session)
     }

--- a/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
@@ -144,6 +144,56 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
         XCTAssertEqual(model.root.topBar.agentStatus, "Idle")
     }
 
+    func testSubmitComposerShowsUserMessageAndThinkingBeforeAgentReturns() async throws {
+        let root = try makeTempDirectory()
+        let model = QuillCodeWorkspaceModel(runner: AgentRunner(llm: SlowLLMClient()))
+
+        model.setDraft("run a slow task")
+        let task = Task {
+            await model.submitComposer(workspaceRoot: root)
+        }
+
+        try await waitUntil(timeoutSeconds: 1) {
+            model.surface().transcript.timelineItems.first?.message?.text == "run a slow task"
+        }
+        XCTAssertEqual(model.composer.draft, "")
+        XCTAssertTrue(model.composer.isSending)
+        XCTAssertEqual(model.selectedThread?.messages.map(\.content), ["run a slow task"])
+        XCTAssertEqual(model.selectedThread?.events.map(\.kind), [.message])
+        XCTAssertEqual(model.surface().transcript.thinking?.title, "Thinking")
+        XCTAssertEqual(model.surface().transcript.thinking?.subtitle, "Preparing the next step")
+
+        task.cancel()
+        await task.value
+    }
+
+    func testSubmitComposerStartedCallbackReceivesOptimisticSurfaceBeforeAgentReturns() async throws {
+        let root = try makeTempDirectory()
+        let model = QuillCodeWorkspaceModel(runner: AgentRunner(llm: SlowLLMClient()))
+        let recorder = StartedSurfaceRecorder()
+
+        model.setDraft("show status quickly")
+        let task = Task {
+            await model.submitComposer(
+                workspaceRoot: root,
+                onStarted: {
+                    recorder.record(model.surface())
+                }
+            )
+        }
+
+        try await waitUntil(timeoutSeconds: 1) {
+            recorder.surface != nil
+        }
+        let surface = try XCTUnwrap(recorder.surface)
+        XCTAssertEqual(surface.transcript.timelineItems.first?.message?.text, "show status quickly")
+        XCTAssertEqual(surface.transcript.thinking?.title, "Thinking")
+        XCTAssertTrue(surface.composer.isSending)
+
+        task.cancel()
+        await task.value
+    }
+
     func testComposerShowsStreamingStatusForStreamingLLM() async throws {
         let root = try makeTempDirectory()
         let model = QuillCodeWorkspaceModel(runner: AgentRunner(
@@ -273,6 +323,15 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
             }
             try await Task.sleep(nanoseconds: 1_000_000)
         }
+    }
+}
+
+@MainActor
+private final class StartedSurfaceRecorder {
+    private(set) var surface: WorkspaceSurface?
+
+    func record(_ surface: WorkspaceSurface) {
+        self.surface = surface
     }
 }
 

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
@@ -128,6 +128,29 @@ final class WorkspaceHTMLChromeRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="send-button""#))
     }
 
+    func testHTMLRendererIncludesOptimisticThinkingSurface() {
+        let thread = ChatThread(
+            messages: [.init(role: .user, content: "run tests")],
+            events: [
+                .init(kind: .message, summary: "run tests"),
+                .init(kind: .toolQueued, summary: "host.shell.run queued")
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id),
+            composer: ComposerState(isSending: true)
+        )
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains("run tests"))
+        XCTAssertTrue(html.contains(#"data-testid="thinking-indicator""#))
+        XCTAssertTrue(html.contains(#"data-testid="thinking-title">Thinking"#))
+        XCTAssertTrue(html.contains(#"data-testid="thinking-subtitle">Queued: host.shell.run queued"#))
+        XCTAssertTrue(html.contains(#"data-testid="thinking-trace""#))
+        XCTAssertFalse(html.contains(#"data-testid="transcript-empty""#))
+    }
+
     func testHTMLRendererUsesMultilineComposer() {
         let model = QuillCodeWorkspaceModel(composer: ComposerState(
             draft: "first line\nsecond line"

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -3,6 +3,46 @@ import QuillCodeCore
 @testable import QuillCodeApp
 
 final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
+    func testThinkingSurfaceShowsWhileSendingAndKeepsTraceCollapsedByDefaultData() {
+        let thread = ChatThread(events: [
+            ThreadEvent(kind: .message, summary: "run tests"),
+            ThreadEvent(kind: .notice, summary: "Streaming model response"),
+            ThreadEvent(kind: .toolQueued, summary: "host.shell.run queued"),
+            ThreadEvent(kind: .toolRunning, summary: "host.shell.run running")
+        ])
+
+        let thinking = WorkspaceTranscriptThinkingSurfaceBuilder(
+            thread: thread,
+            composer: ComposerState(isSending: true),
+            agentStatus: TopBarAgentStatusLabel.running
+        ).surface()
+
+        XCTAssertEqual(thinking?.id, "thinking-\(thread.id.uuidString)")
+        XCTAssertEqual(thinking?.title, "Thinking")
+        XCTAssertEqual(thinking?.subtitle, "Running: host.shell.run running")
+        XCTAssertEqual(thinking?.traceTitle, "Trace")
+        XCTAssertEqual(thinking?.traceLines, [
+            "Streaming model response",
+            "Queued: host.shell.run queued",
+            "Running: host.shell.run running"
+        ])
+    }
+
+    func testThinkingSurfaceHidesAfterAssistantTextArrives() {
+        let thread = ChatThread(messages: [
+            ChatMessage(role: .user, content: "say hello"),
+            ChatMessage(role: .assistant, content: "hel")
+        ])
+
+        let thinking = WorkspaceTranscriptThinkingSurfaceBuilder(
+            thread: thread,
+            composer: ComposerState(isSending: true),
+            agentStatus: TopBarAgentStatusLabel.streaming
+        ).surface()
+
+        XCTAssertNil(thinking)
+    }
+
     func testMessageSurfacesHideToolMessagesAndAttachFeedback() throws {
         let user = ChatMessage(
             id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,9 @@
 # QuillCode Decisions
 
+## 2026-06-26
+
+- Composer sends record the user turn before the async agent run starts. `WorkspaceAgentSendStartPlanner` owns the optimistic user message/event/title update, and `WorkspaceAgentSendSession` can run with `recordsUserMessage: false` so the agent does not duplicate that turn. Desktop surfaces are snapshot-based, so `QuillCodeDesktopComposerCoordinator` must refresh on the model's `onStarted` and progress callbacks; otherwise the model state is correct but the macOS window does not paint the user bubble or thinking indicator until the run finishes.
+
 ## 2026-06-23
 
 - Active sidebar chats are grouped by relative recency through `SidebarSurface.recentSections(now:calendar:)`, not renderer-specific date logic. Native SwiftUI, static HTML, and Playwright should use the same sections: Today, Yesterday, Previous 7 days, Older. Rows sort newest-first inside each bucket. Pinned and Archived remain explicit sections because they are user/workflow state, not recency buckets.


### PR DESCRIPTION
## Summary
- Record the user turn synchronously before the async agent run so the transcript updates immediately.
- Add a transient thinking surface with animated dots and collapsed trace details for native SwiftUI and HTML harness surfaces.
- Refresh the desktop snapshot on send start/progress so the macOS window paints optimistic state before the model/network response.
- Document the send-start ownership decision.

## Tests
- swift test --filter WorkspaceComposerIntegrationTests
- swift test
- swift build -c release --product quill-code-desktop

## Local install
- Rebuilt and relaunched ~/Applications/QuillCode.app from the release binary.