### PR TITLE
Record smoke runtime evidence

### DIFF
--- a/Tests/QuillCodeParityTests/ParitySmokeScriptGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySmokeScriptGateTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+final class ParitySmokeScriptGateTests: QuillCodeParityTestCase {
+    func testLiveTrustedRouterSmokeManifestRecordsSecretFreeRuntimeEvidence() throws {
+        let script = try Self.scriptText(named: "live-tr-smoke.sh")
+
+        XCTAssertTrue(script.contains("API_KEY_SOURCE=\"missing\""))
+        XCTAssertTrue(script.contains("API_KEY_SOURCE=\"env:QUILLCODE_API_KEY\""))
+        XCTAssertTrue(script.contains("API_KEY_SOURCE=\"env:TRUSTEDROUTER_API_KEY\""))
+        XCTAssertTrue(script.contains("API_KEY_SOURCE=\"key-file\""))
+        XCTAssertTrue(script.contains("elif [[ -s \"$KEY_FILE\" ]]"))
+        XCTAssertTrue(script.contains("--arg rawModel \"$RAW_MODEL\""))
+        XCTAssertTrue(script.contains("--arg keySource \"$API_KEY_SOURCE\""))
+        XCTAssertTrue(script.contains("transport: \"TrustedRouter\""))
+        XCTAssertTrue(script.contains("rawModel: $rawModel"))
+        XCTAssertTrue(script.contains("normalizedModel: $model"))
+        XCTAssertTrue(script.contains("keySource: $keySource"))
+        XCTAssertTrue(script.contains("secretFree: true"))
+        XCTAssertFalse(
+            script.contains("--arg apiKey \"$API_KEY\""),
+            "Live smoke manifests must not pass the raw API key into jq."
+        )
+    }
+
+    func testRealWorldSmokeManifestCarriesLiveRuntimeConfiguration() throws {
+        let script = try Self.scriptText(named: "real-world-smoke.sh")
+
+        XCTAssertTrue(script.contains("LIVE_KEY_SOURCE=\"missing\""))
+        XCTAssertTrue(script.contains("LIVE_MODEL=\"${QUILLCODE_LIVE_MODEL:-deepseekv4flash}\""))
+        XCTAssertTrue(script.contains("LIVE_BASE_URL=\"${QUILLCODE_LIVE_BASE_URL:-https://api.trustedrouter.com/v1}\""))
+        XCTAssertTrue(script.contains("live_key_source()"))
+        XCTAssertTrue(script.contains("printf 'env:QUILLCODE_API_KEY'"))
+        XCTAssertTrue(script.contains("printf 'env:TRUSTEDROUTER_API_KEY'"))
+        XCTAssertTrue(script.contains("printf 'key-file'"))
+        XCTAssertTrue(script.contains("\"configured\": {"))
+        XCTAssertTrue(script.contains("\"transport\": \"TrustedRouter\""))
+        XCTAssertTrue(script.contains("\"rawModel\": live_model"))
+        XCTAssertTrue(script.contains("\"baseURL\": live_base_url"))
+        XCTAssertTrue(script.contains("\"keySource\": live_key_source"))
+        XCTAssertTrue(script.contains("\"secretFree\": True"))
+        XCTAssertTrue(script.contains("LIVE_KEY_SOURCE=\"$(live_key_source)\""))
+        XCTAssertFalse(
+            script.contains("QUILLCODE_API_KEY\"") && script.contains("\"apiKey\""),
+            "The real-world wrapper should record key source metadata, never raw key material."
+        )
+    }
+
+    private static func scriptText(named fileName: String) throws -> String {
+        let file = packageRoot()
+            .appendingPathComponent("scripts")
+            .appendingPathComponent(fileName)
+        return try String(contentsOf: file, encoding: .utf8)
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-29 Real-World Smoke Runtime Evidence Pass
+
+Overall grade after this slice: **A release evidence traceability, A secret hygiene, A- live-provider matrix breadth**.
+
+The real-world smoke wrapper already embedded deterministic and live TrustedRouter artifacts, but reviewers still had to inspect nested logs to know which live model/base URL/key source was used. That makes release evidence weaker when testing cheap models or comparing provider endpoints.
+
+| Before | After |
+| --- | --- |
+| `live-tr-smoke.sh` resolved the live key but did not record a secret-free source label in the manifest. | The live manifest now records `keySource` as `env:QUILLCODE_API_KEY`, `env:TRUSTEDROUTER_API_KEY`, `key-file`, or `missing`, plus `secretFree=true`; it never passes the raw key into the manifest writer. |
+| The live manifest exposed only the normalized model under `model`. | It now records `transport`, `rawModel`, and `normalizedModel`, so shorthand such as `deepseekv4flash` can be audited alongside the real model ID. |
+| The top-level real-world manifest did not summarize live runtime configuration before opening nested artifacts. | It now includes a secret-free `liveTrustedRouter.configured` block with transport, raw model, base URL, and key source. |
+| Smoke-script evidence contracts were not protected by a focused parity gate. | `ParitySmokeScriptGateTests` checks that live and real-world smoke manifests keep the runtime evidence fields and do not add raw API-key manifest plumbing. |
+
+Residual risk:
+
+- This pass improves evidence metadata, not scenario breadth. Future live-provider smoke should still add deeper git review, patch, browser, and Computer Use flows as those end-to-end paths stabilize.
+
 ## 2026-06-29 Git Read Real-World Smoke Pass
 
 Overall grade after this slice: **A read-only git reliability, A parser ownership, A- broader git workflow coverage**.

--- a/scripts/live-tr-smoke.sh
+++ b/scripts/live-tr-smoke.sh
@@ -12,6 +12,7 @@ RAW_MODEL="${QUILLCODE_LIVE_MODEL:-deepseekv4flash}"
 BASE_URL="${QUILLCODE_LIVE_BASE_URL:-https://api.trustedrouter.com/v1}"
 KEEP_ARTIFACTS="${QUILLCODE_LIVE_KEEP_ARTIFACTS:-0}"
 ARTIFACT_DIR="${QUILLCODE_LIVE_SMOKE_ARTIFACT_DIR:-}"
+API_KEY_SOURCE="missing"
 CURRENT_SCENARIO=""
 CURRENT_PROMPT=""
 CURRENT_SCENARIO_START=0
@@ -66,22 +67,18 @@ trim() {
   awk '{$1=$1; print}'
 }
 
-configured_key() {
-  if [[ -n "${QUILLCODE_API_KEY:-}" ]]; then
-    printf '%s' "$QUILLCODE_API_KEY" | trim
-    return
-  fi
-  if [[ -n "${TRUSTEDROUTER_API_KEY:-}" ]]; then
-    printf '%s' "$TRUSTEDROUTER_API_KEY" | trim
-    return
-  fi
-  if [[ -f "$KEY_FILE" ]]; then
-    trim < "$KEY_FILE"
-    return
-  fi
-}
-
-API_KEY="$(configured_key || true)"
+if [[ -n "${QUILLCODE_API_KEY:-}" ]]; then
+  API_KEY="$(printf '%s' "$QUILLCODE_API_KEY" | trim)"
+  API_KEY_SOURCE="env:QUILLCODE_API_KEY"
+elif [[ -n "${TRUSTEDROUTER_API_KEY:-}" ]]; then
+  API_KEY="$(printf '%s' "$TRUSTEDROUTER_API_KEY" | trim)"
+  API_KEY_SOURCE="env:TRUSTEDROUTER_API_KEY"
+elif [[ -s "$KEY_FILE" ]]; then
+  API_KEY="$(trim < "$KEY_FILE")"
+  API_KEY_SOURCE="key-file"
+else
+  API_KEY=""
+fi
 if [[ -z "$API_KEY" ]]; then
   echo "No TrustedRouter key found. Set QUILLCODE_API_KEY, TRUSTEDROUTER_API_KEY, or create $KEY_FILE." >&2
   exit 2
@@ -269,8 +266,10 @@ write_artifact_manifest() {
     --arg generatedAt "$generated_at" \
     --arg status "$status" \
     --arg detail "$detail" \
+    --arg rawModel "$RAW_MODEL" \
     --arg model "$MODEL" \
     --arg baseURL "$BASE_URL" \
+    --arg keySource "$API_KEY_SOURCE" \
     --arg root "$SMOKE_ROOT" \
     --arg home "$SMOKE_HOME" \
     --arg workspace "$SMOKE_WORKSPACE" \
@@ -282,8 +281,13 @@ write_artifact_manifest() {
       generatedAt: $generatedAt,
       status: ($status | tonumber),
       detail: $detail,
+      transport: "TrustedRouter",
+      rawModel: $rawModel,
+      normalizedModel: $model,
       model: $model,
       baseURL: $baseURL,
+      keySource: $keySource,
+      secretFree: true,
       smokeRoot: $root,
       home: $home,
       workspace: $workspace,

--- a/scripts/real-world-smoke.sh
+++ b/scripts/real-world-smoke.sh
@@ -12,6 +12,9 @@ DETERMINISTIC_DETAIL="not-started"
 LIVE_STATUS="not-run"
 LIVE_DETAIL="not-started"
 FINAL_DETAIL="interrupted"
+LIVE_KEY_SOURCE="missing"
+LIVE_MODEL="${QUILLCODE_LIVE_MODEL:-deepseekv4flash}"
+LIVE_BASE_URL="${QUILLCODE_LIVE_BASE_URL:-https://api.trustedrouter.com/v1}"
 
 cd "$ROOT_DIR"
 
@@ -25,6 +28,22 @@ has_live_key() {
     return 0
   fi
   [[ -s "$KEY_FILE" ]]
+}
+
+live_key_source() {
+  if [[ -n "${QUILLCODE_API_KEY:-}" ]]; then
+    printf 'env:QUILLCODE_API_KEY'
+    return
+  fi
+  if [[ -n "${TRUSTEDROUTER_API_KEY:-}" ]]; then
+    printf 'env:TRUSTEDROUTER_API_KEY'
+    return
+  fi
+  if [[ -s "$KEY_FILE" ]]; then
+    printf 'key-file'
+    return
+  fi
+  printf 'missing'
 }
 
 is_truthy() {
@@ -58,6 +77,9 @@ write_manifest() {
     "$DETERMINISTIC_DETAIL" \
     "$LIVE_STATUS" \
     "$LIVE_DETAIL" \
+    "$LIVE_KEY_SOURCE" \
+    "$LIVE_MODEL" \
+    "$LIVE_BASE_URL" \
     "$REQUIRE_PLAYWRIGHT" \
     "$ARTIFACT_DIR" <<'PY'
 import json
@@ -74,6 +96,9 @@ from datetime import datetime, timezone
     deterministic_detail,
     live_status,
     live_detail,
+    live_key_source,
+    live_model,
+    live_base_url,
     require_playwright,
     artifact_root,
 ) = sys.argv[1:]
@@ -128,6 +153,13 @@ manifest = {
     "liveTrustedRouter": {
         "status": live_status,
         "detail": live_detail,
+        "configured": {
+            "transport": "TrustedRouter",
+            "rawModel": live_model,
+            "baseURL": live_base_url,
+            "keySource": live_key_source,
+            "secretFree": True,
+        },
         "artifactDir": live_dir if os.path.isdir(live_dir) else None,
         "manifest": live_manifest,
         "artifactFiles": collect_files(live_dir),
@@ -175,6 +207,7 @@ else
 fi
 
 if has_live_key; then
+  LIVE_KEY_SOURCE="$(live_key_source)"
   echo "==> Running live TrustedRouter real-world smoke suite"
   if QUILLCODE_LIVE_SMOKE_ARTIFACT_DIR="${ARTIFACT_DIR:+$ARTIFACT_DIR/live-trustedrouter}" \
     "$ROOT_DIR/scripts/live-tr-smoke.sh"; then


### PR DESCRIPTION
## Summary
- add secret-free live TrustedRouter runtime metadata to live smoke manifests
- surface live runtime configuration in the top-level real-world smoke manifest
- add a focused parity gate for the smoke-script evidence contract

## Validation
- bash -n scripts/live-tr-smoke.sh scripts/real-world-smoke.sh scripts/smoke.sh
- swift test --filter ParitySmokeScriptGateTests
- QUILLCODE_REAL_WORLD_SMOKE_ARTIFACT_DIR=<tmp> QUILLCODE_REAL_WORLD_REQUIRE_PLAYWRIGHT=1 ./scripts/real-world-smoke.sh (expected early exit 2 with manifest)
- swift test
- git diff --check