### PR TITLE
Narrow run intent safety matching

### DIFF
--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -28,14 +28,11 @@ struct StaticSafetyPolicy: Sendable {
         if request.containsAny(["remember", "memorize"]) {
             return toolName.contains("memory")
         }
-        if request.containsAny(["run", "execute"]) {
-            return true
-        }
         if request.containsAny(StaticSafetyPullRequestPolicy.requestTriggers) {
             return StaticSafetyPullRequestPolicy.intentMatches(request: request, toolName: toolName)
         }
-        if let rule = intentRules.first(where: { $0.matches(request: request) }) {
-            return rule.allows(toolName: toolName)
+        if intentRules.contains(where: { $0.matches(request: request) && $0.allows(toolName: toolName) }) {
+            return true
         }
         if toolName.contains("computer"),
            request.containsAny(StaticSafetyPolicy.computerUseTriggers) {
@@ -75,6 +72,14 @@ struct StaticSafetyPolicy: Sendable {
     ]
 
     private static let defaultIntentRules: [StaticSafetyIntentRule] = [
+        .init(
+            requestTriggers: ["run", "execute"],
+            allowedToolNames: ["shell.run"]
+        ),
+        .init(
+            requestTriggers: ["mcp"],
+            allowedToolNames: ["mcp.call"]
+        ),
         .init(
             requestTriggers: ["make", "create", "write"],
             allowedToolNames: ["file", "shell", "git.worktree"]

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -129,6 +129,13 @@ final class SafetyTests: XCTestCase {
         host: .local,
         risk: .append
     )
+    private let mcpCall = ToolDefinition(
+        name: "host.mcp.call",
+        description: "Call an MCP tool",
+        parametersJSON: "{}",
+        host: .local,
+        risk: .append
+    )
 
     func testAutoApprovesUserRequestedWhoami() async {
         let reviewer = StaticSafetyReviewer()
@@ -141,6 +148,80 @@ final class SafetyTests: XCTestCase {
             recentMessages: [.init(role: .user, content: "whoami?")]
         ))
         XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
+    }
+
+    func testAutoApprovesUserRequestedShellRun() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(name: shellRun.name, argumentsJSON: #"{"cmd":"swift test"}"#)
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run the tests",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "run the tests")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
+    }
+
+    func testAutoDoesNotTreatRunAsBlanketIntentForGitPush() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(name: gitPush.name, argumentsJSON: #"{"remote":"origin"}"#)
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run the tests",
+            toolCall: call,
+            toolDefinition: gitPush,
+            recentMessages: [.init(role: .user, content: "run the tests")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
+    }
+
+    func testAutoDoesNotTreatExecuteAsBlanketIntentForPullRequestMerge() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: gitPullRequestMerge.name,
+            argumentsJSON: #"{"selector":"42","method":"squash"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "execute the test suite",
+            toolCall: call,
+            toolDefinition: gitPullRequestMerge,
+            recentMessages: [.init(role: .user, content: "execute the test suite")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
+    }
+
+    func testAutoApprovesExplicitMCPToolRequest() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: mcpCall.name,
+            argumentsJSON: #"{"serverID":"mcp_server:filesystem","toolName":"read_file"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run MCP read_file on README",
+            toolCall: call,
+            toolDefinition: mcpCall,
+            recentMessages: [.init(role: .user, content: "run MCP read_file on README")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
+    }
+
+    func testAutoDoesNotTreatRunAsBlanketIntentForMCP() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: mcpCall.name,
+            argumentsJSON: #"{"serverID":"mcp_server:filesystem","toolName":"read_file"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run the tests",
+            toolCall: call,
+            toolDefinition: mcpCall,
+            recentMessages: [.init(role: .user, content: "run the tests")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
     }
 
     func testReadOnlyDeniesWrite() async {


### PR DESCRIPTION
## Summary
- remove the blanket Auto safety approval for any tool whenever the user says run/execute
- add explicit intent matching for shell runs and MCP calls instead
- add regression coverage so generic run/execute requests do not approve git push, PR merge, or unrelated MCP calls

## Validation
- swift test --filter SafetyTests
- swift test --filter WorkspaceMCPIntegrationTests
- swift test --quiet
- git diff --check