### PR TITLE
Harden promised work and click targets

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -2775,6 +2775,13 @@
       .topbar-cluster {
         flex-wrap: wrap;
       }
+      .browser-form {
+        grid-template-columns: minmax(0, 1fr) auto;
+      }
+      .browser-nav-controls {
+        grid-column: 1 / -1;
+        grid-template-columns: repeat(3, var(--hit-target)) minmax(72px, 1fr);
+      }
       .message, .tool-card { max-width: 100%; width: 100%; }
     }
   </style>

--- a/E2E/playwright/tests/interaction-audit.spec.ts
+++ b/E2E/playwright/tests/interaction-audit.spec.ts
@@ -242,3 +242,48 @@ test('mock harness keeps secondary pane actions at least 44px', async ({ page })
   await expectHitTarget(page.getByTestId('automation-primary-action'), 'automation primary action button');
   await expectHitTarget(page.getByTestId('automation-delete'), 'automation delete button');
 });
+
+test('mock harness audits compact viewport click targets across primary states', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(harnessURL());
+
+  await expectInteractionTargetsClean(page, 'compact initial workspace');
+
+  await openTopBarOverflow(page);
+  await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');
+  await expectInteractionTargetsClean(page, 'compact top-bar overflow menu');
+  await page.getByTestId('top-bar-overflow-button').click();
+
+  await page.getByTestId('model-picker-button').click();
+  await expect(page.getByTestId('model-browser')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'compact model picker');
+  await page.getByTestId('model-picker-button').click();
+
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-search').click();
+  await expect(page.getByTestId('search-panel')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'compact search panel');
+  await page.getByTestId('search-close').click();
+
+  await openSettings(page);
+  await expect(page.getByTestId('settings-panel')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'compact settings panel');
+  await page.getByTestId('settings-cancel').click();
+
+  await page.getByLabel('Message').fill('run whoami');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card').last()).toHaveAttribute('data-status', 'done');
+  await expectInteractionTargetsClean(page, 'compact tool-card transcript');
+
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-command-palette').click();
+  await clickCommandPaletteCommand(page, '>terminal', 'toggle-terminal');
+  await expect(page.getByTestId('terminal-pane')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'compact terminal pane');
+
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-command-palette').click();
+  await clickCommandPaletteCommand(page, '>browser', 'toggle-browser');
+  await expect(page.getByTestId('browser-pane')).toBeVisible();
+  await expectInteractionTargetsClean(page, 'compact browser pane');
+});

--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -22,12 +22,15 @@ public protocol StreamingLLMClient: LLMClient {
 
 public enum AgentError: Error, CustomStringConvertible {
     case emptyStreamingResponse
+    case promisedWorkWithoutToolAction
     case tooManyToolSteps(Int)
 
     public var description: String {
         switch self {
         case .emptyStreamingResponse:
             return "The model stream finished without returning an action."
+        case .promisedWorkWithoutToolAction:
+            return "The model promised to perform work but did not return a tool action."
         case .tooManyToolSteps(let limit):
             return "The agent reached the tool-step limit (\(limit)) before returning a final answer."
         }
@@ -62,6 +65,7 @@ public typealias AgentToolExecutionOverride = @Sendable (ToolCall, URL) async ->
 public struct AgentRunner: Sendable {
     public static let streamingNotice = "Streaming model response"
     public static let defaultMaxToolSteps = 6
+    private static let promisedWorkCorrectionLimit = 2
 
     public var llm: LLMClient
     public var safety: SafetyReviewer
@@ -192,25 +196,51 @@ public struct AgentRunner: Sendable {
         userMessage: String,
         tools: [ToolDefinition]
     ) async throws -> AgentAction {
-        guard case .say(let text) = action,
-              AgentPromisedWorkGuard.shouldRequestCorrection(for: text, tools: tools)
-        else {
-            return action
+        var candidate = action
+        var retryThread = thread
+        for _ in 0..<Self.promisedWorkCorrectionLimit {
+            guard case .say(let text) = candidate,
+                  AgentPromisedWorkGuard.shouldRequestCorrection(for: text, tools: tools)
+            else {
+                return candidate
+            }
+
+            if let recovered = Self.recoveredPromisedWorkAction(from: text, tools: tools) {
+                return recovered
+            }
+
+            let correctionPrompt = AgentPromisedWorkGuard.correctionPrompt(
+                assistantText: text,
+                userMessage: userMessage
+            )
+            retryThread.messages.append(.init(role: .assistant, content: text))
+            retryThread.messages.append(.init(role: .user, content: correctionPrompt))
+            retryThread.updatedAt = Date()
+            candidate = try await llm.nextAction(
+                thread: retryThread,
+                userMessage: correctionPrompt,
+                tools: tools
+            )
         }
 
-        let correctionPrompt = AgentPromisedWorkGuard.correctionPrompt(
-            assistantText: text,
-            userMessage: userMessage
-        )
-        var retryThread = thread
-        retryThread.messages.append(.init(role: .assistant, content: text))
-        retryThread.messages.append(.init(role: .user, content: correctionPrompt))
-        retryThread.updatedAt = Date()
-        return try await llm.nextAction(
-            thread: retryThread,
-            userMessage: correctionPrompt,
-            tools: tools
-        )
+        if case .say(let text) = candidate,
+           AgentPromisedWorkGuard.shouldRequestCorrection(for: text, tools: tools) {
+            throw AgentError.promisedWorkWithoutToolAction
+        }
+        return candidate
+    }
+
+    private static func recoveredPromisedWorkAction(
+        from text: String,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard let action = try? AgentActionJSONParser.parse(text),
+              case .tool(let call) = action,
+              tools.contains(where: { $0.name == call.name })
+        else {
+            return nil
+        }
+        return action
     }
 
     private func nextAction(

--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -43,9 +43,9 @@ public struct TrustedRouterPromptBuilder: Sendable {
         - Use the exact tool names and canonical argument keys from the tool schemas below.
         - For shell commands, the argument key is "cmd"; do not use "command", "script", or top-level arguments.
         - For file writes, the argument keys are "path" and "content"; do not use "filename" or "text".
-        - If the user asks to run a command, create a host.shell.run action immediately.
+        - If the user asks to run a command, create a host.shell.run action immediately. Do not answer first with "I'll run ...".
         - host.shell.run MUST include a non-empty "cmd" string. Never emit {} for shell arguments.
-        - If the user asks to create or write a file, use host.file.write with non-empty "path" and "content".
+        - If the user asks to create or write a file, use host.file.write with non-empty "path" and "content". Do not answer first with "I'll create ...".
         - If the user asks to download, save, or fetch a URL or domain, use host.shell.run immediately with curl or wget, save into a relative workspace path such as downloads/example.com.html, and do not pipe remote content into a shell.
         - If the user asks to push or publish a git branch, use host.git.push instead of host.shell.run.
         - If the user asks to open or create a pull request/PR, use host.git.pr.create instead of host.shell.run.
@@ -64,7 +64,8 @@ public struct TrustedRouterPromptBuilder: Sendable {
         - If the user asks to resolve or unresolve an inline pull request/PR review thread, use host.git.pr.review_thread with "threadId" and "action" equal to "resolve" or "unresolve".
         - If the user asks to merge or auto-merge a pull request/PR, use host.git.pr.merge with optional "selector", "method" ("squash", "merge", or "rebase"), "auto", and "deleteBranch".
         - host.git.pr.view, host.git.pr.checks, host.git.pr.diff, host.git.pr.checkout, host.git.pr.reviewers, host.git.pr.labels, host.git.pr.comment, host.git.pr.review, host.git.pr.review_comment, host.git.pr.review_reply, host.git.pr.review_threads, and host.git.pr.merge may omit "selector" for the current branch, or include a PR number, URL, or branch as "selector".
-        - Do not say "I'll do it" unless you are returning the tool call that does it.
+        - If an action can be taken now, do not answer in future tense; return the tool action first, then summarize after the tool result.
+        - Do not say "I'll do it", "I'll run ...", "I'll check ...", or "I'll create ..." unless you are returning the tool call that does it in the same JSON action.
         - Keep commands bounded to the current project unless the user explicitly asks otherwise.
         - After a tool output is provided, return a concise final {"type":"say","text":"..."} answer if the request is satisfied.
         - If the tool output shows more work is needed, return the next tool call. Do not repeat the exact same tool call unless the output shows a transient failure worth retrying.

--- a/Sources/QuillCodeApp/QuillCodeBrowserPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserPaneView.swift
@@ -38,6 +38,27 @@ struct QuillCodeBrowserPaneView: View {
     }
 
     private var navigationBar: some View {
+        ViewThatFits(in: .horizontal) {
+            horizontalNavigationBar
+            compactNavigationBar
+        }
+    }
+
+    private var horizontalNavigationBar: some View {
+        HStack(spacing: 8) {
+            browserNavigationControls
+            browserAddressControls
+        }
+    }
+
+    private var compactNavigationBar: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            browserNavigationControls
+            browserAddressControls
+        }
+    }
+
+    private var browserNavigationControls: some View {
         HStack(spacing: 8) {
             browserNavigationButton(
                 systemName: "chevron.left",
@@ -60,19 +81,24 @@ struct QuillCodeBrowserPaneView: View {
             ) {
                 onCommand("browser-reload")
             }
-            TextField("localhost:3000, docs/page.html, or https://example.com", text: $addressDraft)
-                .textFieldStyle(.roundedBorder)
-                .onSubmit(onOpen)
-                .frame(minHeight: QuillCodeMetrics.minimumHitTarget)
-            Button("Open", action: onOpen)
-                .quillCodeTextButtonTarget()
-                .disabled(addressDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             if let onOpenSession {
                 Button("Session", action: onOpenSession)
                     .quillCodeTextButtonTarget(minWidth: 84)
                     .disabled(!browser.canOpen && browser.currentURL == nil)
                     .help("Open a visible browser session using QuillCode's persistent browser profile.")
             }
+        }
+    }
+
+    private var browserAddressControls: some View {
+        HStack(spacing: 8) {
+            TextField("localhost:3000, docs/page.html, or https://example.com", text: $addressDraft)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(onOpen)
+                .frame(maxWidth: .infinity, minHeight: QuillCodeMetrics.minimumHitTarget)
+            Button("Open", action: onOpen)
+                .quillCodeTextButtonTarget()
+                .disabled(addressDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -214,6 +214,11 @@ struct QuillCodeTranscriptView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
+                    .quillCodeFullRowButtonTarget(
+                        minHeight: 72,
+                        alignment: .center,
+                        radius: 14
+                    )
                     .quillCodeSurface(
                         fill: QuillCodePalette.panel.opacity(0.62),
                         radius: 14,

--- a/Sources/QuillCodeApp/WorkspaceHTMLBrowserRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLBrowserRenderer.swift
@@ -11,16 +11,18 @@ enum WorkspaceHTMLBrowserRenderer {
             <strong>Browser</strong>
             <span data-testid="browser-status-label">\(escape(browser.statusLabel))</span>
           </header>
-          <form data-testid="browser-form">
-            <button type="button" data-testid="browser-back" \(browser.canGoBack ? "" : "disabled")>Back</button>
-            <button type="button" data-testid="browser-forward" \(browser.canGoForward ? "" : "disabled")>Forward</button>
-            <button type="button" data-testid="browser-reload" \(browser.canReload ? "" : "disabled")>Reload</button>
-            <input aria-label="Browser address" value="\(escape(browser.addressDraft))">
-            <button type="submit" data-testid="browser-open" \(browser.canOpen ? "" : "disabled")>Open</button>
+          <form class="browser-form" data-testid="browser-form">
+            <div class="browser-nav-controls" aria-label="Browser navigation">
+              <button class="browser-nav-button" type="button" data-testid="browser-back" aria-label="Back" \(browser.canGoBack ? "" : "disabled")>Back</button>
+              <button class="browser-nav-button" type="button" data-testid="browser-forward" aria-label="Forward" \(browser.canGoForward ? "" : "disabled")>Forward</button>
+              <button class="browser-nav-button" type="button" data-testid="browser-reload" aria-label="Reload" \(browser.canReload ? "" : "disabled")>Reload</button>
+            </div>
+            <input data-testid="browser-address" aria-label="Browser address" value="\(escape(browser.addressDraft))">
+            <button class="browser-open-button" type="submit" data-testid="browser-open" \(browser.canOpen ? "" : "disabled")>Open</button>
           </form>
           \(preview)
-          <form data-testid="browser-comment-form">
-            <input aria-label="Browser comment" placeholder="Add browser comment">
+          <form class="browser-comment-form" data-testid="browser-comment-form">
+            <input data-testid="browser-comment-input" aria-label="Browser comment" placeholder="Add browser comment">
             <button type="submit" data-testid="browser-add-comment" \(browser.currentURL == nil ? "disabled" : "")>Comment</button>
           </form>
           <div data-testid="browser-comments">

--- a/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
@@ -197,6 +197,34 @@ final class AgentStreamingTests: XCTestCase {
         })
     }
 
+    func testStreamingPromisedShellTextRecoversWithoutVisibleDraftOrCorrectionPrompt() async throws {
+        let root = try makeTempDirectory()
+        let recorder = ProgressRecorder()
+        let runner = AgentRunner(llm: StreamingActionLLMClient(chunks: [
+            #"{"type":"say","text":"I'll"#,
+            #" run whoami on the device."}"#
+        ]))
+
+        let result = try await runner.send(
+            "whoami?",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root,
+            onProgress: { thread in
+                await recorder.record(thread)
+            }
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll run") })
+        XCTAssertTrue(result.thread.messages.last?.content.hasPrefix("You are `") == true)
+
+        let progressMessages = await recorder.messageContents()
+        XCTAssertFalse(progressMessages.contains { snapshot in
+            snapshot.contains { $0.contains("I'll run") }
+        })
+    }
+
     private func waitUntil(
         timeoutSeconds: TimeInterval,
         condition: @escaping () async -> Bool

--- a/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
@@ -100,15 +100,11 @@ final class AgentToolLoopTests: XCTestCase {
         ])
     }
 
-    func testAgentRetriesPromisedWorkAnswerBeforeFinalizing() async throws {
+    func testAgentRecoversBacktickedPromisedWorkAnswerBeforeFinalizing() async throws {
         let root = try makeTempDirectory()
         let runner = AgentRunner(llm: SequenceLLMClient(actions: [
             .say("I'll run `whoami` on the device."),
-            .tool(.init(
-                name: ToolDefinition.shellRun.name,
-                argumentsJSON: ToolArguments.json(["cmd": "whoami"])
-            )),
-            .say("Finished.")
+            .say("Done after running whoami.")
         ]))
 
         let result = try await runner.send(
@@ -122,18 +118,15 @@ final class AgentToolLoopTests: XCTestCase {
         XCTAssertFalse(result.thread.messages.contains {
             $0.content.contains("I'll run")
         })
-        XCTAssertEqual(result.thread.messages.last?.content, "Finished.")
+        XCTAssertFalse(result.toolResults[0].stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        XCTAssertEqual(result.thread.messages.last?.content, "Done after running whoami.")
     }
 
-    func testAgentRetriesNonBacktickedPromisedWorkAnswerBeforeFinalizing() async throws {
+    func testAgentRecoversNonBacktickedPromisedWorkAnswerBeforeFinalizing() async throws {
         let root = try makeTempDirectory()
         let runner = AgentRunner(llm: SequenceLLMClient(actions: [
             .say("I'll run whoami on the device."),
-            .tool(.init(
-                name: ToolDefinition.shellRun.name,
-                argumentsJSON: ToolArguments.json(["cmd": "whoami"])
-            )),
-            .say("Finished.")
+            .say("Done after running whoami.")
         ]))
 
         let result = try await runner.send(
@@ -147,7 +140,55 @@ final class AgentToolLoopTests: XCTestCase {
         XCTAssertFalse(result.thread.messages.contains {
             $0.content.contains("I'll run")
         })
-        XCTAssertEqual(result.thread.messages.last?.content, "Finished.")
+        XCTAssertFalse(result.toolResults[0].stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        XCTAssertEqual(result.thread.messages.last?.content, "Done after running whoami.")
+    }
+
+    func testAgentRecoversComplexBacktickedPromisedShellAnswerBeforeFinalizing() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(
+            llm: SequenceLLMClient(actions: [
+                .say("I'll execute `command -v definitely_missing_quillcode_binary || echo not found`."),
+                .say("Done after checking the command.")
+            ]),
+            safety: AlwaysApprovingSafetyReviewer()
+        )
+
+        let result = try await runner.send(
+            "Do you have definitely_missing_quillcode_binary?",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertFalse(result.thread.messages.contains {
+            $0.content.contains("I'll execute")
+        })
+        XCTAssertEqual(result.toolResults[0].stdout.trimmingCharacters(in: .whitespacesAndNewlines), "not found")
+        XCTAssertEqual(result.thread.messages.last?.content, "Done after checking the command.")
+    }
+
+    func testAgentDoesNotFinalizeRepeatedPromisedWorkAnswers() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(llm: SequenceLLMClient(actions: [
+            .say("I'll check the disk usage now."),
+            .say("I'll check the disk usage now."),
+            .say("I'll check the disk usage now.")
+        ]))
+
+        do {
+            _ = try await runner.send(
+                "How much disk is used?",
+                in: ChatThread(mode: .auto),
+                workspaceRoot: root
+            )
+            XCTFail("Expected repeated promised work to throw.")
+        } catch AgentError.promisedWorkWithoutToolAction {
+            // Expected: do not leak another fake final answer into the transcript.
+        } catch {
+            XCTFail("Expected promisedWorkWithoutToolAction, got \(error).")
+        }
     }
 
     func testAgentDoesNotRetryInformationalAnswerThatMentionsCapabilities() async throws {

--- a/Tests/QuillCodeAppTests/WorkspaceBrowserIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceBrowserIntegrationTests.swift
@@ -360,9 +360,11 @@ final class WorkspaceBrowserIntegrationTests: XCTestCase {
 
         XCTAssertTrue(html.contains(#"data-testid="browser-pane""#))
         XCTAssertTrue(html.contains(#"data-testid="browser-preview""#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-back" disabled"#))
-        XCTAssertTrue(html.contains(#"data-testid="browser-forward" disabled"#))
+        XCTAssertTrue(html.contains(#"class="browser-nav-controls" aria-label="Browser navigation""#))
+        XCTAssertTrue(html.contains(#"class="browser-nav-button" type="button" data-testid="browser-back" aria-label="Back" disabled"#))
+        XCTAssertTrue(html.contains(#"class="browser-nav-button" type="button" data-testid="browser-forward" aria-label="Forward" disabled"#))
         XCTAssertTrue(html.contains(#"data-testid="browser-reload" "#))
+        XCTAssertTrue(html.contains(#"data-testid="browser-address" aria-label="Browser address""#))
         XCTAssertTrue(html.contains(#"data-testid="browser-current-url""#))
         XCTAssertTrue(html.contains(#"data-testid="browser-snapshot""#))
         XCTAssertTrue(html.contains(#"data-testid="browser-source""#))

--- a/Tests/QuillCodeParityTests/ParityHTMLGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityHTMLGateTests.swift
@@ -269,6 +269,7 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
 
     func testHTMLInteractiveControlsKeepExplicitHitTargets() throws {
         let primitivesText = try Self.appSourceText(named: "WorkspaceHTMLPrimitives.swift")
+        let browserText = try Self.appSourceText(named: "WorkspaceHTMLBrowserRenderer.swift")
         let toolCardText = try Self.appSourceText(named: "WorkspaceHTMLToolCardRenderer.swift")
         let reviewText = try Self.appSourceText(named: "WorkspaceHTMLReviewRenderer.swift")
         let secondaryText = try Self.appSourceText(named: "WorkspaceHTMLSecondaryPaneRenderer.swift")
@@ -321,6 +322,14 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
             "Memory edit buttons should keep the shared memory action class."
         )
         XCTAssertTrue(
+            browserText.contains(#"class="browser-form""#)
+                && browserText.contains(#"class="browser-nav-controls""#)
+                && browserText.contains(#"class="browser-nav-button""#)
+                && browserText.contains(#"class="browser-open-button""#)
+                && browserText.contains(#"data-testid="browser-address""#),
+            "Browser controls should keep named classes and address test IDs so compact hit-target CSS and audits cannot silently regress."
+        )
+        XCTAssertTrue(
             harnessText.contains(".interactive-hit-target"),
             "The Playwright harness should size semantic non-button click targets explicitly."
         )
@@ -364,6 +373,13 @@ final class ParityHTMLGateTests: QuillCodeParityTestCase {
             harnessText.contains(".extension-card button")
                 && harnessText.contains("min-width: 72px;"),
             "Extension action controls should keep explicit text-button targets in the harness."
+        )
+        XCTAssertTrue(
+            harnessText.contains(".browser-nav-button")
+                && harnessText.contains(".browser-open-button")
+                && harnessText.contains("@media (max-width: 760px)")
+                && harnessText.contains("grid-template-columns: repeat(3, var(--hit-target)) minmax(72px, 1fr);"),
+            "Browser nav controls should have explicit compact target CSS instead of relying on cramped grid auto sizing."
         )
         XCTAssertTrue(
             harnessText.contains(#"class="artifact-chip interactive-hit-target""#),

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
@@ -29,6 +29,11 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
                     violations.append("\(relativePath):\(index + 1) compact platform button style lacks shared hit target")
                 }
 
+                if line.contains(".buttonStyle(QuillCodePressableButtonStyle())"),
+                   !targetMarkers.contains(where: window(in: lines, around: index, radius: 18).contains) {
+                    violations.append("\(relativePath):\(index + 1) pressable button lacks explicit shared hit target")
+                }
+
                 if line.contains(".labelStyle(.iconOnly)"),
                    !window(in: lines, around: index, radius: 8).contains("quillCodeIconButtonTarget") {
                     violations.append("\(relativePath):\(index + 1) icon-only control lacks icon hit target")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,37 @@
 # Code Quality Audit
 
+## 2026-06-27 Promised Work Execution Hardening
+
+Overall grade after this slice: **A action reliability, A streaming behavior, A- model prompt dependence**.
+
+Codex-style interaction breaks down when the assistant says it will do work and then waits for the user to ask again. The agent already corrected a narrow version of this, but the correction path still depended on a single follow-up and did not directly recover explicit shell promises from `say` actions.
+
+- Promised `say` actions like `I'll run whoami` are now parsed into `host.shell.run` before asking the model for a correction.
+- Correction is bounded and repeated promised-work answers now fail as a model-action error instead of becoming a fake final answer.
+- Streaming promised-work drafts stay hidden while the final parsed action can still recover and execute the shell command.
+- The TrustedRouter system prompt now explicitly forbids future-tense action answers when a tool action can be returned immediately.
+
+Residual risk:
+
+- This recovery only handles explicit shell-command promises. Natural-language promises like `I'll check disk usage` still depend on the correction prompt producing a concrete tool call. Broader intent-to-tool planning should stay in the model/tool planner rather than growing ad hoc command heuristics.
+
+## 2026-06-27 Click Target Re-Architecture Pass
+
+Overall grade after this slice: **A native target contracts, A compact viewport coverage, A- native pixel smoke coverage**.
+
+Click targets need to be treated as a product invariant, not as incidental padding. The existing 44 px HTML audit was valuable, but it only covered the default desktop flow and the native source gate did not require every pressable SwiftUI control to declare an explicit target contract.
+
+| Before | After |
+| --- | --- |
+| The empty-state starter cards relied on `QuillCodePressableButtonStyle` to provide target size indirectly. | Starter cards now declare a centered full-row target with a 72 px minimum height and the same 14 px radius as the visible card. |
+| Native source gates only checked compact platform button styles and icon-only labels. | The parity gate now also rejects any `QuillCodePressableButtonStyle` control that lacks a nearby shared hit-target modifier. |
+| The broad Playwright interaction audit ran only through the default desktop workspace states. | Added a compact 390 x 844 audit that exercises top-bar overflow, model picker, search, settings, tool cards, terminal, and browser pane targets. |
+| The browser address field could collapse to 32 px wide on compact layouts because navigation, address, and Open controls were forced into one row. | Browser navigation wraps on compact layouts, preserving a full-width address target while keeping nav buttons at 44 px. Native SwiftUI uses `ViewThatFits` to choose the same desktop-vs-compact structure. |
+
+Residual risk:
+
+- Pixel-perfect native target verification still depends on source gates plus SwiftUI smoke until a packaged native UI automation layer can inspect rendered SwiftUI hit regions directly.
+
 ## 2026-06-27 Browser Navigation Shortcut Pass
 
 Overall grade after this slice: **A shortcut contract, A native/menu parity, A regression coverage**.


### PR DESCRIPTION
## Summary
- Recover promised shell work into concrete tool calls before the model can finalize with “I’ll run/check/create…” text.
- Tighten TrustedRouter prompting around immediate shell/file/download actions and non-empty shell args.
- Re-think click targets as a system: explicit starter-card full-row targets, stricter native parity gates, named browser toolbar target classes, and compact viewport Playwright audits.
- Fix compact browser layout so nav controls keep 44px targets and the address field no longer collapses beside browser buttons.

## Verification
- `swift test` -> 1349 passed
- `npm test` in `E2E/playwright` -> 88 passed
- `scripts/smoke.sh` -> QuillCode smoke passed
- Captured compact UI screenshot: `.artifacts/quillcode-click-targets-compact.png` locally
