### PR TITLE
Add responsiveness budget coverage

### DIFF
--- a/E2E/playwright/tests/responsiveness.spec.ts
+++ b/E2E/playwright/tests/responsiveness.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect, type Page } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+async function now(page: Page) {
+  return page.evaluate(() => performance.now());
+}
+
+test('workspace becomes interactive quickly on first load', async ({ page }) => {
+  const start = Date.now();
+  await page.goto(harnessURL());
+  await expect(page.getByLabel('Message')).toBeEnabled();
+  await expect(page.getByTestId('top-bar-title')).toBeVisible();
+  await expect(page.getByTestId('sidebar')).toBeVisible();
+
+  expect(Date.now() - start).toBeLessThan(1800);
+});
+
+test('simple one-turn shell action completes within the interaction budget', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('whoami?');
+  const start = await now(page);
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByText('You are `mock-user` in this workspace.')).toBeVisible();
+  const elapsed = (await now(page)) - start;
+
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  expect(elapsed).toBeLessThan(700);
+});
+
+test('stop responds quickly while a slow tool is running', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('slow task');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('agent-status')).toHaveText('Running');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'running');
+
+  const start = await now(page);
+  await page.getByTestId('top-bar-stop-button').click();
+  await expect(page.getByTestId('agent-status')).toHaveText('Stopped');
+  const elapsed = (await now(page)) - start;
+
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'failed');
+  expect(elapsed).toBeLessThan(500);
+});
+
+test('tool-card expand and collapse keeps layout stable', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('Can you download LinkedIn.com?');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+
+  const before = await page.evaluate(() => ({
+    scrollX: window.scrollX,
+    viewportWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth
+  }));
+
+  const details = page.getByTestId('tool-card-details');
+  const start = await now(page);
+  await details.locator('summary').click();
+  await expect.poll(() => details.evaluate(element => (element as HTMLDetailsElement).open)).toBe(true);
+  await details.locator('summary').click();
+  await expect.poll(() => details.evaluate(element => (element as HTMLDetailsElement).open)).toBe(false);
+  const elapsed = (await now(page)) - start;
+
+  const after = await page.evaluate(() => ({
+    scrollX: window.scrollX,
+    viewportWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth
+  }));
+  expect(after.scrollX).toBe(before.scrollX);
+  expect(after.scrollWidth).toBeLessThanOrEqual(after.viewportWidth + 1);
+  expect(elapsed).toBeLessThan(700);
+});

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSurfaceGateTests.swift
@@ -420,6 +420,40 @@ final class ParityWorkspaceSurfaceGateTests: QuillCodeParityTestCase {
         }
     }
 
+    func testPlaywrightResponsivenessBudgetsStayInFocusedSpec() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let responsivenessSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("responsiveness.spec.ts"),
+            encoding: .utf8
+        )
+        let coreSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("core.spec.ts"),
+            encoding: .utf8
+        )
+        let chromeSpecText = try String(
+            contentsOf: testRoot.appendingPathComponent("workspace-chrome.spec.ts"),
+            encoding: .utf8
+        )
+        let responsivenessFlowNames = [
+            "workspace becomes interactive quickly on first load",
+            "simple one-turn shell action completes within the interaction budget",
+            "stop responds quickly while a slow tool is running",
+            "tool-card expand and collapse keeps layout stable"
+        ]
+
+        XCTAssertTrue(responsivenessSpecText.contains("harnessURL()"), "Focused responsiveness flows should reuse the shared harness URL helper.")
+        XCTAssertTrue(responsivenessSpecText.contains("performance.now()"), "Responsiveness budgets should use browser timing for interaction measurements.")
+        XCTAssertTrue(responsivenessSpecText.contains("toBeLessThan(1800)"), "First-load interactivity should keep an explicit CI-stable budget.")
+        XCTAssertTrue(responsivenessSpecText.contains("toBeLessThan(700)"), "Simple tool and reflow interactions should keep explicit CI-stable budgets.")
+        XCTAssertTrue(responsivenessSpecText.contains("toBeLessThan(500)"), "Stop latency should keep an explicit CI-stable budget.")
+        XCTAssertTrue(responsivenessSpecText.contains("scrollWidth"), "Responsiveness coverage should guard against layout overflow after interaction.")
+        for flowName in responsivenessFlowNames {
+            XCTAssertTrue(responsivenessSpecText.contains(flowName), "\(flowName) should live in responsiveness.spec.ts.")
+            XCTAssertFalse(coreSpecText.contains(flowName), "\(flowName) should not drift back into core.spec.ts.")
+            XCTAssertFalse(chromeSpecText.contains(flowName), "\(flowName) should not drift back into workspace-chrome.spec.ts.")
+        }
+    }
+
     func testPlaywrightShortcutFlowsStayInFocusedSpec() throws {
         let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
         let shortcutSpecText = try String(

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7858,3 +7858,20 @@ Code quality changes:
 Remaining risk:
 
 - Live TrustedRouter models can still choose a different safe file name or command variant. The safety policy allows common curl/wget output forms, but live smoke coverage should keep checking that model output stays bounded and useful.
+
+## 2026-06-27 Responsiveness Budget E2E Pass
+
+Overall grade after this slice: **A- responsiveness coverage, A CI-stable budgets, A- native measurement gap**.
+
+QuillCode had broad UI coverage, but it lacked explicit speed and reflow budgets for interactions users feel immediately: first-load interactivity, simple one-turn tool completion, stop latency, and tool-card expand/collapse stability. This pass adds focused Playwright coverage with generous CI-stable thresholds so obvious jank regressions fail before they reach users.
+
+Code quality changes:
+
+- Added `responsiveness.spec.ts` with budgets for first load, one-turn shell completion, slow-task stop response, and tool-card expand/collapse.
+- Reused the shared `harnessURL()` helper and real harness interactions instead of synthetic DOM mutation.
+- Checked no horizontal overflow and stable scroll position after expand/collapse.
+- Added a Swift parity gate so responsiveness budgets stay in their focused spec instead of drifting into broad smoke tests.
+
+Remaining risk:
+
+- These are harness-level browser timings, not packaged native-window measurements. Native macOS/Linux UI automation should mirror these once available.


### PR DESCRIPTION
## Summary
- add focused Playwright responsiveness budgets for first-load interactivity, simple one-turn shell completion, stop latency, and tool-card expand/collapse reflow
- add a Swift parity gate so these real-world timing flows stay in `responsiveness.spec.ts`
- document the slice in the code quality audit

## Validation
- `npm test -- tests/responsiveness.spec.ts`
- `swift test --filter ParityWorkspaceSurfaceGateTests/testPlaywrightResponsivenessBudgetsStayInFocusedSpec`
- `git diff --check`