### PR TITLE
Centralize PR command descriptors

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
+++ b/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
@@ -6,6 +6,9 @@ enum QuillCodeCommandIconCatalog {
         if commandID.hasPrefix("local-env:") {
             return "hammer"
         }
+        if let pullRequestIcon = WorkspacePullRequestCommandCatalog.systemImage(for: commandID) {
+            return pullRequestIcon
+        }
 
         switch commandID {
         case "new-chat":
@@ -42,24 +45,6 @@ enum QuillCodeCommandIconCatalog {
             return "brain.head.profile"
         case "toggle-extensions":
             return "puzzlepiece.extension"
-        case "git-pr-create":
-            return "arrow.up.doc"
-        case "git-pr-checkout":
-            return "arrow.down.doc"
-        case "git-pr-reviewers":
-            return "person.2.badge.gearshape"
-        case "git-pr-review-comment":
-            return "text.bubble"
-        case "git-pr-review-reply":
-            return "arrowshape.turn.up.left"
-        case "git-pr-review-threads":
-            return "list.bullet.rectangle"
-        case "git-pr-review-thread":
-            return "checkmark.bubble"
-        case "git-pr-labels":
-            return "tag"
-        case "git-pr-merge":
-            return "arrow.triangle.merge"
         case "git-worktree-list":
             return "point.3.connected.trianglepath.dotted"
         case "git-worktree-create":

--- a/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
@@ -57,12 +57,8 @@ enum WorkspaceCommandPlan: Equatable {
     private static let toolNameByCommandID: [String: String] = [
         "git-status": ToolDefinition.gitStatus.name,
         "git-diff": ToolDefinition.gitDiff.name,
-        "git-pr-view": ToolDefinition.gitPullRequestView.name,
-        "git-pr-checks": ToolDefinition.gitPullRequestChecks.name,
-        "git-pr-diff": ToolDefinition.gitPullRequestDiff.name,
-        "git-pr-review-threads": ToolDefinition.gitPullRequestReviewThreads.name,
         "git-worktree-list": ToolDefinition.gitWorktreeList.name
-    ]
+    ].merging(WorkspacePullRequestCommandCatalog.toolNameByCommandID) { local, _ in local }
 
     private static let toolCallByCommandID: [String: ToolCall] = [
         "git-worktree-prune": WorkspaceWorktreeToolCallPlanner.prune(.init(dryRun: true, verbose: true))
@@ -71,20 +67,10 @@ enum WorkspaceCommandPlan: Equatable {
     private static let draftByCommandID: [String: String] = [
         "memory-add": "/remember ",
         "add-ssh-project": "/ssh user@host:/absolute/path",
-        "git-pr-create": "Create a pull request titled ",
-        "git-pr-checkout": "Checkout pull request ",
-        "git-pr-reviewers": "Request reviewers for the current pull request: ",
-        "git-pr-comment": "Comment on the current pull request: ",
-        "git-pr-review": "Review the current pull request: approve",
-        "git-pr-review-comment": "Comment on a pull request line: ",
-        "git-pr-review-reply": "Reply to pull request review comment: ",
-        "git-pr-review-thread": "Resolve pull request review thread: ",
-        "git-pr-labels": "Label the current pull request: ",
-        "git-pr-merge": "Merge the current pull request with squash",
         "git-worktree-create": "Create a git worktree named ",
         "git-worktree-open": "Open git worktree at ",
         "git-worktree-remove": "Remove git worktree at "
-    ]
+    ].merging(WorkspacePullRequestCommandCatalog.draftByCommandID) { local, _ in local }
 
     private static func prefixPlan(_ commandID: String) -> WorkspaceCommandPlan? {
         if commandID.value(after: "local-env:") != nil {

--- a/Sources/QuillCodeApp/WorkspaceGitCommandCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspaceGitCommandCatalog.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum WorkspaceGitCommandCatalog {
     static func commands(hasWorkspaceOrRemoteProject: Bool) -> [WorkspaceCommandSurface] {
-        [
+        let gitCommands = [
             WorkspaceCommandSurface(
                 id: "git-status",
                 title: "Git status",
@@ -17,104 +17,9 @@ enum WorkspaceGitCommandCatalog {
                 keywords: ["git", "diff", "review", "changes", "remote"],
                 isEnabled: hasWorkspaceOrRemoteProject
             ),
-            WorkspaceCommandSurface(
-                id: "git-pr-create",
-                title: "Create pull request",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "pull request", "review"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-view",
-                title: "View pull request",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "view", "comments", "review"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-checks",
-                title: "Pull request checks",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "checks", "ci", "status"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-diff",
-                title: "Pull request diff",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "pr diff", "pull request diff", "diff", "review", "changes"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-checkout",
-                title: "Checkout pull request",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "checkout", "switch", "branch"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-reviewers",
-                title: "Request pull request reviewers",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "reviewer", "reviewers", "request review"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-comment",
-                title: "Comment on pull request",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "comment", "comment pull", "reply", "discussion"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-review",
-                title: "Review pull request",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "review", "approve", "approve pr", "request changes"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-review-comment",
-                title: "Comment on pull request line",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "review", "inline", "line comment", "review comment"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-review-reply",
-                title: "Reply to pull request line comment",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "review", "reply", "inline reply", "review comment reply"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-review-threads",
-                title: "List pull request review threads",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "review", "thread", "threads", "unresolved", "ids", "browse"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-review-thread",
-                title: "Resolve pull request review thread",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "review", "thread", "resolve", "unresolve"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-labels",
-                title: "Label pull request",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "label", "labels", "triage"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
-            WorkspaceCommandSurface(
-                id: "git-pr-merge",
-                title: "Merge pull request",
-                category: WorkspaceCommandPalette.gitCategory,
-                keywords: ["github", "pr", "merge", "automerge", "merge train"],
-                isEnabled: hasWorkspaceOrRemoteProject
-            ),
+        ]
+
+        let worktreeCommands = [
             WorkspaceCommandSurface(
                 id: "git-worktree-list",
                 title: "List worktrees",
@@ -151,5 +56,9 @@ enum WorkspaceGitCommandCatalog {
                 isEnabled: hasWorkspaceOrRemoteProject
             )
         ]
+
+        return gitCommands
+            + WorkspacePullRequestCommandCatalog.commands(isEnabled: hasWorkspaceOrRemoteProject)
+            + worktreeCommands
     }
 }

--- a/Sources/QuillCodeApp/WorkspacePullRequestCommandCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspacePullRequestCommandCatalog.swift
@@ -1,0 +1,157 @@
+import QuillCodeCore
+
+struct WorkspacePullRequestCommandDescriptor: Equatable {
+    let id: String
+    let title: String
+    let keywords: [String]
+    let systemImage: String
+    let toolName: String?
+    let draft: String?
+
+    init(
+        id: String,
+        title: String,
+        keywords: [String],
+        systemImage: String,
+        toolName: String? = nil,
+        draft: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.keywords = keywords
+        self.systemImage = systemImage
+        self.toolName = toolName
+        self.draft = draft
+    }
+
+    func command(isEnabled: Bool) -> WorkspaceCommandSurface {
+        WorkspaceCommandSurface(
+            id: id,
+            title: title,
+            category: WorkspaceCommandPalette.gitCategory,
+            keywords: keywords,
+            isEnabled: isEnabled
+        )
+    }
+}
+
+enum WorkspacePullRequestCommandCatalog {
+    static let descriptors: [WorkspacePullRequestCommandDescriptor] = [
+        .init(
+            id: "git-pr-create",
+            title: "Create pull request",
+            keywords: ["github", "pr", "pull request", "review"],
+            systemImage: "arrow.up.doc",
+            draft: "Create a pull request titled "
+        ),
+        .init(
+            id: "git-pr-view",
+            title: "View pull request",
+            keywords: ["github", "pr", "view", "comments", "review"],
+            systemImage: "doc.text.magnifyingglass",
+            toolName: ToolDefinition.gitPullRequestView.name
+        ),
+        .init(
+            id: "git-pr-checks",
+            title: "Pull request checks",
+            keywords: ["github", "pr", "checks", "ci", "status"],
+            systemImage: "checklist",
+            toolName: ToolDefinition.gitPullRequestChecks.name
+        ),
+        .init(
+            id: "git-pr-diff",
+            title: "Pull request diff",
+            keywords: ["github", "pr", "pr diff", "pull request diff", "diff", "review", "changes"],
+            systemImage: "doc.text.magnifyingglass",
+            toolName: ToolDefinition.gitPullRequestDiff.name
+        ),
+        .init(
+            id: "git-pr-checkout",
+            title: "Checkout pull request",
+            keywords: ["github", "pr", "checkout", "switch", "branch"],
+            systemImage: "arrow.down.doc",
+            draft: "Checkout pull request "
+        ),
+        .init(
+            id: "git-pr-reviewers",
+            title: "Request pull request reviewers",
+            keywords: ["github", "pr", "reviewer", "reviewers", "request review"],
+            systemImage: "person.2.badge.gearshape",
+            draft: "Request reviewers for the current pull request: "
+        ),
+        .init(
+            id: "git-pr-comment",
+            title: "Comment on pull request",
+            keywords: ["github", "pr", "comment", "comment pull", "reply", "discussion"],
+            systemImage: "bubble.left.and.text.bubble.right",
+            draft: "Comment on the current pull request: "
+        ),
+        .init(
+            id: "git-pr-review",
+            title: "Review pull request",
+            keywords: ["github", "pr", "review", "approve", "approve pr", "request changes"],
+            systemImage: "checkmark.seal",
+            draft: "Review the current pull request: approve"
+        ),
+        .init(
+            id: "git-pr-review-comment",
+            title: "Comment on pull request line",
+            keywords: ["github", "pr", "review", "inline", "line comment", "review comment"],
+            systemImage: "text.bubble",
+            draft: "Comment on a pull request line: "
+        ),
+        .init(
+            id: "git-pr-review-reply",
+            title: "Reply to pull request line comment",
+            keywords: ["github", "pr", "review", "reply", "inline reply", "review comment reply"],
+            systemImage: "arrowshape.turn.up.left",
+            draft: "Reply to pull request review comment: "
+        ),
+        .init(
+            id: "git-pr-review-threads",
+            title: "List pull request review threads",
+            keywords: ["github", "pr", "review", "thread", "threads", "unresolved", "ids", "browse"],
+            systemImage: "list.bullet.rectangle",
+            toolName: ToolDefinition.gitPullRequestReviewThreads.name
+        ),
+        .init(
+            id: "git-pr-review-thread",
+            title: "Resolve pull request review thread",
+            keywords: ["github", "pr", "review", "thread", "resolve", "unresolve"],
+            systemImage: "checkmark.bubble",
+            draft: "Resolve pull request review thread: "
+        ),
+        .init(
+            id: "git-pr-labels",
+            title: "Label pull request",
+            keywords: ["github", "pr", "label", "labels", "triage"],
+            systemImage: "tag",
+            draft: "Label the current pull request: "
+        ),
+        .init(
+            id: "git-pr-merge",
+            title: "Merge pull request",
+            keywords: ["github", "pr", "merge", "automerge", "merge train"],
+            systemImage: "arrow.triangle.merge",
+            draft: "Merge the current pull request with squash"
+        )
+    ]
+
+    static let toolNameByCommandID = dictionary(\.toolName)
+    static let draftByCommandID = dictionary(\.draft)
+    static let systemImageByCommandID = Dictionary(uniqueKeysWithValues: descriptors.map { ($0.id, $0.systemImage) })
+
+    static func commands(isEnabled: Bool) -> [WorkspaceCommandSurface] {
+        descriptors.map { $0.command(isEnabled: isEnabled) }
+    }
+
+    static func systemImage(for commandID: String) -> String? {
+        systemImageByCommandID[commandID]
+    }
+
+    private static func dictionary(_ value: KeyPath<WorkspacePullRequestCommandDescriptor, String?>) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: descriptors.compactMap { descriptor in
+            descriptor[keyPath: value].map { (descriptor.id, $0) }
+        })
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspacePullRequestCommandCatalogTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspacePullRequestCommandCatalogTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeApp
+
+final class WorkspacePullRequestCommandCatalogTests: XCTestCase {
+    func testDescriptorsBuildPaletteCommandsInOrder() {
+        let commands = WorkspacePullRequestCommandCatalog.commands(isEnabled: true)
+
+        XCTAssertEqual(commands.map(\.id), [
+            "git-pr-create",
+            "git-pr-view",
+            "git-pr-checks",
+            "git-pr-diff",
+            "git-pr-checkout",
+            "git-pr-reviewers",
+            "git-pr-comment",
+            "git-pr-review",
+            "git-pr-review-comment",
+            "git-pr-review-reply",
+            "git-pr-review-threads",
+            "git-pr-review-thread",
+            "git-pr-labels",
+            "git-pr-merge"
+        ])
+        XCTAssertTrue(commands.allSatisfy(\.isEnabled))
+        XCTAssertEqual(commands.first?.category, WorkspaceCommandPalette.gitCategory)
+    }
+
+    func testDescriptorsOwnCommandPlansAndIcons() {
+        XCTAssertEqual(
+            WorkspacePullRequestCommandCatalog.toolNameByCommandID,
+            [
+                "git-pr-view": ToolDefinition.gitPullRequestView.name,
+                "git-pr-checks": ToolDefinition.gitPullRequestChecks.name,
+                "git-pr-diff": ToolDefinition.gitPullRequestDiff.name,
+                "git-pr-review-threads": ToolDefinition.gitPullRequestReviewThreads.name
+            ]
+        )
+        XCTAssertEqual(
+            WorkspacePullRequestCommandCatalog.draftByCommandID["git-pr-review-thread"],
+            "Resolve pull request review thread: "
+        )
+        XCTAssertEqual(
+            QuillCodeCommandIconCatalog.systemImage(for: "git-pr-checks"),
+            "checklist"
+        )
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7175,3 +7175,27 @@ Strict grades:
 Remaining parity risk:
 
 - PR command metadata is still duplicated across command catalog, slash catalog, icon catalog, and draft planner. The code is correct and tested, but a future descriptor table would be more DRY if the PR tool family keeps growing.
+
+## 2026-06-27 PR Command Descriptor Slice
+
+Overall grade after this slice: **A command metadata ownership, A command-plan reuse, A- slash catalog still separate**.
+
+The PR command family had grown enough that every new action needed edits across the palette catalog, command planner, icon catalog, and tests. That made command additions correct but expensive, and created an obvious drift risk for parallel agents adding GitHub parity features.
+
+Code quality changes:
+
+- Added `WorkspacePullRequestCommandCatalog` as the single descriptor table for PR command IDs, titles, keywords, SF Symbols, direct tool mappings, and draft-prefill copy.
+- Rewired `WorkspaceGitCommandCatalog`, `WorkspaceCommandPlan`, and `QuillCodeCommandIconCatalog` to consume the descriptor table instead of repeating PR metadata.
+- Added focused descriptor tests that verify PR command order, enabled command surfaces, direct tool mappings, draft mappings, and icon routing.
+- Kept slash parsing separate in this slice because `/pr` subcommands carry additional argument grammar and aliases that are not one-to-one with palette rows.
+
+Strict grades:
+
+- `WorkspacePullRequestCommandCatalog.swift`: **A**. It is small, declarative, and owns exactly the metadata that had been duplicated.
+- `WorkspaceGitCommandCatalog.swift`: **A**. The file now reads as Git basics plus PR descriptors plus worktree commands.
+- `WorkspaceCommandPlan.swift`: **A**. PR direct-tool and draft plans are table-driven without changing existing command behavior.
+- `QuillCodeCommandIconCatalog.swift`: **A**. PR icons no longer require another switch branch when command metadata changes.
+
+Remaining parity risk:
+
+- Slash command catalog/parser entries remain separate because they include grammar and aliases. If PR slash command help starts drifting from palette metadata, add optional slash-usage fields to the descriptor rather than spreading PR copy across another static table.


### PR DESCRIPTION
## Summary
- add `WorkspacePullRequestCommandCatalog` as the descriptor source for PR command IDs, titles, keywords, icons, direct tools, and draft-prefill text
- wire the Git command palette, command planner, and icon catalog through that descriptor table
- add focused descriptor coverage and update the code-quality audit

## Validation
- `git diff --check`
- `swift test --filter 'WorkspacePullRequestCommandCatalogTests|WorkspaceCommandPlanTests|WorkspaceCommandPaletteRankerTests|QuillCodeCommandIconCatalogTests|WorkspaceSurfaceTests|WorkspacePullRequestIntegrationTests|WorkspaceRemoteProjectIntegrationTests'`\n- `swift test --quiet`