### PR TITLE
Assert live smoke transcript integrity

### DIFF
--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7942,3 +7942,20 @@ Code quality changes:
 Remaining risk:
 
 - Live file-write behavior can still vary by model. If a model writes a safe alternate file path, the smoke should fail intentionally because the product contract for this prompt is an exact requested path.
+
+## 2026-06-27 Live Transcript Integrity Smoke Pass
+
+Overall grade after this slice: **A live transcript evidence, A regression detection, B+ external tool dependency**.
+
+The live smoke now proves the user-visible results and the actual persisted thread evidence. This closes a gap where a smoke could pass from stdout alone while saved transcripts still carried malformed, empty, failed, or passive action records.
+
+Code quality changes:
+
+- Added `jq` availability checking to the live smoke because transcript inspection needs structured JSON parsing.
+- Added transcript integrity checks across all saved live-smoke threads: at least one queued tool call per thread, nonempty tool names, nonempty JSON argument objects, no tool failures, successful completed tool results, and no persisted assistant “I’ll run/check/do” or empty-shell-command copy.
+- Kept detailed failure output bounded to the relevant saved thread titles, messages, and events so live-smoke failures are actionable without printing secrets.
+- Updated the test plan to treat persisted transcript integrity as part of live release/prompt/parser validation.
+
+Remaining risk:
+
+- This still runs through the CLI, not the packaged native SwiftUI window. Native smoke should eventually inspect the same transcript evidence after a real app run.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -71,7 +71,7 @@ Drive the QuillCode test harness with mock LLM:
 ## Native Smoke Tests
 
 - `./scripts/smoke.sh` runs Swift tests, mock CLI `run whoami`, mock CLI file creation in a temp workspace, and Playwright E2E when local node modules are installed.
-- `./scripts/live-tr-smoke.sh` is the opt-in real TrustedRouter smoke. It reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`, defaults to the cheap `deepseekv4flash` alias, runs through `quill-code --live`, and fails on empty shell arguments, passive “I’ll run...” answers, missing command output, unreadable live errors, or a model-planned file write that does not actually create the requested temp-workspace file.
+- `./scripts/live-tr-smoke.sh` is the opt-in real TrustedRouter smoke. It reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`, defaults to the cheap `deepseekv4flash` alias, runs through `quill-code --live`, and fails on empty shell arguments, passive “I’ll run...” answers, missing command output, unreadable live errors, model-planned file writes that do not actually create the requested temp-workspace file, or persisted transcripts that lack nonempty queued tool calls and successful completed tool results.
 - Packaged macOS and Linux app launch.
 - Login/dev override.
 - Open repo, chat, run `whoami`, create file, confirm the created file appears as a tool-card artifact and text preview, capture or mock a screenshot artifact and confirm the image preview renders, confirm raw successful-tool details can be opened, review diff, add an SSH Remote, run a noninteractive remote terminal `pwd` smoke, then run `cd` plus `export` and confirm the next remote terminal command inherits both.

--- a/scripts/live-tr-smoke.sh
+++ b/scripts/live-tr-smoke.sh
@@ -18,10 +18,19 @@ case "$RAW_MODEL" in
     ;;
 esac
 
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required tool not found: $1" >&2
+    exit 2
+  fi
+}
+
 cleanup() {
   rm -rf "$SMOKE_ROOT"
 }
 trap cleanup EXIT
+
+require_tool jq
 
 trim() {
   awk '{$1=$1; print}'
@@ -123,6 +132,54 @@ assert_workspace_file_contains_exactly() {
   fi
 }
 
+assert_saved_transcripts_are_actionable() {
+  local threads_dir="$SMOKE_HOME/threads"
+
+  if [[ ! -d "$threads_dir" ]]; then
+    echo "live smoke did not persist any thread directory" >&2
+    exit 1
+  fi
+
+  local thread_count
+  thread_count="$(find "$threads_dir" -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')"
+  if [[ "$thread_count" -lt 3 ]]; then
+    echo "live smoke expected at least 3 persisted thread transcripts, found $thread_count" >&2
+    find "$threads_dir" -maxdepth 1 -type f -name '*.json' -print >&2
+    exit 1
+  fi
+
+  jq -s -e '
+    def queued_calls:
+      [.events[]? | select(.kind == "toolQueued") | .payloadJSON | fromjson];
+    def queued_arguments:
+      [queued_calls[] | .argumentsJSON | fromjson];
+    def completed_results:
+      [.events[]? | select(.kind == "toolCompleted") | .payloadJSON | fromjson];
+    def bad_assistant_promises:
+      [.messages[]?
+        | select(.role == "assistant")
+        | .content
+        | select(test("No shell command was specified|I'\''?ll (run|check|do)"; "i"))];
+
+    all(.[]; (
+      (.messages | length) >= 2
+      and (bad_assistant_promises | length) == 0
+      and (queued_calls | length) >= 1
+      and (queued_arguments | length) == (queued_calls | length)
+      and all(queued_calls[]; (.name | type == "string") and (.name | length) > 0)
+      and all(queued_calls[]; (.argumentsJSON | type == "string") and (.argumentsJSON | length) > 2)
+      and all(queued_arguments[]; (type == "object") and (length > 0))
+      and ([.events[]? | select(.kind == "toolFailed")] | length) == 0
+      and (completed_results | length) >= 1
+      and all(completed_results[]; .ok == true)
+    ))
+  ' "$threads_dir"/*.json >/dev/null || {
+    echo "live smoke persisted transcript integrity check failed" >&2
+    jq '. | {title, messages, events}' "$threads_dir"/*.json >&2 || true
+    exit 1
+  }
+}
+
 echo "==> Running live TrustedRouter shell-action smoke with $MODEL"
 RUN_OUTPUT="$SMOKE_ROOT/run.stdout"
 RUN_ERROR="$SMOKE_ROOT/run.stderr"
@@ -141,5 +198,7 @@ FILE_ERROR="$SMOKE_ROOT/file.stderr"
 run_live_prompt "Create \`live-smoke.txt\` in this workspace with exactly this content: \`quillcode_live_file_smoke\`." "$FILE_OUTPUT" "$FILE_ERROR"
 assert_no_action_regression "$FILE_OUTPUT" "$FILE_ERROR"
 assert_workspace_file_contains_exactly "live-smoke.txt" "quillcode_live_file_smoke"
+
+assert_saved_transcripts_are_actionable
 
 echo "QuillCode live TrustedRouter smoke passed."


### PR DESCRIPTION
## Summary
- extend the opt-in live TrustedRouter smoke to inspect saved thread transcripts
- require nonempty queued tool calls, nonempty argument objects, successful completed results, and no persisted passive promise/empty-shell copy
- document transcript integrity as part of live release/prompt/parser validation

## Validation
- `./scripts/live-tr-smoke.sh`
- `bash -n scripts/live-tr-smoke.sh`
- `git diff --check`