### PR TITLE
Bind Cmd+Shift+R to retry-last-turn

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3677,7 +3677,7 @@
         { id: 'fork-full-context', title: 'Fork full', shortcut: '', category: 'Thread', keywords: ['thread', 'context', 'full', 'fork', 'copy'], isEnabled: false },
         { id: 'compact-context', title: 'Compact context', shortcut: '', category: 'Thread', keywords: ['thread', 'context', 'summarize', 'compact'], isEnabled: false },
         { id: 'sidebar-saved-search-create', title: 'Create sidebar search', shortcut: '', category: 'Thread', keywords: ['thread', 'chat', 'sidebar', 'filter'], isEnabled: true },
-        { id: 'retry-last-turn', title: 'Retry last turn', shortcut: '', category: 'Control', keywords: ['retry', 'rerun', 'again', 'failed'], isEnabled: false },
+        { id: 'retry-last-turn', title: 'Retry last turn', shortcut: 'Cmd+Shift+R', category: 'Control', keywords: ['retry', 'rerun', 'again', 'failed'], isEnabled: false },
         { id: 'search', title: 'Search', shortcut: 'Cmd+K', category: 'Navigation', keywords: ['find', 'threads', 'chat'], isEnabled: true },
         { id: 'find-in-chat', title: 'Find in chat', shortcut: 'Cmd+F', category: 'Navigation', keywords: ['find', 'current', 'transcript', 'message'], isEnabled: false },
         { id: 'copy-conversation', title: 'Copy conversation', shortcut: '', category: 'Navigation', keywords: ['export', 'transcript', 'markdown', 'copy all', 'share'], isEnabled: false },

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -280,3 +280,22 @@ test('Shift+Tab does not cycle mode while focus is in a non-composer input', asy
   // approval mode must not silently change out from under the user.
   await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
 });
+
+test('Cmd+Shift+R retries the last turn, and is a no-op with nothing to retry', async ({ page }) => {
+  await page.goto(harnessURL());
+  const message = page.getByLabel('Message');
+
+  // With no user turn yet, the retry shortcut is disabled — pressing it does nothing.
+  await page.keyboard.press('Meta+Shift+R');
+  await expect(page.getByTestId('message')).toHaveCount(0);
+
+  // Send a turn and let it finish (retry is disabled while a send is in flight).
+  await message.fill('retry me please');
+  await message.press('Enter');
+  await expect(page.getByTestId('message').filter({ hasText: 'retry me please' })).toHaveCount(1);
+  await expect(message).toBeEnabled();
+
+  // Cmd+Shift+R re-runs the last user turn: a second identical user message appears.
+  await page.keyboard.press('Meta+Shift+R');
+  await expect(page.getByTestId('message').filter({ hasText: 'retry me please' })).toHaveCount(2);
+});

--- a/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
@@ -7,6 +7,7 @@ enum WorkspaceCommandStaticCatalog {
             WorkspaceCommandSurface(
                 id: "retry-last-turn",
                 title: "Retry last turn",
+                shortcut: WorkspaceShortcutRegistry.label(for: "retry-last-turn"),
                 category: WorkspaceCommandPalette.controlCategory,
                 keywords: ["retry", "rerun", "again", "failed"],
                 isEnabled: canRetryLastUserTurn

--- a/Sources/QuillCodeApp/WorkspaceShortcutRegistry.swift
+++ b/Sources/QuillCodeApp/WorkspaceShortcutRegistry.swift
@@ -42,6 +42,7 @@ public enum WorkspaceShortcutRegistry {
     public static let shortcuts: [WorkspaceShortcut] = [
         WorkspaceShortcut(commandID: "new-chat", key: "n", modifiers: [.command]),
         WorkspaceShortcut(commandID: "cycle-mode", key: "tab", modifiers: [.shift]),
+        WorkspaceShortcut(commandID: "retry-last-turn", key: "r", modifiers: [.command, .shift]),
         WorkspaceShortcut(commandID: "search", key: "k", modifiers: [.command]),
         WorkspaceShortcut(commandID: "find-in-chat", key: "f", modifiers: [.command]),
         WorkspaceShortcut(commandID: "add-project", key: "o", modifiers: [.command]),

--- a/Sources/quill-code-desktop/DesktopCommands.swift
+++ b/Sources/quill-code-desktop/DesktopCommands.swift
@@ -62,6 +62,7 @@ struct QuillCodeDesktopCommands: Commands {
             Button("Retry Last Turn") {
                 NotificationCenter.default.post(name: .quillCodeRetryLastTurn, object: nil)
             }
+            .quillCodeShortcut("retry-last-turn")
         }
     }
 }

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -15,6 +15,10 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
             XCTAssertTrue(commandsText.contains(".quillCodeShortcut(\"\(commandID)\")"), "\(commandID) should be wired as a native keyboard shortcut.")
             XCTAssertTrue(appText.contains("controller.runWorkspaceCommand(\"\(commandID)\")"), "\(commandID) should route through the workspace command executor.")
         }
+        // retry-last-turn has a dedicated controller action (prepares the retry draft + sends),
+        // not the generic command executor — but its keyboard shortcut must still be bound.
+        XCTAssertTrue(commandsText.contains(".quillCodeShortcut(\"retry-last-turn\")"), "retry-last-turn should be wired as a native keyboard shortcut.")
+        XCTAssertTrue(appText.contains("controller.retryLastTurn()"), "retry-last-turn should route to the dedicated controller action.")
 
         let menuText = try Self.desktopSourceText(named: "QuillCodeMenuBarView.swift")
         XCTAssertTrue(menuText.contains("onDisconnectAll"), "Disconnect All should be wired to a controller action.")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-30 Retry-Last-Turn Shortcut Pass
+
+Overall grade after this slice: **A reuse of an existing command, A keyboard-wiring discipline**.
+
+Binds Codex's quick-retry to a keyboard shortcut: **Cmd+Shift+R reruns the last turn**. The `retry-last-turn` command already existed and worked (palette entry, dedicated `controller.retryLastTurn()` / `model.prepareRetryLastUserTurn`), but had no key — this is purely the binding, applying the keyboard-wiring lesson from the cycle-mode pass.
+
+| Before | After |
+| --- | --- |
+| `retry-last-turn` was palette/menu-click only. | `WorkspaceShortcutRegistry` binds it to **Cmd+Shift+R** (Cmd+R is browser-reload; Cmd+Shift+R is free — guarded by the registry's no-duplicate-bindings test), the catalog surface now carries the shortcut label, and the native "Retry Last Turn" menu button applies `.quillCodeShortcut("retry-last-turn")` so the binding is **live on native**, not a dead registry entry. |
+| — | The shortcut respects the command's conditional enablement (`canRetryLastUserTurn` / harness `hasUserMessages && !isSending`): the harness global keydown only fires enabled commands, proven by `Cmd+Shift+R … is a no-op with nothing to retry` (count stays 0) and that it reruns once a turn exists. |
+| `ParityDesktopGateTests` covered no cycle-mode/retry native wiring beyond browser commands. | The gate now asserts retry's `.quillCodeShortcut("retry-last-turn")` **and** its dedicated `controller.retryLastTurn()` route (not the generic `runWorkspaceCommand`, which retry doesn't use). |
+
+Residual risk:
+
+- Cmd+Shift+R is a sensible free chord but not a universal "retry" convention; it's discoverable via the menu + the keyboard-shortcuts dialog (both now show it). Like every other non-`cycle-mode` shortcut it is Cmd-modified, so it does not collide with focus traversal.
+
 ## 2026-06-30 Shift+Tab Mode Cycling Pass
 
 Overall grade after this slice: **A reuse of the command + shortcut rails, A felt-usability win**.


### PR DESCRIPTION
Binds Codex's quick-retry to a keyboard shortcut: **Cmd+Shift+R reruns the last turn**. The `retry-last-turn` command already existed and worked (palette entry, dedicated `controller.retryLastTurn()` / `model.prepareRetryLastUserTurn`) — it just had no key. This is purely the binding, applying the keyboard-wiring lesson from cycle-mode.

## How

- `WorkspaceShortcutRegistry` binds it to **Cmd+Shift+R** (Cmd+R is browser-reload; Cmd+Shift+R is free, guarded by the registry's no-duplicate-bindings test). The catalog surface carries the shortcut label, and the native **"Retry Last Turn" menu button now applies `.quillCodeShortcut("retry-last-turn")`** so the binding is *live on native*, not a dead registry entry.
- The harness command gets `shortcut: 'Cmd+Shift+R'`; the global keydown only fires *enabled* commands, so the shortcut respects `canRetryLastUserTurn` (`hasUserMessages && !isSending`). The native path likewise guards `!tasks.isRunning(.send) && prepareRetryLastUserTurn()`, so Cmd+Shift+R safely no-ops mid-send or with nothing to retry.
- `ParityDesktopGateTests` asserts retry's `.quillCodeShortcut("retry-last-turn")` **and** its dedicated `controller.retryLastTurn()` route (retry uses a dedicated action, not the generic `runWorkspaceCommand`).

## Tests

Existing registry/surface label tests verify the shortcut end-to-end; Playwright proves Cmd+Shift+R **reruns** the last turn and is a **no-op with nothing to retry** (count stays 0).

Verified: `swift test` 1806 · Playwright 142 · native-desktop smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)