### PR TITLE
Rethink native click target semantics

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -45,7 +45,7 @@ struct QuillCodeComposerView: View {
 
     private var composerSurface: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .bottom, spacing: 10) {
+            HStack(alignment: .bottom, spacing: QuillCodeMetrics.controlClusterSpacing) {
                 composerField
                 composerAction
             }
@@ -71,7 +71,7 @@ struct QuillCodeComposerView: View {
     }
 
     private var composerAccessoryBar: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
             QuillCodeModelPickerView(
                 topBar: topBar,
                 isPresented: $isModelPickerPresented,

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -6,6 +6,8 @@ public enum QuillCodeMetrics {
     public static let compactFormActionMinWidth: CGFloat = 56
     public static let compactControlRadius: CGFloat = 9
     public static let iconControlRadius: CGFloat = 10
+    public static let controlClusterSpacing: CGFloat = 8
+    public static let denseControlClusterSpacing: CGFloat = 6
     public static let topBarHeight: CGFloat = 44
     public static let composerSurfaceRadius: CGFloat = 12
     public static let composerControlRadius: CGFloat = 10

--- a/Sources/QuillCodeApp/QuillCodeModelPickerRows.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerRows.swift
@@ -65,7 +65,7 @@ struct QuillCodeModelRow: View {
                 .help(option.metadataDetails.joined(separator: "\n"))
                 .accessibilityHint(option.metadataDetails.joined(separator: ", "))
 
-                HStack(spacing: 6) {
+                HStack(spacing: QuillCodeMetrics.denseControlClusterSpacing) {
                     modelActionButton(
                         systemImage: isExpanded ? "info.circle.fill" : "info.circle",
                         tint: isExpanded ? QuillCodePalette.blue : QuillCodePalette.muted,

--- a/Sources/QuillCodeApp/QuillCodeSidebarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarView.swift
@@ -81,9 +81,9 @@ private struct QuillCodeSidebarSavedFilterBar: View {
 
     var body: some View {
         LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 100), spacing: 6, alignment: .leading)],
+            columns: [GridItem(.adaptive(minimum: 100), spacing: QuillCodeMetrics.denseControlClusterSpacing, alignment: .leading)],
             alignment: .leading,
-            spacing: 6
+            spacing: QuillCodeMetrics.denseControlClusterSpacing
         ) {
             ForEach(filters) { filter in
                 Button {
@@ -126,7 +126,7 @@ private struct QuillCodeSidebarActionsView: View {
     }
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
             ForEach(visibleCommands) { command in
                 Button {
                     onCommand(command)
@@ -160,7 +160,7 @@ private struct QuillCodeSidebarUtilityActionsView: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
             Menu {
                 ForEach(visibleCommandGroups) { group in
                     Section(group.title) {

--- a/Sources/QuillCodeApp/QuillCodeToolCardControls.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolCardControls.swift
@@ -6,7 +6,7 @@ struct QuillCodeToolCardActionRow: View {
     var onAction: (ToolCardActionSurface) -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
             ForEach(actions) { action in
                 Button {
                     onAction(action)

--- a/Sources/QuillCodeApp/QuillCodeToolCardView.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolCardView.swift
@@ -131,7 +131,7 @@ struct QuillCodeToolCardView: View {
         }
         .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: isDetailsOpen)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
     }
 

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -32,7 +32,7 @@ struct QuillCodeTopBarView: View {
         }
         .background(QuillCodePalette.background)
         .help(topBarHelp)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(topBarAccessibilityLabel)
     }
 
@@ -123,7 +123,7 @@ struct QuillCodeTopBarView: View {
     }
 
     private var topBarActions: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
             if let activeStopCommand {
                 stopButton(activeStopCommand)
                     .transition(reduceMotion ? .identity : .opacity.combined(with: .scale(scale: 0.94)))

--- a/Sources/QuillCodeApp/QuillCodeTranscriptFindView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptFindView.swift
@@ -95,7 +95,7 @@ struct QuillCodeTranscriptFindBar: View {
                 searchIcon
                 queryField
             }
-            HStack(spacing: 8) {
+            HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
                 statusLabel
                     .frame(maxWidth: .infinity, alignment: .leading)
                 navigationButtons
@@ -124,7 +124,7 @@ struct QuillCodeTranscriptFindBar: View {
     }
 
     private var navigationButtons: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
             Button(action: onPrevious) {
                 Image(systemName: "chevron.up")
             }

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
@@ -257,6 +257,37 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
                 && designText.contains("quillCodeSwitchRowTarget"),
             "Native text entry, segmented controls, and switches should have semantic hit-target helpers so call sites do not use raw frames."
         )
+        XCTAssertTrue(
+            designText.contains("static let controlClusterSpacing: CGFloat = 8")
+                && designText.contains("static let denseControlClusterSpacing: CGFloat = 6"),
+            "Dense control groups should use named spacing metrics so adjacent 44 pt hit targets do not drift into overlap-prone magic numbers."
+        )
+    }
+
+    func testInteractiveContainersPreserveChildTargets() throws {
+        let topBarText = try Self.appSourceText(named: "QuillCodeTopBarView.swift")
+        let toolCardText = try Self.appSourceText(named: "QuillCodeToolCardView.swift")
+        let composerText = try Self.appSourceText(named: "QuillCodeComposerView.swift")
+        let sidebarText = try Self.appSourceText(named: "QuillCodeSidebarView.swift")
+        let modelRowsText = try Self.appSourceText(named: "QuillCodeModelPickerRows.swift")
+
+        XCTAssertTrue(
+            topBarText.contains(".accessibilityElement(children: .contain)")
+                && !topBarText.contains(".accessibilityElement(children: .combine)"),
+            "Top bar chrome contains buttons and menus, so it must preserve child targets instead of combining them into one accessibility element."
+        )
+        XCTAssertTrue(
+            toolCardText.contains(".accessibilityElement(children: .contain)")
+                && !toolCardText.contains(".accessibilityElement(children: .combine)"),
+            "Tool cards contain actions and disclosure controls, so they must preserve child click targets instead of combining the whole card."
+        )
+        XCTAssertTrue(
+            topBarText.contains("HStack(spacing: QuillCodeMetrics.controlClusterSpacing)")
+                && composerText.contains("HStack(spacing: QuillCodeMetrics.controlClusterSpacing)")
+                && sidebarText.contains("HStack(spacing: QuillCodeMetrics.controlClusterSpacing)")
+                && modelRowsText.contains("HStack(spacing: QuillCodeMetrics.denseControlClusterSpacing)"),
+            "High-risk adjacent controls should use named hit-target spacing metrics, not local magic numbers."
+        )
     }
 
     func testNativeSourceAuditCoversMenuAndPickerTriggers() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -8420,3 +8420,20 @@ Code quality changes:
 Remaining risk:
 
 - Inline notes are snapshotted when the draft opens. Richer editable pending-review queues, per-note removal/reordering, and a review summary before submit remain future review-pane work.
+
+## 2026-06-28 Click Target Semantics Pass
+
+Overall grade after this slice: **A- native target semantics, A rendered collision audit, B+ packaged-window click automation**.
+
+The app already had broad 44 px hit-target coverage, but two native semantics still needed to be made explicit: interactive parent containers should not collapse live child buttons into one accessibility element, and dense adjacent controls should use named spacing contracts instead of local magic numbers.
+
+Code quality changes:
+
+- Added shared `controlClusterSpacing` and `denseControlClusterSpacing` metrics to the design system so target-spacing decisions are reviewable and consistent.
+- Moved dense top-bar, composer, sidebar, model-row, tool-card action, and find-bar control clusters onto the shared spacing metrics.
+- Changed top-bar and tool-card containers from `.accessibilityElement(children: .combine)` to `.contain`, preserving child targets for buttons, menus, disclosures, and action rows.
+- Added a native parity gate that blocks regressions back to parent-combined interactive containers and checks that high-risk adjacent controls use named target spacing.
+
+Remaining risk:
+
+- The static SwiftUI gate catches source-level target contracts and the Playwright harness catches rendered HTML target size, clipping, overlap, and routing. True packaged-window pixel clicking across every native SwiftUI control remains the deeper future layer.


### PR DESCRIPTION
## Summary
- preserve child controls in top-bar and tool-card accessibility containers instead of combining them into one parent target
- add shared control-cluster spacing metrics for dense 44 pt target groups
- move top-bar, composer, sidebar, model-row, tool-card action, and find-bar clusters onto the shared spacing metrics
- add parity coverage that blocks regressions to parent-combined interactive containers and local magic spacing

## Validation
- `swift test --filter ParityInteractionTargetGateTests`
- `cd E2E/playwright && npm test -- interaction-audit.spec.ts`
- `swift test`
- `cd E2E/playwright && npm test`

## Screenshot
- Local visual smoke: `quillcode-click-target-semantics-pass.png`