### PR TITLE
Draft replies from PR review threads

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4756,6 +4756,7 @@
                     <code data-testid="pr-review-thread-location">${escapeHTML(thread.locationLabel || 'Unknown location')}</code>
                     <blockquote data-testid="pr-review-thread-comment">${escapeHTML(thread.summaryText || '')}</blockquote>
                     <span class="review-actions">
+                      ${thread.replyDraft ? `<button type="button" class="review-action-button hit-target-text" data-testid="pr-review-thread-reply" data-reply-draft="${escapeHTML(thread.replyDraft)}">Reply</button>` : ''}
                       <button type="button" class="review-action-button hit-target-text" data-testid="pr-review-thread-action" data-action="${thread.isResolved ? 'unresolve' : 'resolve'}" data-thread-id="${escapeHTML(thread.id)}">${thread.isResolved ? 'Unresolve' : 'Resolve'}</button>
                     </span>
                   </li>`).join('')}
@@ -5504,6 +5505,11 @@
           const action = event.currentTarget.getAttribute('data-action');
           const threadID = event.currentTarget.getAttribute('data-thread-id');
           runPullRequestReviewThreadAction(action, threadID);
+        });
+      });
+      document.querySelectorAll('[data-testid="pr-review-thread-reply"]').forEach(button => {
+        button.addEventListener('click', event => {
+          usePromptAsDraft(event.currentTarget.getAttribute('data-reply-draft') || '');
         });
       });
       document.querySelectorAll('[data-testid="review-comment-form"]').forEach(form => {
@@ -9512,6 +9518,9 @@
             : `${thread.path}:${thread.line || thread.startLine || ''}`.replace(/:$/, ''),
           statusLabel: `${thread.isResolved ? 'Resolved' : 'Unresolved'}${thread.isOutdated ? ' · outdated' : ''}`,
           summaryText: thread.comments.nodes[0]?.body || 'No comment text.',
+          replyDraft: thread.comments.nodes[0]?.databaseId
+            ? `/pr review-reply ${selector} ${thread.comments.nodes[0].databaseId} `
+            : null,
           selector
         }))
       };

--- a/E2E/playwright/tests/review.spec.ts
+++ b/E2E/playwright/tests/review.spec.ts
@@ -185,11 +185,18 @@ test('mock harness browses and resolves pull request review threads', async ({ p
   await expect(page.getByTestId('pr-review-thread')).toHaveCount(2);
   await expect(page.getByTestId('pr-review-thread').first()).toContainText('Sources/App.swift:42');
   await expect(page.getByTestId('pr-review-thread-comment').first()).toContainText('Please extract this branch');
+  await expect(page.getByTestId('pr-review-thread-reply').first()).toHaveText('Reply');
   await expect(page.getByTestId('pr-review-thread-action').first()).toHaveText('Resolve');
 
+  const replyBounds = await elementRect(page, '[data-testid="pr-review-thread-reply"]:has-text("Reply")');
+  expect(replyBounds.width).toBeGreaterThanOrEqual(40);
+  expect(replyBounds.height).toBeGreaterThanOrEqual(40);
   const resolveBounds = await elementRect(page, '[data-testid="pr-review-thread-action"]:has-text("Resolve")');
   expect(resolveBounds.width).toBeGreaterThanOrEqual(40);
   expect(resolveBounds.height).toBeGreaterThanOrEqual(40);
+
+  await page.getByTestId('pr-review-thread-reply').first().click();
+  await expect(page.getByLabel('Message')).toHaveValue('/pr review-reply 123 171 ');
 
   await page.getByTestId('pr-review-thread-action').first().click();
 

--- a/Sources/QuillCodeApp/QuillCodeReviewPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeReviewPaneView.swift
@@ -4,6 +4,7 @@ struct QuillCodeReviewPaneView: View {
     var review: WorkspaceReviewSurface
     var onReviewAction: (WorkspaceReviewActionSurface) -> Void
     var onPullRequestReviewThreadAction: (WorkspacePullRequestReviewThreadActionSurface) -> Void
+    var onPullRequestReviewThreadReplyDraft: (String) -> Void
     var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
 
     var body: some View {
@@ -80,7 +81,8 @@ struct QuillCodeReviewPaneView: View {
             ForEach(review.pullRequestThreads) { thread in
                 QuillCodePullRequestReviewThreadRowView(
                     thread: thread,
-                    onAction: onPullRequestReviewThreadAction
+                    onAction: onPullRequestReviewThreadAction,
+                    onReplyDraft: onPullRequestReviewThreadReplyDraft
                 )
             }
         }
@@ -90,6 +92,7 @@ struct QuillCodeReviewPaneView: View {
 private struct QuillCodePullRequestReviewThreadRowView: View {
     var thread: WorkspacePullRequestReviewThreadSurface
     var onAction: (WorkspacePullRequestReviewThreadActionSurface) -> Void
+    var onReplyDraft: (String) -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -117,21 +120,39 @@ private struct QuillCodePullRequestReviewThreadRowView: View {
                 }
             }
             Spacer(minLength: 12)
-            ForEach(thread.actions) { action in
-                Button {
-                    onAction(action)
-                } label: {
-                    Label(action.kind.title, systemImage: action.kind.systemImage)
-                        .font(.caption.weight(.semibold))
-                        .labelStyle(.titleAndIcon)
-                        .padding(.horizontal, 12)
-                        .frame(minWidth: 92, minHeight: 40)
-                        .background(QuillCodePalette.blue.opacity(0.14))
-                        .clipShape(Capsule())
+            HStack(spacing: 8) {
+                if let replyDraft = thread.replyDraft {
+                    Button {
+                        onReplyDraft(replyDraft)
+                    } label: {
+                        Label("Reply", systemImage: "arrowshape.turn.up.left")
+                            .font(.caption.weight(.semibold))
+                            .labelStyle(.titleAndIcon)
+                            .padding(.horizontal, 12)
+                            .frame(minWidth: 86, minHeight: 40)
+                            .background(QuillCodePalette.blue.opacity(0.12))
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(QuillCodePressableButtonStyle())
+                    .foregroundStyle(QuillCodePalette.blue)
+                    .help("Draft a reply to review comment \(thread.comments.first?.databaseID ?? 0)")
                 }
-                .buttonStyle(QuillCodePressableButtonStyle())
-                .foregroundStyle(QuillCodePalette.blue)
-                .help("\(action.kind.title) review thread \(thread.id)")
+                ForEach(thread.actions) { action in
+                    Button {
+                        onAction(action)
+                    } label: {
+                        Label(action.kind.title, systemImage: action.kind.systemImage)
+                            .font(.caption.weight(.semibold))
+                            .labelStyle(.titleAndIcon)
+                            .padding(.horizontal, 12)
+                            .frame(minWidth: 92, minHeight: 40)
+                            .background(QuillCodePalette.blue.opacity(0.14))
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(QuillCodePressableButtonStyle())
+                    .foregroundStyle(QuillCodePalette.blue)
+                    .help("\(action.kind.title) review thread \(thread.id)")
+                }
             }
         }
         .padding(10)

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -15,6 +15,7 @@ struct QuillCodeTranscriptView: View {
     var onRuntimeIssueAction: (() -> Void)?
     var onReviewAction: (WorkspaceReviewActionSurface) -> Void
     var onPullRequestReviewThreadAction: (WorkspacePullRequestReviewThreadActionSurface) -> Void
+    var onPullRequestReviewThreadReplyDraft: (String) -> Void
     var onToolCardAction: (ToolCardActionSurface) -> Void
     var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     var onCopyTranscriptItem: (String, String) -> Void
@@ -87,6 +88,7 @@ struct QuillCodeTranscriptView: View {
                                     review: review,
                                     onReviewAction: onReviewAction,
                                     onPullRequestReviewThreadAction: onPullRequestReviewThreadAction,
+                                    onPullRequestReviewThreadReplyDraft: onPullRequestReviewThreadReplyDraft,
                                     onAddReviewComment: onAddReviewComment
                                 )
                             }

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -24,6 +24,7 @@ struct QuillCodeWorkspaceMainPaneView: View {
     var onAddBrowserComment: (String) -> Void
     var onReviewAction: (WorkspaceReviewActionSurface) -> Void
     var onPullRequestReviewThreadAction: (WorkspacePullRequestReviewThreadActionSurface) -> Void
+    var onPullRequestReviewThreadReplyDraft: (String) -> Void
     var onToolCardAction: (ToolCardActionSurface) -> Void
     var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     var onCopyTranscriptItem: (String, String) -> Void
@@ -55,6 +56,7 @@ struct QuillCodeWorkspaceMainPaneView: View {
                         onRuntimeIssueAction: runtimeIssueAction(for: surface.runtimeIssue),
                         onReviewAction: onReviewAction,
                         onPullRequestReviewThreadAction: onPullRequestReviewThreadAction,
+                        onPullRequestReviewThreadReplyDraft: onPullRequestReviewThreadReplyDraft,
                         onToolCardAction: onToolCardAction,
                         onAddReviewComment: onAddReviewComment,
                         onCopyTranscriptItem: onCopyTranscriptItem,

--- a/Sources/QuillCodeApp/WorkspaceHTMLReviewRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLReviewRenderer.swift
@@ -99,9 +99,19 @@ enum WorkspaceHTMLReviewRenderer {
           <code data-testid="pr-review-thread-location">\(escape(thread.locationLabel))</code>
           <blockquote data-testid="pr-review-thread-comment">\(escape(thread.summaryText))</blockquote>
           <span>
+            \(renderPullRequestThreadReply(thread))
             \(thread.actions.map(renderPullRequestThreadAction).joined(separator: "\n"))
           </span>
         </li>
+        """
+    }
+
+    private static func renderPullRequestThreadReply(_ thread: WorkspacePullRequestReviewThreadSurface) -> String {
+        guard let replyDraft = thread.replyDraft else { return "" }
+        return """
+        <button type="button" class="review-action-button \(WorkspaceHTMLPrimitives.textHitTargetClass)" data-testid="pr-review-thread-reply" data-reply-draft="\(escape(replyDraft))">
+          Reply
+        </button>
         """
     }
 

--- a/Sources/QuillCodeApp/WorkspacePullRequestReviewThreadSurface.swift
+++ b/Sources/QuillCodeApp/WorkspacePullRequestReviewThreadSurface.swift
@@ -40,6 +40,13 @@ public struct WorkspacePullRequestReviewThreadSurface: Codable, Sendable, Hashab
         comments.first?.author
     }
 
+    public var replyDraft: String? {
+        guard let commentID = comments.first?.databaseID else { return nil }
+        let trimmedSelector = selector?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let selectorPrefix = trimmedSelector.isEmpty ? "" : "\(trimmedSelector) "
+        return "/pr review-reply \(selectorPrefix)\(commentID) "
+    }
+
     public var actions: [WorkspacePullRequestReviewThreadActionSurface] {
         [
             WorkspacePullRequestReviewThreadActionSurface(

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -32,6 +32,7 @@ public struct QuillCodeWorkspaceView: View {
     public var onStartTrustedRouterSignIn: () -> Void
     public var onReviewAction: (WorkspaceReviewActionSurface) -> Void
     public var onPullRequestReviewThreadAction: (WorkspacePullRequestReviewThreadActionSurface) -> Void
+    public var onPullRequestReviewThreadReplyDraft: (String) -> Void
     public var onToolCardAction: (ToolCardActionSurface) -> Void
     public var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     public var onCreateWorktree: (WorkspaceWorktreeCreateRequest) -> Void
@@ -87,6 +88,7 @@ public struct QuillCodeWorkspaceView: View {
         onStartTrustedRouterSignIn: @escaping () -> Void,
         onReviewAction: @escaping (WorkspaceReviewActionSurface) -> Void,
         onPullRequestReviewThreadAction: @escaping (WorkspacePullRequestReviewThreadActionSurface) -> Void = { _ in },
+        onPullRequestReviewThreadReplyDraft: @escaping (String) -> Void = { _ in },
         onToolCardAction: @escaping (ToolCardActionSurface) -> Void = { _ in },
         onAddReviewComment: @escaping (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void,
         onCreateWorktree: @escaping (WorkspaceWorktreeCreateRequest) -> Void,
@@ -128,6 +130,7 @@ public struct QuillCodeWorkspaceView: View {
         self.onStartTrustedRouterSignIn = onStartTrustedRouterSignIn
         self.onReviewAction = onReviewAction
         self.onPullRequestReviewThreadAction = onPullRequestReviewThreadAction
+        self.onPullRequestReviewThreadReplyDraft = onPullRequestReviewThreadReplyDraft
         self.onToolCardAction = onToolCardAction
         self.onAddReviewComment = onAddReviewComment
         self.onCreateWorktree = onCreateWorktree
@@ -186,6 +189,7 @@ public struct QuillCodeWorkspaceView: View {
                     onAddBrowserComment: onAddBrowserComment,
                     onReviewAction: onReviewAction,
                     onPullRequestReviewThreadAction: onPullRequestReviewThreadAction,
+                    onPullRequestReviewThreadReplyDraft: onPullRequestReviewThreadReplyDraft,
                     onToolCardAction: onToolCardAction,
                     onAddReviewComment: onAddReviewComment,
                     onCopyTranscriptItem: onCopyTranscriptItem,

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -74,6 +74,7 @@ private struct QuillCodeDesktopRootView: View {
             onStartTrustedRouterSignIn: controller.startTrustedRouterSignIn,
             onReviewAction: controller.runReviewAction,
             onPullRequestReviewThreadAction: controller.runPullRequestReviewThreadAction,
+            onPullRequestReviewThreadReplyDraft: controller.usePullRequestReviewThreadReplyDraft,
             onToolCardAction: controller.runToolCardAction,
             onAddReviewComment: controller.addReviewComment,
             onCreateWorktree: controller.createWorktree,

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -299,6 +299,11 @@ final class QuillCodeDesktopController: ObservableObject {
         refresh()
     }
 
+    func usePullRequestReviewThreadReplyDraft(_ draft: String) {
+        workspaceActionCoordinator.useComposerDraft(draft, model: model)
+        refresh()
+    }
+
     func addReviewComment(
         path: String,
         lineNumber: Int?,

--- a/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
@@ -37,6 +37,10 @@ struct QuillCodeDesktopWorkspaceActionCoordinator {
         )
     }
 
+    func useComposerDraft(_ draft: String, model: QuillCodeWorkspaceModel) {
+        model.setDraft(draft)
+    }
+
     func addReviewComment(
         path: String,
         lineNumber: Int?,

--- a/Tests/QuillCodeAppTests/QuillCodeReviewSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeReviewSurfaceTests.swift
@@ -69,6 +69,7 @@ final class QuillCodeReviewSurfaceTests: XCTestCase {
         XCTAssertEqual(resolved.statusLabel, "Resolved · outdated")
         XCTAssertEqual(unresolved.summaryText, "Please extract this helper. Thanks.")
         XCTAssertEqual(unresolved.authorLabel, "reviewer")
+        XCTAssertEqual(unresolved.replyDraft, "/pr review-reply 123 11 ")
         XCTAssertEqual(unresolved.actions.first?.kind, .resolve)
         XCTAssertEqual(unresolved.actions.first?.selector, "123")
         XCTAssertEqual(resolved.actions.first?.kind, .unresolve)

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLReviewRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLReviewRendererTests.swift
@@ -76,6 +76,8 @@ final class WorkspaceHTMLReviewRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="pr-review-thread-status""#))
         XCTAssertTrue(html.contains(#"data-testid="pr-review-thread-location""#))
         XCTAssertTrue(html.contains(#"data-testid="pr-review-thread-comment""#))
+        XCTAssertTrue(html.contains(#"data-testid="pr-review-thread-reply""#))
+        XCTAssertTrue(html.contains(#"data-reply-draft="/pr review-reply 171 ""#))
         XCTAssertTrue(html.contains(#"data-testid="pr-review-thread-action""#))
         XCTAssertTrue(html.contains(#"data-action="resolve""#))
         XCTAssertTrue(html.contains("Sources/App.swift:42"))


### PR DESCRIPTION
## Summary
- add a Reply affordance to PR review-thread rows when the thread payload includes a numeric review comment ID
- prefill the composer with `/pr review-reply ...` so replies use the existing slash-command and tool path
- keep Reply and Resolve/Unresolve as separate actions to avoid sending reply drafts to the resolve tool

## Verification
- `git diff --check`
- `swift test --filter 'QuillCodeReviewSurfaceTests|WorkspaceHTMLReviewRendererTests'`\n- `npm test -- --grep "pull request review threads"` from `E2E/playwright`\n- `swift test --quiet`\n- `npm test` from `E2E/playwright`\n\n## Local screenshot\n- `/tmp/quillcode-pr-review-thread-reply.png`