### PR TITLE
Keep thinking visible while streaming

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceTranscriptThinkingSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptThinkingSurfaceBuilder.swift
@@ -8,9 +8,6 @@ struct WorkspaceTranscriptThinkingSurfaceBuilder: Sendable, Hashable {
 
     func surface() -> TranscriptThinkingSurface? {
         guard composer.isSending, let thread else { return nil }
-        if thread.messages.last(where: { $0.role != .tool })?.role == .assistant {
-            return nil
-        }
         let traceLines = Self.traceLines(from: thread.events)
         return TranscriptThinkingSurface(
             id: "thinking-\(thread.id.uuidString)",

--- a/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
@@ -216,6 +216,7 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
             model.selectedThread?.messages.last?.content == "stream"
         }
         XCTAssertEqual(model.surface().transcript.timelineItems.last?.message?.text, "stream")
+        XCTAssertEqual(model.surface().transcript.thinking?.title, "Streaming")
 
         await task.value
 

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -28,10 +28,13 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         ])
     }
 
-    func testThinkingSurfaceHidesAfterAssistantTextArrives() {
+    func testThinkingSurfaceStaysVisibleWhileAssistantDraftStreams() {
         let thread = ChatThread(messages: [
             ChatMessage(role: .user, content: "say hello"),
             ChatMessage(role: .assistant, content: "hel")
+        ], events: [
+            ThreadEvent(kind: .message, summary: "say hello"),
+            ThreadEvent(kind: .notice, summary: "Streaming model response")
         ])
 
         let thinking = WorkspaceTranscriptThinkingSurfaceBuilder(
@@ -40,7 +43,8 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
             agentStatus: TopBarAgentStatusLabel.streaming
         ).surface()
 
-        XCTAssertNil(thinking)
+        XCTAssertEqual(thinking?.title, "Streaming")
+        XCTAssertEqual(thinking?.subtitle, "Streaming model response")
     }
 
     func testMessageSurfacesHideToolMessagesAndAttachFeedback() throws {


### PR DESCRIPTION
## Summary
- keep the transcript thinking/status row visible while assistant draft text streams
- add builder and composer integration coverage so streaming text still shows the thinking surface

## Validation
- swift test --filter WorkspaceTranscriptSurfaceBuilderTests
- swift test --filter WorkspaceComposerIntegrationTests
- swift test