### PR TITLE
Wire recursive subagent delegation end-to-end (trigger)

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceSubagentModelWorker.swift
+++ b/Sources/QuillCodeApp/WorkspaceSubagentModelWorker.swift
@@ -64,6 +64,13 @@ enum WorkspaceSubagentPromptBuilder {
         objective: what you inspected or produced, key findings, and any next
         steps. Keep it to a few sentences. Do not include credentials, tokens,
         private keys, or other secrets.
+
+        If — and only if — your work genuinely splits into independent sub-tasks
+        that a separate subagent should own, you may delegate by adding one or
+        more markers of the form [[DELEGATE: short name | what that subagent
+        should do]] anywhere in your text. Each marker becomes a child subagent
+        that runs after you and sees your result. Use this sparingly; most roles
+        need no delegation, so prefer to just do the work yourself.
         """
     }
 

--- a/Sources/QuillCodeApp/WorkspaceSubagentScheduler.swift
+++ b/Sources/QuillCodeApp/WorkspaceSubagentScheduler.swift
@@ -242,6 +242,10 @@ struct WorkspaceSubagentScheduler {
                     var item = SubagentProgressItem(name: childName, role: child.role, status: .queued)
                     item.groupPath = childJob.groupPath
                     items.append(item)
+                    // Resolve the child's single dependency directly to the parent index rather than
+                    // through resolvedDependencies(by name): the parent index is known and exact, which
+                    // sidesteps the case-insensitive, first-name-wins name resolution that could
+                    // otherwise mis-resolve dependsOn:[parentName] when two workers share a name.
                     dependencies.append([parentIndex])
                     enqueuedAny = true
                 }

--- a/Sources/QuillCodeApp/WorkspaceSubagentSlashCommandRunner.swift
+++ b/Sources/QuillCodeApp/WorkspaceSubagentSlashCommandRunner.swift
@@ -16,9 +16,17 @@ extension QuillCodeWorkspaceModel {
         threadPersistence.saveIfPossible(selectedThread)
 
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.running)
-        let result = await subagentScheduler.run(request: request) { [weak self] update in
-            await self?.recordSubagentProgress(update)
-        }
+        // A worker may delegate sub-tasks by emitting `[[DELEGATE: name | role]]` markers; the parser
+        // turns them into bounded child workers and the scheduler enforces depth/total-job limits.
+        let result = await subagentScheduler.run(
+            request: request,
+            progress: { [weak self] update in
+                await self?.recordSubagentProgress(update)
+            },
+            spawn: { _, summary in
+                WorkspaceSubagentSpawnDirectiveParser.parse(summary)
+            }
+        )
         guard !Task.isCancelled else {
             refreshTopBar(agentStatus: TopBarAgentStatusLabel.stopped)
             return

--- a/Sources/QuillCodeApp/WorkspaceSubagentSpawnDirectiveParser.swift
+++ b/Sources/QuillCodeApp/WorkspaceSubagentSpawnDirectiveParser.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Parses optional delegation directives a subagent worker may emit in its result text, turning them
+/// into child worker requests for the scheduler's recursive `spawn` path. A worker delegates by
+/// including one or more `[[DELEGATE: <name> | <role>]]` markers anywhere in its result.
+///
+/// The marker is bracket-delimited (not line-based) on purpose: `LLMWorkspaceSubagentWorker.run`
+/// collapses whitespace in the model's reply, which would destroy line structure — but `[[DELEGATE:
+/// ... ]]` survives whitespace collapse intact. Parsing is bounded (children per worker, name/role
+/// lengths) and de-duplicated by name; the scheduler additionally caps recursion depth and total jobs.
+///
+/// A marker is honored wherever it appears in a worker's result, including text the worker echoed from
+/// its input — this is acceptable because a spawned child's role is only ever used as another (tool-
+/// free) subagent prompt, never executed, and the scheduler's depth/total-job caps bound any
+/// echo-triggered fan-out to a small, terminating set of wasted turns.
+enum WorkspaceSubagentSpawnDirectiveParser {
+    static let openMarker = "[[DELEGATE:"
+    static let closeMarker = "]]"
+    static let maxChildrenPerWorker = 3
+    static let maxNameCharacters = 72
+    static let maxRoleCharacters = 160
+
+    static func parse(_ text: String) -> [WorkspaceSubagentWorkerRequest] {
+        var requests: [WorkspaceSubagentWorkerRequest] = []
+        var seen = Set<String>()
+        // Split on the open marker; every segment after the first begins inside a directive.
+        for segment in text.components(separatedBy: openMarker).dropFirst() {
+            guard let close = segment.range(of: closeMarker) else { continue }
+            let inner = segment[segment.startIndex..<close.lowerBound]
+            let parts = inner.components(separatedBy: "|")
+            guard parts.count >= 2 else { continue }
+            // Split on the FIRST pipe only: the name is a short label that never contains a pipe, but
+            // the role is free-form prose that often does (`compile | link`, `grep foo | wc -l`,
+            // `build | test | deploy`). Rejoining the remainder keeps such roles intact instead of
+            // silently dropping the whole directive.
+            // `/` is the scheduler's group-path separator and `#` its dedup-suffix marker; keep child
+            // names clear of both so namespacing stays unambiguous.
+            let name = bounded(parts[0], limit: maxNameCharacters)
+                .replacingOccurrences(of: "/", with: " ")
+                .replacingOccurrences(of: "#", with: " ")
+                .trimmingCharacters(in: .whitespaces)
+            let role = bounded(parts.dropFirst().joined(separator: "|"), limit: maxRoleCharacters)
+            guard !name.isEmpty, !role.isEmpty else { continue }
+            let key = name.lowercased()
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+            requests.append(WorkspaceSubagentWorkerRequest(name: name, role: role))
+            if requests.count >= maxChildrenPerWorker { break }
+        }
+        return requests
+    }
+
+    private static func bounded(_ text: String, limit: Int) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard trimmed.count > limit else { return trimmed }
+        return String(trimmed.prefix(limit)).trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceSubagentModelWorkerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSubagentModelWorkerTests.swift
@@ -48,6 +48,25 @@ final class WorkspaceSubagentModelWorkerTests: XCTestCase {
         XCTAssertTrue(prompt.contains(#"{"type":"say","text":"..."}"#))
     }
 
+    func testPromptOffersOptionalDelegationViaTheParsedMarker() {
+        let prompt = WorkspaceSubagentPromptBuilder.prompt(
+            objective: "ship release",
+            job: WorkspaceSubagentJob(name: "Builder", role: "build")
+        )
+
+        // The marker the prompt advertises must be exactly the one the parser recognizes, and the
+        // guidance must stay opt-in ("only if") so workers do not over-delegate.
+        XCTAssertTrue(prompt.contains(WorkspaceSubagentSpawnDirectiveParser.openMarker))
+        XCTAssertTrue(prompt.contains("only if"))
+        XCTAssertTrue(prompt.contains("sparingly"))
+        // The advertised marker is actually parseable into a child request with the expected name/role
+        // (not just a non-zero count), so prompt wording and parser semantics cannot drift apart.
+        let parsed = WorkspaceSubagentSpawnDirectiveParser.parse("[[DELEGATE: short name | what that subagent should do]]")
+        XCTAssertEqual(parsed.count, 1)
+        XCTAssertEqual(parsed.first?.name, "short name")
+        XCTAssertEqual(parsed.first?.role, "what that subagent should do")
+    }
+
     func testPromptIncludesPrerequisiteResultsWhenPresent() {
         let prompt = WorkspaceSubagentPromptBuilder.prompt(
             objective: "ship release",

--- a/Tests/QuillCodeAppTests/WorkspaceSubagentSpawnDirectiveParserTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSubagentSpawnDirectiveParserTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import QuillCodeAgent
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceSubagentSpawnDirectiveParserTests: XCTestCase {
+    func testParsesBracketedDelegateMarkers() {
+        let text = "Inspected the build. [[DELEGATE: Compile | compile the project]] and [[DELEGATE: Test | run the tests]]."
+        let requests = WorkspaceSubagentSpawnDirectiveParser.parse(text)
+        XCTAssertEqual(requests.map(\.name), ["Compile", "Test"])
+        XCTAssertEqual(requests.map(\.role), ["compile the project", "run the tests"])
+    }
+
+    func testRoleMayContainPipesViaFirstPipeSplit() {
+        // The role is free-form prose that often contains pipes (shell pipes, alternation). Splitting
+        // on the FIRST pipe keeps the whole role instead of dropping the directive.
+        let requests = WorkspaceSubagentSpawnDirectiveParser.parse("[[DELEGATE: Build | compile | link the app]]")
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.first?.name, "Build")
+        XCTAssertEqual(requests.first?.role, "compile | link the app")
+    }
+
+    func testIgnoresMalformedAndEmptyDirectives() {
+        let text = """
+        [[DELEGATE: no pipe here]]
+        [[DELEGATE:  | empty name]]
+        [[DELEGATE: name only | ]]
+        [[NOTADIRECTIVE: x | y]]
+        plain summary text
+        """
+        XCTAssertEqual(WorkspaceSubagentSpawnDirectiveParser.parse(text), [])
+    }
+
+    func testCapsChildrenPerWorker() {
+        let text = (1...10).map { "[[DELEGATE: W\($0) | role \($0)]]" }.joined(separator: " ")
+        XCTAssertEqual(WorkspaceSubagentSpawnDirectiveParser.parse(text).count, 3)
+    }
+
+    func testDeduplicatesByNameCaseInsensitively() {
+        let text = "[[DELEGATE: Dup | first]] [[DELEGATE: dup | second]]"
+        XCTAssertEqual(WorkspaceSubagentSpawnDirectiveParser.parse(text).map(\.name), ["Dup"])
+    }
+
+    func testBoundsNameAndRoleLengthAndStripsPathSeparators() {
+        let longName = String(repeating: "x", count: 200)
+        let longRole = String(repeating: "y", count: 300)
+        let requests = WorkspaceSubagentSpawnDirectiveParser.parse("[[DELEGATE: a/b#c \(longName) | \(longRole)]]")
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertLessThanOrEqual(requests[0].name.count, 72)
+        XCTAssertLessThanOrEqual(requests[0].role.count, 160)
+        XCTAssertFalse(requests[0].name.contains("/"), "path separator must be stripped from child names")
+        XCTAssertFalse(requests[0].name.contains("#"), "dedup-suffix marker must be stripped from child names")
+    }
+
+    func testNoMarkersReturnsEmpty() {
+        XCTAssertEqual(WorkspaceSubagentSpawnDirectiveParser.parse("A normal result with no delegation."), [])
+    }
+
+    /// The directive must survive `LLMWorkspaceSubagentWorker.run`'s whitespace collapse — that is the
+    /// whole reason the marker is bracketed rather than line-based. Drive the real worker with a stub
+    /// client and confirm the collapsed result still parses to the delegated child.
+    func testDirectiveSurvivesTheModelWorkerWhitespaceCollapse() async throws {
+        let llm = StubDelegatingLLMClient(reply: "Did the analysis.\n\n[[DELEGATE: Compile | compile the project]]")
+        let worker = LLMWorkspaceSubagentWorker(llm: llm)
+        let summary = try await worker.run(WorkspaceSubagentJob(name: "Root", role: "plan"))
+
+        // Whitespace is collapsed (no newline), but the bracketed directive is intact.
+        XCTAssertFalse(summary.contains("\n"))
+        let requests = WorkspaceSubagentSpawnDirectiveParser.parse(summary)
+        XCTAssertEqual(requests.map(\.name), ["Compile"])
+        XCTAssertEqual(requests.map(\.role), ["compile the project"])
+    }
+
+    /// End-to-end through the real scheduler: a root worker that emits a directive spawns and runs the
+    /// delegated child when the parser is wired in as the scheduler's `spawn` closure.
+    func testWorkerDelegatesThroughTheSchedulerViaTheParser() async {
+        let scheduler = WorkspaceSubagentScheduler { job in
+            job.depth == 0 ? "Planned. [[DELEGATE: Compile | compile it]]" : "did \(job.role)"
+        }
+        let request = WorkspaceSubagentRunRequest(objective: "build", workers: [.init(name: "Root", role: "plan")])
+
+        let result = await scheduler.run(request: request, spawn: { _, summary in
+            WorkspaceSubagentSpawnDirectiveParser.parse(summary)
+        })
+
+        let names = result.update.subagents.map(\.name)
+        XCTAssertTrue(names.contains("Root/Compile"), "the delegated child should be scheduled and run")
+        XCTAssertEqual(result.update.subagents.first { $0.name == "Root/Compile" }?.summary, "did compile it")
+        XCTAssertTrue(result.update.subagents.allSatisfy { $0.status == SubagentStatus.completed })
+    }
+}
+
+/// Minimal LLMClient that always replies with a fixed `.say` text, for exercising the model worker's
+/// result handling deterministically.
+private struct StubDelegatingLLMClient: LLMClient {
+    let reply: String
+    func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+        .say(reply)
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,25 @@
 # Code Quality Audit
 
+## 2026-06-30 Recursive Subagent Delegation — Trigger Pass (end-to-end)
+
+Overall grade after this slice: **A makes the recursion engine user-reachable, deterministically tested**.
+
+Follow-up to the recursion engine slice: wires a real trigger so a model-backed subagent can actually delegate, completing recursive subagents end-to-end (the deliberate follow-up the engine PR flagged).
+
+| Before | After |
+| --- | --- |
+| `WorkspaceSubagentScheduler.run` accepted a `spawn` closure, but production (`WorkspaceSubagentSlashCommandRunner`) never passed one — the recursion capability was unreachable. | The slash runner now passes `spawn: { _, summary in WorkspaceSubagentSpawnDirectiveParser.parse(summary) }`, so a worker's result can spawn children. |
+| — | New `WorkspaceSubagentSpawnDirectiveParser` extracts `[[DELEGATE: <name> \| <role>]]` markers into bounded child requests. The marker is **bracket-delimited, not line-based, on purpose**: `LLMWorkspaceSubagentWorker.run` collapses whitespace in the model reply, which would destroy line structure — a bracketed marker survives intact (pinned by a test that drives the real worker and parses its collapsed output). Parsing caps children per worker (3), bounds name/role lengths, de-dupes by name, and strips `/`/`#` (the scheduler's path/dedup separators) from names. |
+| — | `WorkspaceSubagentPromptBuilder` gains **opt-in** guidance ("only if your work genuinely splits… use sparingly") advertising the exact marker the parser recognizes — a test asserts the advertised marker is the parser's marker and is itself parseable, so prompt and parser cannot drift. |
+| — | Folded in the recursion-engine re-verify nit: a comment now documents that the child's `dependencies.append([parentIndex])` intentionally bypasses by-name `resolvedDependencies` (exact index avoids a same-name mis-resolution). |
+| — | Eight new tests: parser (valid/malformed/cap/dedup/length+separator-strip/empty), collapse-safety through the real worker, scheduler integration (a directive-emitting worker spawns + runs the child), and the prompt/parser marker-parity test. |
+
+Adversarial-review fix (verdict SHIP; 3 reviewers converged on one real bug): the parser split the marker on **every** `|` and required exactly two parts, so any role containing a pipe — `[[DELEGATE: Build | compile | link]]`, common in technical prose (shell pipes, alternation) the prompt actively invites — was *silently dropped*, the worst failure mode for a delegation feature. Fixed to split on the **first** pipe only (`parts.count >= 2`, role = remainder rejoined), so roles keep their pipes; a new test pins `role == "compile | link the app"`. Also: the prompt/parser parity test now asserts the extracted name *and* role (not just a non-zero count) so wording and semantics can't drift; and the parser doc documents that echo-triggered markers are acceptable (a child's role is only ever another tool-free prompt, never executed, and the scheduler caps bound the fan-out).
+
+Residual risk:
+
+- Whether the model *chooses* to delegate is LLM-dependent (inherent to any prompt feature); the deterministic surface — parsing (incl. pipes-in-role), bounds, collapse-safety, prompt/parser parity, and the spawn round-trip through the scheduler — is fully tested. The scheduler's `maxDepth`/`maxTotalJobs` remain the hard backstop against runaway delegation regardless of model behavior.
+
 ## 2026-06-30 Recursive Subagent Delegation Pass (scheduler engine)
 
 Overall grade after this slice: **A real infra step, bounded + deterministically tested**.


### PR DESCRIPTION
Follow-up to the recursion **engine** slice ([#713](https://github.com/Lore-Hex/QuillCode/pull/713)): a model-backed subagent can now actually *delegate*, completing recursive subagents end-to-end — the deliberate follow-up that PR flagged.

## How

- `WorkspaceSubagentSlashCommandRunner` now passes a `spawn` closure to the scheduler: `spawn: { _, summary in WorkspaceSubagentSpawnDirectiveParser.parse(summary) }`.
- New `WorkspaceSubagentSpawnDirectiveParser` extracts `[[DELEGATE: <name> | <role>]]` markers into bounded child requests. The marker is **bracket-delimited, not line-based, on purpose**: `LLMWorkspaceSubagentWorker.run` collapses whitespace in the model reply, which would destroy line structure — a bracketed marker survives intact (pinned by a test that drives the *real* worker and parses its collapsed output). Caps 3 children/worker, bounds name/role lengths, de-dupes by name, strips `/`/`#` (the scheduler's path/dedup separators).
- `WorkspaceSubagentPromptBuilder` gains **opt-in** guidance ("only if your work genuinely splits… use sparingly") advertising the exact marker the parser recognizes; a test asserts the advertised marker *is* the parser's marker and is parseable, so prompt and parser cannot drift.
- Folds in the engine re-verify nit: a comment documents that the child's `dependencies.append([parentIndex])` intentionally bypasses by-name `resolvedDependencies`.

## Tests

Eight new: parser (valid/malformed/cap/dedup/length+separator-strip/empty), **collapse-safety through the real worker**, **scheduler integration** (a directive-emitting worker spawns + runs the child), and the prompt/parser marker-parity test.

Verified: `swift test` 1831 · native-desktop smoke (Playwright unaffected — no harness/UI change). Whether the model *chooses* to delegate is LLM-dependent; the deterministic surface (parsing, bounds, collapse-safety, prompt/parser parity, spawn round-trip) is fully tested. `maxDepth`/`maxTotalJobs` remain the hard backstop against runaway delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)