### PR TITLE
Close the download host-gate SSRF

### DIFF
--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -382,7 +382,26 @@ struct StaticSafetyRequest: Sendable {
         else {
             return nil
         }
-        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+        return normalizedHost(host)
+    }
+
+    /// Normalizes a host for comparison: strips a leading `www.` and a trailing FQDN-root `.`, then
+    /// requires the result still be a non-empty dotted domain. Guarding the POST-strip value is what
+    /// keeps a dangling `www.` from collapsing to the empty string (which would otherwise let the
+    /// gate's `hasSuffix(".\(requested)")` clause wildcard every trailing-dot host). Used on BOTH the
+    /// requested side and the command-URL side so `169.254.169.254.` and `169.254.169.254` compare equal.
+    static func normalizedHost(_ rawHost: String) -> String? {
+        var host = rawHost.lowercased()
+        if host.hasPrefix("www.") {
+            host = String(host.dropFirst(4))
+        }
+        if host.hasSuffix(".") {
+            host = String(host.dropLast())
+        }
+        guard host.contains("."), !host.hasPrefix(".") else {
+            return nil
+        }
+        return host
     }
 
     private static func normalizedFileURLCandidate(_ value: String) -> String? {
@@ -428,10 +447,46 @@ enum StaticSafetyDownloadPolicy {
                 lowerCommand.contains(fileURL)
             }
         }
+        // The host gate must match the ACTUAL fetched URL(s), not a substring anywhere in the command.
+        // A substring match is satisfiable by an `-e` referer / `-H` header carrying the authorized
+        // host while the real target is an internal/other host — an SSRF (e.g. the cloud-metadata
+        // endpoint `http://169.254.169.254/…`, which would land cloud credentials in the workspace).
+        // Require EVERY http(s) URL in the command to resolve to a user-requested host.
         let requestedHosts = request.requestedDownloadHosts
-        return requestedHosts.contains { host in
-            lowerCommand.contains(host)
+        guard let urlHosts = Self.httpURLHosts(in: command), !urlHosts.isEmpty else {
+            return false
         }
+        return urlHosts.allSatisfy { host in
+            requestedHosts.contains { requested in
+                !requested.isEmpty && (host == requested || host.hasSuffix(".\(requested)"))
+            }
+        }
+    }
+
+    /// Extracts the host of every `http(s)://` URL in the command (quoted or bare), normalized
+    /// (lowercased, `www.` stripped) for comparison with `requestedDownloadHosts`. Returns nil if ANY
+    /// matched URL fails host extraction — fail-closed, so a URL that curl would fetch but `URLComponents`
+    /// cannot parse (a parser differential) drops the whole command to human approval rather than
+    /// slipping through unchecked.
+    private static func httpURLHosts(in command: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: #"https?://[^\s'"`]+"#, options: [.caseInsensitive]) else {
+            return nil
+        }
+        let range = NSRange(command.startIndex..., in: command)
+        var hosts: [String] = []
+        for match in regex.matches(in: command, range: range) {
+            // `URL(string:).host` matches the requested side's parser (same punycode/Unicode treatment),
+            // and `normalizedHost` strips the FQDN-root trailing dot + `www.` so `169.254.169.254.` and
+            // `169.254.169.254` compare equal — closing the trailing-dot parser differential curl exploits.
+            guard let matchRange = Range(match.range, in: command),
+                  let rawHost = URL(string: String(command[matchRange]))?.host,
+                  let host = StaticSafetyRequest.normalizedHost(rawHost)
+            else {
+                return nil
+            }
+            hosts.append(host)
+        }
+        return hosts
     }
 
     private static func shellCommand(from call: ToolCall) -> String? {

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -557,6 +557,98 @@ final class SafetyTests: XCTestCase {
         XCTAssertNotEqual(review.verdict, ApprovalVerdict.approve, "a glob output target must not auto-approve")
     }
 
+    func testAutoDoesNotAutoApproveDownloadSSRFToUnrequestedHostViaReferer() async {
+        let reviewer = StaticSafetyReviewer()
+        // The authorized host (linkedin.com) is carried only by the `-e` referer; the real fetch targets
+        // the cloud-metadata endpoint. The host gate must match the ACTUAL URL, not a substring, so this
+        // SSRF (which would land cloud credentials in the workspace) must not auto-approve.
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"curl -L --fail --silent -e 'https://www.linkedin.com' --output 'downloads/x.json' 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download LinkedIn.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertNotEqual(review.verdict, ApprovalVerdict.approve, "an SSRF to an unrequested host (referer carries the authorized host) must not auto-approve")
+    }
+
+    func testAutoDoesNotAutoApproveDownloadWhenRequestedHostNormalizesEmpty() async {
+        let reviewer = StaticSafetyReviewer()
+        // A bare "www." in the message normalizes to an EMPTY requested host; combined with a trailing
+        // FQDN-root dot on the URL (which curl strips to reach the real target) this previously
+        // wildcarded every host via the suffix clause. The metadata SSRF must not auto-approve.
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"curl -fsSL --output 'downloads/x.json' 'https://169.254.169.254./latest/meta-data/iam/security-credentials/'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "please download from www. into downloads",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "please download from www. into downloads")]
+        ))
+        XCTAssertNotEqual(review.verdict, ApprovalVerdict.approve, "an empty-normalizing requested host must not wildcard a trailing-dot SSRF target")
+    }
+
+    func testAutoDoesNotAutoApproveDownloadWithUserinfoHostConfusion() async {
+        let reviewer = StaticSafetyReviewer()
+        // `https://www.linkedin.com@169.254.169.254/` has the authorized host as USERINFO; the real
+        // host curl connects to is 169.254.169.254. The gate must use the authority host, not be fooled
+        // by the userinfo, so this must not auto-approve.
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"curl -fsSL --output 'downloads/x.json' 'https://www.linkedin.com@169.254.169.254/latest/meta-data/'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download LinkedIn.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertNotEqual(review.verdict, ApprovalVerdict.approve, "userinfo host confusion must not auto-approve")
+    }
+
+    func testAutoDoesNotAutoApproveDownloadToLookalikeHost() async {
+        let reviewer = StaticSafetyReviewer()
+        // "linkedin.com" as a substring of a look-alike host must not pass — the URL host must equal the
+        // requested host or be a subdomain of it.
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"curl -L --fail --output 'downloads/x.html' 'https://linkedin.com.evil.test/'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download LinkedIn.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download LinkedIn.com?")]
+        ))
+        XCTAssertNotEqual(review.verdict, ApprovalVerdict.approve, "a look-alike host must not auto-approve")
+    }
+
+    func testAutoApprovesDownloadFromSubdomainOfRequestedHost() async {
+        let reviewer = StaticSafetyReviewer()
+        // A subdomain of the requested host is legitimate.
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: #"{"cmd":"mkdir -p downloads && curl -fsSL --output 'downloads/x.html' 'https://docs.linkedin.com/page' && ls -lh 'downloads/x.html'"}"#
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: "Can you download from linkedin.com?",
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: "Can you download from linkedin.com?")]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve, review.rationale ?? "")
+    }
+
     func testAutoDoesNotUseDownloadIntentForUnrelatedShellRun() async {
         let reviewer = StaticSafetyReviewer()
         let call = ToolCall(

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-06-30 Close the Download Host-Gate SSRF
+
+The final hole in the download carve-out (the documented follow-up from #728). After all the segment/flag/output hardening, the **host gate** was still a substring match: `requestedHosts.contains { lowerCommand.contains(host) }`. The authorized host could appear anywhere in the command — an `-e` referer or `-H` header — while the *actual* fetched URL pointed elsewhere.
+
+| Before | After |
+| --- | --- |
+| `requestedHosts.contains { lowerCommand.contains(host) }`. Both of these **auto-approved** on "download from linkedin.com": `curl -e 'https://www.linkedin.com' --output x 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'` (a **cloud-metadata SSRF** landing cloud credentials in the workspace) and `curl --output x 'https://linkedin.com.evil.test/'` (a **look-alike host** — "linkedin.com" is a substring). | Extract the host of **every** `http(s)://` URL in the command and require each to equal a requested host or be a subdomain of one (`host == req || host.hasSuffix(".\(req)")`). The referer's host no longer satisfies the gate for a different target URL; the look-alike fails the equality/subdomain check. Host extraction is **fail-closed** — a URL `URLComponents` can't parse drops the whole command to human approval. |
+
+The adversarial review then caught a **bypass in the first cut**: `normalizedHostCandidate("www.")` stripped `www.` to the **empty string**, so a message like "download from www." yielded a requested host of `""` — and the gate's `host.hasSuffix(".\(requested)")` clause became `host.hasSuffix(".")`, wildcarding every *trailing-dot* host (`https://169.254.169.254./…`, which curl resolves to the metadata endpoint by stripping the FQDN-root dot). Closed by: a shared `normalizedHost` that strips the trailing dot **and** re-validates the post-`www.`-strip value is a non-empty dotted domain (used on both the requested and command-URL sides, so `169.254.169.254.` == `169.254.169.254`), an `!requested.isEmpty` guard in the gate, and switching the command side to the same `URL(string:).host` parser as the requested side (also fixing an IDN punycode/Unicode asymmetry that wrongly blocked legit IDN downloads).
+
+Verification — **non-vacuous**, proven by reverting only the source: `testAutoDoesNotAutoApproveDownloadSSRFToUnrequestedHostViaReferer`, `testAutoDoesNotAutoApproveDownloadToLookalikeHost`, and `testAutoDoesNotAutoApproveDownloadWhenRequestedHostNormalizesEmpty` all **fail** without their respective fixes (auto-approved). `testAutoApprovesDownloadFromSubdomainOfRequestedHost` and the existing legit download approves still pass. `swift test` 1912 green · native smoke clean.
+
+With this, the download carve-out has **no remaining documented follow-up** — and the auto-mode over-approval audit is complete across all three `userIntentMatches` paths (`hardDeny` decoding, the download carve-out, the PR policy).
+
+Residual risk:
+
+- `curl -L` follows redirects, so a server at a *requested* host that 30x-redirects to an internal host is an SSRF the static check cannot see (inherent — the policy only sees the initial URL); `hardDeny` and the destructive-risk default remain backstops, and the workspace-relative output bound still applies. Schemeless URLs (`curl example.com`) now fall to human approval (no `http(s)://` to validate) — the safe direction.
+
 ## 2026-06-30 Restrict the PR-Policy Default Fallback to Read-Only
 
 Third stop on the auto-mode over-approval audit (after `hardDeny` decoding and the download carve-out). `StaticSafetyPullRequestPolicy.intentMatches` falls back to `defaultAllowedToolNames` when no specific verb rule matches a PR-related request — and that fallback included **`git.push`** and **`git.pr.create`**. So any PR-*mentioning* request that didn't hit a specific verb auto-approved an outward-facing push/create with no human.


### PR DESCRIPTION
The final hole in the download carve-out — the documented follow-up from #728. After all the segment/flag/output hardening, the **host gate** was still a substring match: `requestedHosts.contains { lowerCommand.contains(host) }`. The authorized host could appear anywhere in the command (an `-e` referer or `-H` header) while the *actual* fetched URL pointed elsewhere.

## The SSRF (both auto-approved on "download from linkedin.com")

```
curl -e 'https://www.linkedin.com' --output x 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'
```
A **cloud-metadata SSRF** — fetches cloud credentials into the workspace, where the agent can read them on a later turn.

```
curl --output x 'https://linkedin.com.evil.test/'
```
A **look-alike host** — "linkedin.com" is a substring of the attacker domain.

## Fix

Extract the host of **every** `http(s)://` URL in the command and require each to equal a requested host or be a subdomain of one (`host == req || host.hasSuffix(".\(req)")`). The referer's host no longer satisfies the gate for a different target; the look-alike fails the equality/subdomain check. Host extraction is **fail-closed** — a URL `URLComponents` can't parse drops the whole command to human approval.

## Tests

**Non-vacuous** — `testAutoDoesNotAutoApproveDownloadSSRFToUnrequestedHostViaReferer` and `testAutoDoesNotAutoApproveDownloadToLookalikeHost` both **fail** without the fix. `testAutoApprovesDownloadFromSubdomainOfRequestedHost` and the existing legit download approves still pass.

Verified: `swift test` 1911 green · native-desktop smoke clean.

Residual (inherent): `curl -L` follows redirects, so a requested host that 30x-redirects to an internal host is an SSRF the static check cannot see — `hardDeny` + the workspace-relative output bound remain backstops. Schemeless URLs now fall to human approval (safe direction). **With this, the download carve-out has no remaining documented follow-up.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)