### PR TITLE
Add status browser coverage

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -5991,6 +5991,64 @@
       return `${model.provider}/${model.displayName}`;
     }
 
+    function canonicalModelID(modelID) {
+      const normalized = String(modelID || '').trim().toLowerCase();
+      const aliases = {
+        fast: 'trustedrouter/fast',
+        '/fast': 'trustedrouter/fast',
+        'tr/fast': 'trustedrouter/fast',
+        nike: 'trustedrouter/fast',
+        '/nike': 'trustedrouter/fast',
+        'nike 1.0': 'trustedrouter/fast',
+        'trustedrouter/nike': 'trustedrouter/fast',
+        synth: 'tr/synth',
+        '/synth': 'tr/synth',
+        'trustedrouter/synth': 'tr/synth',
+        fusion: 'tr/synth',
+        '/fusion': 'tr/synth',
+        'tr/fusion': 'tr/synth',
+        'trustedrouter/fusion': 'tr/synth',
+        'synth-code': 'tr/synth-code',
+        'synth code': 'tr/synth-code',
+        '/synth-code': 'tr/synth-code',
+        'trustedrouter/synth-code': 'tr/synth-code',
+        'fusion-code': 'tr/synth-code',
+        '/fusion-code': 'tr/synth-code',
+        'tr/fusion-code': 'tr/synth-code',
+        'trustedrouter/fusion-code': 'tr/synth-code'
+      };
+      return aliases[normalized] || String(modelID || '').trim();
+    }
+
+    function preferredDisplayModelID(modelID) {
+      const canonical = canonicalModelID(modelID);
+      if (canonical === 'tr/synth') return '/synth';
+      if (canonical === 'tr/synth-code') return '/synth-code';
+      return canonical;
+    }
+
+    function statusModelLabel(modelID) {
+      const canonical = canonicalModelID(modelID);
+      if (canonical === 'trustedrouter/fast') return `Nike 1.0 (${preferredDisplayModelID(canonical)})`;
+      if (canonical === 'tr/synth') return `Synth (${preferredDisplayModelID(canonical)})`;
+      if (canonical === 'tr/synth-code') return `Synth Code (${preferredDisplayModelID(canonical)})`;
+      return canonical;
+    }
+
+    function workspaceStatusText() {
+      const selectedProject = state.projects.items.find(project => project.id === state.projects.selectedProjectID);
+      const selectedThread = state.sidebar.items.find(item => item.id === state.sidebar.selectedThreadID);
+      return [
+        `Project: ${selectedProject?.name || 'No project'}`,
+        `Thread: ${selectedThread?.title || state.topBar.primaryTitle || 'New chat'}`,
+        `Instructions: ${state.topBar.instructionLabel}`,
+        `Memories: ${state.topBar.memoryLabel}`,
+        `Mode: ${state.topBar.modeLabel}`,
+        `Model: ${statusModelLabel(state.topBar.selectedModelID)}`,
+        `Agent: ${state.topBar.agentStatus}`
+      ].join('\n');
+    }
+
     function modelBadgeClass(badge) {
       const normalized = String(badge || '').toLowerCase();
       if (normalized === 'current') return 'current';
@@ -9686,6 +9744,8 @@
           message: "The selected model did not follow QuillCode's action schema. Try Nike 1.0, Synth, or another coding model.",
           actionLabel: 'Switch model'
         }, 'Expected valid QuillCode action JSON but received an empty argument object.');
+      } else if (/^\/status\b/i.test(text)) {
+        addMessage('assistant', workspaceStatusText());
       } else if (/^\/(new|new-chat|newchat)\b/i.test(text)) {
         newChat();
         return;

--- a/E2E/playwright/tests/command-palette.spec.ts
+++ b/E2E/playwright/tests/command-palette.spec.ts
@@ -101,8 +101,8 @@ test('mock harness prunes worktrees from the command palette', async ({ page }) 
 
   await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
   await expect(page.getByTestId('worktree-prune-panel')).toBeVisible();
-  await expect(page.getByTestId('worktree-prune-loading')).toBeVisible();
   await expect(page.getByTestId('worktree-prune-record')).toContainText('/mock/quillcode-stale');
+  await expect(page.getByTestId('worktree-prune-loading')).toHaveCount(0);
   await expect(page.getByTestId('worktree-prune-submit')).toBeEnabled();
 
   await page.getByTestId('worktree-prune-submit').click();

--- a/E2E/playwright/tests/status.spec.ts
+++ b/E2E/playwright/tests/status.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+test('mock harness reports workspace status from composer with branded default model', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await expect(page.getByTestId('model-picker-button')).toHaveText('Nike 1.0');
+  await page.getByLabel('Message').fill('/status');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('top-bar-title')).toHaveText('/status');
+  await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode - Auto - Nike 1.0');
+  await expect(page.getByTestId('tool-card')).toHaveCount(0);
+
+  const statusMessage = page.getByTestId('message').filter({ hasText: 'Project: QuillCode' });
+  await expect(statusMessage).toContainText('Thread: /status');
+  await expect(statusMessage).toContainText('Instructions: 1 instruction file loaded');
+  await expect(statusMessage).toContainText('Memories: 2 memories');
+  await expect(statusMessage).toContainText('Mode: Auto');
+  await expect(statusMessage).toContainText('Model: Nike 1.0 (trustedrouter/fast)');
+  await expect(statusMessage).toContainText('Agent: Idle');
+});
+
+test('mock harness reports Synth status with preferred slash alias after model switch', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByTestId('model-picker-button').click();
+  await page.locator('[data-testid="model-option"][data-model-id="tr/synth"]').click();
+  await expect(page.getByTestId('model-picker-button')).toHaveText('Synth');
+
+  await page.getByLabel('Message').fill('/status');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode - Auto - Synth');
+  const statusMessage = page.getByTestId('message').filter({ hasText: 'Project: QuillCode' });
+  await expect(statusMessage).toContainText('Model: Synth (/synth)');
+});

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -32,6 +32,7 @@ struct ParityFocusedSuiteManifest {
             "testPlaywrightComposerFlowsStayInFocusedSpec",
             "testPlaywrightWorkspaceChromeFlowsStayInFocusedSpec",
             "testPlaywrightWorkspaceStateFlowsStayInFocusedSpec",
+            "testPlaywrightStatusFlowsStayInFocusedSpec",
             "testPlaywrightShortcutFlowsStayInFocusedSpec",
             "testPlaywrightReviewFlowsStayInFocusedSpec"
         ]),

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -359,6 +359,36 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         }
     }
 
+    func testPlaywrightStatusFlowsStayInFocusedSpec() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let statusSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("status.spec.ts"),
+            encoding: .utf8
+        )
+        let coreSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
+            encoding: .utf8
+        )
+        let composerSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("composer.spec.ts"),
+            encoding: .utf8
+        )
+        let statusFlowNames = [
+            "reports workspace status from composer with branded default model",
+            "reports Synth status with preferred slash alias after model switch"
+        ]
+
+        XCTAssertTrue(statusSpecText.contains("harnessURL()"), "Focused status flows should reuse the shared harness URL helper.")
+        XCTAssertTrue(statusSpecText.contains("Model: Nike 1.0 (trustedrouter/fast)"), "Status E2E should cover the branded default model output.")
+        XCTAssertTrue(statusSpecText.contains("Model: Synth (/synth)"), "Status E2E should cover the preferred Synth slash alias output.")
+        XCTAssertTrue(statusSpecText.contains("top-bar-subtitle"), "Status E2E should cover the top-bar state seen by real users.")
+        for flowName in statusFlowNames {
+            XCTAssertTrue(statusSpecText.contains(flowName), "\(flowName) should live in status.spec.ts.")
+            XCTAssertFalse(coreSpecText.contains(flowName), "\(flowName) should not drift back into core.spec.ts.")
+            XCTAssertFalse(composerSpecText.contains(flowName), "\(flowName) should not drift back into composer.spec.ts.")
+        }
+    }
+
     func testPlaywrightShortcutFlowsStayInFocusedSpec() throws {
         let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
         let shortcutSpecText = try String(

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -21,6 +21,21 @@ Overall grade: **A- foundation, B+ product surface maturity**.
 
 The architecture is moving in the right direction: core state is value typed, persistence and runtime adapters are separated, tools use explicit schemas, and SwiftUI plus the Playwright harness render from the same surface contract. The main drag on the grade is file size and feature density in the workspace layer, not a broken abstraction boundary.
 
+## 2026-06-27 Status E2E Coverage Pass
+
+Overall grade after this slice: **A real-world slash coverage, A status copy parity, A spec ownership**.
+
+The `/status` command had strong Swift coverage but no browser-level path through the composer, even though the Playwright harness advertised the command in slash suggestions. That left a realistic user flow untested: type `/status`, submit, and verify the transcript and top bar present the branded model state users actually see.
+
+- Added `status.spec.ts` with composer-driven `/status` coverage for the default Nike 1.0 model and the Synth model after a real model-picker switch.
+- Implemented `/status` in the HTML harness so the mock app exercises the command end to end instead of only documenting it in suggestions.
+- Hardened the worktree-prune Playwright flow to assert the durable loaded state instead of a transient spinner that can disappear before the browser assertion attaches.
+- Added a parity gate so status E2E ownership stays in the focused spec and does not drift into `core.spec.ts` or `composer.spec.ts`.
+
+Residual risk:
+
+- This still uses the HTML harness rather than packaged native automation. Native smoke should eventually assert the same `/status` transcript after app launch/relaunch once the desktop UI runner can inspect SwiftUI text reliably.
+
 ## 2026-06-27 Shared Playwright Hit-Target Audit Pass
 
 Overall grade after this slice: **A reusable UI audit helper, A chrome spec cohesion, A regression coverage**.


### PR DESCRIPTION
## Summary
- add a focused Playwright status spec that drives `/status` through the composer
- implement `/status` in the HTML harness so the advertised slash command has browser-level coverage
- harden the worktree-prune Playwright flow to assert the durable loaded state instead of a transient spinner
- record the testing architecture decision in `docs/CODE_QUALITY_AUDIT.md`

## Validation
- `npm test -- tests/status.spec.ts tests/command-palette.spec.ts --grep "prunes worktrees|reports workspace status|reports Synth status"`
- `npm test`
- `swift test --filter ParityWorkspaceSurfaceGateTests/testPlaywrightStatusFlowsStayInFocusedSpec`
- `swift test --filter ParityGateTests/testParityGatesUseFocusedSuitesAndSharedSupport`
- `swift test --filter ParityGateTests/testPlaywrightTestsAvoidDomForceUnwraps`
- `git diff --check`
