### PR TITLE
Preserve a separate composer draft per thread

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -9081,6 +9081,7 @@
 
     function newChat() {
       clearSidebarSelection();
+      stashComposerDraft(state.sidebar.selectedThreadID);
       state.sidebar.selectedThreadID = null;
       state.sidebar.items = state.sidebar.items.map(item => ({ ...item, isSelected: false }));
       state.transcript.messages = [];
@@ -12465,9 +12466,33 @@
       render();
     }
 
+    function stashComposerDraft(outgoingID) {
+      if (!state.threadDrafts) state.threadDrafts = {};
+      if (!outgoingID) return;
+      if (String(state.composer.draft).trim().length) {
+        state.threadDrafts[outgoingID] = state.composer.draft;
+      } else {
+        delete state.threadDrafts[outgoingID];
+      }
+    }
+
+    function restoreComposerDraft(incomingID) {
+      if (!state.threadDrafts) state.threadDrafts = {};
+      state.composer.draft = (incomingID && state.threadDrafts[incomingID]) || '';
+      if (incomingID) delete state.threadDrafts[incomingID];
+      state.composer.canSend = state.composer.draft.trim().length > 0;
+      state.composer.historyRecallIndex = null;
+      state.composer.historySavedDraft = null;
+    }
+
     function selectThread(threadID) {
       const selected = state.sidebar.items.find(item => item.id === threadID);
       if (!selected) return;
+      const outgoing = state.sidebar.selectedThreadID;
+      if (outgoing !== threadID) {
+        stashComposerDraft(outgoing);
+        restoreComposerDraft(threadID);
+      }
       state.sidebar.selectedThreadID = threadID;
       state.sidebar.items = state.sidebar.items.map(item => ({
         ...item,
@@ -12496,6 +12521,8 @@
       }
       if (action === 'duplicate') {
         const newThreadID = `thread-${state.nextThreadIndex++}`;
+        stashComposerDraft(state.sidebar.selectedThreadID);
+        restoreComposerDraft(newThreadID);
         state.sidebar.selectedThreadID = newThreadID;
         state.sidebar.items = sortSidebarItems([
           {
@@ -12521,8 +12548,10 @@
           item.id === threadID ? { ...item, isArchived: true, isPinned: false, isSelected: false } : item
         )));
         if (state.sidebar.selectedThreadID === threadID) {
+          stashComposerDraft(threadID);
           const next = state.sidebar.items.find(item => !item.isArchived);
           state.sidebar.selectedThreadID = next?.id || null;
+          restoreComposerDraft(state.sidebar.selectedThreadID);
           state.sidebar.items = state.sidebar.items.map(item => ({ ...item, isSelected: item.id === state.sidebar.selectedThreadID }));
           state.topBar.primaryTitle = next?.title || 'QuillCode';
           if (!state.sidebar.selectedThreadID) {
@@ -12533,6 +12562,8 @@
         }
       }
       if (action === 'unarchive') {
+        stashComposerDraft(state.sidebar.selectedThreadID);
+        restoreComposerDraft(threadID);
         state.sidebar.selectedThreadID = threadID;
         state.sidebar.items = sortSidebarItems(state.sidebar.items.map(item => (
           item.id === threadID
@@ -12546,6 +12577,7 @@
         if (state.sidebar.selectedThreadID === threadID) {
           const next = state.sidebar.items.find(item => !item.isArchived);
           state.sidebar.selectedThreadID = next?.id || null;
+          restoreComposerDraft(state.sidebar.selectedThreadID);
           state.sidebar.items = state.sidebar.items.map(item => ({ ...item, isSelected: item.id === state.sidebar.selectedThreadID }));
           state.topBar.primaryTitle = next?.title || 'QuillCode';
           if (!state.sidebar.selectedThreadID) {
@@ -12554,6 +12586,7 @@
             state.transcript.timelineItems = [];
           }
         }
+        if (state.threadDrafts) delete state.threadDrafts[threadID];
       }
       render();
     }
@@ -12721,6 +12754,7 @@
       const text = String(value).trim();
       if (!text) return;
       ensureThread(text.split(/\s+/).slice(0, 6).join(' '));
+      if (state.threadDrafts) delete state.threadDrafts[state.sidebar.selectedThreadID];
       state.composer.draft = '';
       state.composer.canSend = false;
       state.composer.slashActiveIndex = 0;

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -260,6 +260,35 @@ test('mock harness suggests workspace files for @ mentions in the composer', asy
   await expect(page.getByTestId('slash-suggestions')).toBeVisible();
 });
 
+test('mock harness preserves a separate composer draft per thread', async ({ page }) => {
+  await page.goto(harnessURL());
+  const message = page.getByLabel('Message');
+
+  // Create thread A by sending a prompt.
+  await message.fill('alpha topic');
+  await message.press('Enter');
+  await expect(message).toBeEnabled();
+  await expect(page.getByTestId('sidebar-item').filter({ hasText: 'alpha topic' })).toBeVisible();
+
+  // New chat, then create thread B by sending a prompt.
+  await page.getByTestId('new-chat-button').click();
+  await message.fill('beta topic');
+  await message.press('Enter');
+  await expect(message).toBeEnabled();
+  await expect(page.getByTestId('sidebar-item').filter({ hasText: 'beta topic' })).toBeVisible();
+
+  // Leave an unsent draft in thread B.
+  await message.fill('work in progress for beta');
+
+  // Switching to thread A stashes B's draft and shows A's own (empty) draft.
+  await page.getByTestId('sidebar-item').filter({ hasText: 'alpha topic' }).click();
+  await expect(message).toHaveValue('');
+
+  // Switching back to thread B restores its unsent draft verbatim.
+  await page.getByTestId('sidebar-item').filter({ hasText: 'beta topic' }).click();
+  await expect(message).toHaveValue('work in progress for beta');
+});
+
 test('mock harness recalls sent messages with Up and Down', async ({ page }) => {
   await page.goto(harnessURL());
   const message = page.getByLabel('Message');

--- a/Sources/QuillCodeApp/ComposerDraftStore.swift
+++ b/Sources/QuillCodeApp/ComposerDraftStore.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Pure logic for preserving a separate unsent composer draft per thread, so
+/// switching threads stashes the outgoing draft and restores the incoming one
+/// instead of bleeding a single shared draft across threads. The workspace model
+/// owns the `[UUID: String]` map; this type computes the next map and the draft to
+/// show on each switch, keeping the branching unit-testable in isolation.
+public enum ComposerDraftStore {
+    /// The outcome of switching threads: the updated draft map and the draft to
+    /// restore into the composer for the newly selected thread.
+    public struct Switch: Equatable {
+        public var drafts: [UUID: String]
+        public var restoredDraft: String
+
+        public init(drafts: [UUID: String], restoredDraft: String) {
+            self.drafts = drafts
+            self.restoredDraft = restoredDraft
+        }
+    }
+
+    /// Stashes the outgoing thread's live draft and restores the incoming thread's
+    /// saved draft. Empty/whitespace drafts are not stored. Selecting the same
+    /// thread is a no-op that keeps the live draft as-is.
+    public static func select(
+        outgoing: UUID?,
+        incoming: UUID,
+        liveDraft: String,
+        drafts: [UUID: String]
+    ) -> Switch {
+        if outgoing == incoming {
+            return Switch(drafts: drafts, restoredDraft: liveDraft)
+        }
+
+        var next = drafts
+        if let outgoing {
+            if liveDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                next[outgoing] = nil
+            } else {
+                next[outgoing] = liveDraft
+            }
+        }
+
+        let restored = next[incoming] ?? ""
+        next[incoming] = nil
+        return Switch(drafts: next, restoredDraft: restored)
+    }
+
+    /// Drops a thread's saved draft, for use when its draft is sent or the thread
+    /// is removed.
+    public static func cleared(_ id: UUID?, drafts: [UUID: String]) -> [UUID: String] {
+        guard let id else { return drafts }
+        var next = drafts
+        next[id] = nil
+        return next
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -66,6 +66,12 @@ struct QuillCodeComposerView: View {
                 activeFileMentionIndex = min(activeFileMentionIndex, suggestions.count - 1)
             }
         }
+        .onChange(of: sentMessageHistory) { _, _ in
+            // Switching threads swaps the recall history (and may restore a non-empty
+            // draft), so reset the recall cursor to avoid replaying the prior thread.
+            historyRecallIndex = nil
+            historySavedDraft = nil
+        }
     }
 
     private var composerSurface: some View {

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -37,6 +37,9 @@ public final class QuillCodeWorkspaceModel {
     /// Bounded, cached index of the selected local project's files, used to power
     /// composer `@` file mentions. Empty for remote or unselected projects.
     public internal(set) var fileMentionIndex = WorkspaceFileIndex()
+    /// Transient per-thread unsent composer drafts, stashed on thread switch and
+    /// restored on selection so drafts never bleed across threads. Session-only.
+    public internal(set) var threadDrafts: [UUID: String] = [:]
 
     public init(
         root: QuillCodeRootState = QuillCodeRootState(),

--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -32,12 +32,14 @@ extension QuillCodeWorkspaceModel {
         onProgressUpdated: (@MainActor @Sendable () -> Void)? = nil
     ) async {
         let submissionPlan = WorkspaceComposerSubmissionPlanner.plan(draft: composer.draft)
+        let draftThreadID = root.selectedThreadID
         let prompt: String
         switch submissionPlan {
         case .ignore:
             return
         case .slash(let command, let originalPrompt):
             composer.draft = ""
+            threadDrafts = ComposerDraftStore.cleared(draftThreadID, drafts: threadDrafts)
             setLastError(nil)
             await handleSlashCommand(command, originalPrompt: originalPrompt, workspaceRoot: workspaceRoot)
             return
@@ -54,6 +56,7 @@ extension QuillCodeWorkspaceModel {
         updateThreadFromAgentRun(sendStart.thread)
         threadPersistence.save(sendStart.thread)
         applyComposerSendLifecycle(sendStart.lifecycle)
+        threadDrafts = ComposerDraftStore.cleared(draftThreadID, drafts: threadDrafts)
         onStarted?()
 
         let session = agentSendSessionFactory(workspaceRoot: workspaceRoot)

--- a/Sources/QuillCodeApp/WorkspaceModelThreads.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreads.swift
@@ -182,8 +182,49 @@ extension QuillCodeWorkspaceModel {
         }
     }
 
+    /// Stashes the outgoing thread's live draft and restores `newID`'s saved draft
+    /// when a lifecycle change (archive/unarchive/delete) reassigns the selected
+    /// thread without going through `selectThread`. Call BEFORE reassigning
+    /// `root.selectedThreadID`. Pass `removing` to drop a deleted thread's draft.
+    func applyThreadDraftSelection(to newID: UUID?, removing removed: UUID? = nil) {
+        let outgoing = root.selectedThreadID
+        if outgoing != newID {
+            if let newID {
+                let result = ComposerDraftStore.select(
+                    outgoing: outgoing,
+                    incoming: newID,
+                    liveDraft: composer.draft,
+                    drafts: threadDrafts
+                )
+                threadDrafts = result.drafts
+                composer.draft = result.restoredDraft
+            } else if let outgoing {
+                // Selection cleared: stash the outgoing draft and empty the composer.
+                if composer.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    threadDrafts[outgoing] = nil
+                } else {
+                    threadDrafts[outgoing] = composer.draft
+                }
+                composer.draft = ""
+            }
+        }
+        // Prune a removed thread AFTER the swap so a deleted outgoing thread's live
+        // draft is not re-stashed into an orphaned map entry.
+        if let removed {
+            threadDrafts = ComposerDraftStore.cleared(removed, drafts: threadDrafts)
+        }
+    }
+
     public func selectThread(_ id: UUID) {
         guard let thread = root.threads.first(where: { $0.id == id }) else { return }
+        let draftSwitch = ComposerDraftStore.select(
+            outgoing: root.selectedThreadID,
+            incoming: id,
+            liveDraft: composer.draft,
+            drafts: threadDrafts
+        )
+        threadDrafts = draftSwitch.drafts
+        composer.draft = draftSwitch.restoredDraft
         root.selectedThreadID = id
         root.selectedProjectID = knownProjectID(thread.projectID)
         syncTerminalSessionToSelectedProject()
@@ -318,6 +359,10 @@ extension QuillCodeWorkspaceModel {
 
         sidebarSelection = result.nextSelection
         root.threads = result.threads
+        applyThreadDraftSelection(to: result.selectedThreadID)
+        for thread in result.removedThreads {
+            threadDrafts = ComposerDraftStore.cleared(thread.id, drafts: threadDrafts)
+        }
         root.selectedThreadID = result.selectedThreadID
         root.selectedProjectID = result.selectedProjectID
         threadPersistence.save(result.changedThreads)
@@ -381,6 +426,14 @@ extension QuillCodeWorkspaceModel {
         saveThread: Bool
     ) -> UUID {
         clearSidebarSelection()
+        let draftSwitch = ComposerDraftStore.select(
+            outgoing: root.selectedThreadID,
+            incoming: thread.id,
+            liveDraft: composer.draft,
+            drafts: threadDrafts
+        )
+        threadDrafts = draftSwitch.drafts
+        composer.draft = draftSwitch.restoredDraft
         root.threads.insert(thread, at: 0)
         root.selectedThreadID = thread.id
         root.selectedProjectID = selectedProjectID
@@ -413,6 +466,7 @@ extension QuillCodeWorkspaceModel {
             selectedThreadID: root.selectedThreadID
         ) else { return }
         root.threads = threads
+        applyThreadDraftSelection(to: result.selectedThreadID)
         root.selectedThreadID = result.selectedThreadID
         threadPersistence.save(result.changedThread)
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
@@ -428,6 +482,7 @@ extension QuillCodeWorkspaceModel {
             return false
         }
         root.threads = threads
+        applyThreadDraftSelection(to: id)
         root.selectedThreadID = id
         root.selectedProjectID = knownProjectID(result.projectID)
         touchProject(root.selectedProjectID)
@@ -449,6 +504,7 @@ extension QuillCodeWorkspaceModel {
         }
         root.threads = threads
         threadPersistence.delete(id)
+        applyThreadDraftSelection(to: result.selectedThreadID, removing: id)
         root.selectedThreadID = result.selectedThreadID
         if let selectedThread {
             root.selectedProjectID = knownProjectID(selectedThread.projectID)

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -98,17 +98,30 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     func newChat() {
+        // Stash the live draft to the outgoing thread before opening a new chat.
+        model.setDraft(draft)
         navigationCoordinator.newChat(model: model)
+        modelStateCoordinator.syncComposerDraft(from: model, draft: &draft)
         refresh()
     }
 
     func selectThread(_ id: UUID) {
+        // Persist the live in-progress draft to the outgoing thread before switching
+        // so the model can stash it and restore the incoming thread's draft.
+        model.setDraft(draft)
         navigationCoordinator.selectThread(id, model: model)
+        // Force-sync the restored draft even mid-send (the busy gate would otherwise
+        // keep the old thread's text visible under the newly selected thread).
+        modelStateCoordinator.syncComposerDraft(from: model, draft: &draft)
         refresh()
     }
 
     func runThreadAction(_ mutation: WorkspaceThreadRowMutation) {
+        // Stash the live draft before a row action (duplicate/archive/delete) that
+        // may change the selected thread, then force-sync the restored draft.
+        model.setDraft(draft)
         navigationCoordinator.runThreadAction(mutation, model: model)
+        modelStateCoordinator.syncComposerDraft(from: model, draft: &draft)
         refresh()
     }
 
@@ -461,6 +474,9 @@ extension QuillCodeDesktopController: QuillCodeDesktopCommandPerforming {
     }
 
     func runWorkspaceCommand(_ commandID: String) {
+        // Push the live draft so thread-changing commands (new chat / duplicate /
+        // fork / compact) stash it instead of reading a stale model draft.
+        model.setDraft(draft)
         guard workspaceActionCoordinator.runWorkspaceCommand(
             commandID,
             model: model,

--- a/Tests/QuillCodeAppTests/ComposerDraftStoreTests.swift
+++ b/Tests/QuillCodeAppTests/ComposerDraftStoreTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class ComposerDraftStoreTests: XCTestCase {
+    func testSaveOutgoingAndRestoreIncomingRoundTrip() {
+        let a = UUID()
+        let b = UUID()
+
+        // Type in A, switch to B: A's draft is stashed, B restores empty.
+        let toB = ComposerDraftStore.select(outgoing: a, incoming: b, liveDraft: "draft A", drafts: [:])
+        XCTAssertEqual(toB.restoredDraft, "")
+        XCTAssertEqual(toB.drafts[a], "draft A")
+
+        // Type in B, switch back to A: B's draft is stashed, A's draft restored.
+        let toA = ComposerDraftStore.select(outgoing: b, incoming: a, liveDraft: "draft B", drafts: toB.drafts)
+        XCTAssertEqual(toA.restoredDraft, "draft A")
+        XCTAssertEqual(toA.drafts[b], "draft B")
+        // The restored thread's entry is consumed.
+        XCTAssertNil(toA.drafts[a])
+    }
+
+    func testEmptyOrWhitespaceDraftIsNotStored() {
+        let a = UUID()
+        let b = UUID()
+        let blank = ComposerDraftStore.select(outgoing: a, incoming: b, liveDraft: "   \n ", drafts: [a: "stale"])
+        XCTAssertNil(blank.drafts[a])
+        XCTAssertEqual(blank.restoredDraft, "")
+    }
+
+    func testSameThreadSelectionIsNoOp() {
+        let a = UUID()
+        let result = ComposerDraftStore.select(outgoing: a, incoming: a, liveDraft: "in progress", drafts: [:])
+        XCTAssertEqual(result.restoredDraft, "in progress")
+        XCTAssertTrue(result.drafts.isEmpty)
+    }
+
+    func testUnknownIncomingThreadRestoresEmpty() {
+        let a = UUID()
+        let b = UUID()
+        let result = ComposerDraftStore.select(outgoing: a, incoming: b, liveDraft: "draft A", drafts: [:])
+        XCTAssertEqual(result.restoredDraft, "")
+    }
+
+    func testNilOutgoingDoesNotStashButStillRestores() {
+        let b = UUID()
+        let result = ComposerDraftStore.select(outgoing: nil, incoming: b, liveDraft: "ignored", drafts: [b: "draft B"])
+        XCTAssertEqual(result.restoredDraft, "draft B")
+        XCTAssertNil(result.drafts[b])
+    }
+
+    func testClearedDropsThreadDraft() {
+        let a = UUID()
+        let b = UUID()
+        let drafts = [a: "draft A", b: "draft B"]
+        XCTAssertNil(ComposerDraftStore.cleared(a, drafts: drafts)[a])
+        XCTAssertEqual(ComposerDraftStore.cleared(a, drafts: drafts)[b], "draft B")
+        XCTAssertEqual(ComposerDraftStore.cleared(nil, drafts: drafts), drafts)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceComposerDraftIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerDraftIntegrationTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceComposerDraftIntegrationTests: XCTestCase {
+    func testDraftIsPreservedPerThreadAcrossSwitches() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        let threadA = model.newChat()
+        model.setDraft("draft for A")
+
+        // New chat stashes A's draft and starts empty.
+        let threadB = model.newChat()
+        XCTAssertEqual(model.composer.draft, "")
+        model.setDraft("draft for B")
+
+        // Switching back to A restores its draft; switching to B restores B's.
+        model.selectThread(threadA)
+        XCTAssertEqual(model.composer.draft, "draft for A")
+        model.selectThread(threadB)
+        XCTAssertEqual(model.composer.draft, "draft for B")
+
+        // The surface snapshot mirrors the restored draft.
+        XCTAssertEqual(model.surface().composer.draft, "draft for B")
+    }
+
+    func testSubmittedDraftIsNotResurrected() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        let threadA = model.newChat()
+        model.setDraft("draft for A")
+        let threadB = model.newChat()
+        model.setDraft("run whoami")
+        await model.submitComposer(workspaceRoot: root)
+
+        // A's unsent draft survives; B's sent draft is gone, not resurrected.
+        model.selectThread(threadA)
+        XCTAssertEqual(model.composer.draft, "draft for A")
+        model.selectThread(threadB)
+        XCTAssertEqual(model.composer.draft, "")
+    }
+
+    func testDeletingActiveThreadDoesNotBleedDraftAndPrunesIt() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        let threadA = model.newChat()
+        model.setDraft("draft for A")
+        let threadB = model.newChat()
+        model.setDraft("draft for B")
+
+        // Deleting the active thread B auto-selects A; B's draft must not bleed into A.
+        _ = model.deleteThread(threadB)
+        XCTAssertEqual(model.composer.draft, "draft for A")
+        XCTAssertNil(model.threadDrafts[threadB])
+    }
+
+    func testArchivingActiveThreadRestoresAutoSelectedThreadDraft() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        let threadA = model.newChat()
+        model.setDraft("draft for A")
+        let threadB = model.newChat()
+        model.setDraft("draft for B")
+
+        // Archiving the active thread B auto-selects A and shows A's own draft.
+        model.archiveThread(threadB)
+        XCTAssertEqual(model.composer.draft, "draft for A")
+        // Restoring archived B brings back its stashed draft without bleeding A.
+        _ = model.unarchiveThread(threadB)
+        XCTAssertEqual(model.composer.draft, "draft for B")
+        _ = threadA
+    }
+
+    func testSlashSubmitPrunesActiveThreadDraft() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        let threadA = model.newChat()
+        model.setDraft("draft for A")
+        let threadB = model.newChat()
+        model.setDraft("/diff")
+        await model.submitComposer(workspaceRoot: root)
+
+        model.selectThread(threadA)
+        XCTAssertEqual(model.composer.draft, "draft for A")
+        model.selectThread(threadB)
+        XCTAssertEqual(model.composer.draft, "")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-29 Per-Thread Composer Draft Pass
+
+Overall grade after this slice: **A correctness fix, A cross-surface coverage**.
+
+Fixes a real data-loss bug: the composer draft was a single global string, so typing in thread A then switching threads showed A's text under another thread and could send it into the wrong conversation. Each thread now keeps its own unsent draft, stashed on switch and restored on selection. Feature picked and designed by a judge-panel and hardened by an adversarial review pass (which found four selection-change sites the happy-path tests missed).
+
+| Before | After |
+| --- | --- |
+| `ComposerState.draft` was global; `selectThread`/`newChat`/archive/delete/duplicate reassigned the selected thread without touching the draft, bleeding it across threads. | A transient `threadDrafts: [UUID:String]` on the model (no Codable/persistence change) plus a pure `ComposerDraftStore` (stash/restore/clear) wired through `selectThread`, `insertCreatedThread`, submit-prune, and — from the review — `archiveThread`/`unarchiveThread`/`deleteThread`/bulk-delete via a shared `applyThreadDraftSelection`. |
+| The desktop controller only pushed the live `@Published` draft to the model on send; thread switches and context-menu/command-palette new-chat/duplicate/fork/compact lost the in-progress text, and the `isComposerBusy` refresh gate dropped the restored draft when switching during a send. | `selectThread`/`newChat`/`runThreadAction`/`runWorkspaceCommand` now push the live draft first and force-sync the restored draft past the busy gate. |
+| No coverage. | `ComposerDraftStore` unit tests (round-trip, empty-not-stored, same-thread no-op, unknown-incoming, prune); model integration tests for switch/new-chat/submit-prune and delete/archive/unarchive non-bleed + prune; Playwright per-thread draft preservation across thread switches; the JS harness mirrors the swap in select/new-chat/send and the duplicate/archive/unarchive/delete row actions. |
+
+Residual risk:
+
+- Drafts are session-only (transient map), not persisted across relaunch — a deliberate follow-up (would need a ThreadStore migration + parity-core snapshot update). The history-recall cursor reset is keyed on `sentMessageHistory` change rather than thread-identity (benign today); a Playwright recall-across-switch test is a follow-up.
+
 ## 2026-06-29 Git Diff/Status Slash Quick-Action Pass
 
 Overall grade after this slice: **A quick-action coverage, A cross-surface parity**.


### PR DESCRIPTION
## Summary

Fixes a real **data-loss bug**: the composer draft was a single global string, so typing in thread A then switching threads showed A's text under another thread and could send it into the wrong conversation. Each thread now keeps its own unsent draft, stashed on switch and restored on selection.

This feature was **picked and designed by a multi-lens judge-panel** (all three lenses + synthesis converged on it as the highest-value/cleanest gap) and **hardened by an adversarial review pass** that found four selection-change sites the happy-path tests missed.

## Implementation

- Pure **`ComposerDraftStore`** (stash/restore/clear) + a transient **`threadDrafts: [UUID:String]`** map on the model (no Codable/persistence change), wired through `selectThread`, `insertCreatedThread`, and a submit-prune.
- **Review-driven fixes** (the real bugs): `archiveThread`/`unarchiveThread`/`deleteThread`/bulk-delete route through a shared `applyThreadDraftSelection` (with prune-on-delete); the desktop controller pushes the live `@Published` draft before thread-changing actions (`selectThread`/`newChat`/`runThreadAction`/`runWorkspaceCommand`) and **force-syncs the restored draft past the `isComposerBusy` gate** so switching mid-send can't corrupt drafts.
- Native composer resets the Up/Down history-recall cursor on thread switch. The JS harness mirrors the swap in select/new-chat/send and the duplicate/archive/unarchive/delete row actions.

## Tests

- `ComposerDraftStore` unit tests (round-trip, empty-not-stored, same-thread no-op, unknown-incoming, prune).
- Model integration: switch/new-chat/submit-prune **and** delete/archive/unarchive non-bleed + prune.
- Playwright: per-thread draft preservation across thread switches.

`swift test` green (1694); Playwright green (127); native desktop smoke passes. No new command IDs, so the rendered command-routing parity audit is untouched.

## Notes

Drafts are **session-only** (transient map); cross-relaunch persistence is a deliberate follow-up (would need a ThreadStore migration + parity-core snapshot update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)