### PR TITLE
Cover real device diagnostic prompts

### DIFF
--- a/E2E/playwright/tests/real-world-actions.spec.ts
+++ b/E2E/playwright/tests/real-world-actions.spec.ts
@@ -49,3 +49,34 @@ test('writes requested file content immediately without a confirmation loop', as
   await expect(page.getByText('Wrote `hello.txt`.')).toBeVisible();
   await expect(page.getByText(/I'?ll write|should I|do you want me to|ok\?/i)).toHaveCount(0);
 });
+
+test('answers device diagnostic prompts with concrete shell actions', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('How much hd?');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(1);
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-input')).toContainText('"cmd": "df -h / /Quill 2>/dev/null || df -h /"');
+  await expect(page.getByTestId('tool-card-input')).not.toContainText('{}');
+  await expect(page.getByTestId('tool-card-output')).toContainText('/mock/QuillCode');
+  await expect(page.getByText('Workspace storage: 15% used.')).toBeVisible();
+  await expect(page.getByText(/No shell command was specified/i)).toHaveCount(0);
+  await expect(page.getByText(/I'?ll check|should I|do you want me to/i)).toHaveCount(0);
+
+  await page.getByLabel('Message').fill('Do you have openclaw?');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(2);
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.shell.run');
+  await expect(page.getByTestId('tool-card').last()).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-input').last())
+    .toContainText('"cmd": "command -v openclaw || which openclaw || echo \'not found\'"');
+  await expect(page.getByTestId('tool-card-input').last()).not.toContainText('{}');
+  await expect(page.getByTestId('tool-card-output').last()).toContainText('not found');
+  await expect(page.getByText('OpenClaw is not installed.')).toBeVisible();
+  await expect(page.getByText(/No shell command was specified/i)).toHaveCount(0);
+  await expect(page.getByText(/I'?ll check|should I|do you want me to/i)).toHaveCount(0);
+});

--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -119,6 +119,7 @@ struct StaticSafetyPolicy: Sendable {
     ]
 
     private static let commonDiagnosticTriggers = [
+        "hd",
         "openclaw",
         "whoami",
         "disk",

--- a/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
@@ -22,12 +22,31 @@ final class AgentImmediateActionTests: XCTestCase {
         XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll run") })
         XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
 
-        let queued = try XCTUnwrap(result.thread.events.first { $0.kind == .toolQueued })
-        let payloadJSON = try XCTUnwrap(queued.payloadJSON)
-        let call = try JSONDecoder().decode(ToolCall.self, from: Data(payloadJSON.utf8))
-        let arguments = try ToolArguments(call.argumentsJSON)
-        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
-        XCTAssertEqual(try arguments.requiredString("cmd"), "whoami")
+        XCTAssertEqual(try queuedShellCommand(in: result), "whoami")
+    }
+
+    func testDiskUsageQuestionExecutesImmediately() async throws {
+        let root = try makeTempDirectory()
+        let result = try await AgentRunner().send("How much hd?", in: ChatThread(mode: .auto), workspaceRoot: root)
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        let toolResult = try XCTUnwrap(result.toolResults.first)
+        XCTAssertTrue(toolResult.ok, toolResult.error ?? "")
+        XCTAssertEqual(try queuedShellCommand(in: result), "df -h / /Quill 2>/dev/null || df -h /")
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll check") })
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
+    }
+
+    func testOpenClawDiscoveryExecutesImmediately() async throws {
+        let root = try makeTempDirectory()
+        let result = try await AgentRunner().send("Do you have openclaw?", in: ChatThread(mode: .auto), workspaceRoot: root)
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        let toolResult = try XCTUnwrap(result.toolResults.first)
+        XCTAssertTrue(toolResult.ok, toolResult.error ?? "")
+        XCTAssertEqual(try queuedShellCommand(in: result), "command -v openclaw || which openclaw || echo 'not found'")
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll check") })
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
     }
 
     func testBacktickCommandDoesNotBecomeEmptyToolCall() async throws {
@@ -90,5 +109,14 @@ final class AgentImmediateActionTests: XCTestCase {
         XCTAssertEqual(result.toolResults.count, 1)
         XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
         XCTAssertEqual(result.thread.events.filter { $0.summary.contains("host.git.push") }.count, 3)
+    }
+
+    private func queuedShellCommand(in result: AgentRunResult) throws -> String {
+        let queued = try XCTUnwrap(result.thread.events.first { $0.kind == .toolQueued })
+        let payloadJSON = try XCTUnwrap(queued.payloadJSON)
+        let call = try JSONDecoder().decode(ToolCall.self, from: Data(payloadJSON.utf8))
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
+        return try arguments.requiredString("cmd")
     }
 }

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -180,6 +180,22 @@ final class SafetyTests: XCTestCase {
         XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
     }
 
+    func testAutoApprovesHdDiagnosticShellRunWithoutRunVerb() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"df -h / /Quill 2>/dev/null || df -h /"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "How much hd?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "How much hd?")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
+    }
+
     func testAutoDoesNotTreatDiagnosticRequestAsBlanketIntentForGitPush() async {
         let reviewer = StaticSafetyReviewer()
         let call = ToolCall(name: gitPush.name, argumentsJSON: #"{"remote":"origin"}"#)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7808,3 +7808,19 @@ Code quality changes:
 Remaining risk:
 
 - Plain-text command recovery is intentionally narrow and allowlisted. Broader command recovery should come from stronger TrustedRouter structured output and live-model smoke tests, not from making this fallback permissive.
+
+## 2026-06-27 Device Diagnostic Prompt Coverage Pass
+
+Overall grade after this slice: **A real-device prompt coverage, A agent/browser parity, A DRY test helper**.
+
+The previous real-world action coverage protected `whoami?`, `Run \`ls\``, and file creation. The next user-visible device prompts from Feather testing were disk usage and OpenClaw discovery. Both now have direct browser-harness and agent-level coverage so they cannot regress into empty shell calls, passive promises, or extra confirmation turns.
+
+Code quality changes:
+
+- Added Playwright coverage for `How much hd?` and `Do you have openclaw?` with exact nonempty shell commands, final answer text, and no confirmation-loop copy.
+- Added agent immediate-action tests for disk usage and OpenClaw discovery.
+- Reused a focused `queuedShellCommand` helper to keep command-payload assertions DRY across immediate-action tests.
+
+Remaining risk:
+
+- “Download a site” still needs a product decision: it could mean browser-open, file download into the workspace, or a remote shell `curl`. That should be specified before locking in E2E semantics.


### PR DESCRIPTION
## Summary
- add real-world Playwright coverage for Feather-style `How much hd?` and `Do you have openclaw?` prompts
- add agent immediate-action tests that assert the exact nonempty shell commands
- approve `hd` as a narrow diagnostic trigger so disk usage requests do not get blocked as arbitrary shell actions
- record the coverage pass and remaining download-site product decision in the audit doc

## Validation
- `swift test --filter AgentImmediateActionTests`
- `swift test --filter SafetyTests`
- `cd E2E/playwright && npm test -- tests/real-world-actions.spec.ts`
- `git diff --check`