### PR TITLE
Move desktop workspace actions into coordinator

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -30,6 +30,7 @@ final class QuillCodeDesktopController: ObservableObject {
     private let composerCoordinator: QuillCodeDesktopComposerCoordinator
     private let copyCoordinator: QuillCodeDesktopCopyCoordinator
     private let projectImportCoordinator: QuillCodeDesktopProjectImportCoordinator
+    private let workspaceActionCoordinator: QuillCodeDesktopWorkspaceActionCoordinator
     private let terminalCoordinator: QuillCodeDesktopTerminalCoordinator
     private let worktreeCoordinator: QuillCodeDesktopWorktreeCoordinator
     private let tasks = QuillCodeDesktopTaskCoordinator()
@@ -59,6 +60,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.composerCoordinator = QuillCodeDesktopComposerCoordinator()
         self.copyCoordinator = QuillCodeDesktopCopyCoordinator()
         self.projectImportCoordinator = QuillCodeDesktopProjectImportCoordinator()
+        self.workspaceActionCoordinator = QuillCodeDesktopWorkspaceActionCoordinator()
         self.terminalCoordinator = QuillCodeDesktopTerminalCoordinator()
         self.worktreeCoordinator = QuillCodeDesktopWorktreeCoordinator()
         do {
@@ -248,7 +250,7 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func runToolCardAction(_ action: ToolCardActionSurface) {
-        _ = model.runToolCardAction(action, workspaceRoot: model.activeWorkspaceRoot ?? workspaceRoot)
+        workspaceActionCoordinator.runToolCardAction(action, model: model, fallbackWorkspaceRoot: workspaceRoot)
         refresh()
     }
 
@@ -281,7 +283,7 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func runReviewAction(_ action: WorkspaceReviewActionSurface) {
-        model.runReviewAction(action, workspaceRoot: model.activeWorkspaceRoot ?? workspaceRoot)
+        workspaceActionCoordinator.runReviewAction(action, model: model, fallbackWorkspaceRoot: workspaceRoot)
         refresh()
     }
 
@@ -292,12 +294,13 @@ final class QuillCodeDesktopController: ObservableObject {
         lineKind: WorkspaceReviewLineKind?,
         text: String
     ) {
-        _ = model.addReviewComment(
+        workspaceActionCoordinator.addReviewComment(
             path: path,
             lineNumber: lineNumber,
             endLineNumber: endLineNumber,
             lineKind: lineKind,
-            text: text
+            text: text,
+            model: model
         )
         refresh()
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
@@ -1,0 +1,48 @@
+import Foundation
+import QuillCodeApp
+
+@MainActor
+struct QuillCodeDesktopWorkspaceActionCoordinator {
+    func runToolCardAction(
+        _ action: ToolCardActionSurface,
+        model: QuillCodeWorkspaceModel,
+        fallbackWorkspaceRoot: URL
+    ) {
+        _ = model.runToolCardAction(
+            action,
+            workspaceRoot: activeWorkspaceRoot(for: model, fallback: fallbackWorkspaceRoot)
+        )
+    }
+
+    func runReviewAction(
+        _ action: WorkspaceReviewActionSurface,
+        model: QuillCodeWorkspaceModel,
+        fallbackWorkspaceRoot: URL
+    ) {
+        model.runReviewAction(
+            action,
+            workspaceRoot: activeWorkspaceRoot(for: model, fallback: fallbackWorkspaceRoot)
+        )
+    }
+
+    func addReviewComment(
+        path: String,
+        lineNumber: Int?,
+        endLineNumber: Int?,
+        lineKind: WorkspaceReviewLineKind?,
+        text: String,
+        model: QuillCodeWorkspaceModel
+    ) {
+        _ = model.addReviewComment(
+            path: path,
+            lineNumber: lineNumber,
+            endLineNumber: endLineNumber,
+            lineKind: lineKind,
+            text: text
+        )
+    }
+
+    private func activeWorkspaceRoot(for model: QuillCodeWorkspaceModel, fallback: URL) -> URL {
+        model.activeWorkspaceRoot ?? fallback
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -248,6 +248,24 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(controllerText.contains("fileExists(atPath:"), "Desktop controller should not own import directory validation.")
     }
 
+    func testDesktopControllerDelegatesWorkspaceActionMutations() throws {
+        let text = try Self.desktopSourceText()
+        let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let actionCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopWorkspaceActionCoordinator.swift")
+
+        XCTAssertTrue(text.contains("QuillCodeDesktopWorkspaceActionCoordinator"), "Desktop workspace action mutations should be isolated from UI routing.")
+        XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.runToolCardAction"), "Desktop controller should delegate tool-card actions.")
+        XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.runReviewAction"), "Desktop controller should delegate review actions.")
+        XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.addReviewComment"), "Desktop controller should delegate review comment mutation.")
+        XCTAssertTrue(actionCoordinatorText.contains("model.runToolCardAction"), "Workspace action coordinator should own tool-card mutation routing.")
+        XCTAssertTrue(actionCoordinatorText.contains("model.runReviewAction"), "Workspace action coordinator should own review action routing.")
+        XCTAssertTrue(actionCoordinatorText.contains("model.addReviewComment"), "Workspace action coordinator should own review-comment mutation routing.")
+        XCTAssertTrue(actionCoordinatorText.contains("model.activeWorkspaceRoot ?? fallback"), "Workspace action coordinator should centralize active workspace root fallback.")
+        XCTAssertFalse(controllerText.contains("model.runToolCardAction"), "Desktop controller should not run tool-card actions directly.")
+        XCTAssertFalse(controllerText.contains("model.runReviewAction"), "Desktop controller should not run review actions directly.")
+        XCTAssertFalse(controllerText.contains("model.addReviewComment"), "Desktop controller should not add review comments directly.")
+    }
+
     func testDesktopControllerDelegatesNavigationMutations() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")

--- a/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceModelGateTests.swift
@@ -86,6 +86,7 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         let htmlRendererText = try Self.appSourceText(named: "WorkspaceHTMLToolCardRenderer.swift")
         let desktopAppText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
         let desktopControllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let desktopActionCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopWorkspaceActionCoordinator.swift")
 
         XCTAssertTrue(toolCardSurfaceText.contains("public struct ToolCardActionSurface"), "Tool-card actions should be first-class surface state.")
         XCTAssertTrue(toolCardSurfaceText.contains("public enum ToolCardReviewState"), "Tool-card review substates should be explicit surface state.")
@@ -124,7 +125,8 @@ final class ParityWorkspaceModelGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(modelText.contains("private func appendApprovalDecision"), "Workspace model should not own approval-decision event construction.")
         XCTAssertFalse(modelText.contains("approvalVerdict"), "Workspace model should not own tool-card action verdict mapping.")
         XCTAssertTrue(desktopAppText.contains("controller.runToolCardAction"), "Desktop app should connect UI actions to the controller.")
-        XCTAssertTrue(desktopControllerText.contains("model.runToolCardAction"), "Desktop controller should forward review-card actions to the model.")
+        XCTAssertTrue(desktopControllerText.contains("workspaceActionCoordinator.runToolCardAction"), "Desktop controller should forward review-card actions through a focused coordinator.")
+        XCTAssertTrue(desktopActionCoordinatorText.contains("model.runToolCardAction"), "Desktop workspace action coordinator should forward review-card actions to the model.")
     }
 
     func testWorkspaceModelDelegatesExecutionContextSurfaceBuilding() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7454,3 +7454,26 @@ Strict grades:
 Remaining risk:
 
 - This is still source-gated rather than directly unit tested through an importable desktop library. If desktop coordinators move into a testable target, add fake-bootstrap tests for settings save, catalog refresh, API-key clear/replace, and runtime rebuild flows.
+
+## 2026-06-27 Desktop Workspace Action Coordinator Pass
+
+Overall grade after this slice: **A action routing boundary, A active-root fallback ownership, A- desktop executable coverage**.
+
+`QuillCodeDesktopController.swift` still directly routed tool-card actions, review actions, and review-comment mutations into the workspace model. Those calls are compact, but they share active-workspace-root fallback and are likely to grow as review UX, comments, and tool-card affordances mature.
+
+Code quality changes:
+
+- Added `QuillCodeDesktopWorkspaceActionCoordinator` for tool-card actions, review actions, and review-comment mutation routing.
+- Centralized active-workspace-root fallback for desktop tool-card and review actions.
+- Reduced the desktop controller to invoking the coordinator and refreshing published UI state.
+- Strengthened the desktop parity gate so tool-card action routing, review action routing, review-comment mutation, and active-root fallback do not drift back into the controller.
+
+Strict grades:
+
+- `QuillCodeDesktopWorkspaceActionCoordinator.swift`: **A**. Small, focused coordinator with no UI state and one clear fallback rule.
+- `QuillCodeDesktopController.swift`: **A-**. The controller keeps shrinking toward UI-state glue while preserving direct refresh ownership.
+- `ParityDesktopGateTests.swift`: **A**. The new source gate protects the next likely review/tool-card growth boundary.
+
+Remaining risk:
+
+- The coordinator is intentionally source-gated for now. If desktop coordinators move into a testable library target, add direct fake-model tests for review action routing and comment mutation edge cases.


### PR DESCRIPTION
## Summary
- add QuillCodeDesktopWorkspaceActionCoordinator for tool-card actions, review actions, and review comments
- keep active workspace root fallback in one desktop action boundary
- update parity gates and the code-quality audit so the controller stays out of direct workspace action mutation routing

## Validation
- git diff --check
- swift test --filter 'ParityWorkspaceModelGateTests|ParityDesktopGateTests'
- swift test --quiet (1266 tests, 0 failures)