### PR TITLE
Use PR descriptors for slash discovery

### DIFF
--- a/Sources/QuillCodeApp/SlashCommandCatalog.swift
+++ b/Sources/QuillCodeApp/SlashCommandCatalog.swift
@@ -30,7 +30,12 @@ struct SlashCommandDefinition: Sendable, Hashable {
 enum SlashCommandCatalog {
     static let commandPaletteIDPrefix = "slash-command:"
 
-    static let definitions: [SlashCommandDefinition] = [
+    static let definitions: [SlashCommandDefinition] =
+        prefixDefinitions
+        + WorkspacePullRequestCommandCatalog.slashDefinitions
+        + suffixDefinitions
+
+    private static let prefixDefinitions: [SlashCommandDefinition] = [
         .init(usage: "/help", title: "Show slash commands", detail: "List the available composer commands.", insertText: "/help", aliases: ["?"]),
         .init(usage: "/status", title: "Show status", detail: "Summarize the active project, mode, model, and loaded context.", insertText: "/status", aliases: []),
         .init(usage: "/new", title: "New chat", detail: "Start a fresh thread in the selected project.", insertText: "/new", aliases: ["new-chat", "newchat"]),
@@ -56,20 +61,9 @@ enum SlashCommandCatalog {
         .init(usage: "/worktree open path", title: "Open worktree", detail: "Open an existing registered git worktree as a focused project.", insertText: "/worktree open ", aliases: ["worktree switch", "wt open"]),
         .init(usage: "/worktree remove path", title: "Remove worktree", detail: "Remove an existing registered git worktree. Add --force only when needed.", insertText: "/worktree remove ", aliases: ["worktree rm", "wt remove"]),
         .init(usage: "/worktree prune", title: "Prune stale worktrees", detail: "Clean stale git worktree administrative records. Add --dry-run to preview.", insertText: "/worktree prune --dry-run", aliases: ["worktree cleanup", "wt prune"]),
-        .init(usage: "/pr create", title: "Create pull request", detail: "Draft a pull request request in the composer.", insertText: "/pr create", aliases: ["pull-request", "pullrequest"]),
-        .init(usage: "/pr view [selector]", title: "View pull request", detail: "View the current or selected pull request with comments.", insertText: "/pr view ", aliases: ["pr show", "pull request view"]),
-        .init(usage: "/pr checks [selector]", title: "Pull request checks", detail: "Show CI status for the current or selected pull request.", insertText: "/pr checks ", aliases: ["pr ci", "pull request status"]),
-        .init(usage: "/pr diff [selector]", title: "Pull request diff", detail: "Show the unified diff for the current or selected pull request.", insertText: "/pr diff ", aliases: ["pr changes", "pull request diff"]),
-        .init(usage: "/pr checkout selector", title: "Checkout pull request", detail: "Check out a pull request branch.", insertText: "/pr checkout ", aliases: ["pr switch"]),
-        .init(usage: "/pr comment body", title: "Comment on pull request", detail: "Post a top-level comment on the current pull request.", insertText: "/pr comment ", aliases: ["pr reply"]),
-        .init(usage: "/pr review approve|comment|request_changes", title: "Review pull request", detail: "Submit an approve, comment, or request_changes review.", insertText: "/pr review approve", aliases: ["pr approve", "request changes"]),
-        .init(usage: "/pr review-comment path line body", title: "Inline pull request comment", detail: "Post an inline review comment on a pull request diff line.", insertText: "/pr review-comment ", aliases: ["pr inline", "line comment", "review comment"]),
-        .init(usage: "/pr review-reply commentId body", title: "Reply to inline review comment", detail: "Reply to an existing pull request line comment.", insertText: "/pr review-reply ", aliases: ["inline reply", "review reply"]),
-        .init(usage: "/pr review-threads [selector]", title: "List review threads", detail: "List review-thread IDs and first comment IDs for reply or resolve actions.", insertText: "/pr review-threads ", aliases: ["pr threads", "review thread ids"]),
-        .init(usage: "/pr review-thread resolve|unresolve threadId", title: "Resolve review thread", detail: "Resolve or unresolve a pull request review thread.", insertText: "/pr review-thread resolve ", aliases: ["resolve thread", "unresolve thread"]),
-        .init(usage: "/pr reviewers add|remove login", title: "Manage pull request reviewers", detail: "Request or remove pull request reviewers.", insertText: "/pr reviewers add ", aliases: ["request reviewer", "remove reviewer"]),
-        .init(usage: "/pr labels add|remove label", title: "Manage pull request labels", detail: "Add or remove pull request labels. Use commas for labels with spaces.", insertText: "/pr labels add ", aliases: ["pr label", "triage label"]),
-        .init(usage: "/pr merge [squash|merge|rebase]", title: "Merge pull request", detail: "Merge or enable auto-merge for the current pull request.", insertText: "/pr merge squash", aliases: ["automerge", "merge train"]),
+    ]
+
+    private static let suffixDefinitions: [SlashCommandDefinition] = [
         .init(usage: "/env name", title: "Run local environment action", detail: "List or run project-local environment scripts.", insertText: "/env ", aliases: ["environment", "local-env"]),
         .init(usage: "/mode auto|review|read-only", title: "Set approval mode", detail: "Switch between Auto, Review, and Read-only behavior.", insertText: "/mode ", aliases: []),
         .init(

--- a/Sources/QuillCodeApp/WorkspacePullRequestCommandCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspacePullRequestCommandCatalog.swift
@@ -1,5 +1,21 @@
 import QuillCodeCore
 
+private func pullRequestSlash(
+    usage: String,
+    title: String,
+    detail: String,
+    insertText: String,
+    aliases: [String]
+) -> SlashCommandDefinition {
+    SlashCommandDefinition(
+        usage: usage,
+        title: title,
+        detail: detail,
+        insertText: insertText,
+        aliases: aliases
+    )
+}
+
 struct WorkspacePullRequestCommandDescriptor: Equatable {
     let id: String
     let title: String
@@ -7,6 +23,7 @@ struct WorkspacePullRequestCommandDescriptor: Equatable {
     let systemImage: String
     let toolName: String?
     let draft: String?
+    let slash: SlashCommandDefinition?
 
     init(
         id: String,
@@ -14,7 +31,8 @@ struct WorkspacePullRequestCommandDescriptor: Equatable {
         keywords: [String],
         systemImage: String,
         toolName: String? = nil,
-        draft: String? = nil
+        draft: String? = nil,
+        slash: SlashCommandDefinition? = nil
     ) {
         self.id = id
         self.title = title
@@ -22,6 +40,7 @@ struct WorkspacePullRequestCommandDescriptor: Equatable {
         self.systemImage = systemImage
         self.toolName = toolName
         self.draft = draft
+        self.slash = slash
     }
 
     func command(isEnabled: Bool) -> WorkspaceCommandSurface {
@@ -42,104 +61,203 @@ enum WorkspacePullRequestCommandCatalog {
             title: "Create pull request",
             keywords: ["github", "pr", "pull request", "review"],
             systemImage: "arrow.up.doc",
-            draft: "Create a pull request titled "
+            draft: "Create a pull request titled ",
+            slash: pullRequestSlash(
+                usage: "/pr create",
+                title: "Create pull request",
+                detail: "Draft a pull request request in the composer.",
+                insertText: "/pr create",
+                aliases: ["pull-request", "pullrequest"]
+            )
         ),
         .init(
             id: "git-pr-view",
             title: "View pull request",
             keywords: ["github", "pr", "view", "comments", "review"],
             systemImage: "doc.text.magnifyingglass",
-            toolName: ToolDefinition.gitPullRequestView.name
+            toolName: ToolDefinition.gitPullRequestView.name,
+            slash: pullRequestSlash(
+                usage: "/pr view [selector]",
+                title: "View pull request",
+                detail: "View the current or selected pull request with comments.",
+                insertText: "/pr view ",
+                aliases: ["pr show", "pull request view"]
+            )
         ),
         .init(
             id: "git-pr-checks",
             title: "Pull request checks",
             keywords: ["github", "pr", "checks", "ci", "status"],
             systemImage: "checklist",
-            toolName: ToolDefinition.gitPullRequestChecks.name
+            toolName: ToolDefinition.gitPullRequestChecks.name,
+            slash: pullRequestSlash(
+                usage: "/pr checks [selector]",
+                title: "Pull request checks",
+                detail: "Show CI status for the current or selected pull request.",
+                insertText: "/pr checks ",
+                aliases: ["pr ci", "pull request status"]
+            )
         ),
         .init(
             id: "git-pr-diff",
             title: "Pull request diff",
             keywords: ["github", "pr", "pr diff", "pull request diff", "diff", "review", "changes"],
             systemImage: "doc.text.magnifyingglass",
-            toolName: ToolDefinition.gitPullRequestDiff.name
+            toolName: ToolDefinition.gitPullRequestDiff.name,
+            slash: pullRequestSlash(
+                usage: "/pr diff [selector]",
+                title: "Pull request diff",
+                detail: "Show the unified diff for the current or selected pull request.",
+                insertText: "/pr diff ",
+                aliases: ["pr changes", "pull request diff"]
+            )
         ),
         .init(
             id: "git-pr-checkout",
             title: "Checkout pull request",
             keywords: ["github", "pr", "checkout", "switch", "branch"],
             systemImage: "arrow.down.doc",
-            draft: "Checkout pull request "
+            draft: "Checkout pull request ",
+            slash: pullRequestSlash(
+                usage: "/pr checkout selector",
+                title: "Checkout pull request",
+                detail: "Check out a pull request branch.",
+                insertText: "/pr checkout ",
+                aliases: ["pr switch"]
+            )
         ),
         .init(
             id: "git-pr-reviewers",
             title: "Request pull request reviewers",
             keywords: ["github", "pr", "reviewer", "reviewers", "request review"],
             systemImage: "person.2.badge.gearshape",
-            draft: "Request reviewers for the current pull request: "
+            draft: "Request reviewers for the current pull request: ",
+            slash: pullRequestSlash(
+                usage: "/pr reviewers add|remove login",
+                title: "Manage pull request reviewers",
+                detail: "Request or remove pull request reviewers.",
+                insertText: "/pr reviewers add ",
+                aliases: ["request reviewer", "remove reviewer"]
+            )
         ),
         .init(
             id: "git-pr-comment",
             title: "Comment on pull request",
             keywords: ["github", "pr", "comment", "comment pull", "reply", "discussion"],
             systemImage: "bubble.left.and.text.bubble.right",
-            draft: "Comment on the current pull request: "
+            draft: "Comment on the current pull request: ",
+            slash: pullRequestSlash(
+                usage: "/pr comment body",
+                title: "Comment on pull request",
+                detail: "Post a top-level comment on the current pull request.",
+                insertText: "/pr comment ",
+                aliases: ["pr reply"]
+            )
         ),
         .init(
             id: "git-pr-review",
             title: "Review pull request",
             keywords: ["github", "pr", "review", "approve", "approve pr", "request changes"],
             systemImage: "checkmark.seal",
-            draft: "Review the current pull request: approve"
+            draft: "Review the current pull request: approve",
+            slash: pullRequestSlash(
+                usage: "/pr review approve|comment|request_changes",
+                title: "Review pull request",
+                detail: "Submit an approve, comment, or request_changes review.",
+                insertText: "/pr review approve",
+                aliases: ["pr approve", "request changes"]
+            )
         ),
         .init(
             id: "git-pr-review-comment",
             title: "Comment on pull request line",
             keywords: ["github", "pr", "review", "inline", "line comment", "review comment"],
             systemImage: "text.bubble",
-            draft: "Comment on a pull request line: "
+            draft: "Comment on a pull request line: ",
+            slash: pullRequestSlash(
+                usage: "/pr review-comment path line body",
+                title: "Inline pull request comment",
+                detail: "Post an inline review comment on a pull request diff line.",
+                insertText: "/pr review-comment ",
+                aliases: ["pr inline", "line comment", "review comment"]
+            )
         ),
         .init(
             id: "git-pr-review-reply",
             title: "Reply to pull request line comment",
             keywords: ["github", "pr", "review", "reply", "inline reply", "review comment reply"],
             systemImage: "arrowshape.turn.up.left",
-            draft: "Reply to pull request review comment: "
+            draft: "Reply to pull request review comment: ",
+            slash: pullRequestSlash(
+                usage: "/pr review-reply commentId body",
+                title: "Reply to inline review comment",
+                detail: "Reply to an existing pull request line comment.",
+                insertText: "/pr review-reply ",
+                aliases: ["inline reply", "review reply"]
+            )
         ),
         .init(
             id: "git-pr-review-threads",
             title: "List pull request review threads",
             keywords: ["github", "pr", "review", "thread", "threads", "unresolved", "ids", "browse"],
             systemImage: "list.bullet.rectangle",
-            toolName: ToolDefinition.gitPullRequestReviewThreads.name
+            toolName: ToolDefinition.gitPullRequestReviewThreads.name,
+            slash: pullRequestSlash(
+                usage: "/pr review-threads [selector]",
+                title: "List review threads",
+                detail: "List review-thread IDs and first comment IDs for reply or resolve actions.",
+                insertText: "/pr review-threads ",
+                aliases: ["pr threads", "review thread ids"]
+            )
         ),
         .init(
             id: "git-pr-review-thread",
             title: "Resolve pull request review thread",
             keywords: ["github", "pr", "review", "thread", "resolve", "unresolve"],
             systemImage: "checkmark.bubble",
-            draft: "Resolve pull request review thread: "
+            draft: "Resolve pull request review thread: ",
+            slash: pullRequestSlash(
+                usage: "/pr review-thread resolve|unresolve threadId",
+                title: "Resolve review thread",
+                detail: "Resolve or unresolve a pull request review thread.",
+                insertText: "/pr review-thread resolve ",
+                aliases: ["resolve thread", "unresolve thread"]
+            )
         ),
         .init(
             id: "git-pr-labels",
             title: "Label pull request",
             keywords: ["github", "pr", "label", "labels", "triage"],
             systemImage: "tag",
-            draft: "Label the current pull request: "
+            draft: "Label the current pull request: ",
+            slash: pullRequestSlash(
+                usage: "/pr labels add|remove label",
+                title: "Manage pull request labels",
+                detail: "Add or remove pull request labels. Use commas for labels with spaces.",
+                insertText: "/pr labels add ",
+                aliases: ["pr label", "triage label"]
+            )
         ),
         .init(
             id: "git-pr-merge",
             title: "Merge pull request",
             keywords: ["github", "pr", "merge", "automerge", "merge train"],
             systemImage: "arrow.triangle.merge",
-            draft: "Merge the current pull request with squash"
+            draft: "Merge the current pull request with squash",
+            slash: pullRequestSlash(
+                usage: "/pr merge [squash|merge|rebase]",
+                title: "Merge pull request",
+                detail: "Merge or enable auto-merge for the current pull request.",
+                insertText: "/pr merge squash",
+                aliases: ["automerge", "merge train"]
+            )
         )
     ]
 
     static let toolNameByCommandID = dictionary(\.toolName)
     static let draftByCommandID = dictionary(\.draft)
     static let systemImageByCommandID = Dictionary(uniqueKeysWithValues: descriptors.map { ($0.id, $0.systemImage) })
+    static let slashDefinitions = descriptors.compactMap(\.slash)
 
     static func commands(isEnabled: Bool) -> [WorkspaceCommandSurface] {
         descriptors.map { $0.command(isEnabled: isEnabled) }

--- a/Tests/QuillCodeAppTests/WorkspacePullRequestCommandCatalogTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspacePullRequestCommandCatalogTests.swift
@@ -46,4 +46,36 @@ final class WorkspacePullRequestCommandCatalogTests: XCTestCase {
             "checklist"
         )
     }
+
+    func testDescriptorsOwnSlashDefinitionsUsedByCatalog() {
+        let slashDefinitions = WorkspacePullRequestCommandCatalog.slashDefinitions
+        let slashUsages = slashDefinitions.map(\.usage)
+
+        XCTAssertEqual(slashUsages, [
+            "/pr create",
+            "/pr view [selector]",
+            "/pr checks [selector]",
+            "/pr diff [selector]",
+            "/pr checkout selector",
+            "/pr reviewers add|remove login",
+            "/pr comment body",
+            "/pr review approve|comment|request_changes",
+            "/pr review-comment path line body",
+            "/pr review-reply commentId body",
+            "/pr review-threads [selector]",
+            "/pr review-thread resolve|unresolve threadId",
+            "/pr labels add|remove label",
+            "/pr merge [squash|merge|rebase]"
+        ])
+        XCTAssertEqual(
+            slashDefinitions.first { $0.usage == "/pr labels add|remove label" }?.insertText,
+            "/pr labels add "
+        )
+
+        let catalogPullRequestUsages = SlashCommandCatalog.definitions
+            .filter { $0.usage.hasPrefix("/pr ") }
+            .map(\.usage)
+        XCTAssertEqual(catalogPullRequestUsages, slashUsages)
+        XCTAssertTrue(SlashCommandCatalog.helpText().contains("/pr review-threads [selector]"))
+    }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7199,3 +7199,27 @@ Strict grades:
 Remaining parity risk:
 
 - Slash command catalog/parser entries remain separate because they include grammar and aliases. If PR slash command help starts drifting from palette metadata, add optional slash-usage fields to the descriptor rather than spreading PR copy across another static table.
+
+## 2026-06-27 PR Slash Descriptor Slice
+
+Overall grade after this slice: **A slash discovery ownership, A command descriptor cohesion, A- parser grammar boundary**.
+
+The PR command descriptor table now owns `/pr ...` slash discovery metadata as well as palette rows, direct-tool mappings, icons, and draft-prefill copy. `SlashCommandCatalog` still owns global slash ordering and non-PR commands, but it now imports PR slash definitions from `WorkspacePullRequestCommandCatalog` instead of duplicating another static PR table.
+
+Code quality changes:
+
+- Added optional `SlashCommandDefinition` metadata to `WorkspacePullRequestCommandDescriptor`.
+- Rebuilt `SlashCommandCatalog.definitions` from prefix commands, PR descriptor slash definitions, and suffix commands so `/help`, slash suggestions, and command-palette slash rows use the same PR source.
+- Added descriptor tests that lock PR slash ordering, catalog reuse, labels insert text, and `/pr review-threads` help coverage.
+- Kept `SlashPullRequestCommandParser` separate because it owns grammar, aliases, selector/body parsing, and tool-call construction rather than discovery metadata.
+
+Strict grades:
+
+- `WorkspacePullRequestCommandCatalog.swift`: **A**. PR command metadata is now cohesive and readable; future PR actions can add palette/tool/draft/icon/slash metadata in one row.
+- `SlashCommandCatalog.swift`: **A**. The catalog now describes global slash command order without owning PR copy.
+- `SlashPullRequestCommandParser.swift`: **A-**. Parser ownership remains correct, but PR grammar is still broad enough that grouped parser helpers may be worthwhile if more subcommands land.
+- `WorkspacePullRequestCommandCatalogTests.swift`: **A**. The test catches the exact drift this slice removes.
+
+Remaining parity risk:
+
+- Slash metadata is now DRY, but parser behavior still needs separate tests for every PR grammar branch. That is intentional because parser grammar is behavior, not display metadata.


### PR DESCRIPTION
## Summary
- move `/pr ...` slash help/suggestion metadata into `WorkspacePullRequestCommandCatalog`
- build `SlashCommandCatalog` from prefix definitions + PR descriptor definitions + suffix definitions
- add descriptor coverage proving `/help` and slash suggestion rows use the PR descriptor source

## Validation
- `git diff --check`
- `swift test --filter 'WorkspacePullRequestCommandCatalogTests|QuillCodeTranscriptSurfaceTests|WorkspaceCommandPlanTests|WorkspaceCommandPaletteRankerTests|SlashPullRequestCommandParserTests'`\n- `swift test --quiet`