### PR TITLE
Agent-run notification engine (decision + thread adapter)

### DIFF
--- a/Sources/QuillCodeApp/AgentRunNotification.swift
+++ b/Sources/QuillCodeApp/AgentRunNotification.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// A "come back and look" notification for an agent run that finished while the user was away.
+///
+/// The whole point of daily-driving an agent on a loop is that you do NOT watch it. So when a run
+/// ends, the app should ping the user when it actually needs them — it is blocked on an approval gate
+/// (the agent is waiting on YOU), it errored, or it finished. This type is the pure decision of
+/// WHETHER to notify and WHAT to say; the desktop layer gates delivery on the app being unfocused and
+/// posts the OS notification.
+public struct AgentRunNotification: Sendable, Hashable, Identifiable {
+    public enum Kind: String, Sendable, Hashable {
+        /// The run stopped at an approval gate — the highest priority: the agent is blocked on the user.
+        case needsApproval
+        /// The run hit an error and stopped.
+        case failed
+        /// The run produced a final answer with nothing pending.
+        case finished
+    }
+
+    public var kind: Kind
+    public var title: String
+    public var body: String
+    public var threadID: UUID
+
+    public var id: String { "\(threadID.uuidString)-\(kind.rawValue)" }
+
+    public init(kind: Kind, title: String, body: String, threadID: UUID) {
+        self.kind = kind
+        self.title = title
+        self.body = body
+        self.threadID = threadID
+    }
+}
+
+public enum AgentRunNotificationPlanner {
+    /// Decides the notification for a just-finished run, ordered by urgency for unattended driving: an
+    /// approval gate (blocked on the user) beats a failure beats a normal finish. Returns nil when
+    /// there is nothing worth interrupting the user for (e.g. an empty run, or one the user cancelled
+    /// — they were clearly watching).
+    public static func notification(
+        threadTitle rawTitle: String,
+        threadID: UUID,
+        didFail: Bool,
+        pendingApprovalSummary: String?,
+        finalAnswer: String?
+    ) -> AgentRunNotification? {
+        let title = displayTitle(rawTitle)
+        if let approval = trimmedNonEmpty(pendingApprovalSummary) {
+            return AgentRunNotification(
+                kind: .needsApproval,
+                title: "QuillCode needs your approval",
+                body: "\(title): approve \(approval) to continue.",
+                threadID: threadID
+            )
+        }
+        if didFail {
+            return AgentRunNotification(
+                kind: .failed,
+                title: "QuillCode run failed",
+                body: "\(title) — the run hit an error and stopped.",
+                threadID: threadID
+            )
+        }
+        if let answer = trimmedNonEmpty(finalAnswer) {
+            return AgentRunNotification(
+                kind: .finished,
+                title: "QuillCode finished",
+                body: summaryLine(title: title, answer: answer),
+                threadID: threadID
+            )
+        }
+        return nil
+    }
+
+    private static func summaryLine(title: String, answer: String) -> String {
+        let snippet = firstLine(answer, limit: 100)
+        return snippet.isEmpty ? title : "\(title): \(snippet)"
+    }
+
+    private static func firstLine(_ text: String, limit: Int) -> String {
+        let line = text.split(whereSeparator: \.isNewline).first.map(String.init) ?? text
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > limit else { return trimmed }
+        let cut = trimmed.index(trimmed.startIndex, offsetBy: limit)
+        return String(trimmed[..<cut]).trimmingCharacters(in: .whitespaces) + "…"
+    }
+
+    private static func displayTitle(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Your task" : trimmed
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceRunNotificationBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceRunNotificationBuilder.swift
@@ -1,0 +1,45 @@
+import Foundation
+import QuillCodeCore
+
+/// Turns a just-finished agent run (its resulting thread + whether it errored) into an
+/// `AgentRunNotification`, so the desktop layer can ping the user when a run they were not watching
+/// needs them. Pure + testable: the desktop layer supplies the thread and outcome and posts the OS
+/// notification (gated on the app being unfocused).
+enum WorkspaceRunNotificationBuilder {
+    static func notification(thread: ChatThread, didFail: Bool) -> AgentRunNotification? {
+        AgentRunNotificationPlanner.notification(
+            threadTitle: thread.title,
+            threadID: thread.id,
+            didFail: didFail,
+            pendingApprovalSummary: pendingApprovalToolName(in: thread),
+            finalAnswer: thread.messages.last(where: { $0.role == .assistant })?.content
+        )
+    }
+
+    /// An approval that was requested but never decided means the run stopped waiting on the user —
+    /// the most important thing to surface for unattended driving.
+    private static func pendingApprovalToolName(in thread: ChatThread) -> String? {
+        let decided = Set(thread.events.compactMap { event -> String? in
+            guard event.kind == .approvalDecided,
+                  let decision: ApprovalDecision = decode(from: event.payloadJSON)
+            else {
+                return nil
+            }
+            return decision.requestID
+        })
+        for event in thread.events.reversed() where event.kind == .approvalRequested {
+            guard let request: ApprovalRequest = decode(from: event.payloadJSON),
+                  !decided.contains(request.id)
+            else {
+                continue
+            }
+            return request.toolCall.name
+        }
+        return nil
+    }
+
+    private static func decode<T: Decodable>(from json: String?) -> T? {
+        guard let json, let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/Tests/QuillCodeAppTests/AgentRunNotificationPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/AgentRunNotificationPlannerTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class AgentRunNotificationPlannerTests: XCTestCase {
+    private let threadID = UUID()
+
+    func testApprovalGateTakesPriorityOverAnswer() {
+        // Blocked on the user is the most urgent unattended signal — even if a partial answer exists.
+        let note = AgentRunNotificationPlanner.notification(
+            threadTitle: "Refactor auth",
+            threadID: threadID,
+            didFail: false,
+            pendingApprovalSummary: "host.shell.run",
+            finalAnswer: "I plan to run the migration."
+        )
+        XCTAssertEqual(note?.kind, .needsApproval)
+        XCTAssertEqual(note?.title, "QuillCode needs your approval")
+        XCTAssertTrue(note?.body.contains("host.shell.run") == true, note?.body ?? "")
+        XCTAssertTrue(note?.body.contains("Refactor auth") == true, note?.body ?? "")
+        XCTAssertEqual(note?.threadID, threadID)
+    }
+
+    func testFailedRunNotifies() {
+        let note = AgentRunNotificationPlanner.notification(
+            threadTitle: "Build the parser",
+            threadID: threadID,
+            didFail: true,
+            pendingApprovalSummary: nil,
+            finalAnswer: nil
+        )
+        XCTAssertEqual(note?.kind, .failed)
+        XCTAssertTrue(note?.body.contains("Build the parser") == true, note?.body ?? "")
+    }
+
+    func testFinishedRunSummarizesTheAnswer() {
+        let note = AgentRunNotificationPlanner.notification(
+            threadTitle: "Add tests",
+            threadID: threadID,
+            didFail: false,
+            pendingApprovalSummary: nil,
+            finalAnswer: "Added 6 tests for the login flow.\nAll passing."
+        )
+        XCTAssertEqual(note?.kind, .finished)
+        XCTAssertEqual(note?.title, "QuillCode finished")
+        // Only the first line, and it carries the thread title as context.
+        XCTAssertTrue(note?.body.contains("Added 6 tests for the login flow.") == true, note?.body ?? "")
+        XCTAssertFalse(note?.body.contains("All passing.") == true, note?.body ?? "")
+    }
+
+    func testFinishedRunTruncatesLongAnswer() {
+        let long = String(repeating: "x", count: 300)
+        let note = AgentRunNotificationPlanner.notification(
+            threadTitle: "Task",
+            threadID: threadID,
+            didFail: false,
+            pendingApprovalSummary: nil,
+            finalAnswer: long
+        )
+        XCTAssertEqual(note?.kind, .finished)
+        XCTAssertTrue(note?.body.hasSuffix("…") == true, note?.body ?? "")
+        XCTAssertLessThan(note?.body.count ?? .max, 140)
+    }
+
+    func testNothingToNotifyReturnsNil() {
+        // No answer, no failure, no approval (e.g. a cancelled or empty run) — do not interrupt.
+        XCTAssertNil(AgentRunNotificationPlanner.notification(
+            threadTitle: "Task",
+            threadID: threadID,
+            didFail: false,
+            pendingApprovalSummary: nil,
+            finalAnswer: "   "
+        ))
+    }
+
+    func testEmptyThreadTitleFallsBack() {
+        let note = AgentRunNotificationPlanner.notification(
+            threadTitle: "   ",
+            threadID: threadID,
+            didFail: true,
+            pendingApprovalSummary: nil,
+            finalAnswer: nil
+        )
+        XCTAssertTrue(note?.body.contains("Your task") == true, note?.body ?? "")
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceRunNotificationBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRunNotificationBuilderTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceRunNotificationBuilderTests: XCTestCase {
+    private func thread(
+        title: String = "Refactor auth",
+        messages: [ChatMessage] = [],
+        events: [ThreadEvent] = []
+    ) -> ChatThread {
+        ChatThread(title: title, messages: messages, events: events)
+    }
+
+    private func approvalRequested(id: String, tool: String) -> ThreadEvent {
+        let request = ApprovalRequest(
+            id: id,
+            toolCall: ToolCall(name: tool, argumentsJSON: "{}"),
+            toolDefinition: nil,
+            reason: "gate"
+        )
+        return ThreadEvent(
+            kind: .approvalRequested,
+            summary: "approval requested",
+            payloadJSON: String(decoding: (try? JSONEncoder().encode(request)) ?? Data(), as: UTF8.self)
+        )
+    }
+
+    private func approvalDecided(requestID: String) -> ThreadEvent {
+        let decision = ApprovalDecision(requestID: requestID, verdict: .approve, rationale: "ok")
+        return ThreadEvent(
+            kind: .approvalDecided,
+            summary: "approval decided",
+            payloadJSON: String(decoding: (try? JSONEncoder().encode(decision)) ?? Data(), as: UTF8.self)
+        )
+    }
+
+    func testFinishedRunFromAssistantAnswer() {
+        let t = thread(messages: [ChatMessage(role: .assistant, content: "Done: added 6 tests.")])
+        let note = WorkspaceRunNotificationBuilder.notification(thread: t, didFail: false)
+        XCTAssertEqual(note?.kind, .finished)
+        XCTAssertTrue(note?.body.contains("added 6 tests") == true, note?.body ?? "")
+        XCTAssertEqual(note?.threadID, t.id)
+    }
+
+    func testFailedRunNotifies() {
+        let t = thread(messages: [ChatMessage(role: .assistant, content: "partial")])
+        let note = WorkspaceRunNotificationBuilder.notification(thread: t, didFail: true)
+        XCTAssertEqual(note?.kind, .failed)
+    }
+
+    func testUndecidedApprovalIsNeedsApprovalAndBeatsAnswer() {
+        let t = thread(
+            messages: [ChatMessage(role: .assistant, content: "I plan to run it.")],
+            events: [approvalRequested(id: "a1", tool: "host.shell.run")]
+        )
+        let note = WorkspaceRunNotificationBuilder.notification(thread: t, didFail: false)
+        XCTAssertEqual(note?.kind, .needsApproval)
+        XCTAssertTrue(note?.body.contains("host.shell.run") == true, note?.body ?? "")
+    }
+
+    func testDecidedApprovalDoesNotBlock() {
+        // Requested AND decided -> not pending -> falls through to the finished answer.
+        let t = thread(
+            messages: [ChatMessage(role: .assistant, content: "All done.")],
+            events: [approvalRequested(id: "a1", tool: "host.shell.run"), approvalDecided(requestID: "a1")]
+        )
+        let note = WorkspaceRunNotificationBuilder.notification(thread: t, didFail: false)
+        XCTAssertEqual(note?.kind, .finished)
+    }
+
+    func testNoAnswerNoApprovalNoFailureIsSilent() {
+        XCTAssertNil(WorkspaceRunNotificationBuilder.notification(thread: thread(), didFail: false))
+    }
+}


### PR DESCRIPTION
**Why:** daily-driving an agent on a loop means you don't watch it. Today QuillCode only notifies for *scheduled automations* — a normal agent run that finishes, errors, or **blocks on an approval gate** pings you with nothing, so you have to babysit it. First slice toward walk-away notifications.

## What

- **`AgentRunNotification` + `AgentRunNotificationPlanner`** — the pure decision of *whether* to notify and *what* to say, ordered by urgency for unattended driving: **blocked-on-approval** (the agent is waiting on YOU) › **failure** › normal **finish**; nothing worth interrupting → `nil`.
- **`WorkspaceRunNotificationBuilder`** — the adapter from a just-finished run (its thread + `didFail`) to a notification: pulls the *pending* approval (an `approvalRequested` with no matching `approvalDecided`), the final assistant answer, and the thread title.

## Tests (11)

approval beats a partial answer; failure; finished-summary (first line only) + truncation; a *decided* approval falls through to finished; silent when there's nothing to say.

Model hook (call the builder on run completion) + desktop `UNUserNotification` delivery (gated on the app being unfocused) are the **next slice**.

Verified: `swift test` **1947** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)