### PR TITLE
Use model branding in status text

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceStatusTextBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceStatusTextBuilder.swift
@@ -36,7 +36,7 @@ struct WorkspaceStatusTextBuilder {
         Instructions: \(instructionLabel(for: context.instructions))
         Memories: \(memoryLabel(for: context.memories))
         Mode: \(modeLabel(context.mode))
-        Model: \(context.model)
+        Model: \(statusModelLabel(context.model))
         Agent: \(context.agentStatus)
         """
     }
@@ -45,7 +45,32 @@ struct WorkspaceStatusTextBuilder {
         guard let thread else {
             return "\(projectName) - Not started"
         }
-        return "\(projectName) - \(modeLabel(thread.mode)) - \(thread.model)"
+        return "\(projectName) - \(modeLabel(thread.mode)) - \(subtitleModelLabel(thread.model))"
+    }
+
+    static func subtitleModelLabel(_ modelID: String) -> String {
+        guard let recommended = recommendedModelDisplay(for: modelID) else {
+            return TrustedRouterDefaults.canonicalModelID(modelID)
+        }
+        return recommended.displayName
+    }
+
+    static func statusModelLabel(_ modelID: String) -> String {
+        guard let recommended = recommendedModelDisplay(for: modelID) else {
+            return TrustedRouterDefaults.canonicalModelID(modelID)
+        }
+        return "\(recommended.displayName) (\(TrustedRouterDefaults.preferredDisplayModelID(recommended.modelID)))"
+    }
+
+    private static func recommendedModelDisplay(for modelID: String) -> (modelID: String, displayName: String)? {
+        let canonicalModelID = TrustedRouterDefaults.canonicalModelID(modelID)
+        guard TrustedRouterDefaults.isRecommendedModel(canonicalModelID) else {
+            return nil
+        }
+        return (
+            modelID: canonicalModelID,
+            displayName: TrustedRouterDefaults.displayName(fromModelID: canonicalModelID)
+        )
     }
 
     static func modeLabel(_ mode: AgentMode) -> String {

--- a/Tests/QuillCodeAppTests/WorkspaceSlashCommandIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSlashCommandIntegrationTests.swift
@@ -278,7 +278,7 @@ final class WorkspaceSlashCommandIntegrationTests: XCTestCase {
         XCTAssertTrue(message.contains("Project: QuillCode"))
         XCTAssertTrue(message.contains("Thread: Status thread"))
         XCTAssertTrue(message.contains("Mode: Auto"))
-        XCTAssertTrue(message.contains("Model: trustedrouter/fast"))
+        XCTAssertTrue(message.contains("Model: Nike 1.0 (trustedrouter/fast)"))
     }
 
     private func makeProjectWithLocalEnvironmentAction(

--- a/Tests/QuillCodeAppTests/WorkspaceStatusTextBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceStatusTextBuilderTests.swift
@@ -34,7 +34,7 @@ final class WorkspaceStatusTextBuilderTests: XCTestCase {
         Instructions: 1 instruction file loaded
         Memories: 1 memory
         Mode: Review
-        Model: \(TrustedRouterDefaults.synthModel)
+        Model: Synth (/synth)
         Agent: Running
         """)
     }
@@ -72,7 +72,16 @@ final class WorkspaceStatusTextBuilderTests: XCTestCase {
         )
         XCTAssertEqual(
             WorkspaceStatusTextBuilder.topBarSubtitle(projectName: "QuillCode", thread: thread),
-            "QuillCode - Auto - \(TrustedRouterDefaults.fastModel)"
+            "QuillCode - Auto - Nike 1.0"
         )
+    }
+
+    func testModelLabelsPreferBrandingForRecommendedModels() {
+        XCTAssertEqual(WorkspaceStatusTextBuilder.subtitleModelLabel("trustedrouter/fusion"), "Synth")
+        XCTAssertEqual(WorkspaceStatusTextBuilder.statusModelLabel("trustedrouter/fusion"), "Synth (/synth)")
+        XCTAssertEqual(WorkspaceStatusTextBuilder.subtitleModelLabel(TrustedRouterDefaults.synthCodeModel), "Synth Code")
+        XCTAssertEqual(WorkspaceStatusTextBuilder.statusModelLabel(TrustedRouterDefaults.synthCodeModel), "Synth Code (/synth-code)")
+        XCTAssertEqual(WorkspaceStatusTextBuilder.subtitleModelLabel("anthropic/claude-opus-4.1"), "anthropic/claude-opus-4.1")
+        XCTAssertEqual(WorkspaceStatusTextBuilder.statusModelLabel("anthropic/claude-opus-4.1"), "anthropic/claude-opus-4.1")
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
@@ -55,7 +55,7 @@ final class WorkspaceTopBarSurfaceBuilderTests: XCTestCase {
 
         XCTAssertEqual(topBar.appName, "QuillCode")
         XCTAssertEqual(topBar.primaryTitle, "Ship QuillCode")
-        XCTAssertEqual(topBar.subtitle, "QuillCode - Auto - \(TrustedRouterDefaults.synthModel)")
+        XCTAssertEqual(topBar.subtitle, "QuillCode - Auto - Synth")
         XCTAssertEqual(topBar.instructionLabel, "1 instruction file loaded")
         XCTAssertEqual(topBar.instructionSources, ["AGENTS.md"])
         XCTAssertEqual(topBar.memoryLabel, "1 memory")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -104,6 +104,20 @@ Residual risk:
 
 - This still combines source gates with HTML Playwright audits rather than native UI automation measuring the built SwiftUI app. Add native accessibility-frame checks once the packaged app test runner can inspect SwiftUI controls directly.
 
+## 2026-06-27 Model Status Display Pass
+
+Overall grade after this slice: **A user-facing model copy, A formatter ownership, A alias compatibility**.
+
+Nike/Synth naming was already enforced in the model picker, slash commands, config, and catalog normalization, but status copy still rendered raw IDs like `tr/synth` in the top-bar subtitle and `/status` transcript. This pass moves model status copy into `WorkspaceStatusTextBuilder` so status surfaces use the same model-branding rule.
+
+- Top-bar subtitles now show recommended model display names such as `Nike 1.0`, `Synth`, and `Synth Code`.
+- `/status` text keeps enough detail for support by showing branded recommended models with their preferred command IDs, such as `Synth (/synth)`.
+- Unknown provider/model IDs remain literal so advanced users can still verify exact custom model routing.
+
+Residual risk:
+
+- The subtitle still includes model identity for now because that matches the existing surface contract. If the top bar gets visually crowded again, remove the model from the subtitle rather than reintroducing raw IDs.
+
 ## 2026-06-27 Computer Use Status Contract Pass
 
 Overall grade after this slice: **A- Computer Use executor contract, A status copy accuracy, B+ platform parity**.


### PR DESCRIPTION
## Summary
- Show Nike/Synth/Synth Code branding in top-bar status copy instead of raw recommended-model IDs.
- Keep /status support detail by showing branded recommended models with preferred command IDs, such as `Synth (/synth)`.
- Preserve literal provider/model IDs for custom models.

## Verification
- `swift test --filter WorkspaceStatusTextBuilderTests`
- `swift test --filter WorkspaceTopBarSurfaceBuilderTests`
- `git diff --check`