### PR TITLE
Add app surface real-action smoke

### DIFF
--- a/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
@@ -57,6 +57,88 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
         XCTAssertEqual(card.textPreviewArtifacts.map(\.label), ["hello.txt"])
     }
 
+    func testWorkspaceSurfaceCoversRealWorldActionPromptFamily() async throws {
+        let root = try makeTempDirectory()
+        let downloadSource = root.appendingPathComponent("source.html")
+        try "<!doctype html><title>QuillCode surface smoke</title>\n"
+            .write(to: downloadSource, atomically: true, encoding: .utf8)
+
+        let cases = [
+            RealWorldSurfaceCase(
+                prompt: "whoami?",
+                toolName: ToolDefinition.shellRun.name,
+                inputContains: ["\"cmd\":\"whoami\""],
+                answerContains: "You are `",
+                sideEffect: nil
+            ),
+            RealWorldSurfaceCase(
+                prompt: "How much hd?",
+                toolName: ToolDefinition.shellRun.name,
+                inputContains: ["df -h / /Quill"],
+                answerContains: "Disk usage:",
+                sideEffect: nil
+            ),
+            RealWorldSurfaceCase(
+                prompt: "Do you have openclaw?",
+                toolName: ToolDefinition.shellRun.name,
+                inputContains: ["command -v openclaw"],
+                answerContains: "openclaw is",
+                sideEffect: nil
+            ),
+            RealWorldSurfaceCase(
+                prompt: "Can you write a file that says \"hello world\"",
+                toolName: ToolDefinition.fileWrite.name,
+                inputContains: ["\"path\":\"hello.txt\"", "hello world"],
+                answerContains: "Wrote `hello.txt`.",
+                sideEffect: .fileContains(path: "hello.txt", text: "hello world")
+            ),
+            RealWorldSurfaceCase(
+                prompt: "Download \(downloadSource.absoluteString) into `downloads/example.html` in this workspace.",
+                toolName: ToolDefinition.shellRun.name,
+                inputContains: [
+                    "mkdir -p 'downloads'",
+                    "--output 'downloads/example.html'",
+                    downloadSource.absoluteString
+                ],
+                answerContains: "Downloaded to `downloads/example.html`.",
+                sideEffect: .fileContains(path: "downloads/example.html", text: "QuillCode surface smoke")
+            )
+        ]
+
+        for testCase in cases {
+            let model = QuillCodeWorkspaceModel()
+            model.setDraft(testCase.prompt)
+            await model.submitComposer(workspaceRoot: root)
+
+            let surface = model.surface()
+            XCTAssertFalse(model.composer.isSending, testCase.prompt)
+            XCTAssertNil(model.lastError, testCase.prompt)
+            XCTAssertEqual(surface.transcript.timelineItems.map(\.kind), [.message, .toolCard, .message], testCase.prompt)
+            XCTAssertEqual(surface.transcript.messages.first?.text, testCase.prompt)
+            XCTAssertEqual(surface.transcript.toolCards.count, 1, testCase.prompt)
+
+            let card = try XCTUnwrap(surface.transcript.toolCards.first, testCase.prompt)
+            XCTAssertEqual(card.title, testCase.toolName, testCase.prompt)
+            XCTAssertEqual(card.status, .done, testCase.prompt)
+            XCTAssertNotEqual(card.inputJSON, "{}", testCase.prompt)
+            let normalizedInputJSON = normalizeToolInputJSON(card.inputJSON)
+            for expectedInput in testCase.inputContains {
+                let normalizedExpectedInput = expectedInput.replacingOccurrences(of: " ", with: "")
+                XCTAssertTrue(
+                    normalizedInputJSON.contains(normalizedExpectedInput),
+                    "\(testCase.prompt): \(expectedInput)"
+                )
+            }
+
+            let answer = try XCTUnwrap(surface.transcript.messages.last?.text, testCase.prompt)
+            XCTAssertTrue(answer.contains(testCase.answerContains), "\(testCase.prompt): \(answer)")
+            XCTAssertFalse(answer.range(of: #"I'?ll (run|check|do|download|create|write)"#, options: .regularExpression) != nil, testCase.prompt)
+            XCTAssertFalse(answer.localizedCaseInsensitiveContains("No shell command was specified"), testCase.prompt)
+
+            try assertSideEffect(testCase.sideEffect, workspaceRoot: root, label: testCase.prompt)
+        }
+    }
+
     func testSubmitComposerDispatchesComputerUseToolThroughBackend() async throws {
         let root = try makeTempDirectory()
         let backend = StubComputerUseBackend()
@@ -325,6 +407,40 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
             try await Task.sleep(nanoseconds: 1_000_000)
         }
     }
+
+    private func assertSideEffect(
+        _ sideEffect: RealWorldSurfaceSideEffect?,
+        workspaceRoot: URL,
+        label: String
+    ) throws {
+        switch sideEffect {
+        case .fileContains(let path, let text):
+            let url = workspaceRoot.appendingPathComponent(path)
+            let contents = try String(contentsOf: url, encoding: .utf8)
+            XCTAssertTrue(contents.contains(text), "\(label): \(url.path)")
+        case .none:
+            break
+        }
+    }
+
+    private func normalizeToolInputJSON(_ inputJSON: String?) -> String {
+        (inputJSON ?? "")
+            .replacingOccurrences(of: "\\/", with: "/")
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: " ", with: "")
+    }
+}
+
+private struct RealWorldSurfaceCase {
+    var prompt: String
+    var toolName: String
+    var inputContains: [String]
+    var answerContains: String
+    var sideEffect: RealWorldSurfaceSideEffect?
+}
+
+private enum RealWorldSurfaceSideEffect {
+    case fileContains(path: String, text: String)
 }
 
 @MainActor

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -7995,3 +7995,19 @@ Code quality changes:
 Remaining risk:
 
 - This still exercises the CLI rather than the packaged SwiftUI app. It is valuable because it is cheap and required in CI, but native UI smoke should eventually drive these same prompts through the desktop window.
+
+## 2026-06-27 App Surface Real-World Action Pass
+
+Overall grade after this slice: **A shared-surface coverage, A side-effect verification, B+ packaged-window coverage**.
+
+The default smoke now catches the real prompt family through the CLI, but the app still needed a Swift-side guard that proves those same actions survive through the workspace model and renderable surface contract used by SwiftUI and the HTML harness.
+
+Code quality changes:
+
+- Added a compact table-driven workspace integration smoke that sends `whoami?`, disk usage, OpenClaw discovery, file creation, and local download prompts through `QuillCodeWorkspaceModel.submitComposer`.
+- The test validates the shared `WorkspaceSurface` timeline shape, tool card title/status/input, visible assistant answer, absence of passive “I'll run...” regressions, and real workspace file side effects.
+- The assertions normalize tool input JSON formatting so the test checks behavior and command content without coupling to pretty-print whitespace or JSON slash escaping.
+
+Remaining risk:
+
+- This still stops at the shared Swift app surface, not the packaged macOS window event loop. A future smoke should launch `quill-code-desktop`, drive the native window, and compare an appshot/screenshot against the same prompt family.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -70,6 +70,7 @@ Drive the QuillCode test harness with mock LLM:
 
 ## Native Smoke Tests
 
+- `WorkspaceComposerIntegrationTests/testWorkspaceSurfaceCoversRealWorldActionPromptFamily` runs the same high-risk prompt family through the Swift workspace model and shared `WorkspaceSurface`, proving native app state, tool cards, final answers, and local side effects stay aligned.
 - `./scripts/smoke.sh` runs Swift tests, mock CLI `run whoami`, natural diagnostic prompts (`whoami?`, disk usage, OpenClaw discovery), mock CLI file creation, a local `file://` download into a requested workspace path, live-mode missing-key error readability, and Playwright E2E when local node modules are installed.
 - `./scripts/live-tr-smoke.sh` is the opt-in real TrustedRouter smoke. It reads `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`, defaults to the cheap `deepseekv4flash` alias, runs through `quill-code --live`, and fails on empty shell arguments, passive “I’ll run...” answers, missing command output, unreadable live errors, model-planned file writes that do not actually create the requested temp-workspace file, OpenClaw/device-discovery prompts without concrete output, public-page download prompts that do not create a nonempty requested file, or persisted transcripts that lack nonempty queued tool calls and successful completed tool results.
 - Packaged macOS and Linux app launch.


### PR DESCRIPTION
## Summary
- Add a table-driven Swift app-surface smoke for the high-risk real-world prompt family: `whoami?`, disk usage, OpenClaw discovery, file creation, and local file download.
- Verify `QuillCodeWorkspaceModel` produces a coherent `WorkspaceSurface`: user message, nonempty tool card, completed status, final assistant answer, and real file side effects.
- Document this added native-surface coverage and the remaining packaged-window smoke gap.

## Validation
- `swift test --filter WorkspaceComposerIntegrationTests/testWorkspaceSurfaceCoversRealWorldActionPromptFamily`
- `npm test` in `E2E/playwright`
- `git diff --check`
- `./scripts/smoke.sh`
