### PR TITLE
Fire attention notifications on run completion (model + desktop wiring)

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -24,6 +24,12 @@ public final class QuillCodeWorkspaceModel {
     public internal(set) var sidebarSelection: SidebarSelectionState
     public private(set) var lastError: String?
 
+    /// Set by the desktop layer to post a "come back and look" OS notification when an agent run
+    /// finishes while the user is away — finished, errored, or blocked on an approval gate. The whole
+    /// point of daily-driving on a loop is not watching, so the app pings you when it needs you. nil in
+    /// tests / the CLI, where there is no desktop notification surface.
+    public var onRunNotification: (@MainActor @Sendable (AgentRunNotification) -> Void)?
+
     var runner: AgentRunner
     var contextSummaryGenerator: any WorkspaceContextSummaryGenerating
     let threadPersistence: WorkspaceThreadPersistence

--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -178,6 +178,26 @@ extension QuillCodeWorkspaceModel {
         case .failed(let error):
             finishFailedSend(error)
         }
+        notifyRunFinishedIfNeeded(outcome: outcome)
+    }
+
+    /// After a run ends, ping the user if they were away and it needs them — finished, errored, or
+    /// blocked on an approval gate. A user-cancelled run is skipped (they were clearly watching). The
+    /// desktop handler additionally gates delivery on the app being unfocused.
+    private func notifyRunFinishedIfNeeded(outcome: WorkspaceAgentSendTaskOutcome) {
+        let didFail: Bool
+        switch outcome {
+        case .completed: didFail = false
+        case .failed: didFail = true
+        case .cancelled: return
+        }
+        guard let handler = onRunNotification,
+              let thread = selectedThread,
+              let notification = WorkspaceRunNotificationBuilder.notification(thread: thread, didFail: didFail)
+        else {
+            return
+        }
+        handler(notification)
     }
 
     private func applyAgentProgress(_ thread: ChatThread, expectedThreadID: UUID) {

--- a/Sources/quill-code-desktop/DesktopAutomationNotifier.swift
+++ b/Sources/quill-code-desktop/DesktopAutomationNotifier.swift
@@ -4,9 +4,35 @@ import QuillCodeApp
 
 protocol QuillCodeAutomationNotifying: Sendable {
     func deliver(_ report: AutomationRunReport)
+    /// Post a "come back and look" notification for a just-finished agent run (finished / errored /
+    /// blocked on approval). Defaulted to a no-op so the smoke/test notifiers need no changes.
+    func deliver(_ notification: AgentRunNotification)
+}
+
+extension QuillCodeAutomationNotifying {
+    func deliver(_ notification: AgentRunNotification) {}
 }
 
 struct MacAutomationNotifier: QuillCodeAutomationNotifying {
+    func deliver(_ notification: AgentRunNotification) {
+        Task {
+            let center = UNUserNotificationCenter.current()
+            guard await Self.ensureAuthorization(center: center) else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = notification.title
+            content.body = notification.body
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: "quillcode-run-\(notification.id)",
+                content: content,
+                trigger: nil
+            )
+            try? await center.add(request)
+        }
+    }
+
     func deliver(_ report: AutomationRunReport) {
         Task {
             let center = UNUserNotificationCenter.current()

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -75,6 +75,12 @@ final class QuillCodeDesktopController: ObservableObject {
         self.workspaceRoot = workspaceRoot
         modelStateCoordinator.ensureDefaultProject(on: model, workspaceRoot: workspaceRoot)
         self.computerUseCoordinator.install(on: model)
+        // Ping the user when a run they walked away from needs them — but not when they are actively
+        // watching QuillCode (it is the frontmost app), which would just be noise.
+        model.onRunNotification = { [automationNotifier] notification in
+            guard !NSApplication.shared.isActive else { return }
+            automationNotifier.deliver(notification)
+        }
         let initialState = modelStateCoordinator.initialState(from: model)
         self.surface = initialState.surface
         self.draft = initialState.draft

--- a/Tests/QuillCodeAppTests/WorkspaceModelRunNotificationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceModelRunNotificationTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class WorkspaceModelRunNotificationTests: XCTestCase {
+    private final class Box: @unchecked Sendable {
+        var value: AgentRunNotification?
+    }
+
+    @MainActor
+    func testCompletedRunFiresComeBackNotification() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        _ = model.newChat()
+
+        let box = Box()
+        model.onRunNotification = { box.value = $0 }
+
+        model.setDraft("run whoami")
+        await model.submitComposer(workspaceRoot: root)
+
+        // A finished run pings the user (they may have walked away) with a summary of what happened.
+        let note = try XCTUnwrap(box.value, "a finished run should fire a come-back notification")
+        XCTAssertEqual(note.kind, .finished)
+        XCTAssertFalse(note.body.isEmpty)
+    }
+
+    @MainActor
+    func testNoHandlerIsANoOp() async throws {
+        // Without a desktop handler (tests / CLI) the run completes normally and nothing is posted.
+        let root = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        _ = model.addProject(path: root, name: "Demo")
+        _ = model.newChat()
+        model.setDraft("run whoami")
+        await model.submitComposer(workspaceRoot: root)
+        XCTAssertNil(model.onRunNotification)
+    }
+}


### PR DESCRIPTION
Wires the run-notification engine (#754) so it actually **pings you when a run you walked away from needs you** — the thing that makes daily-driving on a loop viable.

- **Model hook:** `QuillCodeWorkspaceModel.onRunNotification` fires from `finishAgentSend` on completed/failed runs (a user-cancelled run is skipped — they were clearly watching), building the notification from the resulting thread + `didFail`.
- **Desktop delivery:** the controller sets the handler to post a `UNUserNotification`, **gated on QuillCode not being frontmost** (`NSApplication.isActive`) so it never nags while you're watching. The notifier protocol gains a defaulted no-op `deliver(AgentRunNotification)`, so the smoke/test notifiers are unchanged.

## Tests

A completed mock run fires `onRunNotification` (`.finished`); no handler is a clean no-op. (The decision + adapter logic was tested in #754.)

Verified: `swift test` **1949** green · native-desktop smoke clean · desktop builds.

Next: approve-from-notification (async approval) so a blocked gate doesn't need you in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)