### PR TITLE
Rethink click target contracts

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -58,6 +58,19 @@
     .activity-item span {
       font-variant-numeric: tabular-nums;
     }
+    .interactive-hit-target {
+      min-width: var(--hit-target);
+      min-height: var(--hit-target);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    a.interactive-hit-target {
+      text-decoration: none;
+    }
+    details > summary {
+      min-height: var(--hit-target);
+    }
     .quillcode-workspace { min-height: 100vh; display: grid; grid-template-rows: auto 1fr; }
     .topbar {
       position: relative;
@@ -4493,8 +4506,8 @@
                 <span data-testid="review-file-path">${escapeHTML(file.path)}</span>
                 <span class="review-actions">
                   <small>${escapeHTML(file.changeLabel)}</small>
-                  <button type="button" data-testid="review-action" data-action="stage" data-path="${escapeHTML(file.path)}">Stage</button>
-                  <button type="button" data-testid="review-action" data-action="restore" data-path="${escapeHTML(file.path)}">Restore</button>
+                  <button type="button" class="review-action-button" data-testid="review-action" data-action="stage" data-path="${escapeHTML(file.path)}">Stage</button>
+                  <button type="button" class="review-action-button" data-testid="review-action" data-action="restore" data-path="${escapeHTML(file.path)}">Restore</button>
                 </span>
                 ${(file.hunks || []).length ? `
                   <div class="review-hunks">
@@ -4504,8 +4517,8 @@
                           <code data-testid="review-hunk-header">${escapeHTML(hunk.header)}</code>
                           <span class="review-actions">
                             <small>${escapeHTML(hunk.changeLabel)}</small>
-                            <button type="button" data-testid="review-action" data-action="stage_hunk" data-path="${escapeHTML(file.path)}">Stage hunk</button>
-                            <button type="button" data-testid="review-action" data-action="restore_hunk" data-path="${escapeHTML(file.path)}">Restore hunk</button>
+                            <button type="button" class="review-action-button" data-testid="review-action" data-action="stage_hunk" data-path="${escapeHTML(file.path)}">Stage hunk</button>
+                            <button type="button" class="review-action-button" data-testid="review-action" data-action="restore_hunk" data-path="${escapeHTML(file.path)}">Restore hunk</button>
                           </span>
                         </div>
                         <form class="review-range-comment-form" data-testid="review-range-comment-form" data-path="${escapeHTML(file.path)}">
@@ -4582,7 +4595,7 @@
           <div class="tool-artifacts" data-testid="tool-card-artifacts" aria-label="Artifacts">
             ${artifacts.map(artifact => {
               const href = artifactHref(artifact);
-              return `<a class="artifact-chip" data-testid="tool-card-artifact" data-kind="${escapeHTML(artifact.kind)}" ${href ? `href="${escapeHTML(href)}"` : ''}>
+              return `<a class="artifact-chip interactive-hit-target" data-testid="tool-card-artifact" data-kind="${escapeHTML(artifact.kind)}" ${href ? `href="${escapeHTML(href)}"` : ''}>
                 <span>
                   <strong data-testid="tool-card-artifact-label">${escapeHTML(artifact.label)}</strong>
                   <small data-testid="tool-card-artifact-detail">${escapeHTML(artifactDetail(artifact))}</small>
@@ -4633,7 +4646,7 @@
                   <strong data-testid="tool-card-document-preview-label">${escapeHTML(artifact.label)}</strong>
                   <small data-testid="tool-card-document-preview-detail">${escapeHTML(preview.detail)}</small>
                 </figcaption>
-                ${href ? `<a data-testid="tool-card-document-preview-open" href="${escapeHTML(href)}">Open</a>` : ''}
+                ${href ? `<a class="interactive-hit-target" data-testid="tool-card-document-preview-open" href="${escapeHTML(href)}">Open</a>` : ''}
               </figure>`;
             }).join('')}
           </div>` : '';
@@ -6598,7 +6611,7 @@
     function renderMCPReferenceActions(title, actions, testID, titlePrefix) {
       if (!actions?.length) return '';
       const buttons = actions.map(action => `
-        <button type="button" data-testid="${escapeHTML(testID)}" data-command-id="${escapeHTML(action.commandID)}">
+        <button type="button" class="extension-reference-action" data-testid="${escapeHTML(testID)}" data-command-id="${escapeHTML(action.commandID)}">
           ${escapeHTML(titlePrefix)} ${escapeHTML(action.title)}
         </button>`).join('');
       return `<div class="extension-mcp-group" data-testid="${escapeHTML(testID)}-group">
@@ -6637,10 +6650,10 @@
               ${renderMCPReferenceActions('Resource Actions', item.resourceActions, 'extension-mcp-resource-action', 'Read')}
               ${renderMCPReferenceActions('Prompt Actions', item.promptActions, 'extension-mcp-prompt-action', 'Use')}
               ${item.probeError ? `<p data-testid="extension-mcp-error">${escapeHTML(item.probeError)}</p>` : ''}
-              ${item.installCommandID ? `<button type="button" data-testid="extension-install" data-command-id="${escapeHTML(item.installCommandID)}">Install</button>` : ''}
-              ${item.updateCommandID ? `<button type="button" data-testid="extension-update" data-command-id="${escapeHTML(item.updateCommandID)}">Update</button>` : ''}
-              ${item.stopCommandID ? `<button type="button" data-testid="extension-stop" data-command-id="${escapeHTML(item.stopCommandID)}">Stop</button>` : ''}
-              ${item.startCommandID ? `<button type="button" data-testid="extension-start" data-command-id="${escapeHTML(item.startCommandID)}">Start</button>` : ''}
+              ${item.installCommandID ? `<button type="button" class="extension-action-button" data-testid="extension-install" data-command-id="${escapeHTML(item.installCommandID)}">Install</button>` : ''}
+              ${item.updateCommandID ? `<button type="button" class="extension-action-button" data-testid="extension-update" data-command-id="${escapeHTML(item.updateCommandID)}">Update</button>` : ''}
+              ${item.stopCommandID ? `<button type="button" class="extension-action-button" data-testid="extension-stop" data-command-id="${escapeHTML(item.stopCommandID)}">Stop</button>` : ''}
+              ${item.startCommandID ? `<button type="button" class="extension-action-button" data-testid="extension-start" data-command-id="${escapeHTML(item.startCommandID)}">Start</button>` : ''}
             </article>`).join('')}
         </div>` : `
         <div class="extensions-empty" data-testid="extensions-empty">

--- a/Sources/QuillCodeApp/QuillCodeComputerUseSettingsCard.swift
+++ b/Sources/QuillCodeApp/QuillCodeComputerUseSettingsCard.swift
@@ -95,7 +95,7 @@ struct QuillCodeComputerUseSettingsCard: View {
             Button("Refresh status") {
                 onCommand(settings.computerUseRefreshCommand)
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(QuillCodePressableButtonStyle())
             .quillCodeHitTarget(minWidth: 112, alignment: .leading)
             Spacer()
         }

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -41,6 +41,11 @@ struct QuillCodePressableButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
+            .frame(
+                minWidth: QuillCodeMetrics.minimumHitTarget,
+                minHeight: QuillCodeMetrics.minimumHitTarget
+            )
+            .contentShape(Rectangle())
             .scaleEffect(!reduceMotion && configuration.isPressed ? QuillCodeMetrics.pressScale : 1)
             .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: configuration.isPressed)
     }

--- a/Sources/QuillCodeApp/QuillCodeMemoriesPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeMemoriesPaneView.swift
@@ -96,7 +96,7 @@ struct QuillCodeMemoriesPaneView: View {
                             .help("Forget this memory")
                         }
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(QuillCodePressableButtonStyle())
                     .foregroundStyle(QuillCodePalette.muted)
                 }
             }

--- a/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
@@ -158,9 +158,9 @@ struct QuillCodeModelPickerView: View {
                     clearSearch()
                 }
                 .font(.caption.weight(.semibold))
-                .buttonStyle(.plain)
+                .buttonStyle(QuillCodePressableButtonStyle())
                 .foregroundStyle(QuillCodePalette.blue)
-                .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
+                .frame(minWidth: 56, minHeight: QuillCodeMetrics.minimumHitTarget)
                 .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                 .help("Clear model search")
             }

--- a/Sources/QuillCodeApp/QuillCodeRuntimeIssueView.swift
+++ b/Sources/QuillCodeApp/QuillCodeRuntimeIssueView.swift
@@ -19,7 +19,7 @@ struct QuillCodeRuntimeIssueView: View {
                 if let actionLabel = issue.actionLabel {
                     if let onAction {
                         Button(actionLabel, action: onAction)
-                            .buttonStyle(.borderless)
+                            .buttonStyle(QuillCodePressableButtonStyle())
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(tint)
                             .quillCodeHitTarget(minWidth: 72, alignment: .leading)

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactViews.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactViews.swift
@@ -15,6 +15,7 @@ struct QuillCodeArtifactChip: View {
             }
         }
         .buttonStyle(.plain)
+        .quillCodeHitTarget(minWidth: 96, alignment: .leading)
         .accessibilityLabel("Artifact \(artifact.label)")
     }
 
@@ -33,7 +34,7 @@ struct QuillCodeArtifactChip: View {
         .font(.caption.weight(.semibold))
         .foregroundStyle(QuillCodePalette.blue)
         .frame(maxWidth: 260, alignment: .leading)
-        .frame(minHeight: 40)
+        .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(QuillCodePalette.blue.opacity(0.12))
@@ -77,6 +78,7 @@ struct QuillCodeArtifactDocumentPreview: View {
             }
         }
         .buttonStyle(.plain)
+        .quillCodeHitTarget(minWidth: 160, alignment: .leading)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
     }

--- a/Sources/QuillCodeApp/QuillCodeWorktreeDialogChrome.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorktreeDialogChrome.swift
@@ -116,7 +116,7 @@ struct QuillCodeWorktreeChoiceStatusRow: View {
             Spacer(minLength: 0)
             if let actionTitle, let action {
                 Button(actionTitle, action: action)
-                    .buttonStyle(.borderless)
+                    .buttonStyle(QuillCodePressableButtonStyle())
                     .controlSize(.small)
                     .font(.caption.weight(.semibold))
                     .quillCodeHitTarget(minWidth: 56)

--- a/Sources/QuillCodeApp/WorkspaceHTMLPrimitives.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLPrimitives.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum WorkspaceHTMLPrimitives {
+    static let interactiveHitTargetClass = "interactive-hit-target"
+
     static func escape(_ text: String) -> String {
         text
             .replacingOccurrences(of: "&", with: "&amp;")

--- a/Sources/QuillCodeApp/WorkspaceHTMLReviewRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLReviewRenderer.swift
@@ -71,7 +71,7 @@ enum WorkspaceHTMLReviewRenderer {
 
     private static func renderAction(_ action: WorkspaceReviewActionSurface) -> String {
         """
-        <button type="button" data-testid="review-action" data-action="\(escape(action.kind.rawValue))" data-path="\(escape(action.path))">
+        <button type="button" class="review-action-button" data-testid="review-action" data-action="\(escape(action.kind.rawValue))" data-path="\(escape(action.path))">
           \(escape(action.kind.title))
         </button>
         """

--- a/Sources/QuillCodeApp/WorkspaceHTMLSecondaryPaneRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLSecondaryPaneRenderer.swift
@@ -227,7 +227,7 @@ enum WorkspaceHTMLSecondaryPaneRenderer {
     ) -> String {
         guard !actions.isEmpty else { return "" }
         let buttons = actions.map { action in
-            #"<button type="button" data-testid="\#(escape(testID))" data-command="\#(escape(action.commandID))">\#(escape(titlePrefix)) \#(escape(action.title))</button>"#
+            #"<button type="button" class="extension-reference-action" data-testid="\#(escape(testID))" data-command="\#(escape(action.commandID))">\#(escape(titlePrefix)) \#(escape(action.title))</button>"#
         }.joined()
         return #"<div class="extension-mcp-group" data-testid="\#(escape(testID))-group"><span class="extension-mcp-group-label" data-testid="extension-mcp-group-label">\#(escape(title))</span><div class="extension-mcp-chip-row">\#(buttons)</div></div>"#
     }
@@ -235,16 +235,16 @@ enum WorkspaceHTMLSecondaryPaneRenderer {
     private static func renderExtensionActions(_ item: ProjectExtensionManifestSurface) -> String {
         var buttons: [String] = []
         if let installCommandID = item.installCommandID {
-            buttons.append(#"<button type="button" data-testid="extension-install" data-command="\#(escape(installCommandID))">Install</button>"#)
+            buttons.append(#"<button type="button" class="extension-action-button" data-testid="extension-install" data-command="\#(escape(installCommandID))">Install</button>"#)
         }
         if let updateCommandID = item.updateCommandID {
-            buttons.append(#"<button type="button" data-testid="extension-update" data-command="\#(escape(updateCommandID))">Update</button>"#)
+            buttons.append(#"<button type="button" class="extension-action-button" data-testid="extension-update" data-command="\#(escape(updateCommandID))">Update</button>"#)
         }
         if let stopCommandID = item.stopCommandID {
-            buttons.append(#"<button type="button" data-testid="extension-stop" data-command="\#(escape(stopCommandID))">Stop</button>"#)
+            buttons.append(#"<button type="button" class="extension-action-button" data-testid="extension-stop" data-command="\#(escape(stopCommandID))">Stop</button>"#)
         }
         if let startCommandID = item.startCommandID {
-            buttons.append(#"<button type="button" data-testid="extension-start" data-command="\#(escape(startCommandID))">Start</button>"#)
+            buttons.append(#"<button type="button" class="extension-action-button" data-testid="extension-start" data-command="\#(escape(startCommandID))">Start</button>"#)
         }
         return buttons.joined(separator: "\n")
     }
@@ -255,8 +255,8 @@ enum WorkspaceHTMLSecondaryPaneRenderer {
           <header>
             <span data-testid="memory-scope">\(escape(item.scopeLabel))</span>
             <span data-testid="memory-size">\(escape(item.byteCountLabel))</span>
-            \(item.editCommandID.map { #"<button type="button" data-testid="memory-edit" data-command-id="\#(escape($0))">Edit</button>"# } ?? "")
-            \(item.deleteCommandID.map { #"<button type="button" data-testid="memory-delete" data-command-id="\#(escape($0))">Forget</button>"# } ?? "")
+            \(item.editCommandID.map { #"<button type="button" class="memory-edit-button" data-testid="memory-edit" data-command-id="\#(escape($0))">Edit</button>"# } ?? "")
+            \(item.deleteCommandID.map { #"<button type="button" class="memory-delete-button" data-testid="memory-delete" data-command-id="\#(escape($0))">Forget</button>"# } ?? "")
           </header>
           <strong data-testid="memory-title">\(escape(item.title))</strong>
           <p data-testid="memory-preview">\(escape(item.preview))</p>

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -59,7 +59,7 @@ enum WorkspaceHTMLToolCardRenderer {
         guard card.inputJSON != nil || card.outputJSON != nil else { return "" }
         let isOpen = card.opensDetailsByDefault
         return """
-        <details data-testid="tool-card-details"\(isOpen ? " open" : "")>
+        <details class="tool-details" data-testid="tool-card-details"\(isOpen ? " open" : "")>
           <summary>\(detailsLabel(for: card, isOpen: isOpen))</summary>
           \(card.inputJSON.map { #"<pre data-testid="tool-card-input">\#(escape($0))</pre>"# } ?? "")
           \(card.outputJSON.map { #"<pre data-testid="tool-card-output">\#(escape($0))</pre>"# } ?? "")
@@ -88,7 +88,7 @@ enum WorkspaceHTMLToolCardRenderer {
         let chips = artifacts.map { artifact in
             let href = artifact.href.map { #" href="\#(escape($0))""# } ?? ""
             return """
-            <a class="artifact-chip" data-testid="tool-card-artifact" data-kind="\(escape(artifact.kind.rawValue))"\(href)>
+            <a class="artifact-chip \(WorkspaceHTMLPrimitives.interactiveHitTargetClass)" data-testid="tool-card-artifact" data-kind="\(escape(artifact.kind.rawValue))"\(href)>
               <strong data-testid="tool-card-artifact-label">\(escape(artifact.label))</strong>
               <small data-testid="tool-card-artifact-detail">\(escape(artifact.detail))</small>
             </a>
@@ -125,7 +125,7 @@ enum WorkspaceHTMLToolCardRenderer {
         let previews = documentArtifacts.compactMap { artifact -> String? in
             guard let preview = artifact.documentPreview else { return nil }
             let openLink = artifact.href.map {
-                #"<a data-testid="tool-card-document-preview-open" href="\#(escape($0))">Open</a>"#
+                #"<a class="\#(WorkspaceHTMLPrimitives.interactiveHitTargetClass)" data-testid="tool-card-document-preview-open" href="\#(escape($0))">Open</a>"#
             } ?? ""
             return """
             <figure class="artifact-document-preview" data-testid="tool-card-document-preview" data-kind="\(escape(preview.kind.rawValue))">

--- a/Tests/QuillCodeParityTests/ParityHTMLGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityHTMLGateTests.swift
@@ -267,6 +267,59 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(htmlText.contains("project-empty"), "WorkspaceHTMLRenderer should not own project empty-state markup.")
     }
 
+    func testHTMLInteractiveControlsKeepExplicitHitTargets() throws {
+        let primitivesText = try Self.appSourceText(named: "WorkspaceHTMLPrimitives.swift")
+        let toolCardText = try Self.appSourceText(named: "WorkspaceHTMLToolCardRenderer.swift")
+        let reviewText = try Self.appSourceText(named: "WorkspaceHTMLReviewRenderer.swift")
+        let secondaryText = try Self.appSourceText(named: "WorkspaceHTMLSecondaryPaneRenderer.swift")
+        let harnessText = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("E2E/harness/index.html"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(
+            primitivesText.contains("static let interactiveHitTargetClass"),
+            "HTML renderers should share one semantic class for non-button clickable targets."
+        )
+        XCTAssertTrue(
+            toolCardText.contains(#"class="tool-details""#),
+            "Tool-card details disclosures should opt into the harness hit-target styling."
+        )
+        XCTAssertTrue(
+            toolCardText.contains(#"artifact-chip \(WorkspaceHTMLPrimitives.interactiveHitTargetClass)"#),
+            "Artifact links should keep an explicit 44 px hit target instead of relying on chip padding."
+        )
+        XCTAssertTrue(
+            reviewText.contains(#"class="review-action-button""#),
+            "Review action buttons should use a named class that can be target-sized in CSS."
+        )
+        XCTAssertTrue(
+            secondaryText.contains(#"class="extension-action-button""#),
+            "Extension action buttons should use a named class that can be target-sized in CSS."
+        )
+        XCTAssertTrue(
+            secondaryText.contains(#"class="memory-edit-button""#),
+            "Memory edit buttons should keep the shared memory action class."
+        )
+        XCTAssertTrue(
+            harnessText.contains(".interactive-hit-target"),
+            "The Playwright harness should size semantic non-button click targets explicitly."
+        )
+        XCTAssertTrue(
+            harnessText.contains("details > summary"),
+            "Disclosure summaries should keep a minimum click target in the harness."
+        )
+        XCTAssertTrue(
+            harnessText.contains(#"class="artifact-chip interactive-hit-target""#),
+            "Harness artifact links should match the production target class."
+        )
+        XCTAssertTrue(
+            harnessText.contains(#"class="review-action-button""#),
+            "Harness review buttons should match the production review action class."
+        )
+    }
+
     func testHTMLArchitectureGatesStayOutOfBroadSuite() throws {
         let broadSuiteText = try Self.parityTestSourceText(named: "ParityGateTests.swift")
         let htmlGateNames = [

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -84,12 +84,41 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
     }
 
     func testNativeCompactPlainControlsKeepExplicitHitTargets() throws {
+        let designSystemText = try Self.appSourceText(named: "QuillCodeDesignSystem.swift")
         let computerUseText = try Self.appSourceText(named: "QuillCodeComputerUseSettingsCard.swift")
+        let runtimeIssueText = try Self.appSourceText(named: "QuillCodeRuntimeIssueView.swift")
         let activityText = try Self.appSourceText(named: "WorkspaceActivityPaneView.swift")
+        let memoriesText = try Self.appSourceText(named: "QuillCodeMemoriesPaneView.swift")
+        let worktreeChromeText = try Self.appSourceText(named: "QuillCodeWorktreeDialogChrome.swift")
+
+        XCTAssertTrue(
+            designSystemText.contains("minWidth: QuillCodeMetrics.minimumHitTarget"),
+            "Shared pressable button style should enforce the 44 pt target instead of leaving it to every caller."
+        )
+        XCTAssertTrue(
+            designSystemText.contains(".contentShape(Rectangle())"),
+            "Shared pressable button style should make the full target clickable."
+        )
 
         XCTAssertTrue(
             computerUseText.contains(".quillCodeHitTarget(minWidth: 112, alignment: .leading)"),
             "Computer Use refresh should not rely on borderless button default sizing."
+        )
+        XCTAssertTrue(
+            computerUseText.contains(".buttonStyle(QuillCodePressableButtonStyle())"),
+            "Computer Use refresh should keep press feedback while preserving its expanded hit target."
+        )
+        XCTAssertTrue(
+            runtimeIssueText.contains(".buttonStyle(QuillCodePressableButtonStyle())"),
+            "Runtime issue recovery actions should not use compact borderless defaults."
+        )
+        XCTAssertTrue(
+            memoriesText.contains(".buttonStyle(QuillCodePressableButtonStyle())"),
+            "Memory edit/delete icon buttons should use shared press feedback and hit targets."
+        )
+        XCTAssertTrue(
+            worktreeChromeText.contains(".buttonStyle(QuillCodePressableButtonStyle())"),
+            "Worktree retry actions should use shared press feedback and hit targets."
         )
         XCTAssertTrue(
             activityText.contains(".frame(maxWidth: .infinity, minHeight: QuillCodeMetrics.minimumHitTarget, alignment: .leading)"),

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7333,6 +7333,33 @@ Residual risk:
 
 - Native SwiftUI hit boxes are compile-covered but still not pixel-measured. When native screenshot/UI automation lands, mirror the Playwright bounding-box assertions for AppKit/SwiftUI controls.
 
+## 2026-06-27 Click Target System Audit
+
+Overall grade after this slice: **A native target contract, A HTML target semantics, A- duplicate harness renderer**.
+
+The first click-target pass established the 44 pt/px policy, but too much of the implementation still depended on each caller remembering to add a frame. This pass moves the guarantee closer to the shared interaction primitives and names the HTML click-target contract for non-button controls.
+
+Changes:
+
+- Updated `QuillCodePressableButtonStyle` to enforce the shared 44 pt minimum target and full `contentShape`, so pressable native buttons cannot silently shrink below the design-system target.
+- Replaced remaining compact native borderless/plain action styling for Computer Use refresh, runtime recovery, memory edit/delete, and worktree retry actions with the shared pressable button style.
+- Kept artifact `Link` controls visually compact while explicitly expanding their native target with `quillCodeHitTarget`.
+- Added a shared HTML `interactive-hit-target` class for semantic clickable links such as artifact chips and document preview opens.
+- Added explicit review, extension, and memory action classes in HTML renderers so target sizing is addressable by CSS and guarded by parity tests.
+- Mirrored those semantics in the Playwright harness, including a generic `details > summary` minimum target guard for disclosure controls.
+
+File grades:
+
+- `QuillCodeDesignSystem.swift`: **A**. Native press feedback and target sizing now share one primitive.
+- `QuillCodeToolArtifactViews.swift`: **A-**. Link styling still needs `.plain` for SwiftUI, but target sizing is explicit and localized.
+- `WorkspaceHTMLPrimitives.swift`: **A**. The target class is a small shared semantic primitive beside escaping and chip rendering.
+- `WorkspaceHTMLToolCardRenderer.swift`: **A**. Artifact links and tool details now declare click-target intent in markup.
+- `E2E/harness/index.html`: **A-**. The harness mirrors production target semantics, though its duplicate renderer remains the long-term cleanup target.
+
+Residual risk:
+
+- AppKit/SwiftUI rendered hit boxes still need native UI automation measurement. Until then, parity gates protect the source contract and Playwright measures the HTML harness.
+
 ## 2026-06-27 Agent Answer Formatter Family Split
 
 Overall grade after this slice: **A registry ownership, A formatter family boundaries, A shared argument parsing**.


### PR DESCRIPTION
## Summary
- Enforce the 44 pt minimum click target inside the shared SwiftUI pressable button style.
- Convert remaining compact native action buttons to shared pressable target behavior while keeping artifact links explicitly target-sized.
- Add shared HTML hit-target semantics for artifact links, disclosure summaries, review actions, extension actions, and memory actions, mirrored in the Playwright harness.
- Add parity gates and audit notes to keep the target contract from drifting.

## Validation
- `git diff --check`
- `swift test --filter 'ParityHTMLGateTests|ParityWorkspaceSettingsSheetGateTests'`\n- `swift test --filter 'WorkspaceHTMLToolCardRendererTests|WorkspaceHTMLSecondaryPaneRendererTests|WorkspaceHTMLReviewRendererTests|WorkspaceHTMLChromeRendererTests'`\n- `cd E2E/playwright && npm test -- tests/workspace-chrome.spec.ts`\n- `cd E2E/playwright && npm test -- tests/artifacts.spec.ts tests/extensions.spec.ts tests/memories.spec.ts tests/automations.spec.ts`