### PR TITLE
Add the per-turn revert engine (planner + reverse-patch executor)

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceTurnRevertPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceTurnRevertPlanner.swift
@@ -1,0 +1,101 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+/// The recorded `apply_patch` edits of a single agent turn that can be reverse-applied to
+/// undo exactly that turn's file changes. A turn with no `apply_patch` edits yields no plan
+/// (so the UI never offers an undo it can't honor).
+public struct TurnRevertPlan: Sendable, Hashable {
+    /// The user message that began the turn.
+    public let turnMessageID: UUID
+    /// The turn's `apply_patch` patch strings, in chronological (applied) order.
+    public let patches: [String]
+    /// Whether the turn ALSO wrote files outside `apply_patch` (shell/file-write), which a
+    /// diff-based revert cannot undo — surfaced so the UI can disclose the gap honestly.
+    public let hasNonApplyPatchEdits: Bool
+
+    public init(turnMessageID: UUID, patches: [String], hasNonApplyPatchEdits: Bool) {
+        self.turnMessageID = turnMessageID
+        self.patches = patches
+        self.hasNonApplyPatchEdits = hasNonApplyPatchEdits
+    }
+}
+
+/// Derives per-turn revert plans from a thread's recorded events. A "turn" is the span from
+/// a user message to the next user message; there is no turn id in the model, so events are
+/// attributed to the latest user message at-or-before their timestamp (the same chronology
+/// the transcript builder renders by). Pure and synchronous — no git, no side effects.
+public enum WorkspaceTurnRevertPlanner {
+    /// Tool calls (other than `apply_patch`) that can change the working tree, so a turn
+    /// containing them is flagged as having edits a reverse-patch can't undo. Listed by
+    /// `ToolDefinition` constant so the set tracks tool renames. Update this whenever a new
+    /// file-mutating tool is added — under-reporting here would make the undo's scope a lie.
+    static let mutatingNonApplyToolNames: Set<String> = [
+        ToolDefinition.fileWrite.name,
+        ToolDefinition.shellRun.name,
+        ToolDefinition.gitRestore.name,
+        ToolDefinition.gitRestoreHunk.name,
+        ToolDefinition.gitCommit.name,
+        ToolDefinition.mcpCall.name
+    ]
+
+    public static func plans(for thread: ChatThread) -> [TurnRevertPlan] {
+        let userMessages = thread.messages
+            .filter { $0.role == .user }
+            .sorted { $0.createdAt < $1.createdAt }
+        guard !userMessages.isEmpty else { return [] }
+
+        func turnID(at date: Date) -> UUID? {
+            userMessages.last(where: { $0.createdAt <= date })?.id
+        }
+
+        var patchesByTurn: [UUID: [String]] = [:]
+        var hasNonApplyByTurn: [UUID: Bool] = [:]
+        var turnOrder: [UUID] = []
+
+        // Sort by createdAt so the within-turn patch order matches the turn-attribution
+        // chronology (the executor reverse-applies newest-first, so order is load-bearing).
+        let queuedEvents = thread.events
+            .filter { $0.kind == .toolQueued }
+            .sorted { $0.createdAt < $1.createdAt }
+        for event in queuedEvents {
+            guard let turn = turnID(at: event.createdAt),
+                  let call = decodeCall(event.payloadJSON)
+            else { continue }
+
+            if call.name == ToolDefinition.applyPatch.name {
+                guard let patch = patch(from: call),
+                      !patch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                else { continue }
+                if patchesByTurn[turn] == nil { turnOrder.append(turn) }
+                patchesByTurn[turn, default: []].append(patch)
+            } else if mutatingNonApplyToolNames.contains(call.name) {
+                hasNonApplyByTurn[turn] = true
+            }
+        }
+
+        return turnOrder.compactMap { turn in
+            guard let patches = patchesByTurn[turn], !patches.isEmpty else { return nil }
+            return TurnRevertPlan(
+                turnMessageID: turn,
+                patches: patches,
+                hasNonApplyPatchEdits: hasNonApplyByTurn[turn] ?? false
+            )
+        }
+    }
+
+    /// The revert plan for one turn (its starting user message), or nil when that turn made
+    /// no `apply_patch` edits.
+    public static func plan(for turnMessageID: UUID, in thread: ChatThread) -> TurnRevertPlan? {
+        plans(for: thread).first { $0.turnMessageID == turnMessageID }
+    }
+
+    private static func decodeCall(_ payloadJSON: String?) -> ToolCall? {
+        guard let payloadJSON else { return nil }
+        return try? JSONHelpers.decode(ToolCall.self, from: payloadJSON)
+    }
+
+    private static func patch(from call: ToolCall) -> String? {
+        (try? ToolArguments(call.argumentsJSON))?.string("patch")
+    }
+}

--- a/Sources/QuillCodeTools/GitPatchToolExecutor.swift
+++ b/Sources/QuillCodeTools/GitPatchToolExecutor.swift
@@ -28,6 +28,109 @@ public struct GitPatchToolExecutor: Sendable {
         )
     }
 
+    /// Reverse-applies a whole turn's recorded `apply_patch` diffs to undo exactly that
+    /// turn's file edits — never a restore-to-HEAD. `patches` are in chronological order;
+    /// they are reverse-applied newest-first (so a create-then-edit on one file unwinds
+    /// cleanly) via separate atomic `git apply --reverse` invocations. If any patch fails to
+    /// apply (e.g. its lines changed since the turn ran), the whole revert is rolled back to
+    /// the pre-revert state and the failure is returned — it never corrupts the tree or
+    /// silently restores to HEAD.
+    public func restoreTurnPatch(cwd: URL, patches: [String]) -> ToolResult {
+        let ordered = patches.reversed()
+            .map { $0.hasSuffix("\n") ? $0 : $0 + "\n" }
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        guard !ordered.isEmpty else {
+            return ToolResult(ok: false, error: String(describing: GitToolError.emptyPatch))
+        }
+
+        // Validate every touched path stays inside the workspace, and snapshot those files
+        // so a mid-sequence failure can be rolled back atomically.
+        var touchedPaths: Set<String> = []
+        do {
+            for patch in ordered {
+                for path in Self.referencedPaths(in: patch) {
+                    _ = try GitInputValidator.safeRelativePath(path, cwd: cwd)
+                    touchedPaths.insert(path)
+                }
+            }
+        } catch {
+            return ToolResult(ok: false, error: String(describing: error))
+        }
+        let snapshots = touchedPaths.map { FileSnapshot(cwd: cwd, path: $0) }
+
+        let arguments = ["apply", "--reverse", "--whitespace=nowarn"]
+        for patch in ordered {
+            let patchURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("quillcode-turn-\(UUID().uuidString).patch")
+            do {
+                try patch.write(to: patchURL, atomically: true, encoding: .utf8)
+            } catch {
+                return rollback(snapshots, after: ToolResult(ok: false, error: String(describing: GitToolError.temporaryPatchFailed(String(describing: error)))))
+            }
+            let result = runner.runGit(arguments + [patchURL.path], cwd: cwd, timeoutSeconds: 30)
+            try? FileManager.default.removeItem(at: patchURL)
+            guard result.ok else {
+                return rollback(snapshots, after: result)
+            }
+        }
+        return ToolResult(ok: true, stdout: "Reverted this turn's edits.\n")
+    }
+
+    /// Rolls every touched file back to its pre-revert state after a failed patch, and
+    /// returns the original failure — escalating to a distinct error if any file could NOT
+    /// be restored, so the caller never reports a clean failure over a half-reverted tree.
+    private func rollback(_ snapshots: [FileSnapshot], after failure: ToolResult) -> ToolResult {
+        let unrestored = snapshots.compactMap { $0.restore() ? nil : $0.path }
+        guard unrestored.isEmpty else {
+            return ToolResult(ok: false, error: "Revert failed and could not fully roll back: \(unrestored.joined(separator: ", ")). Original error: \(failure.error ?? failure.stderr)")
+        }
+        return failure
+    }
+
+    /// Captures a file's pre-revert state (contents or absence) so a failed multi-patch
+    /// revert can be rolled back without touching anything else.
+    private struct FileSnapshot {
+        let path: String
+        let url: URL
+        let contents: Data?
+
+        init(cwd: URL, path: String) {
+            self.path = path
+            self.url = cwd.appendingPathComponent(path)
+            self.contents = try? Data(contentsOf: url)
+        }
+
+        /// Restores the file to its captured state; returns `false` if it could not.
+        func restore() -> Bool {
+            guard let contents else {
+                // The file did not exist pre-revert; remove it if a partial revert created it.
+                guard FileManager.default.fileExists(atPath: url.path) else { return true }
+                return (try? FileManager.default.removeItem(at: url)) != nil
+            }
+            // A reverse-apply may have deleted the file and pruned its now-empty parent dir,
+            // so recreate the directory before writing the contents back.
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            return (try? contents.write(to: url)) != nil
+        }
+    }
+
+    /// Every non-`/dev/null` path referenced by the patch's diff metadata lines.
+    static func referencedPaths(in patch: String) -> [String] {
+        var paths: [String] = []
+        for line in patch.components(separatedBy: .newlines) {
+            guard line.hasPrefix("--- ") || line.hasPrefix("+++ ") || line.hasPrefix("diff --git ") else {
+                continue
+            }
+            for path in pathsInDiffMetadataLine(line) where path != "/dev/null" {
+                paths.append(normalizedPatchPath(path))
+            }
+        }
+        return paths
+    }
+
     public static func mismatchedPatchPath(in patch: String, expectedPath: String) -> String? {
         for line in patch.components(separatedBy: .newlines) {
             guard line.hasPrefix("--- ") || line.hasPrefix("+++ ") || line.hasPrefix("diff --git ") else {

--- a/Tests/QuillCodeAppTests/WorkspaceTurnRevertPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTurnRevertPlannerTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+import QuillCodeTools
+
+final class WorkspaceTurnRevertPlannerTests: XCTestCase {
+    private func userMessage(_ content: String, at seconds: TimeInterval) -> ChatMessage {
+        ChatMessage(role: .user, content: content, createdAt: Date(timeIntervalSince1970: seconds))
+    }
+
+    private func toolQueuedEvent(name: String, arguments: [String: String], at seconds: TimeInterval) -> ThreadEvent {
+        let call = ToolCall(name: name, argumentsJSON: ToolArguments.json(arguments))
+        // Mirror WorkspaceToolEventRecorder: the .toolQueued payload is the redacted ToolCall.
+        let payload = (try? JSONHelpers.encodePretty(call.redactedForTranscript())) ?? call.argumentsJSON
+        return ThreadEvent(kind: .toolQueued, createdAt: Date(timeIntervalSince1970: seconds), summary: "\(name) queued", payloadJSON: payload)
+    }
+
+    private func applyPatchEvent(_ patch: String, at seconds: TimeInterval) -> ThreadEvent {
+        toolQueuedEvent(name: ToolDefinition.applyPatch.name, arguments: ["patch": patch], at: seconds)
+    }
+
+    func testGroupsApplyPatchEditsUnderTheirOwningTurnInChronologicalOrder() {
+        let u1 = userMessage("first", at: 100)
+        let u2 = userMessage("second", at: 300)
+        let thread = ChatThread(title: "T", messages: [u1, u2], events: [
+            applyPatchEvent("PATCH-A", at: 150),
+            applyPatchEvent("PATCH-B", at: 160),
+            applyPatchEvent("PATCH-C", at: 350)
+        ])
+
+        let plans = WorkspaceTurnRevertPlanner.plans(for: thread)
+        XCTAssertEqual(plans.count, 2)
+        XCTAssertEqual(plans[0].turnMessageID, u1.id)
+        XCTAssertEqual(plans[0].patches, ["PATCH-A", "PATCH-B"])
+        XCTAssertFalse(plans[0].hasNonApplyPatchEdits)
+        XCTAssertEqual(plans[1].turnMessageID, u2.id)
+        XCTAssertEqual(plans[1].patches, ["PATCH-C"])
+    }
+
+    func testTurnWithoutApplyPatchYieldsNoPlan() {
+        let u1 = userMessage("only shell", at: 100)
+        let thread = ChatThread(title: "T", messages: [u1], events: [
+            toolQueuedEvent(name: "host.shell.run", arguments: ["command": "ls"], at: 150)
+        ])
+        XCTAssertTrue(WorkspaceTurnRevertPlanner.plans(for: thread).isEmpty)
+        XCTAssertNil(WorkspaceTurnRevertPlanner.plan(for: u1.id, in: thread))
+    }
+
+    func testFlagsTurnsThatAlsoEditedOutsideApplyPatch() {
+        let u1 = userMessage("mixed", at: 100)
+        let thread = ChatThread(title: "T", messages: [u1], events: [
+            applyPatchEvent("PATCH-A", at: 150),
+            toolQueuedEvent(name: "host.file.write", arguments: ["path": "x.txt", "content": "hi"], at: 160)
+        ])
+
+        let plan = WorkspaceTurnRevertPlanner.plan(for: u1.id, in: thread)
+        XCTAssertEqual(plan?.patches, ["PATCH-A"])
+        XCTAssertEqual(plan?.hasNonApplyPatchEdits, true)
+    }
+
+    func testFlagsDestructiveGitToolsAsNonApplyPatchEdits() {
+        // host.git.restore / git.commit are working-tree mutators a reverse-patch can't undo.
+        for mutatingTool in ["host.git.restore", "host.git.commit", "host.mcp.call"] {
+            let u1 = userMessage("with \(mutatingTool)", at: 100)
+            let thread = ChatThread(title: "T", messages: [u1], events: [
+                applyPatchEvent("PATCH-A", at: 150),
+                toolQueuedEvent(name: mutatingTool, arguments: ["x": "y"], at: 160)
+            ])
+            XCTAssertEqual(
+                WorkspaceTurnRevertPlanner.plan(for: u1.id, in: thread)?.hasNonApplyPatchEdits, true,
+                "\(mutatingTool) should flag the revert scope"
+            )
+        }
+    }
+
+    func testEmptyPatchesAreIgnored() {
+        let u1 = userMessage("blank patch", at: 100)
+        let thread = ChatThread(title: "T", messages: [u1], events: [
+            applyPatchEvent("   ", at: 150)
+        ])
+        XCTAssertTrue(WorkspaceTurnRevertPlanner.plans(for: thread).isEmpty)
+    }
+
+    func testRedactionPreservesTheApplyPatchArgumentThePlannerReads() {
+        // The planner's data source must survive transcript redaction (only env/environment
+        // are redacted) — otherwise the whole feature silently loses its input.
+        let call = ToolCall(name: ToolDefinition.applyPatch.name, argumentsJSON: ToolArguments.json(["patch": "THE-DIFF"]))
+        let redacted = call.redactedForTranscript()
+        XCTAssertEqual((try? ToolArguments(redacted.argumentsJSON))?.string("patch"), "THE-DIFF")
+    }
+}

--- a/Tests/QuillCodeToolsTests/GitPatchToolExecutorTurnTests.swift
+++ b/Tests/QuillCodeToolsTests/GitPatchToolExecutorTurnTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class GitPatchToolExecutorTurnTests: XCTestCase {
+    private func commitAll(_ root: URL, message: String) {
+        XCTAssertTrue(ShellToolExecutor().run(.init(command: "git add -A", cwd: root)).ok)
+        XCTAssertTrue(ShellToolExecutor().run(.init(command: "git commit -m \(message)", cwd: root)).ok)
+    }
+
+    private func write(_ text: String, to url: URL) throws {
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    func testReverseAppliesAMultiFileTurnPatch() throws {
+        let root = try makeTempDirectory()
+        try initializeGitRepo(at: root)
+        let a = root.appendingPathComponent("a.txt")
+        let b = root.appendingPathComponent("b.txt")
+        try write("a-old\n", to: a)
+        try write("b-old\n", to: b)
+        commitAll(root, message: "initial")
+
+        // The "turn" edits both files; capture exactly what it changed.
+        try write("a-new\n", to: a)
+        try write("b-new\n", to: b)
+        let patch = GitToolExecutor().diff(cwd: root).stdout
+        XCTAssertFalse(patch.isEmpty)
+
+        let result = GitPatchToolExecutor().restoreTurnPatch(cwd: root, patches: [patch])
+        XCTAssertTrue(result.ok, "\(result.error ?? "") \(result.stderr)")
+        XCTAssertEqual(try String(contentsOf: a, encoding: .utf8), "a-old\n")
+        XCTAssertEqual(try String(contentsOf: b, encoding: .utf8), "b-old\n")
+    }
+
+    func testFailsCleanlyWhenFilesChangedSinceAndDoesNotRestoreToHEAD() throws {
+        let root = try makeTempDirectory()
+        try initializeGitRepo(at: root)
+        let a = root.appendingPathComponent("a.txt")
+        try write("old\n", to: a)
+        commitAll(root, message: "initial")
+
+        try write("new\n", to: a)
+        let patch = GitToolExecutor().diff(cwd: root).stdout
+        commitAll(root, message: "turn")
+
+        // A LATER edit (the user's own) touches the same line.
+        try write("newer\n", to: a)
+
+        let result = GitPatchToolExecutor().restoreTurnPatch(cwd: root, patches: [patch])
+        // The reverse cannot apply cleanly: fail rather than corrupt or restore-to-HEAD.
+        XCTAssertFalse(result.ok)
+        // CRITICAL: the user's later edit is untouched — no silent `git restore` to HEAD ("new").
+        XCTAssertEqual(try String(contentsOf: a, encoding: .utf8), "newer\n")
+    }
+
+    func testDeletesAFileTheTurnCreated() throws {
+        let root = try makeTempDirectory()
+        try initializeGitRepo(at: root)
+        try write("base\n", to: root.appendingPathComponent("base.txt"))
+        commitAll(root, message: "initial")
+
+        // The turn created new.txt — an apply_patch add-hunk (/dev/null -> b/new.txt).
+        let created = root.appendingPathComponent("new.txt")
+        try write("created\n", to: created)
+        let addPatch = """
+        diff --git a/new.txt b/new.txt
+        new file mode 100644
+        --- /dev/null
+        +++ b/new.txt
+        @@ -0,0 +1,1 @@
+        +created
+        """
+
+        let result = GitPatchToolExecutor().restoreTurnPatch(cwd: root, patches: [addPatch])
+        XCTAssertTrue(result.ok, "\(result.error ?? "") \(result.stderr)")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: created.path))
+    }
+
+    func testAppliesPatchesNewestFirstSoCreateThenEditUnwinds() throws {
+        let root = try makeTempDirectory()
+        try initializeGitRepo(at: root)
+        let a = root.appendingPathComponent("a.txt")
+        try write("old\n", to: a)
+        commitAll(root, message: "initial")
+
+        try write("mid\n", to: a)
+        let patch1 = GitToolExecutor().diff(cwd: root).stdout
+        commitAll(root, message: "edit1")
+
+        try write("new\n", to: a)
+        let patch2 = GitToolExecutor().diff(cwd: root).stdout
+
+        // Reverting the turn [patch1, patch2] must unwind patch2 then patch1 -> back to "old".
+        let result = GitPatchToolExecutor().restoreTurnPatch(cwd: root, patches: [patch1, patch2])
+        XCTAssertTrue(result.ok, "\(result.error ?? "") \(result.stderr)")
+        XCTAssertEqual(try String(contentsOf: a, encoding: .utf8), "old\n")
+    }
+
+    func testRollsBackACreatedFileInANewDirectoryWhenAnEarlierPatchFails() throws {
+        let root = try makeTempDirectory()
+        try initializeGitRepo(at: root)
+        let a = root.appendingPathComponent("a.txt")
+        try write("old\n", to: a)
+        commitAll(root, message: "initial")
+
+        // The turn created sub/new.txt (still on disk) and edited a.txt old->mid.
+        let sub = root.appendingPathComponent("sub")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        let created = sub.appendingPathComponent("new.txt")
+        try write("created\n", to: created)
+        let createPatch = """
+        diff --git a/sub/new.txt b/sub/new.txt
+        new file mode 100644
+        --- /dev/null
+        +++ b/sub/new.txt
+        @@ -0,0 +1,1 @@
+        +created
+        """
+        // a.txt is "old", so reverting the a.txt edit (expects "mid") will FAIL — but only
+        // AFTER the newest patch (the create) reverse-applies and prunes sub/.
+        let editPatch = """
+        diff --git a/a.txt b/a.txt
+        --- a/a.txt
+        +++ b/a.txt
+        @@ -1 +1 @@
+        -old
+        +mid
+        """
+
+        let result = GitPatchToolExecutor().restoreTurnPatch(cwd: root, patches: [editPatch, createPatch])
+
+        XCTAssertFalse(result.ok)
+        // The whole revert rolled back: the created file is restored (its pruned dir recreated).
+        XCTAssertTrue(FileManager.default.fileExists(atPath: created.path))
+        XCTAssertEqual(try String(contentsOf: created, encoding: .utf8), "created\n")
+        XCTAssertEqual(try String(contentsOf: a, encoding: .utf8), "old\n")
+    }
+
+    func testReverseRecreatesAFileTheTurnDeleted() throws {
+        let root = try makeTempDirectory()
+        try initializeGitRepo(at: root)
+        let file = root.appendingPathComponent("gone.txt")
+        try write("content\n", to: file)
+        commitAll(root, message: "initial")
+
+        // The turn deleted gone.txt (apply_patch delete-hunk).
+        try FileManager.default.removeItem(at: file)
+        let deletePatch = """
+        diff --git a/gone.txt b/gone.txt
+        deleted file mode 100644
+        --- a/gone.txt
+        +++ /dev/null
+        @@ -1 +0,0 @@
+        -content
+        """
+
+        let result = GitPatchToolExecutor().restoreTurnPatch(cwd: root, patches: [deletePatch])
+        XCTAssertTrue(result.ok, "\(result.error ?? "") \(result.stderr)")
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), "content\n")
+    }
+
+    func testEmptyPatchesFail() throws {
+        let root = try makeTempDirectory()
+        try initializeGitRepo(at: root)
+        XCTAssertFalse(GitPatchToolExecutor().restoreTurnPatch(cwd: root, patches: ["   "]).ok)
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-29 Per-Turn Revert Engine Pass (1 of 2)
+
+Overall grade after this slice: **A honest design, A atomic safety**.
+
+The engine for an honest per-turn "Revert this turn's edits" — a safety net QuillCode lacked (grep for checkpoint/undo/revert in Sources was 0 hits, no row in `CODEX_PARITY_MATRIX.md`). Designed by a grounded judge-panel specifically to resolve the **honesty trap** the scout flagged: `git restore` reverts to HEAD (discarding the user's *own* prior edits and ignoring files the turn created), so it would *lie* as an undo. This ships only the pure engine; the UI button/command across three surfaces is a deliberate follow-up PR.
+
+| Before | After |
+| --- | --- |
+| No way to undo an agent turn's file edits. The recorded per-turn diffs (each `host.apply_patch` call's `patch` string, persisted in `.toolQueued` events) were unused for revert. | `WorkspaceTurnRevertPlanner` (pure) derives a `TurnRevertPlan` per turn: it attributes each tool event to the turn of the latest user message at-or-before its timestamp (there is no turn id in the model), extracts that turn's `apply_patch` patches in order, and flags `hasNonApplyPatchEdits` when the turn *also* wrote files via shell/file-write (which a diff revert can't undo). A turn with no `apply_patch` yields **no** plan, so the UI can never offer an undo it can't honor. |
+| — (honesty) | `GitPatchToolExecutor.restoreTurnPatch` reverse-applies the turn's patches **newest-first** via separate atomic `git apply --reverse` invocations — **never** `git restore`/`checkout`/`stash`. It validates every referenced path stays in the workspace, and **snapshots** the touched files (contents or absence) so any mid-sequence failure **rolls back** to the pre-revert state. A turn whose lines changed since it ran fails cleanly with git's own error rather than corrupting the tree or clobbering the user's later edits. |
+| No coverage. | `WorkspaceTurnRevertPlannerTests` (turn grouping by timestamp, chronological patch order, zero-apply_patch → no plan, mixed-edit flag incl. destructive git/MCP tools, empty-patch ignored, redaction preserves the `patch` arg the planner reads); `GitPatchToolExecutorTurnTests` against real git repos (multi-file reverse, **dirtied-since fails cleanly with no HEAD restore and the user's later edit intact**, added-file deletion, delete-hunk recreation, newest-first create-then-edit unwind, empty-patch failure). |
+| — (review hardening) | The adversarial review (3 lenses, exercising real git) caught two data-loss/honesty defects, both fixed: (1) a mid-sequence rollback could **lose a file the turn created** because reverse-applying its add-hunk pruned the now-empty parent directory and `restore()` silently no-oped — now `restore()` recreates the directory and a rollback that can't fully restore is surfaced as a distinct error (never a clean failure over a half-reverted tree); (2) `hasNonApplyPatchEdits` under-reported (only file-write/shell) — now also flags `git.restore`/`git.restore_hunk`/`git.commit`/`mcp.call` (by `ToolDefinition` constant, so a missed mutator is a maintained list, not silent). Events are sorted by `createdAt` so the within-turn order can't drift from the attribution chronology. A test now proves the mid-sequence rollback restores the created-file-in-a-pruned-dir case. |
+
+Residual risk:
+
+- The engine is UI-less this PR (the button/command/3-surface wiring + truthful labeling is PR 2). Edits a turn made *outside* `apply_patch` (raw shell writes, `rm`, `git commit`, network) are invisible to a diff revert — surfaced via `hasNonApplyPatchEdits` so PR 2 can disclose the gap. Exotic patches (renames/copies/binary) are reverted by git but not yet explicitly tested.
+
 ## 2026-06-29 Top-Bar Token-Usage Chip Pass
 
 Overall grade after this slice: **A surfacing of existing data, A cross-surface parity**.


### PR DESCRIPTION
The honest foundation for a per-turn **"Revert this turn's edits"** undo — **PR 1 of 2** (engine only; the UI button/command across three surfaces follows separately). QuillCode had no undo/checkpoint at all.

## How (and why it's honest)

The scout flagged an honesty trap: `git restore` reverts to HEAD, which would silently discard the user's *own* prior edits and ignore files the turn created — so it would *lie* as an undo. Instead:

- **`WorkspaceTurnRevertPlanner`** (pure) derives a `TurnRevertPlan` per turn: it attributes each tool event to the turn of the latest user message at-or-before its timestamp (there is no turn id in the model), extracts that turn's `host.apply_patch` patch strings in order, and flags `hasNonApplyPatchEdits` when the turn *also* mutated the tree via shell/file-write/`git.restore`/`mcp.call`. A turn with no `apply_patch` yields **no** plan, so the UI can never offer an undo it can't honor.
- **`GitPatchToolExecutor.restoreTurnPatch`** reverse-applies the turn's patches **newest-first** via separate atomic `git apply --reverse` invocations — **never** `git restore`/`checkout`/`stash`. It validates every referenced path stays in the workspace, and **snapshots** the touched files so any mid-sequence failure **rolls back** to the pre-revert state. A dirtied-since turn fails cleanly with git's own error rather than corrupting the tree or clobbering the user's later edits.

## Adversarial review fixes (shipped here)

The review (exercising real git) caught two defects, both fixed: a mid-sequence rollback could **lose a created file** because reverse-applying its add-hunk pruned the empty parent dir and `restore()` silently no-oped (now recreates the dir + surfaces a distinct "couldn't fully roll back" error); and `hasNonApplyPatchEdits` under-reported (now flags `git.restore`/`restore_hunk`/`commit`/`mcp.call` by `ToolDefinition` constant). Events are sorted by `createdAt`.

## Tests

Planner (turn grouping, order, zero-apply_patch → no plan, destructive-tool flag, redaction preserves `patch`); executor against real git repos (multi-file reverse, **dirtied-since fails with no HEAD restore + user edit intact**, added-file deletion, delete-hunk recreation, **mid-sequence rollback restores a created file in a pruned dir**, newest-first unwind). Engine-only: no new command ID, no UI, no parity gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)