### PR TITLE
Add transcript starter actions

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -2233,7 +2233,9 @@
     pre { overflow: auto; white-space: pre-wrap; background: rgba(0,0,0,.38); border-radius: 10px; padding: 10px; color: #dff8ff; }
     .empty {
       margin: 0 auto;
+      width: min(100%, 620px);
       max-width: 560px;
+      box-sizing: border-box;
       padding: 32px 0 20px;
       color: var(--muted);
       text-align: center;
@@ -2250,6 +2252,57 @@
       margin: 0;
       font-size: 14px;
       line-height: 1.35;
+      text-wrap: pretty;
+    }
+    .empty-starters {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(156px, 1fr));
+      gap: 10px;
+      width: 100%;
+      max-width: 620px;
+      margin: 16px auto 0;
+    }
+    .empty-starter {
+      min-height: var(--hit-target);
+      border: 0;
+      border-radius: 14px;
+      padding: 10px 12px;
+      color: var(--text);
+      text-align: left;
+      background: rgba(25, 41, 48, 0.64);
+      box-shadow: var(--shadow-border);
+      cursor: pointer;
+      transition-property: transform, background-color, box-shadow;
+      transition-duration: 150ms;
+      transition-timing-function: var(--ease-out);
+    }
+    .empty-starter:hover {
+      background: rgba(35, 58, 68, 0.78);
+      box-shadow: var(--shadow-border-hover);
+    }
+    .empty-starter:active {
+      transform: scale(0.96);
+    }
+    .empty-starter strong,
+    .empty-starter span {
+      display: block;
+    }
+    .empty-starter strong {
+      font-size: 13px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+    .empty-starter span {
+      margin-top: 3px;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.25;
+      text-wrap: pretty;
+    }
+    @media (max-width: 600px) {
+      .empty-starters {
+        grid-template-columns: 1fr;
+      }
     }
     .composer {
       align-self: end;
@@ -2616,7 +2669,27 @@
         toolCards: [],
         timelineItems: [],
         emptyTitle: 'Ask QuillCode to inspect, edit, or run this project.',
-        emptySubtitle: 'Use Auto for normal coding work, Review for manual gates, or Read-only for exploration.'
+        emptySubtitle: 'Use Auto for normal coding work, Review for manual gates, or Read-only for exploration.',
+        emptyStarterActions: [
+          {
+            id: 'review-changes',
+            title: 'Review changes',
+            subtitle: 'Find risks in the current diff',
+            prompt: 'Review the current git diff and call out risks, missing tests, and next steps.'
+          },
+          {
+            id: 'run-tests',
+            title: 'Run tests',
+            subtitle: 'Pick the right validation',
+            prompt: 'Find and run the most relevant tests for this project.'
+          },
+          {
+            id: 'explain-project',
+            title: 'Explain project',
+            subtitle: 'Map the important files',
+            prompt: 'Give me a concise map of this project and the most important files.'
+          }
+        ]
       },
       mockFiles: {},
       review: {
@@ -4704,10 +4777,20 @@
           + state.transcript.toolCards.map(renderToolCard).join('');
       const hasTimelineContent = Boolean(context || runtimeIssue || review || transcriptItems);
       const shouldHideEmptyTranscript = state.automations.isVisible && !hasTimelineContent;
+      const emptyStarterActions = (state.transcript.emptyStarterActions || []).length ? `
+        <div class="empty-starters" data-testid="empty-starter-actions">
+          ${state.transcript.emptyStarterActions.map(action => `
+            <button type="button" class="empty-starter" data-testid="empty-starter-action" data-action-id="${escapeHTML(action.id)}" data-prompt="${escapeHTML(action.prompt)}">
+              <strong>${escapeHTML(action.title)}</strong>
+              <span>${escapeHTML(action.subtitle)}</span>
+            </button>
+          `).join('')}
+        </div>` : '';
       const timeline = hasTimelineContent ? context + runtimeIssue + review + transcriptItems : shouldHideEmptyTranscript ? '' : `
         <section class="empty" data-testid="transcript-empty">
           <h1>${escapeHTML(state.transcript.emptyTitle)}</h1>
           <p>${escapeHTML(state.transcript.emptySubtitle)}</p>
+          ${emptyStarterActions}
         </section>`;
       const projectsContent = state.projects.items.length
         ? state.projects.items.map(item => `
@@ -5048,6 +5131,11 @@
       document.querySelectorAll('[data-testid="message-use-as-draft"]').forEach(button => {
         button.addEventListener('click', event => {
           useMessageAsDraft(event.currentTarget.getAttribute('data-message-id'));
+        });
+      });
+      document.querySelectorAll('[data-testid="empty-starter-action"]').forEach(button => {
+        button.addEventListener('click', event => {
+          usePromptAsDraft(event.currentTarget.getAttribute('data-prompt'));
         });
       });
       document.querySelectorAll('[data-testid="message-retry"]').forEach(button => {
@@ -6033,7 +6121,11 @@
       if (!messageID) return;
       const message = state.transcript.messages.find(entry => entry.id === messageID && entry.role === 'user');
       if (!message) return;
-      state.composer.draft = message.text || '';
+      usePromptAsDraft(message.text || '');
+    }
+
+    function usePromptAsDraft(prompt) {
+      state.composer.draft = String(prompt || '');
       state.composer.canSend = state.composer.draft.trim().length > 0;
       state.composer.slashActiveIndex = 0;
       render();

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -14,6 +14,12 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('project-item')).toContainText('QuillCode');
   await expect(page.getByTestId('project-item')).toHaveAttribute('aria-current', 'true');
   await expect(page.getByTestId('transcript-empty')).toBeVisible();
+  await expect(page.getByTestId('empty-starter-action')).toHaveCount(3);
+  await page.getByTestId('empty-starter-action').filter({ hasText: 'Review changes' }).click();
+  await expect(page.getByLabel('Message')).toHaveValue('Review the current git diff and call out risks, missing tests, and next steps.');
+  await expect(page.getByLabel('Message')).toBeFocused();
+  await expect(page.getByTestId('send-button')).toBeEnabled();
+  await page.getByLabel('Message').fill('');
   await expect(page.locator('[data-testid="top-bar"] [data-testid="model-picker-button"]')).toHaveCount(0);
   await expect(page.getByTestId('composer-surface')).toBeVisible();
   await expect(page.getByTestId('composer-controls')).toBeVisible();

--- a/E2E/playwright/tests/workspace-chrome.spec.ts
+++ b/E2E/playwright/tests/workspace-chrome.spec.ts
@@ -145,7 +145,8 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
     sidebarStyle,
     sidebarToolsButtonStyle,
     sidebarToolActionStyle,
-    sidebarSettingsButtonStyle
+    sidebarSettingsButtonStyle,
+    emptyStarterStyle
   ] = await Promise.all([
     computedStyleProperties(page, 'html', ['-webkit-font-smoothing']),
     computedStyleProperties(page, '[data-testid="send-button"]', ['min-height', 'transition-property']),
@@ -157,7 +158,8 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
     computedStyleProperties(page, '[data-testid="sidebar"]', ['border-radius']),
     computedStyleProperties(page, '[data-testid="sidebar-tools-button"]', ['min-height', 'transition-property']),
     computedStyleProperties(page, '[data-testid="sidebar-search-button"]', ['min-height', 'transition-property']),
-    computedStyleProperties(page, '[data-testid="settings-button"]', ['width', 'min-height'])
+    computedStyleProperties(page, '[data-testid="settings-button"]', ['width', 'min-height']),
+    computedStyleProperties(page, '[data-testid="empty-starter-action"]', ['min-height', 'transition-property', 'border-radius'])
   ]);
 
   const polish = {
@@ -177,7 +179,10 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
     sidebarToolActionTransitionProperty: sidebarToolActionStyle['transition-property'],
     sidebarSettingsWidth: parseFloat(sidebarSettingsButtonStyle.width),
     sidebarSettingsMinHeight: parseFloat(sidebarSettingsButtonStyle['min-height']),
-    sidebarRadius: parseFloat(sidebarStyle['border-radius'])
+    sidebarRadius: parseFloat(sidebarStyle['border-radius']),
+    emptyStarterMinHeight: parseFloat(emptyStarterStyle['min-height']),
+    emptyStarterTransitionProperty: emptyStarterStyle['transition-property'],
+    emptyStarterRadius: parseFloat(emptyStarterStyle['border-radius'])
   };
 
   expect(polish.rootFontSmoothing).toBe('antialiased');
@@ -202,8 +207,14 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
   expect(polish.titleTextWrap).toContain('balance');
   expect(polish.agentStatusNumbers).toContain('tabular-nums');
   expect(polish.sidebarRadius).toBeLessThanOrEqual(4);
+  expect(polish.emptyStarterMinHeight).toBeGreaterThanOrEqual(MINIMUM_HIT_TARGET);
+  expect(polish.emptyStarterTransitionProperty).toContain('transform');
+  expect(polish.emptyStarterTransitionProperty).toContain('box-shadow');
+  expect(polish.emptyStarterTransitionProperty).not.toContain('all');
+  expect(polish.emptyStarterRadius).toBe(14);
 
   await expectHitTarget(page.getByTestId('top-bar-overflow-button'), 'top-bar overflow button');
+  await expectHitTarget(page.getByTestId('empty-starter-action'), 'empty starter action');
   await expectHitTarget(page.getByTestId('new-chat-button'), 'new chat button');
   await expectHitTarget(page.getByTestId('sidebar-search-button'), 'sidebar search button');
   await expectHitTarget(page.getByTestId('extensions-button'), 'plugins button');

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -8,6 +8,7 @@ public struct TranscriptSurface: Codable, Sendable, Hashable {
     public var thinking: TranscriptThinkingSurface?
     public var emptyTitle: String
     public var emptySubtitle: String
+    public var emptyStarterActions: [TranscriptStarterActionSurface]
 
     public init(
         messages: [MessageSurface],
@@ -15,7 +16,8 @@ public struct TranscriptSurface: Codable, Sendable, Hashable {
         timelineItems: [TranscriptTimelineItemSurface]? = nil,
         thinking: TranscriptThinkingSurface? = nil,
         emptyTitle: String = "Ask QuillCode to inspect, edit, or run this project.",
-        emptySubtitle: String = "Use Auto for normal coding work, Review for manual gates, or Read-only for exploration."
+        emptySubtitle: String = "Use Auto for normal coding work, Review for manual gates, or Read-only for exploration.",
+        emptyStarterActions: [TranscriptStarterActionSurface] = TranscriptStarterActionSurface.defaults
     ) {
         self.messages = messages
         self.toolCards = toolCards
@@ -24,7 +26,82 @@ public struct TranscriptSurface: Codable, Sendable, Hashable {
         self.thinking = thinking
         self.emptyTitle = emptyTitle
         self.emptySubtitle = emptySubtitle
+        self.emptyStarterActions = emptyStarterActions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case messages
+        case toolCards
+        case timelineItems
+        case thinking
+        case emptyTitle
+        case emptySubtitle
+        case emptyStarterActions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.messages = try container.decode([MessageSurface].self, forKey: .messages)
+        self.toolCards = try container.decode([ToolCardState].self, forKey: .toolCards)
+        self.timelineItems = try container.decodeIfPresent([TranscriptTimelineItemSurface].self, forKey: .timelineItems)
+            ?? messages.map(TranscriptTimelineItemSurface.message)
+            + toolCards.map(TranscriptTimelineItemSurface.toolCard)
+        self.thinking = try container.decodeIfPresent(TranscriptThinkingSurface.self, forKey: .thinking)
+        self.emptyTitle = try container.decodeIfPresent(String.self, forKey: .emptyTitle)
+            ?? "Ask QuillCode to inspect, edit, or run this project."
+        self.emptySubtitle = try container.decodeIfPresent(String.self, forKey: .emptySubtitle)
+            ?? "Use Auto for normal coding work, Review for manual gates, or Read-only for exploration."
+        self.emptyStarterActions = try container.decodeIfPresent(
+            [TranscriptStarterActionSurface].self,
+            forKey: .emptyStarterActions
+        ) ?? TranscriptStarterActionSurface.defaults
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(messages, forKey: .messages)
+        try container.encode(toolCards, forKey: .toolCards)
+        try container.encode(timelineItems, forKey: .timelineItems)
+        try container.encodeIfPresent(thinking, forKey: .thinking)
+        try container.encode(emptyTitle, forKey: .emptyTitle)
+        try container.encode(emptySubtitle, forKey: .emptySubtitle)
+        try container.encode(emptyStarterActions, forKey: .emptyStarterActions)
+    }
+}
+
+public struct TranscriptStarterActionSurface: Codable, Sendable, Hashable, Identifiable {
+    public var id: String
+    public var title: String
+    public var subtitle: String
+    public var prompt: String
+
+    public init(id: String, title: String, subtitle: String, prompt: String) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.prompt = prompt
+    }
+
+    public static let defaults: [TranscriptStarterActionSurface] = [
+        TranscriptStarterActionSurface(
+            id: "review-changes",
+            title: "Review changes",
+            subtitle: "Find risks in the current diff",
+            prompt: "Review the current git diff and call out risks, missing tests, and next steps."
+        ),
+        TranscriptStarterActionSurface(
+            id: "run-tests",
+            title: "Run tests",
+            subtitle: "Pick the right validation",
+            prompt: "Find and run the most relevant tests for this project."
+        ),
+        TranscriptStarterActionSurface(
+            id: "explain-project",
+            title: "Explain project",
+            subtitle: "Map the important files",
+            prompt: "Give me a concise map of this project and the most important files."
+        )
+    ]
 }
 
 public struct TranscriptThinkingSurface: Codable, Sendable, Hashable, Identifiable {

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -176,18 +176,53 @@ struct QuillCodeTranscriptView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 14) {
             Text(transcript.emptyTitle)
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(QuillCodePalette.text)
             Text(transcript.emptySubtitle)
                 .font(.callout)
                 .foregroundStyle(QuillCodePalette.muted)
+            starterActions
+                .padding(.top, 2)
         }
         .multilineTextAlignment(.center)
-        .frame(maxWidth: 540)
+        .frame(maxWidth: 620)
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 22)
+    }
+
+    private var starterActions: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 156), spacing: 10)], spacing: 10) {
+            ForEach(transcript.emptyStarterActions) { action in
+                Button {
+                    onUseMessageAsDraft(action.prompt)
+                } label: {
+                    VStack(spacing: 3) {
+                        Text(action.title)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(QuillCodePalette.text)
+                        Text(action.subtitle)
+                            .font(.caption)
+                            .foregroundStyle(QuillCodePalette.muted)
+                            .lineLimit(2)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .quillCodeSurface(
+                        fill: QuillCodePalette.panel.opacity(0.62),
+                        radius: 14,
+                        stroke: Color.white.opacity(0.08),
+                        shadow: false
+                    )
+                }
+                .buttonStyle(QuillCodePressableButtonStyle())
+                .accessibilityLabel(Text(action.title))
+                .accessibilityHint(Text(action.prompt))
+            }
+        }
+        .frame(maxWidth: 620)
     }
 
     private func copyText(for card: ToolCardState) -> String {

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -28,6 +28,7 @@ enum WorkspaceHTMLTranscriptRenderer {
             <section class="empty" data-testid="transcript-empty">
               <h1>\(escape(transcript.emptyTitle))</h1>
               <p>\(escape(transcript.emptySubtitle))</p>
+              \(renderStarterActions(transcript.emptyStarterActions))
             </section>
             """
         }
@@ -67,6 +68,17 @@ enum WorkspaceHTMLTranscriptRenderer {
         default:
             return "auto"
         }
+    }
+
+    private static func renderStarterActions(_ actions: [TranscriptStarterActionSurface]) -> String {
+        guard !actions.isEmpty else { return "" }
+        return """
+        <div class="empty-starters" data-testid="empty-starter-actions">
+          \(actions.map { action in
+            #"<button type="button" class="empty-starter" data-testid="empty-starter-action" data-action-id="\#(escape(action.id))" data-prompt="\#(escape(action.prompt))"><strong>\#(escape(action.title))</strong><span>\#(escape(action.subtitle))</span></button>"#
+          }.joined(separator: "\n"))
+        </div>
+        """
     }
 
     private static func renderRuntimeIssue(_ issue: RuntimeIssueSurface?) -> String {

--- a/Tests/QuillCodeAppTests/QuillCodeTranscriptSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeTranscriptSurfaceTests.swift
@@ -22,6 +22,8 @@ final class QuillCodeTranscriptSurfaceTests: XCTestCase {
 
         XCTAssertEqual(transcript.emptyTitle, "Ask QuillCode to inspect, edit, or run this project.")
         XCTAssertEqual(transcript.emptySubtitle, "Use Auto for normal coding work, Review for manual gates, or Read-only for exploration.")
+        XCTAssertEqual(transcript.emptyStarterActions.map(\.id), ["review-changes", "run-tests", "explain-project"])
+        XCTAssertEqual(transcript.emptyStarterActions.first?.prompt, "Review the current git diff and call out risks, missing tests, and next steps.")
         XCTAssertNil(transcript.thinking)
         XCTAssertEqual(transcript.timelineItems.map(\.kind), [.message, .toolCard])
         XCTAssertEqual(transcript.timelineItems.map(\.id), [
@@ -30,6 +32,21 @@ final class QuillCodeTranscriptSurfaceTests: XCTestCase {
         ])
         XCTAssertEqual(transcript.timelineItems[0].message?.text, "run whoami")
         XCTAssertEqual(transcript.timelineItems[1].toolCard?.title, "Run Shell")
+    }
+
+    func testTranscriptSurfaceDecodesOlderPayloadWithDefaultStarterActions() throws {
+        let data = """
+        {
+          "messages": [],
+          "toolCards": [],
+          "emptyTitle": "Ask QuillCode to inspect, edit, or run this project.",
+          "emptySubtitle": "Use Auto for normal coding work, Review for manual gates, or Read-only for exploration."
+        }
+        """.data(using: .utf8)!
+
+        let transcript = try JSONDecoder().decode(TranscriptSurface.self, from: data)
+
+        XCTAssertEqual(transcript.emptyStarterActions, TranscriptStarterActionSurface.defaults)
     }
 
     func testMessageSurfaceMapsRoleContentAccessibilityAndFeedback() {

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
@@ -128,6 +128,17 @@ final class WorkspaceHTMLChromeRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="send-button""#))
     }
 
+    func testHTMLRendererIncludesEmptyStarterActions() {
+        let html = WorkspaceHTMLRenderer.render(QuillCodeWorkspaceModel().surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="transcript-empty""#))
+        XCTAssertTrue(html.contains(#"data-testid="empty-starter-actions""#))
+        XCTAssertTrue(html.contains(#"data-testid="empty-starter-action" data-action-id="review-changes""#))
+        XCTAssertTrue(html.contains(#"Review the current git diff and call out risks, missing tests, and next steps."#))
+        XCTAssertTrue(html.contains("Run tests"))
+        XCTAssertTrue(html.contains("Explain project"))
+    }
+
     func testHTMLRendererIncludesOptimisticThinkingSurface() {
         let thread = ChatThread(
             messages: [.init(role: .user, content: "run tests")],

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -277,6 +277,11 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertEqual(surface.topBar.primaryTitle, "QuillCode")
         XCTAssertEqual(surface.sidebar.items.count, 0)
         XCTAssertEqual(surface.transcript.emptyTitle, "Ask QuillCode to inspect, edit, or run this project.")
+        XCTAssertEqual(surface.transcript.emptyStarterActions.map(\.title), [
+            "Review changes",
+            "Run tests",
+            "Explain project"
+        ])
         XCTAssertFalse(surface.review.isVisible)
         XCTAssertFalse(surface.composer.canSend)
         XCTAssertTrue(surface.topBar.showsComputerUseSetup)


### PR DESCRIPTION
## Summary
- Add typed transcript starter actions for the empty QuillCode workspace state.
- Render starter actions in SwiftUI and the HTML/Playwright harness with responsive 44px+ hit targets and explicit transitions.
- Reuse the composer draft path so clicking a starter focuses the composer with an editable prompt.

## Validation
- swift test --filter 'QuillCodeTranscriptSurfaceTests|WorkspaceSurfaceTests|WorkspaceHTMLChromeRendererTests'
- npx playwright test tests/core.spec.ts tests/workspace-chrome.spec.ts
- swift test --quiet
- npm test
- git diff --check