### PR TITLE
Seed plan authoring in Plan mode (Plan mode PR3)

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -16,6 +16,7 @@ public struct TrustedRouterPromptBuilder: Sendable {
             Self.chatMessage(role: "system", content: Self.systemPrompt(tools: tools))
         ]
 
+        appendPlanModeGuidance(from: thread, to: &messages)
         appendProjectInstructions(from: thread, to: &messages)
         appendMemories(from: thread, to: &messages)
         appendRecentHistory(from: thread, to: &messages)
@@ -121,6 +122,18 @@ public struct TrustedRouterPromptBuilder: Sendable {
             content: Self.memoryPrompt(thread.memories)
         ))
     }
+
+    private func appendPlanModeGuidance(from thread: ChatThread, to messages: inout [[String: Any]]) {
+        guard thread.mode == .plan else { return }
+        messages.append(Self.chatMessage(role: "system", content: Self.planModePrompt))
+    }
+
+    static let planModePrompt = """
+    You are in Plan mode. Before proposing any change to the workspace, call host.plan.update \
+    with a concise numbered plan of the steps you intend to take, then update it as you go. \
+    Investigate read-only first; every mutating step is gated for the user's explicit approval \
+    before it runs, so lay out the plan so they can review it.
+    """
 
     private func appendRecentHistory(from thread: ChatThread, to messages: inout [[String: Any]]) {
         for message in thread.messages.suffix(historyLimit) {

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -56,6 +56,35 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         XCTAssertTrue((messages[1]["content"] as? String)?.contains("Always run swift test") == true)
     }
 
+    private func systemContent(for mode: AgentMode) -> [String] {
+        let thread = ChatThread(mode: mode, messages: [.init(role: .user, content: "build the feature")])
+        let messages = TrustedRouterPromptBuilder().messages(
+            thread: thread,
+            userMessage: "build the feature",
+            tools: [.shellRun, .planUpdate]
+        )
+        return messages
+            .filter { $0["role"] as? String == "system" }
+            .compactMap { $0["content"] as? String }
+    }
+
+    func testPlanModeSeedsExactlyOneHostPlanUpdateGuidanceMessage() {
+        let planGuidance = systemContent(for: .plan).filter {
+            $0.contains("You are in Plan mode") && $0.contains("host.plan.update")
+        }
+        XCTAssertEqual(planGuidance.count, 1, "Plan-mode guidance should appear exactly once, not be double-injected")
+        XCTAssertTrue(planGuidance.first?.contains("gated for the user") == true)
+    }
+
+    func testNonPlanModesOmitPlanModeGuidance() {
+        for mode in [AgentMode.auto, .review, .readOnly] {
+            XCTAssertFalse(
+                systemContent(for: mode).contains { $0.contains("You are in Plan mode") },
+                "mode \(mode.rawValue) must not receive Plan-mode plan-authoring guidance"
+            )
+        }
+    }
+
     func testMessagesIncludeMemoriesAsAuditableSystemContext() {
         let thread = ChatThread(
             messages: [.init(role: .user, content: "status")],

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-30 Plan-Mode Prompt Seeding Pass (Plan mode PR3)
+
+Overall grade after this slice: **A completes the Plan-mode story, A reuses existing machinery**.
+
+Completes the Plan-mode arc (PR1 gate, PR2 resume, **PR3 seeding**): when a thread is in `.plan` mode, the agent's prompt now instructs it to author a `host.plan.update` plan *before* proposing changes — so entering Plan mode surfaces a real reviewable plan in the Activity pane instead of just silently blocking the first mutation.
+
+| Before | After |
+| --- | --- |
+| `TrustedRouterPromptBuilder.messages(thread:)` never varied the prompt by approval mode; a planning agent had no nudge to author the plan artifact. | `appendPlanModeGuidance(from:to:)` appends one system message (mirroring `appendProjectInstructions`/`appendMemories`) **only when `thread.mode == .plan`**, telling the agent to call `host.plan.update` with a numbered plan and that every mutating step is gated for approval. |
+| — | The plan tool is reachable while planning: `host.plan.update` is `risk: .read`, so the Plan-mode safety arm auto-approves it — the agent can author/refresh the plan without an approval prompt. The plan artifact already renders tri-surface (`AgentPlanUpdate` → Activity pane), so no new UI is needed. |
+| — | `testPlanModeSeedsExactlyOneHostPlanUpdateGuidanceMessage` (present once, not double-injected) and `testNonPlanModesOmitPlanModeGuidance` (absent for `.auto`/`.review`/`.read-only`) lock the mode-conditional behavior. `MockLLMClient` ignores the prompt, so the agent suite is unaffected. |
+
+Residual risk:
+
+- This is a prompt nudge; whether the real model authors the plan is LLM-dependent (the deterministic part — the instruction is present only in Plan mode — is unit-tested). A future PR could seed a deterministic skeleton plan on Plan-mode entry for an immediate visual cue, and link approving a step to marking the corresponding `AgentPlanItem` complete.
+
 ## 2026-06-30 Native Refresh Parity Guard Pass
 
 Overall grade after this slice: **A regression guard for a whole bug class, A tests-the-shipped-path discipline**.


### PR DESCRIPTION
Completes the Plan-mode arc (PR1 gate, PR2 resume, **PR3 seeding**): when a thread is in `.plan` mode, the agent's prompt now instructs it to author a `host.plan.update` plan *before* proposing changes — so entering Plan mode surfaces a real reviewable plan in the Activity pane instead of just silently blocking the first mutation.

## How

- `TrustedRouterPromptBuilder.appendPlanModeGuidance(from:to:)` appends one system message (mirroring `appendProjectInstructions`/`appendMemories`) **only when `thread.mode == .plan`**, telling the agent to call `host.plan.update` with a numbered plan and that every mutating step is gated for approval.
- The plan tool is reachable while planning: `host.plan.update` is `risk: .read`, so the Plan-mode safety arm auto-approves it. The plan artifact already renders tri-surface (`AgentPlanUpdate` → Activity pane), so there's no new UI.

## Tests

`testPlanModeSeedsExactlyOneHostPlanUpdateGuidanceMessage` (present once, not double-injected) and `testNonPlanModesOmitPlanModeGuidance` (absent for `.auto`/`.review`/`.read-only`). `MockLLMClient` ignores the prompt, so the agent suite is unaffected.

Verified: `swift test` 1810 · native-desktop smoke (Playwright unaffected — no harness/UI change). Whether the real model authors the plan is LLM-dependent; the deterministic part (instruction present only in Plan mode) is unit-tested. A deterministic skeleton-plan-on-entry + linking approvals to `AgentPlanItem` status are natural follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)