### PR TITLE
Add focus-composer shortcut (Cmd+L)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3655,6 +3655,7 @@
       commands: [
         { id: 'new-chat', title: 'New chat', shortcut: 'Cmd+N', category: 'Thread', keywords: ['thread', 'conversation'], isEnabled: true },
         { id: 'cycle-mode', title: 'Cycle approval mode', shortcut: 'Shift+Tab', category: 'Workspace', keywords: ['mode', 'approval', 'auto', 'plan', 'review', 'read-only', 'safety', 'cycle'], isEnabled: true },
+        { id: 'focus-composer', title: 'Focus message input', shortcut: 'Cmd+L', category: 'Workspace', keywords: ['focus', 'composer', 'message', 'input', 'prompt', 'type'], isEnabled: true },
         { id: 'sidebar-filter:all', title: 'Show all chats', shortcut: '', category: 'Thread', keywords: ['thread', 'chat', 'sidebar', 'filter', 'all'], isEnabled: true },
         { id: 'sidebar-filter:pinned', title: 'Show pinned chats', shortcut: '', category: 'Thread', keywords: ['thread', 'chat', 'sidebar', 'filter', 'pinned'], isEnabled: true },
         { id: 'sidebar-filter:recent', title: 'Show recent chats', shortcut: '', category: 'Thread', keywords: ['thread', 'chat', 'sidebar', 'filter', 'recent'], isEnabled: true },
@@ -10393,6 +10394,7 @@
       'add-project',
       'add-ssh-project',
       'cycle-mode',
+      'focus-composer',
       'automation-create-thread-follow-up',
       'automation-create-thread-follow-up-every:daily',
       'automation-create-thread-follow-up-tomorrow',
@@ -10686,6 +10688,10 @@
       }
       if (commandID === 'cycle-mode') {
         cycleMode();
+        return;
+      }
+      if (commandID === 'focus-composer') {
+        document.getElementById('message')?.focus();
         return;
       }
       if (commandID === 'thread-rename') {

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -299,3 +299,16 @@ test('Cmd+Shift+R retries the last turn, and is a no-op with nothing to retry', 
   await page.keyboard.press('Meta+Shift+R');
   await expect(page.getByTestId('message').filter({ hasText: 'retry me please' })).toHaveCount(2);
 });
+
+test('Cmd+L focuses the message input from elsewhere', async ({ page }) => {
+  await page.goto(harnessURL());
+  const message = page.getByLabel('Message');
+
+  // Move focus off the composer.
+  await page.locator('body').click({ position: { x: 4, y: 4 } });
+  await expect(message).not.toBeFocused();
+
+  // Cmd+L jumps focus to the message input.
+  await page.keyboard.press('Meta+L');
+  await expect(message).toBeFocused();
+});

--- a/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
+++ b/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
@@ -15,6 +15,8 @@ enum QuillCodeCommandIconCatalog {
             return "square.and.pencil"
         case "cycle-mode":
             return "arrow.triangle.2.circlepath"
+        case "focus-composer":
+            return "text.cursor"
         case "search":
             return "magnifyingglass"
         case "command-palette":

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -307,6 +307,8 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
     public var fileMentionSuggestions: [FileMentionSuggestionSurface]
     /// Previously sent user messages (oldest first) for Up/Down history recall.
     public var sentMessageHistory: [String]
+    /// Bumped by the `focus-composer` command; the view focuses the input when it changes.
+    public var focusToken: Int
 
     public init(
         composer: ComposerState,
@@ -325,5 +327,6 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
             changedPaths: changedFilePaths
         )
         self.sentMessageHistory = sentMessageHistory
+        self.focusToken = composer.focusToken
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
@@ -22,6 +22,8 @@ extension QuillCodeWorkspaceModel {
             return true
         case .cycleMode:
             return cycleMode()
+        case .focusComposer:
+            return focusComposer()
         case .toggleTerminal:
             toggleTerminal()
             return true

--- a/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
@@ -4,6 +4,7 @@ import QuillCodeCore
 enum WorkspaceCommandActionEffect: Sendable, Hashable {
     case newChat
     case cycleMode
+    case focusComposer
     case toggleTerminal
     case clearTerminal
     case toggleBrowser
@@ -47,6 +48,8 @@ struct WorkspaceCommandActionPlanner: Sendable, Hashable {
             return .newChat
         case .cycleMode:
             return .cycleMode
+        case .focusComposer:
+            return .focusComposer
         case .toggleTerminal:
             return .toggleTerminal
         case .clearTerminal:

--- a/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
@@ -207,6 +207,7 @@ enum WorkspaceCommandPlan: Equatable {
 enum WorkspaceCommandAction: String, Equatable {
     case newChat = "new-chat"
     case cycleMode = "cycle-mode"
+    case focusComposer = "focus-composer"
     case toggleTerminal = "toggle-terminal"
     case clearTerminal = "terminal-clear"
     case toggleBrowser = "toggle-browser"

--- a/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandStaticCatalog.swift
@@ -60,6 +60,13 @@ enum WorkspaceCommandStaticCatalog {
                 keywords: ["mode", "approval", "auto", "plan", "review", "read-only", "safety", "cycle"]
             ),
             WorkspaceCommandSurface(
+                id: "focus-composer",
+                title: "Focus message input",
+                shortcut: WorkspaceShortcutRegistry.label(for: "focus-composer"),
+                category: WorkspaceCommandPalette.workspaceCategory,
+                keywords: ["focus", "composer", "message", "input", "prompt", "type"]
+            ),
+            WorkspaceCommandSurface(
                 id: "add-project",
                 title: "Open project",
                 shortcut: WorkspaceShortcutRegistry.label(for: "add-project"),

--- a/Sources/QuillCodeApp/WorkspaceModelConfiguration.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelConfiguration.swift
@@ -11,6 +11,15 @@ extension QuillCodeWorkspaceModel {
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
     }
 
+    /// Requests that the message composer grab focus (the `focus-composer` / Cmd+L command).
+    /// Focus is view-layer `FocusState`, so the model can't set it directly — it bumps a token
+    /// the rendered surface carries, and the view focuses the input when the token changes.
+    @discardableResult
+    public func focusComposer() -> Bool {
+        composer.focusToken &+= 1
+        return true
+    }
+
     /// Advances to the next approval mode, mirroring Codex's `Shift+Tab` shortcut. The ring order
     /// matches the top-bar picker and the harness mode pill: Auto → Plan → Review → Read-only → Auto.
     @discardableResult

--- a/Sources/QuillCodeApp/WorkspaceShortcutRegistry.swift
+++ b/Sources/QuillCodeApp/WorkspaceShortcutRegistry.swift
@@ -43,6 +43,7 @@ public enum WorkspaceShortcutRegistry {
         WorkspaceShortcut(commandID: "new-chat", key: "n", modifiers: [.command]),
         WorkspaceShortcut(commandID: "cycle-mode", key: "tab", modifiers: [.shift]),
         WorkspaceShortcut(commandID: "retry-last-turn", key: "r", modifiers: [.command, .shift]),
+        WorkspaceShortcut(commandID: "focus-composer", key: "l", modifiers: [.command]),
         WorkspaceShortcut(commandID: "search", key: "k", modifiers: [.command]),
         WorkspaceShortcut(commandID: "find-in-chat", key: "f", modifiers: [.command]),
         WorkspaceShortcut(commandID: "add-project", key: "o", modifiers: [.command]),

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -226,6 +226,10 @@ public struct QuillCodeWorkspaceView: View {
         .frame(minWidth: 980, minHeight: 640)
         .background(QuillCodePalette.background)
         .foregroundStyle(QuillCodePalette.text)
+        .onChange(of: surface.composer.focusToken) { _, _ in
+            // The `focus-composer` (Cmd+L) command bumps this token; grab focus when it changes.
+            isComposerFocused = true
+        }
         .quillCodeWorkspaceSheets(
             surface: surface,
             isSearchPresented: $isSearchPresented,

--- a/Sources/QuillCodeApp/WorkspaceUIState.swift
+++ b/Sources/QuillCodeApp/WorkspaceUIState.swift
@@ -2,15 +2,21 @@ public struct ComposerState: Sendable, Hashable {
     public var draft: String
     public var isSending: Bool
     public var placeholder: String
+    /// Bumped each time the composer should grab focus (e.g. the `focus-composer` command). The
+    /// view observes this on the rendered surface and sets its `FocusState` when it changes —
+    /// the bridge from a routed (model) command to view-layer focus.
+    public var focusToken: Int
 
     public init(
         draft: String = "",
         isSending: Bool = false,
-        placeholder: String = "Message QuillCode"
+        placeholder: String = "Message QuillCode",
+        focusToken: Int = 0
     ) {
         self.draft = draft
         self.isSending = isSending
         self.placeholder = placeholder
+        self.focusToken = focusToken
     }
 }
 

--- a/Sources/quill-code-desktop/DesktopCommands.swift
+++ b/Sources/quill-code-desktop/DesktopCommands.swift
@@ -13,6 +13,10 @@ struct QuillCodeDesktopCommands: Commands {
                 NotificationCenter.default.post(name: .quillCodeCycleMode, object: nil)
             }
             .quillCodeShortcut("cycle-mode")
+            Button("Focus Message") {
+                NotificationCenter.default.post(name: .quillCodeFocusComposer, object: nil)
+            }
+            .quillCodeShortcut("focus-composer")
             Button("Open Project...") {
                 NotificationCenter.default.post(name: .quillCodeOpenProject, object: nil)
             }
@@ -70,6 +74,7 @@ struct QuillCodeDesktopCommands: Commands {
 extension Notification.Name {
     static let quillCodeNewChat = Notification.Name("QuillCodeNewChat")
     static let quillCodeCycleMode = Notification.Name("QuillCodeCycleMode")
+    static let quillCodeFocusComposer = Notification.Name("QuillCodeFocusComposer")
     static let quillCodeOpenProject = Notification.Name("QuillCodeOpenProject")
     static let quillCodeCommandPalette = Notification.Name("QuillCodeCommandPalette")
     static let quillCodeKeyboardShortcuts = Notification.Name("QuillCodeKeyboardShortcuts")

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -112,6 +112,9 @@ struct QuillCodeDesktopRootView: View {
         .onReceive(NotificationCenter.default.publisher(for: .quillCodeCycleMode)) { _ in
             controller.runWorkspaceCommand("cycle-mode")
         }
+        .onReceive(NotificationCenter.default.publisher(for: .quillCodeFocusComposer)) { _ in
+            controller.runWorkspaceCommand("focus-composer")
+        }
         .onReceive(NotificationCenter.default.publisher(for: .quillCodeToggleTerminal)) { _ in
             controller.toggleTerminal()
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
@@ -40,11 +40,22 @@ struct QuillCodeDesktopModelStateCoordinator {
         if draft != nextState.draft, !isComposerBusy {
             draft = nextState.draft
         }
-        surface.composer = ComposerSurface(composer: ComposerState(
-            draft: draft,
-            isSending: isComposerBusy,
-            placeholder: nextState.surface.composer.placeholder
-        ))
+        // Rebuild from the LOCAL draft so slash/@-mention suggestions reflect live typing, but
+        // carry the model-derived fields the bare rebuild used to silently drop: the focusToken
+        // (focus-composer's signal — without it Cmd+L is dead on native because the view's
+        // .onChange never fires), the file-mention index + changed paths (so @-mentions aren't
+        // computed against an empty index), and the sent-message history (Up/Down recall).
+        surface.composer = ComposerSurface(
+            composer: ComposerState(
+                draft: draft,
+                isSending: isComposerBusy,
+                placeholder: nextState.surface.composer.placeholder,
+                focusToken: model.composer.focusToken
+            ),
+            fileMentionIndex: model.fileMentionIndex,
+            changedFilePaths: nextState.surface.changedFilePaths,
+            sentMessageHistory: nextState.surface.composer.sentMessageHistory
+        )
         if terminalDraft != nextState.terminalDraft, !model.terminal.isRunning {
             terminalDraft = nextState.terminalDraft
         }

--- a/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
@@ -41,6 +41,20 @@ final class WorkspaceConfigurationIntegrationTests: XCTestCase {
         XCTAssertEqual(model.root.topBar.mode, .auto)
     }
 
+    func testFocusComposerCommandBumpsTheSurfaceFocusToken() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [ChatThread()],
+            selectedThreadID: nil
+        ))
+        _ = model.newChat()
+        let before = model.surface().composer.focusToken
+
+        // Driving the real command id bumps the token the view observes to grab focus.
+        XCTAssertTrue(model.runWorkspaceCommand("focus-composer", workspaceRoot: root))
+        XCTAssertEqual(model.surface().composer.focusToken, before + 1)
+    }
+
     func testToggleModelFavoriteUpdatesConfigAndSurface() {
         let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
             config: AppConfig(favoriteModels: ["provider/old"]),

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -91,6 +91,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
             "find-in-chat",
             "copy-conversation",
             "cycle-mode",
+            "focus-composer",
             "add-project",
             "add-ssh-project",
             "project-new-chat",

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -496,6 +496,42 @@ final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
         }
         return url
     }
+
+    func testDesktopRefreshPreservesComposerFocusTokenAndHistory() {
+        let thread = ChatThread(messages: [
+            ChatMessage(role: .user, content: "first"),
+            ChatMessage(role: .assistant, content: "ok"),
+            ChatMessage(role: .user, content: "second")
+        ])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        model.focusComposer()
+        let expectedToken = model.composer.focusToken
+        let expectedHistory = model.surface().composer.sentMessageHistory
+        XCTAssertGreaterThan(expectedToken, 0)
+        XCTAssertFalse(expectedHistory.isEmpty)
+
+        // Drive the REAL desktop refresh path (not model.surface() directly) — the path the live
+        // app renders from. Its composer rebuild must preserve the focus token (or Cmd+L is dead
+        // on native — the view's .onChange never fires) AND the sent-message history (Up/Down
+        // recall) — the bare rebuild used to reset both to their defaults.
+        var surface = model.surface()
+        var draft = ""
+        var terminalDraft = ""
+        var browserAddressDraft = ""
+        QuillCodeDesktopModelStateCoordinator().refreshState(
+            from: model,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft
+        )
+
+        XCTAssertEqual(surface.composer.focusToken, expectedToken)
+        XCTAssertEqual(surface.composer.sentMessageHistory, expectedHistory)
+    }
 }
 
 private struct DesktopRealWorldSmokeCase {

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -11,7 +11,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         for label in ["New Chat", "Open Project", "Command Palette", "Keyboard Shortcuts", "Open Browser Session", "Computer Use Setup", "Settings", "Stop All", "Disconnect All"] {
             XCTAssertTrue(text.contains(label), "Menu-bar widget is missing \(label).")
         }
-        for commandID in ["browser-back", "browser-forward", "browser-reload", "cycle-mode"] {
+        for commandID in ["browser-back", "browser-forward", "browser-reload", "cycle-mode", "focus-composer"] {
             XCTAssertTrue(commandsText.contains(".quillCodeShortcut(\"\(commandID)\")"), "\(commandID) should be wired as a native keyboard shortcut.")
             XCTAssertTrue(appText.contains("controller.runWorkspaceCommand(\"\(commandID)\")"), "\(commandID) should route through the workspace command executor.")
         }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,22 @@
 # Code Quality Audit
 
+## 2026-06-30 Focus-Composer Shortcut Pass
+
+Overall grade after this slice: **A model→view focus bridge, A routed-command consistency**.
+
+Adds **Cmd+L to jump focus to the message input** from anywhere — a standard, constantly-used composer shortcut. The interesting problem: focus is view-layer (`@FocusState`), but every command in this app routes through the *model*. Solved with a **surface token**, so focus-composer stays a normal routed command (palette + native + harness all go through it) rather than a special-case.
+
+| Before | After |
+| --- | --- |
+| No way to focus the composer by keyboard; the existing `focusesComposer` flag only applies to palette-triggered commands, not the native keyboard path. | A routed `focus-composer` command (`WorkspaceCommandAction` → planner → executor → `model.focusComposer()`) bumps a `focusToken` counter that the rendered `ComposerSurface` carries; `WorkspaceSwiftUIView` (which owns the `@FocusState`) observes `surface.composer.focusToken` via `.onChange` and grabs focus when it changes — a clean model→view bridge that fits the snapshot architecture. |
+| — | Bound to **Cmd+L** (verified free, guarded by the registry's no-duplicate-bindings test). Live on every surface: the native "Focus Message" menu button applies `.quillCodeShortcut("focus-composer")` → `runWorkspaceCommand`; the harness command focuses `#message`. Cmd+L is Cmd-modified, so it's unaffected by the Tab focus-guard from the cycle-mode pass. |
+| — (the review's mustFix) | The desktop `refreshState` rebuilt `surface.composer` from a **bare** `ComposerState`, resetting `focusToken` to 0 — so `.onChange` never fired and native Cmd+L was **dead** (the bare rebuild also dropped `sentMessageHistory` + the file-mention index, silently breaking native Up/Down recall + @-mentions). The rebuild now carries `focusToken`, `fileMentionIndex`, `changedFilePaths`, and `sentMessageHistory`. My first test read `model.surface()` directly and missed this; a `QuillCodeDesktopControllerSmokeTests` regression now drives the **real `refreshState` path** and asserts both the token and the history survive. |
+| — | `ParityDesktopGateTests` asserts the native `.quillCodeShortcut` + `runWorkspaceCommand("focus-composer")` route; Playwright proves Cmd+L moves focus to the input from a neutral element. |
+
+Residual risk:
+
+- The token is a monotonically-incrementing `Int` (`&+=` wrapping), so a focus request is a *change*, never a level — robust against repeated Cmd+L and snapshot dedup. Like the other Cmd shortcuts, no focus-traversal collision.
+
 ## 2026-06-30 Retry-Last-Turn Shortcut Pass
 
 Overall grade after this slice: **A reuse of an existing command, A keyboard-wiring discipline**.


### PR DESCRIPTION
Adds **Cmd+L to jump focus to the message input** from anywhere — a standard composer shortcut. The interesting problem: focus is view-layer (`@FocusState`), but every command in this app routes through the *model*. Solved with a **surface token** so `focus-composer` stays a normal routed command across all three surfaces.

## How

- A routed `focus-composer` command (`WorkspaceCommandAction` → planner → executor → `model.focusComposer()`) bumps a `focusToken` counter (`&+= 1`) carried on the rendered `ComposerSurface`. `WorkspaceSwiftUIView` (which owns the `@FocusState`) observes `surface.composer.focusToken` via `.onChange` and grabs focus when it changes. The native `runWorkspaceCommand` ends with `refresh()`, which rebuilds the `@Published surface` with the new token — so the bridge fires reliably (and every press is a distinct value, so rapid Cmd+L re-fires).
- Bound to **Cmd+L** (free, guarded by the registry's no-duplicate-bindings test). Live on every surface: the native "Focus Message" menu button applies `.quillCodeShortcut("focus-composer")` → `runWorkspaceCommand`; the harness focuses `#message`. Cmd+L is Cmd-modified, so it's unaffected by the Tab focus-guard.

## Tests

`ParityDesktopGateTests` asserts the native `.quillCodeShortcut` + `runWorkspaceCommand("focus-composer")` route; a model test drives the real command id and asserts the token bumps; Playwright proves Cmd+L moves focus to the input from a neutral element. The registry/surface label test verifies the Cmd+L binding end-to-end.

Verified: `swift test` 1807 · Playwright 143 · native-desktop smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)