### PR TITLE
Wire file mentions into the native composer

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 import QuillCodeCore
+import QuillCodeTools
 
 struct QuillCodeComposerView: View {
     var composer: ComposerSurface
     var topBar: TopBarSurface
+    var fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex()
     @Binding var draft: String
     @Binding var isModelPickerPresented: Bool
     var isFocused: FocusState<Bool>.Binding
@@ -15,6 +17,7 @@ struct QuillCodeComposerView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var activeSlashSuggestionIndex = 0
+    @State private var activeFileMentionIndex = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -25,6 +28,13 @@ struct QuillCodeComposerView: View {
                     onSelect: acceptSlashSuggestion
                 )
                 .transition(reduceMotion ? .identity : .opacity.combined(with: .move(edge: .bottom)))
+            } else if !fileMentionSuggestions.isEmpty {
+                QuillCodeFileMentionSuggestionPanel(
+                    suggestions: fileMentionSuggestions,
+                    selectedIndex: activeFileMentionIndex,
+                    onSelect: acceptFileMention
+                )
+                .transition(reduceMotion ? .identity : .opacity.combined(with: .move(edge: .bottom)))
             }
 
             composerSurface
@@ -33,12 +43,20 @@ struct QuillCodeComposerView: View {
         .background(QuillCodePalette.panel)
         .onChange(of: draft) { _, _ in
             activeSlashSuggestionIndex = 0
+            activeFileMentionIndex = 0
         }
         .onChange(of: slashSuggestions) { _, suggestions in
             if suggestions.isEmpty {
                 activeSlashSuggestionIndex = 0
             } else {
                 activeSlashSuggestionIndex = min(activeSlashSuggestionIndex, suggestions.count - 1)
+            }
+        }
+        .onChange(of: fileMentionSuggestions) { _, suggestions in
+            if suggestions.isEmpty {
+                activeFileMentionIndex = 0
+            } else {
+                activeFileMentionIndex = min(activeFileMentionIndex, suggestions.count - 1)
             }
         }
     }
@@ -64,7 +82,7 @@ struct QuillCodeComposerView: View {
     }
 
     private var composerSurfaceStroke: Color {
-        if !slashSuggestions.isEmpty {
+        if !slashSuggestions.isEmpty || !fileMentionSuggestions.isEmpty {
             return QuillCodePalette.blue.opacity(0.34)
         }
         return Color.white.opacity(isFocused.wrappedValue ? 0.18 : 0.08)
@@ -72,6 +90,11 @@ struct QuillCodeComposerView: View {
 
     private var slashSuggestions: [SlashCommandSuggestionSurface] {
         SlashCommandCatalog.suggestions(for: draft)
+    }
+
+    private var fileMentionSuggestions: [FileMentionSuggestionSurface] {
+        guard slashSuggestions.isEmpty else { return [] }
+        return FileMentionCatalog.suggestions(for: draft, in: fileMentionIndex)
     }
 
     private var canSendDraft: Bool {
@@ -111,22 +134,36 @@ struct QuillCodeComposerView: View {
             .disabled(composer.isSending)
             .focused(isFocused)
             .onKeyPress(.downArrow) {
-                guard !slashSuggestions.isEmpty else { return .ignored }
-                activeSlashSuggestionIndex = min(activeSlashSuggestionIndex + 1, slashSuggestions.count - 1)
-                return .handled
+                if !slashSuggestions.isEmpty {
+                    activeSlashSuggestionIndex = min(activeSlashSuggestionIndex + 1, slashSuggestions.count - 1)
+                    return .handled
+                }
+                if !fileMentionSuggestions.isEmpty {
+                    activeFileMentionIndex = min(activeFileMentionIndex + 1, fileMentionSuggestions.count - 1)
+                    return .handled
+                }
+                return .ignored
             }
             .onKeyPress(.upArrow) {
-                guard !slashSuggestions.isEmpty else { return .ignored }
-                activeSlashSuggestionIndex = max(activeSlashSuggestionIndex - 1, 0)
-                return .handled
+                if !slashSuggestions.isEmpty {
+                    activeSlashSuggestionIndex = max(activeSlashSuggestionIndex - 1, 0)
+                    return .handled
+                }
+                if !fileMentionSuggestions.isEmpty {
+                    activeFileMentionIndex = max(activeFileMentionIndex - 1, 0)
+                    return .handled
+                }
+                return .ignored
             }
             .onKeyPress(.tab) {
-                guard acceptActiveSlashSuggestion(force: true) else { return .ignored }
-                return .handled
+                if acceptActiveSlashSuggestion(force: true) { return .handled }
+                if acceptActiveFileMention(force: true) { return .handled }
+                return .ignored
             }
             .onKeyPress(.return) {
-                guard acceptActiveSlashSuggestion(force: false) else { return .ignored }
-                return .handled
+                if acceptActiveSlashSuggestion(force: false) { return .handled }
+                if acceptActiveFileMention(force: false) { return .handled }
+                return .ignored
             }
             .onSubmit(onSend)
             .accessibilityLabel("Message")
@@ -184,6 +221,22 @@ struct QuillCodeComposerView: View {
     }
 
     private func acceptSlashSuggestion(_ suggestion: SlashCommandSuggestionSurface) {
+        draft = suggestion.insertText
+        DispatchQueue.main.async {
+            isFocused.wrappedValue = true
+        }
+    }
+
+    private func acceptActiveFileMention(force: Bool) -> Bool {
+        guard !fileMentionSuggestions.isEmpty else { return false }
+        let index = min(max(activeFileMentionIndex, 0), fileMentionSuggestions.count - 1)
+        let suggestion = fileMentionSuggestions[index]
+        guard force || draft != suggestion.insertText else { return false }
+        acceptFileMention(suggestion)
+        return true
+    }
+
+    private func acceptFileMention(_ suggestion: FileMentionSuggestionSurface) {
         draft = suggestion.insertText
         DispatchQueue.main.async {
             isFocused.wrappedValue = true
@@ -277,5 +330,93 @@ private struct QuillCodeSlashSuggestionRow: View {
         .buttonStyle(QuillCodePressableButtonStyle())
         .accessibilityLabel("\(suggestion.usage), \(suggestion.title)")
         .accessibilityHint(suggestion.detail)
+    }
+}
+
+private struct QuillCodeFileMentionSuggestionPanel: View {
+    var suggestions: [FileMentionSuggestionSurface]
+    var selectedIndex: Int
+    var onSelect: (FileMentionSuggestionSurface) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
+                Text("Files")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .textCase(.uppercase)
+                Spacer()
+                Text("↑↓ choose · Tab complete")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(QuillCodePalette.muted)
+            }
+
+            ForEach(Array(suggestions.enumerated()), id: \.element.id) { index, suggestion in
+                QuillCodeFileMentionSuggestionRow(
+                    suggestion: suggestion,
+                    isSelected: index == selectedIndex,
+                    onSelect: onSelect
+                )
+            }
+        }
+        .padding(10)
+        .background(QuillCodePalette.background.opacity(0.78))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.09), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("File mentions")
+    }
+}
+
+private struct QuillCodeFileMentionSuggestionRow: View {
+    var suggestion: FileMentionSuggestionSurface
+    var isSelected: Bool
+    var onSelect: (FileMentionSuggestionSurface) -> Void
+
+    var body: some View {
+        Button {
+            onSelect(suggestion)
+        } label: {
+            HStack(alignment: .center, spacing: QuillCodeMetrics.controlClusterSpacing) {
+                Image(systemName: "doc.text")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .frame(width: 22)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(suggestion.name)
+                        .font(.callout.weight(.semibold))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(suggestion.path)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(QuillCodePalette.muted)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "arrow.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(isSelected ? QuillCodePalette.blue : QuillCodePalette.muted.opacity(0.7))
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .quillCodeFullRowButtonTarget(radius: 12)
+            .background(isSelected ? QuillCodePalette.blue.opacity(0.13) : Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(isSelected ? QuillCodePalette.blue.opacity(0.24) : Color.clear, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(QuillCodePressableButtonStyle())
+        .accessibilityLabel("Mention \(suggestion.path)")
+        .accessibilityHint(suggestion.directory.isEmpty ? "Workspace root" : "In \(suggestion.directory)")
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeCore
+import QuillCodeTools
 
 public struct TranscriptSurface: Codable, Sendable, Hashable {
     public var messages: [MessageSurface]
@@ -272,12 +273,14 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
     public var isSending: Bool
     public var canSend: Bool
     public var slashSuggestions: [SlashCommandSuggestionSurface]
+    public var fileMentionSuggestions: [FileMentionSuggestionSurface]
 
-    public init(composer: ComposerState) {
+    public init(composer: ComposerState, fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex()) {
         self.draft = composer.draft
         self.placeholder = composer.placeholder
         self.isSending = composer.isSending
         self.canSend = !composer.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !composer.isSending
         self.slashSuggestions = SlashCommandCatalog.suggestions(for: composer.draft)
+        self.fileMentionSuggestions = FileMentionCatalog.suggestions(for: composer.draft, in: fileMentionIndex)
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -125,6 +125,7 @@ struct QuillCodeWorkspaceMainPaneView: View {
                 QuillCodeComposerView(
                     composer: surface.composer,
                     topBar: surface.topBar,
+                    fileMentionIndex: surface.fileMentionIndex,
                     draft: $draft,
                     isModelPickerPresented: $isModelPickerPresented,
                     isFocused: isComposerFocused,

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -34,6 +34,9 @@ public final class QuillCodeWorkspaceModel {
     let mcpRuntime: WorkspaceMCPRuntime
     var activeTerminalSession: (any ShellInteractiveSession)?
     var subagentScheduler = WorkspaceSubagentScheduler()
+    /// Bounded, cached index of the selected local project's files, used to power
+    /// composer `@` file mentions. Empty for remote or unselected projects.
+    public internal(set) var fileMentionIndex = WorkspaceFileIndex()
 
     public init(
         root: QuillCodeRootState = QuillCodeRootState(),
@@ -92,6 +95,7 @@ public final class QuillCodeWorkspaceModel {
         }
         syncTerminalSessionToSelectedProject()
         refreshTopBar()
+        refreshFileMentionIndex()
     }
 
     deinit {
@@ -137,6 +141,17 @@ public final class QuillCodeWorkspaceModel {
             projectID: id,
             projects: &root.projects
         )
+        refreshFileMentionIndex()
+    }
+
+    /// Recomputes the cached composer file-mention index from the selected local
+    /// project. Remote or unselected projects clear the index so mentions stay empty.
+    func refreshFileMentionIndex() {
+        guard let activeWorkspaceRoot else {
+            fileMentionIndex = WorkspaceFileIndex()
+            return
+        }
+        fileMentionIndex = WorkspaceFileIndexer(workspaceRoot: activeWorkspaceRoot).index()
     }
 
     func workspaceThreadContext(_ projectID: UUID?) -> WorkspaceThreadContextSnapshot {

--- a/Sources/QuillCodeApp/WorkspaceModelProjects.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelProjects.swift
@@ -15,6 +15,7 @@ extension QuillCodeWorkspaceModel {
         )
         root.selectedProjectID = result.projectID
         syncTerminalSessionToSelectedProject()
+        refreshFileMentionIndex()
         saveProjects()
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
         return result.projectID
@@ -29,6 +30,7 @@ extension QuillCodeWorkspaceModel {
         case .success(let result):
             root.selectedProjectID = result.projectID
             syncTerminalSessionToSelectedProject()
+            refreshFileMentionIndex()
             saveProjects()
             refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
             return result.projectID

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -16,6 +16,9 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
     public var activity: WorkspaceActivitySurface
     public var automations: WorkspaceAutomationsSurface
     public var composer: ComposerSurface
+    /// Cached index of the selected local project's files, used by the native
+    /// composer to rank `@` mention suggestions live as the user types.
+    public var fileMentionIndex: WorkspaceFileIndex
     public var commands: [WorkspaceCommandSurface]
     public var settings: WorkspaceSettingsSurface
     public var runtimeIssue: RuntimeIssueSurface?
@@ -35,6 +38,7 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
         activity: WorkspaceActivitySurface = WorkspaceActivitySurface(),
         automations: WorkspaceAutomationsSurface = WorkspaceAutomationsSurface(),
         composer: ComposerSurface,
+        fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex(),
         commands: [WorkspaceCommandSurface],
         settings: WorkspaceSettingsSurface,
         runtimeIssue: RuntimeIssueSurface? = nil,
@@ -53,6 +57,7 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
         self.activity = activity
         self.automations = automations
         self.composer = composer
+        self.fileMentionIndex = fileMentionIndex
         self.commands = commands
         self.settings = settings
         self.runtimeIssue = runtimeIssue
@@ -156,7 +161,8 @@ public extension QuillCodeWorkspaceModel {
                 hasSelectedThread: thread != nil,
                 hasSelectedProject: selectedProject != nil
             ).surface(),
-            composer: ComposerSurface(composer: composer),
+            composer: ComposerSurface(composer: composer, fileMentionIndex: fileMentionIndex),
+            fileMentionIndex: fileMentionIndex,
             commands: commandSurfaceBuilder().commands,
             settings: WorkspaceSettingsSurface(
                 config: root.config,

--- a/Tests/QuillCodeAppTests/WorkspaceFileMentionIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceFileMentionIntegrationTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeTools
+
+@MainActor
+final class WorkspaceFileMentionIntegrationTests: XCTestCase {
+    private func makeProject(files: [String]) throws -> URL {
+        let root = try makeQuillCodeTestDirectory()
+        let executor = FileToolExecutor(workspaceRoot: root)
+        for path in files {
+            XCTAssertTrue(executor.write(path: path, content: "// \(path)\n").ok)
+        }
+        return root
+    }
+
+    func testAddingLocalProjectPopulatesFileMentionIndex() throws {
+        let root = try makeProject(files: ["Sources/App.swift", "README.md"])
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        let paths = model.fileMentionIndex.entries.map(\.path)
+        XCTAssertTrue(paths.contains("Sources/App.swift"))
+        XCTAssertTrue(paths.contains("README.md"))
+    }
+
+    func testComposerSurfaceSuggestsWorkspaceFilesForActiveMention() throws {
+        let root = try makeProject(files: ["Sources/App.swift", "Sources/Helper.swift"])
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        model.setDraft("please read @App")
+        let suggestions = model.surface().composer.fileMentionSuggestions
+
+        XCTAssertEqual(suggestions.first?.path, "Sources/App.swift")
+        XCTAssertEqual(suggestions.first?.insertText, "please read @Sources/App.swift ")
+    }
+
+    func testComposerSurfaceHasNoMentionSuggestionsWithoutActiveMention() throws {
+        let root = try makeProject(files: ["Sources/App.swift"])
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        model.setDraft("no mention here")
+        XCTAssertTrue(model.surface().composer.fileMentionSuggestions.isEmpty)
+    }
+
+    func testSlashCommandDraftSuppressesFileMentionSuggestions() throws {
+        let root = try makeProject(files: ["Sources/App.swift"])
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        model.setDraft("/help")
+        let surface = model.surface().composer
+        XCTAssertFalse(surface.slashSuggestions.isEmpty)
+        XCTAssertTrue(surface.fileMentionSuggestions.isEmpty)
+    }
+
+    func testRefreshContextPicksUpNewlyCreatedFiles() throws {
+        let root = try makeProject(files: ["Sources/App.swift"])
+        let model = QuillCodeWorkspaceModel()
+        let projectID = model.addProject(path: root, name: "Demo")
+
+        XCTAssertTrue(FileToolExecutor(workspaceRoot: root).write(path: "Sources/Added.swift", content: "// new\n").ok)
+        XCTAssertFalse(model.fileMentionIndex.entries.map(\.path).contains("Sources/Added.swift"))
+
+        _ = model.refreshProjectContext(projectID)
+        XCTAssertTrue(model.fileMentionIndex.entries.map(\.path).contains("Sources/Added.swift"))
+    }
+
+    func testSelectingSSHRemoteProjectClearsFileMentionIndex() throws {
+        let root = try makeProject(files: ["Sources/App.swift"])
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        XCTAssertFalse(model.fileMentionIndex.isEmpty)
+
+        _ = model.addSSHProject("user@host:/srv/app", name: "Remote")
+        XCTAssertTrue(model.fileMentionIndex.isEmpty)
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-29 Native Composer File Mention Pass
+
+Overall grade after this slice: **A native composer wiring, A per-project index lifecycle, B+ cross-surface parity (native + data; JS harness/Playwright pending)**.
+
+Builds on the file-mention engine: the native SwiftUI composer now offers Codex-style `@path` mentions as the user types, ranked against a cached per-project file index.
+
+| Before | After |
+| --- | --- |
+| The engine existed but nothing rendered mentions; the composer only suggested slash commands. | `QuillCodeComposerView` renders a file-mention panel (reusing the audited row/press primitives) when the trailing token is an `@` mention, with ↑/↓ navigation, Tab/Return accept, and click-to-insert, mutually exclusive with slash suggestions. |
+| No workspace file index existed in the model. | The model caches a bounded `WorkspaceFileIndex` for the selected local project, refreshed on add/select/refresh-context and cleared for SSH Remote or unselected projects, surfaced through `WorkspaceSurface.fileMentionIndex` and `ComposerSurface.fileMentionSuggestions`. |
+| No coverage for composer mention wiring. | 6 new integration tests cover index population on project add, active-mention suggestions and acceptance text, no-mention and slash-suppression cases, refresh-context picking up new files, and SSH Remote index clearing. |
+
+Residual risk:
+
+- The static HTML renderer and JS harness still render slash/mention suggestions only at the live (JS) layer; the next slice mirrors `FileMentionCatalog` into the harness and adds Playwright `@` mention coverage. New session-created files surface on the next Refresh context rather than instantly.
+
 ## 2026-06-29 File Mention Suggestion Engine Pass
 
 Overall grade after this slice: **A bounded workspace indexing, A pure mention-ranking logic, B+ surface wiring (engine only)**.


### PR DESCRIPTION
## Summary

Builds on the file-mention engine (#681): the native SwiftUI composer now offers **Codex-style `@path` file mentions** as the user types, ranked against a cached per-project workspace file index.

- **Model index lifecycle**: `QuillCodeWorkspaceModel` caches a bounded `WorkspaceFileIndex` for the selected local project, refreshed on project add/select/refresh-context and cleared for SSH Remote or unselected projects.
- **Surfaces**: `ComposerSurface` gains `fileMentionSuggestions`; `WorkspaceSurface` carries the `fileMentionIndex` so the native composer can rank mentions live as the user types.
- **Native composer**: `QuillCodeComposerView` renders a file-mention panel (reusing the audited row/press primitives) when the trailing token is an `@` mention — ↑/↓ navigation, Tab/Return accept, click-to-insert — mutually exclusive with slash suggestions.

## Tests

6 new integration tests: index population on project add, active-mention suggestions + acceptance text, no-mention and slash-suppression cases, refresh-context picking up newly created files, and SSH Remote index clearing.

`swift build` clean; full `swift test` green (1669 tests, 0 failures, 1 pre-existing skip); `./scripts/native-desktop-smoke.sh` passes (hit-target audit healthy).

## Scope

Native + data surfaces. The static HTML renderer and JS harness still render suggestions at the live (JS) layer; the next slice mirrors `FileMentionCatalog` into the harness and adds Playwright `@` mention coverage. Newly session-created files surface on the next Refresh context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)