### PR TITLE
Add file mention suggestion engine

### DIFF
--- a/Sources/QuillCodeApp/FileMentionCatalog.swift
+++ b/Sources/QuillCodeApp/FileMentionCatalog.swift
@@ -1,0 +1,141 @@
+import Foundation
+import QuillCodeTools
+
+/// A single ranked file suggestion for an in-progress composer `@` mention.
+public struct FileMentionSuggestionSurface: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { path }
+    /// Workspace-relative path, for example `Sources/App.swift`.
+    public var path: String
+    /// Last path component, for example `App.swift`.
+    public var name: String
+    /// Workspace-relative parent directory, or `""` for root files.
+    public var directory: String
+    /// The full composer draft after this suggestion is accepted, with the active
+    /// `@query` token replaced by `@path` and a trailing space.
+    public var insertText: String
+
+    public init(path: String, name: String, directory: String, insertText: String) {
+        self.path = path
+        self.name = name
+        self.directory = directory
+        self.insertText = insertText
+    }
+}
+
+/// Detects an in-progress `@` file mention in the composer draft and ranks bounded
+/// workspace files against it, mirroring ``SlashCommandCatalog`` so the composer can
+/// reuse the same suggestion panel for both surfaces.
+public enum FileMentionCatalog {
+    /// The active mention being typed at the end of the draft, if any.
+    public struct ActiveMention: Equatable {
+        /// Text before the mention's `@`, preserved verbatim on acceptance.
+        public var prefix: String
+        /// The mention query (the text after `@`, lowercased for matching is done elsewhere).
+        public var query: String
+
+        public init(prefix: String, query: String) {
+            self.prefix = prefix
+            self.query = query
+        }
+    }
+
+    /// Returns the active `@` mention the user is composing at the end of the draft.
+    ///
+    /// A mention is the trailing whitespace-delimited token that starts with `@`. The
+    /// `@` must begin a fresh token (start of draft or preceded by whitespace), so
+    /// values like `name@example.com` are not treated as mentions.
+    public static func activeMention(in draft: String) -> ActiveMention? {
+        guard let atIndex = trailingMentionStart(in: draft) else { return nil }
+        let prefix = String(draft[draft.startIndex..<atIndex])
+        let query = String(draft[draft.index(after: atIndex)..<draft.endIndex])
+        return ActiveMention(prefix: prefix, query: query)
+    }
+
+    /// Ranks workspace files against the active mention, returning bounded suggestions
+    /// whose acceptance replaces the `@query` token with `@path `.
+    public static func suggestions(
+        for draft: String,
+        in index: WorkspaceFileIndex,
+        limit: Int = 6
+    ) -> [FileMentionSuggestionSurface] {
+        guard let mention = activeMention(in: draft) else { return [] }
+        return suggestions(prefix: mention.prefix, query: mention.query, entries: index.entries, limit: limit)
+    }
+
+    static func suggestions(
+        prefix: String,
+        query: String,
+        entries: [WorkspaceFileIndexEntry],
+        limit: Int
+    ) -> [FileMentionSuggestionSurface] {
+        let normalizedQuery = query.lowercased()
+        let scored = entries.enumerated().compactMap { offset, entry -> (Int, Int, WorkspaceFileIndexEntry)? in
+            score(entry, query: normalizedQuery).map { ($0, offset, entry) }
+        }
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.0 != rhs.0 { return lhs.0 > rhs.0 }
+                if lhs.2.path.count != rhs.2.path.count { return lhs.2.path.count < rhs.2.path.count }
+                return lhs.2.path < rhs.2.path
+            }
+            .prefix(limit)
+            .map { _, _, entry in
+                FileMentionSuggestionSurface(
+                    path: entry.path,
+                    name: entry.name,
+                    directory: entry.directory,
+                    insertText: "\(prefix)@\(entry.path) "
+                )
+            }
+    }
+
+    private static func trailingMentionStart(in draft: String) -> String.Index? {
+        guard !draft.isEmpty else { return nil }
+        var index = draft.endIndex
+        while index > draft.startIndex {
+            let previous = draft.index(before: index)
+            let character = draft[previous]
+            if character.isWhitespace { return nil }
+            if character == "@" {
+                // The `@` must begin a fresh token: at draft start or after whitespace.
+                if previous == draft.startIndex { return previous }
+                let beforeAt = draft[draft.index(before: previous)]
+                return beforeAt.isWhitespace ? previous : nil
+            }
+            index = previous
+        }
+        return nil
+    }
+
+    private static func score(_ entry: WorkspaceFileIndexEntry, query: String) -> Int? {
+        guard !query.isEmpty else {
+            // Empty mention: surface shallow files first.
+            let depth = entry.path.reduce(into: 0) { $0 += $1 == "/" ? 1 : 0 }
+            return 100 - min(depth, 20)
+        }
+        let name = entry.name.lowercased()
+        let path = entry.path.lowercased()
+        if name == query { return 200 }
+        if name.hasPrefix(query) { return 170 }
+        if path.hasPrefix(query) { return 150 }
+        if name.contains(query) { return 120 }
+        if path.contains(query) { return 90 }
+        if isSubsequence(query, of: name) { return 60 }
+        if isSubsequence(query, of: path) { return 40 }
+        return nil
+    }
+
+    /// Returns whether `needle` appears as an in-order (not necessarily contiguous)
+    /// subsequence of `haystack`, enabling lightweight fuzzy matching.
+    static func isSubsequence(_ needle: String, of haystack: String) -> Bool {
+        guard !needle.isEmpty else { return true }
+        var needleIndex = needle.startIndex
+        for character in haystack {
+            if character == needle[needleIndex] {
+                needleIndex = needle.index(after: needleIndex)
+                if needleIndex == needle.endIndex { return true }
+            }
+        }
+        return false
+    }
+}

--- a/Sources/QuillCodeTools/WorkspaceFileIndexer.swift
+++ b/Sources/QuillCodeTools/WorkspaceFileIndexer.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// A single workspace-relative file discovered by ``WorkspaceFileIndexer``.
+public struct WorkspaceFileIndexEntry: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { path }
+    /// Workspace-relative path using forward slashes, for example `Sources/App.swift`.
+    public var path: String
+    /// Last path component, for example `App.swift`.
+    public var name: String
+    /// Workspace-relative parent directory, or `""` for files at the workspace root.
+    public var directory: String
+
+    public init(path: String, name: String, directory: String) {
+        self.path = path
+        self.name = name
+        self.directory = directory
+    }
+}
+
+/// A bounded snapshot of the regular files inside a workspace, used to power
+/// composer file mentions and other path-completion surfaces without scanning
+/// heavy dependency or build directories.
+public struct WorkspaceFileIndex: Codable, Sendable, Hashable {
+    public var entries: [WorkspaceFileIndexEntry]
+    /// Whether the scan stopped early because the file cap was reached.
+    public var truncated: Bool
+
+    public init(entries: [WorkspaceFileIndexEntry] = [], truncated: Bool = false) {
+        self.entries = entries
+        self.truncated = truncated
+    }
+
+    public var isEmpty: Bool { entries.isEmpty }
+}
+
+/// Enumerates the regular files inside a workspace root in a bounded, deterministic
+/// way. It skips the same heavy dependency/build directories as ``FileToolExecutor``
+/// search, skips hidden entries by default, and caps the number of returned files so
+/// large repositories cannot stall path-completion surfaces.
+public struct WorkspaceFileIndexer: Sendable {
+    public var workspaceRoot: URL
+
+    static let defaultMaxFiles = 4_000
+    static let absoluteMaxFiles = 20_000
+    static let excludedDirectoryNames: Set<String> = [
+        ".build",
+        ".git",
+        ".swiftpm",
+        "DerivedData",
+        "build",
+        "node_modules"
+    ]
+
+    public init(workspaceRoot: URL) {
+        self.workspaceRoot = workspaceRoot.standardizedFileURL
+    }
+
+    /// Returns a bounded, path-sorted index of the workspace's regular files.
+    ///
+    /// - Parameters:
+    ///   - includeHidden: When `false` (the default) dotfiles and files nested
+    ///     inside dot-directories are skipped.
+    ///   - maxFiles: Optional override for the file cap. Bounded to a safe range.
+    public func index(includeHidden: Bool = false, maxFiles: Int? = nil) -> WorkspaceFileIndex {
+        let limit = boundedMaxFiles(maxFiles)
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: workspaceRoot.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            return WorkspaceFileIndex()
+        }
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: workspaceRoot,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsPackageDescendants]
+        ) else {
+            return WorkspaceFileIndex()
+        }
+
+        var entries: [WorkspaceFileIndexEntry] = []
+        var truncated = false
+
+        for case let candidate as URL in enumerator {
+            let name = candidate.lastPathComponent
+
+            if shouldSkipDirectory(candidate, name: name, includeHidden: includeHidden) {
+                enumerator.skipDescendants()
+                continue
+            }
+
+            if !includeHidden, name.hasPrefix(".") {
+                continue
+            }
+
+            let values = try? candidate.resourceValues(forKeys: [.isDirectoryKey, .isRegularFileKey])
+            guard values?.isDirectory != true else { continue }
+            guard values?.isRegularFile == true else { continue }
+
+            guard let relative = relativePath(for: candidate) else { continue }
+            entries.append(WorkspaceFileIndexEntry(
+                path: relative,
+                name: name,
+                directory: parentDirectory(of: relative)
+            ))
+
+            if entries.count >= limit {
+                truncated = true
+                break
+            }
+        }
+
+        entries.sort { $0.path < $1.path }
+        return WorkspaceFileIndex(entries: entries, truncated: truncated)
+    }
+
+    private func shouldSkipDirectory(_ url: URL, name: String, includeHidden: Bool) -> Bool {
+        let values = try? url.resourceValues(forKeys: [.isDirectoryKey])
+        guard values?.isDirectory == true else { return false }
+        if Self.excludedDirectoryNames.contains(name) { return true }
+        if !includeHidden, name.hasPrefix(".") { return true }
+        return false
+    }
+
+    private func boundedMaxFiles(_ value: Int?) -> Int {
+        min(max(value ?? Self.defaultMaxFiles, 1), Self.absoluteMaxFiles)
+    }
+
+    private func relativePath(for url: URL) -> String? {
+        let standardized = url.standardizedFileURL
+        let rootPath = workspaceRoot.path.hasSuffix("/") ? workspaceRoot.path : "\(workspaceRoot.path)/"
+        guard standardized.path.hasPrefix(rootPath) else { return nil }
+        let relative = String(standardized.path.dropFirst(rootPath.count))
+        return relative.isEmpty ? nil : relative
+    }
+
+    private func parentDirectory(of relativePath: String) -> String {
+        guard let slashIndex = relativePath.lastIndex(of: "/") else { return "" }
+        return String(relativePath[relativePath.startIndex..<slashIndex])
+    }
+}

--- a/Tests/QuillCodeAppTests/FileMentionCatalogTests.swift
+++ b/Tests/QuillCodeAppTests/FileMentionCatalogTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeTools
+
+final class FileMentionCatalogTests: XCTestCase {
+    private func index(_ paths: [String]) -> WorkspaceFileIndex {
+        let entries = paths.map { path -> WorkspaceFileIndexEntry in
+            let name = path.split(separator: "/").last.map(String.init) ?? path
+            let directory = path.contains("/") ? String(path[path.startIndex..<path.lastIndex(of: "/")!]) : ""
+            return WorkspaceFileIndexEntry(path: path, name: name, directory: directory)
+        }
+        return WorkspaceFileIndex(entries: entries, truncated: false)
+    }
+
+    func testActiveMentionDetectsTrailingToken() {
+        let mention = FileMentionCatalog.activeMention(in: "look at @App")
+        XCTAssertEqual(mention?.prefix, "look at ")
+        XCTAssertEqual(mention?.query, "App")
+    }
+
+    func testActiveMentionAtDraftStart() {
+        let mention = FileMentionCatalog.activeMention(in: "@read")
+        XCTAssertEqual(mention?.prefix, "")
+        XCTAssertEqual(mention?.query, "read")
+    }
+
+    func testBareAtSignIsAnEmptyMention() {
+        let mention = FileMentionCatalog.activeMention(in: "explain @")
+        XCTAssertEqual(mention?.prefix, "explain ")
+        XCTAssertEqual(mention?.query, "")
+    }
+
+    func testEmailAddressIsNotAMention() {
+        XCTAssertNil(FileMentionCatalog.activeMention(in: "ping name@example.com"))
+    }
+
+    func testCompletedMentionFollowedBySpaceIsNotActive() {
+        XCTAssertNil(FileMentionCatalog.activeMention(in: "compare @App.swift and"))
+    }
+
+    func testNoMentionWithoutAtSign() {
+        XCTAssertNil(FileMentionCatalog.activeMention(in: "just some text"))
+    }
+
+    func testSuggestionsRankNamePrefixAbovePathContains() {
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "open @app",
+            in: index(["Sources/App.swift", "Tests/AppSupport/Helper.swift", "docs/app-notes.md"]),
+            limit: 6
+        )
+        XCTAssertEqual(suggestions.first?.path, "Sources/App.swift")
+        XCTAssertTrue(suggestions.contains { $0.path == "docs/app-notes.md" })
+    }
+
+    func testSuggestionAcceptanceReplacesActiveTokenAndAddsTrailingSpace() {
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "please read @App",
+            in: index(["Sources/App.swift"]),
+            limit: 6
+        )
+        XCTAssertEqual(suggestions.first?.insertText, "please read @Sources/App.swift ")
+    }
+
+    func testEmptyMentionSurfacesShallowFilesFirst() {
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "@",
+            in: index(["a/b/c/Deep.swift", "Top.swift", "a/Mid.swift"]),
+            limit: 6
+        )
+        XCTAssertEqual(suggestions.first?.path, "Top.swift")
+    }
+
+    func testNoSuggestionsWithoutActiveMention() {
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "no mention here",
+            in: index(["Sources/App.swift"]),
+            limit: 6
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    func testSuggestionsHonorLimit() {
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "@swift",
+            in: index((0..<10).map { "File\($0).swift" }),
+            limit: 3
+        )
+        XCTAssertEqual(suggestions.count, 3)
+    }
+
+    func testFuzzySubsequenceMatchesScatteredCharacters() {
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "@wks",
+            in: index(["Sources/WorkspaceState.swift", "Sources/Other.swift"]),
+            limit: 6
+        )
+        XCTAssertEqual(suggestions.map(\.path), ["Sources/WorkspaceState.swift"])
+    }
+
+    func testSubsequenceHelper() {
+        XCTAssertTrue(FileMentionCatalog.isSubsequence("abc", of: "aXbYcZ"))
+        XCTAssertFalse(FileMentionCatalog.isSubsequence("acb", of: "abc"))
+        XCTAssertTrue(FileMentionCatalog.isSubsequence("", of: "anything"))
+    }
+}

--- a/Tests/QuillCodeToolsTests/WorkspaceFileIndexerTests.swift
+++ b/Tests/QuillCodeToolsTests/WorkspaceFileIndexerTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class WorkspaceFileIndexerTests: XCTestCase {
+    func testIndexReturnsSortedWorkspaceRelativeFiles() throws {
+        let root = try makeTempDirectory()
+        let files = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(files.write(path: "Sources/App.swift", content: "struct App {}\n").ok)
+        XCTAssertTrue(files.write(path: "Sources/Helpers/Util.swift", content: "enum Util {}\n").ok)
+        XCTAssertTrue(files.write(path: "README.md", content: "# Readme\n").ok)
+
+        let index = WorkspaceFileIndexer(workspaceRoot: root).index()
+
+        XCTAssertEqual(index.entries.map(\.path), [
+            "README.md",
+            "Sources/App.swift",
+            "Sources/Helpers/Util.swift"
+        ])
+        XCTAssertFalse(index.truncated)
+    }
+
+    func testIndexCarriesNameAndDirectoryMetadata() throws {
+        let root = try makeTempDirectory()
+        let files = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(files.write(path: "Sources/Helpers/Util.swift", content: "enum Util {}\n").ok)
+        XCTAssertTrue(files.write(path: "README.md", content: "# Readme\n").ok)
+
+        let entries = WorkspaceFileIndexer(workspaceRoot: root).index().entries
+        let util = try XCTUnwrap(entries.first { $0.path == "Sources/Helpers/Util.swift" })
+        XCTAssertEqual(util.name, "Util.swift")
+        XCTAssertEqual(util.directory, "Sources/Helpers")
+
+        let readme = try XCTUnwrap(entries.first { $0.path == "README.md" })
+        XCTAssertEqual(readme.name, "README.md")
+        XCTAssertEqual(readme.directory, "")
+    }
+
+    func testIndexSkipsHeavyDependencyAndBuildDirectories() throws {
+        let root = try makeTempDirectory()
+        let files = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(files.write(path: "Sources/App.swift", content: "struct App {}\n").ok)
+        XCTAssertTrue(files.write(path: "node_modules/dep/index.js", content: "module.exports = {}\n").ok)
+        XCTAssertTrue(files.write(path: ".build/debug/App.o", content: "binary\n").ok)
+        XCTAssertTrue(files.write(path: ".git/config", content: "[core]\n").ok)
+
+        let paths = WorkspaceFileIndexer(workspaceRoot: root).index().entries.map(\.path)
+
+        XCTAssertEqual(paths, ["Sources/App.swift"])
+    }
+
+    func testIndexSkipsHiddenEntriesByDefaultAndIncludesThemOnRequest() throws {
+        let root = try makeTempDirectory()
+        let files = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(files.write(path: "Sources/App.swift", content: "struct App {}\n").ok)
+        XCTAssertTrue(files.write(path: ".env", content: "TOKEN=x\n").ok)
+        XCTAssertTrue(files.write(path: ".config/settings.json", content: "{}\n").ok)
+
+        let defaultPaths = WorkspaceFileIndexer(workspaceRoot: root).index().entries.map(\.path)
+        XCTAssertEqual(defaultPaths, ["Sources/App.swift"])
+
+        let hiddenPaths = WorkspaceFileIndexer(workspaceRoot: root).index(includeHidden: true).entries.map(\.path)
+        XCTAssertEqual(hiddenPaths, [".config/settings.json", ".env", "Sources/App.swift"])
+    }
+
+    func testIndexHonorsFileCapAndReportsTruncation() throws {
+        let root = try makeTempDirectory()
+        let files = FileToolExecutor(workspaceRoot: root)
+        for offset in 0..<5 {
+            XCTAssertTrue(files.write(path: "file-\(offset).txt", content: "x\n").ok)
+        }
+
+        let index = WorkspaceFileIndexer(workspaceRoot: root).index(maxFiles: 3)
+
+        XCTAssertEqual(index.entries.count, 3)
+        XCTAssertTrue(index.truncated)
+    }
+
+    func testIndexOnMissingRootReturnsEmpty() {
+        let missing = URL(fileURLWithPath: "/tmp/quillcode-missing-\(UUID().uuidString)")
+        let index = WorkspaceFileIndexer(workspaceRoot: missing).index()
+        XCTAssertTrue(index.isEmpty)
+        XCTAssertFalse(index.truncated)
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-29 File Mention Suggestion Engine Pass
+
+Overall grade after this slice: **A bounded workspace indexing, A pure mention-ranking logic, B+ surface wiring (engine only)**.
+
+A core coding-harness usability affordance was missing: there was no way to reference a workspace file from the composer the way Codex/Claude Code support `@path` mentions. This slice lands the deterministic, fully tested foundation for that feature so the composer surfaces (SwiftUI, static HTML, Playwright) can wire onto a stable engine next.
+
+| Before | After |
+| --- | --- |
+| No bounded recursive workspace file listing existed; only single-directory `host.file.list` and content `host.file.search`. | `WorkspaceFileIndexer` returns a bounded, path-sorted index of regular files, skipping `.git`/`.build`/`node_modules`/etc. and hidden entries by default, with a file cap and truncation flag. |
+| The composer could not detect or rank an in-progress `@` mention. | `FileMentionCatalog` detects the active trailing `@token` (and rejects `name@example.com`-style non-mentions), ranks files by name/path prefix, contains, and fuzzy subsequence, and produces a ready-to-apply replacement draft. |
+| No coverage for path-completion logic. | 19 new unit tests cover indexer bounds/exclusions/hidden/truncation and mention detection, ranking order, acceptance text, empty-mention shallow ordering, limits, and fuzzy matching. |
+
+Residual risk:
+
+- This is the engine only. The next slice wires it into the composer suggestion panel across SwiftUI, the static HTML renderer, and Playwright, sourced from a workspace file index refreshed per selected local project.
+
 ## 2026-06-29 Near-Edge Click-Target Activation Pass
 
 Overall grade after this slice: **A target activation coverage, A native/rendered probe parity, A- packaged click synthesis**.


### PR DESCRIPTION
## Summary

Lands the deterministic, fully tested foundation for Codex-style `@path` file mentions in the composer — a hallmark coding-harness usability affordance that was missing.

- **`WorkspaceFileIndexer`** (QuillCodeTools): bounded, path-sorted recursive listing of a workspace's regular files. Skips `.git`/`.build`/`.swiftpm`/`DerivedData`/`build`/`node_modules` and hidden entries by default, with a file cap and truncation flag (mirrors `FileToolExecutor` search discipline).
- **`FileMentionCatalog`** (QuillCodeApp): detects the in-progress trailing `@token` (and rejects `name@example.com`-style non-mentions), ranks files by name/path prefix, contains, and fuzzy subsequence, and produces the full replacement draft on acceptance — mirroring `SlashCommandCatalog` so the composer can reuse the same suggestion panel.

## Tests

19 new unit tests:
- Indexer: sorted relative paths, name/directory metadata, dependency/build exclusions, hidden-by-default + include-hidden, file cap + truncation, missing-root empty.
- Catalog: trailing-token detection, draft-start mentions, bare `@`, email rejection, completed-mention rejection, ranking order, acceptance text, empty-mention shallow ordering, limit honoring, fuzzy subsequence.

`swift build` clean; full `swift test` green (1663 tests, 0 failures, 1 pre-existing skip).

## Scope

Engine only. The next slice wires it into the composer suggestion panel across SwiftUI, the static HTML renderer, and Playwright, sourced from a per-project workspace file index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)