### PR TITLE
Add /pr fill one-step pull request handoff

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3663,6 +3663,7 @@
         { id: 'git-status', title: 'Git status', shortcut: '', category: 'Git', keywords: ['git', 'status', 'changes', 'remote'], isEnabled: true },
         { id: 'git-diff', title: 'Review diff', shortcut: '', category: 'Git', keywords: ['git', 'diff', 'review', 'changes', 'remote'], isEnabled: true },
         { id: 'git-pr-create', title: 'Create pull request', shortcut: '', category: 'Git', keywords: ['github', 'pr', 'pull request', 'review'], isEnabled: true },
+        { id: 'git-pr-fill', title: 'Create pull request from commits', shortcut: '', category: 'Git', keywords: ['github', 'pr', 'pull request', 'fill', 'autofill', 'branch', 'commits'], isEnabled: true },
         { id: 'git-pr-view', title: 'View pull request', shortcut: '', category: 'Git', keywords: ['github', 'pr', 'view', 'comments', 'review'], isEnabled: true },
         { id: 'git-pr-checks', title: 'Pull request checks', shortcut: '', category: 'Git', keywords: ['github', 'pr', 'checks', 'ci', 'status'], isEnabled: true },
         { id: 'git-pr-diff', title: 'Pull request diff', shortcut: '', category: 'Git', keywords: ['github', 'pr', 'pr diff', 'pull request diff', 'diff', 'review', 'changes'], isEnabled: true },
@@ -5282,6 +5283,7 @@
         command.id === 'git-status' ? { ...command, isEnabled: hasProject } :
         command.id === 'git-diff' ? { ...command, isEnabled: hasProject } :
         command.id === 'git-pr-create' ? { ...command, isEnabled: hasLocalProject } :
+        command.id === 'git-pr-fill' ? { ...command, isEnabled: hasLocalProject } :
         command.id === 'git-worktree-list' ? { ...command, isEnabled: hasLocalProject } :
         command.id === 'git-worktree-create' ? { ...command, isEnabled: hasLocalProject } :
         command.id === 'git-worktree-open' ? { ...command, isEnabled: hasLocalProject } :
@@ -9399,6 +9401,25 @@
       render();
     }
 
+    function runGitPullRequestFillAction() {
+      ensureThread('Create pull request from commits');
+      const url = 'https://github.com/Lore-Hex/QuillCode/pull/77';
+      addToolCard({
+        title: 'host.git.pr.create',
+        subtitle: 'Completed',
+        status: 'done',
+        inputJSON: JSON.stringify({ fill: true }, null, 2),
+        outputJSON: JSON.stringify({
+          ok: true,
+          stdout: url + '\n',
+          artifacts: [url]
+        }, null, 2)
+      });
+      addMessage('assistant', 'Opened a pull request for the current branch:\n' + url + '\n');
+      syncSelectedThreadSearchText();
+      render();
+    }
+
     function runGitPullRequestViewAction() {
       ensureThread('View pull request');
       const stdout = [
@@ -10095,6 +10116,7 @@
       'git-pr-checkout',
       'git-pr-comment',
       'git-pr-create',
+      'git-pr-fill',
       'git-pr-diff',
       'git-pr-labels',
       'git-pr-merge',
@@ -10643,6 +10665,10 @@
       }
       if (commandID === 'git-pr-create') {
         usePromptAsDraft('Create a pull request titled ');
+        return;
+      }
+      if (commandID === 'git-pr-fill') {
+        runGitPullRequestFillAction();
         return;
       }
       if (commandID === 'git-pr-view') {
@@ -12931,6 +12957,9 @@
           outputJSON: JSON.stringify({ ok: true, stdout: JSON.stringify(payload, null, 2), stderr: '', exitCode: 0 }, null, 2)
         });
         addMessage('assistant', 'Found 2 review threads: 1 unresolved, 1 resolved.');
+      } else if (/^\/(pr|pull-?request)\s+(fill|autofill|create\s+--?fill)\b/i.test(text)) {
+        runGitPullRequestFillAction();
+        return;
       } else if (/^\/(pr|pull-?request)\b/i.test(text)) {
         state.composer.draft = 'Create a pull request titled ';
         addMessage('assistant', 'Pull request prompt prepared.');

--- a/E2E/playwright/tests/command-palette.spec.ts
+++ b/E2E/playwright/tests/command-palette.spec.ts
@@ -143,11 +143,26 @@ test('mock harness prepares pull request creation from the command palette', asy
 
   await clickSidebarTool(page, 'command-palette-button');
   await fillCommandPalette(page, '>create pull request');
-  await expect(page.getByTestId('command-palette-result')).toHaveCount(1);
+  await expect(commandPaletteResult(page, 'git-pr-create')).toBeVisible();
+  await expect(commandPaletteResult(page, 'git-pr-fill')).toBeVisible();
   await commandPaletteResult(page, 'git-pr-create').click();
 
   await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
   await expect(page.getByLabel('Message')).toHaveValue('Create a pull request titled ');
+});
+
+test('mock harness opens a pull request from commits via the command palette', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await clickSidebarTool(page, 'command-palette-button');
+  await fillCommandPalette(page, '>pull request from commits');
+  await expect(commandPaletteResult(page, 'git-pr-fill')).toBeVisible();
+  await commandPaletteResult(page, 'git-pr-fill').click();
+
+  await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.pr.create');
+  await expect(page.getByTestId('tool-card-input').last()).toContainText('"fill": true');
+  await expect(page.getByTestId('message').last()).toContainText('Opened a pull request for the current branch');
 });
 
 test('mock harness views pull request details, checks, and diff from the command palette', async ({ page }) => {

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -142,6 +142,12 @@ test('mock harness routes slash commands to workspace actions', async ({ page })
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByLabel('Message')).toHaveValue('Create a pull request titled ');
 
+  await page.getByLabel('Message').fill('/pr fill');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.pr.create');
+  await expect(page.getByTestId('tool-card-input').last()).toContainText('"fill": true');
+  await expect(page.getByTestId('message').last()).toContainText('Opened a pull request for the current branch');
+
   await page.getByLabel('Message').fill('/compact');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('top-bar-title')).toContainText('Compact:');

--- a/Sources/QuillCodeApp/SlashPullRequestCommandParser.swift
+++ b/Sources/QuillCodeApp/SlashPullRequestCommandParser.swift
@@ -15,7 +15,13 @@ enum SlashPullRequestCommandParser {
 
         switch subcommand {
         case "create", "new", "open":
+            let normalizedRest = rest.lowercased()
+            if normalizedRest == "--fill" || normalizedRest == "fill" {
+                return .workspaceCommand("git-pr-fill")
+            }
             return .workspaceCommand("git-pr-create")
+        case "fill", "autofill":
+            return .workspaceCommand("git-pr-fill")
         case "view", "show", "inspect", "comments":
             return pullRequestTool(.gitPullRequestView, selector: rest)
         case "checks", "ci", "status":
@@ -72,7 +78,7 @@ enum SlashPullRequestCommandParser {
         case "merge", "automerge", "auto_merge":
             return parseMerge(rest, autoByDefault: subcommand != "merge")
         default:
-            return .invalid("Unknown pull request command '\(rawSubcommand)'. Use create, view, checks, diff, checkout, comment, review, review-comment, review-reply, review-threads, review-thread, reviewers, labels, or merge.")
+            return .invalid("Unknown pull request command '\(rawSubcommand)'. Use create, fill, view, checks, diff, checkout, comment, review, review-comment, review-reply, review-threads, review-thread, reviewers, labels, or merge.")
         }
     }
 

--- a/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
@@ -72,7 +72,11 @@ enum WorkspaceCommandPlan: Equatable {
     ].merging(WorkspacePullRequestCommandCatalog.toolNameByCommandID) { local, _ in local }
 
     private static let toolCallByCommandID: [String: ToolCall] = [
-        "git-worktree-prune": WorkspaceWorktreeToolCallPlanner.prune(.init(dryRun: true, verbose: true))
+        "git-worktree-prune": WorkspaceWorktreeToolCallPlanner.prune(.init(dryRun: true, verbose: true)),
+        "git-pr-fill": ToolCall(
+            name: ToolDefinition.gitPullRequestCreate.name,
+            argumentsJSON: ToolArguments.json(["fill": true])
+        )
     ]
 
     private static let draftByCommandID: [String: String] = [

--- a/Sources/QuillCodeApp/WorkspacePullRequestCommandCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspacePullRequestCommandCatalog.swift
@@ -71,6 +71,19 @@ enum WorkspacePullRequestCommandCatalog {
             )
         ),
         .init(
+            id: "git-pr-fill",
+            title: "Create pull request from commits",
+            keywords: ["github", "pr", "pull request", "fill", "autofill", "branch", "commits"],
+            systemImage: "arrow.up.doc.on.clipboard",
+            slash: pullRequestSlash(
+                usage: "/pr fill",
+                title: "Create PR from commits",
+                detail: "Open a pull request for the current branch with title and body filled from its commits.",
+                insertText: "/pr fill",
+                aliases: ["pr autofill", "pull request fill", "pr from commits"]
+            )
+        ),
+        .init(
             id: "git-pr-view",
             title: "View pull request",
             keywords: ["github", "pr", "view", "comments", "review"],

--- a/Tests/QuillCodeAppTests/SlashPullRequestCommandParserTests.swift
+++ b/Tests/QuillCodeAppTests/SlashPullRequestCommandParserTests.swift
@@ -9,6 +9,14 @@ final class SlashPullRequestCommandParserTests: XCTestCase {
         XCTAssertEqual(SlashCommandParser.parse("/pr"), .workspaceCommand("git-pr-create"))
     }
 
+    func testFillPullRequestCommandRoutesToAutoFillCreate() {
+        XCTAssertEqual(SlashPullRequestCommandParser.parse("fill"), .workspaceCommand("git-pr-fill"))
+        XCTAssertEqual(SlashPullRequestCommandParser.parse("autofill"), .workspaceCommand("git-pr-fill"))
+        XCTAssertEqual(SlashPullRequestCommandParser.parse("create --fill"), .workspaceCommand("git-pr-fill"))
+        XCTAssertEqual(SlashPullRequestCommandParser.parse("create fill"), .workspaceCommand("git-pr-fill"))
+        XCTAssertEqual(SlashCommandParser.parse("/pr fill"), .workspaceCommand("git-pr-fill"))
+    }
+
     func testReadOnlyPullRequestCommandsBuildToolCallsWithSelectors() throws {
         try assertToolCall(
             SlashPullRequestCommandParser.parse("view #456"),
@@ -130,7 +138,7 @@ final class SlashPullRequestCommandParserTests: XCTestCase {
         )
         XCTAssertEqual(
             SlashPullRequestCommandParser.parse("unknown"),
-            .invalid("Unknown pull request command 'unknown'. Use create, view, checks, diff, checkout, comment, review, review-comment, review-reply, review-threads, review-thread, reviewers, labels, or merge.")
+            .invalid("Unknown pull request command 'unknown'. Use create, fill, view, checks, diff, checkout, comment, review, review-comment, review-reply, review-threads, review-thread, reviewers, labels, or merge.")
         )
     }
 

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPlanTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPlanTests.swift
@@ -40,6 +40,13 @@ final class WorkspaceCommandPlanTests: XCTestCase {
         XCTAssertEqual(pruneCall.name, ToolDefinition.gitWorktreePrune.name)
         XCTAssertEqual(pruneArguments.bool("dryRun"), true)
         XCTAssertEqual(pruneArguments.bool("verbose"), true)
+
+        guard case .runToolCall(let fillCall) = WorkspaceCommandPlan(commandID: "git-pr-fill") else {
+            return XCTFail("Expected git pr fill to dispatch an explicit tool call.")
+        }
+        let fillArguments = try ToolArguments(fillCall.argumentsJSON)
+        XCTAssertEqual(fillCall.name, ToolDefinition.gitPullRequestCreate.name)
+        XCTAssertEqual(fillArguments.bool("fill"), true)
     }
 
     func testDraftCommandsMapToComposerText() {

--- a/Tests/QuillCodeAppTests/WorkspacePullRequestCommandCatalogTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspacePullRequestCommandCatalogTests.swift
@@ -9,6 +9,7 @@ final class WorkspacePullRequestCommandCatalogTests: XCTestCase {
 
         XCTAssertEqual(commands.map(\.id), [
             "git-pr-create",
+            "git-pr-fill",
             "git-pr-view",
             "git-pr-checks",
             "git-pr-diff",
@@ -53,6 +54,7 @@ final class WorkspacePullRequestCommandCatalogTests: XCTestCase {
 
         XCTAssertEqual(slashUsages, [
             "/pr create",
+            "/pr fill",
             "/pr view [selector]",
             "/pr checks [selector]",
             "/pr diff [selector]",

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -120,6 +120,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
             "git-status",
             "git-diff",
             "git-pr-create",
+            "git-pr-fill",
             "git-pr-view",
             "git-pr-checks",
             "git-pr-diff",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-29 Pull Request Auto-Fill Handoff Pass
+
+Overall grade after this slice: **A one-step PR handoff, A cross-surface parity**.
+
+Adds a one-step "open a PR for this branch" handoff so a worktree or feature branch can become a pull request with title and body auto-filled from its commits.
+
+| Before | After |
+| --- | --- |
+| Creating a PR always meant drafting a title in the composer; there was no quick auto-fill path for the current branch. | `/pr fill` (and `/pr create --fill`) plus a "Create pull request from commits" command-palette action dispatch `host.git.pr.create` with `fill: true`, which `gh pr create --fill` turns into a PR titled/bodied from the branch's commits. |
+| The native command surface, harness routing registry, and JS harness only knew `git-pr-create`. | `git-pr-fill` is registered across the slash parser, the pull-request command catalog/descriptors, the `WorkspaceCommandPlan` tool-call map, the harness static command registry, and the JS harness command routing + mock execution, keeping the rendered command-routing parity audit green. |
+| No coverage for the fill handoff. | Parser, command-plan, and catalog unit tests plus Playwright slash and command-palette tests assert the `fill: true` dispatch and the resulting PR tool card. |
+
+Residual risk:
+
+- The fill path relies on `gh pr create --fill`, which needs the branch pushed; surfacing a clear push prompt on failure is a future polish.
+
 ## 2026-06-29 Composer History Recall Native Pass
 
 Overall grade after this slice: **A native recall UX; harness/Playwright parity pending**.


### PR DESCRIPTION
## Summary

Adds a one-step **"open a PR for this branch"** handoff — a worktree or feature branch becomes a pull request with title and body auto-filled from its commits, closing part of the flagged worktree → PR handoff parity gap.

- **`/pr fill`** and **`/pr create --fill`**, plus a **"Create pull request from commits"** command-palette action, dispatch `host.git.pr.create` with `fill: true` — which `gh pr create --fill` turns into a PR titled/bodied from the branch's commits.
- `git-pr-fill` is registered across the slash parser, the pull-request command catalog/descriptors, the `WorkspaceCommandPlan` tool-call map, the harness static command registry, and the JS harness command routing + mock execution — keeping the rendered command-routing **parity audit** green (the audit forced the harness side into this same PR).

## Tests

- Swift: parser (`/pr fill`, `--fill`, `autofill`), command-plan (`git-pr-fill` → `host.git.pr.create` + `fill:true`), and catalog ordering/slash-usage tests.
- Playwright: slash `/pr fill` and command-palette "from commits" both produce the `host.git.pr.create` tool card with `fill: true`.

`swift test` green (1682); Playwright green (126); `./scripts/native-desktop-smoke.sh` passes.

## Notes

The fill path relies on `gh pr create --fill`, which needs the branch pushed; a clearer push prompt on failure is a future polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)