### PR TITLE
Mirror composer history recall in the test harness

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3510,7 +3510,9 @@
         isSending: false,
         canSend: false,
         slashActiveIndex: 0,
-        mentionActiveIndex: 0
+        mentionActiveIndex: 0,
+        historyRecallIndex: null,
+        historySavedDraft: null
       },
       settings: {
         isOpen: false,
@@ -4382,6 +4384,64 @@
       input?.focus();
       input?.setSelectionRange(state.composer.draft.length, state.composer.draft.length);
       resizeComposerInput(input);
+      return true;
+    }
+
+    function composerSentHistory() {
+      const entries = [];
+      for (const message of state.transcript.messages) {
+        if (message.role !== 'user') continue;
+        const text = String(message.text || '').trim();
+        if (!text) continue;
+        if (entries[entries.length - 1] === text) continue;
+        entries.push(text);
+      }
+      return entries.slice(-50);
+    }
+
+    function showingUneditedRecall(history) {
+      const index = state.composer.historyRecallIndex;
+      return index !== null && index >= 0 && index < history.length && state.composer.draft === history[index];
+    }
+
+    function applyComposerHistoryDraft(text) {
+      state.composer.draft = text;
+      state.composer.canSend = state.composer.draft.trim().length > 0;
+      render();
+      const input = document.getElementById('message');
+      input?.focus();
+      input?.setSelectionRange(state.composer.draft.length, state.composer.draft.length);
+      resizeComposerInput(input);
+    }
+
+    function recallOlderHistory() {
+      const history = composerSentHistory();
+      if (!history.length) return false;
+      if (state.composer.historyRecallIndex === null) {
+        if (state.composer.draft.length) return false;
+        state.composer.historySavedDraft = state.composer.draft;
+        state.composer.historyRecallIndex = history.length - 1;
+        applyComposerHistoryDraft(history[state.composer.historyRecallIndex]);
+        return true;
+      }
+      if (!showingUneditedRecall(history)) return false;
+      state.composer.historyRecallIndex = Math.max(0, state.composer.historyRecallIndex - 1);
+      applyComposerHistoryDraft(history[state.composer.historyRecallIndex]);
+      return true;
+    }
+
+    function recallNewerHistory() {
+      const history = composerSentHistory();
+      if (!showingUneditedRecall(history)) return false;
+      if (state.composer.historyRecallIndex + 1 < history.length) {
+        state.composer.historyRecallIndex += 1;
+        applyComposerHistoryDraft(history[state.composer.historyRecallIndex]);
+      } else {
+        const restored = state.composer.historySavedDraft || '';
+        state.composer.historyRecallIndex = null;
+        state.composer.historySavedDraft = null;
+        applyComposerHistoryDraft(restored);
+      }
       return true;
     }
 
@@ -6471,6 +6531,9 @@
         state.composer.canSend = state.composer.draft.trim().length > 0;
         state.composer.slashActiveIndex = 0;
         state.composer.mentionActiveIndex = 0;
+        // A user edit exits message-history recall (programmatic recall sets do not fire input).
+        state.composer.historyRecallIndex = null;
+        state.composer.historySavedDraft = null;
         resizeComposerInput(event.target);
         const shouldRenderSuggestions = state.composer.draft.trimStart().startsWith('/')
           || activeFileMention(state.composer.draft) !== null;
@@ -6508,6 +6571,10 @@
         } else if (mentions.length && event.key === 'Tab') {
           event.preventDefault();
           acceptFileMentionSuggestion({ force: true });
+        } else if (!suggestions.length && !mentions.length && event.key === 'ArrowUp') {
+          if (recallOlderHistory()) event.preventDefault();
+        } else if (!suggestions.length && !mentions.length && event.key === 'ArrowDown') {
+          if (recallNewerHistory()) event.preventDefault();
         } else if (event.key === 'Enter') {
           if (event.shiftKey) return;
           if (suggestions.length && acceptSlashSuggestion({ force: false })) {
@@ -12629,6 +12696,8 @@
       state.composer.draft = '';
       state.composer.canSend = false;
       state.composer.slashActiveIndex = 0;
+      state.composer.historyRecallIndex = null;
+      state.composer.historySavedDraft = null;
       state.runtimeIssue = null;
       addMessage('user', text);
       touchSelectedThread();

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -246,6 +246,40 @@ test('mock harness suggests workspace files for @ mentions in the composer', asy
   await expect(page.getByTestId('slash-suggestions')).toBeVisible();
 });
 
+test('mock harness recalls sent messages with Up and Down', async ({ page }) => {
+  await page.goto(harnessURL());
+  const message = page.getByLabel('Message');
+
+  await message.fill('first prompt');
+  await message.press('Enter');
+  await expect(message).toBeEnabled();
+  await expect(message).toHaveValue('');
+
+  await message.fill('second prompt');
+  await message.press('Enter');
+  await expect(message).toBeEnabled();
+  await expect(message).toHaveValue('');
+
+  // Up recalls the newest message first, then older, clamping at the oldest.
+  await message.press('ArrowUp');
+  await expect(message).toHaveValue('second prompt');
+  await message.press('ArrowUp');
+  await expect(message).toHaveValue('first prompt');
+  await message.press('ArrowUp');
+  await expect(message).toHaveValue('first prompt');
+
+  // Down walks back toward newer entries, then restores the empty in-progress draft.
+  await message.press('ArrowDown');
+  await expect(message).toHaveValue('second prompt');
+  await message.press('ArrowDown');
+  await expect(message).toHaveValue('');
+
+  // Up does not hijack editing once the composer already has text.
+  await message.fill('half typed');
+  await message.press('ArrowUp');
+  await expect(message).toHaveValue('half typed');
+});
+
 test('mock harness searches and selects models from the composer', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -14,6 +14,20 @@ Wires the history-recall engine into the native composer so Up/Down recalls prev
 Residual risk:
 
 - The JS harness and Playwright mirror of the Up/Down recall flow is the next slice; existing Playwright coverage is unaffected.
+## 2026-06-29 Composer History Recall Harness Pass
+
+Overall grade after this slice: **A cross-surface recall parity, A E2E flow coverage**.
+
+Mirrors the composer Up/Down message-history recall into the mock harness so the flow is exercised end-to-end like the native composer.
+
+| Before | After |
+| --- | --- |
+| The JS harness had no message-history recall; Up/Down only drove slash/mention suggestions. | The harness recalls older/newer sent user messages on Up/Down when no slash/mention suggestions are active, beginning only from an empty composer, continuing only while the recalled text is unedited, restoring the in-progress draft past the newest entry, and exiting recall on user edits or send. |
+| No E2E coverage for history recall. | A Playwright test sends two messages then drives Up/Up/Up (clamp), Down/Down (restore empty), and verifies Up does not hijack a non-empty composer. Full Playwright suite stays green (125 tests). |
+
+Residual risk:
+
+- None specific to this slice; recall is keyboard-only and reuses the existing composer surface.
 
 ## 2026-06-29 Composer History Recall Engine Pass
 


### PR DESCRIPTION
## Summary

Completes the composer Up/Down **message-history recall** feature (engine #688, native composer #689) by mirroring it into the mock test harness, so the flow is exercised end-to-end like the native composer.

- The JS harness recalls older/newer sent user messages on Up/Down when no slash/mention suggestions are active, beginning only from an empty composer, continuing only while the recalled text is unedited, restoring the in-progress draft past the newest entry, and exiting recall on user edits or send.

## Tests

A Playwright test sends two messages then drives Up/Up/Up (clamp at oldest), Down/Down (restore the empty in-progress draft), and verifies Up does not hijack a non-empty composer. Full Playwright suite green (125 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)