### PR TITLE
Add Shift+Tab approval-mode cycling

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3654,6 +3654,7 @@
       },
       commands: [
         { id: 'new-chat', title: 'New chat', shortcut: 'Cmd+N', category: 'Thread', keywords: ['thread', 'conversation'], isEnabled: true },
+        { id: 'cycle-mode', title: 'Cycle approval mode', shortcut: 'Shift+Tab', category: 'Workspace', keywords: ['mode', 'approval', 'auto', 'plan', 'review', 'read-only', 'safety', 'cycle'], isEnabled: true },
         { id: 'sidebar-filter:all', title: 'Show all chats', shortcut: '', category: 'Thread', keywords: ['thread', 'chat', 'sidebar', 'filter', 'all'], isEnabled: true },
         { id: 'sidebar-filter:pinned', title: 'Show pinned chats', shortcut: '', category: 'Thread', keywords: ['thread', 'chat', 'sidebar', 'filter', 'pinned'], isEnabled: true },
         { id: 'sidebar-filter:recent', title: 'Show recent chats', shortcut: '', category: 'Thread', keywords: ['thread', 'chat', 'sidebar', 'filter', 'recent'], isEnabled: true },
@@ -6686,7 +6687,9 @@
         } else if (suggestions.length && event.key === 'ArrowUp') {
           event.preventDefault();
           moveSlashSuggestion(-1);
-        } else if (suggestions.length && event.key === 'Tab') {
+        } else if (suggestions.length && event.key === 'Tab' && !event.shiftKey) {
+          // Plain Tab accepts the suggestion; Shift+Tab is left to bubble to the global
+          // cycle-mode shortcut, so mode cycling works even while composing.
           event.preventDefault();
           acceptSlashSuggestion({ force: true });
         } else if (mentions.length && event.key === 'ArrowDown') {
@@ -6695,7 +6698,7 @@
         } else if (mentions.length && event.key === 'ArrowUp') {
           event.preventDefault();
           moveFileMentionSuggestion(-1);
-        } else if (mentions.length && event.key === 'Tab') {
+        } else if (mentions.length && event.key === 'Tab' && !event.shiftKey) {
           event.preventDefault();
           acceptFileMentionSuggestion({ force: true });
         } else if (!suggestions.length && !mentions.length && event.key === 'ArrowUp') {
@@ -10389,6 +10392,7 @@
     const harnessStaticCommandIDs = new Set([
       'add-project',
       'add-ssh-project',
+      'cycle-mode',
       'automation-create-thread-follow-up',
       'automation-create-thread-follow-up-every:daily',
       'automation-create-thread-follow-up-tomorrow',
@@ -10678,6 +10682,10 @@
       state.commandPalette.isOpen = false;
       if (commandID === 'new-chat') {
         newChat();
+        return;
+      }
+      if (commandID === 'cycle-mode') {
+        cycleMode();
         return;
       }
       if (commandID === 'thread-rename') {
@@ -13850,9 +13858,26 @@
         candidate.isEnabled && shortcutMatches(event, candidate.shortcut)
       ));
       if (!command) return;
+      // Tab is the universal focus-traversal key. Only let a Tab-bound shortcut (cycle-mode)
+      // fire when focus is on the composer or not in an editable field — otherwise leave
+      // Shift+Tab to move focus backward through search boxes, the terminal, dialogs, etc.,
+      // instead of silently changing the agent's approval mode out from under the user.
+      if (event.key === 'Tab' && !focusAllowsTabShortcut()) return;
       event.preventDefault();
       runCommand(command.id);
     });
+
+    // The composer is the one editable field where Tab shortcuts are intended (Shift+Tab cycles
+    // mode, plain Tab accepts a suggestion). Everywhere else, Tab/Shift+Tab is focus traversal.
+    function focusAllowsTabShortcut() {
+      const active = document.activeElement;
+      if (!active) return true;
+      if (active.getAttribute && active.getAttribute('aria-label') === 'Message') return true;
+      const editable = active.isContentEditable
+        || active.tagName === 'INPUT'
+        || active.tagName === 'TEXTAREA';
+      return !editable;
+    }
 
     window.__quillCodeCommandRoutingAudit = commandRoutingAuditReport;
     window.__quillCodeTestCreateMonitorAutomation = createMonitorAutomation;

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -234,3 +234,49 @@ test('mock harness resumes the agent after approving a Plan-mode block', async (
   // The resumed next step surfaces as a new review card awaiting approval.
   await expect(page.getByTestId('tool-card').filter({ hasText: 'touch step-two.txt' })).toHaveAttribute('data-status', 'review');
 });
+
+test('Shift+Tab cycles approval mode, including while composing, without double-firing', async ({ page }) => {
+  await page.goto(harnessURL());
+  const message = page.getByLabel('Message');
+  const pill = page.getByTestId('mode-pill');
+
+  // Shift+Tab cycles the full Codex ring: Auto → Plan → Review → Read-only → Auto.
+  await expect(pill).toHaveText('Auto');
+  await page.keyboard.press('Shift+Tab');
+  await expect(pill).toHaveText('Plan');
+  await page.keyboard.press('Shift+Tab');
+  await expect(pill).toHaveText('Review');
+  await page.keyboard.press('Shift+Tab');
+  await expect(pill).toHaveText('Read-only');
+  await page.keyboard.press('Shift+Tab');
+  await expect(pill).toHaveText('Auto');
+  await expect(page.getByTestId('mode-picker-button')).toHaveAttribute('data-mode-tone', 'auto');
+
+  // The killer: with a slash draft present, plain Tab still ACCEPTS the suggestion…
+  await message.fill('/mod');
+  await message.focus();
+  await page.keyboard.press('Tab');
+  await expect(message).toHaveValue('/mode ');
+
+  // …while Shift+Tab cycles the mode WITHOUT accepting a suggestion or disturbing the draft
+  // (no double-fire — the composer leaves Shift+Tab to the global shortcut).
+  await message.fill('/mod');
+  await message.focus();
+  await page.keyboard.press('Shift+Tab');
+  await expect(pill).toHaveText('Plan');
+  await expect(message).toHaveValue('/mod');
+});
+
+test('Shift+Tab does not cycle mode while focus is in a non-composer input', async ({ page }) => {
+  await page.goto(harnessURL());
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+
+  // Open the model picker and focus its search field — a non-composer editable input.
+  await page.getByTestId('model-picker-button').click();
+  await page.getByTestId('model-search').focus();
+  await page.keyboard.press('Shift+Tab');
+
+  // Shift+Tab in a search field is reverse focus traversal, NOT mode cycling — the agent's
+  // approval mode must not silently change out from under the user.
+  await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
+});

--- a/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
+++ b/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
@@ -13,6 +13,8 @@ enum QuillCodeCommandIconCatalog {
         switch commandID {
         case "new-chat":
             return "square.and.pencil"
+        case "cycle-mode":
+            return "arrow.triangle.2.circlepath"
         case "search":
             return "magnifyingglass"
         case "command-palette":

--- a/Sources/QuillCodeApp/QuillCodeTopBarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarView.swift
@@ -241,7 +241,7 @@ struct QuillCodeModePickerButton: View {
     }
 
     private var orderedModes: [AgentMode] {
-        [.auto, .plan, .review, .readOnly]
+        AgentMode.cycleOrder
     }
 
     private var selectedModeColor: Color {

--- a/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
@@ -20,6 +20,8 @@ extension QuillCodeWorkspaceModel {
         case .newChat:
             _ = newChat()
             return true
+        case .cycleMode:
+            return cycleMode()
         case .toggleTerminal:
             toggleTerminal()
             return true

--- a/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
@@ -3,6 +3,7 @@ import QuillCodeCore
 
 enum WorkspaceCommandActionEffect: Sendable, Hashable {
     case newChat
+    case cycleMode
     case toggleTerminal
     case clearTerminal
     case toggleBrowser
@@ -44,6 +45,8 @@ struct WorkspaceCommandActionPlanner: Sendable, Hashable {
         switch action {
         case .newChat:
             return .newChat
+        case .cycleMode:
+            return .cycleMode
         case .toggleTerminal:
             return .toggleTerminal
         case .clearTerminal:

--- a/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
@@ -206,6 +206,7 @@ enum WorkspaceCommandPlan: Equatable {
 
 enum WorkspaceCommandAction: String, Equatable {
     case newChat = "new-chat"
+    case cycleMode = "cycle-mode"
     case toggleTerminal = "toggle-terminal"
     case clearTerminal = "terminal-clear"
     case toggleBrowser = "toggle-browser"

--- a/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
@@ -52,6 +52,13 @@ enum WorkspaceCommandStaticCatalog {
     ) -> [WorkspaceCommandSurface] {
         [
             WorkspaceCommandSurface(
+                id: "cycle-mode",
+                title: "Cycle approval mode",
+                shortcut: WorkspaceShortcutRegistry.label(for: "cycle-mode"),
+                category: WorkspaceCommandPalette.workspaceCategory,
+                keywords: ["mode", "approval", "auto", "plan", "review", "read-only", "safety", "cycle"]
+            ),
+            WorkspaceCommandSurface(
                 id: "add-project",
                 title: "Open project",
                 shortcut: WorkspaceShortcutRegistry.label(for: "add-project"),

--- a/Sources/QuillCodeApp/WorkspaceModelConfiguration.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelConfiguration.swift
@@ -11,6 +11,17 @@ extension QuillCodeWorkspaceModel {
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
     }
 
+    /// Advances to the next approval mode, mirroring Codex's `Shift+Tab` shortcut. The ring order
+    /// matches the top-bar picker and the harness mode pill: Auto → Plan → Review → Read-only → Auto.
+    @discardableResult
+    public func cycleMode() -> Bool {
+        let current = selectedThread?.mode ?? root.config.mode
+        let order = AgentMode.cycleOrder
+        let index = order.firstIndex(of: current) ?? 0
+        setMode(order[(index + 1) % order.count])
+        return true
+    }
+
     @discardableResult
     public func setModel(_ model: String) -> String {
         let modelID = WorkspaceConfigurationEngine.setModel(model, config: &root.config)

--- a/Sources/QuillCodeApp/WorkspaceShortcutRegistry.swift
+++ b/Sources/QuillCodeApp/WorkspaceShortcutRegistry.swift
@@ -18,6 +18,8 @@ public struct WorkspaceShortcut: Codable, Sendable, Hashable, Identifiable {
         switch key {
         case "escape":
             keyLabel = "Esc"
+        case "tab":
+            keyLabel = "Tab"
         case "`", ",":
             keyLabel = key
         default:
@@ -39,6 +41,7 @@ public struct WorkspaceShortcut: Codable, Sendable, Hashable, Identifiable {
 public enum WorkspaceShortcutRegistry {
     public static let shortcuts: [WorkspaceShortcut] = [
         WorkspaceShortcut(commandID: "new-chat", key: "n", modifiers: [.command]),
+        WorkspaceShortcut(commandID: "cycle-mode", key: "tab", modifiers: [.shift]),
         WorkspaceShortcut(commandID: "search", key: "k", modifiers: [.command]),
         WorkspaceShortcut(commandID: "find-in-chat", key: "f", modifiers: [.command]),
         WorkspaceShortcut(commandID: "add-project", key: "o", modifiers: [.command]),

--- a/Sources/QuillCodeCore/Models.swift
+++ b/Sources/QuillCodeCore/Models.swift
@@ -7,6 +7,10 @@ public enum AgentMode: String, Codable, Sendable, CaseIterable {
     // Appended (not inserted mid-enum) so existing cases keep their discriminants — inserting
     // shifts them and corrupts incremental builds. Menu order is set explicitly elsewhere.
     case plan
+
+    /// The order the top-bar picker, the `Shift+Tab` cycle, and the harness mode pill all advance
+    /// through — kept separate from `allCases` (which is discriminant order) so the UX ring is stable.
+    public static let cycleOrder: [AgentMode] = [.auto, .plan, .review, .readOnly]
 }
 
 public enum ChatRole: String, Codable, Sendable {

--- a/Sources/quill-code-desktop/DesktopCommands.swift
+++ b/Sources/quill-code-desktop/DesktopCommands.swift
@@ -9,6 +9,10 @@ struct QuillCodeDesktopCommands: Commands {
                 NotificationCenter.default.post(name: .quillCodeNewChat, object: nil)
             }
             .quillCodeShortcut("new-chat")
+            Button("Cycle Approval Mode") {
+                NotificationCenter.default.post(name: .quillCodeCycleMode, object: nil)
+            }
+            .quillCodeShortcut("cycle-mode")
             Button("Open Project...") {
                 NotificationCenter.default.post(name: .quillCodeOpenProject, object: nil)
             }
@@ -64,6 +68,7 @@ struct QuillCodeDesktopCommands: Commands {
 
 extension Notification.Name {
     static let quillCodeNewChat = Notification.Name("QuillCodeNewChat")
+    static let quillCodeCycleMode = Notification.Name("QuillCodeCycleMode")
     static let quillCodeOpenProject = Notification.Name("QuillCodeOpenProject")
     static let quillCodeCommandPalette = Notification.Name("QuillCodeCommandPalette")
     static let quillCodeKeyboardShortcuts = Notification.Name("QuillCodeKeyboardShortcuts")
@@ -95,6 +100,8 @@ private extension WorkspaceShortcut {
         switch key {
         case "escape":
             return .escape
+        case "tab":
+            return .tab
         case "`":
             return "`"
         case ",":

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -109,6 +109,9 @@ struct QuillCodeDesktopRootView: View {
         .onReceive(NotificationCenter.default.publisher(for: .quillCodeNewChat)) { _ in
             controller.newChat()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .quillCodeCycleMode)) { _ in
+            controller.runWorkspaceCommand("cycle-mode")
+        }
         .onReceive(NotificationCenter.default.publisher(for: .quillCodeToggleTerminal)) { _ in
             controller.toggleTerminal()
         }

--- a/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
@@ -22,6 +22,25 @@ final class WorkspaceConfigurationIntegrationTests: XCTestCase {
         XCTAssertEqual(model.root.topBar.model, "provider/model")
     }
 
+    func testCycleModeAdvancesThroughTheFullRingAndWrapsBack() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let thread = ChatThread(mode: .auto)
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        // Auto → Plan → Review → Read-only → Auto (the Codex Shift+Tab ring), driven through the
+        // real `cycle-mode` command id so the whole route (command → planner → executor) is covered.
+        var seen: [AgentMode] = []
+        for _ in 0..<AgentMode.cycleOrder.count {
+            XCTAssertTrue(model.runWorkspaceCommand("cycle-mode", workspaceRoot: root))
+            seen.append(try XCTUnwrap(model.selectedThread?.mode))
+        }
+        XCTAssertEqual(seen, [.plan, .review, .readOnly, .auto])
+        XCTAssertEqual(model.root.topBar.mode, .auto)
+    }
+
     func testToggleModelFavoriteUpdatesConfigAndSurface() {
         let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
             config: AppConfig(favoriteModels: ["provider/old"]),

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -90,6 +90,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
             "search",
             "find-in-chat",
             "copy-conversation",
+            "cycle-mode",
             "add-project",
             "add-ssh-project",
             "project-new-chat",

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -11,7 +11,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         for label in ["New Chat", "Open Project", "Command Palette", "Keyboard Shortcuts", "Open Browser Session", "Computer Use Setup", "Settings", "Stop All", "Disconnect All"] {
             XCTAssertTrue(text.contains(label), "Menu-bar widget is missing \(label).")
         }
-        for commandID in ["browser-back", "browser-forward", "browser-reload"] {
+        for commandID in ["browser-back", "browser-forward", "browser-reload", "cycle-mode"] {
             XCTAssertTrue(commandsText.contains(".quillCodeShortcut(\"\(commandID)\")"), "\(commandID) should be wired as a native keyboard shortcut.")
             XCTAssertTrue(appText.contains("controller.runWorkspaceCommand(\"\(commandID)\")"), "\(commandID) should route through the workspace command executor.")
         }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-30 Shift+Tab Mode Cycling Pass
+
+Overall grade after this slice: **A reuse of the command + shortcut rails, A felt-usability win**.
+
+Adds Codex's single most-used shortcut: **Shift+Tab cycles the approval mode** (Auto → Plan → Review → Read-only → Auto). Mode could previously only change by clicking the pill or typing `/mode …`. Picked by a docs-grounded scout that read the parity matrix (every area is "Partial" — the harness is feature-complete) and chose the highest-value *felt* usability gap.
+
+| Before | After |
+| --- | --- |
+| No keyboard shortcut and no `cycle-mode` command id existed; the harness `cycleMode()` was click-only. | A routed `cycle-mode` command (id → `WorkspaceCommandAction` → planner → executor → `model.cycleMode()`) rides the existing command rails; `WorkspaceShortcutRegistry` binds it to **Shift+Tab**, wired on every surface: a native **"Cycle Approval Mode" menu command** (`keyEquivalent` `.tab` + notification → `runWorkspaceCommand("cycle-mode")` — the registry entry is not dead) and the harness global keydown. |
+| The picker order, the (future) cycle, and the harness pill each hard-coded their own mode list. | One canonical `AgentMode.cycleOrder` ring — kept separate from `allCases` (which is discriminant order, `.plan` appended last) — is shared by the picker, `cycleMode()`, and the harness, so the three can't drift. |
+| — (the killer: double-fire) | Shift+Tab while the composer has slash/mention suggestions could fire BOTH suggestion-accept AND cycle-mode. Resolved by having the composer consume only **plain Tab** (`Tab && !shiftKey`) for suggestions, so Shift+Tab cleanly bubbles to the global cycle — mode cycles **even while composing**, and plain Tab still accepts. The Playwright killer test asserts the full ring, plus that a `/mod` draft survives Shift+Tab (cycled, not accepted) while plain Tab accepts it. |
+
+Residual risk:
+
+- **Harness focus guard (fixed):** the adversarial review caught that the global keydown fired the `cycle-mode` shortcut regardless of focus, so Shift+Tab in a search box / terminal / dialog silently flipped the *safety mode* instead of moving focus backward. The handler now only lets a Tab-bound shortcut fire when focus is the composer (`aria-label="Message"`) or not an editable field — proven by `Shift+Tab does not cycle mode while focus is in a non-composer input`.
+- **Native macOS (documented tradeoff):** the menu `keyEquivalent(.tab, .shift)` is matched by the main menu before the responder chain, so on native it likewise takes Shift+Tab from AppKit's reverse focus-traversal app-wide (forward Tab and Cmd-nav unaffected). This is inherent to binding Codex's Tab-based shortcut on a platform where Tab is focus traversal. A follow-up should scope it via a `FocusedValue`/first-responder guard (disable the menu command when an editable non-composer field holds focus) — verify on-device first. `retry-last-turn` and `focus-composer` shortcuts were deliberately kept out to keep this PR razor-tight.
+
 ## 2026-06-30 Plan Mode Resume Pass (PR2)
 
 Overall grade after this slice: **A safe-by-construction continuation, A reuse of the send loop**.


### PR DESCRIPTION
Adds Codex's single most-used shortcut: **Shift+Tab cycles the approval mode** (Auto → Plan → Review → Read-only → Auto). Mode could previously only change by clicking the pill or typing `/mode …`. Picked by a docs-grounded scout that read the parity matrix (every area is "Partial" — the harness is feature-complete) and chose the highest-value *felt* usability gap.

## How

- A routed **`cycle-mode`** command (`WorkspaceCommandAction` → planner → executor → `model.cycleMode()`) rides the existing command rails. `WorkspaceShortcutRegistry` binds it to **Shift+Tab**, wired on every surface: a native **"Cycle Approval Mode" menu command** (`keyEquivalent` `.tab` + notification → `runWorkspaceCommand("cycle-mode")`) and the harness global keydown. Palette + icon + `harnessStaticCommandIDs` entries added.
- One canonical **`AgentMode.cycleOrder`** ring (separate from `allCases`, which is discriminant order with `.plan` appended last) is shared by the top-bar picker, `cycleMode()`, and the harness pill — so the three can't drift.
- **The killer (no double-fire):** Shift+Tab while the composer has slash/mention suggestions could fire BOTH suggestion-accept AND cycle-mode. The composer now consumes only **plain Tab** (`Tab && !shiftKey`) for suggestions, so Shift+Tab cleanly bubbles to the global cycle — mode cycles **even while composing**, and plain Tab still accepts.

## Tests

`cycleMode` ring driven through the real `cycle-mode` command id (all 4 transitions + wrap); shortcut-registry + icon + routing-parity gates; Playwright proves the full ring, that a `/mod` draft **survives** Shift+Tab (cycled, not accepted) while plain Tab still accepts it. `retry-last-turn`/`focus-composer` shortcuts deliberately deferred to keep this razor-tight.

Verified: `swift test` 1806 · Playwright 140 · native-desktop smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)