### PR TITLE
Show streamed thinking traces

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -344,6 +344,10 @@ public struct AgentRunner: Sendable {
             },
             onUsage: { usage in
                 latestUsage = usage
+            },
+            onReasoning: { summary in
+                publishReasoningSummary(summary, in: &draftThread)
+                await onProgress?(draftThread)
             }
         )
 
@@ -363,6 +367,17 @@ public struct AgentRunner: Sendable {
         } else {
             thread.messages.append(.init(role: .assistant, content: text))
         }
+        thread.updatedAt = Date()
+    }
+
+    private static func publishReasoningSummary(_ summary: String, in thread: inout ChatThread) {
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let notice = "Thinking: \(trimmed)"
+        guard thread.events.last?.kind != .notice || thread.events.last?.summary != notice else {
+            return
+        }
+        thread.events.append(.init(kind: .notice, summary: notice))
         thread.updatedAt = Date()
     }
 

--- a/Sources/QuillCodeAgent/AgentActionStreaming.swift
+++ b/Sources/QuillCodeAgent/AgentActionStreaming.swift
@@ -3,6 +3,7 @@ import QuillCodeCore
 
 public enum AgentTextStreamEvent: Sendable, Hashable {
     case text(String)
+    case reasoning(String)
     case usage(ModelTokenUsage)
 }
 
@@ -52,10 +53,12 @@ public enum AgentActionStreamCollector {
         from stream: AsyncThrowingStream<AgentTextStreamEvent, Error>,
         emptyError: @autoclosure () -> any Error,
         onVisibleAssistantText: ((String) async -> Void)?,
-        onUsage: ((ModelTokenUsage) async -> Void)?
+        onUsage: ((ModelTokenUsage) async -> Void)?,
+        onReasoning: ((String) async -> Void)? = nil
     ) async throws -> AgentAction {
         var rawActionText = ""
         var lastVisibleText = ""
+        var lastReasoningText = ""
         for try await event in stream {
             try Task.checkCancellation()
             switch event {
@@ -70,6 +73,13 @@ public enum AgentActionStreamCollector {
                 }
                 lastVisibleText = visibleText
                 await onVisibleAssistantText?(visibleText)
+            case .reasoning(let summary):
+                let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty, trimmed != lastReasoningText else {
+                    continue
+                }
+                lastReasoningText = trimmed
+                await onReasoning?(trimmed)
             case .usage(let usage):
                 await onUsage?(usage)
             }

--- a/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
@@ -106,6 +106,9 @@ public struct TrustedRouterLLMClient: UsageStreamingLLMClient {
             Task {
                 do {
                     for try await chunk in chunks {
+                        if let reasoning = chunk.choices.first?.delta?.reasoning, !reasoning.isEmpty {
+                            continuation.yield(.reasoning(reasoning))
+                        }
                         if let content = chunk.choices.first?.delta?.content, !content.isEmpty {
                             continuation.yield(.text(content))
                         }
@@ -173,6 +176,39 @@ private struct UsageChatCompletionChunk: Decodable {
 
         struct Delta: Decodable {
             var content: String?
+            var reasoning: String?
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.content = try container.decodeIfPresent(String.self, forKey: .content)
+                self.reasoning = try Self.firstNonEmptyString(in: container, keys: [
+                    .reasoningContent,
+                    .reasoning,
+                    .reasoningSummary
+                ])
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case content
+                case reasoning
+                case reasoningContent = "reasoning_content"
+                case reasoningSummary = "reasoning_summary"
+            }
+
+            private static func firstNonEmptyString(
+                in container: KeyedDecodingContainer<CodingKeys>,
+                keys: [CodingKeys]
+            ) throws -> String? {
+                for key in keys {
+                    guard let value = try container.decodeIfPresent(String.self, forKey: key),
+                          value.contains(where: { !$0.isWhitespace })
+                    else {
+                        continue
+                    }
+                    return value
+                }
+                return nil
+            }
         }
     }
 }

--- a/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
@@ -205,6 +205,44 @@ final class AgentStreamingTests: XCTestCase {
         XCTAssertEqual(result.thread.events[1].summary, AgentRunner.streamingNotice)
     }
 
+    func testUsageStreamingReasoningSummariesAreRecordedAsThinkingTrace() async throws {
+        let root = try makeTempDirectory()
+        let recorder = ProgressRecorder()
+        let runner = AgentRunner(llm: UsageStreamingActionLLMClient(events: [
+            .reasoning("Inspecting the request."),
+            .reasoning("Choosing the shell tool."),
+            .text(#"{"type":"tool","name":"host.shell.run","arguments":{"cmd":"whoami"}}"#)
+        ]))
+
+        let result = try await runner.send(
+            "run whoami",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root,
+            onProgress: { thread in
+                await recorder.record(thread)
+            }
+        )
+
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults[0].ok, result.toolResults[0].error ?? "")
+        XCTAssertTrue(result.thread.events.contains {
+            $0.kind == .notice && $0.summary == "Thinking: Inspecting the request."
+        })
+        XCTAssertTrue(result.thread.events.contains {
+            $0.kind == .notice && $0.summary == "Thinking: Choosing the shell tool."
+        })
+
+        let snapshots = await recorder.eventSnapshots()
+        XCTAssertTrue(snapshots.contains { events in
+            events.last?.kind == .notice &&
+                events.last?.summary == "Thinking: Inspecting the request."
+        })
+        XCTAssertTrue(snapshots.contains { events in
+            events.last?.kind == .notice &&
+                events.last?.summary == "Thinking: Choosing the shell tool."
+        })
+    }
+
     func testStreamingPromisedWorkDraftIsSuppressedBeforeCorrectionToolRuns() async throws {
         let root = try makeTempDirectory()
         let recorder = ProgressRecorder()

--- a/Tests/QuillCodeAgentTests/TrustedRouterStreamingActionTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterStreamingActionTests.swift
@@ -46,6 +46,30 @@ final class TrustedRouterStreamingActionTests: XCTestCase {
         XCTAssertEqual(action, .say("hello"))
     }
 
+    func testCollectActionPublishesReasoningSummariesSeparatelyFromText() async throws {
+        var reasoning: [String] = []
+        let action = try await AgentActionStreamCollector.collect(
+            from: eventStream([
+                .reasoning("Inspecting request."),
+                .reasoning("Inspecting request."),
+                .reasoning("Choosing shell."),
+                .text(#"{"type":"tool","name":"host.shell.run","arguments":{"cmd":"whoami"}}"#)
+            ]),
+            emptyError: AgentError.emptyStreamingResponse,
+            onVisibleAssistantText: nil,
+            onUsage: nil,
+            onReasoning: { summary in
+                reasoning.append(summary)
+            }
+        )
+
+        XCTAssertEqual(reasoning, ["Inspecting request.", "Choosing shell."])
+        guard case .tool(let call) = action else {
+            return XCTFail("Expected streamed tool action")
+        }
+        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
+    }
+
     func testStreamingPreviewExposesOnlySayText() {
         XCTAssertEqual(
             AgentActionStreamPreview.visibleAssistantText(from: #"{"type":"say","text":"hello\nwor"#),
@@ -59,6 +83,15 @@ final class TrustedRouterStreamingActionTests: XCTestCase {
         AsyncThrowingStream { continuation in
             for chunk in chunks {
                 continuation.yield(chunk)
+            }
+            continuation.finish()
+        }
+    }
+
+    private func eventStream(_ events: [AgentTextStreamEvent]) -> AsyncThrowingStream<AgentTextStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            for event in events {
+                continuation.yield(event)
             }
             continuation.finish()
         }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -9056,3 +9056,20 @@ Code quality changes:
 Remaining risk:
 
 - This deliberately handles only high-confidence file-write phrasing. Full Codex parity still needs model/tool-call reliability across richer edit intents, multi-file creation, and follow-up clarification flows.
+
+## 2026-06-28 Streaming Thinking Trace Pass
+
+Overall grade after this slice: **A live run feedback, A stream event separation, A- provider reasoning coverage**.
+
+The composer already pre-recorded user messages before provider work, which gives the UI the immediate echo Codex users expect. The weaker spot was visibility while the model is planning: streamed provider reasoning or summary deltas were dropped, so the existing thinking trace could show local tool progress but not model-side progress.
+
+Code quality changes:
+
+- Added `AgentTextStreamEvent.reasoning` so provider thinking summaries are represented separately from assistant text and token usage.
+- Updated the TrustedRouter streaming decoder to forward common chat-completion reasoning delta fields without contaminating the final assistant answer.
+- Recorded reasoning summaries as live `Thinking: ...` notices during active runs, letting the existing transcript thinking disclosure render them as trace lines.
+- Added focused streaming tests proving duplicate reasoning summaries are de-duped, live progress receives the trace notices, and tool execution still proceeds normally.
+
+Remaining risk:
+
+- This covers common chat-completion reasoning fields. Full parity still needs live verification against every TrustedRouter provider family and richer controls for hiding, expanding, or copying longer reasoning traces.


### PR DESCRIPTION
## Summary
- add a separate streamed reasoning event for TrustedRouter provider thinking summaries
- record live reasoning summaries as Thinking trace notices without polluting assistant text
- cover collector de-duping and agent progress snapshots with focused tests

## Validation
- swift test --filter AgentStreamingTests --filter TrustedRouterStreamingActionTests --filter WorkspaceTranscriptSurfaceBuilderTests --filter WorkspaceComposerIntegrationTests
- swift test --filter ParityTrustedRouterGateTests --filter AgentStreamingTests --filter TrustedRouterStreamingActionTests
- swift test
- ./scripts/smoke.sh
- docker run --rm -v "$PWD":/workspace -w /workspace swift:6.2-noble swift build --product quill-code

## Screenshot
Captured local harness state at /tmp/quillcode-thinking-trace-current.png showing immediate user echo, running tool state, and visible Thinking card with trace disclosure.