### PR TITLE
PTY job control: suspend/resume a running command (engine)

### DIFF
--- a/Sources/QuillCodeTools/PTYProcessSession.swift
+++ b/Sources/QuillCodeTools/PTYProcessSession.swift
@@ -44,6 +44,7 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
     private var didFinish = false
     private var didCancel = false
     private var didTimeOut = false
+    private var didSuspend = false
 
     public init(request: ShellExecutionRequest, windowSize: PTYWindowSize? = nil) {
         self.request = request
@@ -67,8 +68,27 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
         }
         didCancel = true
         let activeProcess = process
+        didSuspend = false
         lock.unlock()
-        activeProcess?.terminate()
+        if let activeProcess {
+            Self.terminate(activeProcess)
+        }
+    }
+
+    /// Terminates `process`, always continuing it with `SIGCONT` first: a stopped process does not act
+    /// on the `SIGTERM` from `terminate()` until it has been continued, so a suspended command would
+    /// otherwise survive cancellation and time-outs. The `SIGCONT` is sent unconditionally because it
+    /// is a harmless no-op on a running or already-reaped process — doing it every time immunizes all
+    /// three terminate paths against a `suspend()` that races in after `didSuspend` was cleared, with no
+    /// dependency on which guard flag happened to be set.
+    ///
+    /// Like `cancel()` before it, this signals only the session's direct child (`/bin/sh`); a pipeline
+    /// or backgrounded grandchild in a separate process group is not covered. True process-group job
+    /// control would require spawning the child as a group leader (`posix_spawn` with a new pgid), a
+    /// larger change than this session's Foundation `Process` model — left for a follow-up.
+    private static func terminate(_ process: Process) {
+        kill(process.processIdentifier, SIGCONT)
+        process.terminate()
     }
 
     /// Writes `text` to the terminal as if the user typed it, so interactive
@@ -107,6 +127,42 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
         lock.unlock()
         guard !finished, fd >= 0 else { return false }
         return cquill_pty_set_winsize(fd, windowSize.rows, windowSize.columns) == 0
+    }
+
+    /// Suspends the running command (terminal job control, like Ctrl+Z) by stopping its process with
+    /// `SIGSTOP`. Returns `false` if the session has not started, has finished/cancelled, or is already
+    /// suspended. `SIGSTOP` cannot be caught or ignored, so a successful send guarantees the process is
+    /// stopped until `resume()`.
+    @discardableResult
+    public func suspend() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        // Refuse once any terminal intent is set (finish/cancel/timeout): together with the
+        // unconditional SIGCONT in `terminate(_:)`, this closes the window where a suspend racing a
+        // cancel/timeout could re-stop the process after it was continued for termination.
+        guard !didFinish, !didCancel, !didTimeOut, !didSuspend, let process, process.isRunning else { return false }
+        guard kill(process.processIdentifier, SIGSTOP) == 0 else { return false }
+        didSuspend = true
+        return true
+    }
+
+    /// Resumes a previously `suspend()`ed command by continuing its process with `SIGCONT`. Returns
+    /// `false` if the session is not currently suspended (or has finished/cancelled).
+    @discardableResult
+    public func resume() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard didSuspend, !didFinish, !didCancel, !didTimeOut, let process, process.isRunning else { return false }
+        guard kill(process.processIdentifier, SIGCONT) == 0 else { return false }
+        didSuspend = false
+        return true
+    }
+
+    /// Whether the command is currently suspended.
+    public var isSuspended: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didSuspend
     }
 
     private func run() {
@@ -219,8 +275,11 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
         }
         didTimeOut = true
         let activeProcess = process
+        didSuspend = false
         lock.unlock()
-        activeProcess?.terminate()
+        if let activeProcess {
+            Self.terminate(activeProcess)
+        }
     }
 
     private func ptyEnvironment(_ environment: [String: String]?) -> [String: String] {
@@ -274,12 +333,13 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
         didFinish = true
         out = output
         activeProcess = process
+        didSuspend = false
         process = nil
         masterFD = -1
         lock.unlock()
 
         if let activeProcess, activeProcess.isRunning {
-            activeProcess.terminate()
+            Self.terminate(activeProcess)
         }
 
         continuation.yield(.finished(ToolResult(

--- a/Tests/QuillCodeToolsTests/PTYProcessSessionTests.swift
+++ b/Tests/QuillCodeToolsTests/PTYProcessSessionTests.swift
@@ -152,4 +152,118 @@ final class PTYProcessSessionTests: XCTestCase {
         XCTAssertEqual(result?.ok, false)
         XCTAssertEqual(result?.error, ShellToolMessages.missingCommand)
     }
+
+    func testSuspendAndResumeAreRejectedBeforeStartAndAfterFinish() async throws {
+        let request = ShellExecutionRequest(
+            command: "printf done",
+            cwd: URL(fileURLWithPath: NSTemporaryDirectory()),
+            timeoutSeconds: 15
+        )
+        let session = PTYProcessSession(request: request)
+
+        // Before start there is no process to signal.
+        XCTAssertFalse(session.suspend(), "Cannot suspend a session that has not started.")
+        XCTAssertFalse(session.resume(), "Cannot resume a session that has not started.")
+        XCTAssertFalse(session.isSuspended)
+
+        session.start()
+        for await event in session.events {
+            if case .finished = event { break }
+        }
+
+        // After the command finishes, job-control signals are no-ops.
+        XCTAssertFalse(session.suspend(), "A finished session cannot be suspended.")
+        XCTAssertFalse(session.resume(), "A finished session cannot be resumed.")
+        XCTAssertFalse(session.isSuspended)
+    }
+
+    func testSuspendThenResumeStillDrivesTheRunningProcess() async throws {
+        let request = ShellExecutionRequest(
+            command: "read x; echo \"got:$x\"",
+            cwd: URL(fileURLWithPath: NSTemporaryDirectory()),
+            timeoutSeconds: 15
+        )
+        let session = PTYProcessSession(request: request)
+        session.start()
+
+        // A successful suspend both proves the child has launched and (SIGSTOP being uncatchable)
+        // deterministically guarantees it is stopped — no timing race on output.
+        var suspended = false
+        for _ in 0..<300 {
+            if session.suspend() {
+                suspended = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(suspended, "Expected to suspend the running child.")
+        XCTAssertTrue(session.isSuspended)
+        XCTAssertFalse(session.suspend(), "Suspending an already-suspended session is a no-op.")
+
+        XCTAssertTrue(session.resume(), "Expected to resume the suspended child.")
+        XCTAssertFalse(session.isSuspended)
+        XCTAssertFalse(session.resume(), "Resuming a non-suspended session is a no-op.")
+
+        // The resumed process must still accept input and run to completion — proving resume restored
+        // it rather than leaving it stopped.
+        var delivered = false
+        for _ in 0..<300 {
+            if session.sendInput("hello\n") {
+                delivered = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(delivered, "Expected to deliver input to the resumed session.")
+
+        var output = ""
+        var result: ToolResult?
+        for await event in session.events {
+            switch event {
+            case .stdout(let text), .stderr(let text):
+                output += text
+            case .finished(let toolResult):
+                result = toolResult
+            }
+        }
+
+        XCTAssertTrue(output.contains("got:hello"), "Expected the resumed read to receive input, got: \(output)")
+        XCTAssertEqual(result?.ok, true)
+    }
+
+    func testCancellingASuspendedProcessStillTerminatesIt() async throws {
+        // The load-bearing path: cancel() must SIGCONT-before-terminate, or a SIGSTOP-ped child would
+        // ignore the SIGTERM and the run would hang to the timeout. The 90s timeout is far above the
+        // expected near-instant cancellation, so a finished stream proves termination, not a time-out.
+        let request = ShellExecutionRequest(
+            command: "sleep 90",
+            cwd: URL(fileURLWithPath: NSTemporaryDirectory()),
+            timeoutSeconds: 90
+        )
+        let session = PTYProcessSession(request: request)
+        session.start()
+
+        var suspended = false
+        for _ in 0..<300 {
+            if session.suspend() {
+                suspended = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(suspended, "Expected to suspend the running sleep.")
+
+        session.cancel()
+
+        var result: ToolResult?
+        for await event in session.events {
+            if case .finished(let toolResult) = event {
+                result = toolResult
+            }
+        }
+
+        // Without the SIGCONT before terminate, the stopped sleep would never receive the SIGTERM and
+        // this stream would not finish until the 90s timeout — the test would visibly hang.
+        XCTAssertEqual(result?.ok, false, "A cancelled suspended process must still terminate.")
+    }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-06-30 PTY Job Control — Suspend/Resume (terminal engine)
+
+Overall grade after this slice: **A real terminal job control, deterministically tested**.
+
+The ROADMAP's flagged next PTY step ("Job control … remain the next steps"): the workspace terminal can now suspend and resume a running command, like a shell's Ctrl+Z / `fg`.
+
+| Before | After |
+| --- | --- |
+| `PTYProcessSession` could start, send input, resize, and cancel a command, but had no way to pause a long-running one. | `suspend()` stops the child with `SIGSTOP`; `resume()` continues it with `SIGCONT`; `isSuspended` reports state. Lock-guarded and idempotent: no-ops before start, after finish/cancel, on double-suspend, or resume-without-suspend. |
+| — | **Correctness detail handled:** a `SIGSTOP`-ped process does not act on the `SIGTERM` from `terminate()` until it is continued — so `cancel()`, `timeout()`, and the finish safety-net now `SIGCONT`-before-terminate via a shared `terminate(_:wasSuspended:)` helper. Without this, a suspended command would survive cancellation and time-outs. |
+| — | Two deterministic tests (no timing races): a state-machine test (suspend/resume rejected before start and after finish) and a live integration test that suspends a running `read` (a successful `suspend()` both proves the child launched and — `SIGSTOP` being uncatchable — guarantees it is stopped), then resumes and drives the previously-blocked read to completion, asserting on output content (`got:hello`). Verified stable across repeated runs. |
+
+Adversarial-review fix (verdict SHIP; the standout was a TOCTOU race): `suspend()` omitted a `!didTimeOut` guard, so a timeout firing in the window between its unlock and its `terminate()` could race a concurrent `suspend()`, leaving the captured `wasSuspended=false` and the process `SIGSTOP`-ped — a stopped process ignores `SIGTERM`, so it would leak as an orphaned, never-killed process (and the read loop would park forever). Fixed with defense in depth: `suspend()`/`resume()` now also guard on `!didTimeOut` (refusing once any terminal intent is set, closing the race at the source), *and* `terminate(_:)` sends `SIGCONT` **unconditionally** before `terminate()` — a harmless no-op on a running/reaped process — which immunizes all three terminate paths against an already-suspended process *and* removes the `wasSuspended` plumbing entirely. Also closed the matching test gap (the second `should`): a new `testCancellingASuspendedProcessStillTerminatesIt` suspends a `sleep 90`, cancels, and asserts the stream finishes `ok=false` — without the `SIGCONT` it would hang to the 90s timeout, so this is the regression guard for the feature's core behavior (runs in ~0.1s).
+
+Residual risk:
+
+- This is the **engine slice**: the `PTYProcessSession` API is built and tested; wiring it to a terminal-pane control (a Ctrl+Z / Suspend button driving `suspend()`/`resume()`) is the deliberate follow-up. `suspend()`/`resume()`/`cancel()` all signal the session's direct child (`/bin/sh`); a pipeline or backgrounded grandchild in a separate process group is not covered — true process-group job control needs spawning the child as a group leader (`posix_spawn` with a new pgid), a larger change than this session's Foundation `Process` model, left for a follow-up.
+
 ## 2026-06-30 Recursive Subagent Delegation — Trigger Pass (end-to-end)
 
 Overall grade after this slice: **A makes the recursion engine user-reachable, deterministically tested**.


### PR DESCRIPTION
The ROADMAP's flagged next PTY step ("Job control … remain the next steps"): the workspace terminal session can now **suspend and resume** a running command, like a shell's Ctrl+Z / `fg`.

## How

- `PTYProcessSession.suspend()` stops the child with `SIGSTOP`; `resume()` continues it with `SIGCONT`; `isSuspended` reports state. Lock-guarded and idempotent: no-ops before start, after finish/cancel, on double-suspend, and on resume-without-suspend.
- **Correctness detail handled:** a `SIGSTOP`-ped process does not act on the `SIGTERM` from `terminate()` until it is continued — so `cancel()`, `timeout()`, and the finish safety-net now `SIGCONT`-before-terminate via a shared `terminate(_:wasSuspended:)` helper. Without this, a suspended command would survive cancellation and time-outs.

## Tests (deterministic, no timing races)

- **State machine:** suspend/resume rejected before start and after finish.
- **Live integration:** suspends a running `read` — a successful `suspend()` both proves the child launched *and*, since `SIGSTOP` is uncatchable, guarantees it is stopped — then resumes and drives the previously-blocked read to completion, asserting on output content (`got:hello`). Verified stable across repeated runs.

Verified: `swift test` 1825 · native-desktop smoke (Playwright unaffected — no harness/UI change).

## Scope

**Engine slice:** the `PTYProcessSession` API is built and tested; wiring a terminal-pane Suspend/Ctrl+Z control to it is the deliberate follow-up. `suspend()` signals the session's direct child shell, matching the single-process model `cancel()` already uses (a deeply-nested foreground child group is out of scope, documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)