### PR TITLE
feat(tools): preserve BOM + CRLF/LF on file write, normalize on read

### DIFF
--- a/Sources/QuillCodeTools/FileEncodingPreservation.swift
+++ b/Sources/QuillCodeTools/FileEncodingPreservation.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// The byte-level encoding traits of a text file that a full-content rewrite must preserve: a leading
+/// UTF-8 BOM and the dominant line-ending style. Without this, writing model-authored content (always
+/// bare-LF, no BOM) over a Windows-authored file silently flips every line to LF and drops the BOM —
+/// turning a one-line edit into a whole-file diff.
+public enum FileLineEnding: Sendable, Hashable {
+    case lf
+    case crlf
+
+    var terminator: String { self == .crlf ? "\r\n" : "\n" }
+}
+
+public struct FileEncodingStyle: Sendable, Hashable {
+    public var hasBOM: Bool
+    public var lineEnding: FileLineEnding
+
+    public init(hasBOM: Bool, lineEnding: FileLineEnding) {
+        self.hasBOM = hasBOM
+        self.lineEnding = lineEnding
+    }
+
+    /// What a brand-new file gets: bare UTF-8, LF, no BOM.
+    public static let `default` = FileEncodingStyle(hasBOM: false, lineEnding: .lf)
+}
+
+public enum FileEncodingPreservation {
+    static let utf8BOM: [UInt8] = [0xEF, 0xBB, 0xBF]
+
+    /// Detect the BOM + dominant line ending of an existing file's raw bytes.
+    public static func detect(_ data: Data) -> FileEncodingStyle {
+        let hasBOM = data.starts(with: utf8BOM)
+        let body = hasBOM ? data.dropFirst(utf8BOM.count) : data[...]
+        return FileEncodingStyle(hasBOM: hasBOM, lineEnding: detectLineEnding(body))
+    }
+
+    /// Count CRLF vs bare-LF newlines; the majority wins. No newlines (or a tie) defaults to LF, so a
+    /// single-line file or an empty file is treated as LF rather than guessing CRLF.
+    static func detectLineEnding<S: Sequence>(_ bytes: S) -> FileLineEnding where S.Element == UInt8 {
+        var crlf = 0
+        var lf = 0
+        var previous: UInt8 = 0
+        for byte in bytes {
+            if byte == 0x0A {   // \n
+                if previous == 0x0D { crlf += 1 } else { lf += 1 }
+            }
+            previous = byte
+        }
+        return crlf > lf ? .crlf : .lf
+    }
+
+    /// Encode model-authored content (canonically bare-LF) as bytes matching the target file's style:
+    /// re-apply CRLF if the original used it, and re-prepend the BOM if the original had one.
+    public static func apply(_ content: String, style: FileEncodingStyle) -> Data {
+        // Canonicalize any incoming CRLF to LF first so re-lining is idempotent and never yields CRCRLF.
+        let canonical = content.replacingOccurrences(of: "\r\n", with: "\n")
+        let relined = style.lineEnding == .crlf
+            ? canonical.replacingOccurrences(of: "\n", with: "\r\n")
+            : canonical
+        var data = Data()
+        if style.hasBOM { data.append(contentsOf: utf8BOM) }
+        data.append(contentsOf: relined.utf8)
+        return data
+    }
+
+    /// Strip a leading BOM and normalize CRLF→LF for on-screen rendering, so the numbered read view is
+    /// not polluted by a U+FEFF on line 1 or a trailing `\r` on every line. Does not alter the file.
+    public static func normalizeForDisplay(_ text: String) -> String {
+        var result = text
+        if result.first == "\u{FEFF}" { result.removeFirst() }
+        return result.replacingOccurrences(of: "\r\n", with: "\n")
+    }
+}

--- a/Sources/QuillCodeTools/FileToolExecutor.swift
+++ b/Sources/QuillCodeTools/FileToolExecutor.swift
@@ -33,9 +33,12 @@ public struct FileToolExecutor: Sendable {
                 )
             }
             let text = String(data: data, encoding: .utf8) ?? ""
+            // Strip a leading BOM and normalize CRLF→LF so the numbered view is not polluted by a
+            // U+FEFF on line 1 or a trailing `\r` on every line. The file on disk is untouched.
+            let display = FileEncodingPreservation.normalizeForDisplay(text)
             return ToolResult(
                 ok: true,
-                stdout: FileReadRenderer.render(text, offset: offset, limit: limit),
+                stdout: FileReadRenderer.render(display, offset: offset, limit: limit),
                 artifacts: [url.path]
             )
         } catch {
@@ -50,7 +53,11 @@ public struct FileToolExecutor: Sendable {
                 at: url.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
-            try content.write(to: url, atomically: true, encoding: .utf8)
+            // Preserve the existing file's BOM + line-ending style so a content edit doesn't silently
+            // rewrite every line. A new file gets the default (bare UTF-8, LF, no BOM).
+            let style = (try? Data(contentsOf: url)).map(FileEncodingPreservation.detect) ?? .default
+            let data = FileEncodingPreservation.apply(content, style: style)
+            try data.write(to: url, options: .atomic)
             return ToolResult(ok: true, stdout: "Wrote \(url.path)\n", artifacts: [url.path])
         } catch {
             return ToolResult(ok: false, error: String(describing: error))

--- a/Tests/QuillCodeToolsTests/FileEncodingPreservationTests.swift
+++ b/Tests/QuillCodeToolsTests/FileEncodingPreservationTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import Foundation
+@testable import QuillCodeTools
+
+// MARK: - Unit: the pure detect/apply/normalize helper
+
+final class FileEncodingPreservationTests: XCTestCase {
+    private let bom = Data([0xEF, 0xBB, 0xBF])
+
+    // detect
+
+    func testDetectPlainLF() {
+        let style = FileEncodingPreservation.detect(Data("a\nb\n".utf8))
+        XCTAssertFalse(style.hasBOM)
+        XCTAssertEqual(style.lineEnding, .lf)
+    }
+
+    func testDetectCRLF() {
+        let style = FileEncodingPreservation.detect(Data("a\r\nb\r\n".utf8))
+        XCTAssertFalse(style.hasBOM)
+        XCTAssertEqual(style.lineEnding, .crlf)
+    }
+
+    func testDetectBOMWithCRLF() {
+        let style = FileEncodingPreservation.detect(bom + Data("a\r\nb\r\n".utf8))
+        XCTAssertTrue(style.hasBOM)
+        XCTAssertEqual(style.lineEnding, .crlf)
+    }
+
+    func testDetectBOMWithLF() {
+        let style = FileEncodingPreservation.detect(bom + Data("a\nb\n".utf8))
+        XCTAssertTrue(style.hasBOM)
+        XCTAssertEqual(style.lineEnding, .lf)
+    }
+
+    func testDetectEmptyDefaultsToLFNoBOM() {
+        XCTAssertEqual(FileEncodingPreservation.detect(Data()), .default)
+    }
+
+    func testDetectSingleLineNoNewlineDefaultsToLF() {
+        XCTAssertEqual(FileEncodingPreservation.detect(Data("no newline here".utf8)).lineEnding, .lf)
+    }
+
+    func testDetectMajorityWins() {
+        // Two CRLF, one LF → CRLF.
+        XCTAssertEqual(FileEncodingPreservation.detect(Data("a\r\nb\r\nc\nd".utf8)).lineEnding, .crlf)
+        // Two LF, one CRLF → LF.
+        XCTAssertEqual(FileEncodingPreservation.detect(Data("a\nb\nc\r\nd".utf8)).lineEnding, .lf)
+    }
+
+    // apply
+
+    func testApplyLFStyleLeavesContent() {
+        let data = FileEncodingPreservation.apply("a\nb\n", style: .default)
+        XCTAssertEqual(data, Data("a\nb\n".utf8))
+    }
+
+    func testApplyCRLFStyleRelines() {
+        let data = FileEncodingPreservation.apply("a\nb\n", style: .init(hasBOM: false, lineEnding: .crlf))
+        XCTAssertEqual(data, Data("a\r\nb\r\n".utf8))
+    }
+
+    func testApplyBOMStylePrepends() {
+        let data = FileEncodingPreservation.apply("a\n", style: .init(hasBOM: true, lineEnding: .lf))
+        XCTAssertEqual(data, bom + Data("a\n".utf8))
+    }
+
+    func testApplyCanonicalizesIncomingCRLFNoDoubling() {
+        // Incoming content that already has CRLF must not become CR-CR-LF under a CRLF style.
+        let data = FileEncodingPreservation.apply("a\r\nb\r\n", style: .init(hasBOM: false, lineEnding: .crlf))
+        XCTAssertEqual(data, Data("a\r\nb\r\n".utf8))
+    }
+
+    func testRoundTripPreserves() {
+        let original = bom + Data("x\r\ny\r\nz".utf8)
+        let style = FileEncodingPreservation.detect(original)
+        // The model reads it as LF (display-normalized) and writes that back.
+        let rewritten = FileEncodingPreservation.apply("x\ny\nz", style: style)
+        XCTAssertEqual(rewritten, original)
+    }
+
+    // normalizeForDisplay
+
+    func testNormalizeStripsBOMAndCRLF() {
+        XCTAssertEqual(FileEncodingPreservation.normalizeForDisplay("\u{FEFF}a\r\nb\r\n"), "a\nb\n")
+    }
+
+    func testNormalizeLeavesPlainText() {
+        XCTAssertEqual(FileEncodingPreservation.normalizeForDisplay("a\nb\n"), "a\nb\n")
+    }
+}

--- a/Tests/QuillCodeToolsTests/FileEncodingRoundTripTests.swift
+++ b/Tests/QuillCodeToolsTests/FileEncodingRoundTripTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import Foundation
+import QuillCodeCore
+@testable import QuillCodeTools
+
+// Shared helpers for the encoding round-trip tests.
+private let bom = Data([0xEF, 0xBB, 0xBF])
+
+private func makeWorkspace() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("qc-enc-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+}
+
+private func containsCRLF(_ data: Data) -> Bool {
+    let bytes = [UInt8](data)
+    for i in bytes.indices.dropLast() where bytes[i] == 0x0D && bytes[i + 1] == 0x0A {
+        return true
+    }
+    return false
+}
+
+// MARK: - Functional: through FileToolExecutor.write / .read
+
+final class FileEncodingExecutorFunctionalTests: XCTestCase {
+    func testWritePreservesBOMAndCRLFOfExistingFile() throws {
+        let root = try makeWorkspace()
+        let files = FileToolExecutor(workspaceRoot: root)
+        let url = root.appendingPathComponent("windows.txt")
+        try (bom + Data("old\r\nlines\r\n".utf8)).write(to: url)
+
+        // The model edits it with bare-LF content (as it always does).
+        XCTAssertTrue(files.write(path: "windows.txt", content: "new\nlines\n").ok)
+
+        let raw = try Data(contentsOf: url)
+        XCTAssertTrue(raw.starts(with: [0xEF, 0xBB, 0xBF]), "BOM must be preserved")
+        XCTAssertTrue(containsCRLF(raw), "CRLF must be preserved")
+        XCTAssertEqual(raw, bom + Data("new\r\nlines\r\n".utf8))
+    }
+
+    func testWriteNewFileIsPlainLFNoBOM() throws {
+        let root = try makeWorkspace()
+        let files = FileToolExecutor(workspaceRoot: root)
+        XCTAssertTrue(files.write(path: "fresh.txt", content: "a\nb\n").ok)
+        let raw = try Data(contentsOf: root.appendingPathComponent("fresh.txt"))
+        XCTAssertEqual(raw, Data("a\nb\n".utf8))
+    }
+
+    func testWriteOverLFFileStaysLF() throws {
+        let root = try makeWorkspace()
+        let files = FileToolExecutor(workspaceRoot: root)
+        let url = root.appendingPathComponent("unix.txt")
+        try Data("one\ntwo\n".utf8).write(to: url)
+        XCTAssertTrue(files.write(path: "unix.txt", content: "three\nfour\n").ok)
+        XCTAssertEqual(try Data(contentsOf: url), Data("three\nfour\n".utf8))
+    }
+
+    func testReadNormalizesBOMAndCRLFForDisplay() throws {
+        let root = try makeWorkspace()
+        let files = FileToolExecutor(workspaceRoot: root)
+        let url = root.appendingPathComponent("windows.txt")
+        try (bom + Data("a\r\nb\r\n".utf8)).write(to: url)
+        // The numbered view must be clean: no U+FEFF on line 1, no trailing \r.
+        XCTAssertEqual(files.read(path: "windows.txt").stdout, "1\ta\n2\tb")
+    }
+}
+
+// MARK: - Integration: through the ToolRouter dispatch the agent uses
+
+final class FileEncodingRouterIntegrationTests: XCTestCase {
+    func testRouterFileWritePreservesExistingStyle() throws {
+        let root = try makeWorkspace()
+        let url = root.appendingPathComponent("windows.txt")
+        try (bom + Data("old\r\n".utf8)).write(to: url)
+
+        let router = ToolRouter(workspaceRoot: root)
+        let call = ToolCall(
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: #"{"path":"windows.txt","content":"changed\n"}"#
+        )
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok, result.error ?? "")
+
+        let raw = try Data(contentsOf: url)
+        XCTAssertEqual(raw, bom + Data("changed\r\n".utf8))
+    }
+}


### PR DESCRIPTION
## What

`FileToolExecutor.write` re-encoded content as bare UTF-8/LF, so editing a **Windows-line-ending or BOM-prefixed file silently rewrote every line** — a one-line change became a whole-file diff (noise + a real correctness hazard on shared repos). This preserves the original file's byte-level style.

## How

- **`FileEncodingPreservation`** — a pure `detect` / `apply` / `normalizeForDisplay` helper.
  - `detect` reads the existing file's BOM + dominant line ending (CRLF-vs-LF by majority; ties / newline-free default to LF).
  - `apply` re-encodes model-authored (bare-LF) content to match — re-lining to CRLF and re-prepending the BOM when the original had them, canonicalizing any incoming CRLF first so it never doubles to CR-CR-LF.
  - `normalizeForDisplay` strips a leading BOM + CRLF for the read view **without touching the file**.
- `write` detects the existing file's style and writes matching bytes; a **new** file still gets the default (bare UTF-8, LF, no BOM).
- `read` normalizes for display so the numbered view isn't polluted by a U+FEFF on line 1 or a trailing `\r` on every line.

The **apply_patch path is unaffected**: `git apply` patches existing file bytes in place and never rewrites untouched lines, so it already preserves BOM + line endings.

## Tests — full pyramid

- **unit** — `FileEncodingPreservationTests`: detect (LF/CRLF/BOM combinations, empty, no-newline, majority), apply (re-line, BOM prepend, no CR-CR-LF doubling, full round-trip), normalizeForDisplay.
- **functional** — `FileEncodingExecutorFunctionalTests`: write over a BOM+CRLF file with LF content preserves BOM+CRLF byte-for-byte; a new file is plain LF/no-BOM; an LF file stays LF; read of a BOM+CRLF file renders clean numbered output.
- **integration** — `FileEncodingRouterIntegrationTests`: the same preservation through `ToolRouter.execute(fileWrite)`, the agent-facing dispatch.
- **playwright** — N/A: backend file I/O; the read view flows through already-tested numbered rendering.

Closes #854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)