### PR TITLE
Recall composer history with Up/Down keys

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -6,6 +6,7 @@ struct QuillCodeComposerView: View {
     var composer: ComposerSurface
     var topBar: TopBarSurface
     var fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex()
+    var sentMessageHistory: [String] = []
     @Binding var draft: String
     @Binding var isModelPickerPresented: Bool
     var isFocused: FocusState<Bool>.Binding
@@ -18,6 +19,8 @@ struct QuillCodeComposerView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var activeSlashSuggestionIndex = 0
     @State private var activeFileMentionIndex = 0
+    @State private var historyRecallIndex: Int?
+    @State private var historySavedDraft: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -41,9 +44,13 @@ struct QuillCodeComposerView: View {
         }
         .padding(12)
         .background(QuillCodePalette.panel)
-        .onChange(of: draft) { _, _ in
+        .onChange(of: draft) { _, newValue in
             activeSlashSuggestionIndex = 0
             activeFileMentionIndex = 0
+            if newValue.isEmpty {
+                historyRecallIndex = nil
+                historySavedDraft = nil
+            }
         }
         .onChange(of: slashSuggestions) { _, suggestions in
             if suggestions.isEmpty {
@@ -142,7 +149,7 @@ struct QuillCodeComposerView: View {
                     activeFileMentionIndex = min(activeFileMentionIndex + 1, fileMentionSuggestions.count - 1)
                     return .handled
                 }
-                return .ignored
+                return recallNewerHistory() ? .handled : .ignored
             }
             .onKeyPress(.upArrow) {
                 if !slashSuggestions.isEmpty {
@@ -153,7 +160,7 @@ struct QuillCodeComposerView: View {
                     activeFileMentionIndex = max(activeFileMentionIndex - 1, 0)
                     return .handled
                 }
-                return .ignored
+                return recallOlderHistory() ? .handled : .ignored
             }
             .onKeyPress(.tab) {
                 if acceptActiveSlashSuggestion(force: true) { return .handled }
@@ -241,6 +248,47 @@ struct QuillCodeComposerView: View {
         DispatchQueue.main.async {
             isFocused.wrappedValue = true
         }
+    }
+
+    private func showingUneditedRecall(at index: Int?) -> Bool {
+        guard let index, sentMessageHistory.indices.contains(index) else { return false }
+        return draft == sentMessageHistory[index]
+    }
+
+    private func recallOlderHistory() -> Bool {
+        guard !sentMessageHistory.isEmpty else { return false }
+        if historyRecallIndex == nil {
+            // Only begin recall from an empty composer so multiline editing keeps Up.
+            guard draft.isEmpty else { return false }
+            guard let step = ComposerHistoryRecall.older(history: sentMessageHistory, currentIndex: nil) else {
+                return false
+            }
+            historySavedDraft = draft
+            historyRecallIndex = step.index
+            draft = step.draft
+            return true
+        }
+        // Continue only while the recalled message is unedited.
+        guard showingUneditedRecall(at: historyRecallIndex) else { return false }
+        guard let step = ComposerHistoryRecall.older(history: sentMessageHistory, currentIndex: historyRecallIndex) else {
+            return false
+        }
+        historyRecallIndex = step.index
+        draft = step.draft
+        return true
+    }
+
+    private func recallNewerHistory() -> Bool {
+        guard let index = historyRecallIndex, showingUneditedRecall(at: index) else { return false }
+        if let step = ComposerHistoryRecall.newer(history: sentMessageHistory, currentIndex: index) {
+            historyRecallIndex = step.index
+            draft = step.draft
+        } else {
+            draft = historySavedDraft ?? ""
+            historyRecallIndex = nil
+            historySavedDraft = nil
+        }
+        return true
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -274,13 +274,20 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
     public var canSend: Bool
     public var slashSuggestions: [SlashCommandSuggestionSurface]
     public var fileMentionSuggestions: [FileMentionSuggestionSurface]
+    /// Previously sent user messages (oldest first) for Up/Down history recall.
+    public var sentMessageHistory: [String]
 
-    public init(composer: ComposerState, fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex()) {
+    public init(
+        composer: ComposerState,
+        fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex(),
+        sentMessageHistory: [String] = []
+    ) {
         self.draft = composer.draft
         self.placeholder = composer.placeholder
         self.isSending = composer.isSending
         self.canSend = !composer.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !composer.isSending
         self.slashSuggestions = SlashCommandCatalog.suggestions(for: composer.draft)
         self.fileMentionSuggestions = FileMentionCatalog.suggestions(for: composer.draft, in: fileMentionIndex)
+        self.sentMessageHistory = sentMessageHistory
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -126,6 +126,7 @@ struct QuillCodeWorkspaceMainPaneView: View {
                     composer: surface.composer,
                     topBar: surface.topBar,
                     fileMentionIndex: surface.fileMentionIndex,
+                    sentMessageHistory: surface.composer.sentMessageHistory,
                     draft: $draft,
                     isModelPickerPresented: $isModelPickerPresented,
                     isFocused: isComposerFocused,

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -161,7 +161,11 @@ public extension QuillCodeWorkspaceModel {
                 hasSelectedThread: thread != nil,
                 hasSelectedProject: selectedProject != nil
             ).surface(),
-            composer: ComposerSurface(composer: composer, fileMentionIndex: fileMentionIndex),
+            composer: ComposerSurface(
+                composer: composer,
+                fileMentionIndex: fileMentionIndex,
+                sentMessageHistory: ComposerHistoryRecall.history(from: thread?.messages ?? [])
+            ),
             fileMentionIndex: fileMentionIndex,
             commands: commandSurfaceBuilder().commands,
             settings: WorkspaceSettingsSurface(

--- a/Tests/QuillCodeAppTests/WorkspaceComposerHistoryIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerHistoryIntegrationTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceComposerHistoryIntegrationTests: XCTestCase {
+    func testSurfaceExposesSentMessageHistoryOldestFirst() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        XCTAssertTrue(model.surface().composer.sentMessageHistory.isEmpty)
+
+        model.setDraft("run whoami")
+        await model.submitComposer(workspaceRoot: root)
+        model.setDraft("list the files here")
+        await model.submitComposer(workspaceRoot: root)
+
+        let history = model.surface().composer.sentMessageHistory
+        XCTAssertEqual(history, ["run whoami", "list the files here"])
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,20 @@
 # Code Quality Audit
 
+## 2026-06-29 Composer History Recall Native Pass
+
+Overall grade after this slice: **A native recall UX; harness/Playwright parity pending**.
+
+Wires the history-recall engine into the native composer so Up/Down recalls previously sent messages like a shell or Codex prompt.
+
+| Before | After |
+| --- | --- |
+| The recall engine existed but nothing used it; the composer ignored Up/Down except for slash/mention suggestions. | `QuillCodeComposerView` recalls older/newer sent messages on Up/Down when no slash/mention suggestions are active, beginning only from an empty composer (so multiline editing keeps Up/Down), continuing only while the recalled text is unedited, and restoring the in-progress draft when stepping past the newest entry. `ComposerSurface` now carries `sentMessageHistory`, built from the selected thread. |
+| No coverage for surface history exposure. | An integration test sends two messages and asserts the surface exposes them oldest-first. |
+
+Residual risk:
+
+- The JS harness and Playwright mirror of the Up/Down recall flow is the next slice; existing Playwright coverage is unaffected.
+
 ## 2026-06-29 Composer History Recall Engine Pass
 
 Overall grade after this slice: **A pure recall logic; UI wiring pending**.


### PR DESCRIPTION
## Summary

Wires the history-recall engine (#688) into the native composer so **Up/Down recall previously sent messages** like a shell or Codex prompt — a classic coding-harness affordance the chat composer was missing.

- `QuillCodeComposerView` recalls older/newer sent messages on Up/Down when no slash/mention suggestions are active. It begins recall only from an **empty composer** (so multiline editing keeps Up/Down), continues only while the recalled text is **unedited**, and restores the **in-progress draft** when stepping past the newest entry.
- `ComposerSurface` carries `sentMessageHistory`, built from the selected thread's user messages via `ComposerHistoryRecall`.

## Tests

Integration test asserts the surface exposes sent messages oldest-first. `swift test` green (1681); native desktop smoke passes; existing Playwright unaffected.

## Scope

Native + data surfaces. The JS harness + Playwright mirror of the Up/Down recall flow is a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)