### PR TITLE
Add runtime recovery real-world evidence

### DIFF
--- a/E2E/playwright/tests/real-world-action-evidence.ts
+++ b/E2E/playwright/tests/real-world-action-evidence.ts
@@ -129,6 +129,16 @@ const evidenceScenarios: RealWorldEvidenceScenario[] = [
       'negative write intent creates no artifact',
       'negative download intent creates no artifact'
     ]
+  },
+  {
+    name: 'recovers transient runtime failures with the same actionable turn',
+    prompts: ['trigger network failure', 'Retry runtime issue'],
+    expectedToolNames: ['host.shell.run'],
+    regressionGuards: [
+      'runtime issue retry clears the transient failure',
+      'retry dispatches a concrete nonempty shell action',
+      'retry preserves the user turn instead of creating draft-only limbo'
+    ]
   }
 ];
 

--- a/E2E/playwright/tests/real-world-actions.spec.ts
+++ b/E2E/playwright/tests/real-world-actions.spec.ts
@@ -295,3 +295,28 @@ test('respects explicit negative action prompts without tool cards or side effec
   await expect(page.getByText('Downloaded to `downloads/forbidden.html`.')).toHaveCount(0);
   await expect(page.getByText(/I'?ll run|I'?ll write|I'?ll download|should I|do you want me to/i)).toHaveCount(0);
 });
+
+test('recovers transient runtime failures with the same actionable turn', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('trigger network failure');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('runtime-issue')).toBeVisible();
+  await expect(page.getByTestId('runtime-issue-title')).toHaveText('TrustedRouter network issue');
+  await expect(page.getByTestId('runtime-issue-action')).toHaveText('Retry');
+  await expect(page.getByTestId('tool-card')).toHaveCount(0);
+
+  await page.getByTestId('runtime-issue-action').click();
+
+  await expect(page.getByTestId('runtime-issue')).toHaveCount(0);
+  await expect(page.getByTestId('message').filter({ hasText: 'trigger network failure' })).toHaveCount(2);
+  await expect(page.getByText('Retry completed after reconnecting to TrustedRouter.')).toBeVisible();
+  await expect(page.getByTestId('tool-card')).toHaveCount(1);
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
+  await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
+  await expect(page.getByTestId('tool-card-input')).toContainText('"cmd": "whoami"');
+  await expect(page.getByTestId('tool-card-input')).not.toContainText('{}');
+  await expect(page.getByTestId('tool-card-output')).toContainText('mock-user');
+  await expect(page.getByText(/No shell command was specified|should I|do you want me to|ok\?/i)).toHaveCount(0);
+});

--- a/Tests/QuillCodeParityTests/ParityLiveSmokeScriptGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSmokeScriptGateTests.swift
@@ -87,9 +87,9 @@ final class ParityLiveSmokeScriptGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(script.contains("steps should be an object"))
         XCTAssertTrue(script.contains("steps.playwright should be an object"))
         XCTAssertTrue(script.contains("steps.playwright.realWorldActions should be an object"))
-        XCTAssertTrue(script.contains("scenarioCount should be at least 10"))
-        XCTAssertTrue(script.contains("promptCount should be at least 18"))
-        XCTAssertTrue(script.contains("regressionGuardCount should be at least 30"))
+        XCTAssertTrue(script.contains("scenarioCount should be at least 12"))
+        XCTAssertTrue(script.contains("promptCount should be at least 22"))
+        XCTAssertTrue(script.contains("regressionGuardCount should be at least 36"))
     }
 
     func testDeterministicSmokeCoversExplicitNegativeActionIntent() throws {
@@ -140,8 +140,8 @@ final class ParityLiveSmokeScriptGateTests: QuillCodeParityTestCase {
 
         XCTAssertTrue(script.contains("validate-playwright-real-world-manifest.py"))
         XCTAssertTrue(validator.contains("REQUIRED_SCENARIOS"))
-        XCTAssertTrue(validator.contains("MIN_PROMPT_COUNT = 20"))
-        XCTAssertTrue(validator.contains("MIN_REGRESSION_GUARD_COUNT = 33"))
+        XCTAssertTrue(validator.contains("MIN_PROMPT_COUNT = 22"))
+        XCTAssertTrue(validator.contains("MIN_REGRESSION_GUARD_COUNT = 36"))
         XCTAssertTrue(validator.contains("runs natural shell requests immediately with nonempty arguments"))
         XCTAssertTrue(validator.contains("lists workspace entries with the structured file list tool"))
         XCTAssertTrue(validator.contains("writes requested file content immediately without a confirmation loop"))
@@ -153,6 +153,7 @@ final class ParityLiveSmokeScriptGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(validator.contains("dispatches slash git read shortcuts as real workspace actions"))
         XCTAssertTrue(validator.contains("starter cards launch real workspace actions immediately"))
         XCTAssertTrue(validator.contains("respects explicit negative action prompts without tool cards or side effects"))
+        XCTAssertTrue(validator.contains("recovers transient runtime failures with the same actionable turn"))
         XCTAssertTrue(validator.contains("Please check git status."))
         XCTAssertTrue(validator.contains("what changed?"))
         XCTAssertTrue(validator.contains("/git-status"))
@@ -161,6 +162,8 @@ final class ParityLiveSmokeScriptGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(validator.contains("Can you list the files here?"))
         XCTAssertTrue(validator.contains("Where is AgentRunner defined?"))
         XCTAssertTrue(validator.contains("Review changes starter card"))
+        XCTAssertTrue(validator.contains("trigger network failure"))
+        XCTAssertTrue(validator.contains("Retry runtime issue"))
         XCTAssertTrue(validator.contains("shell arguments are never {}"))
         XCTAssertTrue(validator.contains("assistant does not answer with passive promises"))
         XCTAssertTrue(validator.contains("file list uses host.file.list instead of shell ls fallback"))
@@ -171,6 +174,8 @@ final class ParityLiveSmokeScriptGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(validator.contains("slash git status dispatches host.git.status"))
         XCTAssertTrue(validator.contains("slash diff dispatches host.git.diff"))
         XCTAssertTrue(validator.contains("starter card creates a user turn without draft-only limbo"))
+        XCTAssertTrue(validator.contains("runtime issue retry clears the transient failure"))
+        XCTAssertTrue(validator.contains("retry dispatches a concrete nonempty shell action"))
     }
 
     func testRealWorldSmokeWorkflowRunsReleaseCandidateWrapperWithArtifacts() throws {

--- a/Tests/QuillCodeParityTests/ParityWorkspacePlaywrightRealWorldSpecGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspacePlaywrightRealWorldSpecGateTests.swift
@@ -26,7 +26,8 @@ final class ParityWorkspacePlaywrightRealWorldSpecGateTests: QuillCodeParityTest
             "writes requested file content immediately without a confirmation loop",
             "reads requested file contents immediately with the structured file tool",
             "answers natural git read requests with structured git tools",
-            "respects explicit negative action prompts without tool cards or side effects"
+            "respects explicit negative action prompts without tool cards or side effects",
+            "recovers transient runtime failures with the same actionable turn"
         ]
         let actionSpecSnippets = [
             "harnessURL()",
@@ -50,6 +51,8 @@ final class ParityWorkspacePlaywrightRealWorldSpecGateTests: QuillCodeParityTest
             "Do not run whoami.",
             "forbidden.txt",
             "downloads/forbidden.html",
+            "trigger network failure",
+            "Retry runtime issue",
             "confirmation loop"
         ]
         let actionEvidenceSnippets = [
@@ -57,6 +60,8 @@ final class ParityWorkspacePlaywrightRealWorldSpecGateTests: QuillCodeParityTest
             "file list uses host.file.list instead of shell ls fallback",
             "file read uses host.file.read instead of shell cat fallback",
             "git status uses host.git.status instead of shell fallback",
+            "runtime issue retry clears the transient failure",
+            "retry dispatches a concrete nonempty shell action",
             "QUILLCODE_PLAYWRIGHT_REAL_WORLD_ARTIFACT_DIR",
             "playwright-real-world-actions-manifest.json",
             "regressionGuardCount"

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -60,6 +60,7 @@ Drive the QuillCode test harness with mock LLM:
 - reuse a user message as the focused composer draft without mutating transcript history
 - mark assistant responses Helpful or Not helpful and preserve the selected state after rerender
 - retry the latest assistant answer and verify it reuses the latest user turn without duplicating Retry buttons on older answers
+- recover from a transient TrustedRouter/runtime failure with the visible Retry action, proving the issue clears and the original actionable turn dispatches a concrete nonempty tool call
 - edit file
 - review diff, post-patch review refresh, and file/line/range review notes
 - Auto approve/deny/clarify
@@ -81,6 +82,7 @@ Drive the QuillCode test harness with mock LLM:
 
 - Real-world smoke must include natural file-reading such as "What is in README.md?" and prove it routes through `host.file.read`, not shell `cat` fallback or passive chat.
 - Real-world smoke must include natural workspace listing such as "Can you list the files here?" and prove it routes through `host.file.list`, not shell `ls` fallback or passive chat.
+- Real-world smoke must include a transient runtime failure plus visible Retry recovery and prove the retried turn dispatches a concrete nonempty tool call instead of leaving the thread in draft-only limbo.
 - Real-world smoke must include natural workspace text search such as "Where is SmokeSearchSymbol defined?" and prove it routes through `host.file.search`, not shell grep fallback or passive chat.
 - Real-world smoke must include the first-run "Review changes" starter card and prove it creates a user turn, dispatches `host.git.diff`, renders final diff text, clears the composer, and does not leave the user in draft-only limbo.
 - Real-world smoke must include `/git-status` and `/diff` slash shortcuts and prove they dispatch `host.git.status`/`host.git.diff`, render final chat text, clear the composer, and avoid passive "I'll check/review" copy.

--- a/scripts/real-world-smoke.sh
+++ b/scripts/real-world-smoke.sh
@@ -103,13 +103,13 @@ if real_world.get("manifestPath") != "playwright-real-world/playwright-real-worl
 scenario_count = real_world.get("scenarioCount")
 prompt_count = real_world.get("promptCount")
 regression_guard_count = real_world.get("regressionGuardCount")
-if not isinstance(scenario_count, int) or scenario_count < 10:
-    errors.append(f"scenarioCount should be at least 10, got {scenario_count!r}")
-if not isinstance(prompt_count, int) or prompt_count < 18:
-    errors.append(f"promptCount should be at least 18, got {prompt_count!r}")
-if not isinstance(regression_guard_count, int) or regression_guard_count < 30:
+if not isinstance(scenario_count, int) or scenario_count < 12:
+    errors.append(f"scenarioCount should be at least 12, got {scenario_count!r}")
+if not isinstance(prompt_count, int) or prompt_count < 22:
+    errors.append(f"promptCount should be at least 22, got {prompt_count!r}")
+if not isinstance(regression_guard_count, int) or regression_guard_count < 36:
     errors.append(
-        f"regressionGuardCount should be at least 30, got {regression_guard_count!r}"
+        f"regressionGuardCount should be at least 36, got {regression_guard_count!r}"
     )
 
 if errors:

--- a/scripts/validate-playwright-real-world-manifest.py
+++ b/scripts/validate-playwright-real-world-manifest.py
@@ -21,6 +21,7 @@ REQUIRED_SCENARIOS = {
     "dispatches slash git read shortcuts as real workspace actions",
     "starter cards launch real workspace actions immediately",
     "respects explicit negative action prompts without tool cards or side effects",
+    "recovers transient runtime failures with the same actionable turn",
 }
 
 REQUIRED_PROMPT_FRAGMENTS = [
@@ -43,6 +44,8 @@ REQUIRED_PROMPT_FRAGMENTS = [
     "Do not run whoami.",
     "forbidden.txt",
     "downloads/forbidden.html",
+    "trigger network failure",
+    "Retry runtime issue",
 ]
 
 REQUIRED_REGRESSION_GUARDS = [
@@ -58,10 +61,13 @@ REQUIRED_REGRESSION_GUARDS = [
     "slash diff dispatches host.git.diff",
     "starter card creates a user turn without draft-only limbo",
     "negative shell intent creates no tool card",
+    "runtime issue retry clears the transient failure",
+    "retry dispatches a concrete nonempty shell action",
+    "retry preserves the user turn instead of creating draft-only limbo",
 ]
 
-MIN_PROMPT_COUNT = 20
-MIN_REGRESSION_GUARD_COUNT = 33
+MIN_PROMPT_COUNT = 22
+MIN_REGRESSION_GUARD_COUNT = 36
 
 
 def string_items(value: Any) -> list[str]:


### PR DESCRIPTION
## Summary
- add release-candidate Playwright evidence for transient runtime failure recovery
- require the real-world manifest to prove Retry clears the issue and dispatches a concrete nonempty shell tool call
- document the new recovery-path release gate in the test plan

## Validation
- npm test -- real-world-actions.spec.ts
- env QUILLCODE_PLAYWRIGHT_REAL_WORLD_ARTIFACT_DIR=/private/tmp/quillcode-real-world-actions-recovery-evidence-final npm test -- real-world-actions.spec.ts
- scripts/validate-playwright-real-world-manifest.py /private/tmp/quillcode-real-world-actions-recovery-evidence-final/playwright-real-world-actions-manifest.json
- swift test --filter ParitySmokeScriptGateTests