### PR TITLE
Expand default real-action smoke coverage

### DIFF
--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -262,9 +262,10 @@ public struct MockLLMClient: LLMClient {
             return nil
         }
         let url = normalizedWebURLString(target)
-        let path = "downloads/\(downloadFileName(for: url))"
+        let path = extractRequestedDownloadPath(from: request) ?? "downloads/\(downloadFileName(for: url))"
+        let parentDirectory = parentDirectory(for: path)
         return [
-            "mkdir -p downloads",
+            "mkdir -p \(shellSingleQuoted(parentDirectory))",
             "curl -L --fail --silent --show-error --output \(shellSingleQuoted(path)) \(shellSingleQuoted(url))",
             "ls -lh \(shellSingleQuoted(path))"
         ].joined(separator: " && ")
@@ -296,27 +297,39 @@ public struct MockLLMClient: LLMClient {
     }
 
     private static func extractDownloadTarget(from request: String) -> String? {
-        if let quoted = firstBacktickQuotedValue(in: request), looksLikeBrowserTarget(quoted) {
-            return quoted
-        }
         let tokenSeparators = CharacterSet.whitespacesAndNewlines
-            .union(CharacterSet(charactersIn: "\"'(),<>[]{}"))
-        return request
+            .union(CharacterSet(charactersIn: "`\"'(),<>[]{}"))
+        let tokens = request
             .components(separatedBy: tokenSeparators)
             .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: ".:;!?")) }
-            .first(where: looksLikeBrowserTarget)
+            .filter { !$0.isEmpty }
+
+        if let token = tokens.first(where: looksLikeDownloadSource) {
+            return token
+        }
+        if let quoted = backtickQuotedValues(in: request).first(where: looksLikeDownloadSource) {
+            return quoted
+        }
+        return backtickQuotedValues(in: request).first(where: looksLikeBrowserTarget)
     }
 
     private static func firstBacktickQuotedValue(in request: String) -> String? {
-        guard let first = request.firstIndex(of: "`"),
-              let last = request[request.index(after: first)...].lastIndex(of: "`"),
-              first < last
-        else {
-            return nil
+        backtickQuotedValues(in: request).first
+    }
+
+    private static func backtickQuotedValues(in request: String) -> [String] {
+        var values: [String] = []
+        var cursor = request.startIndex
+        while let first = request[cursor...].firstIndex(of: "`"),
+              let last = request[request.index(after: first)...].firstIndex(of: "`") {
+            let value = String(request[request.index(after: first)..<last])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty {
+                values.append(value)
+            }
+            cursor = request.index(after: last)
         }
-        let value = String(request[request.index(after: first)..<last])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        return values
     }
 
     private static func looksLikeBrowserTarget(_ value: String) -> Bool {
@@ -333,9 +346,71 @@ public struct MockLLMClient: LLMClient {
             || (lower.contains(".") && !lower.contains("@"))
     }
 
+    private static func looksLikeDownloadSource(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        if lower.hasPrefix("http://") || lower.hasPrefix("https://") || lower.hasPrefix("file://") {
+            return true
+        }
+        guard !lower.hasPrefix("./"),
+              !lower.hasPrefix("/"),
+              !lower.contains("@")
+        else {
+            return false
+        }
+        let firstPathComponent = lower.split(separator: "/", maxSplits: 1).first ?? ""
+        return firstPathComponent.contains(".")
+    }
+
+    private static func extractRequestedDownloadPath(from request: String) -> String? {
+        if let quotedPath = backtickQuotedValues(in: request)
+            .compactMap(safeRelativeWorkspacePath)
+            .first {
+            return quotedPath
+        }
+
+        let lower = request.lowercased()
+        for marker in [" into ", " to ", " as "] {
+            guard let range = lower.range(of: marker) else { continue }
+            let suffix = String(request[range.upperBound...])
+            let token = suffix
+                .split(whereSeparator: { $0.isWhitespace || "\"'(),<>[]{}".contains($0) })
+                .first
+                .map(String.init)?
+                .trimmingCharacters(in: CharacterSet(charactersIn: "`.:;!?"))
+            if let token, let safePath = safeRelativeWorkspacePath(token) {
+                return safePath
+            }
+        }
+        return nil
+    }
+
+    private static func safeRelativeWorkspacePath(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        guard !trimmed.isEmpty,
+              !trimmed.hasPrefix("/"),
+              !trimmed.hasPrefix("~"),
+              !lower.hasPrefix("http://"),
+              !lower.hasPrefix("https://"),
+              !lower.hasPrefix("file://"),
+              !trimmed.split(separator: "/").contains("..")
+        else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func parentDirectory(for path: String) -> String {
+        guard let slash = path.lastIndex(of: "/") else { return "." }
+        let parent = path[..<slash]
+        return parent.isEmpty ? "." : String(parent)
+    }
+
     private static func normalizedWebURLString(_ value: String) -> String {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.lowercased().hasPrefix("http://") || trimmed.lowercased().hasPrefix("https://") {
+        if trimmed.lowercased().hasPrefix("http://")
+            || trimmed.lowercased().hasPrefix("https://")
+            || trimmed.lowercased().hasPrefix("file://") {
             return trimmed
         }
         return "https://\(trimmed)"

--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -197,6 +197,14 @@ struct StaticSafetyRequest: Sendable {
             .compactMap(Self.normalizedHostCandidate)
     }
 
+    var requestedDownloadFileURLs: [String] {
+        let separators = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet(charactersIn: "\"'`()[]{}<>"))
+        return text
+            .components(separatedBy: separators)
+            .compactMap(Self.normalizedFileURLCandidate)
+    }
+
     func containsAffirmedAny(_ phrases: [String]) -> Bool {
         phrases.contains { containsAffirmed($0) }
     }
@@ -312,7 +320,11 @@ struct StaticSafetyRequest: Sendable {
 
     private static func normalizedHostCandidate(_ value: String) -> String? {
         var candidate = value.trimmingCharacters(in: CharacterSet(charactersIn: ",:;!?"))
-        guard candidate.contains(".") && !candidate.contains("@") else {
+        let lowerCandidate = candidate.lowercased()
+        guard !lowerCandidate.hasPrefix("file://"),
+              candidate.contains("."),
+              !candidate.contains("@")
+        else {
             return nil
         }
         if !candidate.contains("://") {
@@ -324,6 +336,13 @@ struct StaticSafetyRequest: Sendable {
             return nil
         }
         return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+    }
+
+    private static func normalizedFileURLCandidate(_ value: String) -> String? {
+        let candidate = value
+            .trimmingCharacters(in: CharacterSet(charactersIn: ",;!?"))
+            .lowercased()
+        return candidate.hasPrefix("file://") ? candidate : nil
     }
 }
 
@@ -343,10 +362,13 @@ enum StaticSafetyDownloadPolicy {
         else {
             return false
         }
-        let requestedHosts = request.requestedDownloadHosts
-        guard !requestedHosts.isEmpty else {
-            return false
+        let requestedFileURLs = request.requestedDownloadFileURLs
+        if !requestedFileURLs.isEmpty {
+            return requestedFileURLs.contains { fileURL in
+                lowerCommand.contains(fileURL)
+            }
         }
+        let requestedHosts = request.requestedDownloadHosts
         return requestedHosts.contains { host in
             lowerCommand.contains(host)
         }

--- a/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
@@ -68,9 +68,39 @@ final class AgentImmediateActionTests: XCTestCase {
         XCTAssertTrue(toolResult.ok, toolResult.error ?? "")
         XCTAssertEqual(
             try queuedShellCommand(in: result),
-            "mkdir -p downloads && curl -L --fail --silent --show-error --output 'downloads/linkedin.com.html' 'https://LinkedIn.com' && ls -lh 'downloads/linkedin.com.html'"
+            "mkdir -p 'downloads' && curl -L --fail --silent --show-error --output 'downloads/linkedin.com.html' 'https://LinkedIn.com' && ls -lh 'downloads/linkedin.com.html'"
         )
         XCTAssertEqual(result.thread.messages.last?.content, "Downloaded to `downloads/linkedin.com.html`.")
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll download") })
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
+    }
+
+    func testDownloadURLIntoExplicitPathUsesRequestedPath() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(toolExecutionOverride: { call, _ in
+            guard call.name == ToolDefinition.shellRun.name else { return nil }
+            return ToolResult(
+                ok: true,
+                stdout: "-rw-r--r--  1 mock  staff  559B downloads/example.html\n",
+                stderr: "",
+                exitCode: 0
+            )
+        })
+
+        let result = try await runner.send(
+            "Download https://example.com into `downloads/example.html` in this workspace.",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        let toolResult = try XCTUnwrap(result.toolResults.first)
+        XCTAssertTrue(toolResult.ok, toolResult.error ?? "")
+        XCTAssertEqual(
+            try queuedShellCommand(in: result),
+            "mkdir -p 'downloads' && curl -L --fail --silent --show-error --output 'downloads/example.html' 'https://example.com' && ls -lh 'downloads/example.html'"
+        )
+        XCTAssertEqual(result.thread.messages.last?.content, "Downloaded to `downloads/example.html`.")
         XCTAssertFalse(result.thread.messages.contains { $0.content.contains("I'll download") })
         XCTAssertFalse(result.thread.messages.contains { $0.content.contains("No shell command was specified") })
     }

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -212,6 +212,25 @@ final class SafetyTests: XCTestCase {
         XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
     }
 
+    func testAutoApprovesExplicitLocalFileURLDownloadShellRun() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"mkdir -p 'downloads' && curl -L --fail --silent --show-error --output 'downloads/example.html' 'file:///tmp/quillcode-smoke/source.html' && ls -lh 'downloads/example.html'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Download file:///tmp/quillcode-smoke/source.html into `downloads/example.html` in this workspace.",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(
+                role: .user,
+                content: "Download file:///tmp/quillcode-smoke/source.html into `downloads/example.html` in this workspace."
+            )]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
+    }
+
     func testAutoDoesNotUseDownloadIntentForUnrelatedShellRun() async {
         let reviewer = StaticSafetyReviewer()
         let call = ToolCall(
@@ -240,6 +259,25 @@ final class SafetyTests: XCTestCase {
             toolCall: call,
             toolDefinition: shellRun,
             recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
+    }
+
+    func testAutoDoesNotApproveDownloadForDifferentLocalFileURL() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"curl -L --output 'downloads/source.html' 'file:///tmp/other/source.html'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Download file:///tmp/quillcode-smoke/source.html into `downloads/source.html`.",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(
+                role: .user,
+                content: "Download file:///tmp/quillcode-smoke/source.html into `downloads/source.html`."
+            )]
         ))
         XCTAssertEqual(review.verdict, ApprovalVerdict.clarify)
     }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7978,3 +7978,20 @@ Remaining risk:
 
 - This still depends on live model, network, and public-page availability, so it remains an opt-in release/prompt/parser gate rather than a required PR check.
 - The smoke still drives the CLI entrypoint. Native macOS/Linux UI automation should later run the same scenarios through the packaged SwiftUI app and inspect saved transcripts.
+
+## 2026-06-27 Default Smoke Real-World Action Pass
+
+Overall grade after this slice: **A default-entrypoint coverage, A local side-effect isolation, A- mock planner realism**.
+
+The optional live smoke catches real provider drift, but every PR also needs cheap coverage for the same user-visible action family. The default smoke now runs natural prompts through the real `quill-code` CLI with the deterministic mock model, real shell execution, real filesystem writes, and a local curl download.
+
+Code quality changes:
+
+- Added default smoke assertions that reject empty-shell and passive “I’ll run/check/do...” output for CLI prompts.
+- Expanded `scripts/smoke.sh` beyond `run whoami` and file creation to cover `whoami?`, `How much hd?`, `Do you have openclaw?`, and a local `file://` download into the requested `downloads/example.html` path.
+- Hardened the mock LLM download planner so it distinguishes source URLs/domains from requested output paths and supports local `file://` smoke sources.
+- Added agent-level coverage for explicit download output paths so deterministic tests catch the exact command shape before CI smoke runs.
+
+Remaining risk:
+
+- This still exercises the CLI rather than the packaged SwiftUI app. It is valuable because it is cheap and required in CI, but native UI smoke should eventually drive these same prompts through the desktop window.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -70,7 +70,7 @@ Drive the QuillCode test harness with mock LLM:
 
 ## Native Smoke Tests
 
-- `./scripts/smoke.sh` runs Swift tests, mock CLI `run whoami`, mock CLI file creation in a temp workspace, and Playwright E2E when local node modules are installed.
+- `./scripts/smoke.sh` runs Swift tests, mock CLI `run whoami`, natural diagnostic prompts (`whoami?`, disk usage, OpenClaw discovery), mock CLI file creation, a local `file://` download into a requested workspace path, live-mode missing-key error readability, and Playwright E2E when local node modules are installed.
 - `./scripts/live-tr-smoke.sh` is the opt-in real TrustedRouter smoke. It reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`, defaults to the cheap `deepseekv4flash` alias, runs through `quill-code --live`, and fails on empty shell arguments, passive “I’ll run...” answers, missing command output, unreadable live errors, model-planned file writes that do not actually create the requested temp-workspace file, OpenClaw/device-discovery prompts without concrete output, public-page download prompts that do not create a nonempty requested file, or persisted transcripts that lack nonempty queued tool calls and successful completed tool results.
 - Packaged macOS and Linux app launch.
 - Login/dev override.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -14,15 +14,50 @@ trap cleanup EXIT
 mkdir -p "$SMOKE_HOME" "$SMOKE_WORKSPACE"
 cd "$ROOT_DIR"
 
+assert_cli_no_action_regression() {
+  local output="$1"
+  local label="$2"
+
+  if [[ -z "$output" ]]; then
+    echo "quill-code returned no output for $label" >&2
+    exit 1
+  fi
+  if grep -Eqi "No shell command was specified|I'?ll (run|check|do|download|create|write)" <<<"$output"; then
+    echo "quill-code regressed into passive or empty-tool output for $label" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+assert_cli_output_contains() {
+  local output="$1"
+  local expected="$2"
+  local label="$3"
+
+  assert_cli_no_action_regression "$output" "$label"
+  if ! grep -Fqi "$expected" <<<"$output"; then
+    echo "quill-code output for $label did not contain expected text: $expected" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
 echo "==> Running Swift test suite"
 swift test
 
 echo "==> Running mock CLI shell command"
 whoami_output="$(swift run quill-code --home "$SMOKE_HOME" --cwd "$SMOKE_WORKSPACE" "run whoami")"
-if [[ -z "$whoami_output" ]]; then
-  echo "quill-code did not return output for run whoami" >&2
-  exit 1
-fi
+assert_cli_no_action_regression "$whoami_output" "run whoami"
+
+echo "==> Running mock CLI natural diagnostic prompts"
+whoami_question_output="$(swift run quill-code --home "$SMOKE_HOME" --cwd "$SMOKE_WORKSPACE" "whoami?")"
+assert_cli_output_contains "$whoami_question_output" "$(id -un)" "whoami?"
+
+disk_output="$(swift run quill-code --home "$SMOKE_HOME" --cwd "$SMOKE_WORKSPACE" "How much hd?")"
+assert_cli_output_contains "$disk_output" "Disk usage" "How much hd?"
+
+openclaw_output="$(swift run quill-code --home "$SMOKE_HOME" --cwd "$SMOKE_WORKSPACE" "Do you have openclaw?")"
+assert_cli_output_contains "$openclaw_output" "openclaw" "Do you have openclaw?"
 
 echo "==> Running mock CLI file creation"
 swift run quill-code --home "$SMOKE_HOME" --cwd "$SMOKE_WORKSPACE" "make a file that says hello world" >/dev/null
@@ -32,6 +67,25 @@ if [[ ! -f "$SMOKE_WORKSPACE/hello.txt" ]]; then
 fi
 if [[ "$(tr -d '\r' < "$SMOKE_WORKSPACE/hello.txt")" != "hello world" ]]; then
   echo "hello.txt did not contain the expected smoke content" >&2
+  exit 1
+fi
+
+echo "==> Running mock CLI local download"
+DOWNLOAD_SOURCE="$SMOKE_ROOT/source.html"
+printf '<!doctype html><title>QuillCode smoke</title>\n' > "$DOWNLOAD_SOURCE"
+download_output="$(swift run quill-code \
+  --home "$SMOKE_HOME" \
+  --cwd "$SMOKE_WORKSPACE" \
+  "Download file://$DOWNLOAD_SOURCE into \`downloads/example.html\` in this workspace.")"
+assert_cli_output_contains "$download_output" "downloads/example.html" "local file download"
+if [[ ! -s "$SMOKE_WORKSPACE/downloads/example.html" ]]; then
+  echo "quill-code did not create downloads/example.html in the smoke workspace" >&2
+  find "$SMOKE_WORKSPACE" -maxdepth 3 -type f -print >&2
+  exit 1
+fi
+if ! grep -q "QuillCode smoke" "$SMOKE_WORKSPACE/downloads/example.html"; then
+  echo "downloads/example.html did not contain the expected downloaded content" >&2
+  cat "$SMOKE_WORKSPACE/downloads/example.html" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Expand required smoke coverage from simple CLI checks to real user prompt families: natural diagnostics, OpenClaw discovery, file creation, and local file download.
- Harden the mock download planner so it distinguishes source URLs from requested output paths and creates parent directories before download writes.
- Tighten static safety matching for local file downloads so file:// intents require exact source matching instead of loose host matching.
- Update the test plan and code quality audit with the new default-smoke coverage grade and remaining UI smoke gap.

## Validation
- swift test --filter SafetyTests/testAutoApprovesExplicitLocalFileURLDownloadShellRun --filter SafetyTests/testAutoDoesNotApproveDownloadForDifferentLocalFileURL
- swift test --filter AgentImmediateActionTests/testDownload
- bash -n scripts/smoke.sh && git diff --check
- ./scripts/smoke.sh
- ./scripts/live-tr-smoke.sh