### PR TITLE
Guard blended aux-model cost against finite-price overflow

### DIFF
--- a/Sources/QuillCodeAgent/AuxiliaryModelSelector.swift
+++ b/Sources/QuillCodeAgent/AuxiliaryModelSelector.swift
@@ -103,14 +103,18 @@ public enum AuxiliaryModelSelector {
     }
 
     /// Auxiliary calls are prompt-heavy and reply short, so weight input cost 3:1.
-    /// nil when either price is missing, non-finite, zero, or negative.
+    /// nil when either price is missing, non-finite, zero, or negative — or when the blend itself
+    /// overflows to infinity (finite prices above ~6e307 do; an infinite blend would put NaN into
+    /// the cost-ratio scores and break the comparator's strict weak ordering).
     private static func blendedCost(_ capabilities: ModelCapabilities) -> Double? {
         guard let input = capabilities.inputPricePerMillionTokens,
               let output = capabilities.outputPricePerMillionTokens,
               input.isFinite, output.isFinite,
               input > 0, output > 0
         else { return nil }
-        return (3 * input + output) / 4
+        let blended = (3 * input + output) / 4
+        guard blended.isFinite else { return nil }
+        return blended
     }
 
     private static func blendedCost(ofCanonicalModelID modelID: String, in models: [ModelInfo]) -> Double? {

--- a/Tests/QuillCodeAgentTests/AuxiliaryModelSelectorTests.swift
+++ b/Tests/QuillCodeAgentTests/AuxiliaryModelSelectorTests.swift
@@ -172,6 +172,30 @@ final class AuxiliaryModelSelectorTests: XCTestCase {
         XCTAssertEqual(onlyPoisoned.source, .sessionModelFallback)
     }
 
+    func testFinitePricesWhoseBlendOverflowsCannotPoisonSelection() {
+        // (3 * input + output) / 4 overflows to +inf for finite prices above ~6e307/Mtok. If such
+        // blends became candidates, cheapestCost/cost = inf/inf = NaN would poison the scores,
+        // break the comparator's strict weak ordering, and make the winner catalog-order-dependent.
+        let junkA = pricedModel(id: "acme/junk-a", input: 7e307, output: 7e307)
+        let junkB = pricedModel(id: "acme/junk-b", input: 1e308, output: 1e308)
+
+        // Overflowing blends are not candidates at all: with nothing else in the catalog, both
+        // orders fall back to the (unpriced) session model instead of picking order-dependent junk.
+        for models in [[junkA, junkB], [junkB, junkA]] {
+            let selection = AuxiliaryModelSelector.selection(models: models, sessionModelID: "acme/flagship")
+            XCTAssertEqual(selection.modelID, "acme/flagship")
+            XCTAssertEqual(selection.source, .sessionModelFallback)
+        }
+
+        // And a legitimately priced model beats the junk in either order.
+        let sane = pricedModel(id: "acme/sane", input: 0.5, output: 2)
+        for models in [[junkA, junkB, sane], [sane, junkB, junkA]] {
+            let selection = AuxiliaryModelSelector.selection(models: models, sessionModelID: "acme/flagship")
+            XCTAssertEqual(selection.modelID, "acme/sane")
+            XCTAssertEqual(selection.source, .catalogHeuristic)
+        }
+    }
+
     func testZeroOrNegativePriceComponentsAreRejected() {
         let partialZeroInput = pricedModel(id: "acme/zero-input-nano", input: 0, output: 0.1)
         let partialZeroOutput = pricedModel(id: "acme/zero-output-nano", input: 0.1, output: 0)


### PR DESCRIPTION
## Defect

Residual minor defect found by the [post-merge adversarial re-verification of PR #892](https://github.com/Lore-Hex/QuillCode/pull/892#issuecomment-4862427483): `AuxiliaryModelSelector.blendedCost` validates that the input/output prices are finite but **not** that the blended result is. `(3 * input + output) / 4` overflows to `+inf` for finite prices above ~6e307/Mtok.

When every candidate overflows, `cheapestCost / cost = inf / inf = NaN` poisons the scores, `max(by:)` loses strict weak ordering, and the selection becomes catalog-order-dependent — verified repro: `[junk-a, junk-b]` picks junk-a, `[junk-b, junk-a]` picks junk-b. This contradicts the in-code invariant comment that all score inputs are finite and the comparator is a strict weak ordering regardless of catalog order.

## Fix

`blendedCost` now also requires the blended result itself to be finite (`guard blended.isFinite else { return nil }`), so overflow-priced entries are excluded from candidacy (and from the session-model cost ceiling) exactly like any other unpriced model.

## Tests

New regression test `testFinitePricesWhoseBlendOverflowsCannotPoisonSelection`:
- two candidates with finite-but-overflowing prices (7e307/7e307 and 1e308/1e308) plus an unpriced session model → both catalog orders fall back to the session model (`sessionModelFallback`), identical result
- adding a legitimately priced third candidate → it wins in either order (`catalogHeuristic`)

Verified the test bites: without the source fix it fails with the exact order-dependence (junk-a in one order, junk-b reversed).

- `swift test --filter QuillCodeAgentTests`: 265 tests, 0 failures
- full `swift test`: 2328 tests, 1 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)