### PR TITLE
Delegate desktop workspace commands and feedback

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -349,7 +349,9 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func setMessageFeedback(messageID: UUID, value: MessageFeedbackValue) {
-        guard model.setMessageFeedback(messageID: messageID, value: value) else { return }
+        guard workspaceActionCoordinator.setMessageFeedback(messageID: messageID, value: value, model: model) else {
+            return
+        }
         refresh()
     }
 
@@ -409,7 +411,11 @@ extension QuillCodeDesktopController: QuillCodeDesktopCommandPerforming {
     }
 
     func runWorkspaceCommand(_ commandID: String) {
-        guard model.runWorkspaceCommand(commandID, workspaceRoot: model.activeWorkspaceRoot ?? workspaceRoot) else {
+        guard workspaceActionCoordinator.runWorkspaceCommand(
+            commandID,
+            model: model,
+            fallbackWorkspaceRoot: workspaceRoot
+        ) else {
             return
         }
         draft = model.composer.draft

--- a/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeApp
+import QuillCodeCore
 
 @MainActor
 struct QuillCodeDesktopWorkspaceActionCoordinator {
@@ -39,6 +40,27 @@ struct QuillCodeDesktopWorkspaceActionCoordinator {
             endLineNumber: endLineNumber,
             lineKind: lineKind,
             text: text
+        )
+    }
+
+    @discardableResult
+    func setMessageFeedback(
+        messageID: UUID,
+        value: MessageFeedbackValue,
+        model: QuillCodeWorkspaceModel
+    ) -> Bool {
+        model.setMessageFeedback(messageID: messageID, value: value)
+    }
+
+    @discardableResult
+    func runWorkspaceCommand(
+        _ commandID: String,
+        model: QuillCodeWorkspaceModel,
+        fallbackWorkspaceRoot: URL
+    ) -> Bool {
+        model.runWorkspaceCommand(
+            commandID,
+            workspaceRoot: activeWorkspaceRoot(for: model, fallback: fallbackWorkspaceRoot)
         )
     }
 

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -280,13 +280,19 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.runToolCardAction"), "Desktop controller should delegate tool-card actions.")
         XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.runReviewAction"), "Desktop controller should delegate review actions.")
         XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.addReviewComment"), "Desktop controller should delegate review comment mutation.")
+        XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.setMessageFeedback"), "Desktop controller should delegate message feedback mutation.")
+        XCTAssertTrue(controllerText.contains("workspaceActionCoordinator.runWorkspaceCommand"), "Desktop controller should delegate generic workspace command execution.")
         XCTAssertTrue(actionCoordinatorText.contains("model.runToolCardAction"), "Workspace action coordinator should own tool-card mutation routing.")
         XCTAssertTrue(actionCoordinatorText.contains("model.runReviewAction"), "Workspace action coordinator should own review action routing.")
         XCTAssertTrue(actionCoordinatorText.contains("model.addReviewComment"), "Workspace action coordinator should own review-comment mutation routing.")
+        XCTAssertTrue(actionCoordinatorText.contains("model.setMessageFeedback"), "Workspace action coordinator should own message feedback mutation routing.")
+        XCTAssertTrue(actionCoordinatorText.contains("model.runWorkspaceCommand"), "Workspace action coordinator should own generic workspace command execution.")
         XCTAssertTrue(actionCoordinatorText.contains("model.activeWorkspaceRoot ?? fallback"), "Workspace action coordinator should centralize active workspace root fallback.")
         XCTAssertFalse(controllerText.contains("model.runToolCardAction"), "Desktop controller should not run tool-card actions directly.")
         XCTAssertFalse(controllerText.contains("model.runReviewAction"), "Desktop controller should not run review actions directly.")
         XCTAssertFalse(controllerText.contains("model.addReviewComment"), "Desktop controller should not add review comments directly.")
+        XCTAssertFalse(controllerText.contains("model.setMessageFeedback"), "Desktop controller should not mutate message feedback directly.")
+        XCTAssertFalse(controllerText.contains("model.runWorkspaceCommand"), "Desktop controller should not execute generic workspace commands directly.")
     }
 
     func testDesktopControllerDelegatesNavigationMutations() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -44,6 +44,20 @@ Residual risk:
 
 - This is still source-gated because desktop coordinators are not yet built as directly importable units. Keep each coordinator thin until the desktop target gains focused unit-test seams.
 
+## 2026-06-27 Desktop Workspace Action Follow-Up
+
+Overall grade after this slice: **A desktop action mutation routing, A active-root fallback consistency, A- controller mutation hygiene**.
+
+After moving tool-card, review, review-comment, pane, and browser-comment flows out of `QuillCodeDesktopController.swift`, two action mutations still remained inline: message feedback and generic workspace command execution. Those are small, but they kept the controller as a direct model mutation fallback for transcript and command-surface actions.
+
+- Extended `QuillCodeDesktopWorkspaceActionCoordinator` to own message feedback mutation and generic workspace command execution.
+- Reused the same active workspace root fallback helper for generic workspace commands.
+- Tightened the desktop parity gate so direct message feedback and generic workspace command execution do not drift back into the controller.
+
+Residual risk:
+
+- The controller still owns refresh/draft mirroring because those are published UI state concerns. That boundary is acceptable for now; extract it only if refresh rules become more complex.
+
 ## Component Grades
 
 | Component | Grade | Notes |
@@ -74,7 +88,7 @@ Residual risk:
 | `Sources/QuillCodeApp/QuillCodeReviewFileRowView.swift` | A- | File rows, hunk rows, range-note controls, file/hunk actions, and hunk-to-line composition live together. Split hunk controls only if review workflows grow beyond compact stage/restore/comment actions. |
 | `Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift` | A | Line content, marker/background styling, inline comments, and line-note composer live together without expanding the review pane shell. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
-| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI state, refresh, and host capability routing. Pasteboard feedback, project-import resolution, project/thread navigation, pane toggles/browser comments, worktree routing/loading, terminal run/history, composer send/retry, automation ticking/notification fan-out, command action dispatch, and stop/disconnect orchestration now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
+| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI state, refresh, and host capability routing. Pasteboard feedback, project-import resolution, project/thread navigation, pane toggles/browser comments, workspace action/message-feedback/command routing, worktree routing/loading, terminal run/history, composer send/retry, automation ticking/notification fan-out, command action dispatch, and stop/disconnect orchestration now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
 | `Sources/QuillCodeAgent/Agent.swift` | A- | Good test coverage; keep tool continuation limits and transcript filtering explicit. |
 | `Sources/QuillCodeCore/Models.swift` | A | General chat/thread/memory domain models only; app config, automation scheduling, project/workspace records, tool payloads, and TrustedRouter defaults/catalog records now live in focused core files. Watch for persistence, workflow, tool, or provider-specific behavior trying to drift back in. |
 | `Sources/QuillCodeCore/AppConfig.swift` | A | App settings, auth mode compatibility, signed-in account metadata, and favorite model normalization live together without pulling UI/runtime dependencies into core. |


### PR DESCRIPTION
## Summary
- move message feedback mutation into QuillCodeDesktopWorkspaceActionCoordinator
- move generic workspace command execution and active-root fallback into the same coordinator
- update desktop parity coverage and the code-quality audit

## Validation
- git diff --check
- swift test --filter ParityDesktopGateTests
- swift test --quiet (1268 tests, 0 failures)