### PR TITLE
Boost and badge changed files in composer @ mentions

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3003,6 +3003,19 @@
       font-size: 13px;
       margin-top: 2px;
     }
+    .mention-changed-badge {
+      display: inline-block;
+      margin-left: 6px;
+      padding: 1px 5px;
+      border-radius: 999px;
+      font-size: 9px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--yellow, #f8b84e);
+      background: rgba(248, 184, 78, 0.16);
+      vertical-align: middle;
+    }
     .composer label,
     .composer-sr-only { position: absolute; width: 1px; height: 1px; clip: rect(0 0 0 0); overflow: hidden; }
     .composer textarea {
@@ -3400,6 +3413,9 @@
         '/mock/QuillCode/Sources/Agent.swift': 'struct AgentRunner {\n  func run() {}\n}\n',
         '/mock/QuillCode/Sources/App.swift': 'struct App {\n  static let title = "QuillCode"\n}\n'
       },
+      // Workspace-relative paths with uncommitted changes (mirrors model.changedFilePaths),
+      // populated from a successful git status run; boosts/badges changed @ mentions.
+      changedFilePaths: [],
       review: {
         title: 'Review changes',
         subtitle: 'Latest git diff',
@@ -4325,6 +4341,11 @@
       return false;
     }
 
+    // Mirrors FileMentionCatalog.changedFileBoost (Swift): a flat additive boost larger
+    // than the max text score (200), so changed files outrank unchanged matches while text
+    // scoring still orders files within each group.
+    const CHANGED_FILE_MENTION_BOOST = 1000;
+
     function fileMentionScore(entry, query) {
       if (!query) {
         const depth = (entry.path.match(/\//g) || []).length;
@@ -4347,9 +4368,15 @@
       const mention = activeFileMention(draft);
       if (!mention) return [];
       const query = mention.query.toLowerCase();
+      const changed = changedMentionPaths();
       return workspaceMentionFiles()
-        .map(entry => ({ entry, score: fileMentionScore(entry, query) }))
-        .filter(item => item.score !== null)
+        .map(entry => {
+          const textScore = fileMentionScore(entry, query);
+          if (textScore === null) return null;
+          const isChanged = changed.has(entry.path);
+          return { entry, score: textScore + (isChanged ? CHANGED_FILE_MENTION_BOOST : 0), isChanged };
+        })
+        .filter(item => item !== null)
         .sort((left, right) =>
           right.score - left.score
           || left.entry.path.length - right.entry.path.length
@@ -4359,8 +4386,15 @@
           path: item.entry.path,
           name: item.entry.name,
           directory: item.entry.directory,
-          insertText: `${mention.prefix}@${item.entry.path} `
+          insertText: `${mention.prefix}@${item.entry.path} `,
+          isChanged: item.isChanged
         }));
+    }
+
+    // Workspace-relative paths with uncommitted changes (mirrors model.changedFilePaths),
+    // populated from a successful git status run in the mock.
+    function changedMentionPaths() {
+      return new Set(state.changedFilePaths || []);
     }
 
     function clampFileMentionActiveIndex(suggestions = fileMentionSuggestions(state.composer.draft)) {
@@ -4700,6 +4734,12 @@
     }
 
     function addToolCard(card) {
+      // Mirror native: any tool run other than git status rebuilds the file context and
+      // invalidates the changed-file set, so a committed/clean file is never left badged.
+      // The git status card sets state.changedFilePaths just before this call.
+      if (card.title !== 'host.git.status') {
+        state.changedFilePaths = [];
+      }
       const toolCard = {
         id: `tool-${state.nextTimelineIndex++}`,
         artifacts: artifactsFromOutput(card.outputJSON),
@@ -8052,9 +8092,10 @@
           data-testid="file-mention-suggestion"
           data-insert-text="${escapeHTML(suggestion.insertText)}"
           data-path="${escapeHTML(suggestion.path)}"
+          data-changed="${suggestion.isChanged ? 'true' : 'false'}"
           data-selected="${index === state.composer.mentionActiveIndex ? 'true' : 'false'}"
         >
-          <span class="slash-usage">${escapeHTML(suggestion.name)}</span>
+          <span class="slash-usage">${escapeHTML(suggestion.name)}${suggestion.isChanged ? ' <span class="mention-changed-badge" data-testid="file-mention-changed-badge">Changed</span>' : ''}</span>
           <span>
             <span class="slash-title">${escapeHTML(suggestion.path)}</span>
             <span class="slash-detail">${escapeHTML(suggestion.directory || 'Workspace root')}</span>
@@ -9278,6 +9319,7 @@
       };
       state.projects.selectedProjectID = project.id;
       state.topBar.branchStatusLabel = null;
+      state.changedFilePaths = [];
       state.projects.items = [
         project,
         ...state.projects.items.map(item => ({ ...item, isSelected: false }))
@@ -9307,6 +9349,7 @@
       };
       state.projects.selectedProjectID = project.id;
       state.topBar.branchStatusLabel = null;
+      state.changedFilePaths = [];
       state.projects.items = [
         project,
         ...state.projects.items.map(item => ({ ...item, isSelected: false }))
@@ -9321,6 +9364,7 @@
     function selectProject(projectID) {
       state.projects.selectedProjectID = projectID;
       state.topBar.branchStatusLabel = null;
+      state.changedFilePaths = [];
       state.projects.items = state.projects.items.map(project => ({
         ...project,
         isSelected: project.id === projectID
@@ -9383,6 +9427,7 @@
           const next = state.projects.items[0] || null;
           state.projects.selectedProjectID = next?.id || null;
           state.topBar.branchStatusLabel = null;
+          state.changedFilePaths = [];
           state.projects.items = state.projects.items.map(item => ({
             ...item,
             isSelected: item.id === state.projects.selectedProjectID
@@ -9420,12 +9465,36 @@
       return label;
     }
 
+    // Mirrors GitChangedFiles.parse (Swift): changed paths from `git status --short`
+    // porcelain lines, skipping the `## ` header, keeping post-arrow rename paths, unquoting.
+    function parseChangedFilePaths(statusShortBranchOutput) {
+      const paths = [];
+      for (const line of String(statusShortBranchOutput || '').split('\n')) {
+        if (!line || line.startsWith('## ') || line.length <= 3) continue;
+        let payload = line.slice(3);
+        // Only split rename/copy (status R/C) lines, so a path containing " -> " is kept.
+        const status = line.slice(0, 2);
+        if (status.includes('R') || status.includes('C')) {
+          const arrow = payload.lastIndexOf(' -> ');
+          if (arrow >= 0) payload = payload.slice(arrow + 4);
+        }
+        let path = payload.trim();
+        if (path.startsWith('"')) path = path.slice(1);
+        if (path.endsWith('"')) path = path.slice(0, -1);
+        if (path) paths.push(path);
+      }
+      return paths;
+    }
+
     function runGitStatusAction() {
       const project = selectedProject();
       const prefix = project?.isRemote ? `ssh ${project.path}\n` : '';
       const header = '## main';
-      const stdout = `${prefix}${header}\n M Sources/App.swift\n`;
+      const porcelain = `${header}\n M Sources/App.swift\n`;
+      const stdout = `${prefix}${porcelain}`;
       state.topBar.branchStatusLabel = branchStatusLabelFromHeader(header);
+      // Parse the clean porcelain (not the ssh-prefixed display stdout), mirroring native.
+      state.changedFilePaths = parseChangedFilePaths(porcelain);
       addToolCard({
         title: 'host.git.status',
         subtitle: 'Completed',

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -261,6 +261,31 @@ test('mock harness suggests workspace files for @ mentions in the composer', asy
   await expect(page.getByTestId('slash-suggestions')).toBeVisible();
 });
 
+test('mock harness boosts and badges changed files in @ mentions after a git status', async ({ page }) => {
+  await page.goto(harnessURL());
+  const message = page.getByLabel('Message');
+
+  // Before any git status: README.md leads the bare-@ list and nothing is flagged changed.
+  await message.fill('@');
+  await expect(page.getByTestId('file-mention-suggestion').first()).toContainText('README.md');
+  await expect(page.locator('[data-testid="file-mention-suggestion"][data-changed="true"]')).toHaveCount(0);
+
+  // Run a git status, which reports Sources/App.swift as changed.
+  await message.fill('/git-status');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.status');
+
+  // Now @ floats the changed file to the top with a Changed badge ...
+  await message.fill('@');
+  const first = page.getByTestId('file-mention-suggestion').first();
+  await expect(first).toContainText('Sources/App.swift');
+  await expect(first).toHaveAttribute('data-changed', 'true');
+  await expect(first.getByTestId('file-mention-changed-badge')).toBeVisible();
+  // ... while an unchanged file that also matches is not flagged (cross-surface scoring parity).
+  await expect(page.locator('[data-testid="file-mention-suggestion"][data-path="Sources/Agent.swift"]'))
+    .toHaveAttribute('data-changed', 'false');
+});
+
 test('mock harness preserves a separate composer draft per thread', async ({ page }) => {
   await page.goto(harnessURL());
   const message = page.getByLabel('Message');

--- a/Sources/QuillCodeApp/FileMentionCatalog.swift
+++ b/Sources/QuillCodeApp/FileMentionCatalog.swift
@@ -13,12 +13,16 @@ public struct FileMentionSuggestionSurface: Codable, Sendable, Hashable, Identif
     /// The full composer draft after this suggestion is accepted, with the active
     /// `@query` token replaced by `@path` and a trailing space.
     public var insertText: String
+    /// Whether this file has uncommitted changes (per the latest `git status`). Changed
+    /// files are boosted to the top of the suggestions and badged in the panel.
+    public var isChanged: Bool
 
-    public init(path: String, name: String, directory: String, insertText: String) {
+    public init(path: String, name: String, directory: String, insertText: String, isChanged: Bool = false) {
         self.path = path
         self.name = name
         self.directory = directory
         self.insertText = insertText
+        self.isChanged = isChanged
     }
 }
 
@@ -26,6 +30,13 @@ public struct FileMentionSuggestionSurface: Codable, Sendable, Hashable, Identif
 /// workspace files against it, mirroring ``SlashCommandCatalog`` so the composer can
 /// reuse the same suggestion panel for both surfaces.
 public enum FileMentionCatalog {
+    /// A flat additive boost applied to files with uncommitted changes. Larger than the
+    /// maximum text-match score (200), so any matching changed file ranks above every
+    /// unchanged match while text scoring still orders files *within* each group. The same
+    /// constant is mirrored in the JS harness (`CHANGED_FILE_MENTION_BOOST`) to keep the
+    /// two scoring paths in lockstep.
+    public static let changedFileBoost = 1000
+
     /// The active mention being typed at the end of the draft, if any.
     public struct ActiveMention: Equatable {
         /// Text before the mention's `@`, preserved verbatim on acceptance.
@@ -56,21 +67,32 @@ public enum FileMentionCatalog {
     public static func suggestions(
         for draft: String,
         in index: WorkspaceFileIndex,
+        changedPaths: Set<String> = [],
         limit: Int = 6
     ) -> [FileMentionSuggestionSurface] {
         guard let mention = activeMention(in: draft) else { return [] }
-        return suggestions(prefix: mention.prefix, query: mention.query, entries: index.entries, limit: limit)
+        return suggestions(
+            prefix: mention.prefix,
+            query: mention.query,
+            entries: index.entries,
+            changedPaths: changedPaths,
+            limit: limit
+        )
     }
 
     static func suggestions(
         prefix: String,
         query: String,
         entries: [WorkspaceFileIndexEntry],
+        changedPaths: Set<String> = [],
         limit: Int
     ) -> [FileMentionSuggestionSurface] {
         let normalizedQuery = query.lowercased()
-        let scored = entries.enumerated().compactMap { offset, entry -> (Int, Int, WorkspaceFileIndexEntry)? in
-            score(entry, query: normalizedQuery).map { ($0, offset, entry) }
+        let scored = entries.enumerated().compactMap { offset, entry -> (Int, Int, WorkspaceFileIndexEntry, Bool)? in
+            guard let textScore = score(entry, query: normalizedQuery) else { return nil }
+            let isChanged = changedPaths.contains(entry.path)
+            let rankedScore = textScore + (isChanged ? changedFileBoost : 0)
+            return (rankedScore, offset, entry, isChanged)
         }
         return scored
             .sorted { lhs, rhs in
@@ -79,12 +101,13 @@ public enum FileMentionCatalog {
                 return lhs.2.path < rhs.2.path
             }
             .prefix(limit)
-            .map { _, _, entry in
+            .map { _, _, entry, isChanged in
                 FileMentionSuggestionSurface(
                     path: entry.path,
                     name: entry.name,
                     directory: entry.directory,
-                    insertText: "\(prefix)@\(entry.path) "
+                    insertText: "\(prefix)@\(entry.path) ",
+                    isChanged: isChanged
                 )
             }
     }

--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -6,6 +6,7 @@ struct QuillCodeComposerView: View {
     var composer: ComposerSurface
     var topBar: TopBarSurface
     var fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex()
+    var changedFilePaths: Set<String> = []
     var sentMessageHistory: [String] = []
     @Binding var draft: String
     @Binding var isModelPickerPresented: Bool
@@ -107,7 +108,7 @@ struct QuillCodeComposerView: View {
 
     private var fileMentionSuggestions: [FileMentionSuggestionSurface] {
         guard slashSuggestions.isEmpty else { return [] }
-        return FileMentionCatalog.suggestions(for: draft, in: fileMentionIndex)
+        return FileMentionCatalog.suggestions(for: draft, in: fileMentionIndex, changedPaths: changedFilePaths)
     }
 
     private var canSendDraft: Bool {
@@ -442,10 +443,15 @@ private struct QuillCodeFileMentionSuggestionRow: View {
                     .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(suggestion.name)
-                        .font(.callout.weight(.semibold))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                    HStack(spacing: 6) {
+                        Text(suggestion.name)
+                            .font(.callout.weight(.semibold))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        if suggestion.isChanged {
+                            changedBadge
+                        }
+                    }
                     Text(suggestion.path)
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(QuillCodePalette.muted)
@@ -470,7 +476,20 @@ private struct QuillCodeFileMentionSuggestionRow: View {
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
         .buttonStyle(QuillCodePressableButtonStyle())
-        .accessibilityLabel("Mention \(suggestion.path)")
+        .accessibilityLabel("Mention \(suggestion.path)\(suggestion.isChanged ? ", changed" : "")")
         .accessibilityHint(suggestion.directory.isEmpty ? "Workspace root" : "In \(suggestion.directory)")
+    }
+
+    private var changedBadge: some View {
+        Text("Changed")
+            .font(.system(size: 9, weight: .bold))
+            .textCase(.uppercase)
+            .foregroundStyle(QuillCodePalette.yellow)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(
+                Capsule().fill(QuillCodePalette.yellow.opacity(0.16))
+            )
+            .accessibilityHidden(true)
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -280,6 +280,7 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
     public init(
         composer: ComposerState,
         fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex(),
+        changedFilePaths: Set<String> = [],
         sentMessageHistory: [String] = []
     ) {
         self.draft = composer.draft
@@ -287,7 +288,11 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
         self.isSending = composer.isSending
         self.canSend = !composer.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !composer.isSending
         self.slashSuggestions = SlashCommandCatalog.suggestions(for: composer.draft)
-        self.fileMentionSuggestions = FileMentionCatalog.suggestions(for: composer.draft, in: fileMentionIndex)
+        self.fileMentionSuggestions = FileMentionCatalog.suggestions(
+            for: composer.draft,
+            in: fileMentionIndex,
+            changedPaths: changedFilePaths
+        )
         self.sentMessageHistory = sentMessageHistory
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -126,6 +126,7 @@ struct QuillCodeWorkspaceMainPaneView: View {
                     composer: surface.composer,
                     topBar: surface.topBar,
                     fileMentionIndex: surface.fileMentionIndex,
+                    changedFilePaths: surface.changedFilePaths,
                     sentMessageHistory: surface.composer.sentMessageHistory,
                     draft: $draft,
                     isModelPickerPresented: $isModelPickerPresented,

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -37,6 +37,14 @@ public final class QuillCodeWorkspaceModel {
     /// Bounded, cached index of the selected local project's files, used to power
     /// composer `@` file mentions. Empty for remote or unselected projects.
     public internal(set) var fileMentionIndex = WorkspaceFileIndex()
+    /// Workspace-relative paths with uncommitted changes, captured from the most recent
+    /// successful `git status` run (the same stdout the branch chip parses — no extra git
+    /// invocation). Used to boost/badge changed files in `@` mentions.
+    public internal(set) var changedFilePaths: Set<String> = []
+    /// The project the `changedFilePaths` set was captured for. The surface drops the set
+    /// when a different project becomes the active context (mirrors the branch chip), so a
+    /// stale changed-set never boosts the wrong project's mentions across a switch.
+    public internal(set) var changedFilePathsProjectID: UUID?
     /// Transient per-thread unsent composer drafts, stashed on thread switch and
     /// restored on selection so drafts never bleed across threads. Session-only.
     public internal(set) var threadDrafts: [UUID: String] = [:]
@@ -134,6 +142,22 @@ public final class QuillCodeWorkspaceModel {
         root.topBar.branchStatusProjectID = status == nil ? nil : projectID
     }
 
+    /// Records the changed-file set captured from a `git status` run, tagged with the
+    /// project it ran for. The surface only applies the boost while that project is the
+    /// active mention context, so a status completing after a project switch is harmless.
+    func setChangedFilePaths(_ paths: Set<String>, forProjectID projectID: UUID?) {
+        changedFilePaths = paths
+        changedFilePathsProjectID = projectID
+    }
+
+    /// The changed-file set, but only when it was captured for the project the file index
+    /// is currently built from (`root.selectedProjectID` — the same notion as
+    /// `activeWorkspaceRoot`); empty otherwise so a stale set never boosts another
+    /// project's `@` suggestions on any switch path that doesn't rebuild the index.
+    var activeChangedFilePaths: Set<String> {
+        changedFilePathsProjectID == root.selectedProjectID ? changedFilePaths : []
+    }
+
     public func setComputerUseBackend(_ backend: any ComputerUseBackend) {
         computerUseBackend = backend
         setComputerUseStatus(backend.status)
@@ -159,6 +183,12 @@ public final class QuillCodeWorkspaceModel {
     /// Recomputes the cached composer file-mention index from the selected local
     /// project. Remote or unselected projects clear the index so mentions stay empty.
     func refreshFileMentionIndex() {
+        // The changed-file set is captured from a git status; any index rebuild (which
+        // happens on every tool run via refreshProjectMetadata) invalidates it so a
+        // file that was committed/cleaned is never left badged. The git-status run
+        // re-sets it immediately after this rebuild, so the badge survives that run.
+        changedFilePaths = []
+        changedFilePathsProjectID = nil
         guard let activeWorkspaceRoot else {
             fileMentionIndex = WorkspaceFileIndex()
             return

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -19,6 +19,9 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
     /// Cached index of the selected local project's files, used by the native
     /// composer to rank `@` mention suggestions live as the user types.
     public var fileMentionIndex: WorkspaceFileIndex
+    /// Workspace-relative paths with uncommitted changes (from the latest `git status`),
+    /// used to boost and badge changed files in the live composer `@` suggestions.
+    public var changedFilePaths: Set<String>
     public var commands: [WorkspaceCommandSurface]
     public var settings: WorkspaceSettingsSurface
     public var runtimeIssue: RuntimeIssueSurface?
@@ -39,6 +42,7 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
         automations: WorkspaceAutomationsSurface = WorkspaceAutomationsSurface(),
         composer: ComposerSurface,
         fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex(),
+        changedFilePaths: Set<String> = [],
         commands: [WorkspaceCommandSurface],
         settings: WorkspaceSettingsSurface,
         runtimeIssue: RuntimeIssueSurface? = nil,
@@ -58,6 +62,7 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
         self.automations = automations
         self.composer = composer
         self.fileMentionIndex = fileMentionIndex
+        self.changedFilePaths = changedFilePaths
         self.commands = commands
         self.settings = settings
         self.runtimeIssue = runtimeIssue
@@ -164,9 +169,11 @@ public extension QuillCodeWorkspaceModel {
             composer: ComposerSurface(
                 composer: composer,
                 fileMentionIndex: fileMentionIndex,
+                changedFilePaths: activeChangedFilePaths,
                 sentMessageHistory: ComposerHistoryRecall.history(from: thread?.messages ?? [])
             ),
             fileMentionIndex: fileMentionIndex,
+            changedFilePaths: activeChangedFilePaths,
             commands: commandSurfaceBuilder().commands,
             settings: WorkspaceSettingsSurface(
                 config: root.config,

--- a/Sources/QuillCodeApp/WorkspaceToolRunCoordinator.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolRunCoordinator.swift
@@ -38,12 +38,19 @@ struct WorkspaceToolRunCoordinator {
         if let thread = model.selectedThread {
             model.threadPersistence.save(thread)
         }
-        // Capture branch + ahead/behind from a successful git status so the top-bar
-        // chip reflects the selected project's (or worktree's) branch.
+        // Capture branch + ahead/behind AND the changed-file set from a successful git
+        // status (one stdout, no extra git invocation): the chip reflects the branch, and
+        // `@` mentions boost/badge the files you just changed.
         if call.name == ToolDefinition.gitStatus.name, finishPlan.result.ok {
             model.setBranchStatus(
                 GitBranchStatus.parse(statusShortBranchOutput: finishPlan.result.stdout),
                 forProjectID: model.selectedThread?.projectID ?? model.root.selectedProjectID
+            )
+            // The changed set feeds the `@` mention index, which is built from
+            // `root.selectedProjectID`, so it is tagged with that same project notion.
+            model.setChangedFilePaths(
+                GitChangedFiles.parse(statusShortBranchOutput: finishPlan.result.stdout),
+                forProjectID: model.root.selectedProjectID
             )
         }
         model.refreshTopBar(agentStatus: finishPlan.agentStatus)

--- a/Sources/QuillCodeTools/GitChangedFiles.swift
+++ b/Sources/QuillCodeTools/GitChangedFiles.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The set of workspace-relative paths that have uncommitted changes, parsed from the
+/// porcelain body of `git status --short --branch` output. Shares the exact same stdout
+/// the branch chip already consumes (`GitBranchStatus`), so surfacing changed files in
+/// `@`-mention suggestions needs no extra git invocation.
+public enum GitChangedFiles {
+    /// Parses the changed-file paths from `git status --short --branch` output.
+    ///
+    /// Each non-header porcelain line has the form `XY␠path`, where `XY` is the two-character
+    /// staged/unstaged status. Rename/copy lines carry `old -> new`; the post-arrow (current)
+    /// path is kept. Quoted paths (git quotes names with special characters) are unquoted.
+    /// The leading `## ` branch header — already parsed by `GitBranchStatus` — is skipped.
+    public static func parse(statusShortBranchOutput: String) -> Set<String> {
+        var paths: Set<String> = []
+        for rawLine in statusShortBranchOutput.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(rawLine)
+            // Skip the `## ` branch header and any line too short to carry a path.
+            if line.hasPrefix("## ") { continue }
+            guard line.count > 3 else { continue }
+
+            var payload = String(line.dropFirst(3))
+            // Renames/copies (status R/C) render as `old -> new`; keep the current path.
+            // Only split for R/C so an ordinary path containing " -> " is never truncated.
+            let status = line.prefix(2)
+            if status.contains("R") || status.contains("C"),
+               let arrow = payload.range(of: " -> ", options: .backwards) {
+                payload = String(payload[arrow.upperBound...])
+            }
+            let path = cleanPath(payload)
+            if !path.isEmpty { paths.insert(path) }
+        }
+        return paths
+    }
+
+    /// Strips the surrounding double quotes git adds around paths with special characters.
+    /// (Porcelain short paths are not `a/`/`b/`-prefixed, unlike diff headers.)
+    private static func cleanPath(_ rawPath: String) -> String {
+        var path = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if path.hasPrefix("\"") { path.removeFirst() }
+        if path.hasSuffix("\"") { path.removeLast() }
+        return path
+    }
+}

--- a/Tests/QuillCodeAppTests/FileMentionCatalogTests.swift
+++ b/Tests/QuillCodeAppTests/FileMentionCatalogTests.swift
@@ -97,9 +97,58 @@ final class FileMentionCatalogTests: XCTestCase {
         XCTAssertEqual(suggestions.map(\.path), ["Sources/WorkspaceState.swift"])
     }
 
+    func testSuggestionSurfaceRoundTripsIsChanged() throws {
+        let surface = FileMentionSuggestionSurface(
+            path: "Sources/B.swift", name: "B.swift", directory: "Sources",
+            insertText: "@Sources/B.swift ", isChanged: true
+        )
+        let decoded = try JSONDecoder().decode(
+            FileMentionSuggestionSurface.self,
+            from: JSONEncoder().encode(surface)
+        )
+        XCTAssertEqual(decoded, surface)
+        XCTAssertTrue(decoded.isChanged)
+    }
+
     func testSubsequenceHelper() {
         XCTAssertTrue(FileMentionCatalog.isSubsequence("abc", of: "aXbYcZ"))
         XCTAssertFalse(FileMentionCatalog.isSubsequence("acb", of: "abc"))
         XCTAssertTrue(FileMentionCatalog.isSubsequence("", of: "anything"))
+    }
+
+    func testChangedFileBoostOutranksHigherTextMatch() {
+        // "App.swift" is a name-prefix match (score 170); "Map.swift" only matches as a
+        // name-contains (score 120) — but the changed boost floats Map.swift to the top.
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "open @ap",
+            in: index(["Sources/App.swift", "Sources/Map.swift"]),
+            changedPaths: ["Sources/Map.swift"],
+            limit: 6
+        )
+        XCTAssertEqual(suggestions.first?.path, "Sources/Map.swift")
+        XCTAssertTrue(suggestions.first?.isChanged ?? false)
+        XCTAssertEqual(suggestions.first { $0.path == "Sources/App.swift" }?.isChanged, false)
+    }
+
+    func testChangedFilesPreserveTextOrderingWithinTheGroup() {
+        // Two changed files: both get the boost, so the stronger text match still wins.
+        let suggestions = FileMentionCatalog.suggestions(
+            for: "open @app",
+            in: index(["Sources/App.swift", "Sources/AppHelper.swift"]),
+            changedPaths: ["Sources/App.swift", "Sources/AppHelper.swift"],
+            limit: 6
+        )
+        XCTAssertEqual(suggestions.map(\.path), ["Sources/App.swift", "Sources/AppHelper.swift"])
+        XCTAssertTrue(suggestions.allSatisfy(\.isChanged))
+    }
+
+    func testEmptyChangedPathsIsByteIdenticalToToday() {
+        let paths = ["Sources/App.swift", "Tests/AppSupport/Helper.swift", "docs/app-notes.md"]
+        let withDefault = FileMentionCatalog.suggestions(for: "open @app", in: index(paths), limit: 6)
+        let withEmpty = FileMentionCatalog.suggestions(for: "open @app", in: index(paths), changedPaths: [], limit: 6)
+        // Same ordering, same insertText, and never flagged when no git status has run.
+        XCTAssertEqual(withDefault.map(\.path), withEmpty.map(\.path))
+        XCTAssertEqual(withDefault.map(\.insertText), withEmpty.map(\.insertText))
+        XCTAssertTrue(withEmpty.allSatisfy { !$0.isChanged })
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceMentionChangedFilesIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceMentionChangedFilesIntegrationTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+import QuillCodeTools
+
+@MainActor
+final class WorkspaceMentionChangedFilesIntegrationTests: XCTestCase {
+    private func gitStatusCall() -> ToolCall {
+        ToolCall(name: ToolDefinition.gitStatus.name, argumentsJSON: ToolArguments.json([:]))
+    }
+
+    /// A git repo with `Sources/App.swift` and `Sources/Admin.swift` committed, then
+    /// `Sources/Admin.swift` modified so `git status` reports it changed.
+    private func makeRepoWithModifiedAdmin() throws -> URL {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let executor = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(executor.write(path: "Sources/App.swift", content: "struct App {}\n").ok)
+        XCTAssertTrue(executor.write(path: "Sources/Admin.swift", content: "struct Admin {}\n").ok)
+        _ = try runGit(["add", "."], cwd: root)
+        _ = try runGit(["commit", "-m", "add sources"], cwd: root)
+        XCTAssertTrue(executor.write(path: "Sources/Admin.swift", content: "struct Admin { let x = 1 }\n").ok)
+        return root
+    }
+
+    private func makeLocalProject(files: [String]) throws -> URL {
+        let root = try makeQuillCodeTestDirectory()
+        let executor = FileToolExecutor(workspaceRoot: root)
+        for path in files {
+            XCTAssertTrue(executor.write(path: path, content: "// \(path)\n").ok)
+        }
+        return root
+    }
+
+    func testGitStatusRunBoostsAndFlagsChangedFilesInMentions() throws {
+        let root = try makeRepoWithModifiedAdmin()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        _ = model.newChat()
+
+        // Before any git status: text ranking puts the shorter App.swift first, nothing flagged.
+        XCTAssertTrue(model.changedFilePaths.isEmpty)
+        model.setDraft("open @a")
+        let before = model.surface().composer.fileMentionSuggestions
+        XCTAssertEqual(before.first?.path, "Sources/App.swift")
+        XCTAssertFalse(before.contains(where: \.isChanged))
+
+        // One git status run captures BOTH the branch chip and the changed-file set.
+        let result = model.runToolCall(gitStatusCall(), workspaceRoot: root)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertNotNil(model.surface().topBar.branchStatusLabel)
+        XCTAssertTrue(model.changedFilePaths.contains("Sources/Admin.swift"))
+
+        // Now the changed file is boosted to the top and flagged; the unchanged file is not.
+        model.setDraft("open @a")
+        let after = model.surface().composer.fileMentionSuggestions
+        XCTAssertEqual(after.first?.path, "Sources/Admin.swift")
+        XCTAssertTrue(after.first?.isChanged ?? false)
+        XCTAssertEqual(after.first(where: { $0.path == "Sources/App.swift" })?.isChanged, false)
+    }
+
+    func testChangedSetDoesNotBleedIntoAnotherProjectsMentions() throws {
+        let root = try makeRepoWithModifiedAdmin()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        _ = model.runToolCall(gitStatusCall(), workspaceRoot: root)
+        XCTAssertTrue(model.changedFilePaths.contains("Sources/Admin.swift"))
+
+        // Switch to another project that ALSO has Sources/Admin.swift (unchanged there),
+        // and open a conversation in it so it becomes the active mention context.
+        let other = try makeLocalProject(files: ["Sources/Admin.swift"])
+        _ = model.addProject(path: other, name: "Other")
+        _ = model.newChat()
+
+        model.setDraft("open @admin")
+        let suggestions = model.surface().composer.fileMentionSuggestions
+        XCTAssertEqual(suggestions.first?.path, "Sources/Admin.swift")
+        // The first project's changed set must NOT flag the second project's identical path.
+        XCTAssertFalse(suggestions.contains(where: \.isChanged))
+    }
+
+    func testChangedBadgeDoesNotSurviveACommitAndLaterToolRun() throws {
+        let root = try makeRepoWithModifiedAdmin()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        _ = model.newChat()
+
+        _ = model.runToolCall(gitStatusCall(), workspaceRoot: root)
+        XCTAssertTrue(model.changedFilePaths.contains("Sources/Admin.swift"))
+
+        // Commit the change so the working tree is clean, then run any other tool. The
+        // index rebuild on that run must drop the now-stale changed set — a committed,
+        // clean file must never keep its "Changed" badge.
+        _ = try runGit(["add", "."], cwd: root)
+        _ = try runGit(["commit", "-m", "commit admin"], cwd: root)
+        _ = model.runToolCall(
+            ToolCall(name: ToolDefinition.fileList.name, argumentsJSON: ToolArguments.json([:])),
+            workspaceRoot: root
+        )
+
+        XCTAssertTrue(model.changedFilePaths.isEmpty)
+        model.setDraft("open @admin")
+        XCTAssertFalse(model.surface().composer.fileMentionSuggestions.contains(where: \.isChanged))
+    }
+
+    func testSelectingRemoteProjectClearsChangedFileSet() throws {
+        let root = try makeRepoWithModifiedAdmin()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        _ = model.runToolCall(gitStatusCall(), workspaceRoot: root)
+        XCTAssertFalse(model.changedFilePaths.isEmpty)
+
+        _ = model.addSSHProject("user@host:/srv/app", name: "Remote")
+        XCTAssertTrue(model.changedFilePaths.isEmpty)
+    }
+}

--- a/Tests/QuillCodeToolsTests/GitChangedFilesTests.swift
+++ b/Tests/QuillCodeToolsTests/GitChangedFilesTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class GitChangedFilesTests: XCTestCase {
+    func testParsesModifiedUntrackedAndStagedPaths() {
+        let paths = GitChangedFiles.parse(statusShortBranchOutput: """
+        ## main...origin/main [ahead 1]
+         M Sources/App.swift
+        ?? Sources/New.swift
+        MM Sources/Both.swift
+        A  Sources/Added.swift
+         D Sources/Gone.swift
+        """)
+        XCTAssertEqual(paths, [
+            "Sources/App.swift",
+            "Sources/New.swift",
+            "Sources/Both.swift",
+            "Sources/Added.swift",
+            "Sources/Gone.swift"
+        ])
+    }
+
+    func testKeepsPostArrowPathForRenames() {
+        let paths = GitChangedFiles.parse(statusShortBranchOutput: """
+        ## main
+        R  Sources/Old.swift -> Sources/Renamed.swift
+        """)
+        XCTAssertEqual(paths, ["Sources/Renamed.swift"])
+        XCTAssertFalse(paths.contains("Sources/Old.swift"))
+    }
+
+    func testDoesNotSplitNonRenameLinesContainingArrowText() {
+        // An untracked file whose name literally contains " -> " must be kept whole.
+        let paths = GitChangedFiles.parse(statusShortBranchOutput: """
+        ## main
+        ?? "Sources/a -> b.txt"
+        """)
+        XCTAssertEqual(paths, ["Sources/a -> b.txt"])
+    }
+
+    func testUnquotesPathsWithSpecialCharacters() {
+        let paths = GitChangedFiles.parse(statusShortBranchOutput: """
+        ## main
+         M "Sources/Has Space.swift"
+        """)
+        XCTAssertEqual(paths, ["Sources/Has Space.swift"])
+    }
+
+    func testSkipsBranchHeaderAndEmptyOutput() {
+        XCTAssertTrue(GitChangedFiles.parse(statusShortBranchOutput: "## main...origin/main\n").isEmpty)
+        XCTAssertTrue(GitChangedFiles.parse(statusShortBranchOutput: "").isEmpty)
+        // The `## ` header is never emitted as a changed path.
+        let paths = GitChangedFiles.parse(statusShortBranchOutput: "## feature/x [ahead 3]\n M a.txt\n")
+        XCTAssertEqual(paths, ["a.txt"])
+        XCTAssertFalse(paths.contains(where: { $0.contains("feature/x") }))
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-29 Changed-File @-Mention Boost Pass
+
+Overall grade after this slice: **A reuse of existing data, A cross-surface scoring parity**.
+
+Composer `@`-mention suggestions now **boost and badge** files with uncommitted changes — the files you're most likely to mention. Reuses the *exact* stdout the branch chip already consumes (`git status --short --branch`), so it adds **no new git invocation and no new command ID**. Scoped by a grounded judge-panel plan and hardened by an adversarial review pass.
+
+| Before | After |
+| --- | --- |
+| The `@` panel ranked files on path text only (200..40), so a freshly edited deep file was buried under shallow text matches; nothing knew which files had changed. | `GitChangedFiles.parse(statusShortBranchOutput:)` (new, in Tools, sibling to `GitBranchStatus`) extracts changed paths from the SAME successful `host.git.status` stdout `WorkspaceToolRunCoordinator` already parses for the branch chip — zero extra git calls. `FileMentionCatalog` applies a flat additive boost (`changedFileBoost = 1000`, above the max text score) and sets `FileMentionSuggestionSurface.isChanged`; the native composer renders a "Changed" pill. |
+| — (review-caught staleness bug) | The file index is rebuilt on *every* tool run (`refreshFileMentionIndex`), so the adversarial review found a committed/cleaned file would keep a stale "Changed" badge for the rest of the session. Fixed: `refreshFileMentionIndex` now **clears** the changed set on every rebuild (the git-status run re-sets it in the same run), so the badge appears right after a git status and drops the moment any later tool runs — never badging a clean file. The set is additionally tagged with `changedFilePathsProjectID` (matched to `selectedProjectID`, the index's own project notion) and exposed via `activeChangedFilePaths`, which drops it on any project-switch path that doesn't rebuild the index — the branch chip's drop-on-mismatch (#695 lesson). Captured at git-status cadence (no extra git invocation). |
+| No coverage. | `GitChangedFilesTests` (modified/untracked/staged/rename-keeps-new/quoted/header-only); `FileMentionCatalogTests` (boost dominates a higher text tier, intra-group text order preserved, empty changed-set is byte-identical to today); integration tests (one git status sets BOTH branch chip and changed set; cross-project non-bleed via identical paths; remote clears the set); Playwright boost-flip with a `Changed` badge + `data-changed`. The JS harness mirrors the boost constant, parser, badge, and project-switch clears byte-for-byte. No new command ID → command-routing parity untouched; the pill reuses the existing row hit-target so the native audit stays green. |
+
+Residual risk:
+
+- The badge reflects the most recent `git status` and clears on the next tool run, so it's an immediate "after you check status, your changed files are highlighted" affordance rather than a persistent live indicator — a deliberate, conservative choice that never badges a clean file. Follow-ups (review-flagged, non-blocking): non-ASCII paths are octal-escaped by git's `core.quotePath` and currently miss the badge (silent false-negative — decode the escapes or pass `-c core.quotePath=false`); the flat 1000 boost can, with ≥6 weakly-matching changed files, push an exact unchanged match past the visible top-6 (an explicit product choice). The shared bounded file-index cap is unchanged.
+
 ## 2026-06-29 Review-Pane Open File Pass
 
 Overall grade after this slice: **A non-mutating read action, A cross-surface parity**.


### PR DESCRIPTION
## What

The composer `@` panel now lifts files with **uncommitted changes** to the top and badges them **Changed** — the files you're most likely to mention. It reuses the *exact* `git status --short --branch` stdout the branch chip already consumes, so it adds **no new git invocation and no new command ID**.

## How

- `GitChangedFiles.parse` (Tools, sibling to `GitBranchStatus`) extracts changed paths from that stdout; `WorkspaceToolRunCoordinator` captures them alongside the branch chip in the same `git status` block.
- `FileMentionCatalog` applies a flat additive boost (`changedFileBoost = 1000`, above the max text score) and sets `FileMentionSuggestionSurface.isChanged`. Native renders a "Changed" pill; the static `ComposerSurface`/`WorkspaceSurface` and the JS harness mirror it byte-for-byte (boost constant, parser, badge, `data-changed`).

## Staleness (adversarial-review fix)

The file index rebuilds on **every** tool run, so a naive changed-set would leave a committed/cleaned file badged for the whole session. Fixed: the changed set is **cleared on every index rebuild** (re-set in the same `git status` run), so the badge appears right after a status and drops the moment any later tool runs — never badging a clean file. It's also tagged with the index's project notion (`selectedProjectID`) and dropped on any project-switch path that doesn't rebuild the index (the #695 drop-on-mismatch lesson).

## Tests

- `GitChangedFiles` parser: modified/untracked/staged/rename-keeps-new/quoted/`->`-in-name/header-only.
- `FileMentionCatalog`: boost dominates a higher text tier, intra-group order preserved, **empty set byte-identical to today**, Codable round-trip.
- Integration: one git status sets BOTH branch chip and changed set; **committed file drops its badge on the next tool run**; cross-project non-bleed via identical paths; remote clears.
- Playwright boost-flip with a Changed badge + `data-changed`. No new command ID → command-routing parity untouched; the pill reuses the existing row hit-target.

Scoped by a grounded judge-panel plan and hardened by an adversarial review pass (which caught the stale-badge bug — fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)