### PR TITLE
Guard native refreshState against composer-surface field drift

### DIFF
--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -532,6 +532,73 @@ final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
         XCTAssertEqual(surface.composer.focusToken, expectedToken)
         XCTAssertEqual(surface.composer.sentMessageHistory, expectedHistory)
     }
+
+    /// Structural guard against the whole "native refresh drops a composer field" bug class the
+    /// focus-composer review surfaced: `refreshState` is the ONLY place that rebuilds a sub-surface
+    /// (the composer); everything else is copied verbatim. So with the local draft matching the
+    /// model's, the rebuilt composer must EQUAL `model.surface().composer` exactly — any field a
+    /// future rebuild forgets to carry (focusToken, sentMessageHistory, …) trips this immediately.
+    /// (Compares the composer, not the whole surface, because the sidebar carries relative-time
+    /// strings that aren't stable across two `surface()` calls.)
+    func testDesktopRefreshComposerEqualsModelSurfaceWhenDraftUnchanged() {
+        let model = richlyPopulatedModel()
+
+        var surface = model.surface()
+        var draft = model.composer.draft
+        var terminalDraft = model.terminal.draft
+        var browserAddressDraft = model.browser.addressDraft
+        QuillCodeDesktopModelStateCoordinator().refreshState(
+            from: model,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft
+        )
+
+        XCTAssertEqual(surface.composer, model.surface().composer)
+    }
+
+    /// While a send is in flight the live local draft is kept (the model isn't the source of truth
+    /// mid-send), so the composer rebuilds from it — but the non-draft fields the bare rebuild used
+    /// to drop (focusToken, sentMessageHistory) must still survive.
+    func testDesktopRefreshKeepsLocalDraftAndNonDraftFieldsWhileSending() {
+        let model = richlyPopulatedModel()
+        let modelComposer = model.surface().composer
+
+        var surface = model.surface()
+        var draft = "a half-typed message"
+        var terminalDraft = model.terminal.draft
+        var browserAddressDraft = model.browser.addressDraft
+        // isComposerTaskRunning: true ⇒ the local draft is preserved rather than synced to the model.
+        QuillCodeDesktopModelStateCoordinator().refreshState(
+            from: model,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft,
+            isComposerTaskRunning: true
+        )
+
+        XCTAssertEqual(surface.composer.draft, "a half-typed message")
+        XCTAssertTrue(surface.composer.isSending)
+        XCTAssertEqual(surface.composer.focusToken, modelComposer.focusToken)
+        XCTAssertEqual(surface.composer.sentMessageHistory, modelComposer.sentMessageHistory)
+        XCTAssertEqual(surface.composer.placeholder, modelComposer.placeholder)
+    }
+
+    private func richlyPopulatedModel() -> QuillCodeWorkspaceModel {
+        let thread = ChatThread(messages: [
+            ChatMessage(role: .user, content: "first request"),
+            ChatMessage(role: .assistant, content: "did it"),
+            ChatMessage(role: .user, content: "second request")
+        ])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        model.focusComposer()
+        return model
+    }
 }
 
 private struct DesktopRealWorldSmokeCase {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,20 @@
 # Code Quality Audit
 
+## 2026-06-30 Native Refresh Parity Guard Pass
+
+Overall grade after this slice: **A regression guard for a whole bug class, A tests-the-shipped-path discipline**.
+
+A test-only hardening directly motivated by the focus-composer review, which found the desktop `refreshState` silently dropping composer fields (`focusToken`, `sentMessageHistory`, the file-mention index) — invisible because the suite asserts against `model.surface()`, never the *rendered* refresh path. An audit confirmed `refreshState` is the **only** desktop sub-surface override (the composer rebuild; `initialState` uses `model.surface()` verbatim, no other `surface.X =` overrides), so the bug class is contained — but nothing *guarded* against it recurring.
+
+| Before | After |
+| --- | --- |
+| The only desktop test of the composer rebuild checked two specific fields (`focusToken`, history) and was added reactively. | `testDesktopRefreshComposerEqualsModelSurfaceWhenDraftUnchanged` asserts the rebuilt composer **equals `model.surface().composer` in full** (rich model: a thread with history + a bumped focus token) — so any field a future rebuild forgets to carry trips immediately. It compares the *composer* (deterministic), not the whole surface, because the sidebar carries relative-time strings that aren't stable across two `surface()` calls. |
+| The mid-send "keep the local draft" path was untested. | `testDesktopRefreshKeepsLocalDraftAndNonDraftFieldsWhileSending` covers `isComposerTaskRunning: true` (the only path that preserves a differing local draft — idle refresh *syncs* the draft to the model, which writing the test surfaced) and asserts the non-draft fields still survive. |
+
+Residual risk:
+
+- The guard covers the composer (the one rebuilt sub-surface). Other sub-surfaces are copied verbatim in `refreshState`, so they can't drift there; if a future change adds another override, this file is the place to extend the guard.
+
 ## 2026-06-30 Focus-Composer Shortcut Pass
 
 Overall grade after this slice: **A model→view focus bridge, A routed-command consistency**.


### PR DESCRIPTION
A test-only hardening directly motivated by the [#709](https://github.com/Lore-Hex/QuillCode/pull/709) focus-composer review, which found the desktop `refreshState` silently dropping composer fields (`focusToken`, `sentMessageHistory`, the file-mention index) — **invisible because the suite asserts against `model.surface()`, never the rendered refresh path**. An audit confirmed `refreshState` is the *only* desktop sub-surface override (the composer rebuild), so the bug class is contained — but nothing *guarded* against it recurring.

## Tests

- **`testDesktopRefreshComposerEqualsModelSurfaceWhenDraftUnchanged`** — asserts the rebuilt composer **equals `model.surface().composer` in full** (rich model: a thread with history + a bumped focus token), so any field a future rebuild forgets to carry trips immediately. Compares the *composer* (deterministic), not the whole surface, because the sidebar's relative-time strings aren't stable across two `surface()` calls.
- **`testDesktopRefreshKeepsLocalDraftAndNonDraftFieldsWhileSending`** — covers the mid-send path (`isComposerTaskRunning: true`), the only one that preserves a differing local draft (idle refresh *syncs* the draft to the model — writing the test surfaced this), asserting the non-draft fields survive.

Test-only; no source change. Verified: `swift test` 1810 · Playwright 143 · native-desktop smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)