### PR TITLE
Extend live smoke to file writes

### DIFF
--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7925,3 +7925,20 @@ Code quality changes:
 Remaining risk:
 
 - Live provider behavior can be flaky or rate-limited. Keep this out of normal PR gates unless a stable CI secret, retry policy, and provider budget are explicitly configured.
+
+## 2026-06-27 Live File-Write Smoke Pass
+
+Overall grade after this slice: **A- live write-path coverage, A bounded workspace safety, B+ provider-output variability**.
+
+The first live TrustedRouter smoke proved real shell/diagnostic actions, but it still did not cover the user-visible “make a file” workflow that previously regressed into passive promises and empty tool calls. This pass extends the opt-in smoke to require a real temp-workspace file write with exact content verification.
+
+Code quality changes:
+
+- Split live smoke assertions into reusable output-regression checks and expected-output checks.
+- Added a live prompt for `live-smoke.txt` with exact content, then verified the file exists under the temp workspace and contains only the requested content.
+- Kept the write path bounded to a temporary workspace so the smoke tests real model/tool behavior without touching user files.
+- Updated the test plan so release and prompt/parser changes include live write-path validation.
+
+Remaining risk:
+
+- Live file-write behavior can still vary by model. If a model writes a safe alternate file path, the smoke should fail intentionally because the product contract for this prompt is an exact requested path.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -71,7 +71,7 @@ Drive the QuillCode test harness with mock LLM:
 ## Native Smoke Tests
 
 - `./scripts/smoke.sh` runs Swift tests, mock CLI `run whoami`, mock CLI file creation in a temp workspace, and Playwright E2E when local node modules are installed.
-- `./scripts/live-tr-smoke.sh` is the opt-in real TrustedRouter smoke. It reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`, defaults to the cheap `deepseekv4flash` alias, runs through `quill-code --live`, and fails on empty shell arguments, passive “I’ll run...” answers, missing command output, or unreadable live errors.
+- `./scripts/live-tr-smoke.sh` is the opt-in real TrustedRouter smoke. It reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`, defaults to the cheap `deepseekv4flash` alias, runs through `quill-code --live`, and fails on empty shell arguments, passive “I’ll run...” answers, missing command output, unreadable live errors, or a model-planned file write that does not actually create the requested temp-workspace file.
 - Packaged macOS and Linux app launch.
 - Login/dev override.
 - Open repo, chat, run `whoami`, create file, confirm the created file appears as a tool-card artifact and text preview, capture or mock a screenshot artifact and confirm the image preview renders, confirm raw successful-tool details can be opened, review diff, add an SSH Remote, run a noninteractive remote terminal `pwd` smoke, then run `cd` plus `export` and confirm the next remote terminal command inherits both.

--- a/scripts/live-tr-smoke.sh
+++ b/scripts/live-tr-smoke.sh
@@ -73,6 +73,18 @@ assert_useful_output() {
   local stderr_file="$2"
   local expected="$3"
 
+  assert_no_action_regression "$output_file" "$stderr_file"
+  if ! grep -Fq "$expected" "$output_file"; then
+    echo "live smoke output did not contain expected text: $expected" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+}
+
+assert_no_action_regression() {
+  local output_file="$1"
+  local stderr_file="$2"
+
   if [[ ! -s "$output_file" ]]; then
     echo "live smoke returned no stdout" >&2
     cat "$stderr_file" >&2 || true
@@ -88,9 +100,25 @@ assert_useful_output() {
     cat "$output_file" >&2
     exit 1
   fi
-  if ! grep -Fq "$expected" "$output_file"; then
-    echo "live smoke output did not contain expected text: $expected" >&2
-    cat "$output_file" >&2
+}
+
+assert_workspace_file_contains_exactly() {
+  local relative_path="$1"
+  local expected_content="$2"
+  local file_path="$SMOKE_WORKSPACE/$relative_path"
+
+  if [[ ! -f "$file_path" ]]; then
+    echo "live smoke did not create expected workspace file: $relative_path" >&2
+    find "$SMOKE_WORKSPACE" -maxdepth 2 -type f -print >&2
+    exit 1
+  fi
+
+  local actual_content
+  actual_content="$(tr -d '\r' < "$file_path")"
+  actual_content="${actual_content%$'\n'}"
+  if [[ "$actual_content" != "$expected_content" ]]; then
+    echo "live smoke file content mismatch for $relative_path" >&2
+    printf 'expected: %s\nactual: %s\n' "$expected_content" "$actual_content" >&2
     exit 1
   fi
 }
@@ -106,5 +134,12 @@ DIAG_OUTPUT="$SMOKE_ROOT/diag.stdout"
 DIAG_ERROR="$SMOKE_ROOT/diag.stderr"
 run_live_prompt "whoami?" "$DIAG_OUTPUT" "$DIAG_ERROR"
 assert_useful_output "$DIAG_OUTPUT" "$DIAG_ERROR" "$(id -un)"
+
+echo "==> Running live TrustedRouter file-write smoke with $MODEL"
+FILE_OUTPUT="$SMOKE_ROOT/file.stdout"
+FILE_ERROR="$SMOKE_ROOT/file.stderr"
+run_live_prompt "Create \`live-smoke.txt\` in this workspace with exactly this content: \`quillcode_live_file_smoke\`." "$FILE_OUTPUT" "$FILE_ERROR"
+assert_no_action_regression "$FILE_OUTPUT" "$FILE_ERROR"
+assert_workspace_file_contains_exactly "live-smoke.txt" "quillcode_live_file_smoke"
 
 echo "QuillCode live TrustedRouter smoke passed."


### PR DESCRIPTION
## Summary
- extend the opt-in live TrustedRouter smoke to cover an actual temp-workspace file write
- split reusable live-smoke output regression checks from expected-output checks
- document the live write-path release/prompt/parser validation

## Validation
- `./scripts/live-tr-smoke.sh`
- `bash -n scripts/live-tr-smoke.sh`
- `git diff --check`