### PR TITLE
Hide input copy action behind tool details

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4905,11 +4905,14 @@
         if (card.outputJSON) return 'Show output';
         return 'Show details';
       };
-      const renderToolDetails = card => card.inputJSON || card.outputJSON ? `
+      const hasInputOnlyPayload = card => Boolean(card.inputJSON && !card.outputJSON);
+      const toolCardCopyLabel = card => card.outputJSON ? 'Copy output' : card.inputJSON ? 'Copy input' : 'Copy';
+      const renderToolDetails = (card, copyID = '') => card.inputJSON || card.outputJSON ? `
           <details class="tool-details" data-testid="tool-card-details" ${card.density === 'expanded' ? 'open' : ''}>
             <summary>${detailsLabel(card)}</summary>
             ${card.inputJSON ? `<pre data-testid="tool-card-input">${escapeHTML(card.inputJSON)}</pre>` : ''}
             ${card.outputJSON ? `<pre data-testid="tool-card-output">${escapeHTML(card.outputJSON)}</pre>` : ''}
+            ${hasInputOnlyPayload(card) ? copyButton('tool-card-copy', copyID || card.id, toolCardCopyLabel(card)) : ''}
           </details>` : '';
       const renderToolActions = card => (card.actions || []).length ? `
           <div class="tool-card-actions" data-testid="tool-card-actions">
@@ -4921,6 +4924,7 @@
         const density = card.density || toolCardDensity(card.status, card.isExpanded);
         const statusDisplayLabel = toolCardStatusDisplayLabel(card);
         const statusAccessibilityLabel = toolCardStatusAccessibilityLabel(card);
+        const copyID = timelineID || card.id;
         return `
         <article class="tool-card ${escapeHTML(card.status)}${activeClass(timelineID)}" data-testid="tool-card" data-status="${escapeHTML(card.status)}" data-review-state="${escapeHTML(card.reviewState || 'none')}" data-status-label="${escapeHTML(statusDisplayLabel)}" data-density="${escapeHTML(density)}" data-timeline-id="${escapeHTML(timelineID)}"${card.executionContext ? ` data-execution-context="${escapeHTML(card.executionContext.kind)}"` : ''} aria-label="${escapeHTML(card.title)}, ${escapeHTML(statusAccessibilityLabel)}, ${escapeHTML(density)}${card.executionContext ? `, ${card.executionContext.label} ${card.executionContext.detail}` : ''}">
           <header>
@@ -4932,12 +4936,12 @@
           </header>
           <p data-testid="tool-card-subtitle">${escapeHTML(card.subtitle)}</p>
           ${renderToolActions(card)}
-          ${copyButton('tool-card-copy', timelineID || card.id, card.outputJSON ? 'Copy output' : card.inputJSON ? 'Copy input' : 'Copy')}
+          ${hasInputOnlyPayload(card) ? '' : copyButton('tool-card-copy', copyID, toolCardCopyLabel(card))}
           ${renderArtifacts(card.artifacts)}
           ${renderTextPreviews(card.artifacts)}
           ${renderDocumentPreviews(card.artifacts)}
           ${renderImagePreviews(card.artifacts)}
-          ${renderToolDetails(card)}
+          ${renderToolDetails(card, copyID)}
         </article>`;
       };
       const transcriptItems = state.transcript.timelineItems.length

--- a/E2E/playwright/tests/review.spec.ts
+++ b/E2E/playwright/tests/review.spec.ts
@@ -45,11 +45,16 @@ test('mock harness exposes actionable approval buttons on review cards', async (
   await expect(page.getByTestId('tool-card-status')).toHaveText('Ready');
   await expect(page.getByTestId('tool-card-actions')).toBeVisible();
   await expect(page.getByTestId('tool-card-input')).not.toBeVisible();
+  await expect(page.getByTestId('tool-card-copy')).not.toBeVisible();
   await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Run' })).toBeVisible();
   await expect(page.getByTestId('tool-card-action').filter({ hasText: 'Skip' })).toBeVisible();
   const runBounds = await elementRect(page, '[data-testid="tool-card-action"]:has-text("Run")');
   const skipBounds = await elementRect(page, '[data-testid="tool-card-action"]:has-text("Skip")');
   expect(runBounds.width).toBeGreaterThan(skipBounds.width);
+  await page.getByTestId('tool-card-details').locator('summary').click();
+  await expect(page.getByTestId('tool-card-input')).toBeVisible();
+  await expect(page.getByTestId('tool-card-copy')).toBeVisible();
+  await expect(page.getByTestId('tool-card-copy')).toHaveText('Copy input');
 
   await page.getByTestId('tool-card-action').filter({ hasText: 'Run' }).click();
 

--- a/Sources/QuillCodeApp/QuillCodeToolCardView.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolCardView.swift
@@ -28,14 +28,8 @@ struct QuillCodeToolCardView: View {
             if !card.actions.isEmpty {
                 QuillCodeToolCardActionRow(actions: card.actions, onAction: onAction)
             }
-            HStack {
-                QuillCodeTranscriptCopyButton(
-                    label: copyActionLabel,
-                    copiedLabel: "Copied",
-                    isCopied: isCopied,
-                    action: onCopy
-                )
-                Spacer()
+            if showsTopLevelCopyAction {
+                copyActionButton
             }
             if !card.artifacts.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {
@@ -96,6 +90,9 @@ struct QuillCodeToolCardView: View {
                         }
                         if let outputJSON = card.outputJSON {
                             QuillCodeCodeBlock(title: "Output", text: outputJSON)
+                        }
+                        if showsDetailsCopyAction {
+                            copyActionButton
                         }
                     }
                     .padding(.top, 4)
@@ -175,6 +172,18 @@ struct QuillCodeToolCardView: View {
             )
         }
         .frame(minHeight: QuillCodeMetrics.toolCardHeaderHeight, alignment: .top)
+    }
+
+    private var copyActionButton: some View {
+        HStack {
+            QuillCodeTranscriptCopyButton(
+                label: copyActionLabel,
+                copiedLabel: "Copied",
+                isCopied: isCopied,
+                action: onCopy
+            )
+            Spacer()
+        }
     }
 
     private var minimumHeight: CGFloat {
@@ -263,6 +272,14 @@ struct QuillCodeToolCardView: View {
             return "Copy input"
         }
         return "Copy"
+    }
+
+    private var showsTopLevelCopyAction: Bool {
+        !showsDetailsCopyAction
+    }
+
+    private var showsDetailsCopyAction: Bool {
+        card.inputJSON != nil && card.outputJSON == nil
     }
 
     private var accessibilityLabel: String {

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -19,16 +19,36 @@ enum WorkspaceHTMLToolCardRenderer {
           </header>
           <p data-testid="tool-card-subtitle">\(escape(card.subtitle))</p>
           \(renderActions(card.actions))
-          <footer class="transcript-actions">
-            <button type="button" data-testid="tool-card-copy" data-copy-id="\(escape(copyID))">\(escape(copyActionLabel(for: card)))</button>
-          </footer>
+          \(renderTopLevelCopyAction(for: card, copyID: copyID))
           \(renderArtifacts(card.artifacts))
           \(renderTextPreviews(card.artifacts))
           \(renderDocumentPreviews(card.artifacts))
           \(renderImagePreviews(card.artifacts))
-          \(renderDetails(card))
+          \(renderDetails(card, copyID: copyID))
         </article>
         """
+    }
+
+    private static func renderTopLevelCopyAction(for card: ToolCardState, copyID: String) -> String {
+        guard !showsDetailsCopyAction(for: card) else { return "" }
+        return renderCopyAction(for: card, copyID: copyID)
+    }
+
+    private static func renderDetailsCopyAction(for card: ToolCardState, copyID: String) -> String {
+        guard showsDetailsCopyAction(for: card) else { return "" }
+        return renderCopyAction(for: card, copyID: copyID)
+    }
+
+    private static func renderCopyAction(for card: ToolCardState, copyID: String) -> String {
+        """
+        <footer class="transcript-actions">
+          <button type="button" data-testid="tool-card-copy" data-copy-id="\(escape(copyID))">\(escape(copyActionLabel(for: card)))</button>
+        </footer>
+        """
+    }
+
+    private static func showsDetailsCopyAction(for card: ToolCardState) -> Bool {
+        card.inputJSON != nil && card.outputJSON == nil
     }
 
     private static func copyActionLabel(for card: ToolCardState) -> String {
@@ -55,7 +75,7 @@ enum WorkspaceHTMLToolCardRenderer {
         """
     }
 
-    private static func renderDetails(_ card: ToolCardState) -> String {
+    private static func renderDetails(_ card: ToolCardState, copyID: String) -> String {
         guard card.inputJSON != nil || card.outputJSON != nil else { return "" }
         let isOpen = card.opensDetailsByDefault
         return """
@@ -63,6 +83,7 @@ enum WorkspaceHTMLToolCardRenderer {
           <summary>\(detailsLabel(for: card, isOpen: isOpen))</summary>
           \(card.inputJSON.map { #"<pre data-testid="tool-card-input">\#(escape($0))</pre>"# } ?? "")
           \(card.outputJSON.map { #"<pre data-testid="tool-card-output">\#(escape($0))</pre>"# } ?? "")
+          \(renderDetailsCopyAction(for: card, copyID: copyID))
         </details>
         """
     }

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -31,9 +31,12 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains("Copy output"))
         XCTAssertTrue(html.contains(#"data-testid="tool-card-output""#))
         XCTAssertTrue(html.contains("Show details"))
+        let copyIndex = try XCTUnwrap(html.range(of: #"data-testid="tool-card-copy""#)?.lowerBound)
+        let detailsIndex = try XCTUnwrap(html.range(of: #"data-testid="tool-card-details""#)?.lowerBound)
+        XCTAssertLessThan(copyIndex, detailsIndex)
     }
 
-    func testHTMLToolCardRendererIncludesApprovalActions() {
+    func testHTMLToolCardRendererIncludesApprovalActions() throws {
         let card = ToolCardState(
             id: "shell-review",
             title: ToolDefinition.shellRun.name,
@@ -72,6 +75,11 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-status">Ready"#))
         XCTAssertTrue(html.contains(#"aria-label="host.shell.run, ready to run, preview"#))
         XCTAssertFalse(html.contains(#"data-testid="tool-card-details" open"#))
+        XCTAssertTrue(html.contains("Show input"))
+        XCTAssertTrue(html.contains("Copy input"))
+        let detailsIndex = try XCTUnwrap(html.range(of: #"data-testid="tool-card-details""#)?.lowerBound)
+        let copyIndex = try XCTUnwrap(html.range(of: #"data-testid="tool-card-copy""#)?.lowerBound)
+        XCTAssertLessThan(detailsIndex, copyIndex)
         XCTAssertTrue(html.contains(#"data-testid="tool-card-action" data-action-kind="approve" data-action-style="primary" data-request-id="approval-html">Run"#))
         XCTAssertTrue(html.contains(#"data-testid="tool-card-action" data-action-kind="edit" data-action-style="secondary" data-request-id="approval-html">Edit"#))
         XCTAssertTrue(html.contains(#"data-testid="tool-card-action" data-action-kind="deny" data-action-style="secondary" data-request-id="approval-html">Skip"#))


### PR DESCRIPTION
## Summary
- keep output copy actions visible on completed/output tool cards
- move input-only Copy input actions into the details disclosure so compact approval cards stay focused on decision buttons
- mirror the behavior in the static HTML renderer and Playwright harness

## Validation
- swift test --filter WorkspaceHTMLToolCardRendererTests
- npm test -- tests/review.spec.ts --grep "approval buttons"
- swift test --quiet
- npm test
- git diff --check

Screenshot: /tmp/quillcode-tool-card-copy-disclosure.png