### PR TITLE
Route final answers through tool formatters

### DIFF
--- a/Sources/QuillCodeAgent/AgentFinalAnswerBuilder.swift
+++ b/Sources/QuillCodeAgent/AgentFinalAnswerBuilder.swift
@@ -4,6 +4,8 @@ import QuillCodeTools
 import QuillComputerUseKit
 
 enum AgentFinalAnswerBuilder {
+    private typealias ToolAnswerFormatter = (ToolCall, ToolResult, ToolResult?) -> String?
+
     static func finalAnswer(
         for call: ToolCall,
         result: ToolResult,
@@ -19,90 +21,34 @@ enum AgentFinalAnswerBuilder {
             return "Command failed:\n\(truncated(details))"
         }
 
-        if call.name == ToolDefinition.fileWrite.name {
-            if let path = argument("path", in: call) {
-                return "Wrote `\(path)`."
-            }
-            if let path = result.artifacts.first {
-                return "Wrote `\(path)`."
-            }
-            return "Wrote the file."
-        }
-
-        if call.name == ToolDefinition.applyPatch.name {
-            if let followUpReviewResult, !followUpReviewResult.ok {
-                let details = [followUpReviewResult.error, followUpReviewResult.stderr.trimmedNonEmpty]
-                    .compactMap { $0 }
-                    .joined(separator: "\n")
-                if details.isEmpty {
-                    return "Patch applied, but I could not refresh the review diff."
-                }
-                return "Patch applied, but I could not refresh the review diff:\n\(truncated(details))"
-            }
-            return followUpReviewResult == nil
-                ? "Patch applied."
-                : "Patch applied. Review the resulting diff below."
-        }
-
-        if call.name == ToolDefinition.gitWorktreePrune.name {
-            return gitWorktreePruneAnswer(call: call, result: result)
-        }
-
-        if call.name == ToolDefinition.gitPullRequestReviewThreads.name,
-           let answer = pullRequestReviewThreadsAnswer(result.stdout) {
-            return answer
-        }
-
-        if call.name == ToolDefinition.planUpdate.name {
-            return "Updated the task plan."
-        }
-
-        if call.name == ToolDefinition.memoryRemember.name {
-            if let output = try? JSONHelpers.decode(MemoryRememberToolOutput.self, from: result.stdout) {
-                return "Saved memory: \(output.title). It will be included as background context in future turns."
-            }
-            return "Saved memory."
-        }
-
-        if call.name == ToolDefinition.shellRun.name,
-           let command = argument("cmd", in: call) {
-            if let answer = shellAnswer(command: command, result: result) {
+        for formatter in toolAnswerFormatters {
+            if let answer = formatter(call, result, followUpReviewResult) {
                 return answer
             }
         }
 
-        if call.name == ToolDefinition.browserInspect.name,
-           let inspection = try? JSONHelpers.decode(BrowserInspectionToolOutput.self, from: result.stdout) {
-            return browserInspectionAnswer(inspection)
-        }
+        return defaultAnswer(result)
+    }
 
-        if call.name == ToolDefinition.browserOpen.name,
-           let inspection = try? JSONHelpers.decode(BrowserInspectionToolOutput.self, from: result.stdout) {
-            return browserOpenAnswer(inspection)
-        }
+    private static var toolAnswerFormatters: [ToolAnswerFormatter] {
+        [
+            fileWriteAnswer,
+            applyPatchAnswer,
+            worktreePruneAnswer,
+            pullRequestReviewThreadsAnswer,
+            planUpdateAnswer,
+            memoryRememberAnswer,
+            shellRunAnswer,
+            browserInspectAnswer,
+            browserOpenAnswer,
+            mcpReadResourceAnswer,
+            mcpGetPromptAnswer,
+            computerScreenshotAnswer,
+            computerUseActionAnswer
+        ]
+    }
 
-        if call.name == ToolDefinition.mcpReadResource.name {
-            let output = result.stdout.trimmedNonEmpty
-            return output.map { "MCP resource contents:\n\(truncated($0))" }
-                ?? "MCP resource read completed with no text content."
-        }
-
-        if call.name == ToolDefinition.mcpGetPrompt.name {
-            let output = result.stdout.trimmedNonEmpty
-            return output.map { "MCP prompt:\n\(truncated($0))" }
-                ?? "MCP prompt loaded."
-        }
-
-        if call.name == ToolDefinition.computerScreenshot.name,
-           let screenshot = try? JSONHelpers.decode(ComputerScreenshotToolOutput.self, from: result.stdout) {
-            return "Captured a screenshot (\(screenshot.width) x \(screenshot.height))."
-        }
-
-        if ToolDefinition.computerUseDefinitions.contains(where: { $0.name == call.name }) {
-            let output = result.stdout.trimmedNonEmpty
-            return output.map { "Computer Use completed: \($0)" } ?? "Computer Use action completed."
-        }
-
+    private static func defaultAnswer(_ result: ToolResult) -> String {
         let output = [result.stdout, result.stderr]
             .compactMap(\.trimmedNonEmpty)
             .joined(separator: "\n")
@@ -110,6 +56,179 @@ enum AgentFinalAnswerBuilder {
             return "Done."
         }
         return "Output:\n\(truncated(output))"
+    }
+
+    private static func fileWriteAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.fileWrite.name else {
+            return nil
+        }
+        if let path = argument("path", in: call) {
+            return "Wrote `\(path)`."
+        }
+        if let path = result.artifacts.first {
+            return "Wrote `\(path)`."
+        }
+        return "Wrote the file."
+    }
+
+    private static func applyPatchAnswer(
+        call: ToolCall,
+        result _: ToolResult,
+        followUpReviewResult: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.applyPatch.name else {
+            return nil
+        }
+        if let followUpReviewResult, !followUpReviewResult.ok {
+            let details = [followUpReviewResult.error, followUpReviewResult.stderr.trimmedNonEmpty]
+                .compactMap { $0 }
+                .joined(separator: "\n")
+            if details.isEmpty {
+                return "Patch applied, but I could not refresh the review diff."
+            }
+            return "Patch applied, but I could not refresh the review diff:\n\(truncated(details))"
+        }
+        return followUpReviewResult == nil
+            ? "Patch applied."
+            : "Patch applied. Review the resulting diff below."
+    }
+
+    private static func worktreePruneAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.gitWorktreePrune.name else {
+            return nil
+        }
+        return gitWorktreePruneAnswer(call: call, result: result)
+    }
+
+    private static func pullRequestReviewThreadsAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.gitPullRequestReviewThreads.name else {
+            return nil
+        }
+        return pullRequestReviewThreadsAnswer(result.stdout)
+    }
+
+    private static func planUpdateAnswer(
+        call: ToolCall,
+        result _: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        call.name == ToolDefinition.planUpdate.name ? "Updated the task plan." : nil
+    }
+
+    private static func memoryRememberAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.memoryRemember.name else {
+            return nil
+        }
+        if let output = try? JSONHelpers.decode(MemoryRememberToolOutput.self, from: result.stdout) {
+            return "Saved memory: \(output.title). It will be included as background context in future turns."
+        }
+        return "Saved memory."
+    }
+
+    private static func shellRunAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.shellRun.name,
+              let command = argument("cmd", in: call)
+        else {
+            return nil
+        }
+        return shellAnswer(command: command, result: result)
+    }
+
+    private static func browserInspectAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.browserInspect.name,
+              let inspection = try? JSONHelpers.decode(BrowserInspectionToolOutput.self, from: result.stdout)
+        else {
+            return nil
+        }
+        return browserInspectionAnswer(inspection)
+    }
+
+    private static func browserOpenAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.browserOpen.name,
+              let inspection = try? JSONHelpers.decode(BrowserInspectionToolOutput.self, from: result.stdout)
+        else {
+            return nil
+        }
+        return browserOpenAnswer(inspection)
+    }
+
+    private static func mcpReadResourceAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.mcpReadResource.name else {
+            return nil
+        }
+        let output = result.stdout.trimmedNonEmpty
+        return output.map { "MCP resource contents:\n\(truncated($0))" }
+            ?? "MCP resource read completed with no text content."
+    }
+
+    private static func mcpGetPromptAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.mcpGetPrompt.name else {
+            return nil
+        }
+        let output = result.stdout.trimmedNonEmpty
+        return output.map { "MCP prompt:\n\(truncated($0))" }
+            ?? "MCP prompt loaded."
+    }
+
+    private static func computerScreenshotAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.computerScreenshot.name,
+              let screenshot = try? JSONHelpers.decode(ComputerScreenshotToolOutput.self, from: result.stdout)
+        else {
+            return nil
+        }
+        return "Captured a screenshot (\(screenshot.width) x \(screenshot.height))."
+    }
+
+    private static func computerUseActionAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard ToolDefinition.computerUseDefinitions.contains(where: { $0.name == call.name }) else {
+            return nil
+        }
+        let output = result.stdout.trimmedNonEmpty
+        return output.map { "Computer Use completed: \($0)" } ?? "Computer Use action completed."
     }
 
     private static func browserInspectionAnswer(_ inspection: BrowserInspectionToolOutput) -> String {

--- a/Tests/QuillCodeParityTests/ParityAgentGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAgentGateTests.swift
@@ -7,6 +7,8 @@ final class ParityAgentGateTests: QuillCodeParityTestCase {
 
         XCTAssertTrue(builderText.contains("enum AgentFinalAnswerBuilder"), "Tool-result final answer copy should live in a focused builder.")
         XCTAssertTrue(builderText.contains("static func finalAnswer"), "Final answer formatting should be directly testable.")
+        XCTAssertTrue(builderText.contains("private static var toolAnswerFormatters"), "Tool-specific final answers should be registered instead of growing the top-level finalAnswer method.")
+        XCTAssertTrue(builderText.contains("for formatter in toolAnswerFormatters"), "The top-level final-answer method should route through the formatter registry.")
         XCTAssertTrue(builderText.contains("ToolDefinition.shellRun.name"), "Shell final-answer special cases should live in the builder.")
         XCTAssertTrue(builderText.contains("ToolDefinition.browserInspect.name"), "Browser final-answer special cases should live in the builder.")
         XCTAssertTrue(agentText.contains("AgentFinalAnswerBuilder.finalAnswer"), "AgentRunner should delegate final-answer formatting.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7248,3 +7248,26 @@ Strict grades:
 Remaining parity risk:
 
 - SwiftUI hit-target coverage is compile-verified but not pixel-measured in native tests. If QuillCode adds native screenshot testing, promote these Playwright assertions into matching AppKit/SwiftUI smoke checks.
+
+## 2026-06-27 Agent Final Answer Formatter Registry
+
+Overall grade after this slice: **A formatter extensibility, A behavior preservation, A- builder file size**.
+
+`AgentFinalAnswerBuilder.finalAnswer` had started accumulating one branch per tool family. That kept behavior correct, but it made the top-level method responsible for dispatching shell, browser, file, patch, MCP, Computer Use, memory, worktree, and PR review-thread summaries directly. The builder now keeps failure/default output at the top level and routes successful tool-specific summaries through a small formatter registry.
+
+Code quality changes:
+
+- Added a `ToolAnswerFormatter` registry for tool-specific final-answer summaries.
+- Moved file-write, apply-patch, worktree prune, PR review-thread, plan, memory, shell, browser, MCP, screenshot, and Computer Use summaries behind small formatter functions.
+- Preserved existing user-facing copy and truncation behavior.
+- Added a parity guard so future tool summaries use the registry instead of regrowing the top-level method.
+
+Strict grades:
+
+- `AgentFinalAnswerBuilder.swift`: **A-**. Dispatch is cleaner and more extensible; the file still owns all final-answer copy, which is acceptable until formatter families become large enough to justify per-domain files.
+- `AgentFinalAnswerBuilderTests.swift`: **A**. Existing behavioral coverage caught the refactor without changing expected copy.
+- `ParityAgentGateTests.swift`: **A**. The gate now protects the registry shape while leaving individual formatters free to evolve.
+
+Remaining parity risk:
+
+- Browser and PR review-thread summaries are the most likely to grow richer. If either gains substantially more formatting logic, split that formatter family into a separate helper rather than expanding this file again.


### PR DESCRIPTION
## Summary
- route successful tool final-answer copy through a formatter registry
- split existing file/patch/worktree/PR/browser/MCP/Computer Use/memory summaries into small formatter functions
- add a parity gate and audit note so new tool summaries do not regrow the top-level method

## Validation
- `git diff --check`
- `swift test --filter 'AgentFinalAnswerBuilderTests|AgentToolLoopTests|AgentImmediateActionTests|ParityAgentGateTests|ParityBrowserGateTests'`\n- `swift test --quiet`