### PR TITLE
Render optimistic thinking state in harness

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -1848,7 +1848,7 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .message, .tool-card, .review-pane, .context-banner, .runtime-issue {
+    .message, .tool-card, .review-pane, .context-banner, .runtime-issue, .thinking {
       max-width: min(760px, 88%);
       padding: 13px 15px;
       border-radius: 20px;
@@ -1858,6 +1858,37 @@
     .message.user { align-self: flex-end; background: linear-gradient(135deg, #45bdec, #d16c5f); }
     .message.assistant { align-self: flex-start; background: rgba(255,255,255,.1); }
     .message { white-space: normal; }
+    .thinking {
+      align-self: flex-start;
+      background: rgba(255,255,255,.09);
+      border: 1px solid rgba(255,255,255,.10);
+    }
+    .thinking header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+    }
+    .thinking p { margin: 0; color: var(--muted); font-size: 13px; }
+    .thinking-dots { display: inline-flex; gap: 4px; align-items: center; }
+    .thinking-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 999px;
+      background: #8be4ff;
+      box-shadow: 0 0 10px rgba(92, 200, 255, .42);
+      opacity: .46;
+      animation: thinkingPulse 1.1s ease-in-out infinite;
+    }
+    .thinking-dot:nth-child(2) { animation-delay: 120ms; }
+    .thinking-dot:nth-child(3) { animation-delay: 240ms; }
+    @keyframes thinkingPulse {
+      0%, 80%, 100% { opacity: .32; transform: translateY(0); }
+      40% { opacity: 1; transform: translateY(-2px); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .thinking-dot { animation: none; opacity: .72; }
+    }
     .message > p,
     .tool-card > p { margin: 0; }
     .message > p { white-space: pre-wrap; }
@@ -5545,6 +5576,35 @@
           <p>${escapeHTML(message.text)}</p>
           ${copyButton('message-copy', timelineID || message.id || `message-${message.text}`, 'Copy', draftButton(message) + retryButton(message) + feedbackButtons(message))}
         </article>`;
+      const thinkingTraceLines = () => state.transcript.toolCards
+        .filter(card => ['queued', 'running', 'review'].includes(card.status))
+        .slice(-6)
+        .map(card => `${toolCardStatusDisplayLabel(card)}: ${card.title} ${card.subtitle || ''}`.trim());
+      const renderThinkingIndicator = () => {
+        if (!state.composer.isSending) return '';
+        const traceLines = thinkingTraceLines();
+        const subtitle = traceLines[traceLines.length - 1] || 'Preparing the next step';
+        const trace = traceLines.length ? `
+          <details data-testid="thinking-trace">
+            <summary class="hit-target-row">Trace</summary>
+            <ul>
+              ${traceLines.map(line => `<li>${escapeHTML(line)}</li>`).join('')}
+            </ul>
+          </details>` : '';
+        return `
+          <article class="thinking" data-testid="thinking-indicator" aria-label="Thinking: ${escapeHTML(subtitle)}">
+            <header>
+              <strong data-testid="thinking-title">Thinking</strong>
+              <span class="thinking-dots" aria-hidden="true">
+                <span class="thinking-dot"></span>
+                <span class="thinking-dot"></span>
+                <span class="thinking-dot"></span>
+              </span>
+            </header>
+            <p data-testid="thinking-subtitle">${escapeHTML(subtitle)}</p>
+            ${trace}
+          </article>`;
+      };
       const renderArtifacts = artifacts => artifacts && artifacts.length ? `
           <div class="tool-artifacts" data-testid="tool-card-artifacts" aria-label="Artifacts">
             ${artifacts.map(artifact => {
@@ -5659,7 +5719,8 @@
         )).join('')
         : state.transcript.messages.map(renderMessage).join('')
           + state.transcript.toolCards.map(renderToolCard).join('');
-      const hasTimelineContent = Boolean(context || runtimeIssue || review || transcriptItems);
+      const thinking = renderThinkingIndicator();
+      const hasTimelineContent = Boolean(context || runtimeIssue || review || transcriptItems || thinking);
       const shouldHideEmptyTranscript = state.automations.isVisible && !hasTimelineContent;
       const emptyStarterActions = (state.transcript.emptyStarterActions || []).length ? `
         <div class="empty-starters" data-testid="empty-starter-actions">
@@ -5670,7 +5731,7 @@
             </button>
           `).join('')}
         </div>` : '';
-      const timeline = hasTimelineContent ? context + runtimeIssue + review + transcriptItems : shouldHideEmptyTranscript ? '' : `
+      const timeline = hasTimelineContent ? context + runtimeIssue + review + transcriptItems + thinking : shouldHideEmptyTranscript ? '' : `
         <section class="empty" data-testid="transcript-empty">
           <h1>${escapeHTML(state.transcript.emptyTitle)}</h1>
           <p>${escapeHTML(state.transcript.emptySubtitle)}</p>
@@ -11318,13 +11379,30 @@
       state.runtimeIssue = null;
       addMessage('user', text);
       touchSelectedThread();
+      state.composer.isSending = true;
+      state.topBar.agentStatus = 'Running';
+      render();
+      window.setTimeout(() => completeMockAgentTurn(text), 0);
+    }
+
+    function finishMockAgentTurn() {
+      state.composer.isSending = false;
+      state.composer.canSend = Boolean(state.composer.draft.trim());
+      if (!['Failed', 'Stopped'].includes(state.topBar.agentStatus)) {
+        state.topBar.agentStatus = 'Idle';
+      }
+      syncSelectedThreadSearchText();
+      render();
+    }
+
+    function completeMockAgentTurn(text) {
+      let shouldFinishMockAgentTurn = true;
+      try {
       const selectedProject = state.projects.items.find(project => project.id === state.projects.selectedProjectID);
       const isRemoteProject = Boolean(selectedProject?.isRemote);
       const browserTarget = browserOpenTargetFromPrompt(text);
       const fileWriteRequest = fileWriteRequestFromPrompt(text);
       if (text.toLowerCase().includes('slow task')) {
-        state.composer.isSending = true;
-        state.topBar.agentStatus = 'Running';
         const card = addToolCard({
           title: 'host.shell.run',
           subtitle: 'Running',
@@ -11346,6 +11424,7 @@
           render();
         }, 2000);
         activeMockRun = { id: runID, timer };
+        shouldFinishMockAgentTurn = false;
       } else if (text.toLowerCase().includes('trigger rate limit')) {
         state.topBar.agentStatus = 'Failed';
         const lastError = 'TrustedRouter request failed with HTTP 429: Rate limit exceeded. Retry-After: 120. x-ratelimit-remaining: 0';
@@ -11397,6 +11476,8 @@
           actionLabel: 'Switch model'
         }, 'Expected valid QuillCode action JSON but received an empty argument object.');
       } else if (/^\/status\b/i.test(text)) {
+        state.composer.isSending = false;
+        state.topBar.agentStatus = 'Idle';
         addMessage('assistant', workspaceStatusText());
       } else if (/^\/(new|new-chat|newchat)\b/i.test(text)) {
         newChat();
@@ -11816,8 +11897,14 @@
         state.review = { ...state.review, files: [], pullRequestThreads: [], subtitle: 'Latest git diff', totalInsertions: 0, totalDeletions: 0, totalHunks: 0 };
         addMessage('assistant', 'I can inspect and edit this project.');
       }
-      syncSelectedThreadSearchText();
-      render();
+      } finally {
+        if (shouldFinishMockAgentTurn) {
+          finishMockAgentTurn();
+        } else {
+          syncSelectedThreadSearchText();
+          render();
+        }
+      }
     }
 
     function retryLastUserTurn() {

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -24,6 +24,21 @@ test('mock harness composer supports multiline editing and Enter-to-send', async
   await expect(page.getByTestId('message').first()).toContainText('second line');
 });
 
+test('mock harness shows sent message and thinking state before async work completes', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('slow task');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByLabel('Message')).toBeDisabled();
+  await expect(page.getByTestId('message').first()).toContainText('slow task');
+  await expect(page.getByTestId('thinking-indicator')).toBeVisible();
+  await expect(page.getByTestId('thinking-title')).toHaveText('Thinking');
+  await expect(page.getByTestId('thinking-subtitle')).toContainText(/Preparing the next step|host\.shell\.run/);
+  await expect(page.getByTestId('agent-status')).toHaveText('Running');
+  await expect(page.getByText('Long-running task completed.')).toHaveCount(0);
+});
+
 test('mock harness stops an active composer run from the composer', async ({ page }) => {
   await page.goto(harnessURL());
 


### PR DESCRIPTION
Summary
- Paint the sent user message and active Thinking state before mock agent work completes.
- Mirror the native thinking indicator in the browser harness with visible dots and trace details.
- Keep /status as a local idle command while preserving active send feedback for agent work.

Validation
- npm test -- --grep "composer|workspace status"
- npm test
- screenshot captured at /tmp/quillcode-optimistic-thinking.png