### PR TITLE
Harden SSH remote exec against option injection

### DIFF
--- a/Sources/QuillCodeTools/SSHRemoteShellExecutor.swift
+++ b/Sources/QuillCodeTools/SSHRemoteShellExecutor.swift
@@ -40,6 +40,10 @@ public struct SSHRemoteShellExecutor: Sendable {
         if let port = connection.port {
             arguments.append(contentsOf: ["-p", "\(port)"])
         }
+        // `--` ends ssh option parsing so the destination can never be mistaken for an option (e.g. a
+        // host like `-oProxyCommand=…` injecting a local command). Belt-and-suspenders with the
+        // leading-`-` rejection in isValidDestinationComponent.
+        arguments.append("--")
         arguments.append(Self.destination(host: host, user: connection.user))
         arguments.append(remoteCommand)
 
@@ -57,7 +61,11 @@ public struct SSHRemoteShellExecutor: Sendable {
     }
 
     private static func isValidDestinationComponent(_ value: String) -> Bool {
-        !value.isEmpty && !value.contains { $0.isWhitespace || $0 == "\u{0}" }
+        // Reject a leading `-` so a host/user can never be parsed by ssh as an option flag
+        // (`-oProxyCommand=…` would run a local command). Whitespace/NUL are rejected too.
+        !value.isEmpty
+            && !value.hasPrefix("-")
+            && !value.contains { $0.isWhitespace || $0 == "\u{0}" }
     }
 
     private static func isValidPort(_ port: Int) -> Bool {

--- a/Tests/QuillCodeAppTests/WorkspaceRemoteProjectShellGitIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRemoteProjectShellGitIntegrationTests.swift
@@ -53,6 +53,7 @@ final class WorkspaceRemoteProjectShellGitIntegrationTests: XCTestCase {
             "ConnectTimeout=4",
             "-p",
             "2222",
+            "--",
             "quill@feather.local",
             "cd '/srv/quill' && pwd"
         ])
@@ -101,7 +102,7 @@ final class WorkspaceRemoteProjectShellGitIntegrationTests: XCTestCase {
         XCTAssertTrue(result.stdout.contains("README.md"), result.stdout)
 
         let arguments = try String(contentsOf: argumentsFile, encoding: .utf8)
-        XCTAssertTrue(arguments.contains("-p\n2222\nquill@feather.local\n"), arguments)
+        XCTAssertTrue(arguments.contains("-p\n2222\n--\nquill@feather.local\n"), arguments)
         XCTAssertTrue(
             arguments.contains("cd '\(remoteRoot.path.replacingOccurrences(of: "'", with: "'\\''"))' && git status --short --branch"),
             arguments

--- a/Tests/QuillCodeAppTests/WorkspaceRemoteProjectToolExecutorTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRemoteProjectToolExecutorTests.swift
@@ -62,6 +62,7 @@ final class WorkspaceRemoteProjectToolExecutorTests: XCTestCase {
             "ConnectTimeout=4",
             "-p",
             "2222",
+            "--",
             "quill@feather.local",
             "cd '/srv/quill repo' && pwd"
         ])

--- a/Tests/QuillCodeAppTests/WorkspaceTerminalIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTerminalIntegrationTests.swift
@@ -167,7 +167,7 @@ final class WorkspaceTerminalIntegrationTests: XCTestCase {
         XCTAssertEqual(surface.terminal.entries.first?.executionContext?.label, "SSH Remote")
         XCTAssertEqual(surface.terminal.entries.first?.executionContext?.detail, "feather.local")
         let arguments = try String(contentsOf: argumentsFile, encoding: .utf8)
-        XCTAssertTrue(arguments.contains("-T\n-o\nBatchMode=yes\n-o\nConnectTimeout=4\n-p\n2222\nquill@feather.local\n"))
+        XCTAssertTrue(arguments.contains("-T\n-o\nBatchMode=yes\n-o\nConnectTimeout=4\n-p\n2222\n--\nquill@feather.local\n"))
         XCTAssertTrue(arguments.contains("cd '/srv/quill repo' &&"))
         XCTAssertTrue(arguments.contains("printf remote-terminal"))
         XCTAssertTrue(arguments.contains("__QUILLCODE_TERMINAL_"))

--- a/Tests/QuillCodeToolsTests/ShellToolExecutorTests.swift
+++ b/Tests/QuillCodeToolsTests/ShellToolExecutorTests.swift
@@ -195,6 +195,7 @@ final class ShellToolExecutorTests: XCTestCase {
             "ConnectTimeout=7",
             "-p",
             "2222",
+            "--",
             "quill@feather.local",
             "cd '/srv/quill repo' && printf 'hi there'"
         ])
@@ -229,5 +230,27 @@ final class ShellToolExecutorTests: XCTestCase {
             command: "pwd",
             connection: .ssh(path: "/srv/quill", host: "feather.local", port: 70_000)
         ))
+    }
+
+    func testSSHRemoteShellRejectsOptionInjectingDestination() {
+        // A host/user beginning with `-` would be parsed by ssh as an option flag (e.g.
+        // `-oProxyCommand=…` runs a local command), so it must be rejected outright.
+        XCTAssertNil(SSHRemoteShellExecutor().request(
+            command: "pwd",
+            connection: .ssh(path: "/srv/quill", host: "-oProxyCommand=touch${IFS}/tmp/pwned")
+        ))
+        XCTAssertNil(SSHRemoteShellExecutor().request(
+            command: "pwd",
+            connection: .ssh(path: "/srv/quill", host: "feather.local", user: "-oProxyCommand=x")
+        ))
+    }
+
+    func testSSHRemoteShellTerminatesOptionsBeforeDestination() throws {
+        // Defense-in-depth: `--` precedes the destination so it can never be read as an option.
+        let request = try XCTUnwrap(SSHRemoteShellExecutor(sshExecutable: "ssh-test").request(
+            command: "pwd",
+            connection: .ssh(path: "/srv/quill", host: "feather.local", user: "quill")
+        ))
+        XCTAssertTrue(request.command.contains("'--' 'quill@feather.local'"), request.command)
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,19 @@
 # Code Quality Audit
 
+## 2026-06-30 Harden SSH Remote Exec Against Option Injection
+
+Moving the audit beyond the auto-mode safety policy into another security-relevant subsystem — SSH remote execution. `SSHRemoteShellExecutor` correctly single-quotes every assembled argument (no *local* shell injection), but the **destination** (`user@host`) was passed to `ssh` with no `--` terminator, and `isValidDestinationComponent` rejected whitespace/NUL but **not a leading `-`**. A host parsed as an option is the classic ssh-injection RCE (the same class git and others have patched).
+
+| Before | After |
+| --- | --- |
+| `ssh -T -o … [-p port] user@host <remote-cmd>`. A connection whose host is `-oProxyCommand=…` (reachable: `parseSSH("-oProxyCommand=touch${IFS}/tmp/pwned:/path")` sets `host` to that string, which passed validation) is read by `ssh` as an **option**, running a **local** command via `ProxyCommand` — local RCE when the agent runs *any* remote `shell.run`. | `isValidDestinationComponent` also rejects a leading `-` (host **and** user), and the arguments now insert `--` before the destination (`ssh … -- user@host <remote-cmd>`) so it can never be parsed as an option. Belt-and-suspenders. |
+
+Verification — **non-vacuous**, proven by reverting only the source: `testSSHRemoteShellRejectsOptionInjectingDestination` (a `-oProxyCommand=…` host/user) and `testSSHRemoteShellTerminatesOptionsBeforeDestination` both **fail** without the fix (the request is built and the ssh command literally carries the injecting option). The existing SSH-argument assertions across four integration tests were updated to include the `--`, confirming the terminator is present on every remote path. `swift test` 1919 green · native smoke clean.
+
+Residual risk:
+
+- The SSH connection is user-configured, so this is primarily a defense against a user pasting a crafted `/ssh …` string (social engineering) — but it is a real reachable local-RCE class and the fix is the standard mitigation. The single-quote escaping of the command/path/env was already correct.
+
 ## 2026-06-30 Close the Download Host-Gate SSRF
 
 The final hole in the download carve-out (the documented follow-up from #728). After all the segment/flag/output hardening, the **host gate** was still a substring match: `requestedHosts.contains { lowerCommand.contains(host) }`. The authorized host could appear anywhere in the command — an `-e` referer or `-H` header — while the *actual* fetched URL pointed elsewhere.


### PR DESCRIPTION
Moving the audit beyond the auto-mode safety policy into another security-relevant subsystem — SSH remote execution. `SSHRemoteShellExecutor` correctly single-quotes every assembled argument (no *local* shell injection), but the **destination** (`user@host`) was passed to `ssh` with no `--` terminator, and `isValidDestinationComponent` rejected whitespace/NUL but **not a leading `-`**.

## The injection (reachable)

`parseSSH("-oProxyCommand=touch${IFS}/tmp/pwned:/path")` (from a pasted `/ssh -oProxyCommand=…:/path`) sets `host` to `-oProxyCommand=…`, which passed validation. `ssh` then reads it as an **option**, running a **local** command via `ProxyCommand` — local RCE whenever the agent runs *any* remote `shell.run`. This is the classic ssh-option-injection class that git and others have patched.

## Fix

- `isValidDestinationComponent` also rejects a **leading `-`** (host **and** user).
- The arguments insert `--` before the destination (`ssh … -- user@host <remote-cmd>`) so it can never be parsed as an option.

## Tests

**Non-vacuous** — `testSSHRemoteShellRejectsOptionInjectingDestination` and `testSSHRemoteShellTerminatesOptionsBeforeDestination` both **fail** without the fix (the request is built and the ssh command carries the injecting option). Four integration tests' SSH-argument assertions were updated to include the `--`, confirming the terminator on every remote path.

Verified: `swift test` 1919 green · native-desktop smoke clean.

Residual: the SSH connection is user-configured, so this primarily defends against a user pasting a crafted `/ssh` string — but it's a real reachable local-RCE class with a standard mitigation. The command/path/env single-quote escaping was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)