### PR TITLE
Refresh file mention index after agent runs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -113,6 +113,9 @@ extension QuillCodeWorkspaceModel {
         }
         updateThreadFromAgentRun(thread)
         try threadPersistence.saveOrThrow(thread)
+        // A completed run may have created, moved, or deleted files; keep composer
+        // `@` mentions current for the selected local project without a manual refresh.
+        refreshFileMentionIndex()
         applyComposerSendLifecycle(completion.lifecycle)
     }
 

--- a/Tests/QuillCodeAppTests/WorkspaceFileMentionIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceFileMentionIntegrationTests.swift
@@ -67,6 +67,18 @@ final class WorkspaceFileMentionIntegrationTests: XCTestCase {
         XCTAssertTrue(model.fileMentionIndex.entries.map(\.path).contains("Sources/Added.swift"))
     }
 
+    func testFileMentionIndexRefreshesAfterAgentFileWrite() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        XCTAssertFalse(model.fileMentionIndex.entries.map(\.path).contains("hello.txt"))
+
+        model.setDraft("Can you write a file that says hello world")
+        await model.submitComposer(workspaceRoot: root)
+
+        XCTAssertTrue(model.fileMentionIndex.entries.map(\.path).contains("hello.txt"))
+    }
+
     func testSelectingSSHRemoteProjectClearsFileMentionIndex() throws {
         let root = try makeProject(files: ["Sources/App.swift"])
         let model = QuillCodeWorkspaceModel()

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -14,6 +14,20 @@ Adds Socrates 1.1, the currently leading frontier model, as the top Recommended 
 Residual risk:
 
 - The default user-facing model is unchanged (Nike 1.0); promoting Socrates 1.1 to the default is a follow-up if desired. The bundled `tr/socrates` ID is the offline default and is superseded by the live TrustedRouter catalog when keyed.
+## 2026-06-29 File Mention Live Refresh Pass
+
+Overall grade after this slice: **A mid-session mention freshness**.
+
+Rounds out the file-mention feature so newly created files are referenceable without a manual context refresh.
+
+| Before | After |
+| --- | --- |
+| The composer `@` mention index only refreshed on project add/select/refresh-context, so files created during a session were invisible to mentions until a manual refresh. | A completed agent run refreshes the selected local project's file-mention index, so files the agent just created, moved, or deleted are immediately available to `@` mentions. |
+| No coverage for post-run index freshness. | A new integration test writes a file through a real agent run and asserts the new path appears in `fileMentionIndex`. |
+
+Residual risk:
+
+- The refresh runs once per completed run regardless of whether files changed; it is bounded and inexpensive, but a future optimization could skip it for read-only runs.
 
 ## 2026-06-29 File Mention Harness Parity Pass
 


### PR DESCRIPTION
## Summary

Keeps composer `@` mentions current within a session: a completed agent run refreshes the selected local project's file-mention index, so files the agent just created, moved, or deleted are immediately referenceable without a manual context refresh.

## Tests

Adds an integration test that writes a file through a real agent run and asserts the new path appears in `fileMentionIndex`. `swift test` green; bounded once-per-run refresh.

Completes the Codex-style `@path` file-mention feature (engine #681, native composer #682, harness/E2E #685).

🤖 Generated with [Claude Code](https://claude.com/claude-code)