### PR TITLE
Suppress promised work streaming drafts

### DIFF
--- a/Sources/QuillCodeAgent/AgentActionStreaming.swift
+++ b/Sources/QuillCodeAgent/AgentActionStreaming.swift
@@ -30,6 +30,7 @@ public enum AgentActionStreamCollector {
             rawActionText.append(chunk)
             guard let visibleText = AgentActionStreamPreview.visibleAssistantText(from: rawActionText),
                   !visibleText.isEmpty,
+                  !AgentPromisedWorkGuard.shouldSuppressStreamingPreview(for: visibleText),
                   visibleText != lastVisibleText
             else {
                 continue

--- a/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
@@ -7,6 +7,18 @@ enum AgentPromisedWorkGuard {
         return promisesExecutableWork(assistantText)
     }
 
+    static func shouldSuppressStreamingPreview(for assistantText: String) -> Bool {
+        let normalized = normalizedText(assistantText)
+        guard !asksForPermission(normalized),
+              !containsNegativePromise(normalized)
+        else {
+            return false
+        }
+
+        return containsFutureWorkPhrase(in: normalized)
+            || containsUnresolvedFutureWorkStarter(in: normalized)
+    }
+
     static func correctionPrompt(assistantText: String, userMessage: String) -> String {
         """
         Your previous response promised to perform work but did not return a QuillCode tool action.
@@ -22,11 +34,7 @@ enum AgentPromisedWorkGuard {
     }
 
     private static func promisesExecutableWork(_ text: String) -> Bool {
-        let normalized = text
-            .lowercased()
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "’", with: "'")
-
+        let normalized = normalizedText(text)
         guard !asksForPermission(normalized),
               !containsNegativePromise(normalized)
         else {
@@ -34,6 +42,13 @@ enum AgentPromisedWorkGuard {
         }
 
         return containsFutureWorkPhrase(in: normalized)
+    }
+
+    private static func normalizedText(_ text: String) -> String {
+        text
+            .lowercased()
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "’", with: "'")
     }
 
     private static func asksForPermission(_ text: String) -> Bool {
@@ -61,6 +76,10 @@ enum AgentPromisedWorkGuard {
         for starter in futureWorkStarters {
             var searchStart = text.startIndex
             while let range = text.range(of: starter, range: searchStart..<text.endIndex) {
+                if isLetMeKnowCourtesy(text, after: range) {
+                    searchStart = range.upperBound
+                    continue
+                }
                 let tail = text[range.upperBound...].prefix(64)
                 if containsWorkVerb(in: tail) {
                     return true
@@ -69,6 +88,28 @@ enum AgentPromisedWorkGuard {
             }
         }
         return false
+    }
+
+    private static func containsUnresolvedFutureWorkStarter(in text: String) -> Bool {
+        for starter in futureWorkStarters {
+            guard let range = text.range(of: starter) else { continue }
+            if isLetMeKnowCourtesy(text, after: range) {
+                continue
+            }
+            let tail = text[range.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if tail.count < unresolvedStarterPreviewCharacterLimit {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func isLetMeKnowCourtesy(_ text: String, after range: Range<String.Index>) -> Bool {
+        text[range] == "let me"
+            && text[range.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .hasPrefix("know")
     }
 
     private static func containsWorkVerb(in text: Substring) -> Bool {
@@ -83,6 +124,8 @@ enum AgentPromisedWorkGuard {
         "i am going to",
         "let me"
     ]
+
+    private static let unresolvedStarterPreviewCharacterLimit = 8
 
     private static let workVerbs: Set<String> = [
         "apply", "build", "check", "commit", "create", "delete", "download",

--- a/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
@@ -36,6 +36,21 @@ final class AgentPromisedWorkGuardTests: XCTestCase {
         ))
     }
 
+    func testSuppressesPromisedWorkStreamingPreview() {
+        XCTAssertTrue(AgentPromisedWorkGuard.shouldSuppressStreamingPreview(
+            for: "I'll"
+        ))
+        XCTAssertTrue(AgentPromisedWorkGuard.shouldSuppressStreamingPreview(
+            for: "I'll check your Quill's disk usage now."
+        ))
+        XCTAssertFalse(AgentPromisedWorkGuard.shouldSuppressStreamingPreview(
+            for: "I can run commands, edit files, and review diffs when you ask."
+        ))
+        XCTAssertFalse(AgentPromisedWorkGuard.shouldSuppressStreamingPreview(
+            for: "Let me know if you want a deeper review."
+        ))
+    }
+
     func testCorrectionPromptKeepsSchemaBoundaryExplicit() {
         let prompt = AgentPromisedWorkGuard.correctionPrompt(
             assistantText: "I'll run whoami.",

--- a/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
@@ -162,6 +162,41 @@ final class AgentStreamingTests: XCTestCase {
         XCTAssertTrue(progressMessages.contains(["say hello", "hello world"]))
     }
 
+    func testStreamingPromisedWorkDraftIsSuppressedBeforeCorrectionToolRuns() async throws {
+        let root = try makeTempDirectory()
+        let recorder = ProgressRecorder()
+        let runner = AgentRunner(llm: PromiseThenToolStreamingLLMClient(
+            promisedChunks: [
+                #"{"type":"say","text":"I'll"#,
+                #" run `whoami` now."}"#
+            ],
+            toolChunks: [
+                #"{"type":"tool","#,
+                #""name":"host.shell.run","#,
+                #""arguments":{"cmd":"whoami"}}"#
+            ]
+        ))
+
+        let result = try await runner.send(
+            "run whoami",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root,
+            onProgress: { thread in
+                await recorder.record(thread)
+            }
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll run") })
+        XCTAssertTrue(result.thread.messages.last?.content.hasPrefix("You are `") == true)
+
+        let progressMessages = await recorder.messageContents()
+        XCTAssertFalse(progressMessages.contains { snapshot in
+            snapshot.contains { $0.contains("I'll run") }
+        })
+    }
+
     private func waitUntil(
         timeoutSeconds: TimeInterval,
         condition: @escaping () async -> Bool
@@ -174,6 +209,62 @@ final class AgentStreamingTests: XCTestCase {
             try await Task.sleep(nanoseconds: 1_000_000)
         }
         XCTFail("Timed out waiting for condition.")
+    }
+}
+
+private actor StreamingRetryState {
+    private var didUsePromise = false
+    private let promisedChunks: [String]
+    private let toolChunks: [String]
+
+    init(promisedChunks: [String], toolChunks: [String]) {
+        self.promisedChunks = promisedChunks
+        self.toolChunks = toolChunks
+    }
+
+    func nextChunks() -> [String] {
+        if didUsePromise {
+            return toolChunks
+        }
+        didUsePromise = true
+        return promisedChunks
+    }
+}
+
+private struct PromiseThenToolStreamingLLMClient: StreamingLLMClient {
+    private let state: StreamingRetryState
+
+    init(promisedChunks: [String], toolChunks: [String]) {
+        self.state = StreamingRetryState(
+            promisedChunks: promisedChunks,
+            toolChunks: toolChunks
+        )
+    }
+
+    func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+        let stream = try await actionTextStream(
+            thread: thread,
+            userMessage: userMessage,
+            tools: tools
+        )
+        return try await AgentActionStreamCollector.collect(
+            from: stream,
+            emptyError: AgentError.emptyStreamingResponse
+        )
+    }
+
+    func actionTextStream(
+        thread: ChatThread,
+        userMessage: String,
+        tools: [ToolDefinition]
+    ) async throws -> AsyncThrowingStream<String, Error> {
+        let chunks = await state.nextChunks()
+        return AsyncThrowingStream { continuation in
+            for chunk in chunks {
+                continuation.yield(chunk)
+            }
+            continuation.finish()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- hide streaming assistant drafts that begin future-tense executable-work promises, so correction can route to the tool call without flashing misleading text
- keep normal streaming say drafts visible and exempt courtesy wording like "Let me know..."
- add coverage for the streaming promise-to-tool retry path

## Validation
- swift test --filter 'AgentPromisedWorkGuardTests|AgentStreamingTests'
- swift test --quiet
- git diff --check