### PR TITLE
Add /diff and /git-status slash quick-actions

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4018,6 +4018,8 @@
       { usage: '/terminal', title: 'Toggle terminal', detail: 'Show or hide the integrated workspace terminal.', insertText: '/terminal', aliases: ['term', 'shell'] },
       { usage: '/terminal clear', title: 'Clear terminal history', detail: 'Clear completed integrated-terminal history without resetting cwd or environment.', insertText: '/terminal clear', aliases: ['term clear', 'shell clear'] },
       { usage: '/browser', title: 'Toggle browser', detail: 'Show or hide the browser preview panel.', insertText: '/browser', aliases: ['preview'] },
+      { usage: '/diff', title: 'Review diff', detail: 'Show the working-tree git diff in the review pane.', insertText: '/diff', aliases: ['changes', 'git diff'] },
+      { usage: '/git-status', title: 'Git status', detail: 'Show the git status of the selected project.', insertText: '/git-status', aliases: ['gitstatus', 'git status'] },
       { usage: '/memories', title: 'Show memories', detail: 'Show loaded global and project memories.', insertText: '/memories', aliases: ['memory'] },
       { usage: '/remember text', title: 'Add memory', detail: 'Save an explicit global memory after redaction checks.', insertText: '/remember ', aliases: [] },
       { usage: '/worktrees', title: 'List worktrees', detail: 'List git worktrees for the selected project.', insertText: '/worktrees', aliases: ['worktree', 'wt'] },
@@ -13194,6 +13196,12 @@
           outputJSON: JSON.stringify({ ok: true, stdout: diff }, null, 2)
         });
         addMessage('assistant', 'Patch applied. Review the resulting diff below.');
+      } else if (/^\/(diff|changes)\b/i.test(text)) {
+        runGitDiffAction();
+        return;
+      } else if (/^\/git-?status\b/i.test(text)) {
+        runGitStatusAction();
+        return;
       } else if (isNaturalGitDiffRequest(text)) {
         runGitDiffAction();
         return;

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -110,6 +110,14 @@ test('mock harness routes slash commands to workspace actions', async ({ page })
   await expect(page.getByTestId('browser-pane')).toBeVisible();
   await expect(page.getByText('Browser opened.')).toBeVisible();
 
+  await page.getByLabel('Message').fill('/diff');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.diff');
+
+  await page.getByLabel('Message').fill('/git-status');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.status');
+
   await page.getByLabel('Message').fill('/worktrees');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.worktree.list');

--- a/Sources/QuillCodeApp/SlashCommandCatalog.swift
+++ b/Sources/QuillCodeApp/SlashCommandCatalog.swift
@@ -55,6 +55,8 @@ enum SlashCommandCatalog {
         .init(usage: "/terminal", title: "Toggle terminal", detail: "Show or hide the integrated workspace terminal.", insertText: "/terminal", aliases: ["term", "shell"]),
         .init(usage: "/terminal clear", title: "Clear terminal history", detail: "Clear completed integrated-terminal history without resetting cwd or environment.", insertText: "/terminal clear", aliases: ["term clear", "shell clear"]),
         .init(usage: "/browser", title: "Toggle browser", detail: "Show or hide the browser preview panel.", insertText: "/browser", aliases: ["preview"]),
+        .init(usage: "/diff", title: "Review diff", detail: "Show the working-tree git diff in the review pane.", insertText: "/diff", aliases: ["changes", "git diff"]),
+        .init(usage: "/git-status", title: "Git status", detail: "Show the git status of the selected project.", insertText: "/git-status", aliases: ["gitstatus", "git status"]),
         .init(usage: "/memories", title: "Show memories", detail: "Show loaded global and project memories.", insertText: "/memories", aliases: ["memory"]),
         .init(usage: "/remember text", title: "Add memory", detail: "Save an explicit global memory after redaction checks.", insertText: "/remember ", aliases: []),
         .init(usage: "/worktrees", title: "List worktrees", detail: "List git worktrees for the selected project.", insertText: "/worktrees", aliases: ["worktree", "wt"]),

--- a/Sources/QuillCodeApp/SlashWorkspaceCommandParser.swift
+++ b/Sources/QuillCodeApp/SlashWorkspaceCommandParser.swift
@@ -4,6 +4,8 @@ enum SlashWorkspaceCommandParser {
     static func supports(_ name: String) -> Bool {
         switch normalizedName(name) {
         case "browser", "preview",
+             "diff", "changes",
+             "git-status", "gitstatus",
              "worktree", "worktrees", "wt":
             return true
         default:
@@ -15,6 +17,10 @@ enum SlashWorkspaceCommandParser {
         switch normalizedName(name) {
         case "browser", "preview":
             return .workspaceCommand("toggle-browser")
+        case "diff", "changes":
+            return .workspaceCommand("git-diff")
+        case "git-status", "gitstatus":
+            return .workspaceCommand("git-status")
         case "worktree", "worktrees", "wt":
             return SlashWorktreeCommandParser.parse(argument)
         default:

--- a/Tests/QuillCodeAppTests/SlashWorkspaceCommandParserTests.swift
+++ b/Tests/QuillCodeAppTests/SlashWorkspaceCommandParserTests.swift
@@ -5,6 +5,8 @@ final class SlashWorkspaceCommandParserTests: XCTestCase {
     func testSupportsWorkspaceAliases() {
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("browser"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("preview"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("diff"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("git-status"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("worktree"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("worktrees"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("wt"))
@@ -16,6 +18,13 @@ final class SlashWorkspaceCommandParserTests: XCTestCase {
         XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "preview"), .workspaceCommand("toggle-browser"))
         XCTAssertEqual(SlashCommandParser.parse("/browser"), .workspaceCommand("toggle-browser"))
         XCTAssertEqual(SlashCommandParser.parse("/preview"), .workspaceCommand("toggle-browser"))
+    }
+
+    func testGitDiffAndStatusAliasesRunGitCommands() {
+        XCTAssertEqual(SlashCommandParser.parse("/diff"), .workspaceCommand("git-diff"))
+        XCTAssertEqual(SlashCommandParser.parse("/changes"), .workspaceCommand("git-diff"))
+        XCTAssertEqual(SlashCommandParser.parse("/git-status"), .workspaceCommand("git-status"))
+        XCTAssertEqual(SlashCommandParser.parse("/gitstatus"), .workspaceCommand("git-status"))
     }
 
     func testWorktreeAliasesListGitWorktrees() {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-29 Git Diff/Status Slash Quick-Action Pass
+
+Overall grade after this slice: **A quick-action coverage, A cross-surface parity**.
+
+Adds composer slash shortcuts for the two most common "what changed?" git actions, which previously lived only in the command palette.
+
+| Before | After |
+| --- | --- |
+| Reviewing the working-tree diff or git status required the command palette or natural-language prompts; there was no slash shortcut. | `/diff` (aliases `/changes`) opens the working-tree diff in the review pane and `/git-status` (alias `/gitstatus`) shows git status, both dispatching the existing `git-diff`/`git-status` commands. |
+| The slash catalog and harness slash list did not surface these git actions. | Both are registered in the slash parser, the slash command catalog suggestions, and the JS harness slash definitions + message routing, reusing existing command IDs so the rendered command-routing parity audit stays green. |
+| No coverage for the new aliases. | A parser unit test covers `/diff`, `/changes`, `/git-status`, `/gitstatus`, and Playwright asserts both produce the `host.git.diff`/`host.git.status` tool cards. |
+
+Residual risk:
+
+- None specific; both reuse existing, already-audited git command execution paths.
+
 ## 2026-06-29 Pull Request Auto-Fill Handoff Pass
 
 Overall grade after this slice: **A one-step PR handoff, A cross-surface parity**.


### PR DESCRIPTION
## Summary

Adds composer slash shortcuts for the two most common "what changed?" git actions, which previously only existed in the command palette.

- **`/diff`** (aliases `/changes`) opens the working-tree diff in the review pane.
- **`/git-status`** (alias `/gitstatus`) shows git status.

Both reuse the existing `git-diff`/`git-status` command IDs, so no new command surface — the rendered command-routing parity audit stays green.

## Tests

- Parser unit test: `/diff`, `/changes`, `/git-status`, `/gitstatus`.
- Playwright: both produce the `host.git.diff` / `host.git.status` tool cards.

`swift test` green; Playwright green (126); native smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)