### PR TITLE
Add critical click-target registry

### DIFF
--- a/E2E/playwright/tests/interaction-audit-helpers.ts
+++ b/E2E/playwright/tests/interaction-audit-helpers.ts
@@ -67,6 +67,11 @@ type InteractionAuditReport = {
   targetIssues: TargetAuditIssue[];
 };
 
+export type CriticalTargetProbe = {
+  label: string;
+  locator: Locator;
+};
+
 export async function interactionAuditReport(page: Page): Promise<InteractionAuditReport> {
   return page.evaluate(({ activeLayerSelector, minimumHitTarget, selector }) => {
     type VisibleTarget = {
@@ -543,6 +548,13 @@ export async function expectHitTarget(locator: Locator, label: string) {
     return issues;
   }, MINIMUM_HIT_TARGET);
   expect(clickableInteriorIssues, `${label} should have a named, unblocked clickable interior`).toEqual([]);
+}
+
+export async function expectCriticalTargetRegistry(label: string, probes: CriticalTargetProbe[]) {
+  expect(probes.length, `${label} should declare at least one critical click target`).toBeGreaterThan(0);
+  for (const probe of probes) {
+    await expectHitTarget(probe.locator, `${label}: ${probe.label}`);
+  }
 }
 
 export async function clickTargetInteriorPoint(

--- a/E2E/playwright/tests/interaction-audit.spec.ts
+++ b/E2E/playwright/tests/interaction-audit.spec.ts
@@ -2,12 +2,14 @@ import { test, expect, type Page } from '@playwright/test';
 import {
   clickCommandPaletteCommand,
   clickSidebarTool,
+  fillCommandPalette,
   harnessURL,
   openSettings,
   openTopBarOverflow
 } from './harness-helpers';
 import {
   expectAllVisibleInteractiveTargets,
+  expectCriticalTargetRegistry,
   expectHitTarget,
   interactionAuditReport,
   clickTargetInteriorPoint,
@@ -46,6 +48,90 @@ async function expectCommandTargetsRoutable(page: Page, label: string) {
     `${label} should not render visible enabled command targets with unroutable command IDs`
   ).toEqual([]);
 }
+
+test('critical click-target registry covers primary workspace surfaces', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await expectCriticalTargetRegistry('primary workspace chrome', [
+    { label: 'new chat', locator: page.getByTestId('new-chat-button') },
+    { label: 'sidebar search', locator: page.getByTestId('sidebar-search-button') },
+    { label: 'sidebar tools', locator: page.getByTestId('sidebar-tools-button') },
+    { label: 'model picker', locator: page.getByTestId('model-picker-button') },
+    { label: 'top-bar overflow', locator: page.getByTestId('top-bar-overflow-button') },
+    { label: 'composer text entry', locator: page.getByLabel('Message') },
+    { label: 'composer send', locator: page.getByRole('button', { name: 'Send' }) }
+  ]);
+
+  await openTopBarOverflow(page);
+  await expectCriticalTargetRegistry('top-bar overflow menu', [
+    { label: 'search', locator: page.getByTestId('top-bar-overflow-search') },
+    { label: 'command palette', locator: page.getByTestId('top-bar-overflow-command-palette') },
+    { label: 'keyboard shortcuts', locator: page.getByTestId('top-bar-overflow-keyboard-shortcuts') },
+    { label: 'settings', locator: page.getByTestId('top-bar-overflow-settings') }
+  ]);
+  await page.getByTestId('top-bar-overflow-button').click();
+
+  await page.getByTestId('model-picker-button').click();
+  await expect(page.getByTestId('model-browser')).toBeVisible();
+  await expectCriticalTargetRegistry('model picker', [
+    { label: 'model search', locator: page.getByTestId('model-search') },
+    { label: 'first model option', locator: page.getByTestId('model-option').first() },
+    { label: 'first model details', locator: page.getByTestId('model-detail-button').first() },
+    { label: 'first model favorite', locator: page.getByTestId('model-favorite-button').first() }
+  ]);
+  await page.getByTestId('model-picker-button').click();
+
+  await openTopBarOverflow(page);
+  await page.getByTestId('top-bar-overflow-command-palette').click();
+  await expect(page.getByTestId('command-palette-panel')).toBeVisible();
+  await fillCommandPalette(page, '>git');
+  await expectCriticalTargetRegistry('command palette', [
+    { label: 'command search', locator: page.getByTestId('command-palette-input') },
+    { label: 'close command palette', locator: page.getByTestId('command-palette-close') },
+    { label: 'first command result', locator: page.getByTestId('command-palette-result').first() }
+  ]);
+  await page.getByTestId('command-palette-close').click();
+
+  await openSettings(page);
+  await expect(page.getByTestId('settings-panel')).toBeVisible();
+  await expectCriticalTargetRegistry('settings panel', [
+    { label: 'API base URL', locator: page.getByLabel('TrustedRouter API base URL') },
+    { label: 'authentication selector', locator: page.getByLabel('Authentication') },
+    { label: 'TrustedRouter sign in', locator: page.getByTestId('settings-sign-in') },
+    { label: 'cancel', locator: page.getByTestId('settings-cancel') },
+    { label: 'save', locator: page.getByTestId('settings-save') }
+  ]);
+  await page.getByTestId('settings-cancel').click();
+
+  await clickSidebarTool(page, 'terminal-button');
+  await expect(page.getByTestId('terminal-pane')).toBeVisible();
+  await expectCriticalTargetRegistry('terminal pane', [
+    { label: 'clear', locator: page.getByTestId('terminal-clear') },
+    { label: 'command input', locator: page.getByTestId('terminal-input') },
+    { label: 'run', locator: page.getByTestId('terminal-run') }
+  ]);
+
+  await clickSidebarTool(page, 'browser-button');
+  await expect(page.getByTestId('browser-pane')).toBeVisible();
+  await expectCriticalTargetRegistry('browser pane', [
+    { label: 'back', locator: page.getByTestId('browser-back') },
+    { label: 'forward', locator: page.getByTestId('browser-forward') },
+    { label: 'reload', locator: page.getByTestId('browser-reload') },
+    { label: 'address', locator: page.getByTestId('browser-address') },
+    { label: 'open', locator: page.getByTestId('browser-open') },
+    { label: 'comment input', locator: page.getByTestId('browser-comment-input') },
+    { label: 'add comment', locator: page.getByTestId('browser-add-comment') }
+  ]);
+
+  await page.getByLabel('Message').fill('run whoami');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card').last()).toHaveAttribute('data-status', 'done');
+  await expectCriticalTargetRegistry('transcript tool card', [
+    { label: 'tool disclosure', locator: page.getByTestId('tool-card-details').last().locator('summary') },
+    { label: 'message composer', locator: page.getByLabel('Message') },
+    { label: 'send after transcript update', locator: page.getByRole('button', { name: 'Send' }) }
+  ]);
+});
 
 test('mock harness audits every visible interactive click target across workspace states', async ({ page }) => {
   await page.goto(harnessURL());

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
@@ -42,6 +42,11 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
             "The rendered click-target audit should keep the same 44 px minimum for whole-screen audits and explicit critical-control probes."
         )
         XCTAssertTrue(
+            auditHelperText.contains("export type CriticalTargetProbe")
+                && auditHelperText.contains("expectCriticalTargetRegistry"),
+            "High-risk click targets should be declared through a named registry instead of scattered one-off assertions."
+        )
+        XCTAssertTrue(
             auditHelperText.contains("target.evaluate")
                 && auditHelperText.contains("elementFromPoint")
                 && auditHelperText.contains("clickableInteriorIssues"),
@@ -134,6 +139,39 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
             interactionSpecText.contains("expectCommandTargetsRoutable(page, label)")
                 && interactionSpecText.contains("command routing audit catches visible dead command targets"),
             "The broad interaction audit should include command routing, with a regression proving dead command targets fail."
+        )
+    }
+
+    func testRenderedCriticalTargetRegistryCoversPrimarySurfaces() throws {
+        let interactionSpecText = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("E2E/playwright/tests/interaction-audit.spec.ts"),
+            encoding: .utf8
+        )
+
+        for requiredSurface in [
+            "primary workspace chrome",
+            "top-bar overflow menu",
+            "model picker",
+            "command palette",
+            "settings panel",
+            "terminal pane",
+            "browser pane",
+            "transcript tool card"
+        ] {
+            XCTAssertTrue(
+                interactionSpecText.contains(requiredSurface),
+                "The critical click-target registry should cover \(requiredSurface)."
+            )
+        }
+
+        XCTAssertTrue(
+            interactionSpecText.contains("model-detail-button")
+                && interactionSpecText.contains("model-favorite-button")
+                && interactionSpecText.contains("settings-sign-in")
+                && interactionSpecText.contains("browser-comment-input")
+                && interactionSpecText.contains("tool-card-details"),
+            "The registry should include small/high-risk controls that commonly regress: model row actions, settings auth, browser inputs, and tool disclosures."
         )
     }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-27 Critical Click-Target Registry Pass
+
+Overall grade after this slice: **A rendered click-target coverage, A registry maintainability, A- native pixel measurement**.
+
+The click-target system already enforced shared 44 px/pt primitives, but high-risk controls were still scattered through individual assertions. This pass makes the user-facing target checklist explicit so primary chrome, model choice, command palette, settings, secondary panes, composer, and transcript tool cards all have named, measured targets.
+
+| Before | After |
+| --- | --- |
+| Critical target checks were spread across state-specific tests, making it easy to miss a small row action or input when chrome changed. | Added `CriticalTargetProbe` and `expectCriticalTargetRegistry` so high-risk surfaces declare their important controls in one readable registry. |
+| Model picker coverage focused on panel visibility and broad audits. | The registry now measures model option rows, details buttons, and favorite buttons, which are exactly the compact row actions most likely to regress. |
+| Settings/browser/transcript coverage depended on broad visible-target sweeps. | The registry now explicitly probes auth/sign-in controls, browser address/comment inputs, and tool-card disclosures. |
+
+Residual risk:
+
+- Native SwiftUI rendered hit regions are still source-gated rather than sampled from a packaged macOS/Linux window. The next upgrade should add platform UI automation that measures real native windows with the same named-target registry.
+
 ## 2026-06-27 Scoped Native Click-Target Audit Pass
 
 Overall grade after this slice: **A scoped native source gates, A call-site target ownership, A- native pixel measurement**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-27
 
+- High-risk click targets should be declared in a named rendered registry, not only checked incidentally during broad sweeps. Primary chrome, top-bar overflow, model picker row actions, command palette, settings auth, terminal, browser, and transcript tool-card disclosures all need explicit `expectCriticalTargetRegistry` coverage so interaction drift is reviewable.
 - Click-target quality is measured by real hittability, not only visual size. The Playwright interaction audit samples a 3x3 interior grid for each visible control, reports visible non-disabled controls with `pointer-events: none`, ignores pointer ownership only for semantically disabled controls, and treats generic dialogs as active interaction layers. This keeps compact Codex-style controls visually calm while making dead or edge-blocked targets fail CI.
 - Native SwiftUI buttons must use shared hit-target helpers plus an explicit press/platform style. Text-entry controls must be tested by clicking interior edge points and then typing, not only by checking visibility. This prevents regressions where search, command palette, terminal, browser, or settings fields look correct but lose focus or route taps to nearby chrome.
 - Native SwiftUI source gates inspect the owning control scope, not a broad source window. A target helper on a sibling control or inside Menu content cannot satisfy the trigger that opens the Menu. Link/artifact previews should put the shared target on the Link label itself so the clickable element owns its contract.


### PR DESCRIPTION
## Summary
- add a reusable Playwright critical click-target registry helper
- cover primary chrome, overflow, model picker, command palette, settings, terminal, browser, and transcript tool-card targets
- add parity gates and docs so the registry stays a maintained interaction contract

## Validation
- `npm test -- tests/interaction-audit.spec.ts`
- `swift test --filter ParityInteractionTargetGateTests`
- `git diff --check`
- `swift test`
- `npm test`