### PR TITLE
Require explicit rendered hit target kinds

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceHTMLBrowserRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLBrowserRenderer.swift
@@ -35,6 +35,7 @@ enum WorkspaceHTMLBrowserRenderer {
                 "Comment",
                 testID: "browser-add-comment",
                 type: "submit",
+                hitTargetKind: .text,
                 disabled: browser.currentURL == nil
             ))
           </form>

--- a/Sources/QuillCodeApp/WorkspaceHTMLSecondaryPaneRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLSecondaryPaneRenderer.swift
@@ -125,16 +125,16 @@ enum WorkspaceHTMLSecondaryPaneRenderer {
             }.joined(separator: "\n")
         }
         let createButton = automations.createThreadFollowUpCommand.map { command in
-            commandButton(command.title, testID: "automation-create-follow-up", commandID: command.id, disabled: !command.isEnabled)
+            commandButton(command.title, testID: "automation-create-follow-up", commandID: command.id, hitTargetKind: .formAction, disabled: !command.isEnabled)
         } ?? ""
         let createWorkspaceButton = automations.createWorkspaceScheduleCommand.map { command in
-            commandButton(command.title, testID: "automation-create-workspace-schedule", commandID: command.id, disabled: !command.isEnabled)
+            commandButton(command.title, testID: "automation-create-workspace-schedule", commandID: command.id, hitTargetKind: .formAction, disabled: !command.isEnabled)
         } ?? ""
         let scheduleButtons = automations.scheduleThreadFollowUpCommands.map { command in
-            commandButton(command.title, testID: "automation-schedule-follow-up", commandID: command.id, disabled: !command.isEnabled)
+            commandButton(command.title, testID: "automation-schedule-follow-up", commandID: command.id, hitTargetKind: .formAction, disabled: !command.isEnabled)
         }.joined(separator: "\n")
         let workspaceScheduleButtons = automations.scheduleWorkspaceScheduleCommands.map { command in
-            commandButton(command.title, testID: "automation-schedule-workspace", commandID: command.id, disabled: !command.isEnabled)
+            commandButton(command.title, testID: "automation-schedule-workspace", commandID: command.id, hitTargetKind: .formAction, disabled: !command.isEnabled)
         }.joined(separator: "\n")
         let createActions = [createButton, createWorkspaceButton, scheduleButtons, workspaceScheduleButtons]
             .filter { !$0.isEmpty }
@@ -276,14 +276,14 @@ enum WorkspaceHTMLSecondaryPaneRenderer {
         var buttons: [String] = []
         if let commandID = workflow.runCommandID,
            let title = workflow.runActionTitle {
-            buttons.append(commandButton(title, testID: "automation-run", commandID: commandID))
+            buttons.append(commandButton(title, testID: "automation-run", commandID: commandID, hitTargetKind: .formAction))
         }
         if let commandID = workflow.primaryCommandID,
            let title = workflow.primaryActionTitle {
-            buttons.append(commandButton(title, testID: "automation-primary-action", commandID: commandID))
+            buttons.append(commandButton(title, testID: "automation-primary-action", commandID: commandID, hitTargetKind: .formAction))
         }
         if let commandID = workflow.deleteCommandID {
-            buttons.append(commandButton("Delete", testID: "automation-delete", commandID: commandID))
+            buttons.append(commandButton("Delete", testID: "automation-delete", commandID: commandID, hitTargetKind: .formAction))
         }
         guard !buttons.isEmpty else { return "" }
         return #"<div class="automation-actions">\#(buttons.joined(separator: "\n"))</div>"#
@@ -377,7 +377,7 @@ enum WorkspaceHTMLSecondaryPaneRenderer {
         _ label: String,
         testID: String,
         commandID: String,
-        hitTargetKind: WorkspaceHTMLHitTargetKind = .text,
+        hitTargetKind: WorkspaceHTMLHitTargetKind,
         classes: [String] = [],
         disabled: Bool = false
     ) -> String {

--- a/Sources/QuillCodeApp/WorkspaceHTMLSidebarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLSidebarRenderer.swift
@@ -255,6 +255,7 @@ enum WorkspaceHTMLSidebarRenderer {
                 action.title,
                 testID: "sidebar-bulk-action",
                 commandID: action.commandID,
+                hitTargetKind: .text,
                 disabled: !action.isEnabled,
                 attributes: [
                     ("data-action", action.kind.rawValue),
@@ -279,6 +280,7 @@ enum WorkspaceHTMLSidebarRenderer {
             action.title,
             testID: "sidebar-bulk-action",
             commandID: action.commandID,
+            hitTargetKind: .text,
             disabled: !action.isEnabled,
             attributes: [
                 ("data-action", action.kind.rawValue),
@@ -291,6 +293,8 @@ enum WorkspaceHTMLSidebarRenderer {
         WorkspaceHTMLPrimitives.button(
             action.kind.title,
             testID: "sidebar-thread-action",
+            hitTargetKind: .icon,
+            ariaLabel: action.kind.title,
             attributes: [
                 ("data-action", action.kind.rawValue),
                 ("data-thread-id", action.threadID.uuidString)
@@ -305,6 +309,7 @@ enum WorkspaceHTMLSidebarRenderer {
             \(WorkspaceHTMLPrimitives.summary(
                 "Tools",
                 testID: "sidebar-tools-button",
+                hitTargetKind: .row,
                 ariaLabel: "Tools",
                 title: "Tools"
             ))

--- a/Sources/QuillCodeApp/WorkspaceHTMLTerminalRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTerminalRenderer.swift
@@ -14,6 +14,7 @@ enum WorkspaceHTMLTerminalRenderer {
             \(WorkspaceHTMLPrimitives.button(
                 "Clear",
                 testID: "terminal-clear",
+                hitTargetKind: .text,
                 disabled: !terminal.canClear
             ))
             \(jobControlButton(terminal))
@@ -27,6 +28,7 @@ enum WorkspaceHTMLTerminalRenderer {
                 terminal.commandActionTitle,
                 testID: "terminal-run",
                 type: "submit",
+                hitTargetKind: .text,
                 disabled: !terminal.canSubmitDraft
             ))
           </form>
@@ -38,10 +40,10 @@ enum WorkspaceHTMLTerminalRenderer {
     /// exclusive). Nothing renders when no command is running.
     private static func jobControlButton(_ terminal: TerminalSurface) -> String {
         if terminal.canResume {
-            return WorkspaceHTMLPrimitives.button("Resume", testID: "terminal-resume")
+            return WorkspaceHTMLPrimitives.button("Resume", testID: "terminal-resume", hitTargetKind: .text)
         }
         if terminal.canSuspend {
-            return WorkspaceHTMLPrimitives.button("Suspend", testID: "terminal-suspend")
+            return WorkspaceHTMLPrimitives.button("Suspend", testID: "terminal-suspend", hitTargetKind: .text)
         }
         return ""
     }

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -45,6 +45,7 @@ enum WorkspaceHTMLToolCardRenderer {
           \(WorkspaceHTMLPrimitives.button(
               copyActionLabel(for: card),
               testID: "tool-card-copy",
+              hitTargetKind: .text,
               attributes: [("data-copy-id", copyID)]
           ))
         </footer>
@@ -71,6 +72,7 @@ enum WorkspaceHTMLToolCardRenderer {
             WorkspaceHTMLPrimitives.button(
                 action.title,
                 testID: "tool-card-action",
+                hitTargetKind: .text,
                 attributes: [
                     ("data-action-kind", action.kind.rawValue),
                     ("data-action-style", action.style.rawValue),
@@ -90,7 +92,7 @@ enum WorkspaceHTMLToolCardRenderer {
         let isOpen = card.opensDetailsByDefault
         return """
         <details class="tool-details" data-testid="tool-card-details"\(isOpen ? " open" : "")>
-          \(WorkspaceHTMLPrimitives.summary(detailsLabel(for: card, isOpen: isOpen)))
+          \(WorkspaceHTMLPrimitives.summary(detailsLabel(for: card, isOpen: isOpen), hitTargetKind: .row))
           \(card.inputJSON.map { #"<pre data-testid="tool-card-input">\#(escape($0))</pre>"# } ?? "")
           \(card.outputJSON.map { #"<pre data-testid="tool-card-output">\#(escape($0))</pre>"# } ?? "")
           \(renderDetailsCopyAction(for: card, copyID: copyID))

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -130,7 +130,7 @@ enum WorkspaceHTMLTranscriptRenderer {
             <span data-testid="runtime-issue-severity">\(escape(issue.severity.rawValue))</span>
           </header>
           <p data-testid="runtime-issue-message">\(escape(issue.message))</p>
-          \(issue.actionLabel.map { WorkspaceHTMLPrimitives.button($0, testID: "runtime-issue-action") } ?? "")
+          \(issue.actionLabel.map { WorkspaceHTMLPrimitives.button($0, testID: "runtime-issue-action", hitTargetKind: .text) } ?? "")
           \(diagnostics)
         </section>
         """
@@ -140,7 +140,7 @@ enum WorkspaceHTMLTranscriptRenderer {
         guard let thinking else { return "" }
         let trace = thinking.traceLines.isEmpty ? "" : """
           <details data-testid="thinking-trace">
-            \(WorkspaceHTMLPrimitives.summary(thinking.traceTitle))
+            \(WorkspaceHTMLPrimitives.summary(thinking.traceTitle, hitTargetKind: .row))
             <ul>
               \(thinking.traceLines.map { #"<li>\#(escape($0))</li>"# }.joined(separator: "\n"))
             </ul>
@@ -173,6 +173,7 @@ enum WorkspaceHTMLTranscriptRenderer {
                 \(WorkspaceHTMLPrimitives.button(
                     "Copy",
                     testID: "message-copy",
+                    hitTargetKind: .text,
                     attributes: [("data-copy-id", item.id)]
                 ))
                 \(renderMessageDraftAction(message))
@@ -196,6 +197,7 @@ enum WorkspaceHTMLTranscriptRenderer {
         \(WorkspaceHTMLPrimitives.button(
             "Helpful",
             testID: "message-feedback-up",
+            hitTargetKind: .text,
             attributes: [
                 ("data-message-id", message.id.uuidString),
                 ("data-selected", helpfulSelected)
@@ -204,6 +206,7 @@ enum WorkspaceHTMLTranscriptRenderer {
         \(WorkspaceHTMLPrimitives.button(
             "Not helpful",
             testID: "message-feedback-down",
+            hitTargetKind: .text,
             attributes: [
                 ("data-message-id", message.id.uuidString),
                 ("data-selected", notHelpfulSelected)
@@ -217,6 +220,7 @@ enum WorkspaceHTMLTranscriptRenderer {
         return WorkspaceHTMLPrimitives.button(
             "Use as draft",
             testID: "message-use-as-draft",
+            hitTargetKind: .text,
             attributes: [("data-message-id", message.id.uuidString)]
         )
     }
@@ -226,6 +230,7 @@ enum WorkspaceHTMLTranscriptRenderer {
         return WorkspaceHTMLPrimitives.button(
             TurnRevertCopy.buttonTitle,
             testID: "message-revert-turn",
+            hitTargetKind: .text,
             ariaLabel: TurnRevertCopy.buttonTitle,
             attributes: [
                 ("data-turn-id", revert.turnMessageID.uuidString),
@@ -246,7 +251,8 @@ enum WorkspaceHTMLTranscriptRenderer {
         return WorkspaceHTMLPrimitives.commandButton(
             command.title,
             testID: "message-retry",
-            commandID: command.id
+            commandID: command.id,
+            hitTargetKind: .text
         )
     }
 
@@ -254,7 +260,7 @@ enum WorkspaceHTMLTranscriptRenderer {
         guard let banner else { return "" }
         let forkButtons = banner.forkCommands.map { command in
             let testID = WorkspaceThreadForkStrategy(commandID: command.id)?.contextBannerTestID ?? "context-fork"
-            return WorkspaceHTMLPrimitives.commandButton(command.title, testID: testID, commandID: command.id)
+            return WorkspaceHTMLPrimitives.commandButton(command.title, testID: testID, commandID: command.id, hitTargetKind: .text)
         }.joined(separator: "\n            ")
         return """
         <section class="context-banner" data-testid="context-banner" aria-label="Context limit warning">
@@ -264,8 +270,8 @@ enum WorkspaceHTMLTranscriptRenderer {
           </header>
           <p data-testid="context-banner-subtitle">\(escape(banner.subtitle))</p>
           <div>
-            \(WorkspaceHTMLPrimitives.commandButton(banner.compactCommand.title, testID: "context-compact", commandID: banner.compactCommand.id))
-            \(WorkspaceHTMLPrimitives.commandButton(banner.newThreadCommand.title, testID: "context-new-thread", commandID: banner.newThreadCommand.id))
+            \(WorkspaceHTMLPrimitives.commandButton(banner.compactCommand.title, testID: "context-compact", commandID: banner.compactCommand.id, hitTargetKind: .text))
+            \(WorkspaceHTMLPrimitives.commandButton(banner.newThreadCommand.title, testID: "context-new-thread", commandID: banner.newThreadCommand.id, hitTargetKind: .text))
             \(forkButtons)
           </div>
         </section>

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetGateTests.swift
@@ -462,6 +462,18 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
         )
     }
 
+    func testRenderedHTMLPrimitiveCallSitesDeclareExplicitHitTargetKinds() throws {
+        let appFiles = try Self.swiftSourceFiles(in: "Sources/QuillCodeApp")
+            .filter { $0.lastPathComponent != "WorkspaceHTMLPrimitives.swift" }
+        let violations = try HTMLPrimitiveHitTargetKindAudit(packageRoot: Self.packageRoot())
+            .violations(in: appFiles)
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "Rendered HTML primitive call sites must choose a semantic click-target kind explicitly:\n\(violations.joined(separator: "\n"))"
+        )
+    }
+
     func testHTMLSourceAuditRequiresSemanticKindForRawSharedTargets() throws {
         let file = try makeTemporarySwiftFile(##"""
         enum BadHTMLRenderer {
@@ -1595,6 +1607,214 @@ final class ParityInteractionTargetGateTests: QuillCodeParityTestCase {
         let fileURL = directory.appendingPathComponent("Fixture.swift")
         try source.write(to: fileURL, atomically: true, encoding: .utf8)
         return fileURL
+    }
+}
+
+private struct HTMLPrimitiveHitTargetKindAudit {
+    var packageRoot: URL
+
+    private let primitiveMarkers = [
+        "WorkspaceHTMLPrimitives.button(",
+        "WorkspaceHTMLPrimitives.commandButton(",
+        "WorkspaceHTMLPrimitives.buttonAttributes(",
+        "WorkspaceHTMLPrimitives.summary("
+    ]
+
+    func violations(in sourceFiles: [URL]) throws -> [String] {
+        try sourceFiles.flatMap(violations(in:))
+    }
+
+    private func violations(in file: URL) throws -> [String] {
+        let source = try String(contentsOf: file, encoding: .utf8)
+        let relativePath = file.path.replacingOccurrences(
+            of: packageRoot.path + "/",
+            with: ""
+        )
+        var violations: [String] = []
+
+        for marker in primitiveMarkers {
+            var searchStart = source.startIndex
+            while searchStart < source.endIndex,
+                  let markerRange = source.range(of: marker, range: searchStart..<source.endIndex) {
+                guard let callRange = callRange(in: source, markerRange: markerRange) else {
+                    violations.append("\(relativePath):\(lineNumber(in: source, at: markerRange.lowerBound)) unterminated \(marker)")
+                    break
+                }
+                let callText = String(source[callRange])
+                if !callText.contains("hitTargetKind:") {
+                    violations.append("\(relativePath):\(lineNumber(in: source, at: markerRange.lowerBound)) \(marker) lacks explicit hitTargetKind")
+                }
+                searchStart = callRange.upperBound
+            }
+        }
+
+        return violations
+    }
+
+    private func callRange(in source: String, markerRange: Range<String.Index>) -> Range<String.Index>? {
+        var depth = 1
+        var index = markerRange.upperBound
+
+        while index < source.endIndex {
+            if source[index] == "/" {
+                if let advanced = skipComment(in: source, from: index) {
+                    index = advanced
+                    continue
+                }
+            }
+            if source[index] == "\"" {
+                index = skipString(in: source, quoteIndex: index, rawPoundCount: 0)
+                continue
+            }
+            if source[index] == "#" {
+                let rawStringStart = rawStringDelimiter(in: source, from: index)
+                if let rawStringStart {
+                    index = skipString(
+                        in: source,
+                        quoteIndex: rawStringStart.quoteIndex,
+                        rawPoundCount: rawStringStart.poundCount
+                    )
+                    continue
+                }
+            }
+
+            switch source[index] {
+            case "(":
+                depth += 1
+            case ")":
+                depth -= 1
+                if depth == 0 {
+                    return markerRange.lowerBound..<source.index(after: index)
+                }
+            default:
+                break
+            }
+            index = source.index(after: index)
+        }
+
+        return nil
+    }
+
+    private func skipComment(in source: String, from index: String.Index) -> String.Index? {
+        guard character(after: index, in: source) == "/" || character(after: index, in: source) == "*" else {
+            return nil
+        }
+        if character(after: index, in: source) == "/" {
+            var cursor = source.index(after: source.index(after: index))
+            while cursor < source.endIndex, source[cursor] != "\n" {
+                cursor = source.index(after: cursor)
+            }
+            return cursor
+        }
+
+        var depth = 1
+        var cursor = source.index(after: source.index(after: index))
+        while cursor < source.endIndex {
+            if source[cursor] == "/", character(after: cursor, in: source) == "*" {
+                depth += 1
+                cursor = source.index(after: source.index(after: cursor))
+                continue
+            }
+            if source[cursor] == "*", character(after: cursor, in: source) == "/" {
+                depth -= 1
+                cursor = source.index(after: source.index(after: cursor))
+                if depth == 0 {
+                    return cursor
+                }
+                continue
+            }
+            cursor = source.index(after: cursor)
+        }
+        return source.endIndex
+    }
+
+    private func rawStringDelimiter(
+        in source: String,
+        from index: String.Index
+    ) -> (quoteIndex: String.Index, poundCount: Int)? {
+        var cursor = index
+        var poundCount = 0
+        while cursor < source.endIndex, source[cursor] == "#" {
+            poundCount += 1
+            cursor = source.index(after: cursor)
+        }
+        guard poundCount > 0, cursor < source.endIndex, source[cursor] == "\"" else {
+            return nil
+        }
+        return (cursor, poundCount)
+    }
+
+    private func skipString(
+        in source: String,
+        quoteIndex: String.Index,
+        rawPoundCount: Int
+    ) -> String.Index {
+        let isTripleQuoted = character(after: quoteIndex, in: source) == "\""
+            && character(after: source.index(after: quoteIndex), in: source) == "\""
+        var cursor = isTripleQuoted
+            ? source.index(after: source.index(after: source.index(after: quoteIndex)))
+            : source.index(after: quoteIndex)
+
+        while cursor < source.endIndex {
+            if rawPoundCount == 0, source[cursor] == "\\" {
+                cursor = source.index(after: cursor)
+                if cursor < source.endIndex {
+                    cursor = source.index(after: cursor)
+                }
+                continue
+            }
+
+            if source[cursor] == "\"" {
+                if isTripleQuoted {
+                    guard character(after: cursor, in: source) == "\"",
+                          character(after: source.index(after: cursor), in: source) == "\"" else {
+                        cursor = source.index(after: cursor)
+                        continue
+                    }
+                    let afterQuotes = source.index(after: source.index(after: source.index(after: cursor)))
+                    if let end = endOfRawStringDelimiter(in: source, from: afterQuotes, poundCount: rawPoundCount) {
+                        return end
+                    }
+                    cursor = afterQuotes
+                    continue
+                }
+
+                let afterQuote = source.index(after: cursor)
+                if let end = endOfRawStringDelimiter(in: source, from: afterQuote, poundCount: rawPoundCount) {
+                    return end
+                }
+            }
+
+            cursor = source.index(after: cursor)
+        }
+
+        return source.endIndex
+    }
+
+    private func endOfRawStringDelimiter(
+        in source: String,
+        from index: String.Index,
+        poundCount: Int
+    ) -> String.Index? {
+        var cursor = index
+        var remaining = poundCount
+        while remaining > 0, cursor < source.endIndex, source[cursor] == "#" {
+            remaining -= 1
+            cursor = source.index(after: cursor)
+        }
+        return remaining == 0 ? cursor : nil
+    }
+
+    private func character(after index: String.Index, in source: String) -> Character? {
+        guard index < source.endIndex else { return nil }
+        let next = source.index(after: index)
+        return next < source.endIndex ? source[next] : nil
+    }
+
+    private func lineNumber(in source: String, at index: String.Index) -> Int {
+        source[..<index].reduce(1) { partial, character in
+            character == "\n" ? partial + 1 : partial
+        }
     }
 }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -53,6 +53,22 @@ Residual risk / follow-up:
 - This narrows an auto-approval (strictly safer); any download with an unusual shape (redirect-style `curl … > out`, `wget`, an unlisted flag, a bundle with an arg-taking short flag) now falls through to **human approval** — the safe direction.
 - **Known pre-existing weakness (follow-up, out of scope for this PR):** the host gate is a substring match — `requestedHosts.contains { lowerCommand.contains(host) }` — so the authorized host can be satisfied by an `-e`/`-H`/`-A` value rather than the *actual* fetched URL. The `file://` local-read path is now closed, but an HTTP **SSRF**-to-workspace (`curl -e 'host' --output x 'https://internal/secret'`) remains auto-approvable. Properly fixing it means parsing the positional URL argument and checking *its* host/scheme — a larger change (and a product decision on `file://` downloads) flagged separately. `hardDeny` and the destructive-risk default remain the backstops.
 
+## 2026-06-30 Explicit Rendered Click-Target Kinds
+
+Overall grade after this slice: **A click-target semantics, A regression gate**.
+
+The rendered HTML layer had strong shared primitives and Playwright geometry audits, but many production primitive calls still relied on default `.text` semantics. That made review harder: an icon action, disclosure row, form action, or ordinary text button could all look the same in code unless the surrounding CSS or label was inspected.
+
+| Before | After |
+| --- | --- |
+| Production renderer calls to `WorkspaceHTMLPrimitives.button`, `commandButton`, `buttonAttributes`, and `summary` often omitted `hitTargetKind`, falling back to default text-button semantics. | Every production call site now declares `hitTargetKind:` explicitly, using `.icon`, `.row`, `.formAction`, or `.text` according to the actual interaction surface. |
+| Details summaries and sidebar icon actions were easy to misread as generic text buttons during review. | Disclosures use `.row`, compact thread actions use `.icon` with explicit labels, and automation actions use `.formAction`, so semantic intent is visible in the renderer source. |
+| Existing audits proved controls were shared, named, and large enough, but did not prevent future primitive calls from silently leaning on defaults. | `ParityInteractionTargetGateTests.testRenderedHTMLPrimitiveCallSitesDeclareExplicitHitTargetKinds` scans balanced multiline primitive calls across app sources and fails any renderer call that omits `hitTargetKind:`. |
+
+Residual risk:
+
+- This is a source-level semantic gate. It complements, but does not replace, rendered Playwright edge-click and clearance audits, which still prove the final DOM is physically clickable.
+
 ## 2026-06-30 Slash Git Real-World Evidence Pass
 
 Overall grade after this slice: **A release-evidence coverage, A shortcut regression guard**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-30
 
+- Rendered click-target kind must be explicit at production primitive call sites. `WorkspaceHTMLPrimitives` still keeps safe default classes as a backstop, but renderers now pass `hitTargetKind:` for every button, command button, button-attribute block, and details summary so reviewers can see whether a control is an icon, row, text button, text entry, or form action without inferring from CSS. A parity source gate scans balanced multiline primitive calls to keep future renderer work from silently falling back to generic text-button semantics.
 - Terminal output rendering should be a pure single-page screen buffer before it becomes a full emulator. `TerminalOutputRenderer` now applies the common cursor-addressed CSI/DEC controls that status dashboards and simple TUIs use to repaint in place (`ESC[H`, row/column moves, relative moves, absolute column/row, save/restore cursor) while preserving raw PTY bytes in state and exposing only cleaned display text through `TerminalCommandSurface`. Full alternate-screen/scroll-region/curses semantics remain deferred until a dedicated emulator model exists.
 
 ## 2026-06-29


### PR DESCRIPTION
## Summary
- Require production rendered HTML primitive calls to pass explicit semantic hit target kinds.
- Mark sidebar icon actions, disclosure summaries, automation actions, terminal/browser buttons, tool-card actions, and transcript/context controls with the appropriate kind.
- Add a parity source gate that scans balanced multiline primitive calls and fails missing `hitTargetKind:` usage.
- Document the decision and code-quality audit.

## Verification
- `swift test --filter ParityInteractionTargetGateTests`
- `swift test --filter WorkspaceHTMLChromeRendererTests`
- `swift test --filter WorkspaceHTMLToolCardRendererTests`
- `swift test` after rebase (1909 tests, 1 skipped, 0 failures)
- Source scan for primitive calls missing `hitTargetKind:`
- `git diff --check`