### PR TITLE
Add composer message-history recall engine

### DIFF
--- a/Sources/QuillCodeApp/ComposerHistoryRecall.swift
+++ b/Sources/QuillCodeApp/ComposerHistoryRecall.swift
@@ -1,0 +1,59 @@
+import Foundation
+import QuillCodeCore
+
+/// Pure logic for recalling previously sent composer messages with the Up/Down keys,
+/// mirroring a shell or Codex prompt history. The composer view owns the transient
+/// recall cursor; this type computes the next draft and cursor for each step and
+/// builds the bounded history list from a thread's sent user messages.
+public enum ComposerHistoryRecall {
+    /// Maximum number of recent sent messages kept for recall.
+    public static let maxEntries = 50
+
+    /// The result of a recall step: the index now being shown and the draft to apply.
+    public struct Step: Equatable {
+        public var index: Int
+        public var draft: String
+
+        public init(index: Int, draft: String) {
+            self.index = index
+            self.draft = draft
+        }
+    }
+
+    /// Builds the recall history (oldest first) from a thread's messages: non-empty
+    /// user messages, with adjacent duplicates collapsed and bounded to ``maxEntries``.
+    public static func history(from messages: [ChatMessage]) -> [String] {
+        var entries: [String] = []
+        for message in messages where message.role == .user {
+            let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            if entries.last == trimmed { continue }
+            entries.append(trimmed)
+        }
+        if entries.count > maxEntries {
+            entries.removeFirst(entries.count - maxEntries)
+        }
+        return entries
+    }
+
+    /// Recalls an older message. With no active recall it starts at the newest entry;
+    /// otherwise it moves one entry older, clamping at the oldest.
+    public static func older(history: [String], currentIndex: Int?) -> Step? {
+        guard !history.isEmpty else { return nil }
+        let index: Int
+        if let currentIndex {
+            index = max(0, currentIndex - 1)
+        } else {
+            index = history.count - 1
+        }
+        return Step(index: index, draft: history[index])
+    }
+
+    /// Recalls a newer message. Returns the next entry, or `nil` when stepping past the
+    /// newest entry, signalling the caller to restore the in-progress draft and exit.
+    public static func newer(history: [String], currentIndex: Int) -> Step? {
+        guard currentIndex >= 0, currentIndex + 1 < history.count else { return nil }
+        let index = currentIndex + 1
+        return Step(index: index, draft: history[index])
+    }
+}

--- a/Tests/QuillCodeAppTests/ComposerHistoryRecallTests.swift
+++ b/Tests/QuillCodeAppTests/ComposerHistoryRecallTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+
+final class ComposerHistoryRecallTests: XCTestCase {
+    private func userMessages(_ texts: [String]) -> [ChatMessage] {
+        texts.map { ChatMessage(role: .user, content: $0) }
+    }
+
+    func testHistoryKeepsNonEmptyUserMessagesOldestFirst() {
+        let messages = [
+            ChatMessage(role: .user, content: "first"),
+            ChatMessage(role: .assistant, content: "answer"),
+            ChatMessage(role: .tool, content: "tool feedback"),
+            ChatMessage(role: .user, content: "  second  ")
+        ]
+        XCTAssertEqual(ComposerHistoryRecall.history(from: messages), ["first", "second"])
+    }
+
+    func testHistorySkipsBlankUserMessages() {
+        let messages = userMessages(["real", "   ", "\n"])
+        XCTAssertEqual(ComposerHistoryRecall.history(from: messages), ["real"])
+    }
+
+    func testHistoryCollapsesAdjacentDuplicates() {
+        let messages = userMessages(["run tests", "run tests", "build", "run tests"])
+        XCTAssertEqual(ComposerHistoryRecall.history(from: messages), ["run tests", "build", "run tests"])
+    }
+
+    func testHistoryBoundsToMaxEntries() {
+        let messages = userMessages((0..<(ComposerHistoryRecall.maxEntries + 10)).map { "msg-\($0)" })
+        let history = ComposerHistoryRecall.history(from: messages)
+        XCTAssertEqual(history.count, ComposerHistoryRecall.maxEntries)
+        XCTAssertEqual(history.first, "msg-10")
+        XCTAssertEqual(history.last, "msg-\(ComposerHistoryRecall.maxEntries + 9)")
+    }
+
+    func testOlderStartsAtNewestThenWalksBack() {
+        let history = ["a", "b", "c"]
+        XCTAssertEqual(ComposerHistoryRecall.older(history: history, currentIndex: nil), .init(index: 2, draft: "c"))
+        XCTAssertEqual(ComposerHistoryRecall.older(history: history, currentIndex: 2), .init(index: 1, draft: "b"))
+        XCTAssertEqual(ComposerHistoryRecall.older(history: history, currentIndex: 1), .init(index: 0, draft: "a"))
+        // Clamps at the oldest entry.
+        XCTAssertEqual(ComposerHistoryRecall.older(history: history, currentIndex: 0), .init(index: 0, draft: "a"))
+    }
+
+    func testOlderOnEmptyHistoryReturnsNil() {
+        XCTAssertNil(ComposerHistoryRecall.older(history: [], currentIndex: nil))
+    }
+
+    func testNewerWalksForwardThenExitsPastNewest() {
+        let history = ["a", "b", "c"]
+        XCTAssertEqual(ComposerHistoryRecall.newer(history: history, currentIndex: 0), .init(index: 1, draft: "b"))
+        XCTAssertEqual(ComposerHistoryRecall.newer(history: history, currentIndex: 1), .init(index: 2, draft: "c"))
+        // Stepping past the newest entry exits recall.
+        XCTAssertNil(ComposerHistoryRecall.newer(history: history, currentIndex: 2))
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,20 @@
 # Code Quality Audit
 
+## 2026-06-29 Composer History Recall Engine Pass
+
+Overall grade after this slice: **A pure recall logic; UI wiring pending**.
+
+Lands the deterministic foundation for shell/Codex-style Up/Down recall of previously sent composer messages.
+
+| Before | After |
+| --- | --- |
+| The chat composer had no message-history recall; only the integrated terminal recalled previous commands. | `ComposerHistoryRecall` builds a bounded history (non-empty user messages, oldest first, adjacent duplicates collapsed) from a thread and steps older/newer with oldest-clamping and a past-newest exit signal for restoring the in-progress draft. |
+| No coverage for composer history logic. | 7 unit tests cover history extraction/dedup/bounds and older/newer stepping including empty-history and exit cases. |
+
+Residual risk:
+
+- Engine only. The composer Up/Down key wiring (with in-progress draft preservation, mutually exclusive with slash/mention suggestions) and harness/Playwright parity follow next.
+
 ## 2026-06-29 Socrates 1.1 Model Pass
 
 Overall grade after this slice: **A model-catalog coverage, A cross-surface parity**.


### PR DESCRIPTION
## Summary

Lands the deterministic foundation for **shell/Codex-style Up/Down recall** of previously sent composer messages — a classic coding-harness affordance the chat composer was missing (only the terminal recalled history).

- **`ComposerHistoryRecall`**: builds a bounded history (non-empty user messages, oldest first, adjacent duplicates collapsed) from a thread, and steps older/newer with oldest-clamping and a past-newest exit signal (for restoring the in-progress draft).

## Tests

7 unit tests: history extraction/dedup/bounds and older/newer stepping including empty-history and past-newest exit cases. `swift test` green.

## Scope

Engine only. The composer Up/Down key wiring (in-progress draft preservation, mutually exclusive with slash/mention suggestions) and harness/Playwright parity follow next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)