### PR TITLE
feat(tools): cap shell command output to protect the context window

### DIFF
--- a/Sources/QuillCodeTools/ShellOutputCapper.swift
+++ b/Sources/QuillCodeTools/ShellOutputCapper.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Bounds shell command output so a chatty command (a big test log, a `find`) can't blow the model's
+/// context window on an unattended run. Truncates from the FRONT (keeps the tail) because for a shell
+/// run the ending — the final status, the error, the summary line — is what matters most. When it
+/// trims, it prepends an honest note so the model knows output was dropped.
+public enum ShellOutputCapper {
+    public static let defaultMaxLines = 2000
+    public static let defaultMaxBytes = 50_000
+
+    public static func cap(
+        _ text: String,
+        maxLines: Int = defaultMaxLines,
+        maxBytes: Int = defaultMaxBytes
+    ) -> (text: String, truncated: Bool) {
+        let totalLines = text.isEmpty ? 0 : text.components(separatedBy: "\n").count
+        let totalBytes = text.utf8.count
+        guard totalLines > maxLines || totalBytes > maxBytes else {
+            return (text, false)
+        }
+
+        var lines = text.components(separatedBy: "\n")
+        if lines.count > maxLines {
+            lines = Array(lines.suffix(maxLines))
+        }
+        var kept = lines.joined(separator: "\n")
+
+        // Byte ceiling on the already line-trimmed tail: keep the last maxBytes bytes. Decoding a tail
+        // that may start mid-codepoint is tolerated (the leading partial byte becomes U+FFFD).
+        if kept.utf8.count > maxBytes {
+            kept = String(decoding: Data(kept.utf8.suffix(maxBytes)), as: UTF8.self)
+        }
+
+        let note = "[output truncated — showing the tail; \(totalLines) line\(totalLines == 1 ? "" : "s"), \(totalBytes) bytes total]\n"
+        return (note + kept, true)
+    }
+}

--- a/Sources/QuillCodeTools/ShellToolExecutor.swift
+++ b/Sources/QuillCodeTools/ShellToolExecutor.swift
@@ -168,8 +168,10 @@ public struct ShellToolExecutor: Sendable {
         }
         processBox?.clear()
 
-        let out = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-        let err = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        // Bound the output so a chatty command can't blow the model's context window on an unattended
+        // run — keep the tail (the final status/error is what matters for a shell command).
+        let out = ShellOutputCapper.cap(String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)).text
+        let err = ShellOutputCapper.cap(String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)).text
         let ok = process.terminationStatus == 0
         return ToolResult(
             ok: ok,

--- a/Tests/QuillCodeToolsTests/ShellOutputCapperTests.swift
+++ b/Tests/QuillCodeToolsTests/ShellOutputCapperTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+// MARK: - Unit: the pure capper
+
+final class ShellOutputCapperTests: XCTestCase {
+    func testUnderLimitPassesThroughUnchanged() {
+        let text = "a\nb\nc"
+        let result = ShellOutputCapper.cap(text, maxLines: 100, maxBytes: 10_000)
+        XCTAssertFalse(result.truncated)
+        XCTAssertEqual(result.text, text)
+    }
+
+    func testOverLineLimitKeepsTheTail() {
+        let text = (1...3000).map { "line\($0)" }.joined(separator: "\n")
+        let result = ShellOutputCapper.cap(text, maxLines: 100, maxBytes: 1_000_000)
+        XCTAssertTrue(result.truncated)
+        XCTAssertTrue(result.text.contains("output truncated"))
+        XCTAssertTrue(result.text.contains("line3000"), "the tail must be kept")     // last line
+        XCTAssertFalse(result.text.contains("line1\n"), "early lines must be dropped")
+        // note line + 100 kept lines
+        XCTAssertLessThanOrEqual(result.text.components(separatedBy: "\n").count, 102)
+    }
+
+    func testOverByteLimitTruncates() {
+        let text = String(repeating: "x", count: 200_000)
+        let result = ShellOutputCapper.cap(text, maxLines: 1_000_000, maxBytes: 1000)
+        XCTAssertTrue(result.truncated)
+        XCTAssertLessThan(result.text.utf8.count, 2000)
+    }
+
+    func testEmptyIsPassthrough() {
+        XCTAssertFalse(ShellOutputCapper.cap("").truncated)
+    }
+}
+
+// MARK: - Functional: through the shell executor with real output
+
+final class ShellToolExecutorCapFunctionalTests: XCTestCase {
+    func testExecutorCapsAChattyCommand() {
+        let request = ShellExecutionRequest(
+            command: "seq 5000",
+            cwd: FileManager.default.temporaryDirectory,
+            timeoutSeconds: 30
+        )
+        let result = ShellToolExecutor().run(request)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("output truncated"), "5000 lines should be capped")
+        XCTAssertTrue(result.stdout.contains("\n5000"), "the tail (final lines) must survive")
+        XCTAssertLessThan(result.stdout.components(separatedBy: "\n").count, 2100, "capped near the 2000-line ceiling")
+    }
+}
+
+// MARK: - Integration: through the ToolRouter dispatch the agent uses
+
+final class ShellToolOutputCapIntegrationTests: XCTestCase {
+    func testRouterDispatchedShellRunIsCapped() {
+        let router = ToolRouter(workspaceRoot: FileManager.default.temporaryDirectory)
+        let call = ToolCall(name: "host.shell.run", argumentsJSON: #"{"cmd":"seq 5000"}"#)
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("output truncated"))
+        XCTAssertTrue(result.stdout.contains("\n5000"))
+    }
+}


### PR DESCRIPTION
## What

Bound `host.shell.run` output to the last **2000 lines / 50KB**, keeping the **tail** and prepending an honest truncation note.

A chatty command (a big test log, a `find`, a `seq`) could dump unbounded output straight into the model's context. On an unattended loop that silently burns the window and can wedge a run — exactly the failure mode OpenCode guards against with its output cap. We keep the tail because for a shell run the ending (final status / error / summary line) is what matters most.

## Scope

Only the **model-facing** path: `ShellToolExecutor.run` → `runProcess`, which is what the agent sees via `ToolRouter` → `ShellToolCallDispatcher`. The interactive **streaming terminal UI** (`runStreaming` / `startStreamingSession`) is intentionally left **uncapped** — a human watching a live PTY wants the full stream.

## Tests — full pyramid

- **unit** — `ShellOutputCapperTests`: passthrough under limit; tail kept over line limit; byte-ceiling over byte limit; note prepended; empty string.
- **functional** — `ShellToolExecutorCapFunctionalTests`: `seq 5000` through the real executor is capped, the tail (line `5000`) survives, count lands near the 2000-line ceiling.
- **integration** — `ShellToolOutputCapIntegrationTests`: the same `seq 5000` through `ToolRouter.execute(host.shell.run)` — the dispatch layer the agent actually calls.
- **playwright** — N/A: pure backend tool behavior; the streaming terminal UI is unchanged and capped output flows through already-tested tool-card rendering.

Closes #850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)