### PR TITLE
Surface worktree branch and ahead/behind in the top bar

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -201,6 +201,17 @@
       gap: 10px;
       text-align: left;
     }
+    .topbar-branch-chip {
+      flex: 0 0 auto;
+      font-size: 12px;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+      color: var(--muted, #9aa4b2);
+      background: rgba(255, 255, 255, 0.06);
+      border-radius: 7px;
+      padding: 2px 7px;
+      white-space: nowrap;
+    }
     .topbar strong { font-size: 17px; }
     .topbar-title-group strong {
       flex: 0 1 auto;
@@ -3286,6 +3297,7 @@
       topBar: {
         primaryTitle: 'QuillCode',
         subtitle: 'QuillCode - Not started',
+        branchStatusLabel: null,
         instructionLabel: '1 instruction file loaded',
         instructionSources: ['AGENTS.md'],
         modelLabel: 'Nike 1.0',
@@ -6426,6 +6438,7 @@
             <div class="topbar-title-group" data-testid="top-bar-title-group">
               <strong data-testid="top-bar-title">${escapeHTML(state.topBar.primaryTitle)}</strong>
               <p class="topbar-context-label" data-testid="top-bar-subtitle">${escapeHTML(state.topBar.subtitle)}</p>
+              ${state.topBar.branchStatusLabel ? `<span class="topbar-branch-chip" data-testid="top-bar-branch" title="${escapeHTML(state.topBar.branchStatusLabel)}">${escapeHTML(state.topBar.branchStatusLabel)}</span>` : ''}
             </div>
             <div class="topbar-clusters" data-testid="top-bar-clusters">
               <div class="topbar-cluster topbar-action-cluster" data-testid="top-bar-action-cluster">
@@ -9262,6 +9275,7 @@
         isSelected: true
       };
       state.projects.selectedProjectID = project.id;
+      state.topBar.branchStatusLabel = null;
       state.projects.items = [
         project,
         ...state.projects.items.map(item => ({ ...item, isSelected: false }))
@@ -9290,6 +9304,7 @@
         isSelected: true
       };
       state.projects.selectedProjectID = project.id;
+      state.topBar.branchStatusLabel = null;
       state.projects.items = [
         project,
         ...state.projects.items.map(item => ({ ...item, isSelected: false }))
@@ -9303,6 +9318,7 @@
 
     function selectProject(projectID) {
       state.projects.selectedProjectID = projectID;
+      state.topBar.branchStatusLabel = null;
       state.projects.items = state.projects.items.map(project => ({
         ...project,
         isSelected: project.id === projectID
@@ -9364,6 +9380,7 @@
         if (state.projects.selectedProjectID === projectID) {
           const next = state.projects.items[0] || null;
           state.projects.selectedProjectID = next?.id || null;
+          state.topBar.branchStatusLabel = null;
           state.projects.items = state.projects.items.map(item => ({
             ...item,
             isSelected: item.id === state.projects.selectedProjectID
@@ -9375,10 +9392,38 @@
       }
     }
 
+    function branchStatusLabelFromHeader(headerLine) {
+      let rest = String(headerLine || '').trim();
+      if (!rest.startsWith('## ')) return null;
+      rest = rest.slice(3).trim();
+      if (rest.startsWith('HEAD (no branch)')) return '(detached)';
+      let ahead = 0;
+      let behind = 0;
+      const bracket = rest.match(/\s*\[([^\]]*)\]$/);
+      if (bracket) {
+        rest = rest.slice(0, bracket.index).trim();
+        for (const segment of bracket[1].split(',')) {
+          const tokens = segment.trim().split(/\s+/);
+          if (tokens.length === 2 && /^\d+$/.test(tokens[1])) {
+            if (tokens[0] === 'ahead') ahead = parseInt(tokens[1], 10);
+            else if (tokens[0] === 'behind') behind = parseInt(tokens[1], 10);
+          }
+        }
+      }
+      const branch = rest.split('...')[0];
+      if (!branch) return null;
+      let label = branch;
+      if (ahead > 0) label += ` ↑${ahead}`;
+      if (behind > 0) label += ` ↓${behind}`;
+      return label;
+    }
+
     function runGitStatusAction() {
       const project = selectedProject();
       const prefix = project?.isRemote ? `ssh ${project.path}\n` : '';
-      const stdout = `${prefix}## main\n M Sources/App.swift\n`;
+      const header = '## main';
+      const stdout = `${prefix}${header}\n M Sources/App.swift\n`;
+      state.topBar.branchStatusLabel = branchStatusLabelFromHeader(header);
       addToolCard({
         title: 'host.git.status',
         subtitle: 'Completed',

--- a/E2E/playwright/tests/status.spec.ts
+++ b/E2E/playwright/tests/status.spec.ts
@@ -35,3 +35,24 @@ test('mock harness reports Synth status with preferred slash alias after model s
   const statusMessage = page.getByTestId('message').filter({ hasText: 'Project: QuillCode' });
   await expect(statusMessage).toContainText('Model: Synth (/synth)');
 });
+
+test('mock harness surfaces the branch and ahead/behind chip after a git status', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  // No branch chip until a git status runs.
+  await expect(page.getByTestId('top-bar-branch')).toHaveCount(0);
+
+  await page.getByLabel('Message').fill('/git-status');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.status');
+  await expect(page.getByTestId('top-bar-branch')).toBeVisible();
+  await expect(page.getByTestId('top-bar-branch')).toHaveText('main');
+
+  // The chip is additive: the existing subtitle is unchanged.
+  await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode');
+
+  // Switching to another project drops the chip so a stale branch is never shown.
+  await page.getByTestId('add-project-button').click();
+  await expect(page.getByTestId('top-bar-branch')).toHaveCount(0);
+});

--- a/Sources/QuillCodeApp/AppState.swift
+++ b/Sources/QuillCodeApp/AppState.swift
@@ -1,6 +1,7 @@
 import Foundation
 import QuillCodeCore
 import QuillCodePersistence
+import QuillCodeTools
 import QuillComputerUseKit
 
 public struct SidebarItem: Sendable, Hashable, Identifiable {
@@ -35,6 +36,13 @@ public struct TopBarState: Sendable, Hashable {
     public var mode: AgentMode
     public var agentStatus: String
     public var computerUseStatus: ComputerUseStatus
+    /// Branch + ahead/behind for the selected local/SSH project (or worktree),
+    /// parsed from the latest `host.git.status` run. Nil until a status runs.
+    public var branchStatus: GitBranchStatus?
+    /// The project the `branchStatus` was captured for, so a refresh can drop it
+    /// once a different project (or worktree) becomes selected — preventing a stale
+    /// branch chip after switching projects via any path.
+    public var branchStatusProjectID: UUID?
 
     public init(
         appName: String = "QuillCode",
@@ -48,7 +56,9 @@ public struct TopBarState: Sendable, Hashable {
             screenRecordingGranted: false,
             accessibilityGranted: false,
             message: "Needs Screen Recording + Accessibility"
-        )
+        ),
+        branchStatus: GitBranchStatus? = nil,
+        branchStatusProjectID: UUID? = nil
     ) {
         self.appName = appName
         self.projectName = projectName
@@ -57,6 +67,8 @@ public struct TopBarState: Sendable, Hashable {
         self.mode = mode
         self.agentStatus = agentStatus
         self.computerUseStatus = computerUseStatus
+        self.branchStatus = branchStatus
+        self.branchStatusProjectID = branchStatusProjectID
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
@@ -18,6 +18,9 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
     public var runtimeIssueSeverity: RuntimeIssueSeverity?
     public var computerUseLabel: String
     public var showsComputerUseSetup: Bool
+    /// Pre-formatted branch + ahead/behind chip (e.g. `feature/x ↑2 ↓1`), or nil
+    /// when no git branch status is known. Renderers display this string as-is.
+    public var branchStatusLabel: String?
 
     public init(
         appName: String,
@@ -35,7 +38,8 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
         runtimeIssueLabel: String? = nil,
         runtimeIssueSeverity: RuntimeIssueSeverity? = nil,
         computerUseLabel: String,
-        showsComputerUseSetup: Bool
+        showsComputerUseSetup: Bool,
+        branchStatusLabel: String? = nil
     ) {
         self.appName = appName
         self.primaryTitle = primaryTitle
@@ -53,6 +57,7 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
         self.runtimeIssueSeverity = runtimeIssueSeverity
         self.computerUseLabel = computerUseLabel
         self.showsComputerUseSetup = showsComputerUseSetup
+        self.branchStatusLabel = branchStatusLabel
     }
 
     public func filteredModelCategories(matching query: String) -> [ModelCategorySurface] {

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -55,6 +55,22 @@ struct QuillCodeTopBarView: View {
                 .foregroundStyle(QuillCodePalette.muted)
                 .lineLimit(1)
                 .truncationMode(.middle)
+
+            if let branchStatusLabel = topBar.branchStatusLabel {
+                Text(branchStatusLabel)
+                    .font(.caption.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(QuillCodePalette.background.opacity(0.6))
+                    )
+                    // The branch is already announced via the top bar's combined label.
+                    .accessibilityHidden(true)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -88,6 +104,9 @@ struct QuillCodeTopBarView: View {
 
     private var topBarAccessibilityLabel: String {
         var label = "\(topBar.primaryTitle), \(topBar.subtitle), \(agentStatus.accessibilityLabel)"
+        if let branchStatusLabel = topBar.branchStatusLabel {
+            label += ", branch: \(branchStatusLabel)"
+        }
         if let runtimeIssue {
             label += ", issue: \(runtimeIssue.label)"
         }

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -9,6 +9,7 @@ enum WorkspaceHTMLTopBarRenderer {
           <div class="topbar-title-group" data-testid="top-bar-title-group">
             <strong data-testid="top-bar-title">\(escape(topBar.primaryTitle))</strong>
             <p class="topbar-context-label" data-testid="top-bar-subtitle">\(escape(topBar.subtitle))</p>
+            \(renderBranchStatus(topBar))
           </div>
           <div class="topbar-clusters" data-testid="top-bar-clusters">
             \(renderActionCluster(topBar, commands: commands))
@@ -29,6 +30,11 @@ enum WorkspaceHTMLTopBarRenderer {
           <span data-testid="computer-use-status">\(escape(topBar.computerUseLabel))</span>
         </div>
         """
+    }
+
+    private static func renderBranchStatus(_ topBar: TopBarSurface) -> String {
+        guard let branchStatusLabel = topBar.branchStatusLabel else { return "" }
+        return #"<span class="topbar-branch-chip" data-testid="top-bar-branch" title="\#(escape(branchStatusLabel))">\#(escape(branchStatusLabel))</span>"#
     }
 
     private static func renderRuntimeIssuePill(_ topBar: TopBarSurface) -> String {

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -125,6 +125,15 @@ public final class QuillCodeWorkspaceModel {
         refreshTopBar(agentStatus: root.topBar.agentStatus)
     }
 
+    /// Records the latest git branch/ahead-behind status for a project, surfaced as
+    /// a top-bar chip. Tagged with the project it came from so `refreshTopBar` drops
+    /// it once a different project is selected (no stale branch after a switch). The
+    /// caller is expected to `refreshTopBar` afterward.
+    func setBranchStatus(_ status: GitBranchStatus?, forProjectID projectID: UUID?) {
+        root.topBar.branchStatus = status
+        root.topBar.branchStatusProjectID = status == nil ? nil : projectID
+    }
+
     public func setComputerUseBackend(_ backend: any ComputerUseBackend) {
         computerUseBackend = backend
         setComputerUseStatus(backend.status)

--- a/Sources/QuillCodeApp/WorkspaceToolRunCoordinator.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolRunCoordinator.swift
@@ -38,6 +38,14 @@ struct WorkspaceToolRunCoordinator {
         if let thread = model.selectedThread {
             model.threadPersistence.save(thread)
         }
+        // Capture branch + ahead/behind from a successful git status so the top-bar
+        // chip reflects the selected project's (or worktree's) branch.
+        if call.name == ToolDefinition.gitStatus.name, finishPlan.result.ok {
+            model.setBranchStatus(
+                GitBranchStatus.parse(statusShortBranchOutput: finishPlan.result.stdout),
+                forProjectID: model.selectedThread?.projectID ?? model.root.selectedProjectID
+            )
+        }
         model.refreshTopBar(agentStatus: finishPlan.agentStatus)
         return finishPlan.result
     }

--- a/Sources/QuillCodeApp/WorkspaceTopBarStateBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarStateBuilder.swift
@@ -11,6 +11,13 @@ enum WorkspaceTopBarStateBuilder {
             root.projects.first { $0.id == selectedProjectID }
         }
 
+        // Only carry the branch chip forward while it still belongs to the selected
+        // project, so switching projects (via any path) never shows a stale branch.
+        let branchMatchesSelection = root.topBar.branchStatusProjectID != nil
+            && root.topBar.branchStatusProjectID == projectID
+        let branchStatus = branchMatchesSelection ? root.topBar.branchStatus : nil
+        let branchStatusProjectID = branchMatchesSelection ? root.topBar.branchStatusProjectID : nil
+
         return TopBarState(
             appName: root.topBar.appName,
             projectName: project?.name,
@@ -18,7 +25,9 @@ enum WorkspaceTopBarStateBuilder {
             model: thread?.model ?? root.config.defaultModel,
             mode: thread?.mode ?? root.config.mode,
             agentStatus: agentStatus ?? root.topBar.agentStatus,
-            computerUseStatus: root.topBar.computerUseStatus
+            computerUseStatus: root.topBar.computerUseStatus,
+            branchStatus: branchStatus,
+            branchStatusProjectID: branchStatusProjectID
         )
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
@@ -34,7 +34,11 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
             runtimeIssueLabel: runtimeIssue?.title,
             runtimeIssueSeverity: runtimeIssue?.severity,
             computerUseLabel: topBarState.computerUseStatus.message,
-            showsComputerUseSetup: !topBarState.computerUseStatus.available
+            showsComputerUseSetup: !topBarState.computerUseStatus.available,
+            branchStatusLabel: topBarState.branchStatus.flatMap { status in
+                let label = status.compactLabel
+                return label.isEmpty ? nil : label
+            }
         )
     }
 

--- a/Sources/QuillCodeTools/GitBranchStatus.swift
+++ b/Sources/QuillCodeTools/GitBranchStatus.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// The branch and upstream-tracking state parsed from the leading `## ` header of
+/// `git status --short --branch` output. Used to surface a worktree/project's branch
+/// and how far it is ahead/behind its upstream without any extra git invocation.
+public struct GitBranchStatus: Codable, Sendable, Hashable {
+    public var branch: String
+    public var upstream: String?
+    public var ahead: Int
+    public var behind: Int
+    public var isDetached: Bool
+
+    public init(branch: String, upstream: String? = nil, ahead: Int = 0, behind: Int = 0, isDetached: Bool = false) {
+        self.branch = branch
+        self.upstream = upstream
+        self.ahead = ahead
+        self.behind = behind
+        self.isDetached = isDetached
+    }
+
+    /// A compact one-line label, e.g. `feature/x ↑2 ↓1`, `main`, or `(detached)`.
+    /// Arrows are omitted when the count is zero. This is the single shared place
+    /// label formatting lives, so renderers only display the resulting string.
+    public var compactLabel: String {
+        if isDetached { return "(detached)" }
+        guard !branch.isEmpty else { return "" }
+        var label = branch
+        if ahead > 0 { label += " ↑\(ahead)" }
+        if behind > 0 { label += " ↓\(behind)" }
+        return label
+    }
+
+    /// Parses the `## ` branch header from `git status --short --branch` output.
+    /// Returns `nil` when there is no parseable header (so the chip degrades away).
+    public static func parse(statusShortBranchOutput: String) -> GitBranchStatus? {
+        let firstLine = statusShortBranchOutput
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .first
+            .map(String.init) ?? ""
+        guard firstLine.hasPrefix("## ") else { return nil }
+
+        var rest = String(firstLine.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+        if rest == "HEAD (no branch)" || rest.hasPrefix("HEAD (no branch)") {
+            return GitBranchStatus(branch: "", upstream: nil, ahead: 0, behind: 0, isDetached: true)
+        }
+
+        var ahead = 0
+        var behind = 0
+        if let bracketStart = rest.lastIndex(of: "["), rest.hasSuffix("]") {
+            let inside = String(rest[rest.index(after: bracketStart)..<rest.index(before: rest.endIndex)])
+            rest = String(rest[rest.startIndex..<bracketStart]).trimmingCharacters(in: .whitespaces)
+            for segment in inside.split(separator: ",") {
+                let tokens = segment.trimmingCharacters(in: .whitespaces).split(separator: " ")
+                guard tokens.count == 2, let count = Int(tokens[1]) else { continue }
+                if tokens[0] == "ahead" { ahead = count }
+                else if tokens[0] == "behind" { behind = count }
+            }
+        }
+
+        let branch: String
+        let upstream: String?
+        if let separator = rest.range(of: "...") {
+            branch = String(rest[rest.startIndex..<separator.lowerBound])
+            let upstreamValue = String(rest[separator.upperBound...]).trimmingCharacters(in: .whitespaces)
+            upstream = upstreamValue.isEmpty ? nil : upstreamValue
+        } else {
+            branch = rest
+            upstream = nil
+        }
+        guard !branch.isEmpty else { return nil }
+        return GitBranchStatus(branch: branch, upstream: upstream, ahead: ahead, behind: behind, isDetached: false)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceBranchStatusIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceBranchStatusIntegrationTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+
+@MainActor
+final class WorkspaceBranchStatusIntegrationTests: XCTestCase {
+    private func gitStatusCall() -> ToolCall {
+        ToolCall(name: ToolDefinition.gitStatus.name, argumentsJSON: ToolArguments.json([:]))
+    }
+
+    func testGitStatusRunPopulatesBranchStatusChip() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        // No branch chip until a git status runs.
+        XCTAssertNil(model.surface().topBar.branchStatusLabel)
+
+        let result = model.runToolCall(gitStatusCall(), workspaceRoot: root)
+        XCTAssertTrue(result.ok, result.error ?? "")
+
+        let label = model.surface().topBar.branchStatusLabel
+        XCTAssertNotNil(label)
+        XCTAssertFalse(label?.isEmpty ?? true)
+    }
+
+    func testNonGitStatusRunLeavesBranchStatusUntouched() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+
+        _ = model.runToolCall(gitStatusCall(), workspaceRoot: root)
+        let seeded = model.surface().topBar.branchStatusLabel
+        XCTAssertNotNil(seeded)
+
+        _ = model.runToolCall(
+            ToolCall(name: ToolDefinition.fileList.name, argumentsJSON: ToolArguments.json([:])),
+            workspaceRoot: root
+        )
+        XCTAssertEqual(model.surface().topBar.branchStatusLabel, seeded)
+    }
+
+    func testViewingAnotherProjectsThreadHidesBranchStatus() throws {
+        let rootA = try makeTempGitRepoWithInitialCommit()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: rootA, name: "A")
+        _ = model.newChat()
+        _ = model.runToolCall(gitStatusCall(), workspaceRoot: rootA)
+        XCTAssertNotNil(model.surface().topBar.branchStatusLabel)
+
+        // Viewing a thread in a different project must not bleed A's branch chip.
+        let rootB = try makeQuillCodeTestDirectory()
+        _ = model.addProject(path: rootB, name: "B")
+        _ = model.newChat()
+        XCTAssertNil(model.surface().topBar.branchStatusLabel)
+    }
+}

--- a/Tests/QuillCodeToolsTests/GitBranchStatusIntegrationTests.swift
+++ b/Tests/QuillCodeToolsTests/GitBranchStatusIntegrationTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class GitBranchStatusIntegrationTests: XCTestCase {
+    func testRealRepoStatusParsesCurrentBranch() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let result = GitLocalToolExecutor().status(cwd: root)
+        XCTAssertTrue(result.ok, "\(result.error ?? "") \(result.stderr)")
+
+        let status = try XCTUnwrap(GitBranchStatus.parse(statusShortBranchOutput: result.stdout))
+        // A fresh repo has no upstream, so ahead/behind are zero and the branch is
+        // whatever git initialized (main or master).
+        XCTAssertFalse(status.branch.isEmpty)
+        XCTAssertNil(status.upstream)
+        XCTAssertEqual(status.ahead, 0)
+        XCTAssertEqual(status.behind, 0)
+        XCTAssertFalse(status.isDetached)
+        XCTAssertEqual(status.compactLabel, status.branch)
+    }
+
+    func testRealRepoAheadOfUpstream() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let shell = ShellToolExecutor()
+        // Create a bare upstream, push, then commit locally to go ahead by one.
+        let remote = root.deletingLastPathComponent().appendingPathComponent("upstream.git")
+        XCTAssertTrue(shell.run(.init(command: "git init --bare '\(remote.path)'", cwd: root)).ok)
+        XCTAssertTrue(shell.run(.init(command: "git remote add origin '\(remote.path)' && git push -u origin HEAD", cwd: root)).ok)
+        try "ahead\n".write(to: root.appendingPathComponent("ahead.txt"), atomically: true, encoding: .utf8)
+        XCTAssertTrue(shell.run(.init(command: "git add ahead.txt && git commit -m ahead", cwd: root)).ok)
+
+        let result = GitLocalToolExecutor().status(cwd: root)
+        let status = try XCTUnwrap(GitBranchStatus.parse(statusShortBranchOutput: result.stdout))
+        XCTAssertEqual(status.ahead, 1)
+        XCTAssertEqual(status.behind, 0)
+        XCTAssertNotNil(status.upstream)
+        XCTAssertTrue(status.compactLabel.contains("↑1"))
+    }
+}

--- a/Tests/QuillCodeToolsTests/GitBranchStatusTests.swift
+++ b/Tests/QuillCodeToolsTests/GitBranchStatusTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class GitBranchStatusTests: XCTestCase {
+    func testPlainBranchWithoutUpstream() {
+        let status = GitBranchStatus.parse(statusShortBranchOutput: "## main\n")
+        XCTAssertEqual(status?.branch, "main")
+        XCTAssertNil(status?.upstream)
+        XCTAssertEqual(status?.ahead, 0)
+        XCTAssertEqual(status?.behind, 0)
+        XCTAssertFalse(status?.isDetached ?? true)
+        XCTAssertEqual(status?.compactLabel, "main")
+    }
+
+    func testTrackingBranchWithAheadAndBehind() {
+        let status = GitBranchStatus.parse(
+            statusShortBranchOutput: "## feature/x...origin/feature/x [ahead 2, behind 1]\n M Sources/App.swift\n"
+        )
+        XCTAssertEqual(status?.branch, "feature/x")
+        XCTAssertEqual(status?.upstream, "origin/feature/x")
+        XCTAssertEqual(status?.ahead, 2)
+        XCTAssertEqual(status?.behind, 1)
+        XCTAssertEqual(status?.compactLabel, "feature/x ↑2 ↓1")
+    }
+
+    func testAheadOnlyAndBehindOnly() {
+        let ahead = GitBranchStatus.parse(statusShortBranchOutput: "## work...origin/work [ahead 5]")
+        XCTAssertEqual(ahead?.ahead, 5)
+        XCTAssertEqual(ahead?.behind, 0)
+        XCTAssertEqual(ahead?.compactLabel, "work ↑5")
+
+        let behind = GitBranchStatus.parse(statusShortBranchOutput: "## work...origin/work [behind 3]")
+        XCTAssertEqual(behind?.ahead, 0)
+        XCTAssertEqual(behind?.behind, 3)
+        XCTAssertEqual(behind?.compactLabel, "work ↓3")
+    }
+
+    func testUpstreamGoneKeepsUpstreamWithoutCounts() {
+        let status = GitBranchStatus.parse(statusShortBranchOutput: "## feature/x...origin/feature/x [gone]")
+        XCTAssertEqual(status?.branch, "feature/x")
+        XCTAssertEqual(status?.upstream, "origin/feature/x")
+        XCTAssertEqual(status?.ahead, 0)
+        XCTAssertEqual(status?.behind, 0)
+    }
+
+    func testTrackingBranchUpToDate() {
+        let status = GitBranchStatus.parse(statusShortBranchOutput: "## feature/x...origin/feature/x")
+        XCTAssertEqual(status?.branch, "feature/x")
+        XCTAssertEqual(status?.upstream, "origin/feature/x")
+        XCTAssertEqual(status?.compactLabel, "feature/x")
+    }
+
+    func testDetachedHead() {
+        let status = GitBranchStatus.parse(statusShortBranchOutput: "## HEAD (no branch)\n M file.txt")
+        XCTAssertTrue(status?.isDetached ?? false)
+        XCTAssertEqual(status?.compactLabel, "(detached)")
+    }
+
+    func testEmptyOrUnparseableReturnsNil() {
+        XCTAssertNil(GitBranchStatus.parse(statusShortBranchOutput: ""))
+        XCTAssertNil(GitBranchStatus.parse(statusShortBranchOutput: " M only-changes.txt\n"))
+        XCTAssertNil(GitBranchStatus.parse(statusShortBranchOutput: "not a header"))
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-29 Worktree Branch Status Pass
+
+Overall grade after this slice: **A read-only branch surfacing, A cross-surface parity**.
+
+Surfaces the selected project's (or git worktree's) branch and ahead/behind-vs-upstream as a quiet top-bar chip (`feature/x ↑2 ↓1`), so a worktree feels like a first-class branch workspace. Feature scoped by a grounded design workflow (read-only, zero new command IDs) and hardened by an adversarial review pass.
+
+| Before | After |
+| --- | --- |
+| The top bar showed project/mode/model but no branch or ahead/behind; nothing parsed the git status branch header. | A pure `GitBranchStatus` parser reads the `## <branch>...<upstream> [ahead N, behind M]` header from the EXISTING `host.git.status` output (handles tracking/ahead/behind/`[gone]`/detached/garbage); `WorkspaceToolRunCoordinator` captures it after a successful git status into a `TopBarSurface.branchStatusLabel` chip rendered in the native top bar, the static HTML renderer, and the JS harness. |
+| — (review-driven correctness) | The chip is tagged with the project it was captured for, so `WorkspaceTopBarStateBuilder` drops it the moment a different project/worktree becomes the viewed context (via thread selection or any path) — never showing a stale branch. The JS harness mirrors the clear on project add/select/remove. |
+| No coverage. | `GitBranchStatus` parser unit tests + a real-repo ahead/behind integration test (bare upstream); coordinator capture, non-git-status-untouched, and view-another-project-hides-chip integration tests; Playwright chip-appears-after-git-status and clears-on-project-switch. No new command IDs, so the command-routing parity audit is untouched. |
+
+Residual risk:
+
+- The chip is dropped (not stashed-per-project) when viewing a different project, so it reappears on the next git status rather than being restored on switch-back — a deliberate simplicity choice. A discoverable "open PR for this worktree" affordance, persisting the branch on `ProjectRef`, and per-worktree-list ahead/behind remain follow-up PRs.
+
 ## 2026-06-29 Per-Thread Composer Draft Pass
 
 Overall grade after this slice: **A correctness fix, A cross-surface coverage**.


### PR DESCRIPTION
## Summary

Surfaces the selected project's (or git **worktree's**) branch and **ahead/behind** vs upstream as a quiet top-bar chip (e.g. `feature/x ↑2 ↓1`), so a worktree feels like a first-class branch workspace. Read-only and additive — **no new command IDs** (so the command-routing parity audit is untouched).

This feature was scoped by a grounded design workflow (which chose this read-only header-parsing slice over a heavier new-command approach) and **hardened by an adversarial review pass**.

## Implementation

- Pure **`GitBranchStatus`** parser reads the `## <branch>...<upstream> [ahead N, behind M]` header from the existing `host.git.status` output (handles tracking / ahead / behind / `[gone]` / detached / garbage).
- `WorkspaceToolRunCoordinator` captures it after a successful git status into `TopBarSurface.branchStatusLabel`, rendered in the native top bar, the static HTML renderer, and the JS harness.
- **Review-driven correctness fix:** the chip is tagged with the project it was captured for, so `WorkspaceTopBarStateBuilder` drops it the moment a different project/worktree becomes the viewed context (via thread selection or any path) — never showing a stale branch. The JS harness mirrors the clear on project add/select/remove. (The review caught that the original hand-enumerated clear sites missed `selectThread`.)

## Tests

- `GitBranchStatus` parser unit tests + a **real-repo ahead/behind** integration test (bare upstream, no network).
- Coordinator capture, non-git-status-untouched, and **view-another-project-hides-chip** integration tests.
- Playwright: chip appears after `/git-status`, and clears on project switch.

`swift test` green (1706); Playwright green (128); native desktop smoke passes.

## Notes

The chip is dropped (not stashed-per-project) when viewing a different project, reappearing on the next git status. A discoverable "open PR for this worktree" affordance, persisting the branch on `ProjectRef`, and per-worktree-list ahead/behind are follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)