### PR TITLE
Cover real-world action flows

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8625,6 +8625,45 @@
       return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
     }
 
+    function cleanNaturalCommandFragment(value) {
+      return String(value || '')
+        .trim()
+        .replace(/^(?:please\s+)?(?:can\s+you\s+)?(?:could\s+you\s+)?(?:would\s+you\s+)?/i, '')
+        .replace(/[?.!]+$/g, '')
+        .trim();
+    }
+
+    function shellCommandFromPrompt(text) {
+      const quoted = text.match(/`([^`]+)`/)?.[1]?.trim();
+      if (quoted) return quoted;
+
+      const trimmed = String(text || '').trim();
+      if (/^whoami[?.!]?$/i.test(trimmed)) return 'whoami';
+
+      const runMatch = trimmed.match(/^(?:please\s+)?(?:can\s+you\s+)?(?:could\s+you\s+)?(?:would\s+you\s+)?(?:run|execute)\s+(.+)$/i);
+      if (runMatch) return cleanNaturalCommandFragment(runMatch[1]) || 'whoami';
+
+      if (/\bwhoami\b/i.test(trimmed)) return 'whoami';
+      return cleanNaturalCommandFragment(trimmed.replace(/^run\s+/i, '')) || 'whoami';
+    }
+
+    function mockShellOutputForPrompt(command, selectedProject, isRemoteProject) {
+      const cmd = command.trim();
+      if (isRemoteProject) return remoteTerminalOutput(cmd, selectedProject.path, {});
+      return terminalOutput(cmd, state.terminal.cwdLabel || '/mock/QuillCode', {});
+    }
+
+    function fileWriteRequestFromPrompt(text) {
+      if (!/\b(write|make|create)\b.+\bfile\b/i.test(text)) return null;
+      const quoted = text.match(/["“”]([^"“”]+)["“”]/)?.[1]?.trim();
+      const saysMatch = text.match(/\bsays?\s+(.+)$/i)?.[1]?.trim();
+      const content = cleanNaturalCommandFragment(quoted || saysMatch || 'hello world');
+      return {
+        path: 'hello.txt',
+        content: `${content || 'hello world'}\n`
+      };
+    }
+
     function normalizeMockTerminalPath(cwd, target) {
       const segments = target.startsWith('/') ? [] : cwd.split('/').filter(Boolean);
       for (const part of target.split('/')) {
@@ -9670,6 +9709,7 @@
       const selectedProject = state.projects.items.find(project => project.id === state.projects.selectedProjectID);
       const isRemoteProject = Boolean(selectedProject?.isRemote);
       const browserTarget = browserOpenTargetFromPrompt(text);
+      const fileWriteRequest = fileWriteRequestFromPrompt(text);
       if (text.toLowerCase().includes('slow task')) {
         state.composer.isSending = true;
         state.topBar.agentStatus = 'Running';
@@ -9999,10 +10039,10 @@
           outputJSON: JSON.stringify({ ok: true, stdout: `Captured ${path}\n`, artifacts: [path] }, null, 2)
         });
         addMessage('assistant', 'Captured appshot `checkout.appshot.json`.');
-      } else if (text.toLowerCase().includes('write a file') || text.toLowerCase().includes('make a file')) {
-        const path = 'hello.txt';
+      } else if (fileWriteRequest) {
+        const { path, content } = fileWriteRequest;
         if (isRemoteProject) {
-          const cmd = `printf %s ${shellSingleQuoted('hello world\n')} > ${path}`;
+          const cmd = `printf %s ${shellSingleQuoted(content)} > ${path}`;
           addToolCard({
             title: 'host.shell.run',
             subtitle: 'Completed',
@@ -10012,12 +10052,12 @@
           });
           addMessage('assistant', `Wrote \`${path}\` on ${selectedProject.name}.`);
         } else {
-          state.mockFiles[`/mock/QuillCode/${path}`] = 'hello world\n';
+          state.mockFiles[`/mock/QuillCode/${path}`] = content;
           addToolCard({
             title: 'host.file.write',
             subtitle: 'Completed',
             status: 'done',
-            inputJSON: JSON.stringify({ path, content: 'hello world\n' }, null, 2),
+            inputJSON: JSON.stringify({ path, content }, null, 2),
             outputJSON: JSON.stringify({ ok: true, stdout: `Wrote /mock/QuillCode/${path}\n`, artifacts: [`/mock/QuillCode/${path}`] }, null, 2)
           });
           addMessage('assistant', `Wrote \`${path}\`.`);
@@ -10096,10 +10136,8 @@
         });
         addMessage('assistant', stdout.includes('not found') ? 'OpenClaw is not installed.' : `OpenClaw is installed at \`${stdout.trim()}\`.`);
       } else if (text.toLowerCase().includes('run') || text.toLowerCase().includes('whoami')) {
-        const cmd = text.match(/`([^`]+)`/)?.[1] || text.replace(/^run\s+/i, '') || 'whoami';
-        const output = isRemoteProject
-          ? remoteTerminalOutput(cmd.trim(), selectedProject.path, {})
-          : { stdout: 'mock-user\n', stderr: '', exitCode: 0 };
+        const cmd = shellCommandFromPrompt(text);
+        const output = mockShellOutputForPrompt(cmd, selectedProject, isRemoteProject);
         state.review = { ...state.review, files: [], pullRequestThreads: [], subtitle: 'Latest git diff', totalInsertions: 0, totalDeletions: 0, totalHunks: 0 };
         addToolCard({
           title: 'host.shell.run',

--- a/E2E/playwright/tests/real-world-actions.spec.ts
+++ b/E2E/playwright/tests/real-world-actions.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+test('runs natural shell requests immediately with nonempty arguments', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('whoami?');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(1);
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-input')).toContainText('"cmd": "whoami"');
+  await expect(page.getByTestId('tool-card-input')).not.toContainText('{}');
+  await expect(page.getByTestId('tool-card-input')).not.toContainText('whoami?');
+  await expect(page.getByTestId('tool-card-output')).toContainText('mock-user');
+  await expect(page.getByText('You are `mock-user` in this workspace.')).toBeVisible();
+  await expect(page.getByText(/No shell command was specified/i)).toHaveCount(0);
+  await expect(page.getByText(/I'?ll run|I'?ll check|should I|do you want me to/i)).toHaveCount(0);
+
+  await page.getByLabel('Message').fill('Run `ls`');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(2);
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.shell.run');
+  await expect(page.getByTestId('tool-card-input').last()).toContainText('"cmd": "ls"');
+  await expect(page.getByTestId('tool-card-input').last()).not.toContainText('{}');
+  await expect(page.getByTestId('tool-card-output').last()).toContainText('ran: ls');
+  await expect(page.getByText('Output:\nran: ls')).toBeVisible();
+  await expect(page.getByText(/No shell command was specified/i)).toHaveCount(0);
+});
+
+test('writes requested file content immediately without a confirmation loop', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('Can you write a file that says "hello world"');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('message')).toHaveCount(2);
+  await expect(page.getByTestId('tool-card')).toHaveCount(1);
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.file.write');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-input')).toContainText('"path": "hello.txt"');
+  await expect(page.getByTestId('tool-card-input')).toContainText('hello world');
+  await expect(page.getByTestId('tool-card-input')).not.toContainText('{}');
+  await expect(page.getByTestId('tool-card-artifact-label')).toHaveText('hello.txt');
+  await expect(page.getByTestId('tool-card-text-preview-content')).toHaveText('hello world');
+  await expect(page.getByTestId('tool-card-output')).toContainText('/mock/QuillCode/hello.txt');
+  await expect(page.getByText('Wrote `hello.txt`.')).toBeVisible();
+  await expect(page.getByText(/I'?ll write|should I|do you want me to|ok\?/i)).toHaveCount(0);
+});

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -33,6 +33,7 @@ struct ParityFocusedSuiteManifest {
             "testPlaywrightWorkspaceChromeFlowsStayInFocusedSpec",
             "testPlaywrightWorkspaceStateFlowsStayInFocusedSpec",
             "testPlaywrightStatusFlowsStayInFocusedSpec",
+            "testPlaywrightRealWorldActionFlowsStayInFocusedSpec",
             "testPlaywrightShortcutFlowsStayInFocusedSpec",
             "testPlaywrightReviewFlowsStayInFocusedSpec"
         ]),

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -389,6 +389,37 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         }
     }
 
+    func testPlaywrightRealWorldActionFlowsStayInFocusedSpec() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let actionSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("real-world-actions.spec.ts"),
+            encoding: .utf8
+        )
+        let coreSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
+            encoding: .utf8
+        )
+        let artifactSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("artifacts.spec.ts"),
+            encoding: .utf8
+        )
+        let actionFlowNames = [
+            "runs natural shell requests immediately with nonempty arguments",
+            "writes requested file content immediately without a confirmation loop"
+        ]
+
+        XCTAssertTrue(actionSpecText.contains("harnessURL()"), "Focused real-world action flows should reuse the shared harness URL helper.")
+        XCTAssertTrue(actionSpecText.contains("whoami?"), "Focused real-world action flows should cover natural command punctuation.")
+        XCTAssertTrue(actionSpecText.contains("Run `ls`"), "Focused real-world action flows should cover backticked command extraction.")
+        XCTAssertTrue(actionSpecText.contains("No shell command was specified"), "Focused real-world action flows should guard against empty shell argument regressions.")
+        XCTAssertTrue(actionSpecText.contains("confirmation loop"), "Focused real-world action flows should guard against extra acknowledgement turns.")
+        for flowName in actionFlowNames {
+            XCTAssertTrue(actionSpecText.contains(flowName), "\(flowName) should live in real-world-actions.spec.ts.")
+            XCTAssertFalse(coreSpecText.contains(flowName), "\(flowName) should not drift back into core.spec.ts.")
+            XCTAssertFalse(artifactSpecText.contains(flowName), "\(flowName) should not drift back into artifacts.spec.ts.")
+        }
+    }
+
     func testPlaywrightShortcutFlowsStayInFocusedSpec() throws {
         let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
         let shortcutSpecText = try String(

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7758,3 +7758,21 @@ Ready-to-run approval cards now use progressive disclosure: the user sees the de
 Remaining risk:
 
 - This pass is documentation-only after the implementation merge. If tool-card density evolves again, update `ToolCardState` tests, Playwright review tests, the parity matrix, and this audit together.
+
+## 2026-06-27 Real-World Action E2E Coverage Pass
+
+Overall grade after this slice: **A focused browser coverage, A- mock command realism, A parity guard**.
+
+The user-visible regressions around simple shell/file actions needed a focused browser spec instead of relying on broad coverage buried in `core.spec.ts` and `artifacts.spec.ts`. Natural prompts such as `whoami?`, backticked commands such as `Run \`ls\``, and file creation requests now have direct E2E coverage for one-turn execution, nonempty structured arguments, final-answer rendering, and absence of confirmation-loop placeholder responses.
+
+Code quality changes:
+
+- Added `real-world-actions.spec.ts` for high-signal user flows that should never regress silently.
+- Normalized natural shell prompts in the harness so punctuation and polite wrappers do not become literal command text.
+- Routed mock shell prompts through the same terminal-output simulator used by the integrated terminal.
+- Parsed simple file-write requests into a bounded request object instead of relying on a broad string branch.
+- Added a parity gate so the real-world action spec remains focused and keeps guarding against empty shell arguments.
+
+Remaining risk:
+
+- This is deterministic browser harness coverage. The next layer should connect the same scenarios to a mock TrustedRouter transcript parser or live smoke harness so real model output is checked against the same one-turn action contract.


### PR DESCRIPTION
## Summary
- add focused Playwright coverage for natural shell requests and file-write requests completing in one turn
- normalize mock harness shell prompts so punctuation/backticks produce nonempty command arguments
- add a parity gate and audit note for the real-world action coverage

## Validation
- npm test -- tests/real-world-actions.spec.ts
- npm test -- tests/real-world-actions.spec.ts tests/artifacts.spec.ts tests/core.spec.ts --grep "natural shell|requested file|surfaces file artifacts|executes simple command flow"
- npm test
- swift test --filter ParityWorkspaceSurfaceGateTests/testPlaywrightRealWorldActionFlowsStayInFocusedSpec
- swift test --filter ParityGateTests/testParityGatesUseFocusedSuitesAndSharedSupport
- git diff --check