### PR TITLE
Auto-mode hard-deny matches decoded tool arguments, not raw JSON

### DIFF
--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -53,9 +53,53 @@ struct StaticSafetyPolicy: Sendable {
     }
 
     private func normalizedHaystack(for context: SafetyContext) -> String {
-        "\(context.toolCall.name) \(context.toolCall.argumentsJSON)"
-            .lowercased()
-            .replacingOccurrences(of: "\\/", with: "/")
+        // Match against the DECODED argument values, not the raw JSON wire form. The tool executor
+        // runs the decoded arguments, so the denylist should inspect the same decoded value — not a
+        // wire encoding. A raw-blob match misses any JSON escape (`/` -> `/`, ` ` -> space), so a
+        // blob like `{"cmd":"rm -rf /"}` would slip past the hard-deny and then execute as `rm -rf /`.
+        // Today the model pipeline reserializes tool arguments through JSONSerialization before this
+        // check (AgentActionJSONParser), so escapes are already normalized and no live path delivers
+        // such a blob; matching the decoded value here is defense-in-depth that keeps the denylist
+        // correct on its own rather than depending on that upstream reserialization (e.g. a future
+        // streaming/partial path that carries raw model bytes). It also subsumes the one-off `\/` patch.
+        let arguments = Self.decodedArgumentText(context.toolCall.argumentsJSON)
+            ?? context.toolCall.argumentsJSON.replacingOccurrences(of: "\\/", with: "/")
+        return "\(context.toolCall.name) \(arguments)".lowercased()
+    }
+
+    /// Flattens a JSON argument blob into its decoded string content (keys and values, recursively)
+    /// so the denylist sees what the tool will actually run. Returns nil when the blob is not
+    /// decodable JSON, so the caller falls back to the raw string (no regression for malformed input).
+    private static func decodedArgumentText(_ json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        else {
+            return nil
+        }
+        var parts: [String] = []
+        collectStrings(from: object, into: &parts)
+        return parts.joined(separator: " ")
+    }
+
+    private static func collectStrings(from object: Any, into parts: inout [String]) {
+        // Keys are included so a deny pattern that names an argument can match; no current schema key
+        // collides with a deny substring, but a future key (e.g. one containing "mkfs"/"ddif") could
+        // false-deny a benign call — keep deny patterns specific to command text, not bare arg names.
+        switch object {
+        case let string as String:
+            parts.append(string)
+        case let dictionary as [String: Any]:
+            for (key, value) in dictionary {
+                parts.append(key)
+                collectStrings(from: value, into: &parts)
+            }
+        case let array as [Any]:
+            for value in array {
+                collectStrings(from: value, into: &parts)
+            }
+        default:
+            break
+        }
     }
 
     private static let defaultHardDenyRules: [StaticSafetyHardDenyRule] = [

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -164,6 +164,73 @@ final class SafetyTests: XCTestCase {
         XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
     }
 
+    func testAutoModeHardDenyMatchesJSONUnicodeEscapedDangerousCommand() async {
+        let reviewer = StaticSafetyReviewer()
+        // The hard-deny must match the DECODED argument value, not the wire encoding. This drives the
+        // matcher directly with a hand-built blob carrying a unicode-escaped slash (JSON u002f -> "/",
+        // built from a runtime backslash so the source carries no literal escape). A raw-JSON match
+        // misses it (would auto-approve under the "run" intent); the decode denies it. The live model
+        // pipeline reserializes args before this check, so this guards the matcher's own correctness
+        // against any future/partial path that carries raw model bytes.
+        let backslash = String(UnicodeScalar(0x5C)!)
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: "{\"cmd\":\"rm -rf \(backslash)u002f\"}"
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run this for me",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "run this for me")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.deny, review.rationale ?? "")
+    }
+
+    func testAutoModeHardDenyMatchesJSONSlashEscapedDangerousCommand() async {
+        let reviewer = StaticSafetyReviewer()
+        // `\/` is the JSON escape for `/` that the prior one-off patch handled; the decode must keep
+        // covering it (no regression).
+        let call = ToolCall(name: shellRun.name, argumentsJSON: #"{"cmd":"rm -rf \/"}"#)
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run this for me",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "run this for me")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.deny, review.rationale ?? "")
+    }
+
+    func testAutoModeHardDenyStillMatchesPlainDangerousCommand() async {
+        let reviewer = StaticSafetyReviewer()
+        // Decoding must not weaken the common unescaped case.
+        let call = ToolCall(name: shellRun.name, argumentsJSON: #"{"cmd":"rm -rf /"}"#)
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run this for me",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "run this for me")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.deny, review.rationale ?? "")
+    }
+
+    func testAutoModeHardDenyFallsBackToRawStringForMalformedJSON() async {
+        let reviewer = StaticSafetyReviewer()
+        // Not decodable JSON -> fall back to the raw blob so a dangerous pattern is still caught
+        // (and nothing crashes).
+        let call = ToolCall(name: shellRun.name, argumentsJSON: #"{"cmd": rm -rf / (not json"#)
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "run this for me",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "run this for me")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.deny, review.rationale ?? "")
+    }
+
     func testAutoApprovesDiagnosticShellRunWithoutRunVerb() async {
         let reviewer = StaticSafetyReviewer()
         let call = ToolCall(

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-06-30 Auto-Mode Hard-Deny Matches Decoded Tool Arguments (defense-in-depth)
+
+A latent-bug audit of the auto-mode safety policy (`StaticSafetyPolicy`) found the same *class* as the file-tool symlink escape: **the check inspected a different representation than what executes.** In `.auto` mode `hardDenyReason` is a true block, and if it returns nil and the user's message matches the tool intent (e.g. "run …"), the call is auto-approved and executed with **no human review**. The hard-deny haystack was built from the *raw* `argumentsJSON` wire string — and the code already special-cased one JSON escape (`\/` → `/`), a tell that encoding mattered but only one case was handled.
+
+**Honesty note (from the adversarial review):** this is **defense-in-depth, not a presently-live exploit.** The model→tool pipeline reserializes tool arguments through `JSONSerialization` (`AgentActionJSONParser`, both the buffered and streaming paths) *before* the safety check, and every other `ToolCall` is built from a dict via `ToolArguments.json` — so escapes are already normalized and no current path delivers a raw-escaped blob to the reviewer. The value of the fix is that the denylist is now **correct on its own** rather than depending on that upstream reserialization side-effect (which a future streaming/partial path, or a different LLM client, could bypass).
+
+| Before | After |
+| --- | --- |
+| `normalizedHaystack` = `"name argumentsJSON".lowercased()` with a one-off `\/` → `/` replacement. A blob with any *other* JSON escape — `/` (→ `/`), ` ` (→ space) — would not match the denylist; e.g. `{"cmd":"rm -rf /"}` would slip past the hard-deny and then execute (the tool decodes before running) as `rm -rf /`. (Not reachable through today's reserializing pipeline.) | The haystack is built from the **decoded** argument values: `argumentsJSON` is JSON-parsed and its string content (keys + values, recursively) flattened, so every escape is normalized uniformly before matching. Falls back to the raw string (with the legacy `\/` patch) only when the blob is not decodable JSON, so malformed input is no worse than before. |
+
+Verification — the escape test is **non-vacuous**, proven by reverting only the source fix: with the old raw-JSON match, `testAutoModeHardDenyMatchesJSONUnicodeEscapedDangerousCommand` (which drives the matcher directly with a hand-built `/` blob) **fails**, while the `\/` and plain tests pass either way. With the decode it denies all three, and `swift test` is 1891 green · native smoke clean.
+
+Residual risk:
+
+- This closes the *encoding* gap. The denylist itself remains a backstop, not a complete sandbox — it is still a substring match, so semantically-equivalent rephrasings (`rm -fr /`, `wget … | sh`, whitespace runs) are out of scope and deliberately left to human approval / the destructive-risk default. Keys are flattened into the haystack, so deny patterns must stay specific to command text rather than bare argument names (no current key collides). Broadening the *pattern set* is a separate, debatable effort; matching what actually runs is the correctness fix.
+
 ## 2026-06-30 Unify the Workspace Sandbox Across All Path Validators
 
 Overall grade after this slice: **A makes every agent path gate enforce the same symlink-resolved sandbox**.


### PR DESCRIPTION
A latent-bug audit of the auto-mode safety policy (`StaticSafetyPolicy`) found the same *class* as the file-tool symlink escape (#722/#724): **the safety check inspected a different representation than what executes.**

In `.auto` mode `hardDenyReason` is a true block, and if it returns nil **and** the user's message matches the tool intent (e.g. "run …"), the call is auto-approved and executed with **no human review**. The hard-deny haystack was built from the *raw* `argumentsJSON` wire string — and the code already special-cased one JSON escape (`\/` → `/`), a tell that encoding mattered but only one case was handled.

## Defense-in-depth, not a presently-live exploit (per adversarial review)

The model→tool pipeline reserializes tool arguments through `JSONSerialization` (`AgentActionJSONParser`, both buffered and streaming paths) **before** the safety check, and every other `ToolCall` is built from a dict via `ToolArguments.json` — so escapes are already normalized and **no current path** delivers a raw-escaped blob to the reviewer. The value of the fix is that the denylist becomes **correct on its own** rather than depending on that upstream reserialization side-effect, which a future streaming/partial path (or a different LLM client) could bypass.

## The gap

A blob with any JSON escape other than `\/` — `/` (→ `/`), ` ` (→ space) — would not match the denylist, so e.g. `{"cmd":"rm -rf /"}` would slip past the hard-deny and then execute (the tool JSON-decodes its arguments before running) as `rm -rf /`.

## Fix

Build the haystack from the **decoded** argument values: JSON-parse the blob and flatten its string content (keys + values, recursively) so every escape is normalized uniformly before matching. Falls back to the raw string (with the legacy `\/` patch) only when the blob is not decodable JSON. Keys are flattened too, so deny patterns must stay specific to command text rather than bare arg names (no current key collides).

## Tests

The unicode-escape test drives the matcher directly with a hand-built `/` blob and is **non-vacuous** — proven by reverting only the source fix: with the old raw-JSON match, `testAutoModeHardDenyMatchesJSONUnicodeEscapedDangerousCommand` **fails**, while the `\/` and plain tests pass either way. With the decode it denies all three. Added: unicode-escape, slash-escape (regression), plain (no-weakening), and malformed-JSON-fallback cases.

Verified: `swift test` 1891 green · native-desktop smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)