### PR TITLE
Clarify Computer Use unavailable status

### DIFF
--- a/Sources/QuillComputerUseKit/ComputerUse.swift
+++ b/Sources/QuillComputerUseKit/ComputerUse.swift
@@ -57,17 +57,20 @@ public struct ComputerUseStatus: Codable, Sendable, Hashable {
     public var screenRecordingGranted: Bool
     public var accessibilityGranted: Bool
     public var message: String
+    public var unavailableReason: String?
 
     public init(
         available: Bool,
         screenRecordingGranted: Bool,
         accessibilityGranted: Bool,
-        message: String
+        message: String,
+        unavailableReason: String? = nil
     ) {
         self.available = available
         self.screenRecordingGranted = screenRecordingGranted
         self.accessibilityGranted = accessibilityGranted
         self.message = message
+        self.unavailableReason = unavailableReason
     }
 
     public static func permissionStatus(
@@ -92,6 +95,20 @@ public struct ComputerUseStatus: Codable, Sendable, Hashable {
             accessibilityGranted: accessibilityGranted,
             message: message
         )
+    }
+
+    public static func unavailable(_ reason: String) -> ComputerUseStatus {
+        ComputerUseStatus(
+            available: false,
+            screenRecordingGranted: false,
+            accessibilityGranted: false,
+            message: reason,
+            unavailableReason: reason
+        )
+    }
+
+    public static func unsupportedPlatform(_ reason: String) -> ComputerUseStatus {
+        unavailable("Unsupported platform: \(reason)")
     }
 }
 
@@ -152,7 +169,7 @@ public struct ComputerUseToolExecutor: Sendable {
     }
 
     public func execute(_ call: ToolCall) async -> ToolResult? {
-        if let failure = permissionPreflightFailure(for: call.name) {
+        if let failure = preflightFailure(for: call.name) {
             return failure
         }
 
@@ -205,8 +222,22 @@ public struct ComputerUseToolExecutor: Sendable {
         }
     }
 
-    private func permissionPreflightFailure(for toolName: String) -> ToolResult? {
+    private func preflightFailure(for toolName: String) -> ToolResult? {
+        guard Self.isComputerUseTool(toolName) else {
+            return nil
+        }
+
         let status = backend.status
+        if let unavailableReason = status.unavailableReason {
+            return ToolResult(
+                ok: false,
+                error: Self.unavailablePreflightMessage(
+                    reason: unavailableReason,
+                    toolName: toolName
+                )
+            )
+        }
+
         let missingPermissions = Self.missingPermissions(for: toolName, status: status)
         guard !missingPermissions.isEmpty else {
             return nil
@@ -219,6 +250,10 @@ public struct ComputerUseToolExecutor: Sendable {
                 toolName: toolName
             )
         )
+    }
+
+    private static func isComputerUseTool(_ toolName: String) -> Bool {
+        ToolDefinition.computerUseDefinitions.contains { $0.name == toolName }
     }
 
     private static func missingPermissions(
@@ -248,6 +283,13 @@ public struct ComputerUseToolExecutor: Sendable {
             .joined(separator: " + ")
         return "Computer Use \(toolDisplayName(for: toolName)) needs \(permissionList). "
             + "Open Computer Use setup from Settings, grant \(permissionList), then refresh status."
+    }
+
+    private static func unavailablePreflightMessage(
+        reason: String,
+        toolName: String
+    ) -> String {
+        "Computer Use \(toolDisplayName(for: toolName)) is unavailable: \(reason)"
     }
 
     private static func toolDisplayName(for toolName: String) -> String {

--- a/Tests/QuillComputerUseKitTests/ComputerUseBackendTests.swift
+++ b/Tests/QuillComputerUseKitTests/ComputerUseBackendTests.swift
@@ -45,6 +45,44 @@ final class ComputerUseBackendTests: XCTestCase {
         XCTAssertEqual(status.message, "Needs Accessibility")
     }
 
+    func testUnavailableStatusCarriesBackendReasonSeparatelyFromPermissions() {
+        let status = ComputerUseStatus.unavailable("Computer Use backend is not running.")
+
+        XCTAssertFalse(status.available)
+        XCTAssertFalse(status.screenRecordingGranted)
+        XCTAssertFalse(status.accessibilityGranted)
+        XCTAssertEqual(status.message, "Computer Use backend is not running.")
+        XCTAssertEqual(status.unavailableReason, "Computer Use backend is not running.")
+    }
+
+    func testUnsupportedPlatformStatusIsUnavailableWithPlatformReason() {
+        let status = ComputerUseStatus.unsupportedPlatform("Linux backend not configured.")
+
+        XCTAssertFalse(status.available)
+        XCTAssertEqual(status.message, "Unsupported platform: Linux backend not configured.")
+        XCTAssertEqual(status.unavailableReason, "Unsupported platform: Linux backend not configured.")
+    }
+
+    func testComputerUseStatusDecodesOlderPayloadWithoutUnavailableReason() throws {
+        let status = try JSONDecoder().decode(
+            ComputerUseStatus.self,
+            from: Data("""
+            {
+              "available": false,
+              "screenRecordingGranted": true,
+              "accessibilityGranted": false,
+              "message": "Needs Accessibility"
+            }
+            """.utf8)
+        )
+
+        XCTAssertFalse(status.available)
+        XCTAssertTrue(status.screenRecordingGranted)
+        XCTAssertFalse(status.accessibilityGranted)
+        XCTAssertEqual(status.message, "Needs Accessibility")
+        XCTAssertNil(status.unavailableReason)
+    }
+
     func testStubBackendRecordsActions() async throws {
         let backend = StubComputerUseBackend()
 
@@ -241,6 +279,41 @@ final class ComputerUseBackendTests: XCTestCase {
         XCTAssertTrue(result.ok)
         XCTAssertEqual(actions, ["screenshot"])
         XCTAssertEqual(result.artifacts.count, 1)
+    }
+
+    func testComputerUseToolExecutorReportsUnavailableBackendBeforePermissions() async throws {
+        let backend = PermissionRecordingComputerUseBackend(
+            status: .unavailable("Computer Use backend is not running.")
+        )
+        let executor = ComputerUseToolExecutor(backend: backend)
+
+        let toolResult = await executor.execute(ToolCall(
+            name: ToolDefinition.computerClick.name,
+            argumentsJSON: #"{"x":10,"y":20}"#
+        ))
+        let result = try XCTUnwrap(toolResult)
+        let actions = await backend.recordedActions()
+
+        XCTAssertFalse(result.ok)
+        XCTAssertEqual(
+            result.error,
+            "Computer Use click is unavailable: Computer Use backend is not running."
+        )
+        XCTAssertEqual(actions, [])
+    }
+
+    func testComputerUseToolExecutorIgnoresUnknownToolsEvenWhenBackendUnavailable() async throws {
+        let backend = PermissionRecordingComputerUseBackend(
+            status: .unavailable("Computer Use backend is not running.")
+        )
+        let executor = ComputerUseToolExecutor(backend: backend)
+
+        let toolResult = await executor.execute(ToolCall(
+            name: "host.unknown.tool",
+            argumentsJSON: "{}"
+        ))
+
+        XCTAssertNil(toolResult)
     }
 
     func testMacBackendReportsCurrentPermissionState() {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -6,6 +6,20 @@ Overall grade: **A- foundation, B+ product surface maturity**.
 
 The architecture is moving in the right direction: core state is value typed, persistence and runtime adapters are separated, tools use explicit schemas, and SwiftUI plus the Playwright harness render from the same surface contract. The main drag on the grade is file size and feature density in the workspace layer, not a broken abstraction boundary.
 
+## 2026-06-27 Computer Use Status Contract Pass
+
+Overall grade after this slice: **A- Computer Use executor contract, A status copy accuracy, B+ platform parity**.
+
+Computer Use now has a clearer runtime boundary between permission-missing states and backend-unavailable states. The executor already preflights per-tool permissions before invoking platform APIs; this pass makes unsupported or unavailable backend states explicit so future Linux adapters, helper-process failures, or disabled Computer Use runtimes do not look like macOS permission problems.
+
+- Added a compatibility-safe `unavailableReason` field to `ComputerUseStatus`, with `unavailable` and `unsupportedPlatform` constructors for adapter-owned failures.
+- Updated `ComputerUseToolExecutor` to report backend-unavailable errors before permission guidance, but only for known Computer Use tools so unrelated tool names still fall through to the normal router.
+- Added focused tests for unavailable status construction, unavailable executor behavior, unknown-tool fallthrough, and preserving screenshot capture when only Accessibility is missing.
+
+Residual risk:
+
+- Product parity is still limited by the missing Linux backend, app-specific approval UX, and native visual verification loops. The protocol/executor contract is stronger, but the feature remains B+ until those adapter and UX milestones land.
+
 ## 2026-06-27 Desktop Model State Coordinator Pass
 
 Overall grade after this slice: **A desktop state synchronization, A- controller size, A refresh rule clarity**.
@@ -97,7 +111,7 @@ Residual risk:
 | `QuillCodeTools` | A- | Shell/file/git/MCP executors are bounded and testable. Git and MCP files are necessarily dense; keep extracting parsers/policies when behavior grows. |
 | `QuillCodeSafety` | A- | Small, explicit policy layer. Needs more production prompt telemetry once live Auto reviewer tuning begins. |
 | `QuillCodePersistence` | A | Focused stores, compatibility tests, and clear path ownership. |
-| `QuillComputerUseKit` | B+ | Protocol shape is good and macOS adapter is isolated. Linux adapter, app approvals, and visual feedback loops are still parity gaps. |
+| `QuillComputerUseKit` | A-/B+ | Protocol shape, macOS adapter isolation, per-tool permission preflight, and backend-unavailable status copy are solid. Linux adapter, app approvals, and visual feedback loops are still parity gaps. |
 | `QuillCodeApp` surface contracts | A- | Strong shared surface model and broad tests. Settings, runtime issue, model catalog, top-bar/model contracts, navigation assembly, sidebar/project contracts, command, command palette, review, review-comment planning, tool override composition, remote-project tool execution, context banner, transcript projection, execution-context enrichment, browser location/state transitions, MCP launch/session creation, thread seeding, thread lifecycle transitions, sidebar selection transitions, sidebar bulk action planning, and automation pane assembly now have focused builders; the main remaining risk is `WorkspaceModel`, `WorkspaceSurface`, and `WorkspaceSwiftUIView` continuing to absorb too many responsibilities. |
 | Playwright harness | B+ | Valuable parity harness with broad coverage. It intentionally duplicates rendering behavior, so keep it thin and derived from stable surface concepts. |
 


### PR DESCRIPTION
## Summary
- Add a compatibility-safe unavailable reason to Computer Use status
- Have Computer Use tool execution report unavailable backend/platform states distinctly from missing permissions
- Document the status-contract improvement in the code-quality audit

## Validation
- swift test --filter ComputerUseBackendTests
- swift test --quiet
- git diff --check