### PR TITLE
Fix desktop optimistic send refresh

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopComposerCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComposerCoordinator.swift
@@ -15,7 +15,6 @@ struct QuillCodeDesktopComposerCoordinator {
 
         model.setDraft(prompt)
         draft = ""
-        refresh()
         submitPreparedComposer(
             model: model,
             fallbackWorkspaceRoot: fallbackWorkspaceRoot,
@@ -34,7 +33,6 @@ struct QuillCodeDesktopComposerCoordinator {
         guard !tasks.isRunning(.send), model.prepareRetryLastUserTurn() else { return }
 
         draft = ""
-        refresh()
         submitPreparedComposer(
             model: model,
             fallbackWorkspaceRoot: fallbackWorkspaceRoot,

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -66,6 +66,10 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(composerCoordinatorText.contains("tasks.startIfIdle(.send"), "Composer sends should use the task coordinator.")
         XCTAssertTrue(composerCoordinatorText.contains("draft.trimmingCharacters(in: .whitespacesAndNewlines)"), "Composer coordinator should normalize submitted prompts.")
         XCTAssertTrue(composerCoordinatorText.contains("model.prepareRetryLastUserTurn()"), "Composer retry preparation should live in the composer coordinator.")
+        XCTAssertFalse(
+            composerCoordinatorText.contains("draft = \"\"\n        refresh()\n        submitPreparedComposer"),
+            "Desktop send/retry must not refresh after clearing the visible draft but before submitComposer publishes the optimistic user turn."
+        )
         XCTAssertTrue(controllerText.contains("QuillCodeDesktopTerminalCoordinator"), "Desktop terminal workflow should be isolated behind a coordinator.")
         XCTAssertTrue(controllerText.contains("terminalCoordinator.runCommand"), "Desktop controller should delegate terminal command execution.")
         XCTAssertTrue(controllerText.contains("terminalCoordinator.recallPreviousCommand"), "Desktop controller should delegate terminal history recall.")


### PR DESCRIPTION
## Summary
- Removes the pre-submit desktop refresh that could write the old prompt back into the visible composer after Send.
- Keeps the optimistic user turn/thinking render owned by submitComposer and its onStarted callback.
- Adds a desktop parity regression gate so this sequencing bug does not come back.

## Validation
- swift test --filter ParityDesktopGateTests
- swift test --filter WorkspaceComposerIntegrationTests
