### PR TITLE
Delegate desktop model state synchronization

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -30,6 +30,7 @@ final class QuillCodeDesktopController: ObservableObject {
     private let composerCoordinator: QuillCodeDesktopComposerCoordinator
     private let copyCoordinator: QuillCodeDesktopCopyCoordinator
     private let projectImportCoordinator: QuillCodeDesktopProjectImportCoordinator
+    private let modelStateCoordinator: QuillCodeDesktopModelStateCoordinator
     private let paneCoordinator: QuillCodeDesktopPaneCoordinator
     private let workspaceActionCoordinator: QuillCodeDesktopWorkspaceActionCoordinator
     private let terminalCoordinator: QuillCodeDesktopTerminalCoordinator
@@ -61,6 +62,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.composerCoordinator = QuillCodeDesktopComposerCoordinator()
         self.copyCoordinator = QuillCodeDesktopCopyCoordinator()
         self.projectImportCoordinator = QuillCodeDesktopProjectImportCoordinator()
+        self.modelStateCoordinator = QuillCodeDesktopModelStateCoordinator()
         self.paneCoordinator = QuillCodeDesktopPaneCoordinator()
         self.workspaceActionCoordinator = QuillCodeDesktopWorkspaceActionCoordinator()
         self.terminalCoordinator = QuillCodeDesktopTerminalCoordinator()
@@ -71,14 +73,13 @@ final class QuillCodeDesktopController: ObservableObject {
             self.model = QuillCodeWorkspaceModel()
         }
         self.workspaceRoot = workspaceRoot
-        if self.model.root.projects.isEmpty {
-            _ = self.model.addProject(path: workspaceRoot)
-        }
+        modelStateCoordinator.ensureDefaultProject(on: model, workspaceRoot: workspaceRoot)
         self.computerUseCoordinator.install(on: model)
-        self.surface = model.surface()
-        self.draft = model.composer.draft
-        self.terminalDraft = model.terminal.draft
-        self.browserAddressDraft = model.browser.addressDraft
+        let initialState = modelStateCoordinator.initialState(from: model)
+        self.surface = initialState.surface
+        self.draft = initialState.draft
+        self.terminalDraft = initialState.terminalDraft
+        self.browserAddressDraft = initialState.browserAddressDraft
         automationCoordinator.runDueAutomations(
             model: model,
             notifier: automationNotifier,
@@ -387,16 +388,13 @@ final class QuillCodeDesktopController: ObservableObject {
 
     private func refresh() {
         computerUseCoordinator.refreshStatus(on: model)
-        surface = model.surface()
-        if draft != model.composer.draft, !model.composer.isSending {
-            draft = model.composer.draft
-        }
-        if terminalDraft != model.terminal.draft, !model.terminal.isRunning {
-            terminalDraft = model.terminal.draft
-        }
-        if browserAddressDraft != model.browser.addressDraft {
-            browserAddressDraft = model.browser.addressDraft
-        }
+        modelStateCoordinator.refreshState(
+            from: model,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft
+        )
     }
 
     func openComputerUseSystemSettings(_ destination: MacSystemSettingsOpener.Destination) {
@@ -418,7 +416,7 @@ extension QuillCodeDesktopController: QuillCodeDesktopCommandPerforming {
         ) else {
             return
         }
-        draft = model.composer.draft
+        modelStateCoordinator.syncComposerDraft(from: model, draft: &draft)
         refresh()
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
@@ -1,0 +1,52 @@
+import Foundation
+import QuillCodeApp
+
+struct QuillCodeDesktopModelState {
+    let surface: WorkspaceSurface
+    let draft: String
+    let terminalDraft: String
+    let browserAddressDraft: String
+}
+
+@MainActor
+struct QuillCodeDesktopModelStateCoordinator {
+    func ensureDefaultProject(on model: QuillCodeWorkspaceModel, workspaceRoot: URL) {
+        if model.root.projects.isEmpty {
+            _ = model.addProject(path: workspaceRoot)
+        }
+    }
+
+    func initialState(from model: QuillCodeWorkspaceModel) -> QuillCodeDesktopModelState {
+        QuillCodeDesktopModelState(
+            surface: model.surface(),
+            draft: model.composer.draft,
+            terminalDraft: model.terminal.draft,
+            browserAddressDraft: model.browser.addressDraft
+        )
+    }
+
+    func refreshState(
+        from model: QuillCodeWorkspaceModel,
+        surface: inout WorkspaceSurface,
+        draft: inout String,
+        terminalDraft: inout String,
+        browserAddressDraft: inout String
+    ) {
+        let nextState = initialState(from: model)
+        surface = nextState.surface
+
+        if draft != nextState.draft, !model.composer.isSending {
+            draft = nextState.draft
+        }
+        if terminalDraft != nextState.terminalDraft, !model.terminal.isRunning {
+            terminalDraft = nextState.terminalDraft
+        }
+        if browserAddressDraft != nextState.browserAddressDraft {
+            browserAddressDraft = nextState.browserAddressDraft
+        }
+    }
+
+    func syncComposerDraft(from model: QuillCodeWorkspaceModel, draft: inout String) {
+        draft = model.composer.draft
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -295,6 +295,30 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(controllerText.contains("model.runWorkspaceCommand"), "Desktop controller should not execute generic workspace commands directly.")
     }
 
+    func testDesktopControllerDelegatesModelStateSynchronization() throws {
+        let text = try Self.desktopSourceText()
+        let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let stateCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopModelStateCoordinator.swift")
+
+        XCTAssertTrue(text.contains("QuillCodeDesktopModelStateCoordinator"), "Desktop model state synchronization should be isolated from UI routing.")
+        XCTAssertTrue(controllerText.contains("modelStateCoordinator.ensureDefaultProject"), "Desktop controller should delegate bootstrap project fallback.")
+        XCTAssertTrue(controllerText.contains("modelStateCoordinator.initialState"), "Desktop controller should delegate initial surface/draft capture.")
+        XCTAssertTrue(controllerText.contains("modelStateCoordinator.refreshState"), "Desktop controller should delegate refresh-state synchronization.")
+        XCTAssertTrue(controllerText.contains("modelStateCoordinator.syncComposerDraft"), "Desktop controller should delegate forced composer draft synchronization.")
+        XCTAssertTrue(stateCoordinatorText.contains("model.root.projects.isEmpty"), "Model-state coordinator should own bootstrap project fallback checks.")
+        XCTAssertTrue(stateCoordinatorText.contains("model.addProject(path: workspaceRoot)"), "Model-state coordinator should own bootstrap project fallback mutation.")
+        XCTAssertTrue(stateCoordinatorText.contains("model.surface()"), "Model-state coordinator should own surface snapshots.")
+        XCTAssertTrue(stateCoordinatorText.contains("model.composer.draft"), "Model-state coordinator should own composer draft reads.")
+        XCTAssertTrue(stateCoordinatorText.contains("model.terminal.draft"), "Model-state coordinator should own terminal draft reads.")
+        XCTAssertTrue(stateCoordinatorText.contains("model.browser.addressDraft"), "Model-state coordinator should own browser address reads.")
+        XCTAssertFalse(controllerText.contains("model.root.projects.isEmpty"), "Desktop controller should not inspect project state directly during bootstrap.")
+        XCTAssertFalse(controllerText.contains("model.addProject(path: workspaceRoot)"), "Desktop controller should not mutate bootstrap project fallback directly.")
+        XCTAssertFalse(controllerText.contains("model.surface()"), "Desktop controller should not capture surface snapshots directly.")
+        XCTAssertFalse(controllerText.contains("model.composer.draft"), "Desktop controller should not read composer draft state directly.")
+        XCTAssertFalse(controllerText.contains("model.terminal.draft"), "Desktop controller should not read terminal draft state directly.")
+        XCTAssertFalse(controllerText.contains("model.browser.addressDraft"), "Desktop controller should not read browser address state directly.")
+    }
+
     func testDesktopControllerDelegatesNavigationMutations() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -6,6 +6,20 @@ Overall grade: **A- foundation, B+ product surface maturity**.
 
 The architecture is moving in the right direction: core state is value typed, persistence and runtime adapters are separated, tools use explicit schemas, and SwiftUI plus the Playwright harness render from the same surface contract. The main drag on the grade is file size and feature density in the workspace layer, not a broken abstraction boundary.
 
+## 2026-06-27 Desktop Model State Coordinator Pass
+
+Overall grade after this slice: **A desktop state synchronization, A- controller size, A refresh rule clarity**.
+
+`QuillCodeDesktopController.swift` was down to mostly UI routing, but it still directly inspected the workspace model for bootstrap defaults, surface snapshots, composer draft mirroring, terminal draft mirroring, and browser address mirroring. Those rules are small, but they are also easy to break when native Codex-style interactions add more panes, status banners, or command surfaces.
+
+- Added `QuillCodeDesktopModelStateCoordinator` for bootstrap project fallback, initial state capture, refresh-state synchronization, and forced composer draft synchronization after workspace commands.
+- Rewired `QuillCodeDesktopController` so published SwiftUI state remains in the controller while model reads and draft-mirroring rules live in one focused coordinator.
+- Added a parity gate so direct `model.surface()`, draft reads, browser address reads, and bootstrap project fallback logic do not drift back into the controller.
+
+Residual risk:
+
+- This remains source-gated because the desktop executable still is not split into a standalone library target. The coordinator is intentionally data-only and should become a direct unit-test target once the desktop module boundary is extracted.
+
 ## 2026-06-27 PR Review Thread Parity Matrix Guard
 
 Overall grade after this slice: **A documentation parity, A regression guard, unchanged execution quality**.
@@ -88,7 +102,7 @@ Residual risk:
 | `Sources/QuillCodeApp/QuillCodeReviewFileRowView.swift` | A- | File rows, hunk rows, range-note controls, file/hunk actions, and hunk-to-line composition live together. Split hunk controls only if review workflows grow beyond compact stage/restore/comment actions. |
 | `Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift` | A | Line content, marker/background styling, inline comments, and line-note composer live together without expanding the review pane shell. |
 | `Sources/quill-code-desktop/QuillCodeDesktopApp.swift` | A- | App scene composition is now small and declarative. Keep it limited to window/menu-bar wiring and root-view routing. |
-| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly UI state, refresh, and host capability routing. Pasteboard feedback, project-import resolution, project/thread navigation, pane toggles/browser comments, workspace action/message-feedback/command routing, worktree routing/loading, terminal run/history, composer send/retry, automation ticking/notification fan-out, command action dispatch, and stop/disconnect orchestration now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
+| `Sources/quill-code-desktop/QuillCodeDesktopController.swift` | A- | Desktop controller is now mostly published UI state and host capability routing. Bootstrap fallback, surface/draft synchronization, pasteboard feedback, project-import resolution, project/thread navigation, pane toggles/browser comments, workspace action/message-feedback/command routing, worktree routing/loading, terminal run/history, composer send/retry, automation ticking/notification fan-out, command action dispatch, and stop/disconnect orchestration now live in focused coordinators; keep future desktop protocol/workflow details out of the controller. |
 | `Sources/QuillCodeAgent/Agent.swift` | A- | Good test coverage; keep tool continuation limits and transcript filtering explicit. |
 | `Sources/QuillCodeCore/Models.swift` | A | General chat/thread/memory domain models only; app config, automation scheduling, project/workspace records, tool payloads, and TrustedRouter defaults/catalog records now live in focused core files. Watch for persistence, workflow, tool, or provider-specific behavior trying to drift back in. |
 | `Sources/QuillCodeCore/AppConfig.swift` | A | App settings, auth mode compatibility, signed-in account metadata, and favorite model normalization live together without pulling UI/runtime dependencies into core. |


### PR DESCRIPTION
## Summary
- add a desktop model-state coordinator for bootstrap fallback, initial state capture, refresh sync, and forced composer draft sync
- rewire the desktop controller to keep published UI state while delegating model reads/draft mirroring
- add a parity gate and audit note to keep direct model-state reads out of the controller

## Validation
- git diff --check origin/main...HEAD
- swift test --filter ParityDesktopGateTests
- swift test --quiet (1275 tests, 0 failures after rebase on #464)