### PR TITLE
Add live TrustedRouter smoke script

### DIFF
--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7875,3 +7875,21 @@ Code quality changes:
 Remaining risk:
 
 - These are harness-level browser timings, not packaged native-window measurements. Native macOS/Linux UI automation should mirror these once available.
+
+## 2026-06-27 Live TrustedRouter Smoke Pass
+
+Overall grade after this slice: **A- real-provider coverage, A secret hygiene, B+ live-flake containment**.
+
+The deterministic mock and Playwright suites now catch many user-visible action regressions, but they still cannot prove that a live TrustedRouter model returns structured QuillCode actions under current prompt wording. This pass adds an explicit opt-in live smoke script instead of folding paid/network work into every PR.
+
+Code quality changes:
+
+- Added `scripts/live-tr-smoke.sh`, which reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile` without printing secrets.
+- Defaulted the live smoke to the user-facing `deepseekv4flash` alias and normalize it to `deepseek/deepseek-v4-flash` for the CLI call.
+- Exercised real `quill-code --live` flows for an exact backticked shell command and a natural `whoami?` diagnostic.
+- Made the script fail on the exact regressions seen in device testing: empty shell arguments, passive “I’ll run...” answers, empty stdout, or missing expected command output.
+- Documented the live smoke as an opt-in release/prompt/parser/safety gate in `docs/TEST_PLAN.md`.
+
+Remaining risk:
+
+- Live provider behavior can be flaky or rate-limited. Keep this out of normal PR gates unless a stable CI secret, retry policy, and provider budget are explicitly configured.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -71,6 +71,7 @@ Drive the QuillCode test harness with mock LLM:
 ## Native Smoke Tests
 
 - `./scripts/smoke.sh` runs Swift tests, mock CLI `run whoami`, mock CLI file creation in a temp workspace, and Playwright E2E when local node modules are installed.
+- `./scripts/live-tr-smoke.sh` is the opt-in real TrustedRouter smoke. It reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`, defaults to the cheap `deepseekv4flash` alias, runs through `quill-code --live`, and fails on empty shell arguments, passive “I’ll run...” answers, missing command output, or unreadable live errors.
 - Packaged macOS and Linux app launch.
 - Login/dev override.
 - Open repo, chat, run `whoami`, create file, confirm the created file appears as a tool-card artifact and text preview, capture or mock a screenshot artifact and confirm the image preview renders, confirm raw successful-tool details can be opened, review diff, add an SSH Remote, run a noninteractive remote terminal `pwd` smoke, then run `cd` plus `export` and confirm the next remote terminal command inherits both.
@@ -82,6 +83,7 @@ Drive the QuillCode test harness with mock LLM:
 - GitHub Actions runs macOS `swift test` and the app-level Linux-conditional guard on each push and PR.
 - GitHub Actions runs Playwright mock-LLM E2E for core agent, tools, approvals, settings, top bar, and browser harness on each push and PR.
 - GitHub Actions runs `./scripts/smoke.sh` from a clean checkout after installing E2E dependencies.
+- Live TrustedRouter smoke is not required for normal PRs; run `./scripts/live-tr-smoke.sh` before releases, model-prompt changes, parser changes, or safety-review changes when a local or CI secret is available.
 - All unit tests pass on macOS and Linux before a stable release.
 - Native app smoke tests pass on packaged macOS and Linux builds.
 - No app target contains `#if linux`; CI enforces this.

--- a/scripts/live-tr-smoke.sh
+++ b/scripts/live-tr-smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/quillcode-live-smoke.XXXXXX")"
+SMOKE_HOME="$SMOKE_ROOT/home"
+SMOKE_WORKSPACE="$SMOKE_ROOT/workspace"
+KEY_FILE="${QUILLCODE_LIVE_KEY_FILE:-$HOME/.quill.code.keyfile}"
+RAW_MODEL="${QUILLCODE_LIVE_MODEL:-deepseekv4flash}"
+BASE_URL="${QUILLCODE_LIVE_BASE_URL:-https://api.trustedrouter.com/v1}"
+
+case "$RAW_MODEL" in
+  deepseekv4flash|deepseek-v4-flash)
+    MODEL="deepseek/deepseek-v4-flash"
+    ;;
+  *)
+    MODEL="$RAW_MODEL"
+    ;;
+esac
+
+cleanup() {
+  rm -rf "$SMOKE_ROOT"
+}
+trap cleanup EXIT
+
+trim() {
+  awk '{$1=$1; print}'
+}
+
+configured_key() {
+  if [[ -n "${QUILLCODE_API_KEY:-}" ]]; then
+    printf '%s' "$QUILLCODE_API_KEY" | trim
+    return
+  fi
+  if [[ -n "${TRUSTEDROUTER_API_KEY:-}" ]]; then
+    printf '%s' "$TRUSTEDROUTER_API_KEY" | trim
+    return
+  fi
+  if [[ -f "$KEY_FILE" ]]; then
+    trim < "$KEY_FILE"
+    return
+  fi
+}
+
+API_KEY="$(configured_key || true)"
+if [[ -z "$API_KEY" ]]; then
+  echo "No TrustedRouter key found. Set QUILLCODE_API_KEY, TRUSTEDROUTER_API_KEY, or create $KEY_FILE." >&2
+  exit 2
+fi
+
+mkdir -p "$SMOKE_HOME" "$SMOKE_WORKSPACE"
+cd "$ROOT_DIR"
+
+run_live_prompt() {
+  local prompt="$1"
+  local output_file="$2"
+  local stderr_file="$3"
+
+  swift run quill-code \
+    --live \
+    --api-key "$API_KEY" \
+    --base-url "$BASE_URL" \
+    --model "$MODEL" \
+    --home "$SMOKE_HOME" \
+    --cwd "$SMOKE_WORKSPACE" \
+    "$prompt" \
+    >"$output_file" \
+    2>"$stderr_file"
+}
+
+assert_useful_output() {
+  local output_file="$1"
+  local stderr_file="$2"
+  local expected="$3"
+
+  if [[ ! -s "$output_file" ]]; then
+    echo "live smoke returned no stdout" >&2
+    cat "$stderr_file" >&2 || true
+    exit 1
+  fi
+  if grep -qi "No shell command was specified" "$output_file"; then
+    echo "live smoke regressed into an empty shell command" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+  if grep -Eq "I'?ll (run|check|do)" "$output_file"; then
+    echo "live smoke returned a passive promise instead of executing" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+  if ! grep -Fq "$expected" "$output_file"; then
+    echo "live smoke output did not contain expected text: $expected" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+}
+
+echo "==> Running live TrustedRouter shell-action smoke with $MODEL"
+RUN_OUTPUT="$SMOKE_ROOT/run.stdout"
+RUN_ERROR="$SMOKE_ROOT/run.stderr"
+run_live_prompt "Run \`printf quillcode_live_smoke\`" "$RUN_OUTPUT" "$RUN_ERROR"
+assert_useful_output "$RUN_OUTPUT" "$RUN_ERROR" "quillcode_live_smoke"
+
+echo "==> Running live TrustedRouter diagnostic-question smoke with $MODEL"
+DIAG_OUTPUT="$SMOKE_ROOT/diag.stdout"
+DIAG_ERROR="$SMOKE_ROOT/diag.stderr"
+run_live_prompt "whoami?" "$DIAG_OUTPUT" "$DIAG_ERROR"
+assert_useful_output "$DIAG_OUTPUT" "$DIAG_ERROR" "$(id -un)"
+
+echo "QuillCode live TrustedRouter smoke passed."


### PR DESCRIPTION
## Summary
- add an opt-in live TrustedRouter smoke script for real model/action-path checks
- read keys from `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile` without printing secrets
- document when to run live smoke separately from default deterministic CI

## Validation
- `./scripts/live-tr-smoke.sh`
- `bash -n scripts/live-tr-smoke.sh`
- `git diff --check`