### PR TITLE
Unify native hit target semantics

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -20,47 +20,14 @@ public enum QuillCodeMetrics {
 }
 
 struct QuillCodeHitTargetSpec {
-    enum Kind {
-        case icon
-        case textButton
-        case formAction
-        case textEntry
-        case segmentedControl
-        case adjustableControl
-        case link
-        case switchRow
-        case ownedGesture
-        case fullRow
-        case capsule
-
-        var action: String {
-            switch self {
-            case .textEntry:
-                return "text-input"
-            case .adjustableControl:
-                return "adjust"
-            case .link:
-                return "link"
-            case .ownedGesture:
-                return "owned-gesture"
-            case .icon, .textButton, .formAction, .segmentedControl, .switchRow, .fullRow, .capsule:
-                return "press"
-            }
-        }
-
-        var allowsNestedInteractiveChildren: Bool { false }
-
-        var requiresUnblockedInterior: Bool { true }
-    }
-
     enum Shape {
         case rectangle
         case rounded(CGFloat)
         case capsule
     }
 
-    var kind: Kind
-    var action: String { kind.action }
+    var kind: QuillCodeNativeHitTargetKind
+    var action: String { kind.action.rawValue }
     var allowsNestedInteractiveChildren: Bool { kind.allowsNestedInteractiveChildren }
     var requiresUnblockedInterior: Bool { kind.requiresUnblockedInterior }
     var minWidth: CGFloat?

--- a/Tests/QuillCodeAppTests/QuillCodeNativeHitTargetAuditTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeNativeHitTargetAuditTests.swift
@@ -5,6 +5,31 @@ import QuillCodeTools
 
 @MainActor
 final class QuillCodeNativeHitTargetAuditTests: XCTestCase {
+    func testDesignSystemHitTargetSpecsUseNativeSemantics() {
+        let cases: [(spec: QuillCodeHitTargetSpec, kind: QuillCodeNativeHitTargetKind, action: QuillCodeNativeHitTargetAction)] = [
+            (.icon(), .icon, .press),
+            (.textButton(), .textButton, .press),
+            (.formAction(), .formAction, .press),
+            (.textEntry(), .textEntry, .textInput),
+            (.segmentedControl(), .segmentedControl, .press),
+            (.adjustableControl(), .adjustableControl, .adjust),
+            (.link(), .link, .link),
+            (.switchRow(), .switchRow, .press),
+            (.ownedGesture(), .ownedGesture, .ownedGesture),
+            (.fullRow(), .fullRow, .press),
+            (.capsule(), .capsule, .press)
+        ]
+
+        XCTAssertEqual(Set(cases.map(\.kind)), Set(QuillCodeNativeHitTargetKind.allCases))
+        for hitTargetCase in cases {
+            XCTAssertEqual(hitTargetCase.spec.kind, hitTargetCase.kind)
+            XCTAssertEqual(hitTargetCase.spec.action, hitTargetCase.action.rawValue)
+            XCTAssertEqual(hitTargetCase.spec.allowsNestedInteractiveChildren, hitTargetCase.kind.allowsNestedInteractiveChildren)
+            XCTAssertEqual(hitTargetCase.spec.requiresUnblockedInterior, hitTargetCase.kind.requiresUnblockedInterior)
+            XCTAssertGreaterThanOrEqual(hitTargetCase.spec.minHeight, QuillCodeMetrics.minimumHitTarget)
+        }
+    }
+
     func testAuditCoversDesignSystemCommandsAndVisibleSecondaryPanes() {
         var surface = makeWorkspaceSurfaceWithRepresentativePanes()
 

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
@@ -377,12 +377,11 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
             "Native controls should use the same 44 pt target baseline as the rendered harness."
         )
         XCTAssertTrue(
-            designText.contains("enum Kind")
-                && designText.contains("var kind: Kind")
+            designText.contains("var kind: QuillCodeNativeHitTargetKind")
                 && designText.contains("var action: String")
                 && designText.contains("var allowsNestedInteractiveChildren: Bool")
                 && designText.contains("var requiresUnblockedInterior: Bool"),
-            "Native hit-target specs should carry explicit semantic intent and behavior flags so controls cannot pass with only generic geometry."
+            "Native hit-target specs should reuse the audited native semantic vocabulary so controls cannot pass with only generic geometry or a parallel enum."
         )
         XCTAssertTrue(
             designText.contains(".frame(\n            minWidth: spec.minWidth")


### PR DESCRIPTION
## Summary
- remove the duplicate private native hit-target kind enum from the design system
- make native hit-target specs use QuillCodeNativeHitTargetKind directly
- update parity gates and add a unit test proving every design primitive uses the audited native semantics

## Validation
- git diff --check
- swift test --filter 'QuillCodeNativeHitTargetAuditTests|ParityInteractionTargetGateTests'
- npm test -- tests/interaction-audit.spec.ts --workers=1
- swift test
- ./scripts/native-desktop-smoke.sh