### PR TITLE
Surface model token usage as a quiet top-bar chip

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -201,7 +201,8 @@
       gap: 10px;
       text-align: left;
     }
-    .topbar-branch-chip {
+    .topbar-branch-chip,
+    .topbar-usage-chip {
       flex: 0 0 auto;
       font-size: 12px;
       font-weight: 600;
@@ -3326,6 +3327,7 @@
         primaryTitle: 'QuillCode',
         subtitle: 'QuillCode - Not started',
         branchStatusLabel: null,
+        usageStatusLabel: null,
         instructionLabel: '1 instruction file loaded',
         instructionSources: ['AGENTS.md'],
         modelLabel: 'Nike 1.0',
@@ -6498,6 +6500,7 @@
               <strong data-testid="top-bar-title">${escapeHTML(state.topBar.primaryTitle)}</strong>
               <p class="topbar-context-label" data-testid="top-bar-subtitle">${escapeHTML(state.topBar.subtitle)}</p>
               ${state.topBar.branchStatusLabel ? `<span class="topbar-branch-chip" data-testid="top-bar-branch" title="${escapeHTML(state.topBar.branchStatusLabel)}">${escapeHTML(state.topBar.branchStatusLabel)}</span>` : ''}
+              ${state.topBar.usageStatusLabel ? `<span class="topbar-usage-chip" data-testid="top-bar-usage" title="${escapeHTML(state.topBar.usageStatusLabel)}">${escapeHTML(state.topBar.usageStatusLabel)}</span>` : ''}
             </div>
             <div class="topbar-clusters" data-testid="top-bar-clusters">
               <div class="topbar-cluster topbar-action-cluster" data-testid="top-bar-action-cluster">
@@ -9241,6 +9244,8 @@
       state.composer.canSend = false;
       state.composer.slashActiveIndex = 0;
       state.topBar.primaryTitle = 'QuillCode';
+      // The usage chip is per-thread; a fresh thread has no usage until its first turn.
+      state.topBar.usageStatusLabel = null;
       const selectedProject = state.projects.items.find(project => project.id === state.projects.selectedProjectID);
       state.topBar.subtitle = `${selectedProject?.name || 'No project'} - Not started`;
       render();
@@ -12979,9 +12984,46 @@
       state.composer.canSend = Boolean(state.composer.draft.trim());
       if (!['Failed', 'Stopped'].includes(state.topBar.agentStatus)) {
         state.topBar.agentStatus = 'Idle';
+        // Mirrors native: the model reports token usage at the end of a turn, surfaced as
+        // the quiet top-bar usage chip. The chip is derived per-thread, so a fresh thread
+        // shows nothing until its first turn completes.
+        state.topBar.usageStatusLabel = mockTokenUsageLabel();
       }
       syncSelectedThreadSearchText();
       render();
+    }
+
+    // Compact token count matching WorkspaceTokenUsageLabelBuilder.abbreviate (Swift):
+    // exact below 1k, one-decimal k below 1m, one-decimal m above; the unit is chosen on
+    // the ROUNDED value so 999999 reads "1m" (not "1000k").
+    function abbreviateTokens(count) {
+      const value = Math.max(0, count);
+      if (value < 1000) return String(value);
+      const trim = scaled => (scaled === Math.round(scaled) ? String(Math.round(scaled)) : scaled.toFixed(1));
+      if (value < 1000000) {
+        const thousands = Math.round((value / 1000) * 10) / 10;
+        if (thousands < 1000) return trim(thousands) + 'k';
+        // Rounding crossed into millions; fall through to the m unit.
+      }
+      return trim(Math.round((value / 1000000) * 10) / 10) + 'm';
+    }
+
+    // A mock per-thread token-usage label estimated from the transcript (chars/4), formatted
+    // exactly like WorkspaceTokenUsageLabelBuilder.label (Swift): "<ctx> ctx · ↑<in> ↓<out>".
+    function mockTokenUsageLabel() {
+      let prompt = 0;
+      let completion = 0;
+      for (const item of transcriptTimelineItems()) {
+        if (item.kind === 'message') {
+          const length = (item.message?.text || '').length;
+          if (item.message?.role === 'assistant') completion += Math.ceil(length / 4);
+          else prompt += Math.ceil(length / 4);
+        } else if (item.kind === 'toolCard') {
+          prompt += Math.ceil((transcriptCopyText(item) || '').length / 4);
+        }
+      }
+      if (prompt + completion === 0) return null;
+      return `${abbreviateTokens(prompt + completion)} ctx · ↑${abbreviateTokens(prompt)} ↓${abbreviateTokens(completion)}`;
     }
 
     function completeMockAgentTurn(text) {

--- a/E2E/playwright/tests/status.spec.ts
+++ b/E2E/playwright/tests/status.spec.ts
@@ -56,3 +56,35 @@ test('mock harness surfaces the branch and ahead/behind chip after a git status'
   await page.getByTestId('add-project-button').click();
   await expect(page.getByTestId('top-bar-branch')).toHaveCount(0);
 });
+
+test('mock harness surfaces the token-usage chip after a turn completes', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  // No usage chip until a turn reports usage.
+  await expect(page.getByTestId('top-bar-usage')).toHaveCount(0);
+
+  await page.getByLabel('Message').fill('Run the tests');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('top-bar-usage')).toBeVisible();
+  await expect(page.getByTestId('top-bar-usage')).toContainText('ctx');
+  await expect(page.getByTestId('top-bar-usage')).toContainText('↑');
+  // Additive: the existing subtitle is unchanged.
+  await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode');
+
+  // The chip is per-thread, so a fresh thread shows nothing until its own first turn.
+  await page.getByTestId('new-chat-button').click();
+  await expect(page.getByTestId('top-bar-usage')).toHaveCount(0);
+});
+
+test('mock harness token abbreviator matches the Swift boundary table byte-for-byte', async ({ page }) => {
+  await page.goto(harnessURL());
+  // Drives the JS twin of WorkspaceTokenUsageLabelBuilder.abbreviate (Swift) across the
+  // same boundaries asserted in WorkspaceTokenUsageLabelBuilderTests, so the two formatters
+  // can't drift (esp. the 999999 -> "1m" unit-roll case the normal flow never reaches).
+  const results = await page.evaluate(() => {
+    const abbreviate = (window as Window & { abbreviateTokens?: (n: number) => string }).abbreviateTokens;
+    return [0, 999, 1000, 1050, 1500, 12000, 999949, 999999, 1000000, 1500000].map(value => abbreviate?.(value));
+  });
+  expect(results).toEqual(['0', '999', '1k', '1.1k', '1.5k', '12k', '999.9k', '1m', '1m', '1.5m']);
+});

--- a/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
@@ -21,6 +21,9 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
     /// Pre-formatted branch + ahead/behind chip (e.g. `feature/x ↑2 ↓1`), or nil
     /// when no git branch status is known. Renderers display this string as-is.
     public var branchStatusLabel: String?
+    /// Pre-formatted token-usage chip (e.g. `847 ctx · ↑500 ↓347`), or nil when the model
+    /// has not reported usage for this thread. Renderers display this string as-is.
+    public var usageStatusLabel: String?
 
     public init(
         appName: String,
@@ -39,7 +42,8 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
         runtimeIssueSeverity: RuntimeIssueSeverity? = nil,
         computerUseLabel: String,
         showsComputerUseSetup: Bool,
-        branchStatusLabel: String? = nil
+        branchStatusLabel: String? = nil,
+        usageStatusLabel: String? = nil
     ) {
         self.appName = appName
         self.primaryTitle = primaryTitle
@@ -58,6 +62,7 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
         self.computerUseLabel = computerUseLabel
         self.showsComputerUseSetup = showsComputerUseSetup
         self.branchStatusLabel = branchStatusLabel
+        self.usageStatusLabel = usageStatusLabel
     }
 
     public func filteredModelCategories(matching query: String) -> [ModelCategorySurface] {

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -71,6 +71,22 @@ struct QuillCodeTopBarView: View {
                     // The branch is already announced via the top bar's combined label.
                     .accessibilityHidden(true)
             }
+
+            if let usageStatusLabel = topBar.usageStatusLabel {
+                Text(usageStatusLabel)
+                    .font(.caption.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(QuillCodePalette.background.opacity(0.6))
+                    )
+                    // The usage is already announced via the top bar's combined label.
+                    .accessibilityHidden(true)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -106,6 +122,9 @@ struct QuillCodeTopBarView: View {
         var label = "\(topBar.primaryTitle), \(topBar.subtitle), \(agentStatus.accessibilityLabel)"
         if let branchStatusLabel = topBar.branchStatusLabel {
             label += ", branch: \(branchStatusLabel)"
+        }
+        if let usageStatusLabel = topBar.usageStatusLabel {
+            label += ", token usage: \(usageStatusLabel)"
         }
         if let runtimeIssue {
             label += ", issue: \(runtimeIssue.label)"

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -10,6 +10,7 @@ enum WorkspaceHTMLTopBarRenderer {
             <strong data-testid="top-bar-title">\(escape(topBar.primaryTitle))</strong>
             <p class="topbar-context-label" data-testid="top-bar-subtitle">\(escape(topBar.subtitle))</p>
             \(renderBranchStatus(topBar))
+            \(renderUsageStatus(topBar))
           </div>
           <div class="topbar-clusters" data-testid="top-bar-clusters">
             \(renderActionCluster(topBar, commands: commands))
@@ -35,6 +36,11 @@ enum WorkspaceHTMLTopBarRenderer {
     private static func renderBranchStatus(_ topBar: TopBarSurface) -> String {
         guard let branchStatusLabel = topBar.branchStatusLabel else { return "" }
         return #"<span class="topbar-branch-chip" data-testid="top-bar-branch" title="\#(escape(branchStatusLabel))">\#(escape(branchStatusLabel))</span>"#
+    }
+
+    private static func renderUsageStatus(_ topBar: TopBarSurface) -> String {
+        guard let usageStatusLabel = topBar.usageStatusLabel else { return "" }
+        return #"<span class="topbar-usage-chip" data-testid="top-bar-usage" title="\#(escape(usageStatusLabel))">\#(escape(usageStatusLabel))</span>"#
     }
 
     private static func renderRuntimeIssuePill(_ topBar: TopBarSurface) -> String {

--- a/Sources/QuillCodeApp/WorkspaceTokenUsageLabelBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTokenUsageLabelBuilder.swift
@@ -1,0 +1,37 @@
+import QuillCodeCore
+
+/// Builds the quiet top-bar token-usage label from a model's reported usage, e.g.
+/// `847 ctx · ↑500 ↓347` (the renderers show it in tabular digits). Returns `nil` when
+/// there is no usage to show. The string is formatted ONCE here so the native, HTML, and
+/// harness surfaces all display the same server-built value and can never drift — the same
+/// single-source pattern the branch chip uses.
+public enum WorkspaceTokenUsageLabelBuilder {
+    public static func label(for usage: ModelTokenUsage?) -> String? {
+        // A nil — or an all-zero/malformed (the decoder defaults missing fields to 0) —
+        // usage has nothing meaningful to show, so the chip is suppressed entirely.
+        guard let usage, usage.contextTokens > 0 else { return nil }
+        return "\(abbreviate(usage.contextTokens)) ctx · ↑\(abbreviate(usage.promptTokens)) ↓\(abbreviate(usage.completionTokens))"
+    }
+
+    /// Compact count: exact below 1k, one-decimal k below 1m, one-decimal m above — so the
+    /// chip stays narrow and never causes layout jitter. The unit is chosen on the ROUNDED
+    /// value, so 999_999 reads `1m` (not `1000k`).
+    static func abbreviate(_ count: Int) -> String {
+        let value = max(0, count)
+        if value < 1_000 { return "\(value)" }
+        if value < 1_000_000 {
+            let thousands = roundedOneDecimal(Double(value) / 1_000)
+            if thousands < 1_000 { return "\(trim(thousands))k" }
+            // Rounding crossed into millions; fall through to the m unit.
+        }
+        return "\(trim(roundedOneDecimal(Double(value) / 1_000_000)))m"
+    }
+
+    private static func roundedOneDecimal(_ value: Double) -> Double {
+        (value * 10).rounded() / 10
+    }
+
+    private static func trim(_ value: Double) -> String {
+        value == value.rounded() ? "\(Int(value))" : String(format: "%.1f", value)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
@@ -38,6 +38,11 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
             branchStatusLabel: topBarState.branchStatus.flatMap { status in
                 let label = status.compactLabel
                 return label.isEmpty ? nil : label
+            },
+            usageStatusLabel: thread.flatMap { thread in
+                WorkspaceTokenUsageLabelBuilder.label(
+                    for: WorkspaceContextBannerBuilder.latestProviderUsage(for: thread)
+                )
             }
         )
     }

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+
+final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
+    private func makeTopBar(usageStatusLabel: String?) -> TopBarSurface {
+        TopBarSurface(
+            appName: "QuillCode",
+            primaryTitle: "Investigate CI",
+            subtitle: "QuillCode - Auto - Nike 1.0",
+            instructionLabel: "1 instruction file loaded",
+            instructionSources: [],
+            memoryLabel: "No memories",
+            memorySources: [],
+            modelLabel: "Nike 1.0",
+            selectedModelID: "trustedrouter/fast",
+            modelCategories: [],
+            modeLabel: "Auto",
+            agentStatus: "Idle",
+            computerUseLabel: "Computer Use unavailable",
+            showsComputerUseSetup: false,
+            usageStatusLabel: usageStatusLabel
+        )
+    }
+
+    func testTopBarRoundTripsUsageStatusLabel() throws {
+        for label in ["847 ctx · ↑500 ↓347", nil] {
+            let decoded = try JSONDecoder().decode(
+                TopBarSurface.self,
+                from: JSONEncoder().encode(makeTopBar(usageStatusLabel: label))
+            )
+            XCTAssertEqual(decoded.usageStatusLabel, label)
+        }
+    }
+
+    func testTopBarDecodesLegacyJSONWithoutUsageKey() throws {
+        // A persisted top bar from before this field existed must still load (key absent -> nil).
+        let encoded = try JSONEncoder().encode(makeTopBar(usageStatusLabel: "847 ctx · ↑500 ↓347"))
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object.removeValue(forKey: "usageStatusLabel")
+        let legacy = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try JSONDecoder().decode(TopBarSurface.self, from: legacy)
+        XCTAssertNil(decoded.usageStatusLabel)
+    }
+
+    func testHTMLRendererEmitsUsageChipOnlyWhenSet() {
+        let withUsage = WorkspaceHTMLTopBarRenderer.render(makeTopBar(usageStatusLabel: "847 ctx · ↑500 ↓347"), commands: [])
+        XCTAssertTrue(withUsage.contains(#"data-testid="top-bar-usage""#))
+        XCTAssertTrue(withUsage.contains("847 ctx · ↑500 ↓347"))
+        XCTAssertTrue(withUsage.contains("topbar-usage-chip"))
+
+        let withoutUsage = WorkspaceHTMLTopBarRenderer.render(makeTopBar(usageStatusLabel: nil), commands: [])
+        XCTAssertFalse(withoutUsage.contains(#"data-testid="top-bar-usage""#))
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageIntegrationTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+
+@MainActor
+final class WorkspaceTokenUsageIntegrationTests: XCTestCase {
+    private func usageEvent(prompt: Int, completion: Int) -> ThreadEvent {
+        ModelTokenUsageEvent.event(usage: ModelTokenUsage(promptTokens: prompt, completionTokens: completion))
+    }
+
+    func testUsageChipReflectsLatestProviderUsageOfSelectedThread() {
+        let thread = ChatThread(title: "Work", events: [usageEvent(prompt: 500, completion: 347)])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+        XCTAssertEqual(model.surface().topBar.usageStatusLabel, "847 ctx · ↑500 ↓347")
+    }
+
+    func testUsesTheMostRecentUsageEvent() {
+        let thread = ChatThread(title: "Work", events: [
+            usageEvent(prompt: 100, completion: 50),
+            usageEvent(prompt: 900, completion: 600)
+        ])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+        XCTAssertEqual(model.surface().topBar.usageStatusLabel, "1.5k ctx · ↑900 ↓600")
+    }
+
+    func testNoUsageChipWithoutAUsageEvent() {
+        let thread = ChatThread(title: "Fresh")
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+        XCTAssertNil(model.surface().topBar.usageStatusLabel)
+    }
+
+    func testUsageChipIsDerivedPerThreadAndDoesNotBleed() {
+        let used = ChatThread(title: "Used", events: [usageEvent(prompt: 100, completion: 50)])
+        let fresh = ChatThread(title: "Fresh")
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [used, fresh], selectedThreadID: used.id)
+        )
+        XCTAssertEqual(model.surface().topBar.usageStatusLabel, "150 ctx · ↑100 ↓50")
+
+        // Selecting the fresh thread shows no usage even though another thread has it.
+        model.selectThread(fresh.id)
+        XCTAssertNil(model.surface().topBar.usageStatusLabel)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageLabelBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageLabelBuilderTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+
+final class WorkspaceTokenUsageLabelBuilderTests: XCTestCase {
+    func testNilUsageProducesNoLabel() {
+        XCTAssertNil(WorkspaceTokenUsageLabelBuilder.label(for: nil))
+    }
+
+    func testExactCountsBelowAThousand() {
+        let usage = ModelTokenUsage(promptTokens: 500, completionTokens: 347)
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.label(for: usage), "847 ctx · ↑500 ↓347")
+    }
+
+    func testAbbreviatesThousandsWithOneDecimal() {
+        let usage = ModelTokenUsage(promptTokens: 8100, completionTokens: 4200)
+        // contextTokens == total == 12300 -> 12.3k
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.label(for: usage), "12.3k ctx · ↑8.1k ↓4.2k")
+    }
+
+    func testAbbreviatorBoundaries() {
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(0), "0")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(999), "999")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(1_000), "1k")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(1_050), "1.1k")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(1_500), "1.5k")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(12_000), "12k")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(999_949), "999.9k")
+        // Rounding up at the k/m edge must roll the unit, not render "1000k".
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(999_999), "1m")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(1_000_000), "1m")
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.abbreviate(1_500_000), "1.5m")
+    }
+
+    func testZeroUsageSuppressesTheChip() {
+        XCTAssertNil(WorkspaceTokenUsageLabelBuilder.label(for: ModelTokenUsage(promptTokens: 0, completionTokens: 0)))
+    }
+
+    func testContextTokensDriveTheCtxFieldIndependentlyOfPromptPlusCompletion() {
+        // A provider may report a total larger than prompt+completion (cached/system tokens),
+        // so ctx can exceed ↑+↓.
+        let usage = ModelTokenUsage(promptTokens: 500, completionTokens: 347, totalTokens: 2_000)
+        XCTAssertEqual(WorkspaceTokenUsageLabelBuilder.label(for: usage), "2k ctx · ↑500 ↓347")
+    }
+
+    func testOnlyPromptOrOnlyCompletion() {
+        XCTAssertEqual(
+            WorkspaceTokenUsageLabelBuilder.label(for: ModelTokenUsage(promptTokens: 120, completionTokens: 0)),
+            "120 ctx · ↑120 ↓0"
+        )
+        XCTAssertEqual(
+            WorkspaceTokenUsageLabelBuilder.label(for: ModelTokenUsage(promptTokens: 0, completionTokens: 90)),
+            "90 ctx · ↑0 ↓90"
+        )
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-29 Top-Bar Token-Usage Chip Pass
+
+Overall grade after this slice: **A surfacing of existing data, A cross-surface parity**.
+
+Surfaces the model's reported token usage as a quiet, non-interactive top-bar chip (`847 ctx · ↑500 ↓347`, tabular digits) — satisfying `docs/CODEX_RESEARCH.md`'s explicit ask for "fixed-width numeric/status zones with tabular digits so token counts never cause layout jitter". Picked by a docs-grounded scout/judge-panel; the data was already parsed but invisible until the context-limit banner tripped.
+
+| Before | After |
+| --- | --- |
+| `ModelTokenUsage` (prompt/completion/total, computed `contextTokens`) was parsed from TrustedRouter and persisted as a `ThreadEvent`, but ONLY fed `WorkspaceContextBannerBuilder`'s show/hide threshold — the user could never see a turn's usage until already near the limit. | A pure `WorkspaceTokenUsageLabelBuilder.label(for:)` formats the chip string (`<ctx> ctx · ↑<in> ↓<out>` with a k/m abbreviator), formatted ONCE so all three surfaces display the same value. `WorkspaceTopBarSurfaceBuilder` populates `TopBarSurface.usageStatusLabel` from the EXISTING `WorkspaceContextBannerBuilder.latestProviderUsage(for: thread)` extractor — no new event parsing, no new git/network call. |
+| — (design choice) | The chip is **derived fresh per-thread** every `surface()` (no captured/tagged state), so unlike the branch chip it has no staleness to guard — switching threads recomputes from that thread's events. It is rendered by the native top bar (chip cloned from the branch chip, announced via the combined accessibility label), the static HTML renderer (`top-bar-usage`), and the JS harness (set on turn completion, cleared on new chat). The cost/dollar half of the original idea was dropped — no price metadata exists, so a figure would be invented. |
+| No coverage. | `WorkspaceTokenUsageLabelBuilderTests` (nil → nil, exact/k/m abbreviator boundaries, prompt-only/completion-only); `WorkspaceTokenUsageIntegrationTests` (chip reflects the selected thread's latest usage event, uses the most recent, nil without an event, derived-per-thread non-bleed across `selectThread`); `WorkspaceTokenUsageChipRenderTests` (Codable round-trip + **legacy-JSON decode without the key**, HTML renderer emits the chip only when set); Playwright surfaces the chip after a turn and clears it on a fresh thread. No new command ID, no interactive control → routing-parity and hit-target audits untouched. |
+| — (review hardening) | The adversarial review caught that the abbreviator chose its unit on the *raw* value, so `999_999` rendered `1000k` (wrong magnitude **and** 5 glyphs that defeat the narrow-chip goal). Fixed in both Swift and JS to roll the unit on the *rounded* value (`999_999` → `1m`, `999_949` → `999.9k`), an all-zero/malformed usage event now **suppresses** the chip (`guard contextTokens > 0`) instead of showing `0 ctx`, and a Playwright test drives the JS abbreviator across the *same* boundary table the Swift test asserts — so the two formatters can't silently drift even though the normal mock flow never reaches the k/m branches. |
+
+Residual risk:
+
+- The chip shows the most recent turn's provider usage, not a running thread total, and `ctx` (= `max(total, in+out)`) can exceed `in+out` when the provider counts cached/system tokens — a compact readout, not a billing breakdown. A running total, a hover tooltip with the split, and a thread-total mode are natural follow-ups. The harness mock estimates tokens (chars/4) for display; only the *format* mirrors native, not the values.
+
 ## 2026-06-29 Copy Conversation (Markdown Export) Pass
 
 Overall grade after this slice: **A reuse of the existing copy path, A single-source serialization**.


### PR DESCRIPTION
## What

Adds a quiet, non-interactive top-bar chip (`847 ctx · ↑500 ↓347`, tabular digits) showing the model's reported token usage — satisfying `docs/CODEX_RESEARCH.md`'s explicit ask for "fixed-width numeric/status zones with tabular digits so token counts never cause layout jitter". `ModelTokenUsage` was already parsed and persisted as a `ThreadEvent` but only fed the context-limit banner threshold; this surfaces it.

## How

- A pure `WorkspaceTokenUsageLabelBuilder.label(for:)` formats the chip string once (k/m abbreviator), so all three surfaces display the same value.
- `WorkspaceTopBarSurfaceBuilder` populates a new `TopBarSurface.usageStatusLabel` from the **existing** `WorkspaceContextBannerBuilder.latestProviderUsage(for: thread)` extractor — no new event parsing, **no new command ID, no interactive control**.
- Derived **fresh per-thread** every `surface()` (no captured state), so unlike the branch chip it has no staleness to guard. Rendered by the native top bar (announced via the combined accessibility label), the HTML renderer (`top-bar-usage`), and the JS harness (set on turn completion, cleared on new chat). The cost/dollar half was dropped — no price metadata exists.

## Adversarial review fixes (shipped here)

The review caught that the abbreviator chose its unit on the *raw* value, so `999_999` rendered `1000k` (wrong magnitude **and** 5 glyphs that defeat the narrow-chip goal). Fixed in both Swift and JS to roll the unit on the *rounded* value (`999_999` → `1m`); an all-zero/malformed usage event now **suppresses** the chip instead of showing `0 ctx`; and a Playwright test drives the JS abbreviator across the *same* boundary table the Swift test asserts, so the two formatters can't silently drift.

## Tests

Label builder (nil/zero suppression, abbreviator boundaries incl. the unit-roll, prompt/completion-only, ctx>↑+↓); integration (per-thread latest usage, most-recent wins, nil without an event, no cross-thread bleed); Codable round-trip + legacy-JSON decode without the key; HTML renderer; Playwright surfaces/clears the chip and pins the JS abbreviator table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)