### PR TITLE
Harden interaction target audits

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -583,6 +583,41 @@
     .search-card h2, .search-card p { margin: 0; }
     .settings-card label { display: grid; gap: 6px; color: var(--muted); font-size: 13px; }
     .search-card label { display: grid; gap: 6px; color: var(--muted); font-size: 13px; }
+    .search-card label:has(input[type="checkbox"]),
+    .settings-card label:has(input[type="checkbox"]) {
+      min-height: var(--hit-target);
+      align-items: start;
+      cursor: pointer;
+    }
+    .search-card label:has(input[type="checkbox"]) span,
+    .settings-card label:has(input[type="checkbox"]) span {
+      min-height: var(--hit-target);
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 0 10px;
+      border-radius: 10px;
+      background: rgba(255,255,255,.045);
+      box-shadow: var(--shadow-border);
+      transition-property: box-shadow, background-color;
+      transition-duration: 150ms;
+      transition-timing-function: var(--ease-out);
+    }
+    .search-card label:has(input[type="checkbox"]) span:hover,
+    .settings-card label:has(input[type="checkbox"]) span:hover {
+      background: rgba(255,255,255,.065);
+      box-shadow: var(--shadow-border-hover);
+    }
+    .search-card input[type="checkbox"],
+    .settings-card input[type="checkbox"] {
+      width: 20px;
+      min-width: 20px;
+      height: 20px;
+      min-height: 20px;
+      margin: 0;
+      accent-color: var(--blue);
+      cursor: pointer;
+    }
     .search-card header { display: flex; justify-content: space-between; gap: 16px; align-items: start; }
     .dialog-choice-list { display: grid; gap: 8px; }
     .dialog-choice-list .eyebrow { color: var(--muted); font-size: 11px; font-weight: 800; text-transform: uppercase; letter-spacing: .08em; }
@@ -1044,7 +1079,11 @@
       padding-right: 12px;
     }
     .sidebar-thread-menu {
+      position: relative;
       z-index: 2;
+    }
+    .sidebar-thread-menu[open] {
+      z-index: 20;
     }
     .sidebar-thread-menu summary {
       display: grid;
@@ -1069,6 +1108,7 @@
       position: absolute;
       right: 0;
       top: 46px;
+      z-index: 21;
       min-width: 152px;
       display: grid;
       gap: 4px;

--- a/E2E/playwright/tests/interaction-audit-helpers.ts
+++ b/E2E/playwright/tests/interaction-audit-helpers.ts
@@ -164,12 +164,39 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
       return { hardClipped, rect: visible, scrollClipped };
     }
 
-    function isTopMostAtCenter(element: Element, rect: RectLike) {
-      if (rect.width <= 0 || rect.height <= 0) return false;
-      const centerX = rect.left + rect.width / 2;
-      const centerY = rect.top + rect.height / 2;
-      const topElement = document.elementFromPoint(centerX, centerY);
+    function isPointOwnedBy(element: Element, x: number, y: number) {
+      const topElement = document.elementFromPoint(x, y);
       return topElement === element || Boolean(topElement && element.contains(topElement));
+    }
+
+    function auditSamplePoints(rect: RectLike) {
+      if (rect.width <= 0 || rect.height <= 0) return [];
+      const insetX = Math.min(10, rect.width / 4);
+      const insetY = Math.min(10, rect.height / 4);
+      return [
+        [rect.left + rect.width / 2, rect.top + rect.height / 2],
+        [rect.left + insetX, rect.top + insetY],
+        [rect.right - insetX, rect.top + insetY],
+        [rect.left + insetX, rect.bottom - insetY],
+        [rect.right - insetX, rect.bottom - insetY]
+      ].filter(([x, y]) => (
+        x >= 0
+          && y >= 0
+          && x <= document.documentElement.clientWidth
+          && y <= document.documentElement.clientHeight
+      ));
+    }
+
+    function isTopMostAtCenter(element: Element, rect: RectLike) {
+      const points = auditSamplePoints(rect);
+      const center = points[0];
+      return Boolean(center && isPointOwnedBy(element, center[0], center[1]));
+    }
+
+    function hasReliableClickableInterior(element: Element, rect: RectLike) {
+      const points = auditSamplePoints(rect);
+      if (!points.length) return false;
+      return points.every(([x, y]) => isPointOwnedBy(element, x, y));
     }
 
     function auditReason(element: Element, rect: DOMRect, clipped: VisibleRectResult) {
@@ -186,6 +213,9 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
       if (!isTopMostAtCenter(element, clipped.rect)) {
         reasons.push('center_blocked_or_clipped');
       }
+      if (!hasReliableClickableInterior(element, clipped.rect)) {
+        reasons.push('interior_click_area_blocked');
+      }
       return reasons.join(',');
     }
 
@@ -196,6 +226,27 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
           Math.round(clipped.rect.width) < minimumHitTarget
           || Math.round(clipped.rect.height) < minimumHitTarget
         );
+    }
+
+    function associatedLabel(element: Element) {
+      if (!(element instanceof HTMLInputElement)) return null;
+      if (!['checkbox', 'radio'].includes(element.type)) return null;
+      if (element.closest('label')) return element.closest('label');
+      if (!element.id) return null;
+      return document.querySelector(`label[for="${CSS.escape(element.id)}"]`);
+    }
+
+    function hasAuditedLabelHitTarget(element: Element) {
+      const label = associatedLabel(element);
+      if (!label) return false;
+      const rect = label.getBoundingClientRect();
+      const clipped = visibleRect(label, rect);
+      return isVisible(label, rect)
+        && Math.round(rect.width) >= minimumHitTarget
+        && Math.round(rect.height) >= minimumHitTarget
+        && Math.round(clipped.rect.width) >= minimumHitTarget
+        && Math.round(clipped.rect.height) >= minimumHitTarget
+        && hasReliableClickableInterior(label, clipped.rect);
     }
 
     function labelFor(element: Element) {
@@ -231,7 +282,7 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
       .map(({ clipped, element, rect }) => ({
         clipped,
         element,
-        reason: auditReason(element, rect, clipped),
+        reason: hasAuditedLabelHitTarget(element) ? '' : auditReason(element, rect, clipped),
         rect
       }))
       .filter(({ reason }) => reason.length > 0)

--- a/E2E/playwright/tests/interaction-audit.spec.ts
+++ b/E2E/playwright/tests/interaction-audit.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import {
   clickCommandPaletteCommand,
   clickSidebarTool,
@@ -12,106 +12,179 @@ import {
   expectNoOverlappingInteractiveTargets
 } from './interaction-audit-helpers';
 
+async function expectInteractionTargetsClean(page: Page, label: string) {
+  await expectAllVisibleInteractiveTargets(page, label);
+  await expectNoOverlappingInteractiveTargets(page, label);
+}
+
 test('mock harness audits every visible interactive click target across workspace states', async ({ page }) => {
   await page.goto(harnessURL());
 
-  await expectAllVisibleInteractiveTargets(page, 'initial workspace');
-  await expectNoOverlappingInteractiveTargets(page, 'initial workspace');
+  await expectInteractionTargetsClean(page, 'initial workspace');
+
+  await page.getByLabel('Message').fill('run whoami');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('sidebar-item')).toContainText('run whoami');
+  await expect(page.getByTestId('tool-card').last()).toHaveAttribute('data-status', 'done');
+
+  await page.getByTestId('sidebar-item-actions').first().locator('summary').click();
+  await expect(page.getByTestId('sidebar-item-actions').first()).toHaveAttribute('open', '');
+  await expectInteractionTargetsClean(page, 'sidebar thread action menu');
+  await page.getByTestId('sidebar-item-actions').first().locator('summary').click();
+
+  await page.getByTestId('project-item-actions').first().locator('summary').click();
+  await expect(page.getByTestId('project-item-actions').first()).toHaveAttribute('open', '');
+  await expectInteractionTargetsClean(page, 'project action menu');
+  await page.getByTestId('project-item-actions').first().locator('summary').click();
+
+  await page.getByTestId('sidebar-bulk-action').filter({ hasText: /^Select$/ }).click();
+  await expect(page.getByTestId('sidebar-selection')).toHaveAttribute('data-active', 'true');
+  await expectInteractionTargetsClean(page, 'sidebar bulk selection controls');
+  await expectHitTarget(page.getByTestId('sidebar-select-toggle').first(), 'sidebar selection toggle');
+  await page.getByTestId('sidebar-bulk-action').filter({ hasText: /^Done$/ }).click();
 
   await openTopBarOverflow(page);
   await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');
-  await expectAllVisibleInteractiveTargets(page, 'top-bar overflow menu');
-  await expectNoOverlappingInteractiveTargets(page, 'top-bar overflow menu');
+  await expectInteractionTargetsClean(page, 'top-bar overflow menu');
   await page.getByTestId('top-bar-overflow-button').click();
 
   await page.getByTestId('model-picker-button').click();
   await expect(page.getByTestId('model-browser')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'model picker');
-  await expectNoOverlappingInteractiveTargets(page, 'model picker');
+  await expectInteractionTargetsClean(page, 'model picker');
+  await page.getByTestId('model-search').fill('no model should match this query');
+  await expect(page.getByTestId('model-empty')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'model picker empty search');
   await page.getByTestId('model-picker-button').click();
 
   await openTopBarOverflow(page);
   await page.getByTestId('top-bar-overflow-search').click();
   await expect(page.getByTestId('search-panel')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'search panel');
-  await expectNoOverlappingInteractiveTargets(page, 'search panel');
+  await expectInteractionTargetsClean(page, 'search panel');
   await page.getByTestId('search-close').click();
 
   await openTopBarOverflow(page);
   await page.getByTestId('top-bar-overflow-command-palette').click();
   await expect(page.getByTestId('command-palette-panel')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'command palette');
-  await expectNoOverlappingInteractiveTargets(page, 'command palette');
+  await expectInteractionTargetsClean(page, 'command palette');
   await page.getByTestId('command-palette-close').click();
 
   await openTopBarOverflow(page);
   await page.getByTestId('top-bar-overflow-keyboard-shortcuts').click();
   await expect(page.getByTestId('keyboard-shortcuts-panel')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'keyboard shortcuts panel');
-  await expectNoOverlappingInteractiveTargets(page, 'keyboard shortcuts panel');
+  await expectInteractionTargetsClean(page, 'keyboard shortcuts panel');
   await page.getByTestId('keyboard-shortcuts-close').click();
 
   await openSettings(page);
   await expect(page.getByTestId('settings-panel')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'settings panel');
-  await expectNoOverlappingInteractiveTargets(page, 'settings panel');
+  await expectInteractionTargetsClean(page, 'settings panel');
   await page.getByTestId('settings-cancel').click();
 
   await clickSidebarTool(page, 'browser-button');
   await expect(page.getByTestId('browser-pane')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'browser pane');
-  await expectNoOverlappingInteractiveTargets(page, 'browser pane');
+  await expectInteractionTargetsClean(page, 'browser pane');
 
   await clickSidebarTool(page, 'terminal-button');
   await expect(page.getByTestId('terminal-pane')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'terminal pane');
-  await expectNoOverlappingInteractiveTargets(page, 'terminal pane');
+  await expectInteractionTargetsClean(page, 'terminal pane');
 
   await page.getByTestId('extensions-button').click();
   await expect(page.getByTestId('extensions-pane')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'extensions pane');
-  await expectNoOverlappingInteractiveTargets(page, 'extensions pane');
+  await expectInteractionTargetsClean(page, 'extensions pane');
 
   await page.getByTestId('automations-button').click();
   await expect(page.getByTestId('automations-pane')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'automations pane');
-  await expectNoOverlappingInteractiveTargets(page, 'automations pane');
+  await expectInteractionTargetsClean(page, 'automations pane');
 
   await clickSidebarTool(page, 'command-palette-button');
   await clickCommandPaletteCommand(page, '>create worktree', 'git-worktree-create');
   await expect(page.getByTestId('worktree-create-panel')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'worktree create dialog');
-  await expectNoOverlappingInteractiveTargets(page, 'worktree create dialog');
+  await expectInteractionTargetsClean(page, 'worktree create dialog');
   await page.getByTestId('worktree-dialog-cancel').click();
 
   await clickSidebarTool(page, 'command-palette-button');
   await clickCommandPaletteCommand(page, '>open worktree', 'git-worktree-open');
   await expect(page.getByTestId('worktree-open-panel')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'worktree open dialog');
-  await expectNoOverlappingInteractiveTargets(page, 'worktree open dialog');
+  await expectInteractionTargetsClean(page, 'worktree open dialog');
+  await page.getByTestId('worktree-dialog-cancel').click();
+
+  await clickSidebarTool(page, 'command-palette-button');
+  await clickCommandPaletteCommand(page, '>remove worktree', 'git-worktree-remove');
+  await expect(page.getByTestId('worktree-remove-panel')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'worktree remove dialog');
+  await page.getByTestId('worktree-dialog-cancel').click();
+
+  await clickSidebarTool(page, 'command-palette-button');
+  await clickCommandPaletteCommand(page, '>prune', 'git-worktree-prune');
+  await expect(page.getByTestId('worktree-prune-panel')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'worktree prune dialog');
   await page.getByTestId('worktree-dialog-cancel').click();
 
   await clickSidebarTool(page, 'memories-button');
   await expect(page.getByTestId('memories-pane')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'memories pane');
-  await expectNoOverlappingInteractiveTargets(page, 'memories pane');
+  await expectInteractionTargetsClean(page, 'memories pane');
 
-  await page.getByLabel('Message').fill('git diff');
+  await page.getByLabel('Message').fill('/git');
+  await expect(page.getByTestId('slash-suggestions')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'slash suggestion menu');
+  await page.keyboard.press('Escape');
+  await page.getByLabel('Message').fill('');
+
+  await page.getByLabel('Message').fill('/pr review-threads 123');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('review-pane')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'review pane');
-  await expectNoOverlappingInteractiveTargets(page, 'review pane');
+  await expect(page.getByTestId('pr-review-thread')).toHaveCount(2);
+  await expectInteractionTargetsClean(page, 'review pane');
+  await page.getByTestId('pr-review-thread-reply').first().click();
+  await expect(page.getByTestId('pr-review-thread-reply-form').first()).toBeVisible();
+  await expectInteractionTargetsClean(page, 'review reply form');
+  await page.getByTestId('pr-review-thread-reply-form').first().getByTestId('pr-review-thread-reply-cancel').click();
 
   await page.getByLabel('Message').fill('run whoami');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('tool-card').last()).toHaveAttribute('data-status', 'done');
-  await expectAllVisibleInteractiveTargets(page, 'tool-card transcript');
-  await expectNoOverlappingInteractiveTargets(page, 'tool-card transcript');
+  await expectInteractionTargetsClean(page, 'tool-card transcript');
+
+  await page.evaluate(() => {
+    const harness = window as typeof window & {
+      addToolCard: (card: Record<string, unknown>) => void;
+      render: () => void;
+    };
+    harness.addToolCard({
+      actions: [
+        {
+          id: 'tool-card-action-approve-interaction-audit',
+          kind: 'approve',
+          requestID: 'interaction-audit',
+          style: 'primary',
+          title: 'Run'
+        },
+        {
+          id: 'tool-card-action-deny-interaction-audit',
+          kind: 'deny',
+          requestID: 'interaction-audit',
+          style: 'secondary',
+          title: 'Skip'
+        }
+      ],
+      density: 'peek',
+      id: 'shell-review-interaction-audit',
+      inputJSON: JSON.stringify({ cmd: 'whoami' }, null, 2),
+      isExpanded: false,
+      reviewState: 'ready',
+      status: 'review',
+      subtitle: 'Ready to run · whoami',
+      title: 'host.shell.run'
+    });
+    harness.render();
+  });
+  const actionBar = page.getByTestId('tool-card-actions').last();
+  await expect(actionBar.getByRole('button', { name: 'Run' })).toBeVisible();
+  await expect(actionBar.getByRole('button', { name: 'Skip' })).toBeVisible();
+  await expectInteractionTargetsClean(page, 'tool-card action controls');
 
   await page.keyboard.press('Meta+F');
   await expect(page.getByTestId('find-bar')).toBeVisible();
-  await expectAllVisibleInteractiveTargets(page, 'find bar');
-  await expectNoOverlappingInteractiveTargets(page, 'find bar');
+  await expectInteractionTargetsClean(page, 'find bar');
   await page.getByTestId('find-close').click();
 });
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -134,6 +134,21 @@ Residual risk:
 
 - This still combines source gates with HTML Playwright audits rather than native UI automation measuring the built SwiftUI app. Add native accessibility-frame checks once the packaged app test runner can inspect SwiftUI controls directly.
 
+## 2026-06-27 Reliable Click Target Audit Pass
+
+Overall grade after this slice: **A reliable hit geometry, A overlap detection, A cross-surface coverage**.
+
+The interaction audit now treats click targets as real pointer surfaces instead of only checking their center point. This caught stacked sidebar menus and form controls whose visible checkbox was intentionally smaller than the user-facing label row.
+
+- Sampled center and inset corner points for every visible interactive target so partially blocked controls fail with `interior_click_area_blocked`.
+- Evaluated checkbox and radio controls through their associated label when the label provides the actual 44 px pointer target.
+- Expanded the Playwright interaction sweep across menus, selection controls, empty model search, worktree dialogs, slash suggestions, PR replies, and approval action buttons.
+- Fixed sidebar menu stacking and checkbox row styling in the harness so the visible target and the DOM click target agree.
+
+Residual risk:
+
+- Native SwiftUI hit areas still need direct accessibility-frame automation. The harness now catches the same layout class before it ships through web parity, but packaged native measurement remains a release-gate improvement.
+
 ## 2026-06-27 Model Status Display Pass
 
 Overall grade after this slice: **A user-facing model copy, A formatter ownership, A alias compatibility**.


### PR DESCRIPTION
## Summary
- expand click-target audits to sample center and inset interior points instead of only the center
- treat checkbox/radio inputs as valid when their associated label provides the 44px target
- expand interaction coverage across menus, model search empty state, worktree dialogs, slash suggestions, PR replies, and approval card actions
- fix sidebar action menu stacking and checkbox row hit styling in the harness

## Validation
- npm test -- tests/interaction-audit.spec.ts tests/visual-polish.spec.ts tests/review.spec.ts
- npm test
- swift test --filter ParityHTMLGateTests/testHTMLInteractiveControlsKeepExplicitHitTargets --filter ParityHTMLGateTests/testHTMLInteractiveLinksUseSharedHitTargetPrimitive --filter ParityWorkspaceSettingsSheetGateTests/testNativeCompactPlainControlsKeepExplicitHitTargets
- swift test
- git diff --check