### PR TITLE
Harden real-world shell action recovery

### DIFF
--- a/Sources/QuillCodeAgent/AgentShellCommandRecovery.swift
+++ b/Sources/QuillCodeAgent/AgentShellCommandRecovery.swift
@@ -3,6 +3,108 @@ import QuillCodeCore
 import QuillCodeTools
 
 enum AgentShellCommandRecovery {
+    private static let negativeExecutionIntents = [
+        "do not run",
+        "don't run",
+        "will not run",
+        "won't run",
+        "cannot run",
+        "can't run",
+        "should not run",
+        "do not execute",
+        "don't execute",
+        "will not execute",
+        "won't execute"
+    ]
+    private static let inlineExecutionIntents = [
+        "i'll run",
+        "i’ll run",
+        "i will run",
+        "i'll execute",
+        "i’ll execute",
+        "i will execute",
+        "i'll check",
+        "i’ll check",
+        "i will check",
+        "i am running",
+        "i'm running",
+        "i’m running",
+        "running",
+        "run ",
+        "execute "
+    ]
+    private static let plainExecutionMarkers = [
+        "i'll run ",
+        "i’ll run ",
+        "i will run ",
+        "i'll execute ",
+        "i’ll execute ",
+        "i will execute ",
+        "i'll check ",
+        "i’ll check ",
+        "i will check ",
+        "i am running ",
+        "i'm running ",
+        "i’m running ",
+        "running ",
+        "run ",
+        "execute ",
+        "check "
+    ]
+    private static let standaloneImperativeMarkers = ["run ", "execute ", "check "]
+    private static let plainCommandPlaceholders = [
+        "it",
+        "that",
+        "this",
+        "the command",
+        "a command",
+        "the requested command",
+        "the shell command"
+    ]
+    private static let trailingDiscoursePhrases = [
+        " on the device",
+        " on your device",
+        " for you",
+        " now",
+        " next",
+        " and show",
+        " and report",
+        " and return",
+        " then "
+    ]
+    private static let knownPlainShellCommands: Set<String> = [
+        "awk",
+        "cat",
+        "command",
+        "curl",
+        "date",
+        "df",
+        "du",
+        "echo",
+        "find",
+        "git",
+        "grep",
+        "id",
+        "ls",
+        "make",
+        "mkdir",
+        "node",
+        "npm",
+        "printf",
+        "pwd",
+        "python",
+        "python3",
+        "rg",
+        "sed",
+        "swift",
+        "touch",
+        "uname",
+        "wc",
+        "which",
+        "whoami",
+        "xcodebuild"
+    ]
+
     static func recoveredAction(from text: String) -> AgentAction? {
         guard let command = explicitCommand(from: text) else {
             return nil
@@ -24,7 +126,7 @@ enum AgentShellCommandRecovery {
             }
             return command
         }
-        return nil
+        return plainExecutionCommand(in: text)
     }
 
     private static func inlineCodeSpans(in text: String) -> [(code: String, range: Range<String.Index>)] {
@@ -52,40 +154,98 @@ enum AgentShellCommandRecovery {
         let prefix = text[lowerBound..<index]
             .lowercased()
             .replacingOccurrences(of: "\n", with: " ")
-        let negativeIntents = [
-            "do not run",
-            "don't run",
-            "will not run",
-            "won't run",
-            "cannot run",
-            "can't run",
-            "should not run",
-            "do not execute",
-            "don't execute",
-            "will not execute",
-            "won't execute"
-        ]
-        guard !negativeIntents.contains(where: { prefix.contains($0) }) else {
+        guard !containsNegativeExecutionIntent(prefix) else {
             return false
         }
-        let intents = [
-            "i'll run",
-            "i’ll run",
-            "i will run",
-            "i'll execute",
-            "i’ll execute",
-            "i will execute",
-            "i'll check",
-            "i’ll check",
-            "i will check",
-            "i am running",
-            "i'm running",
-            "i’m running",
-            "running",
-            "run ",
-            "execute "
-        ]
-        return intents.contains { prefix.contains($0) }
+        return inlineExecutionIntents.contains { prefix.contains($0) }
+    }
+
+    private static func plainExecutionCommand(in text: String) -> String? {
+        let compactText = text.replacingOccurrences(of: "\n", with: " ")
+        let lower = compactText.lowercased()
+        guard !containsNegativeExecutionIntent(lower) else {
+            return nil
+        }
+
+        for marker in plainExecutionMarkers {
+            guard let markerRange = lower.range(of: marker) else { continue }
+            guard isPlainExecutionMarkerAllowed(marker, range: markerRange, in: compactText) else {
+                continue
+            }
+            let commandStart = markerRange.upperBound
+            let rawCandidate = String(compactText[commandStart...])
+            let command = trimmedPlainCommand(from: rawCandidate)
+            if isPlausiblePlainCommand(command) {
+                return command
+            }
+        }
+        return nil
+    }
+
+    private static func isPlainExecutionMarkerAllowed(
+        _ marker: String,
+        range: Range<String.Index>,
+        in text: String
+    ) -> Bool {
+        guard standaloneImperativeMarkers.contains(marker) else {
+            return true
+        }
+        let prefix = text[..<range.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
+        return prefix.isEmpty
+    }
+
+    private static func containsNegativeExecutionIntent(_ text: String) -> Bool {
+        negativeExecutionIntents.contains { text.contains($0) }
+    }
+
+    private static func trimmedPlainCommand(from rawCandidate: String) -> String {
+        var candidate = rawCandidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let boundary = sentenceBoundary(in: candidate) {
+            candidate = String(candidate[..<boundary])
+        }
+        candidate = candidate.trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’ "))
+        candidate = trimTrailingDiscourse(from: candidate)
+        return candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func sentenceBoundary(in text: String) -> String.Index? {
+        var index = text.startIndex
+        while index < text.endIndex {
+            guard ".?!".contains(text[index]) else {
+                index = text.index(after: index)
+                continue
+            }
+            let next = text.index(after: index)
+            if next == text.endIndex || text[next].isWhitespace {
+                return index
+            }
+            index = next
+        }
+        return nil
+    }
+
+    private static func trimTrailingDiscourse(from command: String) -> String {
+        var output = command
+        while true {
+            let lower = output.lowercased()
+            guard let phrase = trailingDiscoursePhrases.first(where: { lower.hasSuffix($0) }) else {
+                return output
+            }
+            output.removeLast(phrase.count)
+            output = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static func isPlausiblePlainCommand(_ command: String) -> Bool {
+        guard isPlausibleShellCommand(command) else {
+            return false
+        }
+        let lower = command.lowercased()
+        guard !plainCommandPlaceholders.contains(lower) else {
+            return false
+        }
+        let firstWord = lower.split(separator: " ", maxSplits: 1).first.map(String.init) ?? lower
+        return knownPlainShellCommands.contains(firstWord)
     }
 
     private static func isPlausibleShellCommand(_ command: String) -> Bool {

--- a/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
@@ -12,6 +12,24 @@ final class AgentImmediateActionTests: XCTestCase {
         XCTAssertTrue(result.thread.messages.last?.content.hasPrefix("You are `") == true)
     }
 
+    func testWhoamiQuestionExecutesImmediatelyWithoutConfirmationLoop() async throws {
+        let root = try makeTempDirectory()
+        let result = try await AgentRunner().send("whoami?", in: ChatThread(mode: .auto), workspaceRoot: root)
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertTrue(result.thread.messages.last?.content.hasPrefix("You are `") == true)
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll run") })
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
+
+        let queued = try XCTUnwrap(result.thread.events.first { $0.kind == .toolQueued })
+        let payloadJSON = try XCTUnwrap(queued.payloadJSON)
+        let call = try JSONDecoder().decode(ToolCall.self, from: Data(payloadJSON.utf8))
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
+        XCTAssertEqual(try arguments.requiredString("cmd"), "whoami")
+    }
+
     func testBacktickCommandDoesNotBecomeEmptyToolCall() async throws {
         let root = try makeTempDirectory()
         let result = try await AgentRunner().send("Run `pwd`", in: ChatThread(mode: .auto), workspaceRoot: root)

--- a/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
@@ -125,6 +125,31 @@ final class AgentToolLoopTests: XCTestCase {
         XCTAssertEqual(result.thread.messages.last?.content, "Finished.")
     }
 
+    func testAgentRetriesNonBacktickedPromisedWorkAnswerBeforeFinalizing() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(llm: SequenceLLMClient(actions: [
+            .say("I'll run whoami on the device."),
+            .tool(.init(
+                name: ToolDefinition.shellRun.name,
+                argumentsJSON: ToolArguments.json(["cmd": "whoami"])
+            )),
+            .say("Finished.")
+        ]))
+
+        let result = try await runner.send(
+            "whoami?",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertFalse(result.thread.messages.contains {
+            $0.content.contains("I'll run")
+        })
+        XCTAssertEqual(result.thread.messages.last?.content, "Finished.")
+    }
+
     func testAgentDoesNotRetryInformationalAnswerThatMentionsCapabilities() async throws {
         let root = try makeTempDirectory()
         let runner = AgentRunner(llm: SequenceLLMClient(actions: [

--- a/Tests/QuillCodeAgentTests/TrustedRouterActionParserTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterActionParserTests.swift
@@ -82,6 +82,37 @@ final class TrustedRouterActionParserTests: XCTestCase {
         XCTAssertEqual(try arguments.requiredString("cmd"), "df -h /")
     }
 
+    func testActionParserRecoversNonBacktickedPromisedShellCommand() throws {
+        let action = try AgentActionJSONParser.parse("I'll run whoami on the device.")
+
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected recovered shell tool action")
+        }
+        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(try arguments.requiredString("cmd"), "whoami")
+    }
+
+    func testActionParserRecoversNonBacktickedDiskCheckCommand() throws {
+        let action = try AgentActionJSONParser.parse("I’ll check df -h / now.")
+
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected recovered shell tool action")
+        }
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(try arguments.requiredString("cmd"), "df -h /")
+    }
+
+    func testActionParserPreservesDottedPlainCommands() throws {
+        let action = try AgentActionJSONParser.parse("I'll run curl https://www.linkedin.com.")
+
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected recovered shell tool action")
+        }
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(try arguments.requiredString("cmd"), "curl https://www.linkedin.com")
+    }
+
     func testActionParserRepairsEmptyShellArgumentsFromExplicitNearbyCommand() throws {
         let action = try AgentActionJSONParser.parse("""
         I'll execute `command -v openclaw || which openclaw || echo 'not found'`.
@@ -99,14 +130,45 @@ final class TrustedRouterActionParserTests: XCTestCase {
         )
     }
 
+    func testActionParserRepairsEmptyShellArgumentsFromNonBacktickedNearbyCommand() throws {
+        let action = try AgentActionJSONParser.parse("""
+        I'll run whoami.
+        {"type":"tool","name":"host.shell.run","arguments":{}}
+        """)
+
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected repaired shell tool action")
+        }
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(try arguments.requiredString("cmd"), "whoami")
+    }
+
     func testActionParserDoesNotRecoverPassiveBacktickedTextAsCommand() {
         XCTAssertThrowsError(try AgentActionJSONParser.parse("You can use `whoami` if you want.")) { error in
             XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))
         }
     }
 
+    func testActionParserDoesNotRecoverPlainCommandWithoutExecutionIntent() {
+        XCTAssertThrowsError(try AgentActionJSONParser.parse("You can use whoami if you want.")) { error in
+            XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))
+        }
+    }
+
+    func testActionParserDoesNotRecoverPassivePlainRunSuggestion() {
+        XCTAssertThrowsError(try AgentActionJSONParser.parse("You can run whoami if you want.")) { error in
+            XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))
+        }
+    }
+
     func testActionParserDoesNotRecoverNegativeBacktickedCommandIntent() {
         XCTAssertThrowsError(try AgentActionJSONParser.parse("I will not run `rm -rf /`.")) { error in
+            XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))
+        }
+    }
+
+    func testActionParserDoesNotRecoverPlainNegativeCommandIntent() {
+        XCTAssertThrowsError(try AgentActionJSONParser.parse("I will not run whoami.")) { error in
             XCTAssertTrue(String(describing: error).contains("valid QuillCode action JSON object"))
         }
     }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7791,3 +7791,20 @@ Code quality changes:
 Remaining risk:
 
 - This is deterministic browser harness coverage. The next layer should connect the same scenarios to a mock TrustedRouter transcript parser or live smoke harness so real model output is checked against the same one-turn action contract.
+
+## 2026-06-27 Agent Real-World Action Coverage Pass
+
+Overall grade after this slice: **A parser recovery guardrails, A agent one-turn action coverage, A- model-output tolerance**.
+
+The browser harness now catches simple action regressions at the UI level, but the deeper agent layer still needed direct coverage for malformed model output seen during device testing: `whoami?` should execute immediately, “I'll run whoami” must not become a dead promise, and an empty `host.shell.run` object should be repaired only when a nearby explicit command exists.
+
+Code quality changes:
+
+- Added agent-level coverage for the exact `whoami?` prompt, including inspection of the queued tool payload to require `{"cmd":"whoami"}`.
+- Added parser coverage for non-backticked promised shell commands, disk checks, dotted URL commands, and empty shell-argument repair from nearby plain-text commands.
+- Preserved conservative guardrails for passive suggestions and negative execution intent so the fallback does not turn arbitrary prose into commands.
+- Added an agent-loop regression that keeps non-backticked “I'll run ...” promises out of the transcript before the actual tool executes.
+
+Remaining risk:
+
+- Plain-text command recovery is intentionally narrow and allowlisted. Broader command recovery should come from stronger TrustedRouter structured output and live-model smoke tests, not from making this fallback permissive.


### PR DESCRIPTION
## Summary
- add agent-level coverage for the exact `whoami?` prompt and require queued shell payloads to contain `cmd: whoami`
- recover narrow non-backticked promised shell commands like `I'll run whoami` and `I’ll check df -h /` without accepting passive suggestions
- repair empty `host.shell.run` arguments from nearby explicit plain-text commands and preserve dotted URL commands
- document the real-world action coverage slice in the code-quality audit

## Validation
- `swift test --filter TrustedRouterActionParserTests`
- `swift test --filter AgentImmediateActionTests`
- `swift test --filter AgentToolLoopTests/testAgentRetriesNonBacktickedPromisedWorkAnswerBeforeFinalizing`
- `swift test --filter AgentToolArgumentNormalizerTests`
- `npm test -- tests/real-world-actions.spec.ts` from `E2E/playwright`
- `git diff --check`