### PR TITLE
Make Computer Use settings status driven

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeComputerUseSettingsCard.swift
+++ b/Sources/QuillCodeApp/QuillCodeComputerUseSettingsCard.swift
@@ -7,7 +7,9 @@ struct QuillCodeComputerUseSettingsCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             cardHeader
-            requirementRows
+            if !settings.computerUseRequirements.isEmpty {
+                requirementRows
+            }
             nextActionRow
             restartHint
             refreshAction
@@ -83,7 +85,7 @@ struct QuillCodeComputerUseSettingsCard: View {
             Image(systemName: "info.circle")
                 .foregroundStyle(QuillCodePalette.blue)
                 .frame(width: 18)
-            Text("After changing macOS permissions, quit and reopen QuillCode if the status does not update.")
+            Text("After changing permissions or desktop helper tools, quit and reopen QuillCode if the status does not update.")
                 .font(.caption2)
                 .foregroundStyle(QuillCodePalette.muted)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/QuillCodeApp/QuillCodeSettingsSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeSettingsSurface.swift
@@ -169,6 +169,9 @@ public struct WorkspaceSettingsSurface: Codable, Sendable, Hashable {
         if status.available {
             return "Ready"
         }
+        if status.unavailableReason != nil {
+            return "Unavailable"
+        }
         if !status.screenRecordingGranted && !status.accessibilityGranted {
             return "Setup needed"
         }
@@ -182,12 +185,18 @@ public struct WorkspaceSettingsSurface: Codable, Sendable, Hashable {
         if status.available {
             return "Ready for screenshots, clicks, typing, scrolling, and keyboard shortcuts."
         }
-        return "Computer Use needs macOS privacy permissions before QuillCode can inspect or control the desktop."
+        if let unavailableReason = status.unavailableReason {
+            return unavailableReason
+        }
+        return "Computer Use needs desktop permissions before QuillCode can inspect or control the screen."
     }
 
     private static func computerUseNextAction(_ status: ComputerUseStatus) -> String {
         if status.available {
             return "Computer Use is enabled. Ask QuillCode to inspect the screen or operate an app."
+        }
+        if status.unavailableReason != nil {
+            return "Install or enable the required desktop backend, then refresh status."
         }
         if !status.screenRecordingGranted && !status.accessibilityGranted {
             return "Open Screen Recording first, enable QuillCode, then open Accessibility."
@@ -203,7 +212,10 @@ public struct WorkspaceSettingsSurface: Codable, Sendable, Hashable {
         screenRecordingCommand: WorkspaceCommandSurface,
         accessibilityCommand: WorkspaceCommandSurface
     ) -> [ComputerUseRequirementSurface] {
-        [
+        guard status.unavailableReason == nil else {
+            return []
+        }
+        return [
             ComputerUseRequirementSurface(
                 id: "screen-recording",
                 title: "Screen Recording",

--- a/Tests/QuillCodeAppTests/WorkspaceSettingsRuntimeSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSettingsRuntimeSurfaceTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import QuillCodeCore
+import QuillComputerUseKit
 @testable import QuillCodeApp
 
 @MainActor
@@ -21,7 +22,7 @@ final class WorkspaceSettingsRuntimeSurfaceTests: XCTestCase {
         XCTAssertEqual(settings.computerUseStatusLabel, "Setup needed")
         XCTAssertEqual(
             settings.computerUseSetupSummary,
-            "Computer Use needs macOS privacy permissions before QuillCode can inspect or control the desktop."
+            "Computer Use needs desktop permissions before QuillCode can inspect or control the screen."
         )
         XCTAssertEqual(
             settings.computerUseNextAction,
@@ -97,6 +98,29 @@ final class WorkspaceSettingsRuntimeSurfaceTests: XCTestCase {
         XCTAssertEqual(settings.computerUseRequirements.map(\.title), ["Screen Recording", "Accessibility"])
         XCTAssertEqual(settings.computerUseRequirements.map(\.statusLabel), ["Granted", "Required"])
         XCTAssertEqual(settings.computerUseRequirements.map(\.command.isEnabled), [false, true])
+    }
+
+    func testSettingsSurfaceUsesUnavailableComputerUseReasonWithoutPermissionRows() {
+        let status = ComputerUseStatus.unavailable(
+            "Linux Computer Use detected Wayland but needs helper tools: ydotool, wtype."
+        )
+        let settings = WorkspaceSettingsSurface(
+            config: AppConfig(),
+            hasStoredAPIKey: false,
+            computerUseStatus: status
+        )
+
+        XCTAssertEqual(settings.computerUseStatusLabel, "Unavailable")
+        XCTAssertEqual(
+            settings.computerUseSetupSummary,
+            "Linux Computer Use detected Wayland but needs helper tools: ydotool, wtype."
+        )
+        XCTAssertEqual(
+            settings.computerUseNextAction,
+            "Install or enable the required desktop backend, then refresh status."
+        )
+        XCTAssertTrue(settings.computerUseRequirements.isEmpty)
+        XCTAssertTrue(settings.computerUseSetupCommand.isEnabled)
     }
 
     func testRuntimeIssueDecodesOlderPayloadWithoutDiagnostics() throws {


### PR DESCRIPTION
## Summary
- use backend unavailable reasons directly in Computer Use settings copy
- hide macOS permission rows when the backend itself is unavailable
- make the restart hint platform-neutral and add coverage for Linux-style unavailable status

## Validation
- `swift test --filter 'WorkspaceSettingsRuntimeSurfaceTests|ParityWorkspaceSettingsSheetGateTests'`
- `swift test`
- `npm test -- tests/settings.spec.ts --workers=1` in `E2E/playwright`
- `./scripts/native-desktop-smoke.sh`