### PR TITLE
fix(tools): UTF-8-boundary output cut, wc-style line count, lone-CR display

### DIFF
--- a/Sources/QuillCodeTools/FileEncodingPreservation.swift
+++ b/Sources/QuillCodeTools/FileEncodingPreservation.swift
@@ -65,9 +65,16 @@ public enum FileEncodingPreservation {
 
     /// Strip a leading BOM and normalize CRLF→LF for on-screen rendering, so the numbered read view is
     /// not polluted by a U+FEFF on line 1 or a trailing `\r` on every line. Does not alter the file.
+    ///
+    /// Lone CR (classic pre-OSX Mac endings) is also mapped to LF — CRLF first so it never doubles —
+    /// otherwise a CR-only file renders as ONE numbered line with embedded control characters.
+    /// (Display only: `detect`/`apply` deliberately stay CRLF-vs-LF; rewriting a CR-only file
+    /// normalizes it to LF, an acceptable edge for a 25-year-dead convention.)
     public static func normalizeForDisplay(_ text: String) -> String {
         var result = text
         if result.first == "\u{FEFF}" { result.removeFirst() }
-        return result.replacingOccurrences(of: "\r\n", with: "\n")
+        return result
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
     }
 }

--- a/Sources/QuillCodeTools/ShellOutputCapper.swift
+++ b/Sources/QuillCodeTools/ShellOutputCapper.swift
@@ -4,6 +4,9 @@ import Foundation
 /// context window on an unattended run. Truncates from the FRONT (keeps the tail) because for a shell
 /// run the ending — the final status, the error, the summary line — is what matters most. When it
 /// trims, it prepends an honest note so the model knows output was dropped.
+///
+/// `maxBytes` bounds the kept PAYLOAD; the one-line note is metadata prepended after capping, so the
+/// returned text can exceed `maxBytes` by the note's length.
 public enum ShellOutputCapper {
     public static let defaultMaxLines = 2000
     public static let defaultMaxBytes = 50_000
@@ -13,22 +16,37 @@ public enum ShellOutputCapper {
         maxLines: Int = defaultMaxLines,
         maxBytes: Int = defaultMaxBytes
     ) -> (text: String, truncated: Bool) {
-        let totalLines = text.isEmpty ? 0 : text.components(separatedBy: "\n").count
+        // A trailing newline TERMINATES the last line — it is not an extra empty line. Count the way
+        // `wc -l` does, so output exactly at the limit isn't truncated one line early (shell output
+        // almost always ends in a newline).
+        let hadTrailingNewline = text.hasSuffix("\n")
+        var lines = text.components(separatedBy: "\n")
+        if hadTrailingNewline {
+            lines.removeLast()
+        }
+        let totalLines = text.isEmpty ? 0 : lines.count
         let totalBytes = text.utf8.count
         guard totalLines > maxLines || totalBytes > maxBytes else {
             return (text, false)
         }
 
-        var lines = text.components(separatedBy: "\n")
         if lines.count > maxLines {
             lines = Array(lines.suffix(maxLines))
         }
         var kept = lines.joined(separator: "\n")
+        if hadTrailingNewline, !kept.isEmpty {
+            kept += "\n"
+        }
 
-        // Byte ceiling on the already line-trimmed tail: keep the last maxBytes bytes. Decoding a tail
-        // that may start mid-codepoint is tolerated (the leading partial byte becomes U+FFFD).
+        // Byte ceiling on the already line-trimmed tail: keep the last maxBytes bytes, then drop any
+        // leading UTF-8 continuation bytes (0b10xxxxxx) so the cut lands on a codepoint boundary — a
+        // raw byte cut can start mid-scalar and would decode to U+FFFD garbage at the head of the tail.
         if kept.utf8.count > maxBytes {
-            kept = String(decoding: Data(kept.utf8.suffix(maxBytes)), as: UTF8.self)
+            var bytes = Array(kept.utf8.suffix(maxBytes))
+            while let first = bytes.first, first & 0b1100_0000 == 0b1000_0000 {
+                bytes.removeFirst()
+            }
+            kept = String(decoding: bytes, as: UTF8.self)
         }
 
         let note = "[output truncated — showing the tail; \(totalLines) line\(totalLines == 1 ? "" : "s"), \(totalBytes) bytes total]\n"

--- a/Tests/QuillCodeToolsTests/FileEncodingPreservationTests.swift
+++ b/Tests/QuillCodeToolsTests/FileEncodingPreservationTests.swift
@@ -88,4 +88,14 @@ final class FileEncodingPreservationTests: XCTestCase {
     func testNormalizeLeavesPlainText() {
         XCTAssertEqual(FileEncodingPreservation.normalizeForDisplay("a\nb\n"), "a\nb\n")
     }
+
+    func testNormalizeMapsLoneCRToLF() {
+        // Classic pre-OSX Mac endings: without this a CR-only file renders as ONE numbered line.
+        XCTAssertEqual(FileEncodingPreservation.normalizeForDisplay("a\rb\rc"), "a\nb\nc")
+    }
+
+    func testNormalizeMixedCRLFAndLoneCRDoesNotDouble() {
+        // CRLF is replaced first, so the \r inside \r\n never becomes a second newline.
+        XCTAssertEqual(FileEncodingPreservation.normalizeForDisplay("a\r\nb\rc\n"), "a\nb\nc\n")
+    }
 }

--- a/Tests/QuillCodeToolsTests/FileEncodingRoundTripTests.swift
+++ b/Tests/QuillCodeToolsTests/FileEncodingRoundTripTests.swift
@@ -64,6 +64,15 @@ final class FileEncodingExecutorFunctionalTests: XCTestCase {
         // The numbered view must be clean: no U+FEFF on line 1, no trailing \r.
         XCTAssertEqual(files.read(path: "windows.txt").stdout, "1\ta\n2\tb")
     }
+
+    func testReadRendersLoneCRFileAsNumberedLines() throws {
+        // Classic-Mac CR-only endings must render as three numbered lines, not one line with
+        // embedded control characters.
+        let root = try makeWorkspace()
+        let files = FileToolExecutor(workspaceRoot: root)
+        try Data("one\rtwo\rthree".utf8).write(to: root.appendingPathComponent("classic.txt"))
+        XCTAssertEqual(files.read(path: "classic.txt").stdout, "1\tone\n2\ttwo\n3\tthree")
+    }
 }
 
 // MARK: - Integration: through the ToolRouter dispatch the agent uses

--- a/Tests/QuillCodeToolsTests/ShellOutputCapperTests.swift
+++ b/Tests/QuillCodeToolsTests/ShellOutputCapperTests.swift
@@ -33,6 +33,39 @@ final class ShellOutputCapperTests: XCTestCase {
     func testEmptyIsPassthrough() {
         XCTAssertFalse(ShellOutputCapper.cap("").truncated)
     }
+
+    func testExactlyMaxLinesWithTrailingNewlineIsNotTruncated() {
+        // 100 lines ending in a newline IS 100 lines (wc -l semantics) — the trailing newline must not
+        // count as a 101st empty line and trip the cap one line early.
+        let text = (1...100).map { "line\($0)\n" }.joined()
+        let result = ShellOutputCapper.cap(text, maxLines: 100, maxBytes: 1_000_000)
+        XCTAssertFalse(result.truncated)
+        XCTAssertEqual(result.text, text)
+    }
+
+    func testNoteReportsWcStyleLineCount() {
+        let text = (1...150).map { "line\($0)\n" }.joined()
+        let result = ShellOutputCapper.cap(text, maxLines: 100, maxBytes: 1_000_000)
+        XCTAssertTrue(result.truncated)
+        XCTAssertTrue(result.text.contains("150 lines"), "must report 150, not 151: \(result.text.prefix(80))")
+    }
+
+    func testByteCutLandsOnCodepointBoundaryNoReplacementChars() {
+        // 34 '€' (3 bytes each = 102 bytes) cut at 50 bytes lands mid-scalar; the cut must back off to
+        // a codepoint boundary instead of decoding dangling continuation bytes to U+FFFD garbage.
+        let text = String(repeating: "\u{20AC}", count: 34)
+        let result = ShellOutputCapper.cap(text, maxLines: 2000, maxBytes: 50)
+        XCTAssertTrue(result.truncated)
+        XCTAssertFalse(result.text.contains("\u{FFFD}"), "no replacement characters allowed")
+        XCTAssertTrue(result.text.hasSuffix("\u{20AC}"), "the tail should still be euro signs")
+    }
+
+    func testByteCutInsideFourByteScalarDropsItCleanly() {
+        // suffix(3) of a 4-byte emoji is pure continuation bytes — they must be dropped, not decoded.
+        let result = ShellOutputCapper.cap("a\u{1F600}", maxLines: 10, maxBytes: 3)
+        XCTAssertTrue(result.truncated)
+        XCTAssertFalse(result.text.contains("\u{FFFD}"))
+    }
 }
 
 // MARK: - Functional: through the shell executor with real output


### PR DESCRIPTION
## What

Hardening follow-ups from the adversarial review of the just-merged #867 (shell output cap) and #869 (BOM/CRLF preservation) — three real defects, each with a concrete failing input.

## Fixes

**`ShellOutputCapper`**
1. **Mid-scalar byte cut (high):** the byte ceiling sliced at a raw byte offset; a cut landing inside a multi-byte UTF-8 scalar decoded dangling continuation bytes to `U+FFFD` garbage at the head of the kept tail — common on any Unicode output (`grep` over emoji/accented source, box-drawing test logs). The cut now drops leading continuation bytes so it always lands on a codepoint boundary.
2. **Trailing-newline off-by-one (medium):** `components(separatedBy:)` counted the trailing newline as an extra empty line, so exactly-at-the-limit output was truncated one line early and the note over-reported the count. Now counted `wc -l` style; the kept tail preserves its trailing newline.
3. **Documented** that `maxBytes` bounds the payload and the one-line note is metadata on top (nit from review).

**`FileEncodingPreservation.normalizeForDisplay`**
4. **Lone-CR collapse (low):** a classic-Mac CR-only file rendered as ONE numbered line with embedded control chars. Lone CR now maps to LF for display (CRLF replaced first so nothing doubles). `detect`/`apply` deliberately stay CRLF-vs-LF.

## Tests — pyramid

- **unit** — exactly-at-limit trailing-newline passthrough; note reports wc-style count; euro-sign boundary cut contains no `U+FFFD` and still ends in `€`; 4-byte-emoji continuation bytes dropped cleanly; lone-CR and mixed CRLF+CR normalization.
- **functional** — a CR-only file reads as three numbered lines through the real `FileToolExecutor`.
- **integration** — existing `ToolRouter.execute` cap/write dispatch tests still green (behavior at the agent-facing layer unchanged except correctness).
- **playwright** — N/A: no DOM surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)