### PR TITLE
Move desktop pane mutations into coordinator

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -30,6 +30,7 @@ final class QuillCodeDesktopController: ObservableObject {
     private let composerCoordinator: QuillCodeDesktopComposerCoordinator
     private let copyCoordinator: QuillCodeDesktopCopyCoordinator
     private let projectImportCoordinator: QuillCodeDesktopProjectImportCoordinator
+    private let paneCoordinator: QuillCodeDesktopPaneCoordinator
     private let workspaceActionCoordinator: QuillCodeDesktopWorkspaceActionCoordinator
     private let terminalCoordinator: QuillCodeDesktopTerminalCoordinator
     private let worktreeCoordinator: QuillCodeDesktopWorktreeCoordinator
@@ -60,6 +61,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.composerCoordinator = QuillCodeDesktopComposerCoordinator()
         self.copyCoordinator = QuillCodeDesktopCopyCoordinator()
         self.projectImportCoordinator = QuillCodeDesktopProjectImportCoordinator()
+        self.paneCoordinator = QuillCodeDesktopPaneCoordinator()
         self.workspaceActionCoordinator = QuillCodeDesktopWorkspaceActionCoordinator()
         self.terminalCoordinator = QuillCodeDesktopTerminalCoordinator()
         self.worktreeCoordinator = QuillCodeDesktopWorktreeCoordinator()
@@ -206,22 +208,22 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func toggleTerminal() {
-        model.toggleTerminal()
+        paneCoordinator.toggleTerminal(on: model)
         refresh()
     }
 
     func toggleBrowser() {
-        model.toggleBrowser()
+        paneCoordinator.toggleBrowser(on: model)
         refresh()
     }
 
     func toggleExtensions() {
-        model.toggleExtensions()
+        paneCoordinator.toggleExtensions(on: model)
         refresh()
     }
 
     func toggleMemories() {
-        model.toggleMemories()
+        paneCoordinator.toggleMemories(on: model)
         refresh()
     }
 
@@ -245,7 +247,7 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func addBrowserComment(_ comment: String) {
-        _ = model.addBrowserComment(comment)
+        paneCoordinator.addBrowserComment(comment, to: model)
         refresh()
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopPaneCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopPaneCoordinator.swift
@@ -1,0 +1,25 @@
+import Foundation
+import QuillCodeApp
+
+@MainActor
+struct QuillCodeDesktopPaneCoordinator {
+    func toggleTerminal(on model: QuillCodeWorkspaceModel) {
+        model.toggleTerminal()
+    }
+
+    func toggleBrowser(on model: QuillCodeWorkspaceModel) {
+        model.toggleBrowser()
+    }
+
+    func toggleExtensions(on model: QuillCodeWorkspaceModel) {
+        model.toggleExtensions()
+    }
+
+    func toggleMemories(on model: QuillCodeWorkspaceModel) {
+        model.toggleMemories()
+    }
+
+    func addBrowserComment(_ comment: String, to model: QuillCodeWorkspaceModel) {
+        _ = model.addBrowserComment(comment)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -248,6 +248,29 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(controllerText.contains("fileExists(atPath:"), "Desktop controller should not own import directory validation.")
     }
 
+    func testDesktopControllerDelegatesPaneMutations() throws {
+        let text = try Self.desktopSourceText()
+        let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let paneCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopPaneCoordinator.swift")
+
+        XCTAssertTrue(text.contains("QuillCodeDesktopPaneCoordinator"), "Desktop pane visibility and browser comment mutations should be isolated from UI routing.")
+        XCTAssertTrue(controllerText.contains("paneCoordinator.toggleTerminal"), "Desktop controller should delegate terminal pane toggles.")
+        XCTAssertTrue(controllerText.contains("paneCoordinator.toggleBrowser"), "Desktop controller should delegate browser pane toggles.")
+        XCTAssertTrue(controllerText.contains("paneCoordinator.toggleExtensions"), "Desktop controller should delegate extensions pane toggles.")
+        XCTAssertTrue(controllerText.contains("paneCoordinator.toggleMemories"), "Desktop controller should delegate memories pane toggles.")
+        XCTAssertTrue(controllerText.contains("paneCoordinator.addBrowserComment"), "Desktop controller should delegate browser comment mutation.")
+        XCTAssertTrue(paneCoordinatorText.contains("model.toggleTerminal()"), "Pane coordinator should own terminal pane visibility mutation.")
+        XCTAssertTrue(paneCoordinatorText.contains("model.toggleBrowser()"), "Pane coordinator should own browser pane visibility mutation.")
+        XCTAssertTrue(paneCoordinatorText.contains("model.toggleExtensions()"), "Pane coordinator should own extensions pane visibility mutation.")
+        XCTAssertTrue(paneCoordinatorText.contains("model.toggleMemories()"), "Pane coordinator should own memories pane visibility mutation.")
+        XCTAssertTrue(paneCoordinatorText.contains("model.addBrowserComment(comment)"), "Pane coordinator should own browser comment mutation.")
+        XCTAssertFalse(controllerText.contains("model.toggleTerminal()"), "Desktop controller should not mutate terminal pane visibility directly.")
+        XCTAssertFalse(controllerText.contains("model.toggleBrowser()"), "Desktop controller should not mutate browser pane visibility directly.")
+        XCTAssertFalse(controllerText.contains("model.toggleExtensions()"), "Desktop controller should not mutate extensions pane visibility directly.")
+        XCTAssertFalse(controllerText.contains("model.toggleMemories()"), "Desktop controller should not mutate memories pane visibility directly.")
+        XCTAssertFalse(controllerText.contains("model.addBrowserComment(comment)"), "Desktop controller should not add browser comments directly.")
+    }
+
     func testDesktopControllerDelegatesWorkspaceActionMutations() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -30,6 +30,20 @@ Residual risk:
 
 - Native SwiftUI hit targets are still source-guarded rather than measured by screenshot/UI automation. Keep mirroring critical controls in Playwright until native UI automation exists.
 
+## 2026-06-27 Desktop Pane Coordinator Pass
+
+Overall grade after this slice: **A- desktop pane routing, A browser-comment mutation ownership, A controller readability**.
+
+Pane visibility toggles and browser comments are small operations, but keeping their model mutations inline in `QuillCodeDesktopController.swift` made the controller the fallback owner for every uncategorized UI action. Moving them behind a named coordinator keeps desktop routing consistent with the existing terminal, browser, workspace action, worktree, and navigation boundaries.
+
+- Added `QuillCodeDesktopPaneCoordinator` for terminal, browser, extensions, and memories pane toggles plus browser comment mutation.
+- Rewired `QuillCodeDesktopController` to delegate pane/comment mutation while retaining refresh and UI action exposure.
+- Added a parity gate so direct pane and browser-comment model mutations do not drift back into the desktop controller.
+
+Residual risk:
+
+- This is still source-gated because desktop coordinators are not yet built as directly importable units. Keep each coordinator thin until the desktop target gains focused unit-test seams.
+
 ## Component Grades
 
 | Component | Grade | Notes |
@@ -60,7 +74,7 @@ Residual risk:
 | `Sources/QuillCodeApp/QuillCodeReviewFileRowView.swift` | A- | File rows, hunk rows, range-note controls, file/hunk actions, and hunk-to-line composition live together. Split hunk controls only if review workflows grow beyond compact stage/restore/comment actions. |
 | `Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift` | A | Line content, marker/background styling, inline comments, and line-note composer live together without expanding the review pane shell. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
-| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI state, refresh, and host capability routing. Pasteboard feedback, project-import resolution, project/thread navigation, worktree routing/loading, terminal run/history, composer send/retry, automation ticking/notification fan-out, command action dispatch, and stop/disconnect orchestration now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
+| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI state, refresh, and host capability routing. Pasteboard feedback, project-import resolution, project/thread navigation, pane toggles/browser comments, worktree routing/loading, terminal run/history, composer send/retry, automation ticking/notification fan-out, command action dispatch, and stop/disconnect orchestration now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
 | `Sources/QuillCodeAgent/Agent.swift` | A- | Good test coverage; keep tool continuation limits and transcript filtering explicit. |
 | `Sources/QuillCodeCore/Models.swift` | A | General chat/thread/memory domain models only; app config, automation scheduling, project/workspace records, tool payloads, and TrustedRouter defaults/catalog records now live in focused core files. Watch for persistence, workflow, tool, or provider-specific behavior trying to drift back in. |
 | `Sources/QuillCodeCore/AppConfig.swift` | A | App settings, auth mode compatibility, signed-in account metadata, and favorite model normalization live together without pulling UI/runtime dependencies into core. |


### PR DESCRIPTION
## Summary
- add QuillCodeDesktopPaneCoordinator for pane visibility toggles and browser comments
- rewire QuillCodeDesktopController to delegate pane/comment mutations while retaining refresh/UI routing
- add parity coverage and update the code-quality audit

## Validation
- git diff --check
- swift test --filter ParityDesktopGateTests
- swift test --quiet (1267 tests, 0 failures)