### PR TITLE
Mode-aware prompt guidance for gated approval modes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,7 @@ let package = Package(
         .testTarget(name: "QuillCodeToolsTests", dependencies: ["QuillCodeTools"]),
         .testTarget(name: "QuillCodePersistenceTests", dependencies: ["QuillCodePersistence"]),
         .testTarget(name: "QuillComputerUseKitTests", dependencies: ["QuillComputerUseKit"]),
-        .testTarget(name: "QuillCodeAgentTests", dependencies: ["QuillCodeAgent", "QuillCodeTools"]),
+        .testTarget(name: "QuillCodeAgentTests", dependencies: ["QuillCodeAgent", "QuillCodeTools", "QuillCodeSafety"]),
         .testTarget(name: "QuillCodeAppTests", dependencies: ["QuillCodeApp", "QuillCodeAgent"]),
         .testTarget(
             name: "QuillCodeDesktopTests",

--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -16,7 +16,7 @@ public struct TrustedRouterPromptBuilder: Sendable {
             Self.chatMessage(role: "system", content: Self.systemPrompt(tools: tools))
         ]
 
-        appendPlanModeGuidance(from: thread, to: &messages)
+        appendModeGuidance(from: thread, to: &messages)
         appendProjectInstructions(from: thread, to: &messages)
         appendMemories(from: thread, to: &messages)
         appendRecentHistory(from: thread, to: &messages)
@@ -123,9 +123,21 @@ public struct TrustedRouterPromptBuilder: Sendable {
         ))
     }
 
-    private func appendPlanModeGuidance(from thread: ChatThread, to messages: inout [[String: Any]]) {
-        guard thread.mode == .plan else { return }
-        messages.append(Self.chatMessage(role: "system", content: Self.planModePrompt))
+    private func appendModeGuidance(from thread: ChatThread, to messages: inout [[String: Any]]) {
+        guard let guidance = Self.modeGuidance(for: thread.mode) else { return }
+        messages.append(Self.chatMessage(role: "system", content: guidance))
+    }
+
+    /// Mode-aware guidance so the agent's behavior matches the active approval mode and it does not
+    /// waste turns proposing tools the mode will block. `.auto` returns `nil`: it has no extra
+    /// constraint to announce (the Auto safety reviewer decides per call), so the base prompt stands.
+    static func modeGuidance(for mode: AgentMode) -> String? {
+        switch mode {
+        case .plan: return planModePrompt
+        case .readOnly: return readOnlyModePrompt
+        case .review: return reviewModePrompt
+        case .auto: return nil
+        }
     }
 
     static let planModePrompt = """
@@ -133,6 +145,30 @@ public struct TrustedRouterPromptBuilder: Sendable {
     with a concise numbered plan of the steps you intend to take, then update it as you go. \
     Investigate read-only first; every mutating step is gated for the user's explicit approval \
     before it runs, so lay out the plan so they can review it.
+    """
+
+    /// The read tools the Read-only guidance advertises as usable. Kept as data — the prompt is built
+    /// from it — so a test can assert every advertised tool is genuinely `.read`-risk (and therefore
+    /// approved by the `.readOnly` safety arm), and the prompt can never drift to naming a tool the
+    /// mode would block. `host.shell.run` is deliberately absent: it is the only shell tool and is
+    /// `.destructive`, so it is blocked in read-only and is named only in the negative below.
+    static let readOnlyUsableTools: [ToolDefinition] = [.fileRead, .fileList, .fileSearch, .gitStatus, .gitDiff]
+
+    static let readOnlyModePrompt: String = {
+        let usable = readOnlyUsableTools.map(\.name).joined(separator: ", ")
+        return """
+        You are in Read-only mode. File writes and every shell command are blocked and will not run — \
+        host.shell.run is unavailable here even for read-only commands like cat or ls, so use the \
+        dedicated read tools instead. Investigate and answer with read-only tools only: \(usable). \
+        Do not propose changes you cannot apply; if the request needs a file edit or a shell command, \
+        explain what you would do and that the user must switch out of Read-only mode to run it.
+        """
+    }()
+
+    static let reviewModePrompt = """
+    You are in Review mode. Read-only tools run automatically, but every mutating or destructive \
+    tool requires the user's explicit approval before it runs. Propose changes normally — each one \
+    is gated for the user to review and approve — and keep proposed steps small and clearly described.
     """
 
     private func appendRecentHistory(from thread: ChatThread, to messages: inout [[String: Any]]) {

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import QuillCodeCore
 import QuillCodeTools
+import QuillCodeSafety
 @testable import QuillCodeAgent
 
 final class TrustedRouterPromptBuilderTests: XCTestCase {
@@ -83,6 +84,97 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
                 "mode \(mode.rawValue) must not receive Plan-mode plan-authoring guidance"
             )
         }
+    }
+
+    func testReadOnlyModeAnnouncesBlockedMutationsExactlyOnce() {
+        let guidance = systemContent(for: .readOnly).filter { $0.contains("You are in Read-only mode") }
+        XCTAssertEqual(guidance.count, 1, "Read-only guidance should appear exactly once, not be double-injected")
+        // Must tell the agent mutations are blocked so it does not waste turns proposing them.
+        XCTAssertTrue(guidance.first?.contains("blocked") == true)
+        XCTAssertTrue(guidance.first?.contains("read-only tools") == true)
+    }
+
+    func testReviewModeAnnouncesApprovalGatingExactlyOnce() {
+        let guidance = systemContent(for: .review).filter { $0.contains("You are in Review mode") }
+        XCTAssertEqual(guidance.count, 1, "Review guidance should appear exactly once, not be double-injected")
+        XCTAssertTrue(guidance.first?.contains("explicit approval") == true)
+    }
+
+    private func readOnlyVerdict(_ tool: ToolDefinition) async -> ApprovalVerdict {
+        await StaticSafetyReviewer().review(SafetyContext(
+            mode: .readOnly,
+            userMessage: "investigate the bug",
+            toolCall: ToolCall(name: tool.name, argumentsJSON: "{}"),
+            toolDefinition: tool,
+            recentMessages: []
+        )).verdict
+    }
+
+    /// The read-only guidance names specific tools as usable. Tie that claim to the actual safety
+    /// arm: every advertised tool must be `.read`-risk and `.approve`d in `.readOnly`, and it must
+    /// actually appear in the prompt text — so the prompt can never silently advertise a tool the
+    /// mode blocks (the original bug: it named "non-mutating shell reads").
+    func testReadOnlyGuidanceOnlyAdvertisesToolsTheReadOnlySafetyArmApproves() async {
+        for tool in TrustedRouterPromptBuilder.readOnlyUsableTools {
+            XCTAssertEqual(tool.risk, .read, "\(tool.name) is advertised in read-only but is not .read-risk")
+            let v = await readOnlyVerdict(tool)
+            XCTAssertEqual(v, .approve, "read-only prompt names \(tool.name) but the safety arm does not approve it")
+            XCTAssertTrue(
+                TrustedRouterPromptBuilder.readOnlyModePrompt.contains(tool.name),
+                "read-only prompt should explicitly name \(tool.name)"
+            )
+        }
+        // host.shell.run is .destructive and hard-denied in read-only.
+        XCTAssertEqual(ToolDefinition.shellRun.risk, .destructive)
+        let shell = await readOnlyVerdict(.shellRun)
+        XCTAssertEqual(shell, .deny, "host.shell.run must be denied in read-only mode")
+    }
+
+    /// Generic drift guard: scan EVERY `host.*` token in the read-only prompt and require each to be
+    /// either an advertised `.read` tool or `host.shell.run` (named only to say it is blocked). This
+    /// catches any future edit that names a different non-`.read` tool (e.g. host.git.commit,
+    /// host.file.write) as usable — not just the literal original "shell read" wording.
+    func testReadOnlyPromptNamesNoToolOutsideTheValidatedReadOnlyAllowlist() {
+        let advertised = Set(TrustedRouterPromptBuilder.readOnlyUsableTools.map(\.name))
+        let prompt = TrustedRouterPromptBuilder.readOnlyModePrompt
+        let tokens = prompt
+            .split(whereSeparator: { !($0.isLetter || $0.isNumber || $0 == "." || $0 == "_") })
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: ".")) }  // drop trailing sentence periods
+            .filter { $0.hasPrefix("host.") }
+
+        XCTAssertFalse(tokens.isEmpty, "read-only prompt should name the tools it allows")
+        for token in tokens {
+            XCTAssertTrue(
+                advertised.contains(token) || token == ToolDefinition.shellRun.name,
+                "read-only prompt names \(token); only advertised .read tools or host.shell.run (as blocked) are allowed"
+            )
+        }
+        // The only non-advertised tool it may name is host.shell.run, and only to declare it blocked.
+        XCTAssertTrue(tokens.contains(ToolDefinition.shellRun.name),
+                      "read-only prompt should state that host.shell.run is blocked")
+    }
+
+    func testEachGatedModeGetsOnlyItsOwnGuidanceAndAutoGetsNone() {
+        // No cross-contamination: each mode's banner appears only under that mode.
+        let banners = ["You are in Plan mode", "You are in Read-only mode", "You are in Review mode"]
+        let expected: [AgentMode: String] = [
+            .plan: "You are in Plan mode",
+            .readOnly: "You are in Read-only mode",
+            .review: "You are in Review mode"
+        ]
+        for (mode, ownBanner) in expected {
+            let content = systemContent(for: mode)
+            for banner in banners {
+                let present = content.contains { $0.contains(banner) }
+                XCTAssertEqual(present, banner == ownBanner, "mode \(mode.rawValue) banner=\(banner)")
+            }
+        }
+        // Auto announces no approval-mode constraint; the base prompt and Auto reviewer stand.
+        let autoContent = systemContent(for: .auto)
+        for banner in banners {
+            XCTAssertFalse(autoContent.contains { $0.contains(banner) }, "auto must not get \(banner)")
+        }
+        XCTAssertNil(TrustedRouterPromptBuilder.modeGuidance(for: .auto))
     }
 
     func testMessagesIncludeMemoriesAsAuditableSystemContext() {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-06-30 Mode-Aware Prompt Guidance Pass
+
+Overall grade after this slice: **A generalizes PR3 cleanly, A closes a real efficiency gap**.
+
+Generalizes the Plan-mode prompt seeding (PR3) into mode-aware guidance for every gated approval mode, so the agent's behavior matches the active mode instead of wasting turns proposing tools the mode silently blocks.
+
+| Before | After |
+| --- | --- |
+| Only Plan mode varied the prompt (`appendPlanModeGuidance`). In **Read-only** mode every mutation is hard-`.deny`'d (`Safety.swift` `.readOnly` arm), but the agent was never told it was read-only — so it would propose file writes / mutating shell commands that get silently blocked, burning turns and risking a retry loop. Review mode was likewise unannounced. | `appendModeGuidance` (renamed) drives a single `modeGuidance(for:)` switch: **Plan** keeps the `host.plan.update` seeding; **Read-only** now tells the agent mutations are blocked and to use only read tools (investigate/answer, explain what it *would* change); **Review** tells it mutations need explicit approval so it proposes small, clearly-described steps. `.auto` returns `nil` — no constraint to announce, the Auto safety reviewer decides per call. |
+| — | The guidance text matches the real safety arms: Read-only `.deny`s mutations (so "blocked, will not run"), Review `.clarify`s them (so "requires the user's explicit approval"). No behavior change to the safety layer — this only aligns the agent's *intent* with the gate it will hit. |
+| — | Tests: each gated mode gets its own banner **exactly once** (no double-inject), no cross-contamination between modes, and `.auto` gets none (`modeGuidance(for: .auto) == nil`). `MockLLMClient` ignores the prompt, so the agent suite is unaffected. |
+
+Adversarial-review fix (caught before merge): the first draft of `readOnlyModePrompt` advertised "non-mutating shell reads" as usable — but `host.shell.run` is the *only* shell tool and is `risk: .destructive` unconditionally, so the `.readOnly` arm hard-`.deny`s it (even `cat`/`ls`). The prompt was inviting the agent to call a tool the mode guarantees to block — the exact waste this guidance exists to prevent, self-inflicted. Fixed: the read-only prompt now names only genuinely `.read`-risk tools (`host.file.read/list/search`, `host.git.status/diff`) and states plainly that **all** shell commands are blocked. The advertised read tools are now a single validated data source (`readOnlyUsableTools`) the prompt is *built* from, guarded by two tests (re-verify hardening): `testReadOnlyGuidanceOnlyAdvertisesToolsTheReadOnlySafetyArmApproves` runs each advertised tool through the real `StaticSafetyReviewer` in `.readOnly` and asserts `.approve` (+ `host.shell.run` → `.deny`); `testReadOnlyPromptNamesNoToolOutsideTheValidatedReadOnlyAllowlist` generically scans **every** `host.*` token in the prompt and requires each to be either an advertised `.read` tool or `host.shell.run` (named only as blocked) — so any future edit naming a *different* non-`.read` tool (e.g. `host.git.commit`) fails, not just the original "shell read" wording. (Required adding `QuillCodeSafety` to the `QuillCodeAgentTests` deps.)
+
+Residual risk:
+
+- Prompt guidance steers but does not enforce; the safety layer remains the actual gate (unchanged). A model could still attempt a blocked tool — it just now knows not to. Whether the real model honors the guidance is LLM-dependent; the deterministic part (correct, mode-specific text present only under that mode, and the advertised read-only tools genuinely being safety-approved) is unit-tested.
+
 ## 2026-06-30 Plan-Mode Prompt Seeding Pass (Plan mode PR3)
 
 Overall grade after this slice: **A completes the Plan-mode story, A reuses existing machinery**.


### PR DESCRIPTION
Generalizes the Plan-mode prompt seeding ([#711](https://github.com/Lore-Hex/QuillCode/pull/711)) into **mode-aware guidance for every gated approval mode**, so the agent's behavior matches the active mode instead of wasting turns proposing tools the mode silently blocks.

## Motivation

In **Read-only** mode every mutation is hard-`.deny`'d (`Safety.swift` `.readOnly` arm), but the agent was never *told* it was read-only — so it would propose file writes / mutating shell commands that get silently blocked, burning turns and risking a retry loop. PR3 only covered Plan mode.

## How

`appendPlanModeGuidance` → `appendModeGuidance`, driven by one `modeGuidance(for:)` switch:

- **Plan** — keeps the `host.plan.update` seeding.
- **Read-only** — tells the agent mutations are blocked and to use only read tools (investigate/answer, explain what it *would* change and that the user must leave Read-only to apply it).
- **Review** — tells it mutations need explicit approval, so it proposes small, clearly-described steps.
- **`.auto`** — returns `nil`; no constraint to announce, the Auto safety reviewer decides per call.

The text matches the real safety arms (Read-only `.deny`s → "blocked, will not run"; Review `.clarify`s → "requires explicit approval"). **No safety-layer behavior change** — this only aligns the agent's *intent* with the gate it will hit.

## Tests

Each gated mode gets its banner **exactly once** (no double-inject), no cross-contamination between modes, and `.auto` gets none (`modeGuidance(for: .auto) == nil`). `MockLLMClient` ignores the prompt, so the agent suite is unaffected.

Verified: `swift test` 1815 · native-desktop smoke (Playwright unaffected — no harness/UI change). Prompt guidance steers but does not enforce; the safety layer remains the actual gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)