### PR TITLE
Add "Copy conversation" — export the thread as Markdown to the clipboard

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -1322,6 +1322,21 @@
       border-bottom: 1px solid rgba(255,255,255,.1);
       background: rgba(18,29,35,.96);
     }
+    .copy-toast {
+      position: fixed;
+      bottom: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 8px 16px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text, #e6edf3);
+      background: rgba(18,29,35,.96);
+      border: 1px solid rgba(255,255,255,.14);
+      box-shadow: 0 6px 24px rgba(0,0,0,.4);
+      z-index: 60;
+    }
     .find-bar span { color: var(--blue); font-weight: 800; }
     .find-bar input { min-width: 0; }
     .find-status {
@@ -3652,6 +3667,7 @@
         { id: 'retry-last-turn', title: 'Retry last turn', shortcut: '', category: 'Control', keywords: ['retry', 'rerun', 'again', 'failed'], isEnabled: false },
         { id: 'search', title: 'Search', shortcut: 'Cmd+K', category: 'Navigation', keywords: ['find', 'threads', 'chat'], isEnabled: true },
         { id: 'find-in-chat', title: 'Find in chat', shortcut: 'Cmd+F', category: 'Navigation', keywords: ['find', 'current', 'transcript', 'message'], isEnabled: false },
+        { id: 'copy-conversation', title: 'Copy conversation', shortcut: '', category: 'Navigation', keywords: ['export', 'transcript', 'markdown', 'copy all', 'share'], isEnabled: false },
         { id: 'add-project', title: 'Open project', shortcut: 'Cmd+O', category: 'Workspace', keywords: ['folder', 'workspace', 'repo'], isEnabled: true },
         { id: 'add-ssh-project', title: 'Project: Add SSH Remote...', shortcut: '', category: 'Workspace', keywords: ['remote', 'ssh', 'server', 'workspace', '/ssh user@host:/path'], isEnabled: true },
         { id: 'project-new-chat', title: 'New chat in project', shortcut: '', category: 'Workspace', keywords: ['project', 'workspace', 'thread', 'chat'], isEnabled: true },
@@ -5350,6 +5366,7 @@
         command.id === 'compact-context' ? { ...command, isEnabled: hasMessages } :
         command.id === 'retry-last-turn' ? { ...command, isEnabled: hasUserMessages && !state.composer.isSending } :
         command.id === 'find-in-chat' ? { ...command, isEnabled: hasThread } :
+        command.id === 'copy-conversation' ? { ...command, isEnabled: hasThread } :
         command.id === 'automation-create-thread-follow-up' ? { ...command, isEnabled: hasThread } :
         command.id === 'automation-create-workspace-schedule' ? { ...command, isEnabled: hasProject } :
         command.id?.startsWith('automation-create-thread-follow-up-after:') ? { ...command, isEnabled: hasThread } :
@@ -6574,6 +6591,7 @@
           ${state.settings.isOpen ? renderSettingsPanel() : ''}
           ${state.search.isOpen ? renderSearchPanel() : ''}
           ${state.commandPalette.isOpen ? renderCommandPalette() : ''}
+          ${state.copiedTranscriptItemID === 'conversation' ? '<div class="copy-toast" data-testid="conversation-copied-toast" role="status">Conversation copied</div>' : ''}
           ${state.shortcuts.isOpen ? renderKeyboardShortcutsPanel() : ''}
           ${state.worktreeDialog.mode ? renderWorktreeDialog() : ''}
           ${renderSidebarSavedSearchDialog()}
@@ -7976,7 +7994,70 @@
         return item.message?.text || '';
       }
       const card = item.toolCard || {};
-      return card.outputJSON || card.inputJSON || [card.title, card.subtitle].filter(Boolean).join('\n');
+      // Mirrors TranscriptItemTextFormatter (Swift): trim before the truthiness check so a
+      // whitespace-only output/input is skipped, and trim each title/subtitle field.
+      const nonBlank = value => (value && value.trim()) ? value : null;
+      return nonBlank(card.outputJSON)
+        || nonBlank(card.inputJSON)
+        || [card.title, card.subtitle].map(value => (value || '').trim()).filter(Boolean).join('\n');
+    }
+
+    // Mirrors TranscriptMarkdownExporter (Swift): walk the timeline in order, `## Role`
+    // + body per user/assistant message, `### title` + fenced block per tool run; reuse
+    // transcriptCopyText for tool-card text so export matches the per-item copy.
+    function transcriptConversationRoleHeading(role) {
+      return { user: 'User', assistant: 'Assistant' }[role] || null;
+    }
+
+    // A backtick fence one longer than the longest backtick run in the body, so a tool
+    // output containing ``` can never close the block early (matches Swift codeFence).
+    function conversationCodeFence(body) {
+      let longestRun = 0;
+      let currentRun = 0;
+      for (const character of String(body)) {
+        if (character === '`') {
+          currentRun += 1;
+          if (currentRun > longestRun) longestRun = currentRun;
+        } else {
+          currentRun = 0;
+        }
+      }
+      return '`'.repeat(Math.max(3, longestRun + 1));
+    }
+
+    function transcriptMarkdown() {
+      const blocks = [];
+      for (const item of transcriptTimelineItems()) {
+        if (item.kind === 'message') {
+          const heading = transcriptConversationRoleHeading(item.message?.role);
+          if (!heading) continue;
+          const body = (item.message?.text || '').trim();
+          if (!body) continue;
+          blocks.push(`## ${heading}\n\n${body}`);
+        } else if (item.kind === 'toolCard') {
+          const title = item.toolCard?.title || '';
+          const text = transcriptCopyText(item);
+          const fence = conversationCodeFence(text);
+          blocks.push(`### ${title}\n\n${fence}\n${text}\n${fence}`);
+        }
+      }
+      return blocks.join('\n\n');
+    }
+
+    function copyConversation() {
+      const markdown = transcriptMarkdown();
+      if (!markdown.trim()) return;
+      navigator.clipboard?.writeText(markdown).catch(() => {});
+      // Exposed for the Playwright parity test to assert byte-identical Markdown.
+      window.__lastConversationMarkdown = markdown;
+      state.copiedTranscriptItemID = 'conversation';
+      render();
+      setTimeout(() => {
+        if (state.copiedTranscriptItemID === 'conversation') {
+          state.copiedTranscriptItemID = null;
+          render();
+        }
+      }, 1500);
     }
 
     function setMessageFeedback(messageID, value) {
@@ -10227,6 +10308,7 @@
       'computer-use-setup',
       'disconnect-all',
       'find-in-chat',
+      'copy-conversation',
       'fork-from-last',
       'fork-full-context',
       'fork-with-summary',
@@ -10576,6 +10658,10 @@
       }
       if (commandID === 'find-in-chat') {
         openFindInChat();
+        return;
+      }
+      if (commandID === 'copy-conversation') {
+        copyConversation();
         return;
       }
       if (commandID === 'add-project') {

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
+  clickSidebarTool,
   elementRect,
   harnessURL,
   openSidebarTools,
@@ -139,4 +140,33 @@ test('empty starter action submits immediately through the normal composer path'
   await expect(page.getByText('Git diff:')).toBeVisible();
   await expect(page.getByLabel('Message')).toHaveValue('');
   await expect(page.getByTestId('send-button')).toBeDisabled();
+});
+
+test('mock harness copies the whole conversation as Markdown from the command palette', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  // Seed a conversation so there is something to export.
+  await page.getByLabel('Message').fill('Run the tests');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('message').first()).toContainText('Run the tests');
+
+  // Run "Copy conversation" from the command palette.
+  await clickSidebarTool(page, 'command-palette-button');
+  await page.getByLabel('Search commands').fill('copy conversation');
+  await page.locator('[data-testid="command-palette-result"][data-command-id="copy-conversation"]').click();
+  await expect(page.getByTestId('command-palette-panel')).toHaveCount(0);
+
+  // A confirmation toast appears — it only shows when the export produced non-empty Markdown.
+  await expect(page.getByTestId('conversation-copied-toast')).toBeVisible();
+
+  // The exported Markdown must match the Swift TranscriptMarkdownExporter byte-for-byte
+  // (the same fixture is asserted in TranscriptMarkdownExporterTests) — this enforces the
+  // Swift↔JS "never drift" contract rather than just trusting the shared-code comments.
+  const markdown = await page.evaluate(() => (window as Window & { __lastConversationMarkdown?: string }).__lastConversationMarkdown);
+  expect(markdown).toBe(
+    '## User\n\nRun the tests\n\n' +
+    '### host.shell.run\n\n```\n' +
+    '{\n  "ok": true,\n  "stdout": "ran: the tests\\n",\n  "stderr": "",\n  "exitCode": 0\n}\n' +
+    '```\n\n## Assistant\n\nOutput:\nran: the tests'
+  );
 });

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -246,18 +246,7 @@ struct QuillCodeTranscriptView: View {
     }
 
     private func copyText(for card: ToolCardState) -> String {
-        if let outputJSON = card.outputJSON,
-           !outputJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return outputJSON
-        }
-        if let inputJSON = card.inputJSON,
-           !inputJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return inputJSON
-        }
-        return [card.title, card.subtitle]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
+        TranscriptItemTextFormatter.text(for: card)
     }
 
     private func selectPreviousFindMatch() {

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceViewCommandPlanner.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceViewCommandPlanner.swift
@@ -15,6 +15,7 @@ enum WorkspaceViewCommandAction: Hashable, Sendable {
     case presentRemoveWorktree
     case presentPruneWorktrees
     case openBrowserSession
+    case copyConversation
     case dispatch(command: WorkspaceCommandSurface, focusesComposer: Bool)
 }
 
@@ -52,6 +53,8 @@ struct WorkspaceViewCommandPlanner: Sendable, Hashable {
             return .presentPruneWorktrees
         case "open-browser-session":
             return .openBrowserSession
+        case "copy-conversation":
+            return .copyConversation
         default:
             guard WorkspaceCommandRoutingCatalog.isDispatchable(command.id) else {
                 return nil

--- a/Sources/QuillCodeApp/TranscriptItemTextFormatter.swift
+++ b/Sources/QuillCodeApp/TranscriptItemTextFormatter.swift
@@ -1,0 +1,21 @@
+import QuillCodeCore
+
+/// Shared per-transcript-item text shaping used by BOTH the per-item copy button and the
+/// whole-conversation Markdown export, so the two can never drift. A tool card's text is
+/// its output, else its input, else its title/subtitle.
+public enum TranscriptItemTextFormatter {
+    public static func text(for card: ToolCardState) -> String {
+        if let outputJSON = card.outputJSON,
+           !outputJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return outputJSON
+        }
+        if let inputJSON = card.inputJSON,
+           !inputJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return inputJSON
+        }
+        return [card.title, card.subtitle]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+}

--- a/Sources/QuillCodeApp/TranscriptMarkdownExporter.swift
+++ b/Sources/QuillCodeApp/TranscriptMarkdownExporter.swift
@@ -1,0 +1,65 @@
+import QuillCodeCore
+
+/// Renders the current thread transcript as Markdown for the clipboard ("Copy
+/// conversation"). It walks the timeline in order, emitting a `## Role` heading + body for
+/// each user/assistant message and a `### title` + fenced block for each tool run, reusing
+/// ``TranscriptItemTextFormatter`` for tool-card text so the export matches the per-item
+/// copy exactly. Returns `""` when there is nothing to copy.
+public enum TranscriptMarkdownExporter {
+    public static func markdown(for transcript: TranscriptSurface) -> String {
+        var blocks: [String] = []
+        for item in transcript.timelineItems {
+            switch item.kind {
+            case .message:
+                guard let message = item.message, let heading = heading(for: message.role) else { continue }
+                let body = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !body.isEmpty else { continue }
+                blocks.append("## \(heading)\n\n\(body)")
+            case .toolCard:
+                guard let card = item.toolCard else { continue }
+                let text = TranscriptItemTextFormatter.text(for: card)
+                let fence = codeFence(for: text)
+                blocks.append("### \(card.title)\n\n\(fence)\n\(text)\n\(fence)")
+            }
+        }
+        return blocks.joined(separator: "\n\n")
+    }
+
+    /// The Markdown to put on the clipboard, or `nil` when there is nothing copyable — the
+    /// single guard both the native command and (mirrored) the harness use.
+    public static func clipboardMarkdown(for transcript: TranscriptSurface) -> String? {
+        let markdown = markdown(for: transcript)
+        return markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : markdown
+    }
+
+    /// Only user/assistant turns belong in a shared conversation. `.tool` turns are already
+    /// filtered from the timeline, and `.system` is skipped so system-prompt content can
+    /// never leak into an exported transcript.
+    private static func heading(for role: ChatRole) -> String? {
+        switch role {
+        case .user:
+            return "User"
+        case .assistant:
+            return "Assistant"
+        case .system, .tool:
+            return nil
+        }
+    }
+
+    /// A backtick fence at least one longer than the longest backtick run in `body`, so a
+    /// tool output containing ``` (e.g. a diff of a Markdown file) can never close the
+    /// block early. Computed identically in the Swift and JS serializers.
+    private static func codeFence(for body: String) -> String {
+        var longestRun = 0
+        var currentRun = 0
+        for character in body {
+            if character == "`" {
+                currentRun += 1
+                longestRun = max(longestRun, currentRun)
+            } else {
+                currentRun = 0
+            }
+        }
+        return String(repeating: "`", count: max(3, longestRun + 1))
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
@@ -30,6 +30,13 @@ enum WorkspaceCommandStaticCatalog {
                 category: WorkspaceCommandPalette.navigationCategory,
                 keywords: ["find", "current", "transcript", "message"],
                 isEnabled: hasSelectedThread
+            ),
+            WorkspaceCommandSurface(
+                id: "copy-conversation",
+                title: "Copy conversation",
+                category: WorkspaceCommandPalette.navigationCategory,
+                keywords: ["export", "transcript", "markdown", "copy all", "share"],
+                isEnabled: hasSelectedThread
             )
         ]
     }

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -327,6 +327,12 @@ public struct QuillCodeWorkspaceView: View {
             worktreeDialogs.presentPrune(loadPreview: onPreviewWorktreePrune)
         case .openBrowserSession:
             onOpenBrowserSession?()
+        case .copyConversation:
+            // Reuses the existing per-item copy closure (-> controller -> pasteboard),
+            // so the whole-conversation export shares the same copy path and feedback.
+            if let markdown = TranscriptMarkdownExporter.clipboardMarkdown(for: surface.transcript) {
+                onCopyTranscriptItem("conversation", markdown)
+            }
         case let .dispatch(command, focusesComposer):
             onCommand(command)
             if focusesComposer {

--- a/Tests/QuillCodeAppTests/QuillCodeWorkspaceViewCommandPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeWorkspaceViewCommandPlannerTests.swift
@@ -19,6 +19,7 @@ final class QuillCodeWorkspaceViewCommandPlannerTests: XCTestCase {
         XCTAssertEqual(planner.action(for: command("git-worktree-remove")), .presentRemoveWorktree)
         XCTAssertEqual(planner.action(for: command("git-worktree-prune")), .presentPruneWorktrees)
         XCTAssertEqual(planner.action(for: command("open-browser-session")), .openBrowserSession)
+        XCTAssertEqual(planner.action(for: command("copy-conversation")), .copyConversation)
     }
 
     func testRenameCommandsUseSelectedItems() throws {

--- a/Tests/QuillCodeAppTests/TranscriptMarkdownExporterTests.swift
+++ b/Tests/QuillCodeAppTests/TranscriptMarkdownExporterTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class TranscriptMarkdownExporterTests: XCTestCase {
+    private func card(
+        id: String, title: String, subtitle: String = "",
+        input: String? = nil, output: String? = nil
+    ) -> ToolCardState {
+        ToolCardState(id: id, title: title, subtitle: subtitle, status: .done, inputJSON: input, outputJSON: output)
+    }
+
+    private func transcript(_ items: [TranscriptTimelineItemSurface]) -> TranscriptSurface {
+        TranscriptSurface(messages: [], toolCards: [], timelineItems: items)
+    }
+
+    func testExportsInterleavedMessagesAndToolCardsInTimelineOrder() {
+        let user = MessageSurface(message: ChatMessage(role: .user, content: "Run the tests"))
+        let tool = card(id: "t1", title: "host.shell.run", input: #"{"command":"swift test"}"#, output: "All tests passed")
+        let assistant = MessageSurface(message: ChatMessage(role: .assistant, content: "Done — all green."))
+
+        let markdown = TranscriptMarkdownExporter.markdown(
+            for: transcript([.message(user), .toolCard(tool), .message(assistant)])
+        )
+
+        XCTAssertEqual(markdown, """
+        ## User
+
+        Run the tests
+
+        ### host.shell.run
+
+        ```
+        All tests passed
+        ```
+
+        ## Assistant
+
+        Done — all green.
+        """)
+    }
+
+    func testToolCardTextPrefersOutputThenInputThenTitleSubtitle() {
+        XCTAssertTrue(TranscriptMarkdownExporter.markdown(
+            for: transcript([.toolCard(card(id: "a", title: "T", input: "the-input", output: "the-output"))])
+        ).contains("```\nthe-output\n```"))
+
+        XCTAssertTrue(TranscriptMarkdownExporter.markdown(
+            for: transcript([.toolCard(card(id: "b", title: "T", input: "the-input"))])
+        ).contains("```\nthe-input\n```"))
+
+        XCTAssertEqual(
+            TranscriptMarkdownExporter.markdown(
+                for: transcript([.toolCard(card(id: "c", title: "host.git.diff", subtitle: "no changes"))])
+            ),
+            "### host.git.diff\n\n```\nhost.git.diff\nno changes\n```"
+        )
+    }
+
+    func testSkipsEmptyMessageBodiesButKeepsHeadingsForRealOnes() {
+        let blank = MessageSurface(message: ChatMessage(role: .user, content: "   "))
+        let real = MessageSurface(message: ChatMessage(role: .assistant, content: "hi"))
+        XCTAssertEqual(
+            TranscriptMarkdownExporter.markdown(for: transcript([.message(blank), .message(real)])),
+            "## Assistant\n\nhi"
+        )
+    }
+
+    func testEmptyTranscriptProducesEmptyString() {
+        XCTAssertEqual(TranscriptMarkdownExporter.markdown(for: transcript([])), "")
+    }
+
+    func testTrimsAtTheTextBoundaryMatchingTheSharedFormatter() {
+        // Whitespace-only output is skipped (falls through to the trimmed title/subtitle),
+        // and the subtitle is trimmed — the exact boundary the Swift↔JS parity contract guards.
+        let tool = card(id: "t1", title: "host.shell.run", subtitle: "  done  ", input: nil, output: "   ")
+        XCTAssertEqual(
+            TranscriptMarkdownExporter.markdown(for: transcript([.toolCard(tool)])),
+            "### host.shell.run\n\n```\nhost.shell.run\ndone\n```"
+        )
+    }
+
+    func testUsesALongerFenceWhenOutputContainsTripleBacktick() {
+        let tool = card(id: "t1", title: "host.shell.run", output: "```\ncode\n```")
+        XCTAssertEqual(
+            TranscriptMarkdownExporter.markdown(for: transcript([.toolCard(tool)])),
+            "### host.shell.run\n\n````\n```\ncode\n```\n````"
+        )
+    }
+
+    func testSkipsSystemAndToolMessageHeadings() {
+        let system = MessageSurface(message: ChatMessage(role: .system, content: "secret system prompt"))
+        let tool = MessageSurface(message: ChatMessage(role: .tool, content: "tool noise"))
+        let user = MessageSurface(message: ChatMessage(role: .user, content: "hi"))
+        XCTAssertEqual(
+            TranscriptMarkdownExporter.markdown(for: transcript([.message(system), .message(tool), .message(user)])),
+            "## User\n\nhi"
+        )
+    }
+
+    func testClipboardMarkdownIsNilWhenNothingCopyable() {
+        XCTAssertNil(TranscriptMarkdownExporter.clipboardMarkdown(for: transcript([])))
+        let blank = MessageSurface(message: ChatMessage(role: .user, content: "   "))
+        XCTAssertNil(TranscriptMarkdownExporter.clipboardMarkdown(for: transcript([.message(blank)])))
+        let real = MessageSurface(message: ChatMessage(role: .assistant, content: "answer"))
+        XCTAssertEqual(
+            TranscriptMarkdownExporter.clipboardMarkdown(for: transcript([.message(real)])),
+            "## Assistant\n\nanswer"
+        )
+    }
+
+    func testMatchesTheHarnessParityFixtureByteForByte() {
+        // The SAME fixture is asserted in core.spec.ts against window.__lastConversationMarkdown,
+        // so Swift and the JS harness are pinned to identical clipboard bytes (parity contract).
+        let user = MessageSurface(message: ChatMessage(role: .user, content: "Run the tests"))
+        let tool = card(
+            id: "t1", title: "host.shell.run",
+            output: "{\n  \"ok\": true,\n  \"stdout\": \"ran: the tests\\n\",\n  \"stderr\": \"\",\n  \"exitCode\": 0\n}"
+        )
+        let assistant = MessageSurface(message: ChatMessage(role: .assistant, content: "Output:\nran: the tests"))
+
+        let markdown = TranscriptMarkdownExporter.markdown(
+            for: transcript([.message(user), .toolCard(tool), .message(assistant)])
+        )
+
+        XCTAssertEqual(markdown,
+            "## User\n\nRun the tests\n\n"
+            + "### host.shell.run\n\n```\n"
+            + "{\n  \"ok\": true,\n  \"stdout\": \"ran: the tests\\n\",\n  \"stderr\": \"\",\n  \"exitCode\": 0\n}\n"
+            + "```\n\n## Assistant\n\nOutput:\nran: the tests"
+        )
+    }
+
+    func testFencedBlockReusesPerItemFormatterVerbatim() {
+        // Locks "export == per-item copy": the fenced block contains exactly the shared
+        // formatter's output, so the two copy paths can never silently diverge.
+        let tool = card(id: "t1", title: "host.git.diff", input: "in", output: "diff-output")
+        let perItem = TranscriptItemTextFormatter.text(for: tool)
+        let markdown = TranscriptMarkdownExporter.markdown(for: transcript([.toolCard(tool)]))
+        XCTAssertEqual(perItem, "diff-output")
+        XCTAssertTrue(markdown.contains("```\n\(perItem)\n```"))
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -89,6 +89,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
             "retry-last-turn",
             "search",
             "find-in-chat",
+            "copy-conversation",
             "add-project",
             "add-ssh-project",
             "project-new-chat",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-29 Copy Conversation (Markdown Export) Pass
+
+Overall grade after this slice: **A reuse of the existing copy path, A single-source serialization**.
+
+Adds a "Copy conversation" palette command that exports the whole current thread as Markdown to the clipboard — the missing "share my session" action (paste into a PR description, a bug report, or a doc). Previously only one transcript item could be copied at a time.
+
+| Before | After |
+| --- | --- |
+| `QuillCodeTranscriptView.copyText(for:)` shaped a single tool card's text inline, and there was no whole-thread export anywhere. | The per-item text shaping is factored into a shared `TranscriptItemTextFormatter` (output ?? input ?? title/subtitle), and a new pure `TranscriptMarkdownExporter.markdown(for:)` walks `transcript.timelineItems` in order — `## Role` + body per message, `### title` + a fenced block per tool run — reusing that one formatter so the export and the per-item copy can never drift. |
+| — (wiring) | The command is registered in `WorkspaceCommandStaticCatalog` (navigation, enabled with a thread) and routed by `QuillCodeWorkspaceViewCommandPlanner` to a new `.copyConversation` action (not model-dispatched). `WorkspaceSwiftUIView.handleCommandAction` builds the Markdown and reuses the existing `onCopyTranscriptItem("conversation", …)` closure → controller → pasteboard, so there is no new clipboard code or hit-target. Like `find-in-chat` it is palette-only (view-handled commands can't route through the model's slash executor). |
+| — (review-caught drift) | The adversarial review found the Swift and JS serializers did **not** actually mirror each other despite the comments: Swift trimmed before its output/input/title-subtitle checks while the JS `||`/`filter(Boolean)` did not, so a whitespace-only output (or padded subtitle) produced different clipboard bytes. Fixed: the JS path trims to match Swift (correcting the per-item copy too), and a **byte-equality fixture** is asserted on both sides — `TranscriptMarkdownExporterTests` and `core.spec.ts` pin the *same* conversation to identical Markdown. Also from the review: a tool output containing ``` no longer breaks the fence (a fence one longer than the longest backtick run, computed identically in both), and `## System`/`## Tool` headings are dropped so system-prompt content can never leak. |
+| No coverage. | `TranscriptMarkdownExporterTests` (interleaved order, output/input/title-subtitle fallback, whitespace-trim boundary, triple-backtick fence, system/tool skip, empty → "", `clipboardMarkdown` nil-guard, per-item-formatter lock, cross-language byte-parity fixture); planner test maps `copy-conversation` → `.copyConversation`; `WorkspaceRenderedCommandRoutingParityTests` enforces the id in BOTH the catalog and `harnessStaticCommandIDs`; the command-list snapshot gains it. The JS harness mirrors the exporter, command, and a confirmation toast; a Playwright test copies from the palette, asserts the toast, and asserts the exact Markdown. |
+
+Residual risk:
+
+- The export sources `timelineItems` (user/assistant messages + tool cards), so content rendered outside the timeline (thinking blocks, the review/diff pane) is not included, and a tool card with both input and output exports only the output — a deliberate "matches what per-item copy shows" scope. A document title/thread name, timestamps, labelled Input/Output blocks, and pretty-printed JSON are natural follow-ups. The raw tool `outputJSON` is dumped verbatim (the user's own clipboard, so no new exposure).
+
 ## 2026-06-29 Changed-File @-Mention Boost Pass
 
 Overall grade after this slice: **A reuse of existing data, A cross-surface scoring parity**.


### PR DESCRIPTION
## What

A new palette command **"Copy conversation"** copies the whole current thread as Markdown (`## Role` + body per message, `### title` + fenced block per tool run) to the clipboard — the missing "share my session" action for pasting into a PR description, bug report, or doc. Previously only a single transcript item could be copied.

## How

- The per-item copy text shaping is factored into a shared `TranscriptItemTextFormatter`, so the new `TranscriptMarkdownExporter` and the existing per-item copy button go through **one** function (export == per-item copy, no drift).
- Registered in `WorkspaceCommandStaticCatalog` (navigation, enabled with a thread), routed by the view command planner as `.copyConversation` (not model-dispatched), reusing the existing `onCopyTranscriptItem` → pasteboard path — no new clipboard code or hit-target. Palette-only like `find-in-chat` (view-handled commands can't route through the model's slash executor).
- The JS harness mirrors the exporter, command, and a confirmation toast.

## Adversarial review fixes (shipped here)

The review caught that the Swift and JS serializers did **not** actually mirror each other: Swift trimmed before its output/input/title-subtitle checks while the JS `||`/`filter(Boolean)` did not, so a whitespace-only output produced different clipboard bytes. Fixed — the JS path trims to match Swift, and a **byte-equality fixture** is asserted on *both* sides (`TranscriptMarkdownExporterTests` + `core.spec.ts` pin the same conversation to identical Markdown). Also: a tool output containing ``` no longer breaks the fence (a fence one longer than the longest backtick run, computed identically), and `## System`/`## Tool` headings are dropped so system-prompt content can't leak.

## Tests

`TranscriptMarkdownExporterTests` (order, fallback, whitespace-trim boundary, triple-backtick fence, system/tool skip, empty → "", `clipboardMarkdown` guard, per-item-formatter lock, cross-language byte-parity); planner maps `copy-conversation` → `.copyConversation`; command-routing parity (catalog + `harnessStaticCommandIDs`); Playwright copies from the palette, shows the toast, and asserts the exact Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)