### PR TITLE
Move desktop sign-in application into coordinator

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -180,8 +180,13 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func startTrustedRouterSignIn() {
-        Task { @MainActor in
-            await completeTrustedRouterSignIn()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await signInCoordinator.completeSignInAndApply(
+                to: model,
+                settingsCoordinator: settingsCoordinator,
+                refresh: { [weak self] in self?.refresh() }
+            )
         }
     }
 
@@ -383,31 +388,6 @@ final class QuillCodeDesktopController: ObservableObject {
             tasks: tasks,
             refresh: { [weak self] in self?.refresh() }
         )
-    }
-
-    private func completeTrustedRouterSignIn() async {
-        do {
-            let result = try await signInCoordinator.completeSignIn(
-                currentConfig: model.root.config
-            ) { [weak self] label, error in
-                self?.model.setAgentStatus(label, lastError: error)
-                self?.refresh()
-            }
-            let settings = settingsCoordinator.result(for: result.config)
-            model.applySettings(
-                config: settings.config,
-                trustedRouterAPIKeyConfigured: settings.trustedRouterAPIKeyConfigured
-            )
-            model.applyRuntime(settings.runtime)
-            refresh()
-            await refreshModelCatalog()
-        } catch {
-            model.setAgentStatus(
-                QuillCodeRuntimeStatusLabel.signInFailed,
-                lastError: String(describing: error)
-            )
-            refresh()
-        }
     }
 
     private func refresh() {

--- a/Sources/quill-code-desktop/QuillCodeDesktopSignInCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSignInCoordinator.swift
@@ -60,6 +60,32 @@ struct QuillCodeDesktopSignInCoordinator {
         )
     }
 
+    func completeSignInAndApply(
+        to model: QuillCodeWorkspaceModel,
+        settingsCoordinator: QuillCodeDesktopSettingsCoordinator,
+        refresh: @escaping @MainActor () -> Void
+    ) async {
+        do {
+            let result = try await completeSignIn(
+                currentConfig: model.root.config
+            ) { label, error in
+                model.setAgentStatus(label, lastError: error)
+                refresh()
+            }
+            applySignInResult(result, to: model, settingsCoordinator: settingsCoordinator)
+            refresh()
+            let models = await bootstrap.fetchModelCatalog(config: model.root.config)
+            model.setModelCatalog(models)
+            refresh()
+        } catch {
+            model.setAgentStatus(
+                QuillCodeRuntimeStatusLabel.signInFailed,
+                lastError: String(describing: error)
+            )
+            refresh()
+        }
+    }
+
     private func accountProfile(
         from token: TrustedRouterOAuthToken,
         client: TrustedRouterOAuthClient
@@ -79,5 +105,18 @@ struct QuillCodeDesktopSignInCoordinator {
             )
         }
         return profile.isEmpty ? nil : profile
+    }
+
+    private func applySignInResult(
+        _ result: QuillCodeDesktopSignInResult,
+        to model: QuillCodeWorkspaceModel,
+        settingsCoordinator: QuillCodeDesktopSettingsCoordinator
+    ) {
+        let settings = settingsCoordinator.result(for: result.config)
+        model.applySettings(
+            config: settings.config,
+            trustedRouterAPIKeyConfigured: settings.trustedRouterAPIKeyConfigured
+        )
+        model.applyRuntime(settings.runtime)
     }
 }

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -20,6 +20,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
     func testDesktopTrustedRouterSignInUsesLoopbackOAuth() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let signInText = try Self.desktopSourceText(named: "QuillCodeDesktopSignInCoordinator.swift")
 
         XCTAssertTrue(text.contains("QuillCodeDesktopSignInCoordinator"), "Desktop sign-in should be isolated from UI routing.")
         XCTAssertTrue(text.contains("TrustedRouterLoopbackCallbackServer"), "Desktop sign-in should own a loopback callback server.")
@@ -28,9 +29,17 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(text.contains("exchangeCode"), "Desktop sign-in should exchange the callback code for a scoped key.")
         XCTAssertTrue(text.contains("saveTrustedRouterAPIKey"), "Desktop sign-in should persist the returned TrustedRouter key.")
         XCTAssertTrue(text.contains("fetchModelCatalog"), "Desktop sign-in should refresh the model catalog after storing the key.")
+        XCTAssertTrue(signInText.contains("func completeSignInAndApply"), "Desktop sign-in coordinator should own applying sign-in results.")
+        XCTAssertTrue(signInText.contains("model.applySettings"), "Desktop sign-in coordinator should apply OAuth settings to the workspace model.")
+        XCTAssertTrue(signInText.contains("model.applyRuntime"), "Desktop sign-in coordinator should refresh runtime after OAuth settings change.")
+        XCTAssertTrue(signInText.contains("model.setModelCatalog"), "Desktop sign-in coordinator should apply the post-auth model catalog.")
+        XCTAssertTrue(signInText.contains("QuillCodeRuntimeStatusLabel.signInFailed"), "Desktop sign-in coordinator should own sign-in failure status.")
+        XCTAssertTrue(controllerText.contains("signInCoordinator.completeSignInAndApply"), "Desktop controller should launch the sign-in workflow through the coordinator.")
         XCTAssertFalse(controllerText.contains("exchangeCode"), "Desktop controller should delegate OAuth exchange work.")
         XCTAssertFalse(controllerText.contains("TrustedRouterOAuthClient"), "Desktop controller should not own OAuth client construction.")
         XCTAssertFalse(controllerText.contains("TrustedRouterLoopbackCallbackServer"), "Desktop controller should not own loopback callback capture.")
+        XCTAssertFalse(controllerText.contains("private func completeTrustedRouterSignIn"), "Desktop controller should not own sign-in result application.")
+        XCTAssertFalse(controllerText.contains("QuillCodeRuntimeStatusLabel.signInFailed"), "Desktop controller should not own sign-in failure handling.")
         XCTAssertFalse(
             text.contains("NSWorkspace.shared.open(url)") && text.contains("TrustedRouterDefaults.signInURL"),
             "Desktop sign-in should not regress to opening the static sign-in documentation page."

--- a/Tests/QuillCodeParityTests/ParityTopBarGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTopBarGateTests.swift
@@ -56,7 +56,7 @@ final class ParityTopBarGateTests: QuillCodeParityTestCase {
         let labelsText = try Self.appSourceText(named: "QuillCodeRuntimeStatusLabel.swift")
         let runtimeFactoryText = try Self.appSourceText(named: "RuntimeFactory.swift")
         let issueBuilderText = try Self.appSourceText(named: "WorkspaceRuntimeIssueBuilder.swift")
-        let desktopControllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let desktopSignInText = try Self.desktopSourceText(named: "QuillCodeDesktopSignInCoordinator.swift")
 
         XCTAssertTrue(labelsText.contains("public enum QuillCodeRuntimeStatusLabel"), "Runtime/auth status labels should live in one focused label boundary.")
         XCTAssertTrue(runtimeFactoryText.contains("QuillCodeRuntimeStatusLabel.signInWithTrustedRouter"), "RuntimeFactory should use shared sign-in-needed copy.")
@@ -64,13 +64,13 @@ final class ParityTopBarGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(runtimeFactoryText.contains("QuillCodeRuntimeStatusLabel.trustedRouterReady"), "RuntimeFactory should use shared TrustedRouter-ready copy.")
         XCTAssertTrue(issueBuilderText.contains("case QuillCodeRuntimeStatusLabel.signInWithTrustedRouter"), "Runtime issue builder should branch on shared sign-in-needed copy.")
         XCTAssertTrue(issueBuilderText.contains("case QuillCodeRuntimeStatusLabel.developerKeyNeeded"), "Runtime issue builder should branch on shared developer-key-needed copy.")
-        XCTAssertTrue(desktopControllerText.contains("QuillCodeRuntimeStatusLabel.signInFailed"), "Desktop sign-in failure should use shared runtime status copy.")
+        XCTAssertTrue(desktopSignInText.contains("QuillCodeRuntimeStatusLabel.signInFailed"), "Desktop sign-in failure should use shared runtime status copy.")
         XCTAssertFalse(runtimeFactoryText.contains("status: \"Mock LLM\""), "RuntimeFactory should not emit raw mock status copy.")
         XCTAssertFalse(runtimeFactoryText.contains("status: \"Sign in with TrustedRouter\""), "RuntimeFactory should not emit raw sign-in-needed status copy.")
         XCTAssertFalse(runtimeFactoryText.contains("status: \"Developer key needed\""), "RuntimeFactory should not emit raw developer-key-needed status copy.")
         XCTAssertFalse(issueBuilderText.contains("case \"Sign in with TrustedRouter\""), "Runtime issue builder should not branch on raw sign-in-needed copy.")
         XCTAssertFalse(issueBuilderText.contains("case \"Developer key needed\""), "Runtime issue builder should not branch on raw developer-key-needed copy.")
-        XCTAssertFalse(desktopControllerText.contains("setAgentStatus(\"Sign-in failed\""), "Desktop controller should not emit raw sign-in-failed status copy.")
+        XCTAssertFalse(desktopSignInText.contains("setAgentStatus(\"Sign-in failed\""), "Desktop sign-in should not emit raw sign-in-failed status copy.")
     }
 
     func testWorkspaceSurfaceDelegatesModelCatalogBuilding() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7393,3 +7393,26 @@ File grades:
 Residual risk:
 
 - This is local runtime-error classification, not live provider-health telemetry. Full parity still needs a stable TrustedRouter provider-status source before QuillCode can proactively warn about outages before a run fails.
+
+## 2026-06-27 Desktop Sign-In Apply Coordinator Pass
+
+Overall grade after this slice: **A OAuth lifecycle ownership, A controller boundary, A- desktop executable coverage**.
+
+`QuillCodeDesktopSignInCoordinator` owned PKCE OAuth, callback capture, token exchange, and key persistence, but `QuillCodeDesktopController` still applied the sign-in result to workspace settings/runtime, refreshed the model catalog, and handled sign-in failure state. That split the OAuth lifecycle across two files and made controller-level auth changes more likely.
+
+Code quality changes:
+
+- Added `completeSignInAndApply` to `QuillCodeDesktopSignInCoordinator`.
+- Moved OAuth result application, runtime refresh, post-auth model catalog refresh, and sign-in failure status into the sign-in coordinator.
+- Reduced the desktop controller to launching the coordinator workflow and refreshing published state through a callback.
+- Strengthened the desktop parity gate so result application and sign-in failure handling do not drift back into the controller.
+
+Strict grades:
+
+- `QuillCodeDesktopSignInCoordinator.swift`: **A-**. It now owns the complete desktop OAuth lifecycle. If it grows further, split raw OAuth transport from model application behind a small result-applier type.
+- `QuillCodeDesktopController.swift`: **A-**. The controller is still broad but no longer owns auth lifecycle decisions.
+- `ParityDesktopGateTests.swift`: **A**. It now protects OAuth transport, result application, post-auth catalog refresh, and failure handling as one coordinator-owned boundary.
+
+Remaining risk:
+
+- Like the other desktop coordinators, this is source-gated rather than covered by a dedicated executable test target. If desktop internals become importable, add fake OAuth/model-application tests around success and failure paths.


### PR DESCRIPTION
## Summary
- Move OAuth result application, runtime refresh, post-auth model catalog refresh, and sign-in failure status into `QuillCodeDesktopSignInCoordinator`.
- Reduce `QuillCodeDesktopController` to launching the sign-in coordinator workflow.
- Update parity gates and audit notes so sign-in lifecycle ownership stays out of the controller.

## Validation
- `swift test --filter ParityDesktopGateTests`
- `swift test --filter 'ParityDesktopGateTests|ParityTopBarGateTests'`\n- `git diff --check`\n- `swift test --quiet` (1262 tests, 0 failures)