### PR TITLE
Polish transcript message actions: contrast + hover-reveal (harness)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -2053,13 +2053,25 @@
     }
     .message.user .transcript-actions { justify-content: flex-end; }
     .message.assistant .transcript-actions { justify-content: flex-start; }
+    /* Message action chips sit inside the bubble, including the bright user gradient — a dark chip
+       with bright text keeps them legible on any background, vs the old muted-grey-on-faint-white. */
+    .transcript-actions {
+      opacity: 0;
+      transition: opacity .12s ease;
+    }
+    .message:hover .transcript-actions,
+    .message:focus-within .transcript-actions,
+    .transcript-item:hover .transcript-actions,
+    .transcript-item:focus-within .transcript-actions {
+      opacity: 1;
+    }
     .transcript-copy-button {
       min-height: var(--hit-target);
       border: 0;
       border-radius: 999px;
       padding: 5px 9px;
-      color: var(--muted);
-      background: rgba(255,255,255,.08);
+      color: rgba(255,255,255,.82);
+      background: rgba(0,0,0,.30);
       font-size: 11px;
       font-weight: 700;
       cursor: pointer;
@@ -2073,8 +2085,8 @@
       border: 0;
       border-radius: 999px;
       padding: 5px 8px;
-      color: var(--muted);
-      background: rgba(255,255,255,.08);
+      color: rgba(255,255,255,.82);
+      background: rgba(0,0,0,.30);
       font-size: 11px;
       font-weight: 800;
       cursor: pointer;


### PR DESCRIPTION
From actually *looking* at faithful DOM screenshots (the new visual smoke), the per-message action chips (Copy / Use as draft / Helpful / Retry) were muted grey on faint white — **unreadable when overlaid on the bright user-bubble gradient** — and always-on, cluttering every turn.

## What

- **Contrast:** chips now use a dark backing (`rgba(0,0,0,.30)`) with bright text (`rgba(255,255,255,.82)`) so they stay legible on any background, including the gradient.
- **Hover-reveal:** `.transcript-actions` is `opacity:0` by default and fades in on message hover / `focus-within` — decluttering the default view while keeping controls keyboard-reachable. Opacity (not `display`), so the 44px hit targets and click-based tests are unaffected (Playwright ignores opacity for actionability).

## Scope (honest)

This is the **harness / design-reference layer** — what the new visual smoke captures. The native SwiftUI message-action components (`QuillCodeMessageFeedbackButton`/`…DraftButton`/etc.) and the HTML transcript renderer should mirror it for full parity — **follow-up** (a separate multi-component SwiftUI change + `.onHover`, which `ImageRenderer` can't verify).

## Verified

Full Playwright suite **150 passed**; before/after DOM screenshots confirm readable-on-gradient chips and a decluttered default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)