### PR TITLE
Wire PTY suspend/resume through the terminal UI (end-to-end)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3757,6 +3757,7 @@
         historyCursor: null,
         historyDraft: null,
         isRunning: false,
+        isSuspended: false,
         cwdLabel: '/mock/QuillCode',
         environment: {},
         entries: []
@@ -7451,6 +7452,16 @@
       document.querySelector('[data-testid="terminal-stop"]')?.addEventListener('click', () => {
         runCommand('stop-all');
       });
+      document.querySelector('[data-testid="terminal-suspend"]')?.addEventListener('click', () => {
+        if (!state.terminal.isRunning) return;
+        state.terminal.isSuspended = true;
+        render();
+      });
+      document.querySelector('[data-testid="terminal-resume"]')?.addEventListener('click', () => {
+        if (!state.terminal.isRunning) return;
+        state.terminal.isSuspended = false;
+        render();
+      });
       document.querySelector('[data-testid="terminal-clear"]')?.addEventListener('click', () => {
         runCommand('terminal-clear');
       });
@@ -8780,6 +8791,8 @@
             <strong>Terminal</strong>
             <code data-testid="terminal-cwd">${escapeHTML(state.terminal.cwdLabel)}</code>
             <button class="hit-target-text" type="button" data-testid="terminal-clear" ${state.terminal.entries.length && !state.terminal.isRunning ? '' : 'disabled'}>Clear</button>
+            ${state.terminal.isRunning && state.terminal.isSuspended ? '<button class="hit-target-text" type="button" data-testid="terminal-resume">Resume</button>' : ''}
+            ${state.terminal.isRunning && !state.terminal.isSuspended ? '<button class="hit-target-text" type="button" data-testid="terminal-suspend">Suspend</button>' : ''}
             ${state.terminal.isRunning ? '<button class="hit-target-text" type="button" data-testid="terminal-stop">Stop</button>' : ''}
           </header>
           <div class="terminal-history" data-testid="terminal-history">${entries}</div>
@@ -11223,6 +11236,7 @@
       state.terminal.historyDraft = null;
       state.terminal.isVisible = true;
       state.terminal.isRunning = true;
+      state.terminal.isSuspended = false;
       const cwd = state.terminal.cwdLabel;
       const entry = {
         command,

--- a/E2E/playwright/tests/terminal.spec.ts
+++ b/E2E/playwright/tests/terminal.spec.ts
@@ -84,3 +84,28 @@ test('mock harness runs a command in the integrated terminal', async ({ page }) 
   await expect(page.getByTestId('terminal-empty')).toBeVisible();
   await expect(page.getByTestId('terminal-clear')).toBeDisabled();
 });
+
+test('mock harness suspends and resumes a running terminal command', async ({ page }) => {
+  await page.goto(harnessURL());
+  await clickSidebarTool(page, 'terminal-button');
+
+  // A command that keeps running (waits for input) so job control applies.
+  await page.getByLabel('Terminal command').fill('read-demo');
+  await page.getByTestId('terminal-run').click();
+  await expect(page.getByTestId('terminal-status').last()).toHaveText('Running · running');
+
+  // While running and not suspended: Suspend is offered, Resume is not.
+  await expect(page.getByTestId('terminal-suspend')).toBeVisible();
+  await expect(page.getByTestId('terminal-resume')).toHaveCount(0);
+
+  // Suspend → Resume replaces Suspend; Stop stays available throughout.
+  await page.getByTestId('terminal-suspend').click();
+  await expect(page.getByTestId('terminal-resume')).toBeVisible();
+  await expect(page.getByTestId('terminal-suspend')).toHaveCount(0);
+  await expect(page.getByTestId('terminal-stop')).toBeVisible();
+
+  // Resume → back to Suspend.
+  await page.getByTestId('terminal-resume').click();
+  await expect(page.getByTestId('terminal-suspend')).toBeVisible();
+  await expect(page.getByTestId('terminal-resume')).toHaveCount(0);
+});

--- a/Sources/QuillCodeApp/QuillCodeTerminalPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTerminalPaneView.swift
@@ -6,6 +6,8 @@ struct QuillCodeTerminalPaneView: View {
     @Binding var draft: String
     var onRun: () -> Void
     var onStop: () -> Void
+    var onSuspend: () -> Void = {}
+    var onResume: () -> Void = {}
     var onClear: () -> Void
     var onHistoryPrevious: () -> Void
     var onHistoryNext: () -> Void
@@ -39,8 +41,21 @@ struct QuillCodeTerminalPaneView: View {
                 .disabled(!terminal.canClear)
                 .accessibilityIdentifier("quillcode-terminal-clear")
             if terminal.isRunning {
-                ProgressView()
-                    .controlSize(.small)
+                if !terminal.isSuspended {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                if terminal.canResume {
+                    Button("Resume", action: onResume)
+                        .buttonStyle(QuillCodePressableButtonStyle())
+                        .quillCodeTextButtonTarget(minWidth: 64)
+                        .accessibilityIdentifier("quillcode-terminal-resume")
+                } else if terminal.canSuspend {
+                    Button("Suspend", action: onSuspend)
+                        .buttonStyle(QuillCodePressableButtonStyle())
+                        .quillCodeTextButtonTarget(minWidth: 64)
+                        .accessibilityIdentifier("quillcode-terminal-suspend")
+                }
                 Button("Stop", action: onStop)
                     .buttonStyle(QuillCodeActionButtonStyle(.destructive, minWidth: 56))
                     .quillCodeFormActionTarget()

--- a/Sources/QuillCodeApp/QuillCodeTerminalSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTerminalSurface.swift
@@ -4,9 +4,19 @@ public struct TerminalSurface: Codable, Sendable, Hashable {
     public var isVisible: Bool
     public var draft: String
     public var isRunning: Bool
+    public var isSuspended: Bool
     public var cwdLabel: String
     public var entries: [TerminalCommandSurface]
     public var emptyTitle: String
+
+    /// A running command can be paused (job control); a paused one can be resumed. Mutually exclusive.
+    public var canSuspend: Bool {
+        isRunning && !isSuspended
+    }
+
+    public var canResume: Bool {
+        isRunning && isSuspended
+    }
 
     public var canRun: Bool {
         !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isRunning
@@ -36,6 +46,7 @@ public struct TerminalSurface: Codable, Sendable, Hashable {
         self.isVisible = terminal.isVisible
         self.draft = terminal.draft
         self.isRunning = terminal.isRunning
+        self.isSuspended = terminal.isSuspended
         self.cwdLabel = cwd?.path ?? terminal.currentDirectoryPath ?? "No project"
         self.entries = terminal.entries.map(TerminalCommandSurface.init)
         self.emptyTitle = emptyTitle

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -20,6 +20,8 @@ struct QuillCodeWorkspaceMainPaneView: View {
     var onTerminalHistoryPrevious: () -> Void
     var onTerminalHistoryNext: () -> Void
     var onTerminalResize: (TerminalWindowSize) -> Void = { _ in }
+    var onTerminalSuspend: () -> Void = {}
+    var onTerminalResume: () -> Void = {}
     var onOpenBrowserPreview: () -> Void
     var onOpenBrowserSession: (() -> Void)?
     var onAddBrowserComment: (String) -> Void
@@ -117,6 +119,8 @@ struct QuillCodeWorkspaceMainPaneView: View {
                         draft: $terminalDraft,
                         onRun: onRunTerminalCommand,
                         onStop: stopActiveRun,
+                        onSuspend: onTerminalSuspend,
+                        onResume: onTerminalResume,
                         onClear: { runCommand(id: "terminal-clear") },
                         onHistoryPrevious: onTerminalHistoryPrevious,
                         onHistoryNext: onTerminalHistoryNext,

--- a/Sources/QuillCodeApp/WorkspaceHTMLTerminalRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTerminalRenderer.swift
@@ -16,6 +16,7 @@ enum WorkspaceHTMLTerminalRenderer {
                 testID: "terminal-clear",
                 disabled: !terminal.canClear
             ))
+            \(jobControlButton(terminal))
           </header>
           <div data-testid="terminal-history">
             \(entries)
@@ -31,6 +32,18 @@ enum WorkspaceHTMLTerminalRenderer {
           </form>
         </section>
         """
+    }
+
+    /// A running command shows a Suspend control; a suspended one shows Resume (job control, mutually
+    /// exclusive). Nothing renders when no command is running.
+    private static func jobControlButton(_ terminal: TerminalSurface) -> String {
+        if terminal.canResume {
+            return WorkspaceHTMLPrimitives.button("Resume", testID: "terminal-resume")
+        }
+        if terminal.canSuspend {
+            return WorkspaceHTMLPrimitives.button("Suspend", testID: "terminal-suspend")
+        }
+        return ""
     }
 
     private static func renderEntry(_ entry: TerminalCommandSurface) -> String {

--- a/Sources/QuillCodeApp/WorkspaceModelTerminal.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelTerminal.swift
@@ -60,6 +60,31 @@ extension QuillCodeWorkspaceModel {
         return activeTerminalSession.sendInput(processInput)
     }
 
+    /// Suspends the running terminal command (job control, like a shell's Ctrl+Z). Returns `false` if
+    /// nothing is running, it is already suspended, or the session does not support suspension (only
+    /// the local PTY does).
+    @discardableResult
+    public func suspendTerminalCommand() -> Bool {
+        guard terminal.isRunning, !terminal.isSuspended,
+              let activeTerminalSession, activeTerminalSession.suspend() else {
+            return false
+        }
+        terminal.isSuspended = true
+        return true
+    }
+
+    /// Resumes a suspended terminal command. Returns `false` if nothing is running or it is not
+    /// currently suspended.
+    @discardableResult
+    public func resumeTerminalCommand() -> Bool {
+        guard terminal.isRunning, terminal.isSuspended,
+              let activeTerminalSession, activeTerminalSession.resume() else {
+            return false
+        }
+        terminal.isSuspended = false
+        return true
+    }
+
     public func runTerminalCommand(_ input: String, workspaceRoot: URL) async {
         let command = WorkspaceTerminalEngine.normalizedCommand(input)
         guard WorkspaceTerminalEngine.canBeginRun(command: command, terminal: terminal) else { return }
@@ -103,6 +128,8 @@ extension QuillCodeWorkspaceModel {
                 finalResult = result
             }
         }
+        // The session has ended (completed, stopped, or cancelled); job control no longer applies.
+        terminal.isSuspended = false
 
         if WorkspaceTerminalEngine.entryIsStopped(id: entryID, terminal: terminal) {
             WorkspaceTerminalEngine.finishStoppedRun(executionContext: executionContext, terminal: &terminal)

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -16,6 +16,8 @@ public struct QuillCodeWorkspaceView: View {
     public var onTerminalHistoryPrevious: () -> Void
     public var onTerminalHistoryNext: () -> Void
     public var onTerminalResize: (TerminalWindowSize) -> Void
+    public var onTerminalSuspend: () -> Void
+    public var onTerminalResume: () -> Void
     public var onOpenBrowserPreview: () -> Void
     public var onOpenBrowserSession: (() -> Void)?
     public var onAddBrowserComment: (String) -> Void
@@ -79,6 +81,8 @@ public struct QuillCodeWorkspaceView: View {
         onTerminalHistoryPrevious: @escaping () -> Void = {},
         onTerminalHistoryNext: @escaping () -> Void = {},
         onTerminalResize: @escaping (TerminalWindowSize) -> Void = { _ in },
+        onTerminalSuspend: @escaping () -> Void = {},
+        onTerminalResume: @escaping () -> Void = {},
         onOpenBrowserPreview: @escaping () -> Void,
         onOpenBrowserSession: (() -> Void)? = nil,
         onAddBrowserComment: @escaping (String) -> Void,
@@ -127,6 +131,8 @@ public struct QuillCodeWorkspaceView: View {
         self.onTerminalHistoryPrevious = onTerminalHistoryPrevious
         self.onTerminalHistoryNext = onTerminalHistoryNext
         self.onTerminalResize = onTerminalResize
+        self.onTerminalSuspend = onTerminalSuspend
+        self.onTerminalResume = onTerminalResume
         self.onOpenBrowserPreview = onOpenBrowserPreview
         self.onOpenBrowserSession = onOpenBrowserSession
         self.onAddBrowserComment = onAddBrowserComment
@@ -205,6 +211,8 @@ public struct QuillCodeWorkspaceView: View {
                     onTerminalHistoryPrevious: onTerminalHistoryPrevious,
                     onTerminalHistoryNext: onTerminalHistoryNext,
                     onTerminalResize: onTerminalResize,
+                    onTerminalSuspend: onTerminalSuspend,
+                    onTerminalResume: onTerminalResume,
                     onOpenBrowserPreview: onOpenBrowserPreview,
                     onOpenBrowserSession: onOpenBrowserSession,
                     onAddBrowserComment: onAddBrowserComment,

--- a/Sources/QuillCodeApp/WorkspaceTerminalState.swift
+++ b/Sources/QuillCodeApp/WorkspaceTerminalState.swift
@@ -68,6 +68,7 @@ public struct TerminalState: Sendable, Hashable {
     public var historyCursor: Int?
     public var historyDraft: String?
     public var isRunning: Bool
+    public var isSuspended: Bool
     public var entries: [TerminalCommandState]
 
     public init(
@@ -81,6 +82,7 @@ public struct TerminalState: Sendable, Hashable {
         historyCursor: Int? = nil,
         historyDraft: String? = nil,
         isRunning: Bool = false,
+        isSuspended: Bool = false,
         entries: [TerminalCommandState] = []
     ) {
         self.projectID = projectID
@@ -93,6 +95,7 @@ public struct TerminalState: Sendable, Hashable {
         self.historyCursor = historyCursor
         self.historyDraft = historyDraft
         self.isRunning = isRunning
+        self.isSuspended = isSuspended
         self.entries = entries
     }
 }

--- a/Sources/QuillCodeTools/ShellToolExecutor.swift
+++ b/Sources/QuillCodeTools/ShellToolExecutor.swift
@@ -36,6 +36,30 @@ public protocol ShellInteractiveSession: AnyObject, Sendable {
     func resize(to windowSize: PTYWindowSize) -> Bool
 
     func cancel()
+
+    /// Suspends the running command (terminal job control). Returns `false` if unsupported or not
+    /// applicable. Default: unsupported.
+    @discardableResult
+    func suspend() -> Bool
+
+    /// Resumes a suspended command. Returns `false` if unsupported or not currently suspended.
+    @discardableResult
+    func resume() -> Bool
+
+    /// Whether the command is currently suspended.
+    var isSuspended: Bool { get }
+}
+
+public extension ShellInteractiveSession {
+    // Job control is a PTY capability; pipe-backed and remote sessions do not support it, so they
+    // inherit these no-ops and report "not suspended".
+    @discardableResult
+    func suspend() -> Bool { false }
+
+    @discardableResult
+    func resume() -> Bool { false }
+
+    var isSuspended: Bool { false }
 }
 
 public final class ShellStreamingSession: ShellInteractiveSession, @unchecked Sendable {

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -71,6 +71,8 @@ struct QuillCodeDesktopRootView: View {
             onTerminalHistoryPrevious: controller.recallPreviousTerminalCommand,
             onTerminalHistoryNext: controller.recallNextTerminalCommand,
             onTerminalResize: controller.resizeTerminal,
+            onTerminalSuspend: controller.suspendTerminal,
+            onTerminalResume: controller.resumeTerminal,
             onOpenBrowserPreview: controller.openBrowserPreview,
             onOpenBrowserSession: controller.openBrowserSession,
             onAddBrowserComment: controller.addBrowserComment,

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -322,6 +322,18 @@ final class QuillCodeDesktopController: ObservableObject {
         terminalCoordinator.resizeTerminal(windowSize, model: model)
     }
 
+    func suspendTerminal() {
+        terminalCoordinator.suspendTerminal(model: model)
+        // Rebuild the published surface so the pane re-renders with the new isSuspended state
+        // (Resume replaces Suspend). isSuspended is a visible surface field, unlike resize.
+        refresh()
+    }
+
+    func resumeTerminal() {
+        terminalCoordinator.resumeTerminal(model: model)
+        refresh()
+    }
+
     func runReviewAction(_ action: WorkspaceReviewActionSurface) {
         workspaceActionCoordinator.runReviewAction(action, model: model, fallbackWorkspaceRoot: workspaceRoot)
         refresh()

--- a/Sources/quill-code-desktop/QuillCodeDesktopTerminalCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopTerminalCoordinator.swift
@@ -71,6 +71,14 @@ struct QuillCodeDesktopTerminalCoordinator {
         )
     }
 
+    func suspendTerminal(model: QuillCodeWorkspaceModel) {
+        model.suspendTerminalCommand()
+    }
+
+    func resumeTerminal(model: QuillCodeWorkspaceModel) {
+        model.resumeTerminalCommand()
+    }
+
     private func recallCommand(
         draft: inout String,
         model: QuillCodeWorkspaceModel,

--- a/Tests/QuillCodeAppTests/WorkspaceTerminalIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTerminalIntegrationTests.swift
@@ -89,6 +89,53 @@ final class WorkspaceTerminalIntegrationTests: XCTestCase {
         )
     }
 
+    func testSuspendAndResumeAreRejectedWhenNoCommandIsRunning() async throws {
+        let model = QuillCodeWorkspaceModel()
+        XCTAssertFalse(model.suspendTerminalCommand(), "Nothing is running to suspend.")
+        XCTAssertFalse(model.resumeTerminalCommand(), "Nothing is running to resume.")
+        XCTAssertFalse(model.terminal.isSuspended)
+    }
+
+    func testLocalTerminalSuspendsAndResumesARunningCommand() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+
+        let task = Task {
+            await model.runTerminalCommand("read x; printf got:$x", workspaceRoot: root)
+        }
+        try await waitUntil(timeoutSeconds: 2) {
+            model.terminal.entries.first?.status == .running
+        }
+
+        // Suspend the live PTY (SIGSTOP); a successful suspend proves the child is stopped.
+        var suspended = false
+        for _ in 0..<300 {
+            if model.suspendTerminalCommand() {
+                suspended = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(suspended, "Expected to suspend the running local PTY command.")
+        XCTAssertTrue(model.terminal.isSuspended)
+        XCTAssertFalse(model.suspendTerminalCommand(), "Suspending an already-suspended command is a no-op.")
+
+        // Resume, then drive the previously-blocked read to completion.
+        XCTAssertTrue(model.resumeTerminalCommand())
+        XCTAssertFalse(model.terminal.isSuspended)
+        XCTAssertFalse(model.resumeTerminalCommand(), "Resuming a non-suspended command is a no-op.")
+
+        XCTAssertTrue(model.sendTerminalInput("hello\n"))
+        await task.value
+
+        XCTAssertEqual(model.terminal.entries.first?.status, .done)
+        XCTAssertFalse(model.terminal.isSuspended, "isSuspended is cleared once the run ends.")
+        XCTAssertTrue(
+            model.terminal.entries.first?.stdout.contains("got:hello") == true,
+            "Expected the resumed read to receive input, got: \(model.terminal.entries.first?.stdout ?? "<nil>")"
+        )
+    }
+
     func testTerminalCommandRunsThroughSSHRemoteProject() async throws {
         let root = try makeTempDirectory()
         let argumentsFile = root.appendingPathComponent("ssh-args.txt")

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -407,6 +407,42 @@ final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
         XCTAssertTrue(toolCards.suffix(2).allSatisfy { $0.status == .done })
     }
 
+    func testControllerSuspendAndResumeRefreshTheRenderedSurface() async throws {
+        let controller = try makeController(workspaceRoot: try makeTempDirectory())
+        controller.terminalDraft = "read x; printf got:$x"
+        controller.runTerminalCommand()
+
+        // Drive suspend through the controller until it takes (the async run must reach the live PTY
+        // first). The rendered surface — not just the underlying model — must then reflect it, or the
+        // native pane shows a dead Suspend button that never becomes Resume. The `read` blocks with no
+        // output, so no event-driven refresh fires; only the controller calling refresh() after
+        // suspend can update the surface, so this would fail without that call.
+        var suspendedInSurface = false
+        for _ in 0..<300 {
+            controller.suspendTerminal()
+            if controller.surface.terminal.isSuspended { suspendedInSurface = true; break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(suspendedInSurface, "Controller.suspendTerminal must refresh the surface so the pane can render Resume.")
+        XCTAssertTrue(controller.surface.terminal.isRunning)
+        XCTAssertTrue(controller.surface.terminal.canResume)
+        XCTAssertFalse(controller.surface.terminal.canSuspend)
+
+        controller.resumeTerminal()
+        XCTAssertFalse(controller.surface.terminal.isSuspended, "Controller.resumeTerminal must refresh the surface back to running.")
+        XCTAssertTrue(controller.surface.terminal.canSuspend)
+
+        // Finish the command so the test does not leak a running PTY (Run sends input while running).
+        controller.terminalDraft = "hello\n"
+        controller.runTerminalCommand()
+        for _ in 0..<300 {
+            if !controller.surface.terminal.isRunning { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertFalse(controller.surface.terminal.isRunning)
+        XCTAssertFalse(controller.surface.terminal.isSuspended)
+    }
+
     private func makeController(
         workspaceRoot: URL,
         browserSessionPresenter: any DesktopBrowserSessionPresenting = NoopDesktopBrowserSessionPresenter()

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,24 @@
 # Code Quality Audit
 
+## 2026-06-30 PTY Job Control — Terminal UI (end-to-end)
+
+Overall grade after this slice: **A completes PTY job control as a user feature, tri-surface + tested**.
+
+Follow-up to the suspend/resume engine: wires it through the model and all three surfaces so a user can actually pause and resume a running terminal command.
+
+| Before | After |
+| --- | --- |
+| `PTYProcessSession.suspend()`/`resume()` existed but only the concrete type had them (review nit [7]); nothing called them. | `ShellInteractiveSession` now declares `suspend()`/`resume()`/`isSuspended` with **no-op default extensions** — the PTY overrides them; pipe-backed (`ShellStreamingSession`) and SSH-remote sessions inherit the no-ops, so the model can call uniformly through `any ShellInteractiveSession`. |
+| — | Model: `suspendTerminalCommand()`/`resumeTerminalCommand()` (mirroring `sendTerminalInput`) gate on `isRunning` + the session result and flip `terminal.isSuspended`, which is cleared when the run ends. `TerminalSurface` exposes `isSuspended`/`canSuspend`/`canResume` (mutually exclusive). |
+| — | Tri-surface control mirroring Stop: native `QuillCodeTerminalPaneView` (Suspend when running, Resume when suspended, threaded through `WorkspaceSwiftUIView` → desktop controller/coordinator), static `WorkspaceHTMLTerminalRenderer`, and the JS harness — all show Resume↔Suspend exclusively while running. |
+| — | Tests across the stack: a model integration test runs `read x` through the real PTY, suspends it (a successful `suspend()` proves the child is stopped), resumes, and drives the blocked read to `got:hello`; a rejected-when-idle test; and a Playwright flow asserting Suspend↔Resume toggling with Stop always present. |
+
+Adversarial-review fix (verdict BLOCKERS → a real mustFix): the native `controller.suspendTerminal()`/`resumeTerminal()` mutated `model.terminal.isSuspended` but never called `refresh()` — and the desktop view renders from the pull-based `@Published surface`, which only rebuilds inside `refresh()`. So on native, clicking Suspend fired `SIGSTOP` but the surface stayed stale: the spinner kept spinning, the button kept reading "Suspend", and Resume never appeared — **you could suspend but never resume**. Fixed by calling `refresh()` after the coordinator call (mirroring every other mutating controller action, e.g. `runReviewAction`). My tests missed it because the model test bypasses the controller→surface→view path and Playwright drives the inline-rendering harness — so I added `testControllerSuspendAndResumeRefreshTheRenderedSurface`, which drives a real PTY *through the controller* and asserts `controller.surface.terminal.isSuspended`/`canResume` flip (it fails without the `refresh()` call). Stable across repeated runs.
+
+Residual risk:
+
+- Whether `suspend()` works is local-PTY-only by design (remote/pipe sessions report `false` and show no control). The model gates on the session's own result, so a non-PTY session never flips `isSuspended`. The native controller→surface→pane path is now covered by the controller regression test; the SwiftUI button geometry itself is still build/parity-checked rather than unit-tested.
+
 ## 2026-06-30 PTY Job Control — Suspend/Resume (terminal engine)
 
 Overall grade after this slice: **A real terminal job control, deterministically tested**.


### PR DESCRIPTION
Follow-up to the suspend/resume engine ([#715](https://github.com/Lore-Hex/QuillCode/pull/715)): makes PTY job control **user-reachable** across the model and all three surfaces, so a user can pause and resume a running terminal command.

## How

- `ShellInteractiveSession` now declares `suspend()`/`resume()`/`isSuspended` with **no-op default extensions** — `PTYProcessSession` overrides them; pipe-backed and SSH-remote sessions inherit the no-ops, so the model calls uniformly through `any ShellInteractiveSession`. (closes review **nit [7]** from #715)
- Model `suspendTerminalCommand()`/`resumeTerminalCommand()` mirror `sendTerminalInput`, gate on `isRunning` + the session result, and flip `terminal.isSuspended` (cleared when the run ends). `TerminalSurface` gains `isSuspended`/`canSuspend`/`canResume` (mutually exclusive).
- Tri-surface control mirroring Stop: native `QuillCodeTerminalPaneView` (threaded through `WorkspaceSwiftUIView` → desktop controller/coordinator), static `WorkspaceHTMLTerminalRenderer`, and the JS harness — all show Resume↔Suspend exclusively while running.

## Tests

- **Model integration** (real PTY): run `read x`, suspend (a successful `suspend()` proves the child is stopped), resume, drive the blocked read to `got:hello`; plus rejected-when-idle.
- **Playwright**: Suspend↔Resume toggle flow with Stop always present.

Verified: `swift test` 1838 · `playwright` 144 · native-desktop smoke.

Native button wiring is exercised by build + parity (SwiftUI view layer); the model, surface, HTML, and harness paths are all unit/integration/E2E covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)