### PR TITLE
Rethink click target semantics

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -58,16 +58,43 @@
     .activity-item span {
       font-variant-numeric: tabular-nums;
     }
-    .interactive-hit-target {
+    .interactive-hit-target,
+    .hit-target-text,
+    .hit-target-row,
+    .hit-target-capsule,
+    .hit-target-form-action {
       min-width: var(--hit-target);
       min-height: var(--hit-target);
       display: inline-flex;
       align-items: center;
       justify-content: center;
     }
+    .hit-target-icon {
+      width: var(--hit-target);
+      min-width: var(--hit-target);
+      height: var(--hit-target);
+      min-height: var(--hit-target);
+      display: inline-grid;
+      place-items: center;
+    }
+    .hit-target-row {
+      width: 100%;
+      justify-content: flex-start;
+    }
+    .hit-target-capsule,
+    .hit-target-form-action {
+      border-radius: 999px;
+    }
+    .hit-target-form-action {
+      min-width: 56px;
+    }
     button,
     summary,
+    input,
+    select,
+    textarea,
     a.interactive-hit-target {
+      min-width: var(--hit-target);
       min-height: var(--hit-target);
       touch-action: manipulation;
     }
@@ -85,11 +112,24 @@
     button:disabled {
       cursor: not-allowed;
     }
+    input,
+    select,
+    textarea {
+      transition-property: box-shadow, border-color, background-color;
+      transition-duration: 150ms;
+      transition-timing-function: var(--ease-out);
+    }
     a.interactive-hit-target {
       text-decoration: none;
     }
     details > summary {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       min-height: var(--hit-target);
+    }
+    details:not([open]) > :not(summary) {
+      display: none !important;
     }
     .quillcode-workspace { min-height: 100vh; display: grid; grid-template-rows: auto 1fr; }
     .topbar {
@@ -954,10 +994,6 @@
       border-color: rgba(255,93,86,.35);
     }
     .sidebar-select-toggle {
-      position: absolute;
-      left: 8px;
-      top: 10px;
-      z-index: 2;
       width: var(--hit-target);
       height: var(--hit-target);
       padding: 0;
@@ -965,7 +1001,7 @@
       border-color: rgba(65,184,232,.45);
     }
     .sidebar-thread-row.selection-mode .sidebar-item {
-      padding-left: 52px;
+      padding-left: 12px;
     }
     .sidebar-thread-row.bulk-selected .sidebar-item {
       border-color: rgba(65,184,232,.58);
@@ -988,20 +1024,26 @@
     .sidebar-thread-row {
       position: relative;
       display: grid;
-      gap: 4px;
+      grid-template-columns: minmax(0, 1fr) var(--hit-target);
+      gap: 6px;
+      align-items: start;
       margin-bottom: 8px;
+    }
+    .sidebar-thread-row.selection-mode {
+      grid-template-columns: var(--hit-target) minmax(0, 1fr) var(--hit-target);
     }
     .project-row {
       position: relative;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) var(--hit-target);
+      gap: 6px;
+      align-items: start;
       margin-bottom: 8px;
     }
     .project-row .project-item {
-      padding-right: 56px;
+      padding-right: 12px;
     }
     .sidebar-thread-menu {
-      position: absolute;
-      right: 8px;
-      top: 8px;
       z-index: 2;
     }
     .sidebar-thread-menu summary {
@@ -4612,8 +4654,8 @@
                 <span data-testid="review-file-path">${escapeHTML(file.path)}</span>
                 <span class="review-actions">
                   <small>${escapeHTML(file.changeLabel)}</small>
-                  <button type="button" class="review-action-button" data-testid="review-action" data-action="stage" data-path="${escapeHTML(file.path)}">Stage</button>
-                  <button type="button" class="review-action-button" data-testid="review-action" data-action="restore" data-path="${escapeHTML(file.path)}">Restore</button>
+                  <button type="button" class="review-action-button hit-target-text" data-testid="review-action" data-action="stage" data-path="${escapeHTML(file.path)}">Stage</button>
+                  <button type="button" class="review-action-button hit-target-text" data-testid="review-action" data-action="restore" data-path="${escapeHTML(file.path)}">Restore</button>
                 </span>
                 ${(file.hunks || []).length ? `
                   <div class="review-hunks">
@@ -4623,15 +4665,15 @@
                           <code data-testid="review-hunk-header">${escapeHTML(hunk.header)}</code>
                           <span class="review-actions">
                             <small>${escapeHTML(hunk.changeLabel)}</small>
-                            <button type="button" class="review-action-button" data-testid="review-action" data-action="stage_hunk" data-path="${escapeHTML(file.path)}">Stage hunk</button>
-                            <button type="button" class="review-action-button" data-testid="review-action" data-action="restore_hunk" data-path="${escapeHTML(file.path)}">Restore hunk</button>
+                            <button type="button" class="review-action-button hit-target-text" data-testid="review-action" data-action="stage_hunk" data-path="${escapeHTML(file.path)}">Stage hunk</button>
+                            <button type="button" class="review-action-button hit-target-text" data-testid="review-action" data-action="restore_hunk" data-path="${escapeHTML(file.path)}">Restore hunk</button>
                           </span>
                         </div>
                         <form class="review-range-comment-form" data-testid="review-range-comment-form" data-path="${escapeHTML(file.path)}">
                           <input data-testid="review-range-start" aria-label="Range note start for ${escapeHTML(file.path)}" placeholder="From" value="${escapeHTML((hunk.lines || [])[0]?.lineNumber || '')}">
                           <input data-testid="review-range-end" aria-label="Range note end for ${escapeHTML(file.path)}" placeholder="To" value="${escapeHTML((hunk.lines || [])[1]?.lineNumber || (hunk.lines || [])[0]?.lineNumber || '')}">
                           <input data-testid="review-range-comment-input" aria-label="Range note for ${escapeHTML(file.path)}" placeholder="Range note">
-                          <button type="submit">Add range note</button>
+                          <button class="hit-target-form-action" type="submit">Add range note</button>
                         </form>
                         <ol class="review-lines" data-testid="review-lines">
                           ${(hunk.lines || []).map(line => `
@@ -4641,7 +4683,7 @@
                               <code class="review-line-content" data-testid="review-line-content">${escapeHTML(line.content)}</code>
                               <form class="review-line-comment-form" data-testid="review-line-comment-form" data-path="${escapeHTML(file.path)}" data-line-number="${escapeHTML(line.lineNumber || '')}" data-line-kind="${escapeHTML(line.kind)}">
                                 <input data-testid="review-line-comment-input" aria-label="Line note for ${escapeHTML(file.path)}:${escapeHTML(line.lineNumber || '')}" placeholder="Line note">
-                                <button type="submit">Add</button>
+                                <button class="hit-target-form-action" type="submit">Add</button>
                               </form>
                               ${(line.comments || []).length ? `
                                 <div class="review-line-comments">
@@ -4657,7 +4699,7 @@
                   </div>` : ''}
                 <form class="review-comment-form" data-testid="review-comment-form" data-path="${escapeHTML(file.path)}">
                   <input data-testid="review-comment-input" aria-label="Review note for ${escapeHTML(file.path)}" placeholder="Add review note">
-                  <button type="submit">Add note</button>
+                  <button class="hit-target-form-action" type="submit">Add note</button>
                 </form>
               </li>`).join('')}
           </ul>

--- a/E2E/playwright/tests/workspace-chrome.spec.ts
+++ b/E2E/playwright/tests/workspace-chrome.spec.ts
@@ -10,6 +10,161 @@ import {
 
 const MINIMUM_HIT_TARGET = 44;
 
+type TargetAuditIssue = {
+  className: string;
+  height: number;
+  label: string;
+  tag: string;
+  testid: string | null;
+  text: string;
+  width: number;
+};
+
+type TargetOverlapIssue = {
+  a: string;
+  b: string;
+  overlapHeight: number;
+  overlapWidth: number;
+};
+
+async function targetAuditIssues(page: Page): Promise<TargetAuditIssue[]> {
+  return page.evaluate((minimumHitTarget) => {
+    const selector = [
+      'button',
+      'summary',
+      'a[href]',
+      '[role="button"]',
+      'input:not([type="hidden"])',
+      'select',
+      'textarea'
+    ].join(',');
+
+    function isVisible(element: Element, rect: DOMRect) {
+      const style = window.getComputedStyle(element);
+      const closedDetails = element.closest('details:not([open])');
+      if (closedDetails && element.tagName.toLowerCase() !== 'summary') return false;
+      return rect.width > 0
+        && rect.height > 0
+        && style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && style.pointerEvents !== 'none'
+        && !element.closest('[hidden],[aria-hidden="true"]');
+    }
+
+    return [...document.querySelectorAll(selector)]
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return { element, rect };
+      })
+      .filter(({ element, rect }) => isVisible(element, rect))
+      .filter(({ rect }) => Math.round(rect.width) < minimumHitTarget || Math.round(rect.height) < minimumHitTarget)
+      .map(({ element, rect }) => ({
+        className: String((element as HTMLElement).className || ''),
+        height: Math.round(rect.height),
+        label: element.getAttribute('aria-label') || '',
+        tag: element.tagName.toLowerCase(),
+        testid: element.getAttribute('data-testid'),
+        text: (element.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 80),
+        width: Math.round(rect.width)
+      }));
+  }, MINIMUM_HIT_TARGET);
+}
+
+async function expectAllVisibleInteractiveTargets(page: Page, label: string) {
+  const issues = await targetAuditIssues(page);
+  expect(issues, `${label} should keep every visible interactive target at least ${MINIMUM_HIT_TARGET}px`).toEqual([]);
+}
+
+async function targetOverlapIssues(page: Page): Promise<TargetOverlapIssue[]> {
+  return page.evaluate(() => {
+    const selector = [
+      'button',
+      'summary',
+      'a[href]',
+      '[role="button"]',
+      'input:not([type="hidden"])',
+      'select',
+      'textarea'
+    ].join(',');
+
+    function isVisible(element: Element, rect: DOMRect) {
+      const style = window.getComputedStyle(element);
+      const closedDetails = element.closest('details:not([open])');
+      if (closedDetails && element.tagName.toLowerCase() !== 'summary') return false;
+      return rect.width > 0
+        && rect.height > 0
+        && style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && style.pointerEvents !== 'none'
+        && !element.closest('[hidden],[aria-hidden="true"]');
+    }
+
+    function isTopMostAtCenter(element: Element, rect: DOMRect) {
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const topElement = document.elementFromPoint(centerX, centerY);
+      return topElement === element || Boolean(topElement && element.contains(topElement));
+    }
+
+    function labelFor(element: Element) {
+      const id = element.getAttribute('data-testid');
+      const aria = element.getAttribute('aria-label');
+      const text = (element.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 48);
+      return [element.tagName.toLowerCase(), id, aria, text].filter(Boolean).join(':');
+    }
+
+    function interactionLayer(element: Element) {
+      const layer = element.closest([
+        '[data-testid="model-browser"]',
+        '[data-testid="settings-panel"]',
+        '[data-testid="search-panel"]',
+        '[data-testid="command-palette-panel"]',
+        '[data-testid="keyboard-shortcuts-panel"]',
+        '[data-testid="find-bar"]',
+        '.sidebar-tools-popover',
+        '.sidebar-thread-menu-popover'
+      ].join(','));
+      if (!layer) return 'workspace';
+      return layer.getAttribute('data-testid') || layer.className || layer.tagName.toLowerCase();
+    }
+
+    const targets = [...document.querySelectorAll(selector)]
+      .map((element) => ({
+        element,
+        layer: interactionLayer(element),
+        rect: element.getBoundingClientRect()
+      }))
+      .filter(({ element, rect }) => isVisible(element, rect) && isTopMostAtCenter(element, rect));
+    const issues: TargetOverlapIssue[] = [];
+
+    for (let i = 0; i < targets.length; i += 1) {
+      for (let j = i + 1; j < targets.length; j += 1) {
+        const first = targets[i];
+        const second = targets[j];
+        if (first.layer !== second.layer) continue;
+        if (first.element.contains(second.element) || second.element.contains(first.element)) continue;
+
+        const overlapWidth = Math.min(first.rect.right, second.rect.right) - Math.max(first.rect.left, second.rect.left);
+        const overlapHeight = Math.min(first.rect.bottom, second.rect.bottom) - Math.max(first.rect.top, second.rect.top);
+        if (overlapWidth > 1 && overlapHeight > 1) {
+          issues.push({
+            a: labelFor(first.element),
+            b: labelFor(second.element),
+            overlapHeight: Math.round(overlapHeight),
+            overlapWidth: Math.round(overlapWidth)
+          });
+        }
+      }
+    }
+    return issues;
+  });
+}
+
+async function expectNoOverlappingInteractiveTargets(page: Page, label: string) {
+  const issues = await targetOverlapIssues(page);
+  expect(issues, `${label} should not have overlapping peer interactive targets`).toEqual([]);
+}
+
 async function expectHitTarget(locator: Locator, label: string) {
   const target = locator.first();
   await expect(target, `${label} should be visible`).toBeVisible();
@@ -316,6 +471,56 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
   expect(transcriptPolish.sidebarMenuWidth).toBeGreaterThanOrEqual(MINIMUM_HIT_TARGET);
   expect(transcriptPolish.sidebarMenuHeight).toBeGreaterThanOrEqual(MINIMUM_HIT_TARGET);
   await expectHitTarget(page.locator('[data-testid="tool-card-details"] summary'), 'tool details disclosure');
+});
+
+test('mock harness audits every visible interactive click target across workspace states', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await expectAllVisibleInteractiveTargets(page, 'initial workspace');
+  await expectNoOverlappingInteractiveTargets(page, 'initial workspace');
+
+  await page.getByTestId('model-picker-button').click();
+  await expect(page.getByTestId('model-browser')).toBeVisible();
+  await expectAllVisibleInteractiveTargets(page, 'model picker');
+  await expectNoOverlappingInteractiveTargets(page, 'model picker');
+  await page.getByTestId('model-picker-button').click();
+
+  await openSettings(page);
+  await expect(page.getByTestId('settings-panel')).toBeVisible();
+  await expectAllVisibleInteractiveTargets(page, 'settings panel');
+  await expectNoOverlappingInteractiveTargets(page, 'settings panel');
+  await page.getByTestId('settings-cancel').click();
+
+  await clickSidebarTool(page, 'browser-button');
+  await expect(page.getByTestId('browser-pane')).toBeVisible();
+  await expectAllVisibleInteractiveTargets(page, 'browser pane');
+  await expectNoOverlappingInteractiveTargets(page, 'browser pane');
+
+  await clickSidebarTool(page, 'terminal-button');
+  await expect(page.getByTestId('terminal-pane')).toBeVisible();
+  await expectAllVisibleInteractiveTargets(page, 'terminal pane');
+  await expectNoOverlappingInteractiveTargets(page, 'terminal pane');
+
+  await page.getByTestId('extensions-button').click();
+  await expect(page.getByTestId('extensions-pane')).toBeVisible();
+  await expectAllVisibleInteractiveTargets(page, 'extensions pane');
+  await expectNoOverlappingInteractiveTargets(page, 'extensions pane');
+
+  await page.getByTestId('automations-button').click();
+  await expect(page.getByTestId('automations-pane')).toBeVisible();
+  await expectAllVisibleInteractiveTargets(page, 'automations pane');
+  await expectNoOverlappingInteractiveTargets(page, 'automations pane');
+
+  await clickSidebarTool(page, 'memories-button');
+  await expect(page.getByTestId('memories-pane')).toBeVisible();
+  await expectAllVisibleInteractiveTargets(page, 'memories pane');
+  await expectNoOverlappingInteractiveTargets(page, 'memories pane');
+
+  await page.getByLabel('Message').fill('run whoami');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  await expectAllVisibleInteractiveTargets(page, 'tool-card transcript');
+  await expectNoOverlappingInteractiveTargets(page, 'tool-card transcript');
 });
 
 test('mock harness keeps banner and recovery actions at least 44px', async ({ page }) => {

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum QuillCodeMetrics {
     static let minimumHitTarget: CGFloat = 44
     static let compactTextButtonMinWidth: CGFloat = 72
+    static let compactFormActionMinWidth: CGFloat = 56
     static let compactControlRadius: CGFloat = 9
     static let iconControlRadius: CGFloat = 10
     static let topBarHeight: CGFloat = 44
@@ -14,6 +15,112 @@ enum QuillCodeMetrics {
     static let toolCardRawDetailsMaxHeight: CGFloat = 240
     static let toolCardRadius: CGFloat = 20
     static let pressScale: CGFloat = 0.96
+}
+
+struct QuillCodeHitTargetSpec {
+    enum Shape {
+        case rectangle
+        case rounded(CGFloat)
+        case capsule
+    }
+
+    var minWidth: CGFloat?
+    var maxWidth: CGFloat?
+    var width: CGFloat?
+    var minHeight: CGFloat
+    var height: CGFloat?
+    var alignment: Alignment
+    var shape: Shape
+
+    static func icon(radius: CGFloat = QuillCodeMetrics.iconControlRadius) -> Self {
+        Self(
+            minWidth: nil,
+            maxWidth: nil,
+            width: QuillCodeMetrics.minimumHitTarget,
+            minHeight: QuillCodeMetrics.minimumHitTarget,
+            height: QuillCodeMetrics.minimumHitTarget,
+            alignment: .center,
+            shape: .rounded(radius)
+        )
+    }
+
+    static func textButton(
+        minWidth: CGFloat = QuillCodeMetrics.compactTextButtonMinWidth,
+        minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        alignment: Alignment = .center,
+        radius: CGFloat = QuillCodeMetrics.compactControlRadius
+    ) -> Self {
+        Self(
+            minWidth: minWidth,
+            maxWidth: nil,
+            width: nil,
+            minHeight: minHeight,
+            height: nil,
+            alignment: alignment,
+            shape: .rounded(radius)
+        )
+    }
+
+    static func formAction(
+        minWidth: CGFloat = QuillCodeMetrics.compactFormActionMinWidth,
+        minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        alignment: Alignment = .center
+    ) -> Self {
+        textButton(
+            minWidth: minWidth,
+            minHeight: minHeight,
+            alignment: alignment,
+            radius: QuillCodeMetrics.minimumHitTarget / 2
+        )
+    }
+
+    static func fullRow(
+        minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        alignment: Alignment = .leading,
+        radius: CGFloat = QuillCodeMetrics.compactControlRadius
+    ) -> Self {
+        Self(
+            minWidth: nil,
+            maxWidth: .infinity,
+            width: nil,
+            minHeight: minHeight,
+            height: nil,
+            alignment: alignment,
+            shape: .rounded(radius)
+        )
+    }
+
+    static func capsule(
+        minWidth: CGFloat? = nil,
+        minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        alignment: Alignment = .center
+    ) -> Self {
+        Self(
+            minWidth: minWidth,
+            maxWidth: nil,
+            width: nil,
+            minHeight: minHeight,
+            height: nil,
+            alignment: alignment,
+            shape: .capsule
+        )
+    }
+
+    static func rectangle(
+        minWidth: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        alignment: Alignment = .center
+    ) -> Self {
+        Self(
+            minWidth: minWidth,
+            maxWidth: nil,
+            width: nil,
+            minHeight: minHeight,
+            height: nil,
+            alignment: alignment,
+            shape: .rectangle
+        )
+    }
 }
 
 enum QuillCodePalette {
@@ -55,13 +162,20 @@ struct QuillCodePressableButtonStyle: ButtonStyle {
 }
 
 extension View {
+    func quillCodeInteractiveTarget(_ spec: QuillCodeHitTargetSpec) -> some View {
+        modifier(QuillCodeHitTargetModifier(spec: spec))
+    }
+
     func quillCodeHitTarget(
         minWidth: CGFloat = QuillCodeMetrics.minimumHitTarget,
         minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
         alignment: Alignment = .center
     ) -> some View {
-        frame(minWidth: minWidth, minHeight: minHeight, alignment: alignment)
-            .contentShape(Rectangle())
+        quillCodeInteractiveTarget(.rectangle(
+            minWidth: minWidth,
+            minHeight: minHeight,
+            alignment: alignment
+        ))
     }
 
     func quillCodeTextButtonTarget(
@@ -70,15 +184,30 @@ extension View {
         alignment: Alignment = .center,
         radius: CGFloat = QuillCodeMetrics.compactControlRadius
     ) -> some View {
-        frame(minWidth: minWidth, minHeight: minHeight, alignment: alignment)
-            .contentShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+        quillCodeInteractiveTarget(.textButton(
+            minWidth: minWidth,
+            minHeight: minHeight,
+            alignment: alignment,
+            radius: radius
+        ))
+    }
+
+    func quillCodeFormActionTarget(
+        minWidth: CGFloat = QuillCodeMetrics.compactFormActionMinWidth,
+        minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
+        alignment: Alignment = .center
+    ) -> some View {
+        quillCodeInteractiveTarget(.formAction(
+            minWidth: minWidth,
+            minHeight: minHeight,
+            alignment: alignment
+        ))
     }
 
     func quillCodeIconButtonTarget(
         radius: CGFloat = QuillCodeMetrics.iconControlRadius
     ) -> some View {
-        frame(width: QuillCodeMetrics.minimumHitTarget, height: QuillCodeMetrics.minimumHitTarget)
-            .contentShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+        quillCodeInteractiveTarget(.icon(radius: radius))
     }
 
     func quillCodeFullRowButtonTarget(
@@ -86,8 +215,11 @@ extension View {
         alignment: Alignment = .leading,
         radius: CGFloat = QuillCodeMetrics.compactControlRadius
     ) -> some View {
-        frame(maxWidth: .infinity, minHeight: minHeight, alignment: alignment)
-            .contentShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+        quillCodeInteractiveTarget(.fullRow(
+            minHeight: minHeight,
+            alignment: alignment,
+            radius: radius
+        ))
     }
 
     func quillCodeCapsuleButtonTarget(
@@ -95,8 +227,11 @@ extension View {
         minHeight: CGFloat = QuillCodeMetrics.minimumHitTarget,
         alignment: Alignment = .center
     ) -> some View {
-        frame(minWidth: minWidth, minHeight: minHeight, alignment: alignment)
-            .contentShape(Capsule())
+        quillCodeInteractiveTarget(.capsule(
+            minWidth: minWidth,
+            minHeight: minHeight,
+            alignment: alignment
+        ))
     }
 
     func quillCodeSurface(
@@ -115,6 +250,39 @@ extension View {
 
     func quillCodeImageOutline(radius: CGFloat) -> some View {
         modifier(QuillCodeImageOutlineModifier(radius: radius))
+    }
+}
+
+private struct QuillCodeHitTargetModifier: ViewModifier {
+    var spec: QuillCodeHitTargetSpec
+
+    func body(content: Content) -> some View {
+        shaped(content)
+    }
+
+    @ViewBuilder
+    private func shaped(_ content: Content) -> some View {
+        switch spec.shape {
+        case .rectangle:
+            framed(content)
+                .contentShape(Rectangle())
+        case .rounded(let radius):
+            framed(content)
+                .contentShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+        case .capsule:
+            framed(content)
+                .contentShape(Capsule())
+        }
+    }
+
+    private func framed(_ content: Content) -> some View {
+        content.frame(
+            minWidth: spec.minWidth,
+            maxWidth: spec.maxWidth,
+            minHeight: spec.minHeight,
+            alignment: spec.alignment
+        )
+        .frame(width: spec.width, height: spec.height, alignment: spec.alignment)
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeReviewHunkView.swift
+++ b/Sources/QuillCodeApp/QuillCodeReviewHunkView.swift
@@ -83,7 +83,7 @@ struct QuillCodeReviewHunkView: View {
                     isAddingRangeComment = false
                 }
                 .font(.caption.weight(.semibold))
-                .quillCodeTextButtonTarget(minWidth: QuillCodeMetrics.minimumHitTarget)
+                .quillCodeFormActionTarget()
                 .buttonStyle(QuillCodePressableButtonStyle())
                 .disabled(!canAddRangeComment)
             }

--- a/Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeReviewLineRowView.swift
@@ -92,7 +92,7 @@ struct QuillCodeReviewLineRowView: View {
                     isAddingComment = false
                 }
                 .font(.caption.weight(.semibold))
-                .quillCodeTextButtonTarget(minWidth: QuillCodeMetrics.minimumHitTarget)
+                .quillCodeFormActionTarget()
                 .buttonStyle(QuillCodePressableButtonStyle())
                 .disabled(commentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }

--- a/Sources/QuillCodeApp/WorkspaceHTMLPrimitives.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLPrimitives.swift
@@ -2,6 +2,11 @@ import Foundation
 
 enum WorkspaceHTMLPrimitives {
     static let interactiveHitTargetClass = "interactive-hit-target"
+    static let iconHitTargetClass = "hit-target-icon"
+    static let textHitTargetClass = "hit-target-text"
+    static let rowHitTargetClass = "hit-target-row"
+    static let capsuleHitTargetClass = "hit-target-capsule"
+    static let formActionHitTargetClass = "hit-target-form-action"
 
     static func escape(_ text: String) -> String {
         text

--- a/Sources/QuillCodeApp/WorkspaceHTMLReviewRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLReviewRenderer.swift
@@ -71,7 +71,7 @@ enum WorkspaceHTMLReviewRenderer {
 
     private static func renderAction(_ action: WorkspaceReviewActionSurface) -> String {
         """
-        <button type="button" class="review-action-button" data-testid="review-action" data-action="\(escape(action.kind.rawValue))" data-path="\(escape(action.path))">
+        <button type="button" class="review-action-button \(WorkspaceHTMLPrimitives.textHitTargetClass)" data-testid="review-action" data-action="\(escape(action.kind.rawValue))" data-path="\(escape(action.path))">
           \(escape(action.kind.title))
         </button>
         """

--- a/Tests/QuillCodeParityTests/ParityHTMLGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityHTMLGateTests.swift
@@ -283,6 +283,14 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
             "HTML renderers should share one semantic class for non-button clickable targets."
         )
         XCTAssertTrue(
+            primitivesText.contains("static let iconHitTargetClass")
+                && primitivesText.contains("static let textHitTargetClass")
+                && primitivesText.contains("static let rowHitTargetClass")
+                && primitivesText.contains("static let capsuleHitTargetClass")
+                && primitivesText.contains("static let formActionHitTargetClass"),
+            "HTML hit-target classes should name the same semantic control categories as the SwiftUI target specs."
+        )
+        XCTAssertTrue(
             toolCardText.contains(#"class="tool-details""#),
             "Tool-card details disclosures should opt into the harness hit-target styling."
         )
@@ -291,7 +299,7 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
             "Artifact links should keep an explicit 44 px hit target instead of relying on chip padding."
         )
         XCTAssertTrue(
-            reviewText.contains(#"class="review-action-button""#),
+            reviewText.contains(#"class="review-action-button \(WorkspaceHTMLPrimitives.textHitTargetClass)""#),
             "Review action buttons should use a named class that can be target-sized in CSS."
         )
         XCTAssertTrue(
@@ -307,8 +315,13 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
             "The Playwright harness should size semantic non-button click targets explicitly."
         )
         XCTAssertTrue(
-            harnessText.contains("button,\n    summary,\n    a.interactive-hit-target"),
-            "The Playwright harness should enforce a global 44 px baseline for buttons, summaries, and link-style controls."
+            harnessText.contains("button,\n    summary,\n    input,\n    select,\n    textarea,\n    a.interactive-hit-target"),
+            "The Playwright harness should enforce a global 44 px baseline for buttons, summaries, fields, and link-style controls."
+        )
+        XCTAssertTrue(
+            harnessText.contains(".hit-target-icon")
+                && harnessText.contains(".hit-target-form-action"),
+            "The Playwright harness should expose semantic target classes for icon and compact form controls."
         )
         XCTAssertTrue(
             harnessText.contains("button:active:not(:disabled)")
@@ -339,8 +352,8 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
             "Harness artifact links should match the production target class."
         )
         XCTAssertTrue(
-            harnessText.contains(#"class="review-action-button""#),
-            "Harness review buttons should match the production review action class."
+            harnessText.contains(#"class="review-action-button hit-target-text""#),
+            "Harness review buttons should match the production review action target class."
         )
     }
 

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -94,8 +94,18 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         let terminalText = try Self.appSourceText(named: "QuillCodeTerminalPaneView.swift")
         let contextBannerText = try Self.appSourceText(named: "QuillCodeContextBannerView.swift")
         let reviewActionText = try Self.appSourceText(named: "QuillCodeReviewActionButton.swift")
+        let reviewLineText = try Self.appSourceText(named: "QuillCodeReviewLineRowView.swift")
+        let reviewHunkText = try Self.appSourceText(named: "QuillCodeReviewHunkView.swift")
         let modelRowsText = try Self.appSourceText(named: "QuillCodeModelPickerRows.swift")
 
+        XCTAssertTrue(
+            designSystemText.contains("struct QuillCodeHitTargetSpec"),
+            "Shared hit-target sizing should be modeled as semantic specs instead of independent frame helpers."
+        )
+        XCTAssertTrue(
+            designSystemText.contains("func quillCodeInteractiveTarget("),
+            "Target helpers should route through one primitive so shapes and sizes stay consistent."
+        )
         XCTAssertTrue(
             designSystemText.contains("minWidth: QuillCodeMetrics.minimumHitTarget"),
             "Shared pressable button style should enforce the 44 pt target instead of leaving it to every caller."
@@ -115,6 +125,10 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(
             designSystemText.contains("func quillCodeCapsuleButtonTarget("),
             "Capsule buttons should use a semantic 44 pt target helper that matches their visual shape."
+        )
+        XCTAssertTrue(
+            designSystemText.contains("func quillCodeFormActionTarget("),
+            "Compact form actions should use their own semantic target instead of shrinking below 44 pt."
         )
         XCTAssertTrue(
             designSystemText.contains(".contentShape(Rectangle())"),
@@ -167,6 +181,11 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(
             reviewActionText.contains(".quillCodeIconButtonTarget()"),
             "Review action icon buttons should use semantic icon click targets."
+        )
+        XCTAssertTrue(
+            reviewLineText.contains(".quillCodeFormActionTarget()")
+                && reviewHunkText.contains(".quillCodeFormActionTarget()"),
+            "Review note Add controls should use the compact form-action target instead of ad hoc small buttons."
         )
         XCTAssertTrue(
             modelRowsText.contains(".quillCodeFullRowButtonTarget(radius: 10)")


### PR DESCRIPTION
## Summary
- Centralize SwiftUI click-target sizing into semantic `QuillCodeHitTargetSpec` categories for icon, text, row, capsule, form-action, and rectangular targets.
- Add matching HTML hit-target classes and tighten the harness CSS baseline for buttons, summaries, inputs, selects, textareas, and link-style controls.
- Rework sidebar/project rows so row actions and menu buttons have distinct grid targets instead of overlapping.
- Add a Playwright audit that checks every visible interactive target is at least 44px and has no same-layer peer overlap across core workspace states.

## Validation
- `git diff --check`
- `swift test --filter 'ParityHTMLGateTests|ParityWorkspaceSettingsSheetGateTests|WorkspaceHTMLReviewRendererTests|WorkspaceHTMLChromeRendererTests'` (30 tests)
- `npm test -- tests/workspace-chrome.spec.ts` (9 tests)
- `swift test` (1,283 tests)
- `npm test` (76 tests)
