### PR TITLE
Mirror message-action contrast to the native SwiftUI app

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeTranscriptMessageView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptMessageView.swift
@@ -92,8 +92,10 @@ private struct QuillCodeMessageDraftButton: View {
                 .labelStyle(.iconOnly)
                 .font(.caption2.weight(.semibold))
                 .quillCodeIconButtonTarget(radius: QuillCodeMetrics.minimumHitTarget / 2)
-                .foregroundStyle(QuillCodePalette.text)
-                .background(Color.white.opacity(0.1))
+                // Dark chip + bright glyph stays legible on the bright user-bubble gradient (matches
+                // the harness contrast fix), vs the old faint white-on-white.
+                .foregroundStyle(Color.white.opacity(0.85))
+                .background(Color.black.opacity(0.30))
                 .clipShape(Capsule())
         }
         .buttonStyle(QuillCodePressableButtonStyle())
@@ -152,8 +154,8 @@ private struct QuillCodeMessageFeedbackButton: View {
                 .labelStyle(.iconOnly)
                 .font(.caption2.weight(.semibold))
                 .quillCodeIconButtonTarget(radius: QuillCodeMetrics.minimumHitTarget / 2)
-                .foregroundStyle(isSelected ? QuillCodePalette.green : QuillCodePalette.muted)
-                .background((isSelected ? QuillCodePalette.green : Color.white).opacity(isSelected ? 0.16 : 0.08))
+                .foregroundStyle(isSelected ? QuillCodePalette.green : Color.white.opacity(0.85))
+                .background(isSelected ? QuillCodePalette.green.opacity(0.16) : Color.black.opacity(0.30))
                 .clipShape(Capsule())
         }
         .buttonStyle(QuillCodePressableButtonStyle())
@@ -175,8 +177,8 @@ struct QuillCodeTranscriptCopyButton: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .quillCodeTextButtonTarget(minWidth: 64, radius: QuillCodeMetrics.minimumHitTarget / 2)
-                .foregroundStyle(isCopied ? QuillCodePalette.green : QuillCodePalette.muted)
-                .background((isCopied ? QuillCodePalette.green : Color.white).opacity(isCopied ? 0.16 : 0.08))
+                .foregroundStyle(isCopied ? QuillCodePalette.green : Color.white.opacity(0.85))
+                .background(isCopied ? QuillCodePalette.green.opacity(0.16) : Color.black.opacity(0.30))
                 .clipShape(Capsule())
         }
         .buttonStyle(QuillCodePressableButtonStyle())


### PR DESCRIPTION
Follow-up to the harness polish (#741): the native message-action chips had the same low-contrast problem — muted/white glyphs on a faint white backing, **unreadable on the bright user-bubble gradient**. This applies the same dark-chip fix in `QuillCodeTranscriptMessageView` so the **shipped app** improves, not just the design-reference harness.

- **Use-as-draft / Copy / Feedback** chips: dark backing (`black .30`) + bright glyph (`white .85`) instead of white/muted on faint white.
- **Revert** (red), **Retry** (blue), and the **selected** feedback state (green) keep their meaningful colors.

The **hover-reveal** declutter stays harness-only: on native the actions render without a mouse in the `ImageRenderer` hit-target audit, so an `opacity:0` default would hide audited targets. The contrast fix already makes the always-visible chips readable — the substantive win — so I didn't ship an unverifiable hover change that could break the audit.

Verified: `swift test` **1922** green · native-desktop smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)