### PR TITLE
Extract visual polish Playwright helper

### DIFF
--- a/E2E/playwright/tests/visual-polish-helpers.ts
+++ b/E2E/playwright/tests/visual-polish-helpers.ts
@@ -1,0 +1,42 @@
+import { expect, type Page } from '@playwright/test';
+
+const HORIZONTAL_OVERFLOW_TOLERANCE = 1;
+
+type HorizontalOverflowIssue = {
+  className: string;
+  left: number;
+  right: number;
+  tag: string;
+  testid: string | null;
+  text: string;
+  width: number;
+};
+
+export async function expectNoHorizontalOverflow(page: Page, label: string) {
+  const overflow = await horizontalOverflowIssues(page);
+
+  expect(overflow, `${label} should not clip horizontally`).toEqual([]);
+}
+
+async function horizontalOverflowIssues(page: Page): Promise<HorizontalOverflowIssue[]> {
+  return page.evaluate((tolerance) => {
+    const viewportWidth = document.documentElement.clientWidth;
+    return Array.from(document.querySelectorAll('body *'))
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName,
+          testid: element.getAttribute('data-testid'),
+          className: String(element.className || ''),
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+          text: (element.textContent || '').trim().slice(0, 80)
+        };
+      })
+      .filter((rect) => (
+        rect.width > 0
+        && (rect.left < -tolerance || rect.right > viewportWidth + tolerance)
+      ));
+  }, HORIZONTAL_OVERFLOW_TOLERANCE);
+}

--- a/E2E/playwright/tests/visual-polish.spec.ts
+++ b/E2E/playwright/tests/visual-polish.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import {
   clickSidebarTool,
   computedStyleProperties,
@@ -10,34 +10,13 @@ import {
   expectHitTarget,
   MINIMUM_HIT_TARGET
 } from './interaction-audit-helpers';
+import { expectNoHorizontalOverflow } from './visual-polish-helpers';
 
 test('mock harness avoids horizontal clipping in key desktop and mobile flows', async ({ browser }) => {
   const viewports = [
     { name: 'desktop', width: 1440, height: 1000 },
     { name: 'mobile', width: 390, height: 844 }
   ];
-
-  const expectNoHorizontalOverflow = async (page: Page, label: string) => {
-    const overflow = await page.evaluate(() => {
-      const viewportWidth = document.documentElement.clientWidth;
-      return [...document.querySelectorAll('body *')]
-        .map((element) => {
-          const rect = element.getBoundingClientRect();
-          return {
-            tag: element.tagName,
-            testid: element.getAttribute('data-testid'),
-            className: String(element.className || ''),
-            left: rect.left,
-            right: rect.right,
-            width: rect.width,
-            text: (element.textContent || '').trim().slice(0, 80)
-          };
-        })
-        .filter((rect) => rect.width > 0 && (rect.left < -1 || rect.right > viewportWidth + 1));
-    });
-
-    expect(overflow, `${label} should not clip horizontally`).toEqual([]);
-  };
 
   for (const viewport of viewports) {
     const page = await browser.newPage({

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -293,6 +293,10 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
             contentsOf: testRoot.appendingPathComponent("visual-polish.spec.ts"),
             encoding: .utf8
         )
+        let visualPolishHelperText = try String(
+            contentsOf: testRoot.appendingPathComponent("visual-polish-helpers.ts"),
+            encoding: .utf8
+        )
         let coreSpecText = try String(
             contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
             encoding: .utf8
@@ -313,6 +317,10 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(visualPolishSpecText.contains("openSettings"), "Focused visual polish flows should cover settings layout safety.")
         XCTAssertTrue(visualPolishSpecText.contains("top-bar-status-metadata"), "Focused visual polish flows should cover quiet top-bar metadata.")
         XCTAssertTrue(visualPolishSpecText.contains("sendTransitionProperty"), "Focused visual polish flows should cover interface polish primitives.")
+        XCTAssertTrue(visualPolishSpecText.contains("from './visual-polish-helpers'"), "Visual polish specs should reuse named visual audit helpers.")
+        XCTAssertTrue(visualPolishHelperText.contains("export async function expectNoHorizontalOverflow"), "Horizontal overflow auditing should live in the visual polish helper.")
+        XCTAssertTrue(visualPolishHelperText.contains("document.querySelectorAll('body *')"), "The helper should own broad horizontal overflow inspection.")
+        XCTAssertFalse(visualPolishSpecText.contains("document.querySelectorAll('body *')"), "Visual polish specs should not inline the broad overflow scanner.")
         for flowName in chromeFlowNames {
             XCTAssertTrue(chromeSpecText.contains(flowName), "\(flowName) should live in workspace-chrome.spec.ts.")
             XCTAssertFalse(coreSpecText.contains(flowName), "\(flowName) should not drift back into core.spec.ts.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -76,6 +76,20 @@ Residual risk:
 
 - `visual-polish.spec.ts` intentionally spans several UI surfaces because the visual contract is cross-cutting. Extract smaller visual specs only when a specific surface accumulates enough unique polish behavior.
 
+## 2026-06-27 Visual Polish Helper Pass
+
+Overall grade after this slice: **A helper ownership, A visual spec readability, A regression coverage**.
+
+The visual polish split created the right spec boundary, but its horizontal overflow audit still lived as an inline browser-side scanner inside the first test. That made the test harder to scan and made it too easy for future clipping checks to copy broad DOM inspection logic.
+
+- Added `visual-polish-helpers.ts` for the reusable horizontal overflow audit.
+- Kept `visual-polish.spec.ts` focused on scenarios: settings, tool flow, interface primitives, and quiet long-status top bar behavior.
+- Added a parity gate so the broad `body *` overflow scanner stays in the helper instead of drifting back into the spec.
+
+Residual risk:
+
+- The helper currently exposes only the horizontal overflow audit. Add more visual helpers only when a second spec needs them, so the module stays narrow and behavior-preserving.
+
 ## 2026-06-27 Computer Use Status Contract Pass
 
 Overall grade after this slice: **A- Computer Use executor contract, A status copy accuracy, B+ platform parity**.


### PR DESCRIPTION
## Summary
- Move the horizontal overflow DOM audit into `visual-polish-helpers.ts`.
- Keep `visual-polish.spec.ts` focused on scenarios instead of broad scanner internals.
- Add a parity gate and audit note so the helper boundary stays intentional.

## Verification
- `npm test -- tests/workspace-chrome.spec.ts tests/visual-polish.spec.ts`
- `swift test --filter ParityWorkspaceSurfaceGateTests/testPlaywrightWorkspaceChromeFlowsStayInFocusedSpec`
- `git diff --check`