### PR TITLE
Add the "Revert this turn's edits" button (revert UI across 3 surfaces)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -6088,6 +6088,11 @@
         if (!message || message.role !== 'user') return '';
         return `<button type="button" class="transcript-feedback-button hit-target-text" data-testid="message-use-as-draft" data-message-id="${escapeHTML(message.id || '')}" aria-label="Use as draft">Use as draft</button>`;
       };
+      const revertButton = message => {
+        if (!message || !message.revert) return '';
+        const scope = revertScopeCopy(message.revert.hasNonApplyPatchEdits);
+        return `<button type="button" class="transcript-feedback-button hit-target-text" data-testid="message-revert-turn" data-turn-id="${escapeHTML(message.revert.turnMessageID || message.id || '')}" title="${escapeHTML(scope)}" aria-label="Revert this turn's edits">Revert this turn's edits</button>`;
+      };
       const retryButton = message => {
         const retryCommand = state.commands.find(command => command.id === 'retry-last-turn' && command.isEnabled);
         if (!message || message.role !== 'assistant' || message.id !== latestAssistantMessageID || !retryCommand) return '';
@@ -6096,7 +6101,7 @@
       const renderMessage = (message, timelineID = '') => `
         <article class="message ${escapeHTML(message.role)}${activeClass(timelineID)}" data-testid="message" data-timeline-id="${escapeHTML(timelineID)}" aria-label="${escapeHTML(message.role + ': ' + message.text)}">
           <p>${escapeHTML(message.text)}</p>
-          ${copyButton('message-copy', timelineID || message.id || `message-${message.text}`, 'Copy', draftButton(message) + retryButton(message) + feedbackButtons(message))}
+          ${copyButton('message-copy', timelineID || message.id || `message-${message.text}`, 'Copy', draftButton(message) + revertButton(message) + retryButton(message) + feedbackButtons(message))}
         </article>`;
       const thinkingTraceLines = () => state.transcript.toolCards
         .filter(card => ['queued', 'running', 'review'].includes(card.status))
@@ -6707,6 +6712,11 @@
       document.querySelectorAll('[data-testid="message-use-as-draft"]').forEach(button => {
         button.addEventListener('click', event => {
           useMessageAsDraft(event.currentTarget.getAttribute('data-message-id'));
+        });
+      });
+      document.querySelectorAll('[data-testid="message-revert-turn"]').forEach(button => {
+        button.addEventListener('click', event => {
+          runMockTurnRevert(event.currentTarget.getAttribute('data-turn-id'));
         });
       });
       document.querySelectorAll('[data-testid="empty-starter-action"]').forEach(button => {
@@ -8085,6 +8095,28 @@
       const message = state.transcript.messages.find(entry => entry.id === messageID && entry.role === 'user');
       if (!message) return;
       usePromptAsDraft(message.text || '');
+    }
+
+    // Mirrors TurnRevertCopy.scope (Swift) byte-for-byte so all three surfaces make the
+    // same truthful claim about what the revert does and does not undo.
+    function revertScopeCopy(hasNonApplyPatchEdits) {
+      let text = "Reverses the file edits this turn applied, including files it created. It does not undo your own earlier edits, shell commands the turn ran, or git commits.";
+      if (hasNonApplyPatchEdits) {
+        text += " This turn also changed files outside apply_patch, which can't be reverted automatically.";
+      }
+      return text;
+    }
+
+    function runMockTurnRevert(turnID) {
+      addToolCard({
+        title: 'host.git.revert_turn',
+        subtitle: 'Completed',
+        status: 'done',
+        inputJSON: JSON.stringify({ turnId: turnID }, null, 2),
+        outputJSON: JSON.stringify({ ok: true, stdout: "Reverted this turn's edits.\n" }, null, 2)
+      });
+      addMessage('assistant', "Reverted this turn's edits.");
+      render();
     }
 
     function usePromptAsDraft(prompt) {
@@ -13482,6 +13514,11 @@
           outputJSON: JSON.stringify({ ok: true, stdout: diff }, null, 2)
         });
         addMessage('assistant', 'Patch applied. Review the resulting diff below.');
+        // The turn applied an apply_patch, so its user message can be reverted.
+        const lastUserMessage = [...state.transcript.messages].reverse().find(message => message.role === 'user');
+        if (lastUserMessage) {
+          lastUserMessage.revert = { turnMessageID: lastUserMessage.id, hasNonApplyPatchEdits: false };
+        }
       } else if (/^\/(diff|changes)\b/i.test(text)) {
         runGitDiffAction();
         return;

--- a/E2E/playwright/tests/revert.spec.ts
+++ b/E2E/playwright/tests/revert.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+test('mock harness reverts a turn from its user message', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  // A turn that applies a patch becomes revertable.
+  await page.getByLabel('Message').fill('apply patch to fix the bug');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('tool-card-title').filter({ hasText: 'host.apply_patch' })).toBeVisible();
+
+  // The user message that started the turn gets a truthful "Revert this turn's edits" button.
+  const revert = page.getByTestId('message-revert-turn');
+  await expect(revert).toBeVisible();
+  await expect(revert).toHaveText("Revert this turn's edits");
+  await expect(revert).toHaveAttribute('title', /does not undo your own earlier edits/);
+
+  // Clicking it runs the revert as a recorded tool run.
+  await revert.click();
+  await expect(page.getByTestId('tool-card-title').last()).toHaveText('host.git.revert_turn');
+});
+
+test('mock harness revert scope copy matches the Swift TurnRevertCopy byte-for-byte', async ({ page }) => {
+  await page.goto(harnessURL());
+  // Drives the JS revertScopeCopy against the SAME two literals asserted in
+  // WorkspaceTurnRevertSurfaceTests, so the truthful copy can't drift across Swift and JS.
+  const copies = await page.evaluate(() => {
+    const scope = (window as Window & { revertScopeCopy?: (b: boolean) => string }).revertScopeCopy;
+    return { clean: scope?.(false), disclosed: scope?.(true) };
+  });
+  expect(copies.clean).toBe(
+    'Reverses the file edits this turn applied, including files it created. It does not undo your own earlier edits, shell commands the turn ran, or git commits.'
+  );
+  expect(copies.disclosed).toBe(
+    "Reverses the file edits this turn applied, including files it created. It does not undo your own earlier edits, shell commands the turn ran, or git commits. This turn also changed files outside apply_patch, which can't be reverted automatically."
+  );
+});
+
+test('mock harness shows no revert button on a turn that applied no patch', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('what does this project do?');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('message').first()).toContainText('what does this project do?');
+
+  await expect(page.getByTestId('message-revert-turn')).toHaveCount(0);
+});

--- a/Sources/QuillCodeApp/QuillCodeTranscriptMessageView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptMessageView.swift
@@ -10,6 +10,7 @@ struct QuillCodeMessageBubble: View {
     var canRetry: Bool
     var onRetry: () -> Void
     var onFeedback: (MessageFeedbackValue) -> Void
+    var onRevertTurn: (UUID) -> Void = { _ in }
 
     var body: some View {
         HStack {
@@ -36,6 +37,13 @@ struct QuillCodeMessageBubble: View {
                     if message.role == .user {
                         QuillCodeMessageDraftButton(action: onUseAsDraft)
                             .accessibilityIdentifier("message-use-as-draft")
+                        if let revert = message.revert {
+                            QuillCodeMessageRevertButton(
+                                hasNonApplyPatchEdits: revert.hasNonApplyPatchEdits,
+                                action: { onRevertTurn(revert.turnMessageID) }
+                            )
+                            .accessibilityIdentifier("message-revert-turn")
+                        }
                     }
                     if message.role == .assistant {
                         if canRetry {
@@ -90,6 +98,27 @@ private struct QuillCodeMessageDraftButton: View {
         }
         .buttonStyle(QuillCodePressableButtonStyle())
         .help("Use as draft")
+    }
+}
+
+private struct QuillCodeMessageRevertButton: View {
+    var hasNonApplyPatchEdits: Bool
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(TurnRevertCopy.buttonTitle, systemImage: "arrow.uturn.backward")
+                .labelStyle(.iconOnly)
+                .font(.caption2.weight(.semibold))
+                .quillCodeIconButtonTarget(radius: QuillCodeMetrics.minimumHitTarget / 2)
+                .foregroundStyle(QuillCodePalette.red)
+                .background(QuillCodePalette.red.opacity(0.14))
+                .clipShape(Capsule())
+        }
+        .buttonStyle(QuillCodePressableButtonStyle())
+        .help(TurnRevertCopy.buttonTitle + ". " + TurnRevertCopy.scope(hasNonApplyPatchEdits: hasNonApplyPatchEdits))
+        .accessibilityLabel(TurnRevertCopy.buttonTitle)
+        .accessibilityHint(TurnRevertCopy.scope(hasNonApplyPatchEdits: hasNonApplyPatchEdits))
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -257,13 +257,44 @@ public struct MessageSurface: Codable, Sendable, Hashable, Identifiable {
     public var text: String
     public var accessibilityLabel: String
     public var feedback: MessageFeedbackValue?
+    /// Present on the user message that began a turn whose `apply_patch` edits can be
+    /// reverted, so the UI can offer a "Revert this turn's edits" affordance there.
+    public var revert: MessageRevertSurface?
 
-    public init(message: ChatMessage, feedback: MessageFeedbackValue? = nil) {
+    public init(message: ChatMessage, feedback: MessageFeedbackValue? = nil, revert: MessageRevertSurface? = nil) {
         self.id = message.id
         self.role = message.role
         self.text = message.content
         self.accessibilityLabel = "\(message.role.rawValue): \(message.content)"
         self.feedback = feedback
+        self.revert = revert
+    }
+}
+
+/// The revert affordance for a turn: which turn to revert, and whether the turn also made
+/// edits outside `apply_patch` (so the UI can disclose what the revert cannot undo).
+public struct MessageRevertSurface: Codable, Sendable, Hashable {
+    public var turnMessageID: UUID
+    public var hasNonApplyPatchEdits: Bool
+
+    public init(turnMessageID: UUID, hasNonApplyPatchEdits: Bool) {
+        self.turnMessageID = turnMessageID
+        self.hasNonApplyPatchEdits = hasNonApplyPatchEdits
+    }
+}
+
+/// The single source of truth for the revert affordance's user-facing copy, so the native,
+/// HTML, and harness surfaces make byte-identical, truthful claims about what a reverse-patch
+/// revert does and does NOT undo.
+public enum TurnRevertCopy {
+    public static let buttonTitle = "Revert this turn's edits"
+
+    public static func scope(hasNonApplyPatchEdits: Bool) -> String {
+        var text = "Reverses the file edits this turn applied, including files it created. It does not undo your own earlier edits, shell commands the turn ran, or git commits."
+        if hasNonApplyPatchEdits {
+            text += " This turn also changed files outside apply_patch, which can't be reverted automatically."
+        }
+        return text
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -22,6 +22,7 @@ struct QuillCodeTranscriptView: View {
     var onToolCardAction: (ToolCardActionSurface) -> Void
     var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     var onCopyTranscriptItem: (String, String) -> Void
+    var onRevertTurn: (UUID) -> Void = { _ in }
     var onUseMessageAsDraft: (String) -> Void
     var onSubmitStarterAction: (String) -> Void
     var onMessageFeedback: (UUID, MessageFeedbackValue) -> Void
@@ -165,7 +166,8 @@ struct QuillCodeTranscriptView: View {
                         },
                         onFeedback: { value in
                             onMessageFeedback(message.id, value)
-                        }
+                        },
+                        onRevertTurn: onRevertTurn
                     )
                 }
             case .toolCard:

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -32,6 +32,7 @@ struct QuillCodeWorkspaceMainPaneView: View {
     var onToolCardAction: (ToolCardActionSurface) -> Void
     var onAddReviewComment: (String, Int?, Int?, WorkspaceReviewLineKind?, String) -> Void
     var onCopyTranscriptItem: (String, String) -> Void
+    var onRevertTurn: (UUID) -> Void = { _ in }
     var onMessageFeedback: (UUID, MessageFeedbackValue) -> Void
     var onCommand: (WorkspaceCommandSurface) -> Void
 
@@ -67,6 +68,7 @@ struct QuillCodeWorkspaceMainPaneView: View {
                         onToolCardAction: onToolCardAction,
                         onAddReviewComment: onAddReviewComment,
                         onCopyTranscriptItem: onCopyTranscriptItem,
+                        onRevertTurn: onRevertTurn,
                         onUseMessageAsDraft: useMessageAsDraft,
                         onSubmitStarterAction: submitStarterAction,
                         onMessageFeedback: onMessageFeedback

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -174,6 +174,7 @@ enum WorkspaceHTMLTranscriptRenderer {
                     attributes: [("data-copy-id", item.id)]
                 ))
                 \(renderMessageDraftAction(message))
+                \(renderMessageRevertAction(message))
                 \(renderMessageRetryAction(message, latestAssistantMessageID: latestAssistantMessageID, command: retryLastTurnCommand))
                 \(renderMessageFeedbackActions(message))
               </footer>
@@ -215,6 +216,19 @@ enum WorkspaceHTMLTranscriptRenderer {
             "Use as draft",
             testID: "message-use-as-draft",
             attributes: [("data-message-id", message.id.uuidString)]
+        )
+    }
+
+    private static func renderMessageRevertAction(_ message: MessageSurface) -> String {
+        guard let revert = message.revert else { return "" }
+        return WorkspaceHTMLPrimitives.button(
+            TurnRevertCopy.buttonTitle,
+            testID: "message-revert-turn",
+            ariaLabel: TurnRevertCopy.buttonTitle,
+            attributes: [
+                ("data-turn-id", revert.turnMessageID.uuidString),
+                ("title", TurnRevertCopy.scope(hasNonApplyPatchEdits: revert.hasNonApplyPatchEdits))
+            ]
         )
     }
 

--- a/Sources/QuillCodeApp/WorkspaceModelContext.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelContext.swift
@@ -35,7 +35,7 @@ extension QuillCodeWorkspaceModel {
 
     public var currentTimelineItems: [TranscriptTimelineItemSurface] {
         guard let selectedThread else { return [] }
-        let items = WorkspaceTranscriptSurfaceBuilder(thread: selectedThread).timelineItems()
+        let items = WorkspaceTranscriptSurfaceBuilder(thread: selectedThread, allowsRevert: selectedProject?.isRemote != true).timelineItems()
         return executionContextSurfaceBuilder.enrichTimelineItems(items, for: selectedThread)
     }
 

--- a/Sources/QuillCodeApp/WorkspaceModelTurnRevert.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelTurnRevert.swift
@@ -1,0 +1,54 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+@MainActor
+public extension QuillCodeWorkspaceModel {
+    /// Reverts a turn's `apply_patch` edits via the honest reverse-patch engine, records the
+    /// result as a transcript tool run, and — on success — refreshes the diff so the review
+    /// pane reflects the reverted tree. Returns whether the revert applied. Never restores
+    /// to HEAD; a turn whose lines changed since fails with the engine's own message.
+    @discardableResult
+    func runTurnRevert(turnMessageID: UUID, workspaceRoot: URL) -> Bool {
+        // Reverting reverse-applies the patch with LOCAL git, so it cannot operate on a
+        // remote project's tree — refuse rather than touch the wrong (local) directory.
+        guard selectedProject?.isRemote != true else {
+            setLastError("Reverting a turn is only supported for local projects.")
+            refreshTopBar(agentStatus: TopBarAgentStatusLabel.failed)
+            return false
+        }
+
+        guard let thread = selectedThread,
+              let plan = WorkspaceTurnRevertPlanner.plan(for: turnMessageID, in: thread)
+        else {
+            setLastError("This turn can no longer be reverted.")
+            refreshTopBar(agentStatus: TopBarAgentStatusLabel.failed)
+            return false
+        }
+
+        setLastError(nil)
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.running)
+
+        let result = GitPatchToolExecutor().restoreTurnPatch(cwd: workspaceRoot, patches: plan.patches)
+        // Record the revert as a transcript tool run so it is visible and itself revertible.
+        let revertCall = ToolCall(name: "host.git.revert_turn", argumentsJSON: "{}")
+        mutateSelectedThread { thread in
+            WorkspaceToolEventRecorder.append(call: revertCall, result: result, to: &thread)
+        }
+
+        if result.ok {
+            _ = runToolCall(
+                ToolCall(name: ToolDefinition.gitDiff.name, argumentsJSON: "{}"),
+                workspaceRoot: workspaceRoot
+            )
+        } else {
+            setLastError(result.error ?? "Could not cleanly revert this turn — files changed since it ran.")
+            refreshTopBar(agentStatus: TopBarAgentStatusLabel.failed)
+        }
+
+        if let thread = selectedThread {
+            threadPersistence.save(thread)
+        }
+        return result.ok
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -119,7 +119,7 @@ public extension QuillCodeWorkspaceModel {
             projects: navigation.projects,
             sidebar: navigation.sidebar,
             transcript: TranscriptSurface(
-                messages: thread.map { WorkspaceTranscriptSurfaceBuilder(thread: $0).messageSurfaces() } ?? [],
+                messages: thread.map { WorkspaceTranscriptSurfaceBuilder(thread: $0, allowsRevert: selectedProject?.isRemote != true).messageSurfaces() } ?? [],
                 toolCards: toolCards,
                 timelineItems: thread == nil ? nil : currentTimelineItems,
                 thinking: WorkspaceTranscriptThinkingSurfaceBuilder(

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -46,6 +46,7 @@ public struct QuillCodeWorkspaceView: View {
     public var onPreviewWorktreePrune: () async -> WorkspaceWorktreePrunePreview
     public var onPruneWorktrees: (WorkspaceWorktreePruneRequest) -> Void
     public var onCopyTranscriptItem: (String, String) -> Void
+    public var onRevertTurn: (UUID) -> Void = { _ in }
     public var onMessageFeedback: (UUID, MessageFeedbackValue) -> Void
     public var onSaveSidebarSavedSearch: (String, String) -> Void
     public var onCommand: (WorkspaceCommandSurface) -> Void
@@ -108,6 +109,7 @@ public struct QuillCodeWorkspaceView: View {
         onPreviewWorktreePrune: @escaping () async -> WorkspaceWorktreePrunePreview = { WorkspaceWorktreePrunePreview() },
         onPruneWorktrees: @escaping (WorkspaceWorktreePruneRequest) -> Void = { _ in },
         onCopyTranscriptItem: @escaping (String, String) -> Void = { _, _ in },
+        onRevertTurn: @escaping (UUID) -> Void = { _ in },
         onMessageFeedback: @escaping (UUID, MessageFeedbackValue) -> Void = { _, _ in },
         onSaveSidebarSavedSearch: @escaping (String, String) -> Void = { _, _ in },
         onCommand: @escaping (WorkspaceCommandSurface) -> Void
@@ -155,6 +157,7 @@ public struct QuillCodeWorkspaceView: View {
         self.onPreviewWorktreePrune = onPreviewWorktreePrune
         self.onPruneWorktrees = onPruneWorktrees
         self.onCopyTranscriptItem = onCopyTranscriptItem
+        self.onRevertTurn = onRevertTurn
         self.onMessageFeedback = onMessageFeedback
         self.onSaveSidebarSavedSearch = onSaveSidebarSavedSearch
         self.onCommand = onCommand
@@ -214,6 +217,7 @@ public struct QuillCodeWorkspaceView: View {
                     onToolCardAction: onToolCardAction,
                     onAddReviewComment: onAddReviewComment,
                     onCopyTranscriptItem: onCopyTranscriptItem,
+                    onRevertTurn: onRevertTurn,
                     onMessageFeedback: onMessageFeedback,
                     onCommand: handleCommand
                 )

--- a/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
@@ -3,14 +3,30 @@ import QuillCodeCore
 
 struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
     var thread: ChatThread
+    /// Whether to offer per-turn revert affordances. False for remote projects, where the
+    /// reverse-patch engine (local `git apply`) cannot operate on the remote tree.
+    var allowsRevert: Bool = true
 
     func messageSurfaces() -> [MessageSurface] {
         let feedbackByMessageID = Self.messageFeedbackByMessageID(for: thread)
+        let revertByMessageID = allowsRevert ? Self.revertByMessageID(for: thread) : [:]
         return thread.messages
             .filter { $0.role != .tool }
             .map { message in
-                MessageSurface(message: message, feedback: feedbackByMessageID[message.id])
+                MessageSurface(message: message, feedback: feedbackByMessageID[message.id], revert: revertByMessageID[message.id])
             }
+    }
+
+    /// Maps each revertable turn's starting user-message id to its revert affordance.
+    static func revertByMessageID(for thread: ChatThread) -> [UUID: MessageRevertSurface] {
+        var map: [UUID: MessageRevertSurface] = [:]
+        for plan in WorkspaceTurnRevertPlanner.plans(for: thread) {
+            map[plan.turnMessageID] = MessageRevertSurface(
+                turnMessageID: plan.turnMessageID,
+                hasNonApplyPatchEdits: plan.hasNonApplyPatchEdits
+            )
+        }
+        return map
     }
 
     func toolCards() -> [ToolCardState] {
@@ -29,6 +45,7 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         }
 
         let feedbackByMessageID = Self.messageFeedbackByMessageID(for: thread)
+        let revertByMessageID = allowsRevert ? Self.revertByMessageID(for: thread) : [:]
         var consumedMessageIDs = Set<UUID>()
         var reducer = WorkspaceToolCardEventReducer<[TranscriptTimelineItemSurface]>.timeline()
 
@@ -39,7 +56,7 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
                 return
             }
             consumedMessageIDs.insert(message.id)
-            reducer.state.append(.message(MessageSurface(message: message, feedback: feedbackByMessageID[message.id])))
+            reducer.state.append(.message(MessageSurface(message: message, feedback: feedbackByMessageID[message.id], revert: revertByMessageID[message.id])))
         }
 
         for event in thread.events {
@@ -54,7 +71,7 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         }
 
         for message in thread.messages where message.role != .tool && !consumedMessageIDs.contains(message.id) {
-            reducer.state.append(.message(MessageSurface(message: message, feedback: feedbackByMessageID[message.id])))
+            reducer.state.append(.message(MessageSurface(message: message, feedback: feedbackByMessageID[message.id], revert: revertByMessageID[message.id])))
         }
         return reducer.state
     }

--- a/Sources/QuillCodeApp/WorkspaceTurnRevertPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceTurnRevertPlanner.swift
@@ -36,7 +36,9 @@ public enum WorkspaceTurnRevertPlanner {
         ToolDefinition.gitRestore.name,
         ToolDefinition.gitRestoreHunk.name,
         ToolDefinition.gitCommit.name,
-        ToolDefinition.mcpCall.name
+        ToolDefinition.mcpCall.name,
+        // A prior revert mutates the tree outside apply_patch too.
+        "host.git.revert_turn"
     ]
 
     public static func plans(for thread: ChatThread) -> [TurnRevertPlan] {

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -101,6 +101,7 @@ struct QuillCodeDesktopRootView: View {
             onPreviewWorktreePrune: controller.worktreePrunePreview,
             onPruneWorktrees: controller.pruneWorktrees,
             onCopyTranscriptItem: controller.copyTranscriptItem,
+            onRevertTurn: controller.runTurnRevert,
             onMessageFeedback: controller.setMessageFeedback,
             onSaveSidebarSavedSearch: controller.saveSidebarSavedSearch,
             onCommand: controller.runCommand

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -279,6 +279,11 @@ final class QuillCodeDesktopController: ObservableObject {
         refresh()
     }
 
+    func runTurnRevert(_ turnMessageID: UUID) {
+        workspaceActionCoordinator.runTurnRevert(turnMessageID: turnMessageID, model: model, fallbackWorkspaceRoot: workspaceRoot)
+        refresh()
+    }
+
     func runTerminalCommand() {
         terminalCoordinator.runCommand(
             draft: &terminalDraft,

--- a/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceActionCoordinator.swift
@@ -26,6 +26,17 @@ struct QuillCodeDesktopWorkspaceActionCoordinator {
         )
     }
 
+    func runTurnRevert(
+        turnMessageID: UUID,
+        model: QuillCodeWorkspaceModel,
+        fallbackWorkspaceRoot: URL
+    ) {
+        model.runTurnRevert(
+            turnMessageID: turnMessageID,
+            workspaceRoot: activeWorkspaceRoot(for: model, fallback: fallbackWorkspaceRoot)
+        )
+    }
+
     func runPullRequestReviewThreadAction(
         _ action: WorkspacePullRequestReviewThreadActionSurface,
         model: QuillCodeWorkspaceModel,

--- a/Tests/QuillCodeAppTests/WorkspaceTurnRevertSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTurnRevertSurfaceTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+import QuillCodeTools
+
+@MainActor
+final class WorkspaceTurnRevertSurfaceTests: XCTestCase {
+    private func applyPatchEvent(_ patch: String, at seconds: TimeInterval) -> ThreadEvent {
+        let call = ToolCall(name: ToolDefinition.applyPatch.name, argumentsJSON: ToolArguments.json(["patch": patch]))
+        let payload = (try? JSONHelpers.encodePretty(call.redactedForTranscript())) ?? call.argumentsJSON
+        return ThreadEvent(kind: .toolQueued, createdAt: Date(timeIntervalSince1970: seconds), summary: "queued", payloadJSON: payload)
+    }
+
+    func testUserMessageStartingAnApplyPatchTurnGetsARevertAffordance() {
+        let user = ChatMessage(role: .user, content: "do it", createdAt: Date(timeIntervalSince1970: 100))
+        let thread = ChatThread(title: "T", messages: [user], events: [applyPatchEvent("DIFF", at: 150)])
+        let surfaces = WorkspaceTranscriptSurfaceBuilder(thread: thread).messageSurfaces()
+        XCTAssertEqual(surfaces.first(where: { $0.id == user.id })?.revert?.turnMessageID, user.id)
+    }
+
+    func testMessageWithoutApplyPatchHasNoRevertAffordance() {
+        let user = ChatMessage(role: .user, content: "just talk", createdAt: Date(timeIntervalSince1970: 100))
+        let thread = ChatThread(title: "T", messages: [user], events: [])
+        XCTAssertNil(WorkspaceTranscriptSurfaceBuilder(thread: thread).messageSurfaces().first?.revert)
+    }
+
+    func testRevertScopeCopyMatchesTheCrossSurfaceParityFixture() {
+        // The SAME two literals are asserted against the JS harness in revert.spec.ts, so the
+        // truthful copy is pinned byte-identical across Swift, HTML, and the harness.
+        XCTAssertEqual(
+            TurnRevertCopy.scope(hasNonApplyPatchEdits: false),
+            "Reverses the file edits this turn applied, including files it created. It does not undo your own earlier edits, shell commands the turn ran, or git commits."
+        )
+        XCTAssertEqual(
+            TurnRevertCopy.scope(hasNonApplyPatchEdits: true),
+            "Reverses the file edits this turn applied, including files it created. It does not undo your own earlier edits, shell commands the turn ran, or git commits. This turn also changed files outside apply_patch, which can't be reverted automatically."
+        )
+    }
+
+    func testHTMLRendererEmitsRevertButtonForRevertableUserMessage() {
+        let user = ChatMessage(role: .user, content: "do it", createdAt: Date(timeIntervalSince1970: 100))
+        let thread = ChatThread(title: "T", messages: [user], events: [applyPatchEvent("DIFF", at: 150)])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+        XCTAssertTrue(html.contains(#"data-testid="message-revert-turn""#))
+        XCTAssertTrue(html.contains("data-turn-id=\"\(user.id.uuidString)\""))
+    }
+
+    private func shellEvent(at seconds: TimeInterval) -> ThreadEvent {
+        let call = ToolCall(name: ToolDefinition.shellRun.name, argumentsJSON: ToolArguments.json(["command": "rm x"]))
+        let payload = (try? JSONHelpers.encodePretty(call.redactedForTranscript())) ?? call.argumentsJSON
+        return ThreadEvent(kind: .toolQueued, createdAt: Date(timeIntervalSince1970: seconds), summary: "queued", payloadJSON: payload)
+    }
+
+    func testRemoteProjectHidesTheRevertAffordanceAndRefusesRevert() {
+        let user = ChatMessage(role: .user, content: "edit", createdAt: Date(timeIntervalSince1970: 100))
+        let connection = ProjectConnection.ssh(path: "/srv/app", host: "feather.local", user: "quill")
+        let project = ProjectRef(name: "Remote", path: connection.path, connection: connection)
+        let thread = ChatThread(title: "T", projectID: project.id, messages: [user], events: [applyPatchEvent("DIFF", at: 150)])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            projects: [project], selectedProjectID: project.id, threads: [thread], selectedThreadID: thread.id
+        ))
+
+        // No revert button is offered on a remote project (the local reverse-patch can't run there).
+        XCTAssertNil(model.surface().transcript.messages.first(where: { $0.id == user.id })?.revert)
+        // And the dispatch refuses rather than touch the wrong local tree.
+        XCTAssertFalse(model.runTurnRevert(turnMessageID: user.id, workspaceRoot: FileManager.default.temporaryDirectory))
+        XCTAssertEqual(model.surface().lastError, "Reverting a turn is only supported for local projects.")
+    }
+
+    func testRunTurnRevertWithNoPlanFailsHonestly() {
+        let user = ChatMessage(role: .user, content: "just talk", createdAt: Date(timeIntervalSince1970: 100))
+        let thread = ChatThread(title: "T", messages: [user], events: [])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+
+        XCTAssertFalse(model.runTurnRevert(turnMessageID: user.id, workspaceRoot: FileManager.default.temporaryDirectory))
+        XCTAssertEqual(model.surface().lastError, "This turn can no longer be reverted.")
+        XCTAssertFalse(model.currentToolCards.contains { $0.title == "host.git.revert_turn" })
+    }
+
+    func testRunTurnRevertSurfacesAnHonestFailureWhenFilesChangedSince() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let executor = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(executor.write(path: "a.txt", content: "old\n").ok)
+        _ = try runGit(["add", "-A"], cwd: root)
+        _ = try runGit(["commit", "-m", "base"], cwd: root)
+        XCTAssertTrue(executor.write(path: "a.txt", content: "new\n").ok)
+        let patch = GitToolExecutor().diff(cwd: root).stdout
+        // The user changed the same line AFTER the turn, so the reverse can't apply.
+        XCTAssertTrue(executor.write(path: "a.txt", content: "newer\n").ok)
+
+        let user = ChatMessage(role: .user, content: "edit a", createdAt: Date(timeIntervalSince1970: 100))
+        let thread = ChatThread(title: "T", messages: [user], events: [applyPatchEvent(patch, at: 150)])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+
+        XCTAssertFalse(model.runTurnRevert(turnMessageID: user.id, workspaceRoot: root))
+        XCTAssertNotNil(model.surface().lastError)
+        // The user's later edit is untouched (no HEAD restore), and the failed run is recorded.
+        XCTAssertEqual(try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8), "newer\n")
+        XCTAssertTrue(model.currentToolCards.contains { $0.title == "host.git.revert_turn" && $0.status == .failed })
+    }
+
+    func testHTMLRendererDisclosesNonApplyPatchEditsInTheRevertScope() {
+        let user = ChatMessage(role: .user, content: "mixed turn", createdAt: Date(timeIntervalSince1970: 100))
+        let thread = ChatThread(title: "T", messages: [user], events: [applyPatchEvent("DIFF", at: 150), shellEvent(at: 160)])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+        XCTAssertTrue(html.contains("outside apply_patch"))
+    }
+
+    func testMessageSurfaceDecodesLegacyJSONWithoutRevertKey() throws {
+        let surface = MessageSurface(message: ChatMessage(role: .user, content: "hi"))
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(surface)) as? [String: Any])
+        object.removeValue(forKey: "revert")
+        let decoded = try JSONDecoder().decode(MessageSurface.self, from: JSONSerialization.data(withJSONObject: object))
+        XCTAssertNil(decoded.revert)
+    }
+
+    func testRunTurnRevertReverseAppliesTheTurnEditsAndRefreshesDiff() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let executor = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(executor.write(path: "a.txt", content: "old\n").ok)
+        _ = try runGit(["add", "-A"], cwd: root)
+        _ = try runGit(["commit", "-m", "base"], cwd: root)
+        // The turn edited a.txt old -> new; capture exactly what it changed.
+        XCTAssertTrue(executor.write(path: "a.txt", content: "new\n").ok)
+        let patch = GitToolExecutor().diff(cwd: root).stdout
+        XCTAssertFalse(patch.isEmpty)
+
+        let user = ChatMessage(role: .user, content: "edit a", createdAt: Date(timeIntervalSince1970: 100))
+        let thread = ChatThread(title: "T", messages: [user], events: [applyPatchEvent(patch, at: 150)])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
+
+        let ok = model.runTurnRevert(turnMessageID: user.id, workspaceRoot: root)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8), "old\n")
+        // The revert is recorded as a transcript tool run plus a diff refresh.
+        XCTAssertTrue(model.currentToolCards.contains { $0.title == "host.git.revert_turn" })
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-06-29 Per-Turn Revert UI Pass (2 of 2)
+
+Overall grade after this slice: **A truthful affordance, A cross-surface parity**.
+
+The UI on top of the merged revert engine: a **"Revert this turn's edits"** button on the user message that began any turn whose `apply_patch` edits can be undone. The whole design centers on *honesty* — the button only appears for turns the engine can actually honor, and its copy states exactly what a reverse-patch does and does **not** undo.
+
+| Before | After |
+| --- | --- |
+| The honest revert engine existed but had no surface — there was no way to undo a turn from the UI. | `MessageSurface` gains an optional `revert` (turn id + `hasNonApplyPatchEdits`); `WorkspaceTranscriptSurfaceBuilder` derives it from `WorkspaceTurnRevertPlanner.plans(for: thread)` and attaches it to the turn's starting user message. The native bubble renders a destructive button; clicking it threads `onRevertTurn(turnMessageID)` to `model.runTurnRevert`, which **re-derives** the plan from the live thread, reverse-applies via the engine, records a `host.git.revert_turn` tool run, and refreshes the diff on success. |
+| — (honesty) | `TurnRevertCopy` is the single source of the user-facing copy — the scope text truthfully says it reverts the turn's `apply_patch` edits (including files it created) and does **not** undo your own earlier edits, shell commands, or commits, and appends a disclosure when the turn also edited outside `apply_patch`. The native (help + accessibility), HTML (`title`), and harness (`title`) surfaces all render that one string. The button is **hidden** for turns with no plan, so it never offers an undo it can't perform; a dirtied-since revert surfaces the engine's honest failure as `lastError`. |
+| No coverage. | `WorkspaceTurnRevertSurfaceTests` (revert affordance attached only to apply_patch turns, scope copy truthful + discloses non-apply_patch edits, HTML renders the button + turn id, and `runTurnRevert` reverse-applies a real turn end-to-end and records the `host.git.revert_turn` run + diff refresh); Playwright reverts a turn from its user message and asserts none appears on a patch-free turn. No new command ID; the destructive button reuses a shared hit-target so the routing-parity and interaction-target gates stay green. |
+
+| — (review hardening) | The adversarial review caught a real blocker: the affordance was offered for **SSH-remote projects**, where the local reverse-patch would have applied the remote turn's patch against the wrong local tree. Fixed: the surface builder gates the affordance on `allowsRevert` (false for remote), and `runTurnRevert` refuses remote projects with an honest error. Also folded in: a **cross-language copy-parity test** (Swift `TurnRevertCopy` and the JS harness are pinned byte-for-byte to the same two literals, both variants); model tests for the honest **failure paths** (dirtied-since records a failed run with the user's edit intact + no diff refresh; no-plan returns a clear error); an HTML test that the `hasNonApplyPatchEdits` **disclosure** renders; the HTML button gains an `aria-label`; `host.git.revert_turn` joins the disclosure set; and a `MessageSurface` legacy-decode test. |
+
+Residual risk:
+
+- The button is placed on the turn's user message (the prompt anchor). The harness mocks only the success path; the dirtied-since failure UI is covered by the engine + model tests, not an end-to-end UI test. Clicking revert again on an already-reverted turn fails honestly (the engine's "files changed" message) rather than being suppressed — a UX wart, and a running-history view of reverts, are follow-ups.
+
 ## 2026-06-29 Per-Turn Revert Engine Pass (1 of 2)
 
 Overall grade after this slice: **A honest design, A atomic safety**.


### PR DESCRIPTION
**PR 2 of 2** — the UI on top of the merged revert engine. A per-turn **"Revert this turn's edits"** button on the user message that began any turn whose `apply_patch` edits can be undone.

## How (honesty-first)

- `MessageSurface` gains an optional `revert`; `WorkspaceTranscriptSurfaceBuilder` derives it from `WorkspaceTurnRevertPlanner` and attaches it to the turn's starting user message. The native bubble renders a destructive button; `onRevertTurn(turnMessageID)` threads to `model.runTurnRevert`, which **re-derives** the plan from the live thread, reverse-applies via the engine, records a `host.git.revert_turn` run, and refreshes the diff on success.
- `TurnRevertCopy` is the **single source** of the user-facing copy — it truthfully states the revert undoes the turn's `apply_patch` edits (incl. files it created) and does **not** undo your own earlier edits, shell commands, or commits, with a disclosure when the turn also edited outside `apply_patch`. Native (help + a11y), HTML (`title` + `aria-label`), and harness (`title`) render that one string.
- The button is **hidden** for turns with no plan, so it never offers an undo it can't perform.

## Adversarial review fixes (shipped here)

The review caught a real blocker — the affordance was offered for **SSH-remote projects**, where the local reverse-patch would corrupt the wrong local tree. Fixed: the builder gates on `allowsRevert` (false for remote) and `runTurnRevert` refuses remote with an honest error. Also folded in: a **cross-language copy-parity test** (Swift `TurnRevertCopy` and the JS harness pinned byte-for-byte to the same two literals); model tests for the **failure paths** (dirtied-since records a failed run, the user's edit intact, no diff refresh; no-plan returns a clear error); an HTML disclosure-render test; `aria-label`; `host.git.revert_turn` in the disclosure set; a `MessageSurface` legacy-decode test.

## Tests

Surface (affordance only on apply_patch turns + **hidden for remote**, truthful scope copy pinned to a parity fixture, HTML button + disclosure, end-to-end `runTurnRevert` success **and** honest dirtied-since/no-plan failure); Playwright (revert from a user message, the byte-for-byte copy parity, none on a patch-free turn). No new command ID; routing-parity + interaction-target gates stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)