### PR TITLE
Harden click target audits

### DIFF
--- a/E2E/playwright/tests/interaction-audit-helpers.ts
+++ b/E2E/playwright/tests/interaction-audit-helpers.ts
@@ -20,6 +20,8 @@ const INTERACTIVE_SELECTOR = [
 ].join(',');
 
 const ACTIVE_LAYER_SELECTOR = [
+  'dialog[open]',
+  '[role="dialog"]',
   '[data-testid="model-browser"]',
   '[data-testid="settings-panel"]',
   '[data-testid="search-panel"]',
@@ -64,7 +66,7 @@ type InteractionAuditReport = {
   targetIssues: TargetAuditIssue[];
 };
 
-async function interactionAuditReport(page: Page): Promise<InteractionAuditReport> {
+export async function interactionAuditReport(page: Page): Promise<InteractionAuditReport> {
   return page.evaluate(({ activeLayerSelector, minimumHitTarget, selector }) => {
     type VisibleTarget = {
       clipped: VisibleRectResult;
@@ -92,6 +94,12 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
       scrollClipped: boolean;
     };
 
+    const targetSampleFractions = [0.2, 0.5, 0.8];
+
+    function isSemanticallyDisabled(element: Element) {
+      return element.matches(':disabled,[aria-disabled="true"]');
+    }
+
     function isVisible(element: Element, rect: DOMRect) {
       const style = window.getComputedStyle(element);
       const closedDetails = element.closest('details:not([open])');
@@ -100,7 +108,6 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
         && rect.height > 0
         && style.display !== 'none'
         && style.visibility !== 'hidden'
-        && style.pointerEvents !== 'none'
         && !element.closest('[hidden],[aria-hidden="true"]');
     }
 
@@ -175,17 +182,14 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
       return topElement === element || Boolean(topElement && element.contains(topElement));
     }
 
-    function auditSamplePoints(rect: RectLike) {
+    function targetInteriorSamplePoints(rect: RectLike) {
       if (rect.width <= 0 || rect.height <= 0) return [];
-      const insetX = Math.min(10, rect.width / 4);
-      const insetY = Math.min(10, rect.height / 4);
-      return [
-        [rect.left + rect.width / 2, rect.top + rect.height / 2],
-        [rect.left + insetX, rect.top + insetY],
-        [rect.right - insetX, rect.top + insetY],
-        [rect.left + insetX, rect.bottom - insetY],
-        [rect.right - insetX, rect.bottom - insetY]
-      ].filter(([x, y]) => (
+      return targetSampleFractions.flatMap((yFraction) => (
+        targetSampleFractions.map((xFraction) => [
+          rect.left + rect.width * xFraction,
+          rect.top + rect.height * yFraction
+        ])
+      )).filter(([x, y]) => (
         x >= 0
           && y >= 0
           && x <= document.documentElement.clientWidth
@@ -194,13 +198,21 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
     }
 
     function isTopMostAtCenter(element: Element, rect: RectLike) {
-      const points = auditSamplePoints(rect);
-      const center = points[0];
-      return Boolean(center && isPointOwnedBy(element, center[0], center[1]));
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      if (
+        x < 0
+        || y < 0
+        || x > document.documentElement.clientWidth
+        || y > document.documentElement.clientHeight
+      ) {
+        return false;
+      }
+      return isPointOwnedBy(element, x, y);
     }
 
     function hasReliableClickableInterior(element: Element, rect: RectLike) {
-      const points = auditSamplePoints(rect);
+      const points = targetInteriorSamplePoints(rect);
       if (!points.length) return false;
       return points.every(([x, y]) => isPointOwnedBy(element, x, y));
     }
@@ -238,9 +250,14 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
     }
 
     function auditReason(element: Element, rect: DOMRect, clipped: VisibleRectResult) {
+      const style = window.getComputedStyle(element);
+      const isDisabled = isSemanticallyDisabled(element);
       const reasons = [];
       if (!accessibleName(element)) {
         reasons.push('missing_accessible_name');
+      }
+      if (style.pointerEvents === 'none' && !isDisabled) {
+        reasons.push('pointer_events_none');
       }
       if (Math.round(rect.width) < minimumHitTarget || Math.round(rect.height) < minimumHitTarget) {
         reasons.push('too_small');
@@ -251,10 +268,10 @@ async function interactionAuditReport(page: Page): Promise<InteractionAuditRepor
       ) {
         reasons.push('visible_area_too_small_or_clipped');
       }
-      if (!isTopMostAtCenter(element, clipped.rect)) {
+      if (!isDisabled && !isTopMostAtCenter(element, clipped.rect)) {
         reasons.push('center_blocked_or_clipped');
       }
-      if (!hasReliableClickableInterior(element, clipped.rect)) {
+      if (!isDisabled && !hasReliableClickableInterior(element, clipped.rect)) {
         reasons.push('interior_click_area_blocked');
       }
       return reasons.join(',');
@@ -427,6 +444,7 @@ export async function expectHitTarget(locator: Locator, label: string) {
   const clickableInteriorIssues = await target.evaluate((element, minimumHitTarget) => {
     const rect = element.getBoundingClientRect();
     const style = window.getComputedStyle(element);
+    const targetSampleFractions = [0.2, 0.5, 0.8];
     const issues: string[] = [];
 
     function accessibleName(targetElement: Element) {
@@ -457,15 +475,13 @@ export async function expectHitTarget(locator: Locator, label: string) {
       return topElement === element || Boolean(topElement && element.contains(topElement));
     }
 
-    const insetX = Math.min(10, rect.width / 4);
-    const insetY = Math.min(10, rect.height / 4);
-    const samplePoints = [
-      [rect.left + rect.width / 2, rect.top + rect.height / 2],
-      [rect.left + insetX, rect.top + insetY],
-      [rect.right - insetX, rect.top + insetY],
-      [rect.left + insetX, rect.bottom - insetY],
-      [rect.right - insetX, rect.bottom - insetY]
-    ].filter(([x, y]) => (
+    const isDisabled = element.matches(':disabled,[aria-disabled="true"]');
+    const samplePoints = targetSampleFractions.flatMap((yFraction) => (
+      targetSampleFractions.map((xFraction) => [
+        rect.left + rect.width * xFraction,
+        rect.top + rect.height * yFraction
+      ])
+    )).filter(([x, y]) => (
       x >= 0
         && y >= 0
         && x <= document.documentElement.clientWidth
@@ -475,16 +491,16 @@ export async function expectHitTarget(locator: Locator, label: string) {
     if (!accessibleName(element)) {
       issues.push('missing_accessible_name');
     }
-    if (style.pointerEvents === 'none') {
+    if (style.pointerEvents === 'none' && !isDisabled) {
       issues.push('pointer_events_none');
     }
     if (Math.round(rect.width) < minimumHitTarget || Math.round(rect.height) < minimumHitTarget) {
       issues.push('too_small');
     }
-    if (samplePoints.length === 0) {
+    if (!isDisabled && samplePoints.length === 0) {
       issues.push('no_visible_sample_points');
     }
-    if (samplePoints.some(([x, y]) => !isPointOwnedByTarget(x, y))) {
+    if (!isDisabled && samplePoints.some(([x, y]) => !isPointOwnedByTarget(x, y))) {
       issues.push('clickable_interior_blocked');
     }
     return issues;

--- a/E2E/playwright/tests/interaction-audit.spec.ts
+++ b/E2E/playwright/tests/interaction-audit.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   expectAllVisibleInteractiveTargets,
   expectHitTarget,
+  interactionAuditReport,
   expectNoNestedInteractiveTargets,
   expectNoOverlappingInteractiveTargets
 } from './interaction-audit-helpers';
@@ -188,6 +189,45 @@ test('mock harness audits every visible interactive click target across workspac
   await expect(page.getByTestId('find-bar')).toBeVisible();
   await expectInteractionTargetsClean(page, 'find bar');
   await page.getByTestId('find-close').click();
+});
+
+test('interaction audit catches dead and edge-blocked visible controls', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.evaluate(() => {
+    const fixture = document.createElement('div');
+    fixture.setAttribute('data-testid', 'interaction-audit-fixture');
+    fixture.innerHTML = `
+      <button
+        type="button"
+        data-testid="bad-pointer-target"
+        style="position: fixed; left: 24px; top: 24px; z-index: 1000; width: 96px; height: 48px; pointer-events: none;"
+      >Dead target</button>
+      <button
+        type="button"
+        disabled
+        data-testid="disabled-pointer-target"
+        style="position: fixed; left: 24px; top: 84px; z-index: 1000; width: 96px; height: 48px; pointer-events: none;"
+      >Disabled target</button>
+      <button
+        type="button"
+        data-testid="edge-blocked-target"
+        style="position: fixed; left: 24px; top: 144px; z-index: 1000; width: 96px; height: 64px;"
+      >Edge blocked</button>
+      <span
+        aria-hidden="true"
+        style="position: fixed; left: 24px; top: 144px; z-index: 1001; width: 28px; height: 28px; background: rgba(255, 93, 82, 0.85);"
+      ></span>
+    `;
+    document.body.appendChild(fixture);
+  });
+
+  const report = await interactionAuditReport(page);
+  const issueFor = (testid: string) => report.targetIssues.find((issue) => issue.testid === testid);
+
+  expect(issueFor('bad-pointer-target')?.reason).toContain('pointer_events_none');
+  expect(issueFor('edge-blocked-target')?.reason).toContain('interior_click_area_blocked');
+  expect(issueFor('disabled-pointer-target')).toBeUndefined();
 });
 
 test('mock harness keeps banner and recovery actions at least 44px', async ({ page }) => {

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
@@ -47,10 +47,25 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
             "Explicit critical-control probes should test the clickable interior, not only raw bounding-box dimensions."
         )
         XCTAssertTrue(
+            auditHelperText.contains("targetSampleFractions = [0.2, 0.5, 0.8]")
+                && auditHelperText.contains("targetInteriorSamplePoints"),
+            "Click-target probes should sample a 3x3 interior grid so edge-blocked controls cannot pass with only the center clickable."
+        )
+        XCTAssertTrue(
+            auditHelperText.contains("pointer_events_none")
+                && auditHelperText.contains("isSemanticallyDisabled"),
+            "Visible interactive controls with pointer-events disabled should fail unless they are semantically disabled."
+        )
+        XCTAssertTrue(
             auditHelperText.contains("closestInteractiveAncestor")
                 && auditHelperText.contains("nestedIssues")
                 && auditHelperText.contains("expectNoNestedInteractiveTargets"),
             "The rendered click-target audit should fail nested interactive controls, not only undersized controls."
+        )
+        XCTAssertTrue(
+            auditHelperText.contains("dialog[open]")
+                && auditHelperText.contains(#"[role="dialog"]"#),
+            "The active-layer audit should cover generic dialogs in addition to QuillCode-specific popovers and panels."
         )
     }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-27 Click Target Hittability Pass
+
+Overall grade after this slice: **A interaction test oracle, A disabled-control semantics, A- native rendered pixel coverage**.
+
+The prior click-target architecture gave QuillCode a strong shared 44 px target contract, but the browser audit could still under-model real user misses: it sampled only the center plus corners, filtered out visible controls with `pointer-events: none`, and did not assert that generic dialogs participate in active-layer scoping. This pass keeps the UI visually compact while making the audit closer to real click behavior.
+
+| Before | After |
+| --- | --- |
+| Visible controls with `pointer-events: none` could be filtered out before the audit produced an issue. | Non-disabled visible controls with `pointer-events: none` now fail with `pointer_events_none`; semantically disabled controls still get size/name checks without false clickable-interior failures. |
+| Explicit hit-target probes sampled five points, leaving edge-only blockers easier to miss. | Probes now sample a 3x3 interior grid at 20%, 50%, and 80% across the target. |
+| Active-layer scoping knew QuillCode-specific panels and popovers. | Generic `dialog[open]` and `[role="dialog"]` surfaces are also treated as active interaction layers. |
+| There was no regression fixture proving the audit catches dead/edge-blocked controls. | Added a Playwright fixture that injects a dead target, an edge-blocked target, and a disabled target, then verifies only the real failures are reported. |
+
+Residual risk:
+
+- Native SwiftUI rendered hit regions are still guarded through source-level semantic target contracts plus desktop smoke, not pixel-level native UI inspection. A future packaged UI automation layer should apply the same grid-sampling idea to actual macOS/Linux rendered controls.
+
 ## 2026-06-27 Real-World Smoke Coverage Pass
 
 Overall grade after this slice: **A deterministic CI stability, A- real-provider release coverage, B+ live workflow observability until secrets are configured**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-27
 
+- Click-target quality is measured by real hittability, not only visual size. The Playwright interaction audit samples a 3x3 interior grid for each visible control, reports visible non-disabled controls with `pointer-events: none`, ignores pointer ownership only for semantically disabled controls, and treats generic dialogs as active interaction layers. This keeps compact Codex-style controls visually calm while making dead or edge-blocked targets fail CI.
 - Real-world smoke coverage is a release lane, not a normal PR requirement. `./scripts/real-world-smoke.sh` runs the deterministic suite first and then runs `./scripts/live-tr-smoke.sh` when a TrustedRouter key is available through `QUILLCODE_API_KEY`, `TRUSTEDROUTER_API_KEY`, or `~/.quill.code.keyfile`. Normal CI stays deterministic, while parser, prompt, safety, and runtime changes can be tested against a real cheap model before shipping.
 - Live TrustedRouter smoke artifacts are preserved on failure. Model regressions such as empty shell arguments, passive “I'll do it” replies, missing file side effects, or bad transcript tool events need stdout/stderr/thread JSON left on disk so the failure can be diagnosed instead of disappearing in cleanup.
 


### PR DESCRIPTION
## Summary
- Strengthen the Playwright interaction audit to sample a 3x3 interior grid instead of a center/corners-only probe.
- Report visible non-disabled controls with `pointer-events: none`, while preserving semantically disabled controls as size/name-only targets.
- Treat generic dialogs as active interaction layers and add a regression fixture for dead, edge-blocked, and disabled controls.
- Document the click-target hittability decision and code-quality audit result.

## Validation
- `swift test --filter ParityInteractionTargetGateTests`
- `npm test -- interaction-audit.spec.ts`
- `npm test -- interaction-audit.spec.ts visual-polish.spec.ts`
- `./scripts/smoke.sh`