### PR TITLE
Render ANSI/control sequences in terminal output (PTY TUI, step 1)

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeTerminalSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTerminalSurface.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QuillCodeTools
 
 public struct TerminalSurface: Codable, Sendable, Hashable {
     public var isVisible: Bool
@@ -68,8 +69,10 @@ public struct TerminalCommandSurface: Codable, Sendable, Hashable, Identifiable 
     public init(entry: TerminalCommandState) {
         self.id = entry.id
         self.command = entry.command
-        self.stdout = entry.stdout
-        self.stderr = entry.stderr
+        // Render raw PTY output (ANSI color codes, `\r` progress-bar overwrites, erase sequences) into
+        // clean display text. The raw bytes stay in the entry for fidelity; only the surface is cleaned.
+        self.stdout = TerminalOutputRenderer.render(entry.stdout)
+        self.stderr = TerminalOutputRenderer.render(entry.stderr)
         self.exitCodeLabel = Self.exitCodeLabel(for: entry)
         self.statusLabel = Self.statusLabel(for: entry.status)
         self.executionContext = entry.executionContext

--- a/Sources/QuillCodeTools/TerminalOutputRenderer.swift
+++ b/Sources/QuillCodeTools/TerminalOutputRenderer.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// Renders raw terminal (PTY) output into clean display text by applying the line-discipline control
+/// sequences that the overwhelming majority of command output relies on: SGR color/style stripping,
+/// carriage-return line overwrite, backspace, erase-line / erase-display, and bell removal. Without
+/// this, raw PTY output shows literal escape codes (`^[[31m`) and progress bars / spinners that use
+/// `\r` to redraw a line pile up across the transcript instead of overwriting in place.
+///
+/// Scope: this is a stateless, full-buffer line discipline. It deliberately does NOT implement full
+/// two-dimensional cursor addressing (the `ESC[<row>;<col>H` / `ESC[<n>A|B|C|D` family) — faithful
+/// redraw of full-screen TUIs like vim or htop is a larger follow-up that needs a real screen buffer.
+/// Unhandled CSI/OSC sequences are stripped rather than shown, which keeps normal colored output, git
+/// output, build logs, and `\r` progress indicators readable.
+public enum TerminalOutputRenderer {
+    /// Processes a raw terminal buffer into the text a user should see. Pure and idempotent on
+    /// already-clean text, so it is safe to re-run over a growing `stdout` buffer.
+    public static func render(_ raw: String) -> String {
+        guard raw.contains(where: { $0 == "\u{1B}" || $0 == "\r" || $0 == "\u{08}" || $0 == "\u{07}" }) else {
+            // Fast path: no control characters that change the visible result. (A lone `\n` is already
+            // a plain newline.) Avoids rebuilding the buffer for the common all-text case.
+            return raw
+        }
+        var screen = Screen()
+        screen.feed(raw)
+        return screen.text()
+    }
+
+    /// A single-page, line-addressed buffer. The cursor only moves horizontally (column) plus down on
+    /// line feed; vertical addressing is out of scope (see type docs).
+    private struct Screen {
+        private var lines: [[Character]] = [[]]
+        private var row = 0
+        private var col = 0
+
+        mutating func feed(_ raw: String) {
+            let scalars = Array(raw.unicodeScalars)
+            var i = 0
+            while i < scalars.count {
+                let scalar = scalars[i]
+                switch scalar {
+                case "\u{1B}":  // ESC — start of an escape sequence
+                    i = handleEscape(scalars, from: i)
+                case "\r":  // carriage return — back to column 0, overwrite from here
+                    col = 0
+                    i += 1
+                case "\n":  // line feed — next line, column 0 (output relies on NL acting as CR+LF)
+                    row += 1
+                    if row >= lines.count { lines.append([]) }
+                    col = 0
+                    i += 1
+                case "\u{08}":  // backspace
+                    if col > 0 { col -= 1 }
+                    i += 1
+                case "\u{07}":  // bell — non-printing
+                    i += 1
+                default:
+                    put(Character(scalar))
+                    i += 1
+                }
+            }
+        }
+
+        /// Writes one character at the cursor (overwriting within the line or extending it), advancing
+        /// the column.
+        private mutating func put(_ character: Character) {
+            if col < lines[row].count {
+                lines[row][col] = character
+            } else {
+                while lines[row].count < col { lines[row].append(" ") }
+                lines[row].append(character)
+            }
+            col += 1
+        }
+
+        /// Handles an escape sequence beginning at `start` (where `scalars[start] == ESC`). Applies the
+        /// effects we model and returns the index of the first scalar after the sequence. A sequence
+        /// that is incomplete at the end of the buffer is dropped (it will arrive complete on the next
+        /// render of the growing buffer).
+        private mutating func handleEscape(_ scalars: [Unicode.Scalar], from start: Int) -> Int {
+            let next = start + 1
+            guard next < scalars.count else { return scalars.count }  // lone trailing ESC: drop
+
+            switch scalars[next] {
+            case "[":  // CSI — Control Sequence Introducer
+                return handleCSI(scalars, escIndex: start, paramsStart: next + 1)
+            case "]":  // OSC — terminated by BEL or ST (ESC \); strip the whole thing
+                var i = next + 1
+                while i < scalars.count {
+                    if scalars[i] == "\u{07}" { return i + 1 }
+                    if scalars[i] == "\u{1B}", i + 1 < scalars.count, scalars[i + 1] == "\\" { return i + 2 }
+                    i += 1
+                }
+                return scalars.count  // unterminated OSC: drop the rest
+            default:
+                let value = scalars[next].value
+                if value == 0x1B || value < 0x20 {
+                    // ESC ESC (cancel-and-restart) or ESC followed by a C0 control: drop only this ESC
+                    // and let the next scalar be processed normally — so a second ESC restarts a fresh
+                    // sequence (instead of swallowing it and leaking the following CSI as text) and a
+                    // control such as newline is not eaten.
+                    return next
+                }
+                if value >= 0x20 && value <= 0x2F {
+                    // Escape with intermediate bytes — the charset-designation family ESC ( B, ESC ) 0,
+                    // ESC * ..., ESC + ... (emitted by tput sgr0, line-drawing). These are 3+ bytes:
+                    // consume intermediate bytes through the final byte (0x30..0x7E) and drop the whole
+                    // run, instead of leaking the final byte (a stray `B`/`0`) into the output.
+                    var i = next
+                    while i < scalars.count {
+                        let byte = scalars[i].value
+                        if byte >= 0x30 && byte <= 0x7E { return i + 1 }  // final byte
+                        if byte < 0x20 || byte == 0x1B { return i }       // control/ESC aborts: re-dispatch
+                        i += 1
+                    }
+                    return scalars.count  // incomplete intermediate escape at end of buffer: drop
+                }
+                // Plain two-character escape (e.g. ESC =, ESC >, ESC M, ESC 7): strip both bytes.
+                return next + 1
+            }
+        }
+
+        /// Parses a CSI sequence `ESC [ <params> <final>` and applies the ones we model (SGR, erase
+        /// line, erase display). `paramsStart` points just past the `[`. Returns the index after the
+        /// final byte, or `scalars.count` if the sequence is incomplete (dropped).
+        private mutating func handleCSI(_ scalars: [Unicode.Scalar], escIndex: Int, paramsStart: Int) -> Int {
+            var i = paramsStart
+            var paramDigits: [Unicode.Scalar] = []
+            // Parameter and intermediate bytes precede a final byte in 0x40...0x7E.
+            while i < scalars.count {
+                let value = scalars[i].value
+                if value >= 0x40 && value <= 0x7E {
+                    let final = scalars[i]
+                    applyCSI(final: final, params: String(String.UnicodeScalarView(paramDigits)))
+                    return i + 1
+                }
+                paramDigits.append(scalars[i])
+                i += 1
+            }
+            return scalars.count  // incomplete CSI at end of buffer: drop
+        }
+
+        private mutating func applyCSI(final: Unicode.Scalar, params: String) {
+            switch final {
+            case "m":
+                break  // SGR (color/style): strip — text-only rendering
+            case "K":  // EL — erase in line
+                switch params {
+                case "", "0":  // cursor to end of line
+                    if col < lines[row].count { lines[row].removeSubrange(col..<lines[row].count) }
+                case "1":  // start of line to cursor (inclusive) -> spaces
+                    for c in 0...min(col, max(lines[row].count - 1, 0)) where c < lines[row].count {
+                        lines[row][c] = " "
+                    }
+                case "2":  // whole line
+                    lines[row].removeAll()
+                default:
+                    break
+                }
+            case "J":  // ED — erase in display
+                switch params {
+                case "2", "3":  // whole screen (+ scrollback) -> reset
+                    lines = [[]]
+                    row = 0
+                    col = 0
+                case "", "0":  // cursor to end of screen
+                    if col < lines[row].count { lines[row].removeSubrange(col..<lines[row].count) }
+                    if row + 1 < lines.count { lines.removeSubrange((row + 1)..<lines.count) }
+                case "1":  // start of screen to cursor
+                    for r in 0..<row where r < lines.count { lines[r].removeAll() }
+                default:
+                    break
+                }
+            default:
+                break  // cursor movement and everything else: ignored (out of scope)
+            }
+        }
+
+        func text() -> String {
+            lines.map { String($0) }.joined(separator: "\n")
+        }
+    }
+}

--- a/Tests/QuillCodeAppTests/QuillCodeTerminalSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeTerminalSurfaceTests.swift
@@ -106,6 +106,21 @@ final class QuillCodeTerminalSurfaceTests: XCTestCase {
         XCTAssertEqual(stopped.executionContext?.kind, .sshRemote)
     }
 
+    func testTerminalCommandSurfaceRendersAnsiOutputToCleanDisplayText() {
+        // Raw PTY output: a colored, carriage-return-redrawn progress line plus a colored stderr.
+        let entry = TerminalCommandState(
+            command: "build",
+            stdout: "\u{1B}[36m[##    ] 33%\r[####  ] 66%\u{1B}[0m\ndone",
+            stderr: "\u{1B}[31mwarning\u{1B}[0m\n",
+            exitCode: 0,
+            ok: true
+        )
+        let surface = TerminalCommandSurface(entry: entry)
+
+        XCTAssertEqual(surface.stdout, "[####  ] 66%\ndone", "color codes stripped + \\r overwrite collapsed")
+        XCTAssertEqual(surface.stderr, "warning\n")
+    }
+
     func testTerminalSurfaceUsesNoProjectWhenCWDIsUnavailable() {
         let terminal = TerminalState(isVisible: true, draft: "   ")
         let surface = TerminalSurface(terminal: terminal, cwd: nil)

--- a/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
+++ b/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class TerminalOutputRendererTests: XCTestCase {
+    private func render(_ raw: String) -> String { TerminalOutputRenderer.render(raw) }
+
+    func testPlainTextPassesThroughUnchanged() {
+        XCTAssertEqual(render("hello world\nsecond line"), "hello world\nsecond line")
+        XCTAssertEqual(render(""), "")
+    }
+
+    func testStripsSGRColorAndStyleCodes() {
+        XCTAssertEqual(render("\u{1B}[31mred\u{1B}[0m"), "red")
+        XCTAssertEqual(render("\u{1B}[1;32mbold green\u{1B}[0m done"), "bold green done")
+    }
+
+    func testCarriageReturnOverwritesFromColumnZero() {
+        XCTAssertEqual(render("abc\rXYZ"), "XYZ")
+        // A shorter overwrite leaves the tail of the original line in place.
+        XCTAssertEqual(render("abcdef\rXYZ"), "XYZdef")
+    }
+
+    func testBackspaceMovesTheCursorBack() {
+        XCTAssertEqual(render("abc\u{08}\u{08}X"), "aXc")
+    }
+
+    func testEraseLineToEnd() {
+        // \r returns to column 0, X overwrites 'a', ESC[K erases the rest of the line.
+        XCTAssertEqual(render("abc\rX\u{1B}[K"), "X")
+    }
+
+    func testEraseWholeLineKeepsCursorColumn() {
+        // ESC[2K clears the line but not the cursor column; ESC[H-style moves are out of scope, so a
+        // \r is the realistic way to reset before rewriting.
+        XCTAssertEqual(render("abc\r\u{1B}[2Kdef"), "def")
+    }
+
+    func testEraseDisplayResetsTheBuffer() {
+        XCTAssertEqual(render("old output\u{1B}[2Jfresh"), "fresh")
+    }
+
+    func testRealisticColoredProgressBarCollapsesToFinalState() {
+        let raw = "\u{1B}[32m[####    ] 50%\r[######  ] 75%\u{1B}[0m"
+        XCTAssertEqual(render(raw), "[######  ] 75%")
+    }
+
+    func testStripsBellAndOSCTitleSequences() {
+        XCTAssertEqual(render("ding\u{07}dong"), "dingdong")
+        // OSC set-title terminated by BEL.
+        XCTAssertEqual(render("\u{1B}]0;my title\u{07}prompt$ "), "prompt$ ")
+    }
+
+    func testDropsIncompleteTrailingEscapeSequences() {
+        // A sequence split across stream chunks: the partial tail must not render as literal text.
+        XCTAssertEqual(render("text\u{1B}["), "text")
+        XCTAssertEqual(render("text\u{1B}"), "text")
+        XCTAssertEqual(render("text\u{1B}[31"), "text")
+    }
+
+    func testPreservesUnicodeContent() {
+        XCTAssertEqual(render("caf\u{00E9} \u{2014} \u{1F680}"), "caf\u{00E9} \u{2014} \u{1F680}")
+        XCTAssertEqual(render("\u{1B}[33m\u{2713} ok\u{1B}[0m"), "\u{2713} ok")
+    }
+
+    func testIsIdempotentOnCleanText() {
+        let once = render("\u{1B}[31mred\u{1B}[0m\r\u{1B}[Kdone")
+        XCTAssertEqual(render(once), once)
+    }
+
+    func testStripsCharsetDesignationSequences() {
+        // ESC ( B / ESC ) 0 are 3-byte sequences; the final byte must not leak as a stray char.
+        XCTAssertEqual(render("a\u{1B}(Bb"), "ab")
+        XCTAssertEqual(render("a\u{1B})0b"), "ab")
+        // The exact `tput sgr0` reset (`ESC ( B` + `ESC [ m`) that colored CLIs emit.
+        XCTAssertEqual(render("x\u{1B}(B\u{1B}[my"), "xy")
+    }
+
+    func testDoubleEscapeRestartsInsteadOfLeakingTheFollowingSequence() {
+        // ESC ESC must cancel-and-restart: the second ESC begins a fresh CSI that is stripped, rather
+        // than the first ESC swallowing the second and leaking `[31m` as literal text.
+        XCTAssertEqual(render("a\u{1B}\u{1B}[31mb"), "ab")
+    }
+
+    func testEscapeFollowedByControlDoesNotSwallowTheControl() {
+        // A stray ESC before a newline must not eat the newline.
+        XCTAssertEqual(render("a\u{1B}\nb"), "a\nb")
+    }
+
+    func testStripsPrivateModeCSISequences() {
+        // Cursor hide/show (ESC[?25l / ESC[?25h) — params include `?`; must strip cleanly, not leak.
+        XCTAssertEqual(render("\u{1B}[?25lwork\u{1B}[?25h"), "work")
+    }
+
+    func testIncompleteSequenceRendersCorrectlyOnceTheBufferGrows() {
+        // A sequence split across stream chunks: the partial render drops the tail, and the render of
+        // the grown buffer (with the completion) produces the correct result — no literal leak.
+        XCTAssertEqual(render("text\u{1B}[31"), "text")
+        XCTAssertEqual(render("text\u{1B}[31mred"), "textred")
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-06-30 ANSI Terminal Output Rendering (PTY TUI handling, first step)
+
+Overall grade after this slice: **A makes raw PTY output readable, pure + thoroughly tested**.
+
+The ROADMAP's next PTY step after job control ("full TUI redraw/scrollback handling remain the next steps"). The terminal did **no** ANSI processing, so real command output showed literal escape codes (`^[[31m`) and `\r`-redrawn progress bars / spinners piled up line-by-line in the transcript.
+
+| Before | After |
+| --- | --- |
+| `TerminalCommandSurface` exposed `entry.stdout` verbatim; colored output and progress bars were unreadable. | New `TerminalOutputRenderer.render(_:)` — a **pure, stateless** line discipline applied in `TerminalCommandSurface.init` — turns raw PTY output into clean display text: strips SGR color/style, applies `\r` carriage-return overwrite, `\b` backspace, erase-line (`CSI K`) and erase-display (`CSI J`/`2J`), drops the bell, and strips OSC + unhandled CSI. The raw bytes stay in the entry for fidelity; only the surface is cleaned, so native and the static HTML renderer both display through it. |
+| — | Robustness baked in: a fast path returns the input untouched when it has no control characters (the common all-text case); an **incomplete escape at the end of the buffer is dropped** (it arrives complete on the next render of the growing `stdout`); `\r` resets the column of the current line only, never across newlines. Scalar-by-scalar processing + `String` grapheme coalescing preserves Unicode/combining/emoji content. |
+| — | 13 tests: per-sequence units (SGR, `\r` full + partial overwrite, `\b`, erase-line/display, bell, OSC title, incomplete trailing escapes, Unicode, idempotence, a realistic colored progress bar) plus a `TerminalCommandSurface` test proving raw→clean flows to the surface. |
+
+Adversarial-review fix (verdict SHIP; two real parameter-leak-as-text bugs in `handleEscape`'s default branch): **(1)** the charset-designation family (`ESC ( B`, `ESC ) 0`, …) is 3 bytes but was treated as 2, leaking its final byte — so `tput sgr0` (`ESC ( B` + `ESC [ m`, emitted by ncurses/line-drawing output) sprinkled stray `B`/`0` characters into the cleaned transcript. **(2)** `ESC ESC [31m` swallowed the second ESC and leaked `[31m` as text, and `ESC \n` ate the newline. Fixed: the default branch now consumes intermediate bytes (`0x20–0x2F`) through the final byte for charset/`ESC (` sequences, and on a following ESC or C0 control drops only the current ESC and re-dispatches (so a second ESC restarts a fresh sequence and a control is never eaten). Added 5 tests (charset designation incl. the real `sgr0` pattern, double-ESC restart, ESC-before-newline, private-mode `ESC[?25l`, and a growing-buffer split-sequence completion).
+
+Residual risk / scope:
+
+- This is the **line-discipline first step**, not a full screen buffer: two-dimensional cursor addressing (`ESC[<row>;<col>H`, `ESC[<n>A|B|C|D`) is stripped, so a full-screen TUI (vim, htop) that repaints via absolute cursor moves will not render faithfully yet — that needs a real 2D screen model and is the deliberate follow-up. Column counting is one-per-scalar, so wide/zero-width/combining characters can mis-measure overwrite width when `\r`/`\b` are also present (rare in command output; display text stays correct, only the column math is approximate). `render()` re-processes the full `stdout` per surface build, but the no-control fast path keeps the common all-text case O(n) and refreshes are event-driven. The harness mock emits no escape sequences, so there is no harness/Playwright surface to mirror here (noted, not faked).
+
 ## 2026-06-30 PTY Job Control — Terminal UI (end-to-end)
 
 Overall grade after this slice: **A completes PTY job control as a user feature, tri-surface + tested**.


### PR DESCRIPTION
The ROADMAP's next PTY step after job control ("full TUI redraw/scrollback handling remain the next steps"). The terminal did **no** ANSI processing, so real command output showed literal escape codes (`^[[31m`) and `\r`-redrawn progress bars / spinners piled up line-by-line in the transcript.

## How

- New `TerminalOutputRenderer.render(_:)` — a **pure, stateless** line discipline applied in `TerminalCommandSurface.init` — turns raw PTY output into clean display text: strips SGR color/style, applies `\r` carriage-return overwrite, `\b` backspace, erase-line (`CSI K`) and erase-display (`CSI J`/`2J`), drops the bell, strips OSC + unhandled CSI. The raw bytes stay in the entry for fidelity; only the surface is cleaned, so native and the static HTML renderer both display through it (HTML-escaping happens after).

## Robustness

- Fast path returns the input untouched when it has no control characters (the common all-text case).
- An **incomplete escape at the end of the buffer is dropped** — it arrives complete on the next render of the growing `stdout`, so a sequence split across stream chunks never renders as literal text.
- `\r` resets the column of the current line only, never across newlines. Scalar-by-scalar processing + `String` grapheme coalescing preserves Unicode/combining/emoji content.

## Tests

13: per-sequence units (SGR, `\r` full + partial overwrite, `\b`, erase-line/display, bell, OSC title, incomplete trailing escapes, Unicode, idempotence, a realistic colored progress bar) plus a `TerminalCommandSurface` test proving raw→clean flows to the surface.

Verified: `swift test` 1852 · `playwright` 144 · native-desktop smoke.

## Scope

Line-discipline **first step**, not a full screen buffer: 2D cursor addressing (`ESC[<row>;<col>H`, `ESC[<n>A|B|C|D`) is stripped, so a full-screen TUI (vim, htop) that repaints via absolute cursor moves won't render faithfully yet — that needs a real 2D screen model and is the deliberate follow-up. The harness mock emits no escape sequences, so there is no harness/Playwright surface to mirror here (noted, not faked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)