### PR TITLE
Add interactive Plan mode (PR1: read-only gate + toggle)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -334,6 +334,9 @@
     .mode-pill-button[data-mode-tone="read-only"] .mode-dot {
       background: var(--muted);
     }
+    .mode-pill-button[data-mode-tone="plan"] .mode-dot {
+      background: var(--blue);
+    }
     .mode-pill-button[data-mode-tone="auto"] .mode-dot {
       background: var(--green);
     }
@@ -4084,7 +4087,8 @@
       { usage: '/worktree prune', title: 'Prune stale worktrees', detail: 'Clean stale git worktree administrative records.', insertText: '/worktree prune --dry-run', aliases: ['wt prune', 'worktree cleanup'] },
       { usage: '/pr', title: 'Prepare pull request', detail: 'Draft a pull request request in the composer.', insertText: '/pr', aliases: ['pull-request', 'pullrequest'] },
       { usage: '/env name', title: 'Run local environment action', detail: 'List or run project-local environment scripts.', insertText: '/env ', aliases: ['environment', 'local-env'] },
-      { usage: '/mode auto|review|read-only', title: 'Set approval mode', detail: 'Switch between Auto, Review, and Read-only behavior.', insertText: '/mode ', aliases: [] },
+      { usage: '/mode auto|plan|review|read-only', title: 'Set approval mode', detail: 'Switch between Auto, Plan, Review, and Read-only behavior.', insertText: '/mode ', aliases: [] },
+      { usage: '/plan', title: 'Enter Plan mode', detail: 'Investigate read-only and propose a plan; mutating tools wait for your approval.', insertText: '/plan', aliases: [] },
       { usage: '/model provider/model', title: 'Set model', detail: 'Switch the active TrustedRouter model.', insertText: '/model ', aliases: [] }
     ];
     const slashCommandPalettePrefix = 'slash-command:';
@@ -7568,7 +7572,7 @@
     }
 
     function cycleMode() {
-      const modes = ['Auto', 'Review', 'Read-only'];
+      const modes = ['Auto', 'Plan', 'Review', 'Read-only'];
       const currentIndex = modes.indexOf(state.topBar.modeLabel);
       setModeLabel(modes[(currentIndex + 1) % modes.length]);
       render();
@@ -7584,6 +7588,7 @@
       const normalized = String(modeLabel || '').toLowerCase();
       if (normalized === 'review') return 'review';
       if (normalized === 'read-only') return 'read-only';
+      if (normalized === 'plan') return 'plan';
       return 'auto';
     }
 
@@ -13191,15 +13196,19 @@
       } else if (/^\/(new|new-chat|newchat)\b/i.test(text)) {
         newChat();
         return;
+      } else if (/^\/plan\b/i.test(text)) {
+        setModeLabel('Plan');
+        render();
+        addMessage('assistant', 'Mode set to Plan.');
       } else if (text.toLowerCase().startsWith('/mode ')) {
         const requestedMode = text.split(/\s+/)[1]?.toLowerCase();
-        const modeMap = { auto: 'Auto', review: 'Review', 'read-only': 'Read-only', readonly: 'Read-only' };
+        const modeMap = { auto: 'Auto', review: 'Review', plan: 'Plan', 'read-only': 'Read-only', readonly: 'Read-only' };
         const nextMode = modeMap[requestedMode] || null;
         if (nextMode) {
           setModeLabel(nextMode);
           addMessage('assistant', `Mode set to ${nextMode}.`);
         } else {
-          addMessage('assistant', 'Usage: /mode auto, /mode review, or /mode read-only');
+          addMessage('assistant', 'Usage: /mode auto, /mode plan, /mode review, or /mode read-only');
         }
       } else if (/^\/(rename|rename-chat|title)\b/i.test(text)) {
         const nextTitle = text.replace(/^\/(rename|rename-chat|title)\b/i, '').trim();

--- a/E2E/playwright/tests/command-palette.spec.ts
+++ b/E2E/playwright/tests/command-palette.spec.ts
@@ -38,7 +38,7 @@ test('mock harness command palette scopes actions and slash commands', async ({ 
   await fillCommandPalette(page, '/mode');
   await expect(page.getByTestId('command-palette-scope')).toHaveText('Slash');
   await expect(page.getByTestId('command-palette-group')).toContainText('Slash Commands');
-  await expect(page.getByTestId('command-palette-result').first()).toContainText('/mode auto|review|read-only');
+  await expect(page.getByTestId('command-palette-result').first()).toContainText('/mode auto|plan|review|read-only');
 
   await page.keyboard.press('Enter');
 

--- a/E2E/playwright/tests/composer.spec.ts
+++ b/E2E/playwright/tests/composer.spec.ts
@@ -88,8 +88,12 @@ test('mock harness changes approval mode independently from model selection', as
   await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
 
   await page.getByTestId('mode-picker-button').click();
-  await expect(page.getByTestId('mode-pill')).toHaveText('Review');
+  await expect(page.getByTestId('mode-pill')).toHaveText('Plan');
+  await expect(page.getByTestId('mode-picker-button')).toHaveAttribute('data-mode-tone', 'plan');
   await expect(page.getByTestId('model-picker-button')).toHaveText('Nike 1.0');
+
+  await page.getByTestId('mode-picker-button').click();
+  await expect(page.getByTestId('mode-pill')).toHaveText('Review');
 
   await page.getByTestId('mode-picker-button').click();
   await expect(page.getByTestId('mode-pill')).toHaveText('Read-only');

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -170,3 +170,24 @@ test('mock harness copies the whole conversation as Markdown from the command pa
     '```\n\n## Assistant\n\nOutput:\nran: the tests'
   );
 });
+
+test('mock harness enters Plan mode via /plan and the mode pill reflects it', async ({ page }) => {
+  await page.goto(harnessURL());
+  const message = page.getByLabel('Message');
+
+  // The pill starts on Auto.
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+  await expect(page.getByTestId('mode-picker-button')).toHaveAttribute('data-mode-tone', 'auto');
+
+  // /plan switches into Plan mode (its own pill tone).
+  await message.fill('/plan');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('mode-pill')).toHaveText('Plan');
+  await expect(page.getByTestId('mode-picker-button')).toHaveAttribute('data-mode-tone', 'plan');
+
+  // /mode auto returns to Auto, proving the toggle is reversible.
+  await message.fill('/mode auto');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+  await expect(page.getByTestId('mode-picker-button')).toHaveAttribute('data-mode-tone', 'auto');
+});

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -241,13 +241,15 @@ struct QuillCodeModePickerButton: View {
     }
 
     private var orderedModes: [AgentMode] {
-        [.auto, .review, .readOnly]
+        [.auto, .plan, .review, .readOnly]
     }
 
     private var selectedModeColor: Color {
         switch selectedMode {
         case .auto:
             return QuillCodePalette.green
+        case .plan:
+            return QuillCodePalette.blue
         case .review:
             return QuillCodePalette.yellow
         case .readOnly:

--- a/Sources/QuillCodeApp/SlashCommand.swift
+++ b/Sources/QuillCodeApp/SlashCommand.swift
@@ -69,6 +69,9 @@ enum SlashCommandParser {
             return SlashEnvironmentCommandParser.parse(argument)
         case "mode":
             return SlashModeCommandParser.parse(argument)
+        case "plan":
+            // `/plan` is a shorthand for entering Plan mode.
+            return .mode(.plan)
         case "model":
             return SlashModelCommandParser.parse(argument)
         default:

--- a/Sources/QuillCodeApp/SlashCommandCatalog.swift
+++ b/Sources/QuillCodeApp/SlashCommandCatalog.swift
@@ -69,7 +69,8 @@ enum SlashCommandCatalog {
 
     private static let suffixDefinitions: [SlashCommandDefinition] = [
         .init(usage: "/env name", title: "Run local environment action", detail: "List or run project-local environment scripts.", insertText: "/env ", aliases: ["environment", "local-env"]),
-        .init(usage: "/mode auto|review|read-only", title: "Set approval mode", detail: "Switch between Auto, Review, and Read-only behavior.", insertText: "/mode ", aliases: []),
+        .init(usage: "/mode auto|plan|review|read-only", title: "Set approval mode", detail: "Switch between Auto, Plan, Review, and Read-only behavior.", insertText: "/mode ", aliases: []),
+        .init(usage: "/plan", title: "Enter Plan mode", detail: "Investigate read-only and propose a plan; mutating tools wait for your approval.", insertText: "/plan", aliases: []),
         .init(
             usage: "/model /synth",
             title: "Set model",

--- a/Sources/QuillCodeApp/SlashModeCommandParser.swift
+++ b/Sources/QuillCodeApp/SlashModeCommandParser.swift
@@ -9,12 +9,14 @@ enum SlashModeCommandParser {
             return .mode(.auto)
         case "review":
             return .mode(.review)
+        case "plan":
+            return .mode(.plan)
         case "read-only", "readonly", "read_only":
             return .mode(.readOnly)
         case "":
-            return .invalid("Usage: /mode auto, /mode review, or /mode read-only")
+            return .invalid("Usage: /mode auto, /mode plan, /mode review, or /mode read-only")
         default:
-            return .invalid("Unknown mode '\(mode)'. Use auto, review, or read-only.")
+            return .invalid("Unknown mode '\(mode)'. Use auto, plan, review, or read-only.")
         }
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -86,6 +86,8 @@ enum WorkspaceHTMLTranscriptRenderer {
             return "review"
         case "read-only":
             return "read-only"
+        case "plan":
+            return "plan"
         default:
             return "auto"
         }

--- a/Sources/QuillCodeApp/WorkspaceModelReview.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelReview.swift
@@ -111,6 +111,15 @@ public extension QuillCodeWorkspaceModel {
         }
 
         if plan.shouldRunTool {
+            // Approving a blocked change while planning applies it AND switches the thread
+            // out of Plan mode so the agent can keep executing. This flips only the thread
+            // (not the global default mode), and runs the held tool directly (bypassing the
+            // gate) the same way every other approved tool does.
+            if selectedThread?.mode == .plan {
+                mutateSelectedThread { thread in
+                    WorkspaceConfigurationEngine.setMode(.auto, thread: &thread)
+                }
+            }
             _ = runToolCall(plan.request.toolCall, workspaceRoot: workspaceRoot)
         } else {
             if let assistantNotice = plan.assistantNotice {

--- a/Sources/QuillCodeApp/WorkspaceStatusTextBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceStatusTextBuilder.swift
@@ -79,6 +79,8 @@ struct WorkspaceStatusTextBuilder {
             return "Read-only"
         case .review:
             return "Review"
+        case .plan:
+            return "Plan"
         case .auto:
             return "Auto"
         }

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -363,6 +363,8 @@ extension AgentMode {
             return "Read-only"
         case .review:
             return "Review"
+        case .plan:
+            return "Plan"
         case .auto:
             return "Auto"
         }

--- a/Sources/QuillCodeCore/Models.swift
+++ b/Sources/QuillCodeCore/Models.swift
@@ -4,6 +4,9 @@ public enum AgentMode: String, Codable, Sendable, CaseIterable {
     case readOnly = "read-only"
     case review
     case auto
+    // Appended (not inserted mid-enum) so existing cases keep their discriminants — inserting
+    // shifts them and corrupts incremental builds. Menu order is set explicitly elsewhere.
+    case plan
 }
 
 public enum ChatRole: String, Codable, Sendable {

--- a/Sources/QuillCodeSafety/Safety.swift
+++ b/Sources/QuillCodeSafety/Safety.swift
@@ -74,6 +74,20 @@ public struct StaticSafetyReviewer: SafetyReviewer {
                 rationale: "Review mode requires explicit approval before this tool runs.",
                 userIntentMatched: userIntentMatches(context)
             )
+        case .plan:
+            // Plan mode investigates read-only and proposes a plan; every mutating tool is
+            // blocked until the user approves it (which applies that step and starts executing).
+            // It returns `.clarify`, NOT `.deny`: the agent loop blocks on any non-`.approve`
+            // verdict either way, but `.deny` is the hard "no approval possible" signal (e.g.
+            // `rm -rf /`) that suppresses the approve button — a plan block must stay approvable.
+            if context.toolDefinition?.risk == .read {
+                return lowRiskReview(context)
+            }
+            return SafetyReview(
+                verdict: .clarify,
+                rationale: "Planning — approve the proposed change to apply it and start executing.",
+                userIntentMatched: userIntentMatches(context)
+            )
         case .auto:
             if let hardDeny = hardDenyReason(context) {
                 return SafetyReview(verdict: .deny, rationale: hardDeny)

--- a/Tests/QuillCodeAgentTests/AgentPlanModeTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentPlanModeTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+final class AgentPlanModeTests: XCTestCase {
+    func testPlanModeBlocksAMutatingToolThatAutoModeWouldRun() async throws {
+        let root = try makeTempDirectory()
+        let planned = root.appendingPathComponent("planned.txt")
+
+        // Plan mode blocks the mutating shell: nothing runs, the file is NOT created, and an
+        // approval is surfaced instead. Asserting the file is absent proves a genuine block —
+        // a leaked execution would have created it, so this is not a vacuous "flag-only" check.
+        let planResult = try await AgentRunner().send(
+            "run touch planned.txt",
+            in: ChatThread(mode: .plan),
+            workspaceRoot: root
+        )
+        XCTAssertTrue(planResult.toolResults.isEmpty, "no tool should execute while planning")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: planned.path),
+            "the mutating shell must not touch the filesystem while planning"
+        )
+        XCTAssertTrue(planResult.thread.events.contains { $0.kind == .approvalRequested })
+
+        // Auto mode runs the exact same command — proving the block above is real, not vacuous.
+        let autoResult = try await AgentRunner().send(
+            "run touch planned.txt",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+        XCTAssertEqual(autoResult.toolResults.count, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: planned.path))
+    }
+
+    func testPlanModeBlocksMutatingToolEvenWithImmediateActionPreflight() async throws {
+        // Production enables the immediate-action preflight (RuntimeFactory). The preflight only
+        // chooses the action faster; it still flows through the same gate — so plan mode must
+        // block a mutating shell on this path too, not just the LLM path.
+        let root = try makeTempDirectory()
+        let planned = root.appendingPathComponent("preflight.txt")
+        let runner = AgentRunner(enablesImmediateActionPreflight: true)
+
+        let result = try await runner.send(
+            "run touch preflight.txt",
+            in: ChatThread(mode: .plan),
+            workspaceRoot: root
+        )
+        XCTAssertTrue(result.toolResults.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: planned.path))
+        XCTAssertTrue(result.thread.events.contains { $0.kind == .approvalRequested })
+    }
+}

--- a/Tests/QuillCodeAppTests/SlashModeCommandParserTests.swift
+++ b/Tests/QuillCodeAppTests/SlashModeCommandParserTests.swift
@@ -6,9 +6,15 @@ final class SlashModeCommandParserTests: XCTestCase {
     func testModeAliasesMapToAgentModes() {
         XCTAssertEqual(SlashModeCommandParser.parse("auto"), .mode(.auto))
         XCTAssertEqual(SlashModeCommandParser.parse("review"), .mode(.review))
+        XCTAssertEqual(SlashModeCommandParser.parse("plan"), .mode(.plan))
         XCTAssertEqual(SlashModeCommandParser.parse("read-only"), .mode(.readOnly))
         XCTAssertEqual(SlashModeCommandParser.parse("readonly"), .mode(.readOnly))
         XCTAssertEqual(SlashModeCommandParser.parse("read_only"), .mode(.readOnly))
+    }
+
+    func testPlanSlashShortcutEntersPlanMode() {
+        XCTAssertEqual(SlashCommandParser.parse("/plan"), .mode(.plan))
+        XCTAssertEqual(SlashCommandParser.parse("/mode plan"), .mode(.plan))
     }
 
     func testModeParsingIsCaseAndWhitespaceTolerant() {
@@ -18,7 +24,7 @@ final class SlashModeCommandParserTests: XCTestCase {
     }
 
     func testEmptyModeReturnsUsageMessage() {
-        let expected = SlashCommand.invalid("Usage: /mode auto, /mode review, or /mode read-only")
+        let expected = SlashCommand.invalid("Usage: /mode auto, /mode plan, /mode review, or /mode read-only")
 
         XCTAssertEqual(SlashModeCommandParser.parse(""), expected)
         XCTAssertEqual(SlashModeCommandParser.parse("   "), expected)
@@ -28,11 +34,11 @@ final class SlashModeCommandParserTests: XCTestCase {
     func testUnknownModeReturnsTrimmedArgumentInError() {
         XCTAssertEqual(
             SlashModeCommandParser.parse("  full-access  "),
-            .invalid("Unknown mode 'full-access'. Use auto, review, or read-only.")
+            .invalid("Unknown mode 'full-access'. Use auto, plan, review, or read-only.")
         )
         XCTAssertEqual(
             SlashCommandParser.parse("/mode full-access"),
-            .invalid("Unknown mode 'full-access'. Use auto, review, or read-only.")
+            .invalid("Unknown mode 'full-access'. Use auto, plan, review, or read-only.")
         )
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
@@ -34,7 +34,7 @@ final class WorkspaceCommandPaletteRankerTests: XCTestCase {
         let commands = QuillCodeWorkspaceModel().surface().commands
         let slashResults = WorkspaceCommandPaletteRanker.rankedCommands(commands, matching: "/mode")
 
-        XCTAssertEqual(slashResults.first?.title, "/mode auto|review|read-only")
+        XCTAssertEqual(slashResults.first?.title, "/mode auto|plan|review|read-only")
         XCTAssertTrue(slashResults.allSatisfy { $0.id.hasPrefix(SlashCommandCatalog.commandPaletteIDPrefix) })
         XCTAssertEqual(
             WorkspaceCommandPaletteRanker.groupedCommands(commands, matching: "/").map(\.title),

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPlanTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPlanTests.swift
@@ -248,7 +248,7 @@ final class WorkspaceCommandPlanTests: XCTestCase {
 
     func testSlashCommandPaletteIDsMapToInsertText() throws {
         let modeCommand = try XCTUnwrap(
-            SlashCommandCatalog.commandPaletteCommands().first { $0.title == "/mode auto|review|read-only" }
+            SlashCommandCatalog.commandPaletteCommands().first { $0.title == "/mode auto|plan|review|read-only" }
         )
         let modelCommand = try XCTUnwrap(
             SlashCommandCatalog.commandPaletteCommands().first { $0.title == "/model /synth" }

--- a/Tests/QuillCodeAppTests/WorkspaceToolCardIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceToolCardIntegrationTests.swift
@@ -78,6 +78,52 @@ final class WorkspaceToolCardIntegrationTests: XCTestCase {
         XCTAssertTrue(cards.contains { $0.title == ToolDefinition.shellRun.name && $0.outputJSON?.contains("exitCode") == true })
     }
 
+    func testApprovingWhilePlanningFlipsThreadToAutoAndRunsTheTool() throws {
+        let root = try makeTempDirectory()
+        let call = ToolCall(
+            id: "plan-approval-tool-run",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "whoami"])
+        )
+        let request = ApprovalRequest(
+            id: "plan-approval-run",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "Planning — approve the proposed change to apply it and start executing."
+        )
+        let thread = ChatThread(mode: .plan, events: [
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: "planning",
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )
+        ])
+        // A distinct global default proves the flip is thread-only, not a global mode change.
+        var config = AppConfig()
+        config.mode = .review
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            config: config,
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let didRun = model.runToolCardAction(ToolCardActionSurface(
+            title: "Approve",
+            kind: .approve,
+            requestID: "plan-approval-run",
+            style: .primary
+        ), workspaceRoot: root)
+
+        XCTAssertTrue(didRun)
+        // Approving the plan flips this thread out of Plan mode so the agent keeps executing,
+        XCTAssertEqual(model.selectedThread?.mode, .auto)
+        // without changing the global default mode,
+        XCTAssertEqual(model.root.config.mode, .review)
+        // and the held tool actually runs.
+        let events = try XCTUnwrap(model.selectedThread?.events)
+        XCTAssertTrue(events.contains { $0.kind == .toolCompleted })
+    }
+
     func testToolCardEditActionPreloadsComposerWithoutDecidingOrRunningTool() throws {
         let root = try makeTempDirectory()
         let call = ToolCall(

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -1,8 +1,51 @@
 import XCTest
 import QuillCodeCore
+import QuillCodeSafety
 @testable import QuillCodeApp
 
 final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
+    func testPlanModeBlockSurfacesAnApprovableToolCard() async throws {
+        // Regression for the missing-approve-button bug: a plan-mode block must stay
+        // APPROVABLE. The verdict is taken from the REAL reviewer and fed into the request the
+        // exact way AgentToolStepRunner.appendBlockedReview builds it, so this fails if the
+        // .plan arm ever returns `.deny` (the hard, button-suppressing signal for `rm -rf /`).
+        let call = ToolCall(
+            id: "plan-block-1",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "touch a.txt"])
+        )
+        let review = await StaticSafetyReviewer().review(.init(
+            mode: .plan,
+            userMessage: "make the change",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            recentMessages: []
+        ))
+        let request = ApprovalRequest(
+            id: "plan-approval-1",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: review.rationale,
+            recommendedVerdict: review.verdict
+        )
+        let thread = ChatThread(mode: .plan, events: [
+            ThreadEvent(kind: .toolQueued, summary: "queued", payloadJSON: try JSONHelpers.encodePretty(call)),
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: "plan block",
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )
+        ])
+
+        let card = try XCTUnwrap(
+            WorkspaceTranscriptSurfaceBuilder(thread: thread).timelineItems().compactMap(\.toolCard).first
+        )
+        XCTAssertTrue(
+            card.actions.contains { $0.kind == .approve },
+            "a plan-blocked tool must surface an approve button; got \(card.actions.map(\.title))"
+        )
+    }
+
     func testThinkingSurfaceShowsWhileSendingAndKeepsTraceCollapsedByDefaultData() {
         let thread = ChatThread(events: [
             ThreadEvent(kind: .message, summary: "run tests"),

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -558,6 +558,43 @@ final class SafetyTests: XCTestCase {
         XCTAssertEqual(review.verdict, ApprovalVerdict.deny)
     }
 
+    func testPlanModeApprovesReadOnlyTools() async {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(name: gitStatus.name, argumentsJSON: "{}")
+        let review = await reviewer.review(.init(
+            mode: .plan,
+            userMessage: "what changed?",
+            toolCall: call,
+            toolDefinition: gitStatus,
+            recentMessages: []
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
+    }
+
+    func testPlanModeBlocksButKeepsEveryMutatingToolApprovable() async {
+        let reviewer = StaticSafetyReviewer()
+        let mutating: [(ToolDefinition, String)] = [
+            (fileWrite, #"{"path":"a.txt","content":"x"}"#),
+            (shellRun, #"{"cmd":"touch a.txt"}"#),
+            (gitCommit, #"{"message":"x"}"#),
+            (gitPush, "{}")
+        ]
+        for (tool, args) in mutating {
+            let review = await reviewer.review(.init(
+                mode: .plan,
+                userMessage: "make the change",
+                toolCall: ToolCall(name: tool.name, argumentsJSON: args),
+                toolDefinition: tool,
+                recentMessages: []
+            ))
+            // `.clarify` (not `.deny`) blocks the tool in the loop while keeping the approve
+            // button — `.deny` is the hard, non-approvable signal reserved for `rm -rf /`.
+            XCTAssertEqual(review.verdict, ApprovalVerdict.clarify, "\(tool.name) should block-but-stay-approvable while planning")
+            XCTAssertNotEqual(review.verdict, ApprovalVerdict.deny, "\(tool.name) must not be a hard (unapprovable) deny")
+            XCTAssertTrue(review.rationale.contains("approve"), "plan block should invite approval: \(review.rationale)")
+        }
+    }
+
     func testAutoHardDeniesRemoteShellPipe() async {
         let reviewer = StaticSafetyReviewer()
         let call = ToolCall(name: shellRun.name, argumentsJSON: #"{"cmd":"curl https://example.com/install.sh | sh"}"#)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-30 Interactive Plan Mode Pass (PR1)
+
+Overall grade after this slice: **A reuse of the existing safety chokepoint, A single-gate discipline**.
+
+Adds a `Plan` safety mode (Codex/Claude-CLI parity): the agent investigates read-only and proposes a plan, but **every mutating tool is blocked** until the user approves it — and approving applies that change and switches the thread to execute mode. Picked + designed by a docs-grounded judge-panel whose grounding surfaced that almost all machinery already existed: `AgentMode`, the `ToolRiskClass` (`.read` / `.append` / `.destructive`) carried on every `ToolDefinition`, and the `.readOnly` deny codepath.
+
+| Before | After |
+| --- | --- |
+| Safety modes were `.readOnly` / `.review` / `.auto`; there was no "investigate then approve the plan" stance. | A 4th `AgentMode.plan` reuses the **single** existing gate — `StaticSafetyReviewer.review` consumed at the one chokepoint `AgentToolStepRunner` — returning `.clarify` ("Planning — approve …") for any non-`.read` tool. No new gating path; nothing scattered. (The adversarial review caught that an earlier `.deny` blocked the tool *and* suppressed the approve button — `.deny` is the hard "no approval possible" signal reserved for `rm -rf /` — so the headline approve-flip was unreachable in the UI. `.clarify` blocks in the loop while keeping the buttons, like `.review`.) |
+| — (the killer) | A mutating tool must never *look* blocked while actually running. The exhaustive `switch AgentMode` (no `default`) forces the gate arm at compile time, and `AgentPlanModeTests` proves it against the filesystem: the same `touch` command leaves **no file** in Plan mode (blocked) but **creates it** in Auto — a leaked execution would fail the test, so it is not a flag-only check. |
+| — | Approving a blocked change flips **only the thread** to `.auto` (proven by `testApprovingWhilePlanningFlipsThreadToAutoAndRunsTheTool`, which asserts the global default mode is unchanged) and runs the held tool through the existing approve affordance — no new routed command id. |
+| Inserting an enum case mid-`AgentMode` shifted `.auto`'s discriminant and silently corrupted incremental builds (50 phantom `.auto`→deny failures + an index-out-of-range crash that *clean* builds did not show). | `.plan` is **appended** after `.auto` so existing discriminants are stable; menu order is set explicitly in `orderedModes`, not derived from `allCases`. |
+
+Residual risk:
+
+- Like `.readOnly`, Plan mode gates at the tool level, so **all** `shell.run` is blocked while planning (even read-only commands like `whoami`); the agent investigates via `.read` tools (`git.status`, `git.diff`, file reads, search). The agent-authored structured **plan artifact** and the **execute-the-whole-plan** handoff (re-sending the thread after one approval) are the deferred PR2 — this PR ships the safety gate + per-change approve handoff, which is the load-bearing slice. Approve currently flips to `.auto` (autonomous execution); a future option could flip to `.review` for step-by-step approval.
+
 ## 2026-06-30 @-Mention Directories Pass
 
 Overall grade after this slice: **A decoupled-cap design, A cross-surface parity**.


### PR DESCRIPTION
A `Plan` safety mode (Codex/Claude-CLI parity): the agent investigates **read-only** and proposes a plan, but every **mutating** tool (file write, shell, git mutations) is blocked until the user approves it — and approving a blocked change applies it and switches the thread to execute mode.

## How

- **Reuses the single existing safety chokepoint.** `StaticSafetyReviewer.review` gains a `.plan` arm that returns `.clarify` for any non-`.read` tool (the existing `ToolRiskClass` classification), consumed at the one gate `AgentToolStepRunner`. No new gating path, nothing scattered. The exhaustive `switch AgentMode` (no `default`) makes a forgotten arm a **compile error**.
- **Why `.clarify`, not `.deny`:** the agent loop blocks on any non-`.approve` verdict either way, but `.deny` is the hard "no approval possible" signal (reserved for `rm -rf /`) that suppresses the approve button. A plan block must stay approvable — so it uses `.clarify`, like `.review`.
- `/plan` and `/mode plan` enter it; the mode pill renders a `plan` tone across native, the static HTML renderer, and the JS harness.
- **Approving** a blocked change flips **only the thread** to `.auto` (not the global default) and runs the held tool through the existing approve affordance — no new routed command id.
- `.plan` is **appended** after `.auto` (not inserted) so existing enum discriminants stay stable — inserting mid-enum shifts them and corrupts incremental builds.

## Tests

`AgentPlanModeTests` proves a mutating tool is blocked in plan (no file created) but runs in auto (file created), **including the production immediate-action-preflight path**; reviewer unit tests (read→approve, write/shell/commit/push→block-but-approvable); a **projection-level regression test** that derives the verdict from the real reviewer and asserts the plan-blocked card exposes an approve button (catches the dead-button class); the thread-only approve-flip; parser + a Playwright pill test.

The adversarial review caught that an earlier `.deny` made the approve-flip unreachable in the UI; this PR ships the `.clarify` fix + the regression test that would have caught it. The agent-authored plan artifact and execute-the-whole-plan handoff are the deferred PR2.

Verified on a clean build: `swift test` 1801 · Playwright 138 · native-desktop smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)