### PR TITLE
Harden immediate file write intents

### DIFF
--- a/Sources/QuillCodeAgent/AgentFileWriteRequestParser.swift
+++ b/Sources/QuillCodeAgent/AgentFileWriteRequestParser.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+struct AgentFileWriteRequest: Sendable, Equatable {
+    var path: String
+    var content: String
+
+    var arguments: [String: String] {
+        [
+            "path": path,
+            "content": content
+        ]
+    }
+}
+
+enum AgentFileWriteRequestParser {
+    static func request(from userMessage: String) -> AgentFileWriteRequest? {
+        let trimmed = userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let lower = trimmed.lowercased()
+        guard containsFileWriteIntent(lower) else { return nil }
+
+        guard let content = extractContent(from: trimmed, lowercasedRequest: lower) else {
+            return nil
+        }
+
+        return AgentFileWriteRequest(
+            path: extractPath(from: trimmed, lowercasedRequest: lower)
+                ?? defaultPath(for: content, lowercasedRequest: lower),
+            content: content.hasSuffix("\n") ? content : "\(content)\n"
+        )
+    }
+
+    private static func containsFileWriteIntent(_ lower: String) -> Bool {
+        lower.contains("file")
+            && ["write", "create", "make", "save"].contains { lower.contains($0) }
+    }
+
+    private static func extractContent(
+        from request: String,
+        lowercasedRequest lower: String
+    ) -> String? {
+        for marker in contentMarkers {
+            guard let markerRange = lower.range(of: marker) else { continue }
+            let suffix = String(request[markerRange.upperBound...])
+            if let quoted = firstQuotedValue(in: suffix) {
+                return normalizedContent(quoted)
+            }
+            if let content = normalizedContent(sentencePrefix(from: suffix)) {
+                return content
+            }
+        }
+
+        if lower.contains("hello world") {
+            return "hello world"
+        }
+        return nil
+    }
+
+    private static func extractPath(
+        from request: String,
+        lowercasedRequest lower: String
+    ) -> String? {
+        for marker in pathMarkers {
+            guard let markerRange = lower.range(of: marker) else { continue }
+            let suffix = String(request[markerRange.upperBound...])
+            if let path = safeRelativeWorkspacePath(firstPathToken(in: suffix)) {
+                return path
+            }
+            if let quoted = firstQuotedValue(in: suffix),
+               let path = safeRelativeWorkspacePath(quoted) {
+                return path
+            }
+        }
+
+        return nil
+    }
+
+    private static func sentencePrefix(from suffix: String) -> String {
+        let trimmed = suffix.trimmingCharacters(in: .whitespacesAndNewlines)
+        var index = trimmed.startIndex
+        while index < trimmed.endIndex {
+            let character = trimmed[index]
+            if ".?!".contains(character) {
+                let next = trimmed.index(after: index)
+                if next == trimmed.endIndex || trimmed[next].isWhitespace {
+                    return String(trimmed[..<index])
+                }
+            }
+            index = trimmed.index(after: index)
+        }
+        return trimmed
+    }
+
+    private static func firstPathToken(in suffix: String) -> String {
+        suffix
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { separator in
+                separator.isWhitespace || "\"'“”‘’(),<>[]{}".contains(separator)
+            })
+            .first
+            .map(String.init) ?? ""
+    }
+
+    private static func firstQuotedValue(in text: String) -> String? {
+        quotedValues(in: text).first
+    }
+
+    private static func quotedValues(in text: String) -> [String] {
+        var values: [String] = []
+        collectDelimitedValues(in: text, opener: "`", closer: "`", into: &values)
+        collectDelimitedValues(in: text, opener: "\"", closer: "\"", into: &values)
+        collectDelimitedValues(in: text, opener: "'", closer: "'", into: &values)
+        collectDelimitedValues(in: text, opener: "“", closer: "”", into: &values)
+        collectDelimitedValues(in: text, opener: "‘", closer: "’", into: &values)
+        return values
+    }
+
+    private static func collectDelimitedValues(
+        in text: String,
+        opener: Character,
+        closer: Character,
+        into values: inout [String]
+    ) {
+        var cursor = text.startIndex
+        while cursor < text.endIndex,
+              let first = text[cursor...].firstIndex(of: opener) {
+            let afterFirst = text.index(after: first)
+            guard afterFirst < text.endIndex,
+                  let last = text[afterFirst...].firstIndex(of: closer)
+            else {
+                break
+            }
+            let value = String(text[afterFirst..<last])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty {
+                values.append(value)
+            }
+            cursor = text.index(after: last)
+        }
+    }
+
+    private static func normalizedContent(_ value: String) -> String? {
+        let trimmed = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’` "))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func safeRelativeWorkspacePath(_ value: String) -> String? {
+        let trimmed = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’`.:;!?"))
+        let lower = trimmed.lowercased()
+        guard !trimmed.isEmpty,
+              !trimmed.hasPrefix("/"),
+              !trimmed.hasPrefix("~"),
+              !lower.hasPrefix("http://"),
+              !lower.hasPrefix("https://"),
+              !lower.hasPrefix("file://"),
+              !trimmed.split(separator: "/").contains("..")
+        else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func defaultPath(for content: String, lowercasedRequest lower: String) -> String {
+        lower.contains("hello world") || content.lowercased() == "hello world"
+            ? "hello.txt"
+            : "note.txt"
+    }
+
+    private static let contentMarkers = [
+        "that says",
+        "saying",
+        "says",
+        "with content",
+        "with text",
+        "containing",
+        "contents:"
+    ]
+
+    private static let pathMarkers = [
+        "file named",
+        "file called",
+        "file at",
+        "file in",
+        "file to",
+        "path"
+    ]
+}

--- a/Sources/QuillCodeAgent/AgentImmediateActionPlanner.swift
+++ b/Sources/QuillCodeAgent/AgentImmediateActionPlanner.swift
@@ -34,11 +34,11 @@ enum AgentImmediateActionPlanner {
             return shell("df -h / /Quill 2>/dev/null || df -h /")
         }
 
-        if let fileWrite = simpleFileWrite(for: request, lowercasedRequest: lower),
+        if let fileWrite = AgentFileWriteRequestParser.request(from: request),
            hasTool(ToolDefinition.fileWrite.name, in: tools) {
             return .tool(.init(
                 name: ToolDefinition.fileWrite.name,
-                argumentsJSON: ToolArguments.json(fileWrite)
+                argumentsJSON: ToolArguments.json(fileWrite.arguments)
             ))
         }
 
@@ -77,20 +77,4 @@ enum AgentImmediateActionPlanner {
             || (lower.contains("how much") && (lower.contains("disk") || lower.contains("storage")))
     }
 
-    private static func simpleFileWrite(
-        for request: String,
-        lowercasedRequest lower: String
-    ) -> [String: String]? {
-        guard lower.contains("file"),
-              lower.contains("hello world"),
-              lower.contains("write") || lower.contains("create") || lower.contains("make")
-        else {
-            return nil
-        }
-
-        return [
-            "path": "hello.txt",
-            "content": "hello world\n"
-        ]
-    }
 }

--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -131,20 +131,19 @@ public struct MockLLMClient: LLMClient {
             ))
         }
 
-        if (lower.contains("make") || lower.contains("create") || lower.contains("write")),
-           lower.contains("file") {
-            let content = lower.contains("hello world") ? "hello world\n" : "\(request)\n"
+        if let fileWrite = AgentFileWriteRequestParser.request(from: request) {
             if tools.contains(where: { $0.name == ToolDefinition.fileWrite.name }) {
                 return .tool(.init(
                     name: ToolDefinition.fileWrite.name,
-                    argumentsJSON: ToolArguments.json([
-                        "path": "hello.txt",
-                        "content": content
-                    ])
+                    argumentsJSON: ToolArguments.json(fileWrite.arguments)
                 ))
             }
             if tools.contains(where: { $0.name == ToolDefinition.shellRun.name }) {
-                let command = "printf %s \(Self.shellSingleQuoted(content)) > hello.txt"
+                let parent = Self.parentDirectory(for: fileWrite.path)
+                let command = [
+                    "mkdir -p \(Self.shellSingleQuoted(parent))",
+                    "printf %s \(Self.shellSingleQuoted(fileWrite.content)) > \(Self.shellSingleQuoted(fileWrite.path))"
+                ].joined(separator: " && ")
                 return .tool(.init(
                     name: ToolDefinition.shellRun.name,
                     argumentsJSON: ToolArguments.json(["cmd": command])
@@ -152,10 +151,7 @@ public struct MockLLMClient: LLMClient {
             }
             return .tool(.init(
                 name: ToolDefinition.fileWrite.name,
-                argumentsJSON: ToolArguments.json([
-                    "path": "hello.txt",
-                    "content": content
-                ])
+                argumentsJSON: ToolArguments.json(fileWrite.arguments)
             ))
         }
 

--- a/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateActionTests.swift
@@ -148,6 +148,58 @@ final class AgentImmediateActionTests: XCTestCase {
         XCTAssertEqual(result.thread.messages.last?.content, "Wrote `hello.txt`.")
     }
 
+    func testNamedFileWriteExecutesImmediatelyWithoutProviderRoundTrip() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(llm: FailingLLMClient(), enablesImmediateActionPreflight: true)
+
+        let result = try await runner.send(
+            "Create a file named notes/todo.txt that says \"buy milk\"",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertEqual(
+            try String(contentsOf: root.appendingPathComponent("notes/todo.txt"), encoding: .utf8),
+            "buy milk\n"
+        )
+        let write = try queuedFileWrite(in: result)
+        XCTAssertEqual(write.path, "notes/todo.txt")
+        XCTAssertEqual(write.content, "buy milk\n")
+    }
+
+    func testFileWriteWithQuotedContentDefaultsToNotePath() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(llm: FailingLLMClient(), enablesImmediateActionPreflight: true)
+
+        let result = try await runner.send(
+            "Make a file with content `ship the first build`",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertEqual(
+            try String(contentsOf: root.appendingPathComponent("note.txt"), encoding: .utf8),
+            "ship the first build\n"
+        )
+        let write = try queuedFileWrite(in: result)
+        XCTAssertEqual(write.path, "note.txt")
+        XCTAssertEqual(write.content, "ship the first build\n")
+    }
+
+    func testAmbiguousMakeFileRequestStillUsesModel() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(llm: FixedSayLLMClient(message: "What should the file contain?"), enablesImmediateActionPreflight: true)
+
+        let result = try await runner.send("Make a file", in: ChatThread(mode: .auto), workspaceRoot: root)
+
+        XCTAssertEqual(result.toolResults.count, 0)
+        XCTAssertEqual(result.thread.messages.last?.content, "What should the file contain?")
+    }
+
     func testCommitChangesExecutesImmediately() async throws {
         let root = try makeTempDirectory()
         try initializeGitRepo(at: root)
@@ -197,6 +249,18 @@ final class AgentImmediateActionTests: XCTestCase {
         XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
         return try arguments.requiredString("cmd")
     }
+
+    private func queuedFileWrite(in result: AgentRunResult) throws -> (path: String, content: String) {
+        let queued = try XCTUnwrap(result.thread.events.first { $0.kind == .toolQueued })
+        let payloadJSON = try XCTUnwrap(queued.payloadJSON)
+        let call = try JSONDecoder().decode(ToolCall.self, from: Data(payloadJSON.utf8))
+        let arguments = try ToolArguments(call.argumentsJSON)
+        XCTAssertEqual(call.name, ToolDefinition.fileWrite.name)
+        return (
+            try arguments.requiredString("path"),
+            try arguments.requiredString("content")
+        )
+    }
 }
 
 private enum FailingLLMClientError: Error {
@@ -206,5 +270,13 @@ private enum FailingLLMClientError: Error {
 private struct FailingLLMClient: LLMClient {
     func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
         throw FailingLLMClientError.shouldNotBeCalled
+    }
+}
+
+private struct FixedSayLLMClient: LLMClient {
+    var message: String
+
+    func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+        .say(message)
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -9023,3 +9023,20 @@ Code quality changes:
 Remaining risk:
 
 - This improves the evidence substrate for native click targets. The final A+ layer remains packaged `.app` Accessibility automation that uses these stable IDs to sample real frames and labels from the running app.
+
+## 2026-06-28 Immediate File-Write Intent Pass
+
+Overall grade after this slice: **A- immediate utility, A parser ownership, A ambiguous-request safety**.
+
+QuillCode already recovered common shell commands and the special hello-world file request, but obvious file-write requests still had too much room to depend on provider behavior. That made it possible for weaker models to answer "I'll create it" before using a tool, or to route through a duplicated mock-only heuristic.
+
+Code quality changes:
+
+- Added `AgentFileWriteRequestParser` as the single high-confidence parser for common "write/create/make a file ... that says/with content ..." requests.
+- Replaced the immediate planner's hard-coded hello-world file block with the shared parser while preserving `hello.txt` for the existing hello-world flow.
+- Reused the same parser from `MockLLMClient`, removing the duplicate mock-only file-write heuristic and keeping fallback shell writes path-aware.
+- Added regression tests proving named nested-path writes run without a provider round trip, quoted-content writes default to `note.txt`, and ambiguous "Make a file" still goes through the model instead of manufacturing an empty write.
+
+Remaining risk:
+
+- This deliberately handles only high-confidence file-write phrasing. Full Codex parity still needs model/tool-call reliability across richer edit intents, multi-file creation, and follow-up clarification flows.


### PR DESCRIPTION
## Summary
- add a shared high-confidence parser for immediate file-write requests
- reuse it from the immediate planner and mock LLM so obvious file writes do not depend on provider behavior
- add regressions for named nested-path writes, quoted-content writes, and ambiguous make-file prompts

## Validation
- swift test --filter AgentImmediateActionTests --filter TrustedRouterActionParserTests --filter AgentToolArgumentNormalizerTests
- swift test
- ./scripts/smoke.sh
- git diff --check
- docker run --rm -v "$PWD":/workspace -w /workspace swift:6.2-noble swift build --product quill-code