### PR TITLE
Recursive subagent delegation in the scheduler (engine slice)

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceSubagentScheduler.swift
+++ b/Sources/QuillCodeApp/WorkspaceSubagentScheduler.swift
@@ -19,6 +19,9 @@ struct WorkspaceSubagentJob: Sendable, Hashable, Identifiable {
     var dependsOn: [String]
     var groupPath: [String]
     var priorResults: [WorkspaceSubagentPriorResult]
+    /// Delegation depth: top-level workers are 0; a child spawned by a worker is its parent's
+    /// depth + 1. The scheduler refuses to spawn past `maxDepth`, which guarantees termination.
+    var depth: Int
 
     init(
         name: String,
@@ -26,7 +29,8 @@ struct WorkspaceSubagentJob: Sendable, Hashable, Identifiable {
         objective: String = "",
         dependsOn: [String] = [],
         groupPath: [String] = [],
-        priorResults: [WorkspaceSubagentPriorResult] = []
+        priorResults: [WorkspaceSubagentPriorResult] = [],
+        depth: Int = 0
     ) {
         self.name = name
         self.role = role
@@ -34,6 +38,7 @@ struct WorkspaceSubagentJob: Sendable, Hashable, Identifiable {
         self.dependsOn = dependsOn
         self.groupPath = groupPath
         self.priorResults = priorResults
+        self.depth = depth
     }
 }
 
@@ -50,19 +55,39 @@ private enum WorkspaceSubagentWorkerOutcome: Sendable, Hashable {
 
 struct WorkspaceSubagentScheduler {
     typealias Worker = @Sendable (WorkspaceSubagentJob) async throws -> String
+    /// Called after a worker completes with its job and result summary; returns child workers to
+    /// delegate to. Returning `[]` (or passing no spawner) keeps the flat, fixed-graph behavior.
+    typealias Spawner = @Sendable (WorkspaceSubagentJob, String) async -> [WorkspaceSubagentWorkerRequest]
     typealias ProgressSink = @Sendable (SubagentProgressUpdate) async -> Void
 
-    private let worker: Worker
+    /// Recursive delegation can spawn workers up to this depth value (top-level workers are depth 0),
+    /// i.e. the default of 3 allows up to four levels: 0 → 1 → 2 → 3. Combined with `maxTotalJobs` it
+    /// bounds an otherwise unbounded recursion so a run always terminates.
+    static let defaultMaxDepth = 3
+    /// Hard ceiling on how many workers a single run may ever schedule (top-level + spawned). A
+    /// backstop against a spawner that keeps delegating within the depth bound.
+    static let defaultMaxTotalJobs = 64
 
-    init(worker: @escaping Worker = Self.defaultWorker) {
+    private let worker: Worker
+    private let maxDepth: Int
+    private let maxTotalJobs: Int
+
+    init(
+        maxDepth: Int = Self.defaultMaxDepth,
+        maxTotalJobs: Int = Self.defaultMaxTotalJobs,
+        worker: @escaping Worker = Self.defaultWorker
+    ) {
         self.worker = worker
+        self.maxDepth = max(0, maxDepth)
+        self.maxTotalJobs = max(1, maxTotalJobs)
     }
 
     func run(
         request: WorkspaceSubagentRunRequest,
-        progress: ProgressSink? = nil
+        progress: ProgressSink? = nil,
+        spawn: Spawner? = nil
     ) async -> WorkspaceSubagentRunResult {
-        let jobs = request.workers.map {
+        var jobs = request.workers.map {
             WorkspaceSubagentJob(
                 name: $0.name,
                 role: $0.role,
@@ -76,7 +101,11 @@ struct WorkspaceSubagentScheduler {
         }
         await progress?(SubagentProgressUpdate(objective: request.objective, subagents: items))
 
-        let dependencies = Self.resolvedDependencies(for: jobs)
+        // Indices into `jobs`/`items` align with `dependencies`. Recursive spawning appends to all
+        // three in lockstep (children resolve to no dependencies — their parent has already
+        // completed), so existing indices stay valid.
+        var dependencies = Self.resolvedDependencies(for: jobs)
+        var usedNames = Set(jobs.map { $0.name.lowercased() })
 
         // Run jobs in dependency waves: each pass starts every job whose dependencies have all
         // completed, fans them out concurrently, then re-evaluates readiness. Jobs still waiting
@@ -129,6 +158,9 @@ struct WorkspaceSubagentScheduler {
             // behavior of fanning every runnable worker out together; a bound seeds that many
             // tasks and starts one more each time a worker finishes.
             let waveLimit = max(1, request.maxConcurrentWorkers ?? runnable.count)
+            // Children requested by workers that completed this wave; applied after the wave so we
+            // never mutate `jobs`/`items` while the task group is still reading them.
+            var spawnedThisWave: [(parentIndex: Int, request: WorkspaceSubagentWorkerRequest)] = []
             await withTaskGroup(of: (Int, WorkspaceSubagentWorkerOutcome).self) { group in
                 var queued = runnable[...]
 
@@ -162,10 +194,19 @@ struct WorkspaceSubagentScheduler {
                 }
 
                 while let (index, outcome) = await group.next() {
+                    // A worker finished, freeing a slot — dispatch the next queued worker immediately,
+                    // before any (possibly slow, model-driven) spawn handling, so a bounded wave keeps
+                    // its concurrency saturated.
+                    startNextWorker()
                     switch outcome {
                     case .completed(let summary):
                         items[index].status = .completed
                         items[index].summary = Self.boundedSummary(summary)
+                        if let spawn {
+                            for child in await spawn(jobs[index], summary) {
+                                spawnedThisWave.append((parentIndex: index, request: child))
+                            }
+                        }
                     case .cancelled:
                         items[index].status = .cancelled
                         items[index].summary = "Cancelled"
@@ -174,7 +215,38 @@ struct WorkspaceSubagentScheduler {
                         items[index].summary = Self.boundedSummary(summary)
                     }
                     await progress?(SubagentProgressUpdate(objective: request.objective, subagents: items))
-                    startNextWorker()
+                }
+            }
+
+            // Enqueue children requested this wave, bounded by depth and the total-job ceiling so the
+            // outer loop always drains to a terminal state. A child depends on its (already-completed)
+            // parent, so it runs in the next pass and inherits the parent's result summary through the
+            // same priorResults plumbing dependent workers use — delegated work keeps parent context.
+            if !spawnedThisWave.isEmpty {
+                var enqueuedAny = false
+                for (parentIndex, child) in spawnedThisWave {
+                    let parentDepth = jobs[parentIndex].depth
+                    guard parentDepth + 1 <= maxDepth else { continue }
+                    guard jobs.count < maxTotalJobs else { break }
+                    let parentName = jobs[parentIndex].name
+                    let childName = Self.uniqueChildName(parent: jobs[parentIndex], child: child, used: &usedNames)
+                    let childJob = WorkspaceSubagentJob(
+                        name: childName,
+                        role: child.role,
+                        objective: request.objective,
+                        dependsOn: [parentName],
+                        groupPath: jobs[parentIndex].groupPath + [parentName],
+                        depth: parentDepth + 1
+                    )
+                    jobs.append(childJob)
+                    var item = SubagentProgressItem(name: childName, role: child.role, status: .queued)
+                    item.groupPath = childJob.groupPath
+                    items.append(item)
+                    dependencies.append([parentIndex])
+                    enqueuedAny = true
+                }
+                if enqueuedAny {
+                    await progress?(SubagentProgressUpdate(objective: request.objective, subagents: items))
                 }
             }
         }
@@ -212,6 +284,25 @@ struct WorkspaceSubagentScheduler {
             }
             return resolved
         }
+    }
+
+    /// Namespaces a spawned child under its parent (mirroring the nested `groupPath`) and guarantees
+    /// the name — which is the job `id` and the key for dependency/progress resolution — is unique
+    /// within the run, so two parents spawning a "Compile" child never collide.
+    private static func uniqueChildName(
+        parent: WorkspaceSubagentJob,
+        child: WorkspaceSubagentWorkerRequest,
+        used: inout Set<String>
+    ) -> String {
+        let base = "\(parent.name)/\(child.name)"
+        var candidate = base
+        var suffix = 2
+        while used.contains(candidate.lowercased()) {
+            candidate = "\(base)#\(suffix)"
+            suffix += 1
+        }
+        used.insert(candidate.lowercased())
+        return candidate
     }
 
     private static func defaultWorker(_ job: WorkspaceSubagentJob) async throws -> String {

--- a/Tests/QuillCodeAppTests/WorkspaceSubagentSchedulerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSubagentSchedulerTests.swift
@@ -240,6 +240,117 @@ final class WorkspaceSubagentSchedulerTests: XCTestCase {
         // A cycle must still terminate with both workers completing.
         XCTAssertEqual(result.update.subagents.map(\.status), [.completed, .completed])
     }
+
+    // MARK: - Recursive delegation
+
+    func testWorkerCanSpawnAChildThatRunsToCompletion() async {
+        let capture = JobCapture()
+        let scheduler = WorkspaceSubagentScheduler { job in
+            await capture.record(job)
+            return "did \(job.role)"
+        }
+        let request = WorkspaceSubagentRunRequest(objective: "build", workers: [.init(name: "Builder", role: "build")])
+
+        // Only the top-level Builder delegates; the child does not delegate further.
+        let result = await scheduler.run(request: request, spawn: { job, _ in
+            job.name == "Builder" ? [WorkspaceSubagentWorkerRequest(name: "Compile", role: "compile")] : []
+        })
+
+        XCTAssertEqual(result.update.subagents.count, 2)
+        let child = result.update.subagents.first { $0.name == "Builder/Compile" }
+        XCTAssertEqual(child?.status, .completed, "the spawned child should run to completion")
+        XCTAssertEqual(child?.groupPath, ["Builder"], "the child should be nested under its parent")
+        XCTAssertEqual(child?.summary, "did compile")
+        let ranChild = await capture.job(named: "Builder/Compile")
+        XCTAssertEqual(ranChild?.depth, 1, "the child runs at the parent's depth + 1")
+        // Delegated work inherits the parent's result through the priorResults plumbing.
+        XCTAssertEqual(ranChild?.priorResults, [WorkspaceSubagentPriorResult(name: "Builder", summary: "did build")])
+    }
+
+    func testTwoSameNamedChildrenFromOneParentAreDeduplicated() async {
+        let scheduler = WorkspaceSubagentScheduler { _ in "ok" }
+        let request = WorkspaceSubagentRunRequest(objective: "dup", workers: [.init(name: "Root", role: "r")])
+
+        // One parent delegates two children that requested the identical name.
+        let result = await scheduler.run(request: request, spawn: { job, _ in
+            job.name == "Root"
+                ? [
+                    WorkspaceSubagentWorkerRequest(name: "Check", role: "c1"),
+                    WorkspaceSubagentWorkerRequest(name: "Check", role: "c2")
+                ]
+                : []
+        })
+
+        let names = result.update.subagents.map(\.name)
+        XCTAssertTrue(names.contains("Root/Check"))
+        XCTAssertTrue(names.contains("Root/Check#2"), "a colliding child name is de-duplicated with a #suffix")
+        XCTAssertEqual(Set(names).count, names.count, "every job id stays unique")
+        XCTAssertEqual(result.update.subagents.count, 3)
+        XCTAssertTrue(result.update.subagents.allSatisfy { $0.status == SubagentStatus.completed })
+    }
+
+    func testRecursiveSpawnsStopAtMaxDepth() async {
+        let capture = JobCapture()
+        let scheduler = WorkspaceSubagentScheduler(maxDepth: 2) { job in
+            await capture.record(job)
+            return "ok"
+        }
+        let request = WorkspaceSubagentRunRequest(objective: "deep", workers: [.init(name: "Root", role: "r")])
+
+        // Every completed worker delegates one more child; only maxDepth bounds the recursion.
+        let result = await scheduler.run(request: request, spawn: { _, _ in
+            [WorkspaceSubagentWorkerRequest(name: "child", role: "c")]
+        })
+
+        let depths = await capture.depths()
+        XCTAssertEqual(depths.max(), 2, "recursion must stop at maxDepth (no depth-3 worker)")
+        XCTAssertEqual(result.update.subagents.count, 3, "depths 0, 1, 2 -> three workers")
+        XCTAssertTrue(result.update.subagents.allSatisfy { $0.status == SubagentStatus.completed })
+    }
+
+    func testRecursiveSpawnsStopAtTheTotalJobCap() async {
+        let scheduler = WorkspaceSubagentScheduler(maxDepth: 10, maxTotalJobs: 5) { _ in "ok" }
+        let request = WorkspaceSubagentRunRequest(objective: "explode", workers: [.init(name: "Root", role: "r")])
+
+        // Two children per worker would explode without the ceiling; the run must still terminate.
+        let result = await scheduler.run(request: request, spawn: { _, _ in
+            [
+                WorkspaceSubagentWorkerRequest(name: "a", role: "a"),
+                WorkspaceSubagentWorkerRequest(name: "b", role: "b")
+            ]
+        })
+
+        XCTAssertLessThanOrEqual(result.update.subagents.count, 5, "the total-job ceiling must bound the run")
+        XCTAssertGreaterThan(result.update.subagents.count, 1, "some children should have spawned")
+        XCTAssertTrue(result.update.subagents.allSatisfy { $0.status == SubagentStatus.completed })
+    }
+
+    func testSpawnerReturningNoChildrenLeavesTheGraphFlat() async {
+        let scheduler = WorkspaceSubagentScheduler { _ in "ok" }
+        let request = WorkspaceSubagentRunRequest(objective: "flat", workers: [.init(name: "Solo", role: "s")])
+
+        let result = await scheduler.run(request: request, spawn: { _, _ in [] })
+
+        XCTAssertEqual(result.update.subagents.map(\.name), ["Solo"])
+    }
+
+    func testTwoParentsSpawningTheSameChildNameGetDistinctNestedJobs() async {
+        let scheduler = WorkspaceSubagentScheduler { _ in "ok" }
+        let request = WorkspaceSubagentRunRequest(
+            objective: "fan",
+            workers: [.init(name: "P1", role: "a"), .init(name: "P2", role: "b")]
+        )
+
+        // Both top-level parents delegate a child with the SAME requested name.
+        let result = await scheduler.run(request: request, spawn: { job, _ in
+            job.depth == 0 ? [WorkspaceSubagentWorkerRequest(name: "Check", role: "check")] : []
+        })
+
+        let names = Set(result.update.subagents.map(\.name))
+        XCTAssertTrue(names.contains("P1/Check"), "child names are namespaced under the parent")
+        XCTAssertTrue(names.contains("P2/Check"))
+        XCTAssertEqual(result.update.subagents.count, 4, "the two same-named children stay distinct jobs")
+    }
 }
 
 private actor OrderRecorder {
@@ -255,6 +366,7 @@ private actor JobCapture {
 
     func record(_ job: WorkspaceSubagentJob) { jobs.append(job) }
     func job(named name: String) -> WorkspaceSubagentJob? { jobs.first { $0.name == name } }
+    func depths() -> [Int] { jobs.map(\.depth) }
 }
 
 private actor ConcurrencyProbe {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,24 @@
 # Code Quality Audit
 
+## 2026-06-30 Recursive Subagent Delegation Pass (scheduler engine)
+
+Overall grade after this slice: **A real infra step, bounded + deterministically tested**.
+
+First slice of the ROADMAP's pending "recursive delegated subagent spawning": the `WorkspaceSubagentScheduler` can now let a worker spawn child workers mid-run, instead of running only the fixed graph it started with — the engine behind a "Builder" subagent delegating "Compile"/"Link" sub-workers.
+
+| Before | After |
+| --- | --- |
+| `WorkspaceSubagentScheduler.run` ran a fixed set of jobs from `request.workers`; a worker returned a summary and could not delegate. | `run(request:progress:spawn:)` takes an optional `Spawner` (`(job, summary) -> [child requests]`). After a worker completes, its returned children are enqueued as new jobs at `depth + 1`, nested under the parent's `groupPath`, and run as roots in the next dependency wave. Passing no spawner (the default) preserves the exact prior flat behavior. |
+| — | **Termination is guaranteed by construction.** Children are refused past `maxDepth` (default 3) and once a run hits `maxTotalJobs` (default 64) — so even a spawner that always delegates halts. Spawned children's names are namespaced under the parent (`Parent/Child`) and de-duplicated, keeping job `id`s (and dependency/progress resolution) unique. |
+| — | Children are applied *after* each wave's task group closes, never mutating `jobs`/`items` while the group still reads them. |
+| — | Five deterministic tests: a child runs to completion nested under its parent at depth+1; recursion stops exactly at `maxDepth`; the total-job ceiling bounds an always-spawning run (proving termination); an empty spawn stays flat; two parents spawning the same child name get distinct jobs. The 9 existing scheduler tests are unchanged (flat-graph behavior identical). |
+
+Adversarial-review improvements (verdict SHIP, no blockers; the high-value concerns — termination, the post-group append vs. in-group reads, index alignment, depth bound — were traced and found sound): three reviewers independently flagged that spawned children ran with **empty `priorResults`**, losing the parent's output. Fixed by making a child depend on its (already-completed) parent, so it inherits the parent's result summary through the *same* `priorResults` plumbing dependent workers use — delegation now carries context. Also: the one `should` (the `#suffix` de-dup branch in `uniqueChildName` had no coverage) is now tested (one parent spawning two same-named children → `Root/Check` + `Root/Check#2`, all ids unique); `startNextWorker()` is dispatched before the spawn `await` so a slow model-driven spawner can't throttle a bounded wave; the `maxDepth` doc clarifies the default of 3 means four levels (0→1→2→3); and an unused test helper was dropped.
+
+Residual risk:
+
+- This is the **engine slice**: the capability is built and tested, but production still calls `run` without a spawner — wiring the model-backed worker (or slash syntax) to actually emit spawn requests is the deliberate follow-up, mirroring how the scheduler itself was landed before model-backing. No behavior change to existing runs.
+
 ## 2026-06-30 Mode-Aware Prompt Guidance Pass
 
 Overall grade after this slice: **A generalizes PR3 cleanly, A closes a real efficiency gap**.


### PR DESCRIPTION
First slice of the ROADMAP's pending **"recursive delegated subagent spawning"**: the `WorkspaceSubagentScheduler` can now let a worker spawn child workers mid-run, instead of running only the fixed graph it started with — the engine behind a "Builder" subagent delegating "Compile"/"Link" sub-workers.

## How

`run(request:progress:spawn:)` takes an optional `Spawner` (`(job, summary) -> [child requests]`). After a worker completes, its returned children are enqueued as new jobs at `depth + 1`, nested under the parent's `groupPath`, and run as roots in the next dependency wave. **Passing no spawner (the default) preserves the exact prior flat behavior** — the 9 existing scheduler tests are unchanged.

**Termination is guaranteed by construction:** children are refused past `maxDepth` (default 3) and once a run hits `maxTotalJobs` (default 64), so even a spawner that always delegates halts. Spawned children's names are namespaced under the parent (`Parent/Child`) and de-duplicated, keeping job `id`s (and dependency/progress resolution) unique. Children are applied *after* each wave's task group closes, never mutating `jobs`/`items` while the group still reads them.

## Tests

Five deterministic tests: a child runs to completion nested under its parent at depth+1; recursion stops exactly at `maxDepth`; the total-job ceiling bounds an always-spawning run (proving termination); an empty spawn stays flat; two parents spawning the same child name get distinct jobs.

Verified: `swift test` 1817 · native-desktop smoke (Playwright unaffected — no harness/UI change).

## Scope

This is the **engine slice**: the capability is built and tested, but production still calls `run` without a spawner — wiring the model-backed worker (or slash syntax) to emit spawn requests is the deliberate follow-up, mirroring how the scheduler itself landed before model-backing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)