### PR TITLE
Harden compact click targets

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeComputerUseSettingsCard.swift
+++ b/Sources/QuillCodeApp/QuillCodeComputerUseSettingsCard.swift
@@ -96,6 +96,7 @@ struct QuillCodeComputerUseSettingsCard: View {
                 onCommand(settings.computerUseRefreshCommand)
             }
             .buttonStyle(.borderless)
+            .quillCodeHitTarget(minWidth: 112, alignment: .leading)
             Spacer()
         }
         .font(.caption.weight(.semibold))

--- a/Sources/QuillCodeApp/WorkspaceActivityPaneView.swift
+++ b/Sources/QuillCodeApp/WorkspaceActivityPaneView.swift
@@ -86,7 +86,9 @@ private struct QuillCodeActivitySectionView: View {
                         .foregroundStyle(QuillCodePalette.blue)
                 }
             }
-            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, minHeight: QuillCodeMetrics.minimumHitTarget, alignment: .leading)
+            .contentShape(Rectangle())
+            .buttonStyle(QuillCodePressableButtonStyle())
             .accessibilityLabel("\(section.isCollapsed ? "Expand" : "Collapse") \(section.title)")
 
             if !section.isCollapsed {

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -83,6 +83,28 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(settingsText.contains("struct QuillCodeSettingsDraft"), "Settings shell should not own settings draft state.")
     }
 
+    func testNativeCompactPlainControlsKeepExplicitHitTargets() throws {
+        let computerUseText = try Self.appSourceText(named: "QuillCodeComputerUseSettingsCard.swift")
+        let activityText = try Self.appSourceText(named: "WorkspaceActivityPaneView.swift")
+
+        XCTAssertTrue(
+            computerUseText.contains(".quillCodeHitTarget(minWidth: 112, alignment: .leading)"),
+            "Computer Use refresh should not rely on borderless button default sizing."
+        )
+        XCTAssertTrue(
+            activityText.contains(".frame(maxWidth: .infinity, minHeight: QuillCodeMetrics.minimumHitTarget, alignment: .leading)"),
+            "Activity section toggles should keep a full-row 44 pt hit target."
+        )
+        XCTAssertTrue(
+            activityText.contains(".contentShape(Rectangle())"),
+            "Activity section toggles should make the full row clickable."
+        )
+        XCTAssertTrue(
+            activityText.contains("QuillCodePressableButtonStyle()"),
+            "Activity section toggles should keep shared 0.96 press feedback."
+        )
+    }
+
     func testNativeSearchDialogsKeepLocalTypingState() throws {
         let searchShortcutText = try Self.appSourceText(named: "QuillCodeSearchAndShortcutDialogs.swift")
         let commandPaletteText = try Self.appSourceText(named: "QuillCodeCommandPaletteDialog.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -16,6 +16,20 @@ The structured PR review reply and review-thread tools already existed locally, 
 - Added a parity gate that fails if the matrix regresses to saying implemented PR review reply/thread execution is still pending.
 - Kept execution code untouched; existing `WorkspaceRemoteProjectToolExecutorTests`, `SlashPullRequestCommandParserTests`, safety tests, parser tests, and command-surface tests already cover the shipped paths.
 
+## 2026-06-27 Compact Click Target Follow-Up
+
+Overall grade after this slice: **A compact control hit targets, A press feedback consistency, A- native measurement**.
+
+The broad click-target pass raised the shared target contract to 44 pt/px and added harness bounding-box coverage. A follow-up audit found two native compact controls that still depended on SwiftUI's small/borderless defaults instead of making the QuillCode hit-target contract explicit.
+
+- Added an explicit 44 pt hit target to the Computer Use settings `Refresh status` action.
+- Made activity-section disclosure rows full-width 44 pt targets with a rectangular content shape and shared 0.96 press feedback.
+- Added a parity gate that keeps those compact/plain controls from regressing back to platform-default hit boxes.
+
+Residual risk:
+
+- Native SwiftUI hit targets are still source-guarded rather than measured by screenshot/UI automation. Keep mirroring critical controls in Playwright until native UI automation exists.
+
 ## Component Grades
 
 | Component | Grade | Notes |


### PR DESCRIPTION
## Summary\n- give the Computer Use refresh action an explicit QuillCode hit target\n- make activity-section disclosure rows full-width 44pt targets with shared press feedback\n- add a parity gate to keep compact/plain controls from regressing\n\n## Validation\n- git diff --check\n- swift test --filter 'ParityWorkspaceSettingsSheetGateTests'\n- cd E2E/playwright && npm test -- tests/workspace-chrome.spec.ts