### PR TITLE
Enforce interaction target contracts

### DIFF
--- a/E2E/playwright/tests/interaction-audit-helpers.ts
+++ b/E2E/playwright/tests/interaction-audit-helpers.ts
@@ -199,8 +199,43 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
       return points.every(([x, y]) => isPointOwnedBy(element, x, y));
     }
 
+    function labelledByText(element: Element) {
+      const labelledBy = element.getAttribute('aria-labelledby');
+      if (!labelledBy) return '';
+      return labelledBy
+        .split(/\s+/)
+        .map((id) => document.getElementById(id)?.textContent || '')
+        .join(' ');
+    }
+
+    function placeholderText(element: Element) {
+      if (
+        element instanceof HTMLInputElement
+        || element instanceof HTMLTextAreaElement
+        || element instanceof HTMLSelectElement
+      ) {
+        return element.getAttribute('placeholder') || element.getAttribute('aria-placeholder') || '';
+      }
+      return '';
+    }
+
+    function accessibleName(element: Element) {
+      const explicitLabel = element.getAttribute('aria-label') || '';
+      const labelledText = labelledByText(element);
+      const title = element.getAttribute('title') || '';
+      const placeholder = placeholderText(element);
+      const visibleText = element.textContent || '';
+      return [explicitLabel, labelledText, title, placeholder, visibleText]
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
     function auditReason(element: Element, rect: DOMRect, clipped: VisibleRectResult) {
       const reasons = [];
+      if (!accessibleName(element)) {
+        reasons.push('missing_accessible_name');
+      }
       if (Math.round(rect.width) < minimumHitTarget || Math.round(rect.height) < minimumHitTarget) {
         reasons.push('too_small');
       }

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+
+final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
+    func testNativeInteractionControlsUseSharedTargetContracts() throws {
+        let sourceFiles = try Self.swiftSourceFiles(in: "Sources/QuillCodeApp")
+        let targetMarkers = [
+            "quillCodeTextButtonTarget",
+            "quillCodeIconButtonTarget",
+            "quillCodeFullRowButtonTarget",
+            "quillCodeCapsuleButtonTarget",
+            "quillCodeFormActionTarget",
+            "quillCodeHitTarget",
+            "quillCodeInteractiveTarget"
+        ]
+        var violations: [String] = []
+
+        for file in sourceFiles {
+            let lines = try String(contentsOf: file, encoding: .utf8)
+                .components(separatedBy: .newlines)
+            let relativePath = file.path.replacingOccurrences(
+                of: Self.packageRoot().path + "/",
+                with: ""
+            )
+
+            for (index, line) in lines.enumerated() {
+                let controlWindow = window(in: lines, around: index, radius: 10)
+                if usesCompactPlatformButtonStyle(line),
+                   !targetMarkers.contains(where: controlWindow.contains) {
+                    violations.append("\(relativePath):\(index + 1) compact platform button style lacks shared hit target")
+                }
+
+                if line.contains(".labelStyle(.iconOnly)"),
+                   !window(in: lines, around: index, radius: 8).contains("quillCodeIconButtonTarget") {
+                    violations.append("\(relativePath):\(index + 1) icon-only control lacks icon hit target")
+                }
+
+                if line.contains(".onTapGesture") || line.contains(".gesture(") {
+                    violations.append("\(relativePath):\(index + 1) gesture-based click target should be a Button or Link")
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "Interactive controls must use shared click-target contracts:\n\(violations.joined(separator: "\n"))"
+        )
+    }
+
+    func testHTMLInteractionAuditRequiresNamedClickableTargets() throws {
+        let auditHelperText = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("E2E/playwright/tests/interaction-audit-helpers.ts"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(
+            auditHelperText.contains("accessibleName(element)")
+                && auditHelperText.contains("missing_accessible_name"),
+            "The rendered click-target audit should fail visible interactive elements that have no user-facing name."
+        )
+        XCTAssertTrue(
+            auditHelperText.contains("button")
+                && auditHelperText.contains("[role=\"button\"]")
+                && auditHelperText.contains("[role=\"tab\"]")
+                && auditHelperText.contains("textarea"),
+            "The rendered click-target audit should cover native controls, ARIA controls, tabs, and text entry."
+        )
+    }
+
+    private func usesCompactPlatformButtonStyle(_ line: String) -> Bool {
+        line.contains(".buttonStyle(.bordered")
+            || line.contains(".buttonStyle(.borderedProminent")
+            || line.contains(".buttonStyle(.borderless")
+            || line.contains(".buttonStyle(.plain")
+    }
+
+    private func window(in lines: [String], around index: Int, radius: Int) -> String {
+        let lowerBound = max(0, index - radius)
+        let upperBound = min(lines.count, index + radius + 1)
+        return lines[lowerBound..<upperBound].joined(separator: "\n")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7824,3 +7824,19 @@ Code quality changes:
 Remaining risk:
 
 - “Download a site” still needs a product decision: it could mean browser-open, file download into the workspace, or a remote shell `curl`. That should be specified before locking in E2E semantics.
+
+## 2026-06-27 Interaction Target Contract Gate
+
+Overall grade after this slice: **A target contract enforcement, A rendered accessibility coverage, A- native pixel measurement**.
+
+The click-target system had good shared primitives and broad Playwright coverage, but it still depended on reviewers noticing new escaped controls. This pass makes the intent fail-fast in tests: compact native button styles, icon-only buttons, and gesture-based interactions now have explicit source gates, and the rendered harness rejects visible click targets that have no user-facing name.
+
+| Principle | Before | After |
+| --- | --- | --- |
+| Minimum hit area | Existing controls mostly used shared 44 pt/px helpers, but future compact `.bordered`, `.plain`, or icon-only controls could bypass the convention. | `ParityInteractionTargetGateTests` scans SwiftUI app sources and fails compact platform button styles without a `quillCode...Target`, icon-only controls without `quillCodeIconButtonTarget`, and gesture-only click handlers. |
+| Accessible targets | The Playwright audit measured size, clipping, center ownership, and overlap, but a nameless visible control could still pass. | `interaction-audit-helpers.ts` now computes accessible names from ARIA, labelled-by text, title, placeholders, and visible text, and fails `missing_accessible_name`. |
+| Future UI slices | Click-target checks were spread across hand-written source assertions plus rendered state audits. | Native source gates and rendered browser audits now cover different failure modes: misuse at code review time and real layout failure at E2E time. |
+
+Remaining risk:
+
+- Native SwiftUI hit boxes are still source-gated rather than pixel-measured in a packaged app. When native UI automation lands, mirror the Playwright visible-rect and overlap checks against the actual macOS/Linux windows.


### PR DESCRIPTION
## Summary
- add a native parity gate that rejects compact SwiftUI controls without shared QuillCode click-target helpers
- make the Playwright interaction audit fail nameless visible interactive controls
- document the interaction-target contract and remaining native pixel-measurement gap

## Validation
- swift test
- npm test
