### PR TITLE
Harden click targets across QuillCode UI

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -1558,8 +1558,9 @@
     .automation-actions button,
     [data-testid="automation-create-follow-up"],
     [data-testid="automation-create-workspace-schedule"],
+    [data-testid="automation-schedule-follow-up"],
     [data-testid="automation-schedule-workspace"] {
-      min-height: 34px;
+      min-height: 40px;
       border: 1px solid var(--line);
       border-radius: 999px;
       background: rgba(92, 200, 255, 0.12);
@@ -1568,14 +1569,18 @@
       font: inherit;
       font-size: 13px;
       font-weight: 700;
-      transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+      transition-property: transform, border-color, background-color;
+      transition-duration: 120ms;
+      transition-timing-function: ease;
     }
     .automation-actions button:active,
     [data-testid="automation-create-follow-up"]:active,
     [data-testid="automation-create-workspace-schedule"]:active,
+    [data-testid="automation-schedule-follow-up"]:active,
     [data-testid="automation-schedule-workspace"]:active { transform: scale(0.96); }
     [data-testid="automation-create-follow-up"]:disabled,
     [data-testid="automation-create-workspace-schedule"]:disabled,
+    [data-testid="automation-schedule-follow-up"]:disabled,
     [data-testid="automation-schedule-workspace"]:disabled {
       opacity: 0.44;
       cursor: not-allowed;
@@ -1907,11 +1912,22 @@
       margin-top: 6px;
     }
     .tool-details summary {
+      display: inline-flex;
+      align-items: center;
+      min-height: 40px;
+      padding: 0 10px;
+      border-radius: 999px;
       cursor: pointer;
       color: #8fe2ff;
       font-size: 12px;
       font-weight: 700;
       user-select: none;
+      transition-property: background-color, color;
+      transition-duration: 150ms;
+      transition-timing-function: var(--ease-out);
+    }
+    .tool-details summary:hover {
+      background: rgba(65,184,232,.08);
     }
     .review-pane {
       align-self: flex-start;
@@ -2391,7 +2407,7 @@
       transition-timing-function: var(--ease-out);
     }
     .topbar-cluster .model-option {
-      min-height: 0;
+      min-height: 40px;
       padding: 8px 10px;
       border: 0;
       border-radius: 12px;
@@ -2435,6 +2451,11 @@
     }
     .topbar-cluster .model-detail-toggle,
     .topbar-cluster .model-favorite {
+      width: 40px;
+      min-width: 40px;
+      min-height: 40px;
+      display: grid;
+      place-items: center;
       padding: 0;
       border: 0;
       background: transparent;

--- a/E2E/playwright/tests/workspace-chrome.spec.ts
+++ b/E2E/playwright/tests/workspace-chrome.spec.ts
@@ -1,11 +1,25 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 import {
+  clickSidebarTool,
   computedStyleProperties,
   elementRect,
   harnessURL,
   openSettings,
   openTopBarOverflow
 } from './harness-helpers';
+
+const MINIMUM_HIT_TARGET = 40;
+
+async function expectHitTarget(locator: Locator, label: string) {
+  const target = locator.first();
+  await expect(target, `${label} should be visible`).toBeVisible();
+  await target.scrollIntoViewIfNeeded();
+  const box = await target.boundingBox();
+  expect(box, `${label} should have layout bounds`).not.toBeNull();
+  if (!box) throw new Error(`${label} should have layout bounds`);
+  expect(Math.round(box.width), `${label} width`).toBeGreaterThanOrEqual(MINIMUM_HIT_TARGET);
+  expect(Math.round(box.height), `${label} height`).toBeGreaterThanOrEqual(MINIMUM_HIT_TARGET);
+}
 
 test('mock harness opens utilities from the top-bar overflow', async ({ page }) => {
   await page.goto(harnessURL());
@@ -189,6 +203,16 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
   expect(polish.agentStatusNumbers).toContain('tabular-nums');
   expect(polish.sidebarRadius).toBeLessThanOrEqual(4);
 
+  await expectHitTarget(page.getByTestId('top-bar-overflow-button'), 'top-bar overflow button');
+  await expectHitTarget(page.getByTestId('model-picker-button'), 'model picker button');
+  await expectHitTarget(page.getByTestId('mode-picker-button'), 'mode picker button');
+
+  await page.getByTestId('model-picker-button').click();
+  await expectHitTarget(page.getByTestId('model-option'), 'model picker row');
+  await expectHitTarget(page.getByTestId('model-detail-button'), 'model detail button');
+  await expectHitTarget(page.getByTestId('model-favorite-button'), 'model favorite button');
+  await page.getByTestId('model-picker-button').click();
+
   await page.getByLabel('Message').fill('run whoami');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
@@ -227,6 +251,45 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
   expect(transcriptPolish.messageCopyMinHeight).toBeGreaterThanOrEqual(40);
   expect(transcriptPolish.sidebarMenuWidth).toBeGreaterThanOrEqual(40);
   expect(transcriptPolish.sidebarMenuHeight).toBeGreaterThanOrEqual(40);
+  await expectHitTarget(page.locator('[data-testid="tool-card-details"] summary'), 'tool details disclosure');
+});
+
+test('mock harness keeps secondary pane actions at least 40px', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await clickSidebarTool(page, 'terminal-button');
+  await expect(page.getByTestId('terminal-pane')).toBeVisible();
+  await expectHitTarget(page.getByTestId('terminal-clear'), 'terminal clear button');
+  await expectHitTarget(page.getByTestId('terminal-run'), 'terminal run button');
+
+  await clickSidebarTool(page, 'browser-button');
+  await expect(page.getByTestId('browser-pane')).toBeVisible();
+  await expectHitTarget(page.getByTestId('browser-back'), 'browser back button');
+  await expectHitTarget(page.getByTestId('browser-forward'), 'browser forward button');
+  await expectHitTarget(page.getByTestId('browser-reload'), 'browser reload button');
+  await expectHitTarget(page.getByTestId('browser-session'), 'browser session button');
+  await expectHitTarget(page.getByTestId('browser-open'), 'browser open button');
+  await expectHitTarget(page.getByTestId('browser-add-comment'), 'browser comment button');
+
+  await page.getByTestId('extensions-button').click();
+  await expect(page.getByTestId('extensions-pane')).toBeVisible();
+  await expectHitTarget(page.getByTestId('extension-install'), 'extension install button');
+  await expectHitTarget(page.getByTestId('extension-start'), 'extension start button');
+
+  await clickSidebarTool(page, 'memories-button');
+  await expect(page.getByTestId('memories-pane')).toBeVisible();
+  await expectHitTarget(page.getByTestId('memories-add'), 'memory add button');
+  await expectHitTarget(page.getByTestId('memory-edit'), 'memory edit button');
+  await expectHitTarget(page.getByTestId('memory-delete'), 'memory delete button');
+
+  await page.getByTestId('automations-button').click();
+  await expect(page.getByTestId('automations-pane')).toBeVisible();
+  await expectHitTarget(page.getByTestId('automation-create-follow-up'), 'automation follow-up button');
+  await expectHitTarget(page.getByTestId('automation-create-workspace-schedule'), 'automation workspace button');
+  await page.getByTestId('automation-create-workspace-schedule').click();
+  await expectHitTarget(page.getByTestId('automation-run'), 'automation run button');
+  await expectHitTarget(page.getByTestId('automation-primary-action'), 'automation primary action button');
+  await expectHitTarget(page.getByTestId('automation-delete'), 'automation delete button');
 });
 
 test('mock harness keeps quiet top bar stable under long status metadata', async ({ page }) => {

--- a/Sources/QuillCodeApp/QuillCodeAutomationsPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeAutomationsPaneView.swift
@@ -92,6 +92,7 @@ struct QuillCodeAutomationsPaneView: View {
                 Label("Create", systemImage: "plus")
             }
             .buttonStyle(.borderedProminent)
+            .quillCodeHitTarget(minWidth: 90)
         }
     }
 
@@ -140,6 +141,7 @@ struct QuillCodeAutomationsPaneView: View {
                         onCommand(automationCommand(id: commandID, title: actionTitle))
                     }
                     .buttonStyle(.borderedProminent)
+                    .quillCodeHitTarget(minWidth: 72)
                 }
                 if let commandID = workflow.primaryCommandID,
                    let actionTitle = workflow.primaryActionTitle {
@@ -147,12 +149,14 @@ struct QuillCodeAutomationsPaneView: View {
                         onCommand(automationCommand(id: commandID, title: actionTitle))
                     }
                     .buttonStyle(.bordered)
+                    .quillCodeHitTarget(minWidth: 72)
                 }
                 if let commandID = workflow.deleteCommandID {
                     Button("Delete", role: .destructive) {
                         onCommand(automationCommand(id: commandID, title: "Delete automation"))
                     }
                     .buttonStyle(.bordered)
+                    .quillCodeHitTarget(minWidth: 72)
                 }
             }
             .font(.caption.weight(.semibold))

--- a/Sources/QuillCodeApp/QuillCodeBrowserPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserPaneView.swift
@@ -63,10 +63,13 @@ struct QuillCodeBrowserPaneView: View {
             TextField("localhost:3000, docs/page.html, or https://example.com", text: $addressDraft)
                 .textFieldStyle(.roundedBorder)
                 .onSubmit(onOpen)
+                .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
             Button("Open", action: onOpen)
+                .quillCodeHitTarget(minWidth: 72)
                 .disabled(addressDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             if let onOpenSession {
                 Button("Session", action: onOpenSession)
+                    .quillCodeHitTarget(minWidth: 84)
                     .disabled(!browser.canOpen && browser.currentURL == nil)
                     .help("Open a visible browser session using QuillCode's persistent browser profile.")
             }
@@ -177,7 +180,9 @@ struct QuillCodeBrowserPaneView: View {
                 .textFieldStyle(.roundedBorder)
                 .disabled(browser.currentURL == nil)
                 .onSubmit(addComment)
+                .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
             Button("Comment", action: addComment)
+                .quillCodeHitTarget(minWidth: 92)
                 .disabled(browser.currentURL == nil || commentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
     }

--- a/Sources/QuillCodeApp/QuillCodeContextBannerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeContextBannerView.swift
@@ -33,15 +33,18 @@ struct QuillCodeContextBannerView: View {
                         onCommand(banner.compactCommand)
                     }
                     .buttonStyle(.borderedProminent)
+                    .quillCodeHitTarget(minWidth: 104)
                     .disabled(!banner.compactCommand.isEnabled)
                     Button(banner.newThreadCommand.title) {
                         onCommand(banner.newThreadCommand)
                     }
                     .buttonStyle(.bordered)
+                    .quillCodeHitTarget(minWidth: 112)
                     Button(banner.forkCommand.title) {
                         onCommand(banner.forkCommand)
                     }
                     .buttonStyle(.bordered)
+                    .quillCodeHitTarget(minWidth: 112)
                     .disabled(!banner.forkCommand.isEnabled)
                 }
             }

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -47,6 +47,15 @@ struct QuillCodePressableButtonStyle: ButtonStyle {
 }
 
 extension View {
+    func quillCodeHitTarget(
+        minWidth: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        alignment: Alignment = .center
+    ) -> some View {
+        frame(minWidth: minWidth, minHeight: minHeight, alignment: alignment)
+            .contentShape(Rectangle())
+    }
+
     func quillCodeSurface(
         fill: Color,
         radius: CGFloat,

--- a/Sources/QuillCodeApp/QuillCodeDialogChrome.swift
+++ b/Sources/QuillCodeApp/QuillCodeDialogChrome.swift
@@ -44,6 +44,7 @@ struct QuillCodeDialogHeader: View {
             }
             Spacer()
             Button(closeTitle, action: onClose)
+                .quillCodeHitTarget(minWidth: 72)
                 .keyboardShortcut(.cancelAction)
         }
     }

--- a/Sources/QuillCodeApp/QuillCodeExtensionsPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeExtensionsPaneView.swift
@@ -151,6 +151,7 @@ struct QuillCodeExtensionsPaneView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .quillCodeHitTarget(minWidth: 74)
         }
         if let updateCommandID = item.updateCommandID {
             Button("Update") {
@@ -158,6 +159,7 @@ struct QuillCodeExtensionsPaneView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .quillCodeHitTarget(minWidth: 74)
         }
         if let stopCommandID = item.stopCommandID {
             Button("Stop") {
@@ -165,12 +167,14 @@ struct QuillCodeExtensionsPaneView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .quillCodeHitTarget(minWidth: 74)
         } else if let startCommandID = item.startCommandID {
             Button("Start") {
                 onCommand(extensionCommand(id: startCommandID, title: "Start \(item.name)"))
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
+            .quillCodeHitTarget(minWidth: 74)
         }
     }
 
@@ -299,6 +303,7 @@ struct QuillCodeExtensionsPaneView: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                        .quillCodeHitTarget(minWidth: 96)
                     }
                 }
             }

--- a/Sources/QuillCodeApp/QuillCodeMemoriesPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeMemoriesPaneView.swift
@@ -45,6 +45,7 @@ struct QuillCodeMemoriesPaneView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
+            .quillCodeHitTarget(minWidth: 72)
         }
     }
 
@@ -81,6 +82,7 @@ struct QuillCodeMemoriesPaneView: View {
                                 Label("Edit", systemImage: "pencil")
                                     .labelStyle(.iconOnly)
                             }
+                            .quillCodeHitTarget()
                             .help("Edit this memory")
                         }
                         if let deleteCommandID = item.deleteCommandID {
@@ -90,6 +92,7 @@ struct QuillCodeMemoriesPaneView: View {
                                 Label("Forget", systemImage: "trash")
                                     .labelStyle(.iconOnly)
                             }
+                            .quillCodeHitTarget()
                             .help("Forget this memory")
                         }
                     }

--- a/Sources/QuillCodeApp/QuillCodeRuntimeIssueView.swift
+++ b/Sources/QuillCodeApp/QuillCodeRuntimeIssueView.swift
@@ -22,6 +22,7 @@ struct QuillCodeRuntimeIssueView: View {
                             .buttonStyle(.borderless)
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(tint)
+                            .quillCodeHitTarget(minWidth: 72, alignment: .leading)
                     } else {
                         Text(actionLabel)
                             .font(.caption.weight(.semibold))

--- a/Sources/QuillCodeApp/QuillCodeSettingsView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSettingsView.swift
@@ -89,6 +89,7 @@ struct QuillCodeSettingsView: View {
                 .foregroundStyle(QuillCodePalette.muted)
             Button("Sign in with TrustedRouter", action: onStartTrustedRouterSignIn)
                 .buttonStyle(.borderedProminent)
+                .quillCodeHitTarget(minWidth: 190)
             Text(settings.signInURL)
                 .font(.caption2.monospaced())
                 .foregroundStyle(QuillCodePalette.muted)
@@ -114,6 +115,7 @@ struct QuillCodeSettingsView: View {
             }
             .disabled(!settings.hasStoredAPIKey)
             .font(.caption)
+            .quillCodeHitTarget(minWidth: 104, alignment: .leading)
         }
     }
 
@@ -121,8 +123,10 @@ struct QuillCodeSettingsView: View {
         HStack {
             Spacer()
             Button("Cancel", action: onCancel)
+                .quillCodeHitTarget(minWidth: 72)
             Button("Save", action: onSave)
                 .buttonStyle(.borderedProminent)
+                .quillCodeHitTarget(minWidth: 72)
                 .disabled(!draft.canSave)
         }
     }

--- a/Sources/QuillCodeApp/QuillCodeTerminalPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTerminalPaneView.swift
@@ -34,6 +34,7 @@ struct QuillCodeTerminalPaneView: View {
             Spacer()
             Button("Clear", action: onClear)
                 .controlSize(.small)
+                .quillCodeHitTarget(minWidth: 56)
                 .disabled(!terminal.canClear)
             if terminal.isRunning {
                 ProgressView()
@@ -41,6 +42,7 @@ struct QuillCodeTerminalPaneView: View {
                 Button("Stop", action: onStop)
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
+                    .quillCodeHitTarget(minWidth: 56)
                     .tint(QuillCodePalette.red)
             }
         }
@@ -82,8 +84,10 @@ struct QuillCodeTerminalPaneView: View {
                     onHistoryNext()
                     return .handled
                 }
+                .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
                 .disabled(terminal.isRunning)
             Button("Run", action: onRun)
+                .quillCodeHitTarget(minWidth: 64)
                 .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || terminal.isRunning)
         }
     }

--- a/Sources/QuillCodeApp/QuillCodeTranscriptFindView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptFindView.swift
@@ -79,14 +79,17 @@ struct QuillCodeTranscriptFindBar: View {
             Button(action: onPrevious) {
                 Image(systemName: "chevron.up")
             }
+            .quillCodeHitTarget()
             .disabled(matchCount == 0)
             Button(action: onNext) {
                 Image(systemName: "chevron.down")
             }
+            .quillCodeHitTarget()
             .disabled(matchCount == 0)
             Button(action: onClose) {
                 Image(systemName: "xmark")
             }
+            .quillCodeHitTarget()
             .keyboardShortcut(.cancelAction)
         }
         .padding(.horizontal, 14)

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceDialogs.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceDialogs.swift
@@ -117,8 +117,10 @@ private struct QuillCodeRenameDialog: View {
             HStack {
                 Spacer()
                 Button("Cancel", action: onCancel)
+                    .quillCodeHitTarget(minWidth: 72)
                 Button("Save", action: onSave)
                     .keyboardShortcut(.defaultAction)
+                    .quillCodeHitTarget(minWidth: 72)
                     .disabled(!canSave)
             }
         }

--- a/Sources/QuillCodeApp/QuillCodeWorktreeDialogChrome.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorktreeDialogChrome.swift
@@ -119,6 +119,7 @@ struct QuillCodeWorktreeChoiceStatusRow: View {
                     .buttonStyle(.borderless)
                     .controlSize(.small)
                     .font(.caption.weight(.semibold))
+                    .quillCodeHitTarget(minWidth: 56)
                     .accessibilityIdentifier("quillcode-worktree-choice-retry")
             }
         }

--- a/Sources/QuillCodeApp/QuillCodeWorktreeDialogs.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorktreeDialogs.swift
@@ -35,8 +35,10 @@ struct QuillCodeWorktreeOpenView: View {
             HStack {
                 Spacer()
                 Button("Cancel", action: onCancel)
+                    .quillCodeHitTarget(minWidth: 72)
                 Button("Open", action: onOpen)
                     .buttonStyle(.borderedProminent)
+                    .quillCodeHitTarget(minWidth: 72)
                     .disabled(!draft.canOpen)
             }
         }
@@ -77,8 +79,10 @@ struct QuillCodeWorktreeCreateView: View {
             HStack {
                 Spacer()
                 Button("Cancel", action: onCancel)
+                    .quillCodeHitTarget(minWidth: 72)
                 Button("Create", action: onCreate)
                     .buttonStyle(.borderedProminent)
+                    .quillCodeHitTarget(minWidth: 82)
                     .disabled(!draft.canCreate)
             }
         }
@@ -123,8 +127,10 @@ struct QuillCodeWorktreeRemoveView: View {
             HStack {
                 Spacer()
                 Button("Cancel", action: onCancel)
+                    .quillCodeHitTarget(minWidth: 72)
                 Button("Remove", action: onRemove)
                     .buttonStyle(.borderedProminent)
+                    .quillCodeHitTarget(minWidth: 84)
                     .disabled(!draft.canRemove)
             }
         }
@@ -159,8 +165,10 @@ struct QuillCodeWorktreePruneView: View {
                     .lineLimit(2)
                 Spacer()
                 Button("Cancel", action: onCancel)
+                    .quillCodeHitTarget(minWidth: 72)
                 Button("Prune", action: onPrune)
                     .buttonStyle(.borderedProminent)
+                    .quillCodeHitTarget(minWidth: 72)
                     .disabled(!draft.canPrune)
             }
         }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7223,3 +7223,28 @@ Strict grades:
 Remaining parity risk:
 
 - Slash metadata is now DRY, but parser behavior still needs separate tests for every PR grammar branch. That is intentional because parser grammar is behavior, not display metadata.
+
+## 2026-06-27 Click Target Audit Slice
+
+Overall grade after this slice: **A hit-target architecture, A dense-pane coverage, A- native visual regression coverage**.
+
+The app already had a `QuillCodeMetrics.minimumHitTarget` constant, but several dense secondary controls still relied on platform button defaults or compact CSS overrides. That made hit behavior inconsistent across terminal controls, extension cards, memories, dialogs, model rows, and raw tool-data disclosures.
+
+Code quality changes:
+
+- Added a shared `quillCodeHitTarget` SwiftUI modifier so native views use one explicit minimum target and content shape instead of repeating frame boilerplate.
+- Applied the modifier to compact terminal, browser, settings, memories, extensions, automations, context-banner, worktree, rename-dialog, runtime-issue, and find-bar controls.
+- Removed the web harness model-picker override that set top-bar model rows to `min-height: 0`.
+- Expanded tool-card disclosure summaries to a real 40 px target with specific hover transitions.
+- Added Playwright bounding-box assertions for top-bar, model-picker, tool-card, terminal, browser, extension, memory, and automation controls.
+
+Strict grades:
+
+- `QuillCodeDesignSystem.swift`: **A**. Hit-target policy now has a small reusable API alongside existing surface and pressable-button primitives.
+- Dense native pane views: **A-**. The risky controls now explicitly meet the target; a future visual snapshot layer would make native layout drift easier to detect.
+- `E2E/harness/index.html`: **A**. The harness no longer has known compact-control exceptions that violate the minimum hit target.
+- `workspace-chrome.spec.ts`: **A**. It now validates rendered bounds for the most failure-prone desktop controls, not just CSS declarations.
+
+Remaining parity risk:
+
+- SwiftUI hit-target coverage is compile-verified but not pixel-measured in native tests. If QuillCode adds native screenshot testing, promote these Playwright assertions into matching AppKit/SwiftUI smoke checks.


### PR DESCRIPTION
## Summary
- add a shared SwiftUI hit-target modifier for compact native controls
- apply explicit 40px targets across terminal, browser, settings, memories, extensions, automations, dialogs, context banners, runtime issues, and find controls
- harden the web harness model picker, automation controls, and tool-details disclosure targets
- add Playwright rendered-bounds assertions for dense secondary controls

## Validation
- git diff --check
- swift test --filter QuillCodeAppTests
- swift test --filter ParityGateTests.testPlaywrightTestsAvoidDomForceUnwraps
- swift test
- npm test -- workspace-chrome.spec.ts
- npm test