### PR TITLE
Harden project header click targets

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -6237,7 +6237,7 @@
               <div class="sidebar-projects-zone" data-testid="sidebar-projects-zone">
                 <div class="sidebar-section-title">
                   <h2>${escapeHTML(state.projects.title)}</h2>
-                  <button class="sidebar-icon-button hit-target-icon" type="button" data-testid="add-project-button" aria-label="Open project">+</button>
+                  <button class="sidebar-icon-button hit-target-icon" type="button" data-testid="add-project-button" aria-label="Open project" data-command-id="add-project">+</button>
                 </div>
                 ${projectsContent}
               </div>
@@ -6261,7 +6261,7 @@
                     </section>
                   </div>
                 </details>
-                <button class="sidebar-settings-button hit-target-row" type="button" data-testid="settings-button" aria-label="Settings" title="Settings">Settings</button>
+                <button class="sidebar-settings-button hit-target-row" type="button" data-testid="settings-button" aria-label="Settings" title="Settings" data-command-id="settings">Settings</button>
               </div>
             </aside>
 	            <main class="transcript" data-testid="transcript">
@@ -6479,8 +6479,8 @@
           );
         });
       });
-      document.querySelector('[data-testid="add-project-button"]').addEventListener('click', () => {
-        addProject();
+      document.querySelector('[data-testid="add-project-button"]').addEventListener('click', event => {
+        runCommand(event.currentTarget.getAttribute('data-command-id'));
       });
       document.querySelectorAll('.topbar-action-cluster [data-command-id]').forEach(button => {
         button.addEventListener('click', event => {

--- a/E2E/playwright/tests/interaction-audit.spec.ts
+++ b/E2E/playwright/tests/interaction-audit.spec.ts
@@ -64,6 +64,14 @@ test('critical click-target registry covers primary workspace surfaces', async (
       ]
     },
     {
+      label: 'project list',
+      requiredKinds: ['icon', 'row'],
+      probes: [
+        { label: 'open project', locator: page.getByTestId('add-project-button'), expectedKind: 'icon' },
+        { label: 'first project row', locator: page.getByTestId('project-item').first(), expectedKind: 'row' }
+      ]
+    },
+    {
       label: 'top bar actions',
       requiredKinds: ['capsule', 'icon'],
       probes: [
@@ -555,6 +563,10 @@ test('command routing audit catches visible dead command targets', async ({ page
 
 test('critical controls respond from the full interior click target, not only the center', async ({ page }) => {
   await page.goto(harnessURL());
+
+  const initialProjectCount = await page.getByTestId('project-item').count();
+  await clickTargetInteriorPoint(page.getByTestId('add-project-button'), 'add project bottom interior', 0.5, 0.82);
+  await expect(page.getByTestId('project-item')).toHaveCount(initialProjectCount + 1);
 
   await clickTargetInteriorPoint(page.getByTestId('top-bar-overflow-button'), 'top-bar overflow leading interior', 0.2, 0.5);
   await expect(page.getByTestId('top-bar-overflow-menu')).toHaveAttribute('open', '');

--- a/Sources/QuillCodeApp/QuillCodeNativeHitTargetAudit.swift
+++ b/Sources/QuillCodeApp/QuillCodeNativeHitTargetAudit.swift
@@ -375,6 +375,7 @@ public struct QuillCodeNativeHitTargetAuditReport: Codable, Sendable, Hashable {
 
 public enum QuillCodeNativeHitTargetAudit {
     public static let requiredCommandIDs = [
+        "add-project",
         "new-chat",
         "search",
         "toggle-extensions",
@@ -781,6 +782,7 @@ public enum QuillCodeNativeHitTargetAudit {
             contract("composer.mode-picker", family: .composer, surface: "Composer", label: "Mode picker", kind: .capsule, minWidth: nil, testID: "mode-picker-button"),
             contract("top-bar.overflow", family: .topBar, surface: "Top bar", label: "More workspace actions", kind: .icon, minWidth: 44, testID: "top-bar-overflow"),
             contract("sidebar.tools-menu", family: .sidebar, surface: "Sidebar", label: "Tools", kind: .fullRow, minWidth: nil, testID: "sidebar-tools-button"),
+            contract("project.clear", family: .sidebar, surface: "Project header", label: "Clear project", kind: .icon, minWidth: 44, testID: "project-clear-button"),
             contract("workspace.chrome", family: .workspaceChrome, surface: "Workspace chrome", label: "Workspace command", kind: .fullRow, minWidth: nil, testID: "workspace-command")
         ]
     }
@@ -835,19 +837,28 @@ public enum QuillCodeNativeHitTargetAudit {
     private static func commandContract(_ command: WorkspaceCommandSurface) -> QuillCodeNativeHitTargetContract {
         let kind: QuillCodeNativeHitTargetKind
         let surface: String
+        let minWidth: Double?
         switch command.id {
+        case "add-project":
+            kind = .icon
+            surface = "Project header"
+            minWidth = 44
         case "new-chat", "search", "toggle-extensions", "toggle-automations":
             kind = .fullRow
             surface = "Sidebar primary"
+            minWidth = nil
         case "toggle-terminal", "toggle-browser", "toggle-memories", "toggle-activity", "command-palette":
             kind = .fullRow
             surface = "Sidebar tools"
+            minWidth = nil
         case "keyboard-shortcuts", "settings":
             kind = .fullRow
             surface = "Top bar overflow"
+            minWidth = nil
         default:
             kind = .textButton
             surface = "Workspace command"
+            minWidth = nil
         }
         return contract(
             "command.\(command.id)",
@@ -855,7 +866,7 @@ public enum QuillCodeNativeHitTargetAudit {
             surface: surface,
             label: command.title,
             kind: kind,
-            minWidth: nil,
+            minWidth: minWidth,
             commandID: command.id,
             source: "WorkspaceCommandSurface"
         )
@@ -863,7 +874,7 @@ public enum QuillCodeNativeHitTargetAudit {
 
     private static func commandFamily(_ commandID: String) -> QuillCodeInteractionSurfaceFamily {
         switch commandID {
-        case "new-chat", "search", "toggle-extensions", "toggle-automations",
+        case "add-project", "new-chat", "search", "toggle-extensions", "toggle-automations",
             "toggle-terminal", "toggle-browser", "toggle-memories", "toggle-activity":
             return .sidebar
         case "keyboard-shortcuts", "settings":

--- a/Sources/QuillCodeApp/QuillCodeProjectListView.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectListView.swift
@@ -31,6 +31,8 @@ struct QuillCodeProjectListView: View {
             }
             .buttonStyle(QuillCodePressableButtonStyle())
             .foregroundStyle(QuillCodePalette.muted)
+            .accessibilityLabel("Open project")
+            .accessibilityIdentifier("quillcode-sidebar-command-add-project")
             .help("Open project")
             Button {
                 onSelectProject(nil)
@@ -41,6 +43,8 @@ struct QuillCodeProjectListView: View {
             }
             .buttonStyle(QuillCodePressableButtonStyle())
             .foregroundStyle(QuillCodePalette.muted)
+            .accessibilityLabel("Clear project")
+            .accessibilityIdentifier("quillcode-project-clear-button")
             .help("Clear project")
         }
     }

--- a/Sources/QuillCodeApp/WorkspaceHTMLSidebarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLSidebarRenderer.swift
@@ -21,9 +21,10 @@ enum WorkspaceHTMLSidebarRenderer {
           <div class="sidebar-projects-zone" data-testid="sidebar-projects-zone">
             <div class="sidebar-section-title">
               <h2>\(escape(projects.title))</h2>
-              \(WorkspaceHTMLPrimitives.button(
+              \(WorkspaceHTMLPrimitives.commandButton(
                   "+",
                   testID: "add-project-button",
+                  commandID: "add-project",
                   hitTargetKind: .icon,
                   ariaLabel: "Open project"
               ))

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityFrameSampler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityFrameSampler.swift
@@ -70,11 +70,13 @@ struct QuillCodeDesktopAccessibilityFrameSampleReport {
 enum QuillCodeDesktopAccessibilityFrameSampler {
     private static let identifierPrefix = "quillcode-"
     static let requiredPrimarySidebarContractIDs: Set<String> = [
+        "command.add-project",
         "command.new-chat",
         "command.search",
         "command.toggle-automations",
         "command.toggle-extensions",
-        "command.settings"
+        "command.settings",
+        "project.clear"
     ]
 
     private static let requiredCoreLiveContractIDs: Set<String> = [

--- a/Sources/quill-code-desktop/QuillCodeDesktopChromeSmoke.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopChromeSmoke.swift
@@ -30,6 +30,7 @@ struct QuillCodeDesktopChromeSmokeReport {
 enum QuillCodeDesktopChromeSmoke {
     static func verify(controller: QuillCodeDesktopController) throws -> QuillCodeDesktopChromeSmokeReport {
         let requiredCommandIDs = [
+            "add-project",
             "new-chat",
             "command-palette",
             "keyboard-shortcuts",

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -322,6 +322,7 @@ enum QuillCodeDesktopNativeHitTargetSmoke {
 
 struct QuillCodeDesktopWindowSmokeSurfaceReport {
     static let requiredCommandIDs = [
+        "add-project",
         "new-chat",
         "command-palette",
         "keyboard-shortcuts",

--- a/Tests/QuillCodeAppTests/QuillCodeNativeHitTargetAuditTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeNativeHitTargetAuditTests.swift
@@ -100,6 +100,7 @@ final class QuillCodeNativeHitTargetAuditTests: XCTestCase {
             "composer.mode-picker",
             "top-bar.overflow",
             "sidebar.tools-menu",
+            "project.clear",
             "workspace.chrome",
             "sidebar.thread-row",
             "sidebar.thread-action",
@@ -124,6 +125,7 @@ final class QuillCodeNativeHitTargetAuditTests: XCTestCase {
             "review.action",
             "secondary-pane.tab",
             "menu-bar.action",
+            "command.add-project",
             "command.new-chat",
             "command.search",
             "command.toggle-extensions",
@@ -172,6 +174,8 @@ final class QuillCodeNativeHitTargetAuditTests: XCTestCase {
         XCTAssertEqual(contractsByID["browser.comment"]?.kind, .textEntry)
         XCTAssertEqual(contractsByID["browser.family-icon"]?.kind, .icon)
         XCTAssertEqual(contractsByID["transcript.thinking-trace"]?.kind, .capsule)
+        XCTAssertEqual(contractsByID["command.add-project"]?.kind, .icon)
+        XCTAssertEqual(contractsByID["project.clear"]?.kind, .icon)
         XCTAssertEqual(contractsByID["browser.comment"]?.action, .textInput)
         XCTAssertEqual(contractsByID["transcript.artifact-link"]?.action, .link)
         XCTAssertEqual(contractsByID["browser.new-tab"]?.action, .press)
@@ -189,12 +193,16 @@ final class QuillCodeNativeHitTargetAuditTests: XCTestCase {
         XCTAssertEqual(contractsByID["command-palette.input"]?.testID, "quillcode-command-palette-input")
         XCTAssertEqual(contractsByID["browser.add-comment"]?.testID, "quillcode-browser-add-comment")
         XCTAssertEqual(contractsByID["automations.delete"]?.testID, "quillcode-automation-delete")
+        XCTAssertEqual(contractsByID["project.clear"]?.testID, "quillcode-project-clear-button")
+        XCTAssertEqual(contractsByID["command.add-project"]?.commandID, "add-project")
         XCTAssertEqual(contractsByID["command.new-chat"]?.commandID, "new-chat")
         XCTAssertEqual(contractsByID["command.settings"]?.commandID, "settings")
         XCTAssertEqual(probesByContractID["composer.send"]?.selectorKind, .testID)
         XCTAssertEqual(probesByContractID["composer.send"]?.selector, "quillcode-send-button")
         XCTAssertEqual(probesByContractID["command.new-chat"]?.selectorKind, .commandID)
         XCTAssertEqual(probesByContractID["command.new-chat"]?.selector, "new-chat")
+        XCTAssertEqual(probesByContractID["project.clear"]?.selectorKind, .testID)
+        XCTAssertEqual(probesByContractID["project.clear"]?.selector, "quillcode-project-clear-button")
         XCTAssertEqual(probesByContractID["terminal.command"]?.selectorKind, .testID)
         XCTAssertEqual(probesByContractID["terminal.command"]?.selector, "quillcode-terminal-command")
         XCTAssertGreaterThanOrEqual(probesByContractID["composer.send"]?.requiredMinWidth ?? 0, 44)

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
@@ -65,7 +65,7 @@ final class WorkspaceHTMLChromeRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="settings-button""#))
         XCTAssertFalse(html.contains(#"class="sidebar-utility-strip""#))
         XCTAssertFalse(html.contains(#"class="sidebar-workspace-actions""#))
-        XCTAssertTrue(html.contains(#"data-testid="add-project-button""#))
+        assertCommandButton(html, testID: "add-project-button", commandID: "add-project", title: "+")
         XCTAssertTrue(html.contains(#"data-testid="project-item""#))
         XCTAssertTrue(html.contains(#"data-testid="transcript""#))
         XCTAssertTrue(html.contains(#"data-testid="composer""#))

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -85,11 +85,13 @@ final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
         XCTAssertEqual(
             QuillCodeDesktopAccessibilityFrameSampler.requiredPrimarySidebarContractIDs,
             [
+                "command.add-project",
                 "command.new-chat",
                 "command.search",
                 "command.toggle-automations",
                 "command.toggle-extensions",
-                "command.settings"
+                "command.settings",
+                "project.clear"
             ]
         )
         XCTAssertTrue(QuillCodeDesktopAccessibilityFrameSampler.requiredLiveContractIDs.isSuperset(


### PR DESCRIPTION
## Summary
- promote the project header open-project action into the native hit-target command contract
- add a persistent clear-project sidebar target for native accessibility sampling
- route the HTML harness project button through the command system and extend Playwright click-target probes

## Verification
- swift test --filter QuillCodeNativeHitTargetAuditTests
- swift test --filter QuillCodeDesktopControllerSmokeTests
- npm --prefix E2E/playwright test -- interaction-audit.spec.ts visual-polish.spec.ts
- swift test (1622 tests, 1 skipped, 0 failures)
