### PR TITLE
Support explicit domain downloads

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -10053,6 +10053,23 @@
           });
           addMessage('assistant', 'Command failed:\nEnter an http, https, file, localhost, or project file URL.');
         }
+      } else if (text.toLowerCase().includes('download') || text.toLowerCase().includes('fetch')) {
+        const path = 'downloads/linkedin.com.html';
+        const url = 'https://www.linkedin.com';
+        const cmd = `mkdir -p downloads && curl -L --fail --silent --show-error --output '${path}' '${url}' && ls -lh '${path}'`;
+        addToolCard({
+          title: 'host.shell.run',
+          subtitle: 'Completed',
+          status: 'done',
+          inputJSON: JSON.stringify({ cmd }, null, 2),
+          outputJSON: JSON.stringify({
+            ok: true,
+            stdout: `-rw-r--r--  1 mock  staff  42K ${path}\n`,
+            stderr: '',
+            exitCode: 0
+          }, null, 2)
+        });
+        addMessage('assistant', `Downloaded to \`${path}\`.`);
       } else if (text.toLowerCase().includes('pdf') || text.toLowerCase().includes('document artifact')) {
         const path = '/mock/QuillCode/reports/briefing.pdf';
         addToolCard({

--- a/E2E/playwright/tests/real-world-actions.spec.ts
+++ b/E2E/playwright/tests/real-world-actions.spec.ts
@@ -80,3 +80,22 @@ test('answers device diagnostic prompts with concrete shell actions', async ({ p
   await expect(page.getByText(/No shell command was specified/i)).toHaveCount(0);
   await expect(page.getByText(/I'?ll check|should I|do you want me to/i)).toHaveCount(0);
 });
+
+test('downloads requested domains with a bounded concrete shell action', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('Can you download LinkedIn.com?');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card')).toHaveCount(1);
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-input')).toContainText('curl -L --fail --silent --show-error');
+  await expect(page.getByTestId('tool-card-input')).toContainText("--output 'downloads/linkedin.com.html'");
+  await expect(page.getByTestId('tool-card-input')).toContainText('https://www.linkedin.com');
+  await expect(page.getByTestId('tool-card-input')).not.toContainText('{}');
+  await expect(page.getByTestId('tool-card-output')).toContainText('downloads/linkedin.com.html');
+  await expect(page.getByText('Downloaded to `downloads/linkedin.com.html`.')).toBeVisible();
+  await expect(page.getByText(/No shell command was specified/i)).toHaveCount(0);
+  await expect(page.getByText(/I'?ll download|should I|do you want me to|confirm user intent/i)).toHaveCount(0);
+});

--- a/Sources/QuillCodeAgent/AgentShellToolAnswerFormatters.swift
+++ b/Sources/QuillCodeAgent/AgentShellToolAnswerFormatters.swift
@@ -41,6 +41,47 @@ enum AgentShellToolAnswerFormatters {
             return "Disk usage:\n\(AgentToolAnswerFormatters.truncated(output))"
         }
 
+        if isDownloadCommand(lower), let path = downloadedPath(from: normalizedCommand) {
+            if result.ok {
+                return "Downloaded to `\(path)`."
+            }
+            let reason = output.isEmpty ? "the command failed with no output" : AgentToolAnswerFormatters.truncated(output)
+            return "Download failed: \(reason)"
+        }
+
         return nil
+    }
+
+    private static func isDownloadCommand(_ command: String) -> Bool {
+        (command.contains("curl ") || command.hasPrefix("curl"))
+            || (command.contains("wget ") || command.hasPrefix("wget"))
+    }
+
+    private static func downloadedPath(from command: String) -> String? {
+        let patterns = [
+            #"--output\s+('[^']+'|"[^"]+"|\S+)"#,
+            #"\s-o\s+('[^']+'|"[^"]+"|\S+)"#,
+            #">\s*('[^']+'|"[^"]+"|\S+)"#
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                  let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
+                  let range = Range(match.range(at: 1), in: command)
+            else {
+                continue
+            }
+            return unquoted(String(command[range]))
+        }
+        return nil
+    }
+
+    private static func unquoted(_ value: String) -> String {
+        var trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if (trimmed.hasPrefix("'") && trimmed.hasSuffix("'"))
+            || (trimmed.hasPrefix("\"") && trimmed.hasSuffix("\"")) {
+            trimmed.removeFirst()
+            trimmed.removeLast()
+        }
+        return trimmed
     }
 }

--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -77,6 +77,14 @@ public struct MockLLMClient: LLMClient {
             ))
         }
 
+        if let downloadCommand = Self.downloadCommand(from: request, lowercasedRequest: lower),
+           tools.contains(where: { $0.name == ToolDefinition.shellRun.name }) {
+            return .tool(.init(
+                name: ToolDefinition.shellRun.name,
+                argumentsJSON: ToolArguments.json(["cmd": downloadCommand])
+            ))
+        }
+
         if let browserTarget = Self.extractBrowserOpenTarget(from: request, lowercasedRequest: lower),
            tools.contains(where: { $0.name == ToolDefinition.browserOpen.name }) {
             return .tool(.init(
@@ -242,6 +250,26 @@ public struct MockLLMClient: LLMClient {
         return browserTerms && inspectionTerms
     }
 
+    static func downloadCommand(from request: String, lowercasedRequest: String) -> String? {
+        let downloadTerms = [
+            "download ",
+            "save ",
+            "fetch "
+        ]
+        guard downloadTerms.contains(where: { lowercasedRequest.contains($0) }),
+              let target = extractDownloadTarget(from: request)
+        else {
+            return nil
+        }
+        let url = normalizedWebURLString(target)
+        let path = "downloads/\(downloadFileName(for: url))"
+        return [
+            "mkdir -p downloads",
+            "curl -L --fail --silent --show-error --output \(shellSingleQuoted(path)) \(shellSingleQuoted(url))",
+            "ls -lh \(shellSingleQuoted(path))"
+        ].joined(separator: " && ")
+    }
+
     static func extractBrowserOpenTarget(from request: String, lowercasedRequest: String) -> String? {
         let navigationTerms = [
             "open ",
@@ -265,6 +293,18 @@ public struct MockLLMClient: LLMClient {
             .filter { !$0.isEmpty }
 
         return tokens.first(where: looksLikeBrowserTarget)
+    }
+
+    private static func extractDownloadTarget(from request: String) -> String? {
+        if let quoted = firstBacktickQuotedValue(in: request), looksLikeBrowserTarget(quoted) {
+            return quoted
+        }
+        let tokenSeparators = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet(charactersIn: "\"'(),<>[]{}"))
+        return request
+            .components(separatedBy: tokenSeparators)
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: ".:;!?")) }
+            .first(where: looksLikeBrowserTarget)
     }
 
     private static func firstBacktickQuotedValue(in request: String) -> String? {
@@ -291,6 +331,28 @@ public struct MockLLMClient: LLMClient {
             || lower.hasSuffix(".html")
             || lower.hasSuffix(".htm")
             || (lower.contains(".") && !lower.contains("@"))
+    }
+
+    private static func normalizedWebURLString(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.lowercased().hasPrefix("http://") || trimmed.lowercased().hasPrefix("https://") {
+            return trimmed
+        }
+        return "https://\(trimmed)"
+    }
+
+    private static func downloadFileName(for urlString: String) -> String {
+        let url = URL(string: urlString)
+        let host = url?.host?.lowercased().replacingOccurrences(of: "www.", with: "") ?? "download"
+        let lastComponent = url?.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let base = lastComponent.contains(".") ? lastComponent : "\(host).html"
+        let sanitized = base.map { character in
+            character.isLetter || character.isNumber || character == "." || character == "-" || character == "_"
+                ? character
+                : "-"
+        }
+        let filename = String(sanitized).trimmingCharacters(in: CharacterSet(charactersIn: ".-"))
+        return filename.isEmpty ? "download.html" : filename
     }
 
     private static func shellSingleQuoted(_ value: String) -> String {

--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -46,6 +46,7 @@ public struct TrustedRouterPromptBuilder: Sendable {
         - If the user asks to run a command, create a host.shell.run action immediately.
         - host.shell.run MUST include a non-empty "cmd" string. Never emit {} for shell arguments.
         - If the user asks to create or write a file, use host.file.write with non-empty "path" and "content".
+        - If the user asks to download, save, or fetch a URL or domain, use host.shell.run immediately with curl or wget, save into a relative workspace path such as downloads/example.com.html, and do not pipe remote content into a shell.
         - If the user asks to push or publish a git branch, use host.git.push instead of host.shell.run.
         - If the user asks to open or create a pull request/PR, use host.git.pr.create instead of host.shell.run.
         - host.git.pr.create should include a non-empty "title" unless you set "fill": true.

--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -31,6 +31,9 @@ struct StaticSafetyPolicy: Sendable {
         if StaticSafetyPullRequestPolicy.requestMatches(request) {
             return StaticSafetyPullRequestPolicy.intentMatches(request: request, toolName: toolName)
         }
+        if StaticSafetyDownloadPolicy.intentMatches(request: request, context: context) {
+            return true
+        }
         if intentRules.contains(where: { $0.matches(request: request) && $0.allows(toolName: toolName) }) {
             return true
         }
@@ -186,6 +189,14 @@ struct StaticSafetyRequest: Sendable {
             .filter { $0.count >= 3 }
     }
 
+    var requestedDownloadHosts: [String] {
+        let separators = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet(charactersIn: "\"'`()[]{}<>"))
+        return text
+            .components(separatedBy: separators)
+            .compactMap(Self.normalizedHostCandidate)
+    }
+
     func containsAffirmedAny(_ phrases: [String]) -> Bool {
         phrases.contains { containsAffirmed($0) }
     }
@@ -297,6 +308,97 @@ struct StaticSafetyRequest: Sendable {
 
     private static func isClauseBoundary(_ character: Character) -> Bool {
         character == ";" || character == "." || character == "!" || character == "?" || character == "\n"
+    }
+
+    private static func normalizedHostCandidate(_ value: String) -> String? {
+        var candidate = value.trimmingCharacters(in: CharacterSet(charactersIn: ",:;!?"))
+        guard candidate.contains(".") && !candidate.contains("@") else {
+            return nil
+        }
+        if !candidate.contains("://") {
+            candidate = "https://\(candidate)"
+        }
+        guard let host = URL(string: candidate)?.host?.lowercased(),
+              host.contains(".")
+        else {
+            return nil
+        }
+        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+    }
+}
+
+enum StaticSafetyDownloadPolicy {
+    static func intentMatches(request: StaticSafetyRequest, context: SafetyContext) -> Bool {
+        guard context.toolCall.name.contains("shell.run"),
+              request.containsAffirmedAny(["download", "save", "fetch"]),
+              let command = shellCommand(from: context.toolCall)
+        else {
+            return false
+        }
+        let lowerCommand = command.lowercased()
+        guard containsDownloadSegment(lowerCommand),
+              let outputPath = outputPath(from: lowerCommand),
+              isWorkspaceRelativePath(outputPath),
+              !lowerCommand.contains("|")
+        else {
+            return false
+        }
+        let requestedHosts = request.requestedDownloadHosts
+        guard !requestedHosts.isEmpty else {
+            return false
+        }
+        return requestedHosts.contains { host in
+            lowerCommand.contains(host)
+        }
+    }
+
+    private static func shellCommand(from call: ToolCall) -> String? {
+        try? ToolArguments(call.argumentsJSON).requiredString("cmd")
+    }
+
+    private static func containsDownloadSegment(_ command: String) -> Bool {
+        command
+            .components(separatedBy: "&&")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .contains { segment in
+                segment.hasPrefix("curl ") || segment.hasPrefix("wget ")
+            }
+    }
+
+    private static func outputPath(from command: String) -> String? {
+        let patterns = [
+            #"--output\s+('[^']+'|"[^"]+"|\S+)"#,
+            #"\s-o\s+('[^']+'|"[^"]+"|\S+)"#,
+            #">\s*('[^']+'|"[^"]+"|\S+)"#
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                  let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
+                  let range = Range(match.range(at: 1), in: command)
+            else {
+                continue
+            }
+            return unquoted(String(command[range]))
+        }
+        return nil
+    }
+
+    private static func isWorkspaceRelativePath(_ path: String) -> Bool {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty
+            && !trimmed.hasPrefix("/")
+            && !trimmed.hasPrefix("~")
+            && !trimmed.contains("..")
+    }
+
+    private static func unquoted(_ value: String) -> String {
+        var trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if (trimmed.hasPrefix("'") && trimmed.hasSuffix("'"))
+            || (trimmed.hasPrefix("\"") && trimmed.hasSuffix("\"")) {
+            trimmed.removeFirst()
+            trimmed.removeLast()
+        }
+        return trimmed
     }
 }
 

--- a/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
@@ -49,6 +49,32 @@ final class AgentImmediateActionTests: XCTestCase {
         XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
     }
 
+    func testDownloadDomainExecutesImmediatelyWithWorkspaceBoundedPath() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(toolExecutionOverride: { call, _ in
+            guard call.name == ToolDefinition.shellRun.name else { return nil }
+            return ToolResult(
+                ok: true,
+                stdout: "-rw-r--r--  1 mock  staff  42K downloads/linkedin.com.html\n",
+                stderr: "",
+                exitCode: 0
+            )
+        })
+
+        let result = try await runner.send("Can you download LinkedIn.com?", in: ChatThread(mode: .auto), workspaceRoot: root)
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        let toolResult = try XCTUnwrap(result.toolResults.first)
+        XCTAssertTrue(toolResult.ok, toolResult.error ?? "")
+        XCTAssertEqual(
+            try queuedShellCommand(in: result),
+            "mkdir -p downloads && curl -L --fail --silent --show-error --output 'downloads/linkedin.com.html' 'https://LinkedIn.com' && ls -lh 'downloads/linkedin.com.html'"
+        )
+        XCTAssertEqual(result.thread.messages.last?.content, "Downloaded to `downloads/linkedin.com.html`.")
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll download") })
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
+    }
+
     func testBacktickCommandDoesNotBecomeEmptyToolCall() async throws {
         let root = try makeTempDirectory()
         let result = try await AgentRunner().send("Run `pwd`", in: ChatThread(mode: .auto), workspaceRoot: root)

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -10,6 +10,8 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         XCTAssertTrue(prompt.contains("canonical argument keys"))
         XCTAssertTrue(prompt.contains("do not use \"command\""))
         XCTAssertTrue(prompt.contains("Do not say \"I'll do it\""))
+        XCTAssertTrue(prompt.contains("save into a relative workspace path"))
+        XCTAssertTrue(prompt.contains("do not pipe remote content into a shell"))
     }
 
     func testMessagesIncludeProjectInstructionsAsSystemContext() {

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -196,6 +196,70 @@ final class SafetyTests: XCTestCase {
         XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
     }
 
+    func testAutoApprovesExplicitFileDownloadShellRun() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"mkdir -p downloads && curl -L --fail --silent --show-error --output 'downloads/linkedin.com.html' 'https://www.linkedin.com' && ls -lh 'downloads/linkedin.com.html'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download LinkedIn.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
+    }
+
+    func testAutoDoesNotUseDownloadIntentForUnrelatedShellRun() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"rm -rf build"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download LinkedIn.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
+    }
+
+    func testAutoDoesNotApproveDownloadForDifferentDomain() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"curl -L --output 'downloads/evil.example.html' 'https://evil.example'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download LinkedIn.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
+    }
+
+    func testAutoDoesNotApproveDownloadOutsideWorkspace() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"curl -L --output '/tmp/linkedin.html' 'https://www.linkedin.com'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download LinkedIn.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
+    }
+
     func testAutoDoesNotTreatDiagnosticRequestAsBlanketIntentForGitPush() async {
         let reviewer = StaticSafetyReviewer()
         let call = ToolCall(name: gitPush.name, argumentsJSON: #"{"remote":"origin"}"#)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7823,7 +7823,7 @@ Code quality changes:
 
 Remaining risk:
 
-- “Download a site” still needs a product decision: it could mean browser-open, file download into the workspace, or a remote shell `curl`. That should be specified before locking in E2E semantics.
+- “Download a site” is now specified in the follow-up pass as a workspace-bounded file download into `downloads/`; keep browser navigation requests separate from file download requests.
 
 ## 2026-06-27 Interaction Target Contract Gate
 
@@ -7840,3 +7840,21 @@ The click-target system had good shared primitives and broad Playwright coverage
 Remaining risk:
 
 - Native SwiftUI hit boxes are still source-gated rather than pixel-measured in a packaged app. When native UI automation lands, mirror the Playwright visible-rect and overlap checks against the actual macOS/Linux windows.
+
+## 2026-06-27 Explicit Download Prompt Coverage Pass
+
+Overall grade after this slice: **A- real-world download behavior, A safety specificity, A prompt/test alignment**.
+
+The phone-visible `Can you download LinkedIn.com?` failure needed a product-level decision. QuillCode now treats explicit `download`, `save`, or `fetch` requests for a URL/domain as a workspace-bounded file download: use `curl`/`wget`, write under a relative path such as `downloads/linkedin.com.html`, and present a concise final answer with the saved path. Browser navigation remains separate: prompts like `open LinkedIn.com` still route to browser-open semantics.
+
+Code quality changes:
+
+- Added TrustedRouter prompt guidance for safe URL/domain downloads, including relative workspace paths and no remote-content shell piping.
+- Added mock planner support for deterministic download commands so local and browser tests exercise the intended one-turn behavior.
+- Added a specific static safety mini-policy that approves only matching curl/wget file downloads for the requested host, while rejecting unrelated shell commands or domain mismatches.
+- Added final-answer formatting for successful shell downloads so users see `Downloaded to ...` instead of raw `ls` output.
+- Added native and Playwright coverage guarding against empty shell arguments, passive confirmation loops, and scary confirmation copy for explicit downloads.
+
+Remaining risk:
+
+- Live TrustedRouter models can still choose a different safe file name or command variant. The safety policy allows common curl/wget output forms, but live smoke coverage should keep checking that model output stays bounded and useful.


### PR DESCRIPTION
## Summary
- define explicit URL/domain download prompts as workspace-bounded file downloads under `downloads/`
- update TrustedRouter prompt guidance and the deterministic mock planner for one-turn download actions
- add a specific static safety policy for curl/wget file downloads matching the requested host while rejecting unrelated commands, domain mismatches, and non-workspace output paths
- format shell download results as a clear final chat answer
- add native and Playwright real-world coverage for `Can you download LinkedIn.com?`

## Validation
- `swift test --filter AgentImmediateActionTests`
- `swift test --filter SafetyTests`
- `swift test --filter TrustedRouterPromptBuilderTests/testPromptRequiresNonEmptyShellCommand`
- `cd E2E/playwright && npm test -- tests/real-world-actions.spec.ts`
- `git diff --check`