### PR TITLE
Honest stop reason: a ceiling-hit run is no longer disguised as a finish

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -113,6 +113,10 @@ public struct AgentRunner: Sendable {
                 }
             }
 
+            // Reaching here means the loop ran its full tool-step budget without the model ever
+            // returning a final answer — the run hit its ceiling. Synthesize an answer as before, but
+            // record it HONESTLY (a notice + a distinct stopReason) so it is not mistaken for a real
+            // finish on an unattended run.
             if let lastCompletion {
                 appendAssistantMessage(Self.finalAnswer(
                     for: lastCompletion.call,
@@ -125,8 +129,16 @@ public struct AgentRunner: Sendable {
                 next.events.append(.init(kind: .message, summary: message))
                 next.updatedAt = Date()
             }
+            next.events.append(.init(
+                kind: .notice,
+                summary: "Reached the \(limit)-step tool limit before finishing; summary is from the latest step."
+            ))
             await onProgress?(next)
-            return AgentRunResult(thread: next, toolResults: toolResults)
+            return AgentRunResult(
+                thread: next,
+                toolResults: toolResults,
+                stopReason: .toolStepCeilingExhausted(limit: limit)
+            )
         } catch is CancellationError {
             AgentCancellationRecorder.recordCancelledRun(in: &next)
             await onProgress?(next)

--- a/Sources/QuillCodeAgent/AgentTypes.swift
+++ b/Sources/QuillCodeAgent/AgentTypes.swift
@@ -43,13 +43,26 @@ public enum AgentError: Error, CustomStringConvertible {
     }
 }
 
+/// Why an agent run ended — so a run that HIT its tool-step ceiling (and had a summary synthesized from
+/// the last tool result) is no longer indistinguishable from a run the model genuinely finished. The
+/// unattended-driving trust story needs "finished" to mean finished, not "gave up at the budget".
+public enum AgentRunStopReason: Sendable, Hashable {
+    /// The model returned a final answer (or a repeated-call was finalized) — a genuine finish.
+    case finished
+    /// The run exhausted `maxToolSteps` without the model returning a final answer; the summary is
+    /// synthesized from the last tool result, not a real conclusion.
+    case toolStepCeilingExhausted(limit: Int)
+}
+
 public struct AgentRunResult: Sendable {
     public var thread: ChatThread
     public var toolResults: [ToolResult]
+    public var stopReason: AgentRunStopReason
 
-    public init(thread: ChatThread, toolResults: [ToolResult]) {
+    public init(thread: ChatThread, toolResults: [ToolResult], stopReason: AgentRunStopReason = .finished) {
         self.thread = thread
         self.toolResults = toolResults
+        self.stopReason = stopReason
     }
 }
 

--- a/Tests/QuillCodeAgentTests/AgentRunStopReasonTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentRunStopReasonTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+import QuillCodeAgent
+
+/// Returns a different tool call each time, so the run never trips the repeated-call finalizer and
+/// instead runs its full tool-step budget — exercising the ceiling-exhaustion path.
+private final class VaryingToolLLMClient: LLMClient, @unchecked Sendable {
+    private var counter = 0
+    func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+        counter += 1
+        return .tool(ToolCall(name: "host.file.read", argumentsJSON: ToolArguments.json(["path": "missing-\(counter).txt"])))
+    }
+}
+
+final class AgentRunStopReasonTests: XCTestCase {
+    private var root: URL { FileManager.default.temporaryDirectory }
+
+    func testCeilingExhaustionIsHonestlyLabeled() async throws {
+        let runner = AgentRunner(llm: VaryingToolLLMClient(), maxToolSteps: 2)
+        let result = try await runner.send("go", in: ChatThread(title: "T", messages: [], events: []), workspaceRoot: root)
+
+        // The run gave up at its budget — not a genuine finish.
+        XCTAssertEqual(result.stopReason, .toolStepCeilingExhausted(limit: 2))
+        XCTAssertTrue(
+            result.thread.events.contains { $0.kind == .notice && $0.summary.contains("step tool limit") },
+            "expected an honest ceiling notice; got \(result.thread.events.map(\.summary))"
+        )
+    }
+
+    func testGenuineFinishIsMarkedFinished() async throws {
+        let runner = AgentRunner(llm: FixedSayLLMClient(message: "All done."))
+        let result = try await runner.send("go", in: ChatThread(title: "T", messages: [], events: []), workspaceRoot: root)
+
+        XCTAssertEqual(result.stopReason, .finished)
+        XCTAssertFalse(result.thread.events.contains { $0.kind == .notice && $0.summary.contains("step tool limit") })
+    }
+}


### PR DESCRIPTION
## Why

The second design panel's pick — a **stuck/run-guard** to close the last uncovered trust hole for unattended driving: *silence*. The shipped reliability stack handles everything that emits a *signal* (transient-retry = thrown errors, verify-gate = test output, async-approval = gates) but not the silent modes. This is the cleanest first slice: one of those silent modes is that **`maxToolSteps` exhaustion masquerades as a genuine finish**.

Verified in source (`Agent.swift:116-129`): when the loop runs its full budget without the model returning a final answer, it synthesizes an answer from the last tool result and returns `.completed` — indistinguishable from a real `.say` finish (line 78-81), so it pings you "QuillCode finished".

## What

- **`AgentRunStopReason`** (`.finished` / `.toolStepCeilingExhausted(limit:)`) + `AgentRunResult.stopReason` (defaulted `.finished`, so every existing construction/caller is byte-identical).
- The ceiling branch now sets `.toolStepCeilingExhausted` **and** appends a visible thread `.notice` ("Reached the N-step tool limit before finishing; summary is from the latest step."), so the give-up shows in the Activity feed instead of masquerading as a clean finish. The synthesized answer is unchanged — it just stops lying about *why* the run ended.

## Testing

2 tests: a run that keeps calling (varying) tools past the budget → `stopReason` ceiling + the notice; a genuine `.say` finish → `.finished` + no notice. Full `swift test` **2079** green.

## Next slices (the rest of the watchdog arc)

- A **wall-clock run watchdog** (`AgentRunGuard`, injected clock) racing the model-stream await against a deadline, so a stalled connection that never throws is cancelled + surfaced instead of hanging forever (verified: `TrustedRouterLLMClient`'s stream drain has no timeout; `RetryingLLMClient` only retries *thrown* errors).
- Surface ceiling/stuck in the finished notification + plan rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)