### PR TITLE
Plan-progress strip above the composer (the always-visible run rail)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3001,6 +3001,40 @@
       transition-duration: 150ms;
       transition-timing-function: var(--ease-out);
     }
+    .composer-plan-progress {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 2px 6px;
+      font-size: 11px;
+      color: var(--muted, rgba(158,176,184,1));
+    }
+    .composer-plan-progress .plan-progress-track {
+      flex: 0 0 72px;
+      height: 3px;
+      border-radius: 2px;
+      background: rgba(255,255,255,.08);
+      overflow: hidden;
+    }
+    .composer-plan-progress .plan-progress-fill {
+      height: 100%;
+      width: 0;
+      background: var(--blue, #40b8e8);
+      transition: width .25s var(--ease-out);
+    }
+    .composer-plan-progress .plan-progress-count {
+      font-variant-numeric: tabular-nums;
+    }
+    .composer-plan-progress .plan-progress-step {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+    .composer-plan-progress[data-state="idle"] { opacity: .35; }
+    .composer-plan-progress[data-state="complete"] { opacity: .55; }
+    .composer-plan-progress[data-state="complete"] .plan-progress-fill { background: var(--green, #52d173); }
+    .composer-plan-progress[data-state="idle"] .plan-progress-fill { background: var(--muted, rgba(158,176,184,1)); }
     .composer-surface:focus-within {
       border-color: rgba(255,255,255,.18);
     }
@@ -3636,7 +3670,10 @@
         slashActiveIndex: 0,
         mentionActiveIndex: 0,
         historyRecallIndex: null,
-        historySavedDraft: null
+        historySavedDraft: null,
+        // The current run's plan progress for the always-visible strip above the input; null => no strip.
+        // Mirrors Swift ComposerSurface.planProgress (the surface renders the pre-computed struct).
+        planProgress: null
       },
       settings: {
         isOpen: false,
@@ -6839,6 +6876,7 @@
               ${renderSlashSuggestions()}
               ${renderFileMentionSuggestions()}
               <form class="composer" data-testid="composer">
+                ${renderComposerPlanProgress()}
                 <div class="composer-surface" data-testid="composer-surface">
                   <label class="composer-sr-only" for="message">Message</label>
                   <div class="composer-input-row">
@@ -8465,6 +8503,22 @@
           <button class="hit-target-icon" type="button" data-testid="find-next" ${matches.length ? '' : 'disabled'}>↓</button>
           <button class="hit-target-icon" type="button" data-testid="find-close" aria-label="Close find">×</button>
         </form>`;
+    }
+
+    // Mirrors Swift WorkspaceHTMLTranscriptRenderer.renderPlanProgress: the always-visible strip above
+    // the input, rendered from the pre-computed state.composer.planProgress (null => nothing).
+    function renderComposerPlanProgress() {
+      const p = state.composer.planProgress;
+      if (!p) return '';
+      const stateName = p.isComplete ? 'complete' : (p.isRunning ? 'running' : 'idle');
+      const percent = Math.round((p.fraction || 0) * 100);
+      const ariaLabel = `Plan progress: step ${p.currentStepIndex} of ${p.totalCount}: ${p.currentStepTitle}`;
+      return `
+        <div class="composer-plan-progress" data-testid="composer-plan-progress" data-state="${stateName}" role="progressbar" aria-valuemin="0" aria-valuemax="${p.totalCount}" aria-valuenow="${p.completedCount}" aria-label="${escapeHTML(ariaLabel)}">
+          <div class="plan-progress-track"><div class="plan-progress-fill" style="width:${percent}%"></div></div>
+          <span class="plan-progress-count" data-testid="plan-progress-count">${escapeHTML(p.stepCounterLabel)}</span>
+          <span class="plan-progress-step" data-testid="plan-progress-step" title="${escapeHTML(p.currentStepTitle)}">${escapeHTML(p.currentStepTitle)}</span>
+        </div>`;
     }
 
     function renderSlashSuggestions() {

--- a/E2E/playwright/tests/plan-progress.spec.ts
+++ b/E2E/playwright/tests/plan-progress.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+// The always-visible plan-progress strip above the composer. The harness renders the pre-computed
+// state.composer.planProgress (mirroring the Swift ComposerSurface field), so we drive that struct
+// directly — the same shape the Swift builder produces.
+
+const runningProgress = {
+  totalCount: 7,
+  completedCount: 2,
+  currentStepIndex: 3,
+  currentStepTitle: 'Running the test suite',
+  isRunning: true,
+  isComplete: false,
+  fraction: 0.5,
+  stepCounterLabel: '3/7',
+};
+
+async function setPlanProgress(page: import('@playwright/test').Page, progress: unknown) {
+  await page.evaluate((p) => {
+    // @ts-expect-error harness globals
+    state.composer.planProgress = p;
+    // @ts-expect-error harness globals
+    render();
+  }, progress);
+}
+
+test('no strip when there is no plan', async ({ page }) => {
+  await page.goto(harnessURL());
+  await expect(page.getByTestId('composer-plan-progress')).toHaveCount(0);
+});
+
+test('running plan shows the bar, counter, and current step', async ({ page }) => {
+  await page.goto(harnessURL());
+  await setPlanProgress(page, runningProgress);
+
+  const strip = page.getByTestId('composer-plan-progress');
+  await expect(strip).toBeVisible();
+  await expect(strip).toHaveAttribute('data-state', 'running');
+  await expect(page.getByTestId('plan-progress-count')).toHaveText('3/7');
+  await expect(page.getByTestId('plan-progress-step')).toHaveText('Running the test suite');
+
+  // The fill width tracks the fraction.
+  const fillWidth = await page.locator('.plan-progress-fill').evaluate((el) => el.style.width);
+  expect(fillWidth).toBe('50%');
+});
+
+test('completed plan is full and marked complete', async ({ page }) => {
+  await page.goto(harnessURL());
+  await setPlanProgress(page, {
+    totalCount: 4, completedCount: 4, currentStepIndex: 4, currentStepTitle: 'Wrap up',
+    isRunning: false, isComplete: true, fraction: 1.0, stepCounterLabel: '4/4',
+  });
+  const strip = page.getByTestId('composer-plan-progress');
+  await expect(strip).toHaveAttribute('data-state', 'complete');
+  const fillWidth = await page.locator('.plan-progress-fill').evaluate((el) => el.style.width);
+  expect(fillWidth).toBe('100%');
+});
+
+test('a stopped run ghosts the strip at the reached step', async ({ page }) => {
+  await page.goto(harnessURL());
+  await setPlanProgress(page, {
+    totalCount: 5, completedCount: 1, currentStepIndex: 2, currentStepTitle: 'Investigate the migration',
+    isRunning: false, isComplete: false, fraction: 0.3, stepCounterLabel: '2/5',
+  });
+  const strip = page.getByTestId('composer-plan-progress');
+  await expect(strip).toHaveAttribute('data-state', 'idle');
+  // Ghosted (dimmed) but still readable — you can see where it stalled.
+  const opacity = await strip.evaluate((el) => Number(getComputedStyle(el).opacity));
+  expect(opacity).toBeLessThan(0.5);
+  await expect(page.getByTestId('plan-progress-step')).toHaveText('Investigate the migration');
+});
+
+test('the strip sits above the composer input in DOM order', async ({ page }) => {
+  await page.goto(harnessURL());
+  await setPlanProgress(page, runningProgress);
+  // Within the composer form, the strip precedes the input surface.
+  const order = await page.locator('form.composer').evaluate((form) => {
+    const strip = form.querySelector('[data-testid="composer-plan-progress"]');
+    const surface = form.querySelector('[data-testid="composer-surface"]');
+    if (!strip || !surface) return 'missing';
+    return strip.compareDocumentPosition(surface) & Node.DOCUMENT_POSITION_FOLLOWING ? 'strip-first' : 'surface-first';
+  });
+  expect(order).toBe('strip-first');
+});

--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -25,6 +25,9 @@ struct QuillCodeComposerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
+            if let planProgress = composer.planProgress {
+                QuillCodePlanProgressStrip(progress: planProgress, reduceMotion: reduceMotion)
+            }
             if !slashSuggestions.isEmpty {
                 QuillCodeSlashSuggestionPanel(
                     suggestions: slashSuggestions,

--- a/Sources/QuillCodeApp/QuillCodePlanProgressStrip.swift
+++ b/Sources/QuillCodeApp/QuillCodePlanProgressStrip.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// The always-visible plan-progress rail: a slim band above the composer input showing a progress bar,
+/// the "k/N" step counter, and the current step title. It sits where your eyes land when you glance
+/// back at an unattended run. The parent gates its presence on a non-nil plan (so a plan-less composer
+/// is byte-identical), and this view owns the visibility POLICY — full while running, a dim "ghost"
+/// once the run stops (so you still read where it stalled, without shouting; the failure alarm stays
+/// the top-bar hairline's job), and a low-key green when complete.
+struct QuillCodePlanProgressStrip: View {
+    var progress: WorkspacePlanProgress
+    var reduceMotion: Bool
+
+    private let trackWidth: CGFloat = 72
+    private let trackHeight: CGFloat = 3
+
+    var body: some View {
+        HStack(spacing: 8) {
+            track
+            Text(progress.stepCounterLabel)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(QuillCodePalette.muted)
+            Text(progress.currentStepTitle)
+                .font(.caption2)
+                .foregroundStyle(QuillCodePalette.muted)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: 0)
+        }
+        .opacity(overallOpacity)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.25), value: progress.fraction)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Plan progress")
+        .accessibilityValue("Step \(progress.currentStepIndex) of \(progress.totalCount): \(progress.currentStepTitle)")
+        .accessibilityIdentifier("quillcode-plan-progress")
+    }
+
+    private var track: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(QuillCodePalette.selection)
+                .frame(width: trackWidth, height: trackHeight)
+            Capsule()
+                .fill(fillColor)
+                .frame(width: max(0, min(trackWidth, trackWidth * progress.fraction)), height: trackHeight)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var fillColor: Color {
+        if progress.isComplete { return QuillCodePalette.green }
+        return progress.isRunning ? QuillCodePalette.blue : QuillCodePalette.muted
+    }
+
+    private var overallOpacity: Double {
+        if progress.isRunning { return 1.0 }
+        return progress.isComplete ? 0.5 : 0.35
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptSurface.swift
@@ -309,12 +309,17 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
     public var sentMessageHistory: [String]
     /// Bumped by the `focus-composer` command; the view focuses the input when it changes.
     public var focusToken: Int
+    /// The current run's plan progress for the always-visible strip above the input. nil ⇒ no plan ⇒
+    /// the strip renders nothing (a plan-less session looks byte-identical). Optional, so it decodes
+    /// safely from surfaces persisted before this field existed.
+    public var planProgress: WorkspacePlanProgress?
 
     public init(
         composer: ComposerState,
         fileMentionIndex: WorkspaceFileIndex = WorkspaceFileIndex(),
         changedFilePaths: Set<String> = [],
-        sentMessageHistory: [String] = []
+        sentMessageHistory: [String] = [],
+        planProgress: WorkspacePlanProgress? = nil
     ) {
         self.draft = composer.draft
         self.placeholder = composer.placeholder
@@ -328,5 +333,6 @@ public struct ComposerSurface: Codable, Sendable, Hashable {
         )
         self.sentMessageHistory = sentMessageHistory
         self.focusToken = composer.focusToken
+        self.planProgress = planProgress
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTranscriptRenderer.swift
@@ -51,6 +51,7 @@ enum WorkspaceHTMLTranscriptRenderer {
             )
         return """
         <form class="composer" data-testid="composer">
+          \(renderPlanProgress(composer.planProgress))
           <div class="composer-surface" data-testid="composer-surface">
             <label class="composer-sr-only" for="message">Message</label>
             <div class="composer-input-row">
@@ -77,6 +78,22 @@ enum WorkspaceHTMLTranscriptRenderer {
             </div>
           </div>
         </form>
+        """
+    }
+
+    /// The always-visible plan-progress strip, emitted as the first child of the composer form so DOM
+    /// order matches native. Empty string when there is no plan (byte-identical to before).
+    private static func renderPlanProgress(_ progress: WorkspacePlanProgress?) -> String {
+        guard let progress else { return "" }
+        let state = progress.isComplete ? "complete" : (progress.isRunning ? "running" : "idle")
+        let percent = Int((progress.fraction * 100).rounded())
+        let ariaLabel = "Plan progress: step \(progress.currentStepIndex) of \(progress.totalCount): \(progress.currentStepTitle)"
+        return """
+        <div class="composer-plan-progress" data-testid="composer-plan-progress" data-state="\(state)" role="progressbar" aria-valuemin="0" aria-valuemax="\(progress.totalCount)" aria-valuenow="\(progress.completedCount)" aria-label="\(escape(ariaLabel))">
+            <div class="plan-progress-track"><div class="plan-progress-fill" style="width:\(percent)%"></div></div>
+            <span class="plan-progress-count" data-testid="plan-progress-count">\(escape(progress.stepCounterLabel))</span>
+            <span class="plan-progress-step" data-testid="plan-progress-step" title="\(escape(progress.currentStepTitle))">\(escape(progress.currentStepTitle))</span>
+          </div>
         """
     }
 

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -185,7 +185,8 @@ public extension QuillCodeWorkspaceModel {
                 composer: composer,
                 fileMentionIndex: fileMentionIndex,
                 changedFilePaths: activeChangedFilePaths,
-                sentMessageHistory: ComposerHistoryRecall.history(from: thread?.messages ?? [])
+                sentMessageHistory: ComposerHistoryRecall.history(from: thread?.messages ?? []),
+                planProgress: WorkspacePlanProgressBuilder.progress(for: thread, agentStatus: topBarState.agentStatus)
             ),
             fileMentionIndex: fileMentionIndex,
             changedFilePaths: activeChangedFilePaths,

--- a/Tests/QuillCodeAppTests/ComposerPlanProgressStripTests.swift
+++ b/Tests/QuillCodeAppTests/ComposerPlanProgressStripTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class ComposerPlanProgressStripTests: XCTestCase {
+    private func composer(planProgress: WorkspacePlanProgress?) -> ComposerSurface {
+        ComposerSurface(composer: ComposerState(), planProgress: planProgress)
+    }
+
+    private func makeTopBar() -> TopBarSurface {
+        TopBarSurface(
+            appName: "QuillCode",
+            primaryTitle: "Task",
+            subtitle: "QuillCode - Auto",
+            instructionLabel: "No instructions",
+            instructionSources: [],
+            memoryLabel: "No memories",
+            memorySources: [],
+            modelLabel: "Nike 1.0",
+            selectedModelID: "trustedrouter/fast",
+            modelCategories: [],
+            modeLabel: "Auto",
+            agentStatus: "Running",
+            computerUseLabel: "Computer Use unavailable",
+            showsComputerUseSetup: false
+        )
+    }
+
+    private func sampleProgress() -> WorkspacePlanProgress {
+        WorkspacePlanProgress(
+            totalCount: 7,
+            completedCount: 2,
+            currentStepIndex: 3,
+            currentStepTitle: "Running the tests",
+            isRunning: true,
+            isComplete: false,
+            fraction: 0.5,
+            stepCounterLabel: "3/7"
+        )
+    }
+
+    // MARK: - Codable safety (the optional-add claim)
+
+    func testLegacyComposerJSONWithoutPlanProgressDecodesToNil() throws {
+        // A ComposerSurface persisted before this field existed must still decode (missing key ⇒ nil).
+        let legacy = """
+        {
+          "draft": "hi",
+          "placeholder": "Message",
+          "isSending": false,
+          "canSend": true,
+          "slashSuggestions": [],
+          "fileMentionSuggestions": [],
+          "sentMessageHistory": [],
+          "focusToken": 0
+        }
+        """
+        let decoded = try JSONDecoder().decode(ComposerSurface.self, from: Data(legacy.utf8))
+        XCTAssertNil(decoded.planProgress)
+        XCTAssertEqual(decoded.draft, "hi")
+    }
+
+    func testPlanProgressRoundTrips() throws {
+        let surface = composer(planProgress: sampleProgress())
+        let data = try JSONEncoder().encode(surface)
+        let decoded = try JSONDecoder().decode(ComposerSurface.self, from: data)
+        XCTAssertEqual(decoded.planProgress, sampleProgress())
+    }
+
+    // MARK: - HTML surface
+
+    func testHTMLComposerEmitsStripWhenPlanProgressPresent() {
+        let html = WorkspaceHTMLTranscriptRenderer.renderComposer(composer(planProgress: sampleProgress()), topBar: makeTopBar())
+        XCTAssertTrue(html.contains("data-testid=\"composer-plan-progress\""), html)
+        XCTAssertTrue(html.contains("data-state=\"running\""), html)
+        XCTAssertTrue(html.contains("width:50%"), html)
+        XCTAssertTrue(html.contains(">3/7<"), html)
+        XCTAssertTrue(html.contains("Running the tests"), html)
+        XCTAssertTrue(html.contains("aria-valuemax=\"7\""), html)
+        XCTAssertTrue(html.contains("aria-valuenow=\"2\""), html)
+    }
+
+    func testHTMLComposerOmitsStripWhenNoPlan() {
+        let html = WorkspaceHTMLTranscriptRenderer.renderComposer(composer(planProgress: nil), topBar: makeTopBar())
+        XCTAssertFalse(html.contains("composer-plan-progress"), html)
+    }
+
+    func testHTMLComposerCompleteStateAndFullBar() {
+        let done = WorkspacePlanProgress(
+            totalCount: 4, completedCount: 4, currentStepIndex: 4, currentStepTitle: "Wrap up",
+            isRunning: false, isComplete: true, fraction: 1.0, stepCounterLabel: "4/4"
+        )
+        let html = WorkspaceHTMLTranscriptRenderer.renderComposer(composer(planProgress: done), topBar: makeTopBar())
+        XCTAssertTrue(html.contains("data-state=\"complete\""), html)
+        XCTAssertTrue(html.contains("width:100%"), html)
+    }
+}


### PR DESCRIPTION
## Why

The always-visible "how far has the run gotten" glance for daily-driving an agent unattended — you look back at the window and, without opening the Activity pane, see the run's plan position. Placement mirrors where **Codex / Claude Code put live status: at the bottom, right by the prompt** (their plan itself is an inline checklist — QuillCode already has that as the Activity "Task Plan" section). Chosen via a 4-placement design panel and confirmed against that Codex precedent.

Builds on the engine from [#765](https://github.com/Lore-Hex/QuillCode/pull/765) (`WorkspacePlanProgress` + builder + the unified `AgentStatusClassifier`).

## What

- **`ComposerSurface.planProgress`** — a new optional field (decode-safe for surfaces persisted before it existed), populated once in the workspace surface builder from the thread's latest plan + agent status. `nil` ⇒ no strip ⇒ byte-identical composer.
- **Tri-surface**, all consuming the same `WorkspacePlanProgress`:
  - **Native** — `QuillCodePlanProgressStrip` (bar + `k/N` + step title), gated into the composer `VStack` so there's zero layout when absent. Full while running; a dim **ghost** once the run stops (you still read where it stalled — the failure *alarm* stays the top-bar hairline's job, so nothing double-shouts); low-key green when complete.
  - **HTML renderer** — emitted as the first composer-form child (DOM order matches native), `role=progressbar` with aria step/among-N.
  - **Harness** — same markup + CSS, driven by `state.composer.planProgress`.

## Testing

- **5 Swift** — legacy-decode → nil, round-trip, HTML markup (running / complete / absent).
- **5 Playwright** — absent, running (bar width = fraction, counter, step), complete (full bar), stopped (ghost/dimmed), DOM order (strip precedes input).
- Full `swift test` **2005**, native desktop smoke, Playwright — all green. Visually verified via the real-DOM harness (running: blue bar + "3/7" + step; complete: low-key green; stopped: ghost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)