### PR TITLE
Agent: Anthropic prompt-cache breakpoints (cache_control) on TrustedRouter requests

### DIFF
--- a/Sources/QuillCodeAgent/ModelOverridingLLMClient.swift
+++ b/Sources/QuillCodeAgent/ModelOverridingLLMClient.swift
@@ -25,3 +25,31 @@ extension RetryingLLMClient: ModelOverridingLLMClient where Base: ModelOverridin
         return copy
     }
 }
+
+/// An LLM client that can turn OFF Anthropic prompt-cache breakpoints on a copy of itself.
+/// One-shot auxiliary call sites (context summaries, compaction, subagent workers) use this:
+/// their prompts are unique and never re-sent, so a breakpoint could only ever be a cache write
+/// with no read — a pure cost premium. See `TrustedRouterPromptCaching`.
+public protocol PromptCacheControllableLLMClient: LLMClient {
+    /// A copy of this client that never adds prompt-cache breakpoints. The receiver is unchanged.
+    func disablingPromptCaching() -> Self
+}
+
+extension TrustedRouterLLMClient: PromptCacheControllableLLMClient {}
+
+extension RetryingLLMClient: PromptCacheControllableLLMClient
+where Base: PromptCacheControllableLLMClient {
+    /// Disables caching on the wrapped client while keeping this wrapper's retry policy.
+    public func disablingPromptCaching() -> RetryingLLMClient<Base> {
+        var copy = self
+        copy.base = base.disablingPromptCaching()
+        return copy
+    }
+}
+
+/// Returns `client` with prompt caching disabled when it supports the control, otherwise the
+/// client unchanged. Lets a call site opt a one-shot auxiliary path out of caching without
+/// knowing the concrete client type (e.g. a mock client in tests is passed through untouched).
+public func disablingPromptCachingIfSupported(_ client: any LLMClient) -> any LLMClient {
+    (client as? any PromptCacheControllableLLMClient)?.disablingPromptCaching() ?? client
+}

--- a/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
@@ -60,6 +60,15 @@ public struct TrustedRouterLLMClient: UsageStreamingLLMClient {
         self.promptCachingPolicy = promptCachingPolicy
     }
 
+    /// A copy of this client that never adds prompt-cache breakpoints. Use it for one-shot
+    /// auxiliary calls (context summaries, compaction) whose unique prompts are never re-sent,
+    /// where a breakpoint could only ever be a cache write with no read.
+    public func disablingPromptCaching() -> TrustedRouterLLMClient {
+        var copy = self
+        copy.promptCachingPolicy = .disabled
+        return copy
+    }
+
     public func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
         let stream = try await actionTextStream(thread: thread, userMessage: userMessage, tools: tools)
         return try await Self.collectAction(from: stream)
@@ -98,15 +107,16 @@ public struct TrustedRouterLLMClient: UsageStreamingLLMClient {
     ) async throws -> AsyncThrowingStream<AgentTextStreamEvent, Error> {
         let apiKey = try configuredAPIKey()
         let client = try TrustedRouter(options: .init(apiKey: apiKey, baseUrl: baseURL))
-        let messages = promptBuilder.messages(thread: thread, userMessage: userMessage, tools: tools)
+        let assembled = promptBuilder.assembled(thread: thread, userMessage: userMessage, tools: tools)
         let (bytes, response) = try await client.rawStreamRequest(
             method: "POST",
             path: "/chat/completions",
             headers: ["accept": "text/event-stream"],
             body: try Self.chatCompletionBody(
                 model: model,
-                messages: messages,
-                promptCachingPolicy: promptCachingPolicy
+                messages: assembled.messages,
+                promptCachingPolicy: promptCachingPolicy,
+                historyPrefixStable: assembled.historyPrefixStable
             )
         )
         if response.statusCode >= 400 {
@@ -155,18 +165,25 @@ public struct TrustedRouterLLMClient: UsageStreamingLLMClient {
     }
 
     /// Internal (not private) so tests can assert over the exact serialized request JSON —
-    /// cache breakpoints present or absent per policy and provider family.
+    /// cache breakpoints present or absent per policy, provider family, and prefix stability.
+    ///
+    /// `historyPrefixStable` defaults to `false` — the SAFE default. A caller that cannot prove
+    /// the request's post-system prefix is byte-stable turn-over-turn (see
+    /// `TrustedRouterPromptBuilder.assembled`) gets no annotation, because a moving prefix turns
+    /// caching into a pure cache-WRITE premium.
     static func chatCompletionBody(
         model: String,
         messages: [[String: Any]],
-        promptCachingPolicy: TrustedRouterPromptCachingPolicy = .automatic
+        promptCachingPolicy: TrustedRouterPromptCachingPolicy = .automatic,
+        historyPrefixStable: Bool = false
     ) throws -> Data {
         var body = TrustedRouterChatParameters.jsonObjectResponse
         body["model"] = model
         body["messages"] = TrustedRouterPromptCaching.annotatedMessages(
             messages,
             modelID: model,
-            policy: promptCachingPolicy
+            policy: promptCachingPolicy,
+            historyPrefixStable: historyPrefixStable
         )
         body["stream"] = true
         body["stream_options"] = ["include_usage": true]

--- a/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterLLMClient.swift
@@ -39,19 +39,25 @@ public struct TrustedRouterLLMClient: UsageStreamingLLMClient {
     public var apiKeyOverride: String?
     public var model: String
     public var baseURL: String
+    /// Prompt-cache breakpoints are placed automatically for Anthropic-family models (a large
+    /// recurring cost and latency win for the agent loop) and never for other routes, whose
+    /// requests stay byte-identical. Set `.disabled` to opt out entirely.
+    public var promptCachingPolicy: TrustedRouterPromptCachingPolicy
 
     public init(
         promptBuilder: TrustedRouterPromptBuilder = .init(),
         sessionStore: (any TrustedRouterSessionStore)? = nil,
         apiKeyOverride: String? = nil,
         model: String = TrustedRouterDefaults.defaultModel,
-        baseURL: String = TrustedRouterDefaults.defaultAPIBaseURL
+        baseURL: String = TrustedRouterDefaults.defaultAPIBaseURL,
+        promptCachingPolicy: TrustedRouterPromptCachingPolicy = .automatic
     ) {
         self.promptBuilder = promptBuilder
         self.sessionStore = sessionStore
         self.apiKeyOverride = apiKeyOverride
         self.model = model
         self.baseURL = baseURL
+        self.promptCachingPolicy = promptCachingPolicy
     }
 
     public func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
@@ -97,7 +103,11 @@ public struct TrustedRouterLLMClient: UsageStreamingLLMClient {
             method: "POST",
             path: "/chat/completions",
             headers: ["accept": "text/event-stream"],
-            body: try Self.chatCompletionBody(model: model, messages: messages)
+            body: try Self.chatCompletionBody(
+                model: model,
+                messages: messages,
+                promptCachingPolicy: promptCachingPolicy
+            )
         )
         if response.statusCode >= 400 {
             throw TrustedRouterAgentError.streamingHTTPError(
@@ -144,10 +154,20 @@ public struct TrustedRouterLLMClient: UsageStreamingLLMClient {
         ).configuredAPIKey()
     }
 
-    private static func chatCompletionBody(model: String, messages: [[String: Any]]) throws -> Data {
+    /// Internal (not private) so tests can assert over the exact serialized request JSON —
+    /// cache breakpoints present or absent per policy and provider family.
+    static func chatCompletionBody(
+        model: String,
+        messages: [[String: Any]],
+        promptCachingPolicy: TrustedRouterPromptCachingPolicy = .automatic
+    ) throws -> Data {
         var body = TrustedRouterChatParameters.jsonObjectResponse
         body["model"] = model
-        body["messages"] = messages
+        body["messages"] = TrustedRouterPromptCaching.annotatedMessages(
+            messages,
+            modelID: model,
+            policy: promptCachingPolicy
+        )
         body["stream"] = true
         body["stream_options"] = ["include_usage": true]
         return try JSONSerialization.data(withJSONObject: body)

--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -12,6 +12,20 @@ public struct TrustedRouterPromptBuilder: Sendable {
         userMessage: String,
         tools: [ToolDefinition]
     ) -> [[String: Any]] {
+        assembled(thread: thread, userMessage: userMessage, tools: tools).messages
+    }
+
+    /// The assembled request messages plus whether the sliding history window is append-stable
+    /// this turn — i.e. `historyLimit` has not yet forced `suffix(historyLimit)` to DROP the
+    /// oldest message. Prompt-cache breakpoints are only safe while it is: once the window
+    /// saturates, the first history block differs turn-over-turn, the whole post-system prefix
+    /// diverges, and a positional breakpoint would write-without-ever-reading (a net cost
+    /// increase). The caller uses this flag to gate annotation. See `TrustedRouterPromptCaching`.
+    func assembled(
+        thread: ChatThread,
+        userMessage: String,
+        tools: [ToolDefinition]
+    ) -> (messages: [[String: Any]], historyPrefixStable: Bool) {
         var messages: [[String: Any]] = [
             Self.chatMessage(role: "system", content: Self.systemPrompt(tools: tools))
         ]
@@ -22,7 +36,7 @@ public struct TrustedRouterPromptBuilder: Sendable {
         appendRecentHistory(from: thread, to: &messages)
         appendCurrentUserMessageIfNeeded(thread: thread, userMessage: userMessage, to: &messages)
 
-        return messages
+        return (messages, thread.messages.count <= historyLimit)
     }
 
     public static func systemPrompt(tools: [ToolDefinition]) -> String {

--- a/Sources/QuillCodeAgent/TrustedRouterPromptCaching.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptCaching.swift
@@ -14,22 +14,33 @@ public enum TrustedRouterPromptCachingPolicy: Sendable, Equatable {
 
 /// Places Anthropic prompt-cache breakpoints on an OpenAI-format `messages` array.
 ///
-/// TrustedRouter's Anthropic adapter forwards user/assistant message `content` verbatim into
-/// the Anthropic Messages payload, so a `cache_control` marker inside an array-shaped content
-/// block reaches api.anthropic.com and turns the entire request prefix — system prompt, tool
-/// definitions (serialized into the system prompt), and conversation history up to the marked
-/// block — into a 5-minute cache entry. Re-sent prefixes then bill at the cached-read rate
-/// (~10% of the input price) instead of full price, which is the dominant recurring cost of
-/// the unattended agent loop.
+/// A `cache_control` marker inside an array-shaped content block is Anthropic's request to turn
+/// the request prefix up to that block into a 5-minute ephemeral cache entry, so re-sent
+/// prefixes bill at the cached-read rate (~10% of input) instead of full price — the dominant
+/// recurring cost of the unattended agent loop.
 ///
-/// Two hard constraints shape the placement rules:
-/// - The gateway concatenates SYSTEM message content with `str()` into Anthropic's top-level
-///   `system` string. Array-shaped system content would therefore be corrupted into a Python
-///   repr, so system messages are never annotated. This costs nothing: a breakpoint on a later
-///   message already caches the system prefix.
+/// GATEWAY STATE (live-verified 2026-07-01, api.trustedrouter.com): the deployed gateway
+/// forwards `cache_control` verbatim on the Anthropic-native `/v1/messages` path
+/// (`cache_creation_input_tokens` then `cache_read_input_tokens` observed on identical calls)
+/// but currently DROPS it on the OpenAI-format `/chat/completions` path that QuillCode uses (a
+/// six-marker request returned 200 there while `/v1/messages` returned Anthropic's own
+/// four-marker 400). So today these breakpoints are a safe no-op on the chat path; they become
+/// the intended win once the gateway forwards them on that path (tracked as a gateway follow-up).
+///
+/// Three constraints shape the placement rules:
+/// - Prefix stability. A breakpoint only pays off when the bytes BEFORE it repeat unchanged on
+///   the next request; otherwise every call is a cache WRITE (billed at 1.25x) with no read — a
+///   net cost INCREASE. `TrustedRouterPromptBuilder` sends a sliding history window, so once it
+///   saturates the post-system prefix diverges each turn. Annotation is gated on
+///   `historyPrefixStable`; when false the request is sent unannotated (durable long-loop
+///   caching needs the builder to pin the window edges — see the gateway/builder follow-up).
+/// - System messages are never annotated: the gateway concatenates SYSTEM content with `str()`
+///   into Anthropic's top-level `system` string, so array-shaped system content would be
+///   corrupted into a Python repr. A breakpoint on a later message already caches the system
+///   prefix, so this costs nothing.
 /// - Non-Anthropic upstreams receive the `messages` array verbatim, and strict providers can
-///   reject unknown fields inside content parts. Annotation is therefore gated to model IDs
-///   whose provider family is Anthropic; every other route's request bytes are unchanged.
+///   reject unknown fields inside content parts. Annotation is gated to model IDs whose provider
+///   family is Anthropic; every other route's request bytes are unchanged.
 public enum TrustedRouterPromptCaching {
     /// Anthropic's default ephemeral cache entry (5-minute TTL).
     static let ephemeralCacheControl = ["type": "ephemeral"]
@@ -46,12 +57,22 @@ public enum TrustedRouterPromptCaching {
 
     /// The messages to send for `modelID` under `policy`: either the input untouched, or the
     /// input with cache breakpoints placed per `breakpointIndexes`.
+    ///
+    /// `historyPrefixStable` must be true for annotation to occur: it asserts the caller has
+    /// proven the request's post-system prefix repeats byte-for-byte on the next turn (the
+    /// sliding history window has not dropped its oldest message). When false, the request is
+    /// returned untouched — a moving prefix would make every breakpoint a cache write with no
+    /// possible read, i.e. a net cost increase in exactly the long-loop regime this targets.
     public static func annotatedMessages(
         _ messages: [[String: Any]],
         modelID: String,
-        policy: TrustedRouterPromptCachingPolicy
+        policy: TrustedRouterPromptCachingPolicy,
+        historyPrefixStable: Bool
     ) -> [[String: Any]] {
-        guard policy == .automatic, supportsCacheBreakpoints(modelID: modelID) else {
+        guard policy == .automatic,
+              historyPrefixStable,
+              supportsCacheBreakpoints(modelID: modelID)
+        else {
             return messages
         }
         return annotated(messages)

--- a/Sources/QuillCodeAgent/TrustedRouterPromptCaching.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptCaching.swift
@@ -1,0 +1,119 @@
+import Foundation
+import QuillCodeCore
+
+/// Whether the request builder may add Anthropic prompt-cache breakpoints (`cache_control`)
+/// to the outgoing chat messages.
+public enum TrustedRouterPromptCachingPolicy: Sendable, Equatable {
+    /// Add breakpoints when the target model's provider family is known to accept them
+    /// (Anthropic models routed through TrustedRouter). Every other route sends the exact
+    /// request it sent before this feature existed.
+    case automatic
+    /// Never add breakpoints.
+    case disabled
+}
+
+/// Places Anthropic prompt-cache breakpoints on an OpenAI-format `messages` array.
+///
+/// TrustedRouter's Anthropic adapter forwards user/assistant message `content` verbatim into
+/// the Anthropic Messages payload, so a `cache_control` marker inside an array-shaped content
+/// block reaches api.anthropic.com and turns the entire request prefix — system prompt, tool
+/// definitions (serialized into the system prompt), and conversation history up to the marked
+/// block — into a 5-minute cache entry. Re-sent prefixes then bill at the cached-read rate
+/// (~10% of the input price) instead of full price, which is the dominant recurring cost of
+/// the unattended agent loop.
+///
+/// Two hard constraints shape the placement rules:
+/// - The gateway concatenates SYSTEM message content with `str()` into Anthropic's top-level
+///   `system` string. Array-shaped system content would therefore be corrupted into a Python
+///   repr, so system messages are never annotated. This costs nothing: a breakpoint on a later
+///   message already caches the system prefix.
+/// - Non-Anthropic upstreams receive the `messages` array verbatim, and strict providers can
+///   reject unknown fields inside content parts. Annotation is therefore gated to model IDs
+///   whose provider family is Anthropic; every other route's request bytes are unchanged.
+public enum TrustedRouterPromptCaching {
+    /// Anthropic's default ephemeral cache entry (5-minute TTL).
+    static let ephemeralCacheControl = ["type": "ephemeral"]
+
+    static let anthropicProviderFamily = "anthropic"
+
+    /// True when `modelID` routes to a provider family that understands `cache_control`
+    /// (Anthropic). Router-native meta-models (`trustedrouter/fast`, `tr/synth`, …) and other
+    /// provider families return false so their requests stay byte-identical.
+    public static func supportsCacheBreakpoints(modelID: String) -> Bool {
+        TrustedRouterDefaults.provider(fromModelID: modelID)
+            .caseInsensitiveCompare(anthropicProviderFamily) == .orderedSame
+    }
+
+    /// The messages to send for `modelID` under `policy`: either the input untouched, or the
+    /// input with cache breakpoints placed per `breakpointIndexes`.
+    public static func annotatedMessages(
+        _ messages: [[String: Any]],
+        modelID: String,
+        policy: TrustedRouterPromptCachingPolicy
+    ) -> [[String: Any]] {
+        guard policy == .automatic, supportsCacheBreakpoints(modelID: modelID) else {
+            return messages
+        }
+        return annotated(messages)
+    }
+
+    static func annotated(_ messages: [[String: Any]]) -> [[String: Any]] {
+        var annotated = messages
+        for index in breakpointIndexes(messages) {
+            guard let text = annotatableText(of: messages[index]) else { continue }
+            var message = messages[index]
+            message["content"] = [
+                [
+                    "type": "text",
+                    "text": text,
+                    "cache_control": ephemeralCacheControl
+                ] as [String: Any]
+            ]
+            annotated[index] = message
+        }
+        return annotated
+    }
+
+    /// Deterministic breakpoint positions, newest-prefix-first semantics:
+    ///
+    /// 1. The LATEST user message. Its breakpoint caches everything before it — system prompt,
+    ///    tool definitions, and history — and stays on the same element for every model call
+    ///    within the turn's tool loop, so intra-turn calls re-read one stable cache entry.
+    /// 2. The FINAL message, when the request continues past the latest user message (tool
+    ///    feedback is appended as assistant messages). Each loop iteration then extends the
+    ///    cache over the previous iteration's tool output instead of re-reading it at full
+    ///    price. Prior turns' breakpoints remain valid cache entries on Anthropic's side, so
+    ///    moving this marker forward never invalidates the cached prefix behind it.
+    ///
+    /// System messages are never candidates (see the type comment: the gateway would corrupt
+    /// array-shaped system content). At most two breakpoints are placed, well under Anthropic's
+    /// four-breakpoint limit.
+    static func breakpointIndexes(_ messages: [[String: Any]]) -> [Int] {
+        var indexes: [Int] = []
+        if let lastUser = messages.lastIndex(where: { role(of: $0) == "user" }) {
+            indexes.append(lastUser)
+        }
+        if let last = messages.indices.last,
+           role(of: messages[last]) == "assistant",
+           indexes.last != last {
+            indexes.append(last)
+        }
+        return indexes
+    }
+
+    /// The message's content when it is a plain non-empty string — the only shape this
+    /// annotator rewrites. Array or missing content is left untouched (never re-wrapped), and
+    /// whitespace-only text is skipped because Anthropic rejects blank text blocks.
+    private static func annotatableText(of message: [String: Any]) -> String? {
+        guard let content = message["content"] as? String,
+              content.contains(where: { !$0.isWhitespace })
+        else {
+            return nil
+        }
+        return content
+    }
+
+    private static func role(of message: [String: Any]) -> String? {
+        message["role"] as? String
+    }
+}

--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -79,10 +79,15 @@ public struct QuillCodeRuntimeFactory: Sendable {
             base: baseClient,
             onRetry: { attempt, kind, _ in retryChannel.record(attempt: attempt, kind: kind) }
         )
-        // Context-summary calls also retry transient blips, but SILENTLY: a background summary self-heal
-        // is not a run event and must not record to the run channel (that would misattribute it onto the
-        // next run's thread). So it gets its own wrapper with no onRetry.
-        let summaryLLM = RetryingLLMClient(base: baseClient)
+        // Context-summary/compaction calls are one-shot auxiliary housekeeping: each prompt is
+        // unique and never re-sent, so a prompt-cache breakpoint on it could only ever be a cache
+        // WRITE (billed at 1.25x) with no possible read. The auxiliary-model selector can pick an
+        // Anthropic model (it bonus-scores haiku), so we must explicitly opt this path OUT of
+        // caching — the run loop keeps it on. Its own retry wrapper carries no onRetry: SILENTLY,
+        // because a background summary self-heal is not a run event and must not record to the run
+        // channel (that would misattribute it onto the next run's thread).
+        let summaryBaseClient = baseClient.disablingPromptCaching()
+        let summaryLLM = RetryingLLMClient(base: summaryBaseClient)
         let safetyClient = TrustedRouterSafetyModelClient(
             sessionStore: sessionStore,
             apiKeyOverride: apiKey,

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -112,8 +112,16 @@ public final class QuillCodeWorkspaceModel {
             : nil
         self.sidebarSelection = sidebarSelection
         self.runner = runner
+        // Subagent-worker calls are one-shot auxiliary housekeeping: LLMWorkspaceSubagentWorker.run
+        // issues a single tool-free nextAction on a fresh, unique-prompt ChatThread that is never
+        // re-sent, so a prompt-cache breakpoint on it could only ever be a cache WRITE with no read
+        // (a pure cost premium) — the same class as the context-summary path RuntimeFactory
+        // disables. Opt this path out too; a non-caching client (e.g. the mock) is passed through
+        // untouched.
         self.subagentScheduler = WorkspaceSubagentScheduler(
-            worker: LLMWorkspaceSubagentWorker.scheduledWorker(llm: runner.llm)
+            worker: LLMWorkspaceSubagentWorker.scheduledWorker(
+                llm: disablingPromptCachingIfSupported(runner.llm)
+            )
         )
         self.contextSummaryGenerator = contextSummaryGenerator
         self.threadPersistence = WorkspaceThreadPersistence(store: threadStore)

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptCachingTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptCachingTests.swift
@@ -1,0 +1,294 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+final class TrustedRouterPromptCachingTests: XCTestCase {
+    private let anthropicModel = "anthropic/claude-sonnet-4.5"
+
+    // MARK: - Helpers
+
+    private func message(_ role: String, _ content: Any) -> [String: Any] {
+        ["role": role, "content": content]
+    }
+
+    /// Decodes the exact request body the client would send, so assertions run over the
+    /// serialized JSON rather than intermediate Swift values.
+    private func serializedBody(
+        model: String,
+        messages: [[String: Any]],
+        policy: TrustedRouterPromptCachingPolicy = .automatic
+    ) throws -> [String: Any] {
+        let data = try TrustedRouterLLMClient.chatCompletionBody(
+            model: model,
+            messages: messages,
+            promptCachingPolicy: policy
+        )
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    private func bodyMessages(_ body: [String: Any]) throws -> [[String: Any]] {
+        try XCTUnwrap(body["messages"] as? [[String: Any]])
+    }
+
+    /// The indexes of messages carrying a cache breakpoint, and the shape check for each:
+    /// content must be exactly one text part with `cache_control: {type: ephemeral}`.
+    private func breakpointIndexes(in messages: [[String: Any]]) -> [Int] {
+        messages.indices.filter { index in
+            guard let parts = messages[index]["content"] as? [[String: Any]] else { return false }
+            return parts.contains { ($0["cache_control"] as? [String: String]) != nil }
+        }
+    }
+
+    private func assertEphemeralTextBreakpoint(
+        _ message: [String: Any],
+        originalText: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let parts = try XCTUnwrap(message["content"] as? [[String: Any]], file: file, line: line)
+        XCTAssertEqual(parts.count, 1, "breakpoint content must stay a single text part", file: file, line: line)
+        XCTAssertEqual(parts[0]["type"] as? String, "text", file: file, line: line)
+        XCTAssertEqual(parts[0]["text"] as? String, originalText, "text must be preserved verbatim", file: file, line: line)
+        XCTAssertEqual(parts[0]["cache_control"] as? [String: String], ["type": "ephemeral"], file: file, line: line)
+    }
+
+    // MARK: - Provider-family gating
+
+    func testOnlyAnthropicFamilyModelsSupportCacheBreakpoints() {
+        XCTAssertTrue(TrustedRouterPromptCaching.supportsCacheBreakpoints(modelID: "anthropic/claude-sonnet-4.5"))
+        XCTAssertTrue(TrustedRouterPromptCaching.supportsCacheBreakpoints(modelID: "anthropic/claude-opus-4.8"))
+        XCTAssertTrue(
+            TrustedRouterPromptCaching.supportsCacheBreakpoints(modelID: "Anthropic/claude-haiku-4.5"),
+            "provider-family match must be case-insensitive"
+        )
+
+        for modelID in [
+            TrustedRouterDefaults.fastModel,
+            TrustedRouterDefaults.synthModel,
+            TrustedRouterDefaults.socratesModel,
+            TrustedRouterDefaults.safetyPrimaryCatalogModel,
+            TrustedRouterDefaults.safetyFallbackCatalogModel,
+            "gemini/gemini-2.5-pro",
+            "openai/gpt-5.2",
+            "claude-sonnet-4.5"  // no provider prefix -> router-native, not provably Anthropic
+        ] {
+            XCTAssertFalse(
+                TrustedRouterPromptCaching.supportsCacheBreakpoints(modelID: modelID),
+                "\(modelID) must not receive cache_control"
+            )
+        }
+    }
+
+    // MARK: - Placement
+
+    func testBreakpointLandsOnLatestUserMessageAndCoversNothingElse() throws {
+        let messages = [
+            message("system", "base system prompt with tool definitions"),
+            message("system", "project instructions"),
+            message("user", "first request"),
+            message("assistant", "first answer"),
+            message("user", "second request")
+        ]
+
+        let sent = try bodyMessages(serializedBody(model: anthropicModel, messages: messages))
+
+        XCTAssertEqual(breakpointIndexes(in: sent), [4], "exactly one breakpoint, on the LAST user message")
+        try assertEphemeralTextBreakpoint(sent[4], originalText: "second request")
+        for index in [0, 1, 2, 3] {
+            XCTAssertEqual(
+                sent[index]["content"] as? String,
+                messages[index]["content"] as? String,
+                "message \(index) must be sent as the original plain string"
+            )
+        }
+    }
+
+    func testToolLoopAddsSecondBreakpointOnFinalAssistantMessage() throws {
+        let messages = [
+            message("system", "base system prompt"),
+            message("user", "run the tests"),
+            message("assistant", "{\"type\":\"tool\",\"name\":\"host.shell.run\"}"),
+            message("assistant", "Tool output: 12 tests passed")
+        ]
+
+        let sent = try bodyMessages(serializedBody(model: anthropicModel, messages: messages))
+
+        XCTAssertEqual(
+            breakpointIndexes(in: sent),
+            [1, 3],
+            "latest user message plus the final tool-feedback message, nothing else"
+        )
+        try assertEphemeralTextBreakpoint(sent[1], originalText: "run the tests")
+        try assertEphemeralTextBreakpoint(sent[3], originalText: "Tool output: 12 tests passed")
+        XCTAssertEqual(sent[2]["content"] as? String, "{\"type\":\"tool\",\"name\":\"host.shell.run\"}")
+    }
+
+    /// The TrustedRouter gateway `str()`-concatenates system message content into Anthropic's
+    /// top-level `system` string, so array-shaped system content would be corrupted into a
+    /// Python repr. System messages must therefore never be annotated — under any layout.
+    func testSystemMessagesAreNeverAnnotated() throws {
+        let onlySystem = [
+            message("system", "base system prompt"),
+            message("system", "project instructions")
+        ]
+        let sent = try bodyMessages(serializedBody(model: anthropicModel, messages: onlySystem))
+        XCTAssertEqual(breakpointIndexes(in: sent), [])
+        for (index, original) in onlySystem.enumerated() {
+            XCTAssertEqual(sent[index]["content"] as? String, original["content"] as? String)
+        }
+    }
+
+    // MARK: - Turn-over-turn stability
+
+    /// Breakpoints must move only FORWARD as the conversation grows: every message that was in
+    /// the previous request's cached prefix is re-sent byte-identically (as a plain string), so
+    /// the prior turn's cache entry still matches and the new breakpoint extends it.
+    func testGrowingHistoryKeepsPreviousPrefixIdenticalAndAdvancesTheBreakpoint() throws {
+        let turnOne = [
+            message("system", "base system prompt"),
+            message("user", "first request")
+        ]
+        let turnTwo = turnOne + [
+            message("assistant", "first answer"),
+            message("user", "second request")
+        ]
+
+        let sentOne = try bodyMessages(serializedBody(model: anthropicModel, messages: turnOne))
+        let sentTwo = try bodyMessages(serializedBody(model: anthropicModel, messages: turnTwo))
+
+        XCTAssertEqual(breakpointIndexes(in: sentOne), [1])
+        XCTAssertEqual(breakpointIndexes(in: sentTwo), [3], "breakpoint advances to the new latest user message")
+
+        // Turn two re-sends turn one's messages exactly as turn one's UNANNOTATED form.
+        // (Anthropic normalizes a plain string to a single text block, so the prefix hash
+        // matches the entry the turn-one breakpoint created.)
+        for index in turnOne.indices {
+            XCTAssertEqual(sentTwo[index]["role"] as? String, turnOne[index]["role"] as? String)
+            XCTAssertEqual(
+                sentTwo[index]["content"] as? String,
+                turnOne[index]["content"] as? String,
+                "previously cached message \(index) must be re-sent as the original plain string"
+            )
+        }
+    }
+
+    /// Within one turn's tool loop the latest user message does not change, so its breakpoint
+    /// must stay on the same element while the trailing breakpoint follows the newest feedback.
+    func testIntraTurnToolLoopKeepsUserBreakpointStable() throws {
+        var messages = [
+            message("system", "base system prompt"),
+            message("user", "run the tests")
+        ]
+        let userIndex = 1
+
+        for step in 0..<3 {
+            messages.append(message("assistant", "Tool output: step \(step)"))
+            let sent = try bodyMessages(serializedBody(model: anthropicModel, messages: messages))
+            XCTAssertEqual(
+                breakpointIndexes(in: sent),
+                [userIndex, messages.count - 1],
+                "step \(step): stable user breakpoint plus trailing feedback breakpoint"
+            )
+        }
+    }
+
+    // MARK: - Non-Anthropic routes stay byte-identical
+
+    func testNonAnthropicRequestsAreExactlyTheUncachedRequest() throws {
+        let messages = [
+            message("system", "base system prompt"),
+            message("user", "run the tests"),
+            message("assistant", "Tool output: ok")
+        ]
+
+        for modelID in [
+            TrustedRouterDefaults.fastModel,
+            TrustedRouterDefaults.synthModel,
+            "z-ai/glm-5.2",
+            "gemini/gemini-2.5-pro"
+        ] {
+            let automatic = try TrustedRouterLLMClient.chatCompletionBody(
+                model: modelID,
+                messages: messages,
+                promptCachingPolicy: .automatic
+            )
+            let disabled = try TrustedRouterLLMClient.chatCompletionBody(
+                model: modelID,
+                messages: messages,
+                promptCachingPolicy: .disabled
+            )
+            let automaticObject = try XCTUnwrap(try JSONSerialization.jsonObject(with: automatic) as? NSDictionary)
+            let disabledObject = try XCTUnwrap(try JSONSerialization.jsonObject(with: disabled) as? NSDictionary)
+            XCTAssertEqual(automaticObject, disabledObject, "\(modelID): automatic policy must not alter the request")
+            XCTAssertFalse(
+                String(decoding: automatic, as: UTF8.self).contains("cache_control"),
+                "\(modelID) must never see cache_control"
+            )
+        }
+    }
+
+    func testDisabledPolicySendsAnthropicRequestUnannotated() throws {
+        let messages = [
+            message("system", "base system prompt"),
+            message("user", "run the tests")
+        ]
+        let body = try serializedBody(model: anthropicModel, messages: messages, policy: .disabled)
+        XCTAssertEqual(breakpointIndexes(in: try bodyMessages(body)), [])
+        let sent = try bodyMessages(body)
+        XCTAssertEqual(sent[1]["content"] as? String, "run the tests")
+    }
+
+    // MARK: - Request envelope regression
+
+    func testAnnotationLeavesTheRestOfTheRequestEnvelopeUntouched() throws {
+        let body = try serializedBody(
+            model: anthropicModel,
+            messages: [message("system", "s"), message("user", "u")]
+        )
+        XCTAssertEqual(body["model"] as? String, anthropicModel)
+        XCTAssertEqual(body["stream"] as? Bool, true)
+        XCTAssertEqual(body["stream_options"] as? [String: Bool], ["include_usage": true])
+        XCTAssertEqual(body["response_format"] as? [String: String], ["type": "json_object"])
+    }
+
+    // MARK: - Robustness
+
+    func testWhitespaceOnlyAndNonStringContentAreLeftUntouched() throws {
+        // Anthropic rejects blank text blocks, and content that is already an array must never
+        // be re-wrapped — skip annotation entirely rather than risk a malformed request.
+        let alreadyArray: [[String: Any]] = [["type": "text", "text": "pre-shaped"]]
+        let messages: [[String: Any]] = [
+            message("system", "base system prompt"),
+            message("user", "   \n"),
+            message("assistant", alreadyArray),
+            message("user", 42)
+        ]
+
+        let sent = try bodyMessages(serializedBody(model: anthropicModel, messages: messages))
+
+        XCTAssertEqual(breakpointIndexes(in: sent), [])
+        XCTAssertEqual(sent[1]["content"] as? String, "   \n")
+        let preserved = try XCTUnwrap(sent[2]["content"] as? [[String: Any]])
+        XCTAssertEqual(preserved.count, 1)
+        XCTAssertEqual(preserved[0]["text"] as? String, "pre-shaped")
+        XCTAssertNil(preserved[0]["cache_control"], "pre-shaped array content must not be annotated")
+        XCTAssertEqual(sent[3]["content"] as? Int, 42)
+    }
+
+    func testEmptyMessageListStaysEmpty() {
+        XCTAssertTrue(TrustedRouterPromptCaching.annotated([]).isEmpty)
+        XCTAssertEqual(TrustedRouterPromptCaching.breakpointIndexes([]), [])
+    }
+
+    func testClientDefaultsToAutomaticPolicyAndModelOverrideKeepsIt() {
+        let client = TrustedRouterLLMClient(promptCachingPolicy: .disabled)
+        XCTAssertEqual(client.promptCachingPolicy, .disabled)
+        XCTAssertEqual(TrustedRouterLLMClient().promptCachingPolicy, .automatic)
+        XCTAssertEqual(
+            TrustedRouterLLMClient().overridingModel("anthropic/claude-haiku-4.5").promptCachingPolicy,
+            .automatic,
+            "retargeting the model must keep the caching policy"
+        )
+    }
+}

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptCachingTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptCachingTests.swift
@@ -384,6 +384,39 @@ final class TrustedRouterPromptCachingTests: XCTestCase {
         )
     }
 
+    /// A one-shot auxiliary call (subagent worker / context summary) sends a tool-free request on
+    /// a FRESH thread — so the (empty) history prefix is trivially stable and an .automatic
+    /// Anthropic-route client WOULD annotate it, even though the unique prompt is never re-sent
+    /// (a cache write with no possible read). The `.disabled` policy those call sites use must
+    /// suppress the breakpoint. Fails on revert of the aux-disable wiring's effect.
+    func testFreshThreadOneShotRequestIsAnnotatedOnlyWhenCachingEnabled() throws {
+        let assembled = TrustedRouterPromptBuilder().assembled(
+            thread: ChatThread(title: "Subagent: Explorer"),
+            userMessage: "You are the Explorer subagent. Investigate and report.",
+            tools: []
+        )
+        XCTAssertTrue(assembled.historyPrefixStable, "a fresh thread's prefix is trivially stable")
+
+        func body(policy: TrustedRouterPromptCachingPolicy) throws -> String {
+            let data = try TrustedRouterLLMClient.chatCompletionBody(
+                model: anthropicModel,
+                messages: assembled.messages,
+                promptCachingPolicy: policy,
+                historyPrefixStable: assembled.historyPrefixStable
+            )
+            return String(decoding: data, as: UTF8.self)
+        }
+
+        XCTAssertTrue(
+            try body(policy: .automatic).contains("cache_control"),
+            "sanity: without the opt-out this one-shot request would be annotated"
+        )
+        XCTAssertFalse(
+            try body(policy: .disabled).contains("cache_control"),
+            "a one-shot aux call must not annotate its unique never-repeated prompt"
+        )
+    }
+
     /// End-to-end through the builder + client: a short thread caches, a saturated thread does
     /// not. This is the regression that would FAIL if positional annotation were reinstated
     /// without the stability gate.

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptCachingTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptCachingTests.swift
@@ -16,12 +16,14 @@ final class TrustedRouterPromptCachingTests: XCTestCase {
     private func serializedBody(
         model: String,
         messages: [[String: Any]],
-        policy: TrustedRouterPromptCachingPolicy = .automatic
+        policy: TrustedRouterPromptCachingPolicy = .automatic,
+        historyPrefixStable: Bool = true
     ) throws -> [String: Any] {
         let data = try TrustedRouterLLMClient.chatCompletionBody(
             model: model,
             messages: messages,
-            promptCachingPolicy: policy
+            promptCachingPolicy: policy,
+            historyPrefixStable: historyPrefixStable
         )
         let object = try JSONSerialization.jsonObject(with: data)
         return try XCTUnwrap(object as? [String: Any])
@@ -208,15 +210,19 @@ final class TrustedRouterPromptCachingTests: XCTestCase {
             "z-ai/glm-5.2",
             "gemini/gemini-2.5-pro"
         ] {
+            // historyPrefixStable: true isolates the provider-family gate — even with a stable
+            // prefix, a non-Anthropic route must still see no cache_control.
             let automatic = try TrustedRouterLLMClient.chatCompletionBody(
                 model: modelID,
                 messages: messages,
-                promptCachingPolicy: .automatic
+                promptCachingPolicy: .automatic,
+                historyPrefixStable: true
             )
             let disabled = try TrustedRouterLLMClient.chatCompletionBody(
                 model: modelID,
                 messages: messages,
-                promptCachingPolicy: .disabled
+                promptCachingPolicy: .disabled,
+                historyPrefixStable: true
             )
             let automaticObject = try XCTUnwrap(try JSONSerialization.jsonObject(with: automatic) as? NSDictionary)
             let disabledObject = try XCTUnwrap(try JSONSerialization.jsonObject(with: disabled) as? NSDictionary)
@@ -290,5 +296,112 @@ final class TrustedRouterPromptCachingTests: XCTestCase {
             .automatic,
             "retargeting the model must keep the caching policy"
         )
+    }
+
+    // MARK: - Prefix-stability gate (the feature-inverting regime)
+
+    /// The core guard: once the sliding history window is saturated the post-system prefix
+    /// diverges every turn, so a positional breakpoint would only ever WRITE the cache (1.25x)
+    /// and never read it — a net cost increase. An unstable prefix must therefore produce a
+    /// byte-identical, un-annotated request even on an Anthropic route. FAILS on revert of the
+    /// stability gate.
+    func testUnstableHistoryPrefixIsSentUnannotatedOnAnthropicRoute() throws {
+        let messages = [
+            message("system", "base system prompt"),
+            message("user", "run the tests"),
+            message("assistant", "Tool output: ok")
+        ]
+
+        let stable = try TrustedRouterLLMClient.chatCompletionBody(
+            model: anthropicModel,
+            messages: messages,
+            promptCachingPolicy: .automatic,
+            historyPrefixStable: true
+        )
+        let unstable = try TrustedRouterLLMClient.chatCompletionBody(
+            model: anthropicModel,
+            messages: messages,
+            promptCachingPolicy: .automatic,
+            historyPrefixStable: false
+        )
+
+        XCTAssertTrue(
+            String(decoding: stable, as: UTF8.self).contains("cache_control"),
+            "sanity: a stable prefix on the anthropic route is annotated"
+        )
+        XCTAssertFalse(
+            String(decoding: unstable, as: UTF8.self).contains("cache_control"),
+            "an unstable (saturated-window) prefix must never carry cache_control"
+        )
+        let unstableMessages = try bodyMessages(
+            try XCTUnwrap(try JSONSerialization.jsonObject(with: unstable) as? [String: Any])
+        )
+        XCTAssertEqual(breakpointIndexes(in: unstableMessages), [])
+        // And the un-annotated request equals what .disabled would have sent, byte-for-byte.
+        let disabled = try TrustedRouterLLMClient.chatCompletionBody(
+            model: anthropicModel,
+            messages: messages,
+            promptCachingPolicy: .disabled,
+            historyPrefixStable: true
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(try JSONSerialization.jsonObject(with: unstable) as? NSDictionary),
+            try XCTUnwrap(try JSONSerialization.jsonObject(with: disabled) as? NSDictionary)
+        )
+    }
+
+    /// `historyPrefixStable` defaults to false at the annotation seam — the safe default. A
+    /// caller that forgets to prove stability gets no annotation rather than a possible cost
+    /// increase.
+    func testAnnotationSeamDefaultsToNotStableAndSkips() {
+        let annotated = TrustedRouterPromptCaching.annotatedMessages(
+            [message("system", "s"), message("user", "u")],
+            modelID: anthropicModel,
+            policy: .automatic,
+            historyPrefixStable: false
+        )
+        XCTAssertEqual(breakpointIndexes(in: annotated), [])
+    }
+
+    // MARK: - Prompt builder stability signal
+
+    /// The builder reports the prefix stable only while the whole thread fits in the history
+    /// window; once `thread.messages.count` exceeds `historyLimit`, `suffix` drops the oldest
+    /// message and the prefix is no longer append-stable.
+    func testPromptBuilderReportsPrefixUnstableOnceHistoryWindowSaturates() {
+        let builder = TrustedRouterPromptBuilder(historyLimit: 4)
+        func thread(messageCount: Int) -> ChatThread {
+            ChatThread(messages: (0..<messageCount).map { .init(role: .user, content: "m\($0)") })
+        }
+
+        XCTAssertTrue(
+            builder.assembled(thread: thread(messageCount: 4), userMessage: "next", tools: [.shellRun]).historyPrefixStable,
+            "count == historyLimit is still stable (nothing dropped yet)"
+        )
+        XCTAssertFalse(
+            builder.assembled(thread: thread(messageCount: 5), userMessage: "next", tools: [.shellRun]).historyPrefixStable,
+            "count > historyLimit drops the oldest message; prefix is no longer stable"
+        )
+    }
+
+    /// End-to-end through the builder + client: a short thread caches, a saturated thread does
+    /// not. This is the regression that would FAIL if positional annotation were reinstated
+    /// without the stability gate.
+    func testSaturatedThreadThroughBuilderAndClientEmitsNoCacheControl() throws {
+        let builder = TrustedRouterPromptBuilder(historyLimit: 4)
+        func body(messageCount: Int) throws -> String {
+            let thread = ChatThread(messages: (0..<messageCount).map { .init(role: .user, content: "m\($0)") })
+            let assembled = builder.assembled(thread: thread, userMessage: "next", tools: [.shellRun])
+            let data = try TrustedRouterLLMClient.chatCompletionBody(
+                model: anthropicModel,
+                messages: assembled.messages,
+                promptCachingPolicy: .automatic,
+                historyPrefixStable: assembled.historyPrefixStable
+            )
+            return String(decoding: data, as: UTF8.self)
+        }
+
+        XCTAssertTrue(try body(messageCount: 3).contains("cache_control"), "short thread caches")
+        XCTAssertFalse(try body(messageCount: 20).contains("cache_control"), "saturated thread must not cache")
     }
 }

--- a/Tests/QuillCodeAppTests/RuntimeFactoryRetryWiringTests.swift
+++ b/Tests/QuillCodeAppTests/RuntimeFactoryRetryWiringTests.swift
@@ -23,4 +23,37 @@ final class RuntimeFactoryRetryWiringTests: XCTestCase {
         XCTAssertEqual(runtime.mode, .mock)
         XCTAssertFalse(runtime.runner.llm is RetryingLLMClient<TrustedRouterLLMClient>)
     }
+
+    /// The run-loop client keeps prompt caching ON (its prefix repeats across turns), but the
+    /// one-shot context-summary/compaction client must be OFF: each summary prompt is unique and
+    /// never re-sent, so a breakpoint there could only ever be a cache write with no read — and
+    /// the auxiliary-model selector can steer it onto an Anthropic model. Asserts the two clients
+    /// carry opposite caching policies. FAILS on revert of the aux-disable wiring.
+    func testSummaryClientDisablesPromptCachingWhileRunLoopKeepsItOn() throws {
+        let factory = QuillCodeRuntimeFactory(environment: ["QUILLCODE_API_KEY": "test-key"])
+        let runtime = factory.makeRuntime(config: AppConfig())
+
+        let runLoop = try XCTUnwrap(runtime.runner.llm as? RetryingLLMClient<TrustedRouterLLMClient>)
+        XCTAssertEqual(
+            runLoop.base.promptCachingPolicy, .automatic,
+            "the run-loop client must keep prompt caching enabled"
+        )
+
+        let summaryGenerator = try XCTUnwrap(
+            runtime.contextSummaryGenerator as? LLMWorkspaceContextSummaryGenerator
+        )
+        let summaryClient = try XCTUnwrap(
+            summaryGenerator.llm as? RetryingLLMClient<TrustedRouterLLMClient>
+        )
+        XCTAssertEqual(
+            summaryClient.base.promptCachingPolicy, .disabled,
+            "one-shot summary/compaction calls must never carry a prompt-cache breakpoint"
+        )
+
+        // And retargeting the summary client at an Anthropic aux model must not re-enable it.
+        XCTAssertEqual(
+            summaryClient.base.overridingModel("anthropic/claude-haiku-4.5").promptCachingPolicy,
+            .disabled
+        )
+    }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceSubagentModelWorkerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSubagentModelWorkerTests.swift
@@ -117,6 +117,25 @@ final class WorkspaceSubagentModelWorkerTests: XCTestCase {
             // Expected: scheduler turns a thrown worker error into a failed subagent.
         }
     }
+
+    // MARK: - Prompt caching opt-out (one-shot aux class)
+
+    /// The opt-out the WorkspaceModel applies to the subagent worker: it disables caching on a
+    /// caching-capable client (threading through the production retry-wrapped TrustedRouter shape)
+    /// and returns a non-caching client (the mock) unchanged. A subagent worker issues a single
+    /// tool-free nextAction on a FRESH, unique-prompt thread that is never re-sent, so a
+    /// breakpoint there could only ever be a cache write with no read — this opt-out prevents it.
+    /// Fails on revert of disablingPromptCachingIfSupported / its conformances.
+    func testDisablingPromptCachingIfSupportedActsOnCachingClientsOnly() throws {
+        let retryWrapped = RetryingLLMClient(base: TrustedRouterLLMClient(promptCachingPolicy: .automatic))
+        let disabled = disablingPromptCachingIfSupported(retryWrapped)
+        let disabledClient = try XCTUnwrap(disabled as? RetryingLLMClient<TrustedRouterLLMClient>)
+        XCTAssertEqual(disabledClient.base.promptCachingPolicy, .disabled)
+
+        // A client that does not support the control is returned unchanged (not wrapped/altered).
+        let mock = SubagentStubSayLLMClient(text: "ok")
+        XCTAssertTrue(disablingPromptCachingIfSupported(mock) is SubagentStubSayLLMClient)
+    }
 }
 
 private struct SubagentStubSayLLMClient: LLMClient {

--- a/Tests/QuillCodeParityTests/ParitySubagentPromptCacheGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySubagentPromptCacheGateTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+/// Locks the construction-site invariant: the subagent worker — a one-shot auxiliary call whose
+/// unique prompt is never re-sent — must be wired to a prompt-caching-DISABLED client, the same
+/// class RuntimeFactory disables for context summaries. A breakpoint there could only ever be a
+/// cache write with no read. This gate fails if a future edit reverts the WorkspaceModel wiring
+/// back to the raw run-loop client.
+final class ParitySubagentPromptCacheGateTests: QuillCodeParityTestCase {
+    func testSubagentWorkerIsWiredToACachingDisabledClient() throws {
+        let source = try Self.appSourceText(named: "WorkspaceModel.swift")
+
+        XCTAssertTrue(
+            source.contains("LLMWorkspaceSubagentWorker.scheduledWorker"),
+            "expected the subagent scheduler to be built from LLMWorkspaceSubagentWorker.scheduledWorker"
+        )
+        XCTAssertTrue(
+            source.contains("scheduledWorker(\n                llm: disablingPromptCachingIfSupported(runner.llm)")
+                || source.contains("disablingPromptCachingIfSupported(runner.llm)"),
+            "the subagent worker's llm must be routed through disablingPromptCachingIfSupported(runner.llm)"
+        )
+        XCTAssertFalse(
+            source.contains("scheduledWorker(llm: runner.llm)"),
+            "the subagent worker must NOT be wired to the raw run-loop client (that one keeps caching on)"
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityTrustedRouterPromptGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTrustedRouterPromptGateTests.swift
@@ -10,7 +10,9 @@ final class ParityTrustedRouterPromptGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(builder.contains("systemPrompt(tools"))
         XCTAssertTrue(builder.contains("projectInstructionsPrompt"))
         XCTAssertTrue(builder.contains("memoryPrompt"))
-        XCTAssertTrue(client.contains("promptBuilder.messages"))
+        // The client delegates prompt assembly to the builder; `assembled` is the entry point
+        // that returns the messages plus the prefix-stability flag prompt caching needs.
+        XCTAssertTrue(client.contains("promptBuilder.assembled"))
 
         XCTAssertFalse(client.contains("systemPrompt(tools"))
         XCTAssertFalse(client.contains("projectInstructionsPrompt"))


### PR DESCRIPTION
## What

Auto-places Anthropic prompt-cache breakpoints (`cache_control: {type: ephemeral}`, 5-minute TTL) on the agent's outgoing chat requests, centrally in the one seam every request passes through (`TrustedRouterLLMClient.chatCompletionBody`). New `TrustedRouterPromptCaching` implements the placement; a client policy flag `promptCachingPolicy` (default `.automatic`) controls it.

Fixes #857

## Placement (deterministic, ≤2 breakpoints, well under Anthropic's 4-marker limit)

- **Latest user message** — a breakpoint here caches the entire prefix before it: system prompt, tool definitions (QuillCode serializes tool defs *into* the system prompt on this wire format), and history. It stays on the same element for every model call within a turn's tool loop.
- **Final message**, when tool feedback continues past the latest user message — each tool-loop iteration then extends the cache over the previous iteration's output instead of re-reading it at full price. Prior breakpoints remain valid cache entries upstream, so advancing the marker never invalidates the cached prefix.
- **System messages are never annotated.** Verified in the TrustedRouter gateway source: `chat_to_anthropic` concatenates system message content with `str()` into Anthropic's top-level `system` string, so array-shaped system content would be corrupted into a Python repr. This is also why the issue's "last tool / last system" breakpoints are unreachable through this gateway — and why they're unnecessary: the user-message breakpoint already covers that prefix.

## Provider gating & robustness

- Annotation is gated to Anthropic-family model IDs (`TrustedRouterDefaults.provider(fromModelID:)`, case-insensitive). Router meta-models (`trustedrouter/fast`, `tr/synth`, …) and all other provider families send **byte-for-byte identical** requests — asserted by serialized-JSON regression tests — so strict OpenAI-compatible upstreams (which receive `messages` verbatim from the gateway) never see the field.
- Only plain non-empty string content is rewritten (to a single text block carrying the marker — Anthropic hashes `"x"` and `[{"type":"text","text":"x"}]` identically, so turn-over-turn prefixes still match). Pre-shaped array content, empty, or non-string content is left untouched. No force-unwraps.
- `overridingModel(_:)` (auxiliary/summary calls) keeps the policy; gating re-evaluates against the effective model at request-build time.

## Live passthrough verification (api.trustedrouter.com, anthropic/claude-haiku-4.5)

- **Annotated requests are safe on the real gateway**: streaming and non-streaming chat/completions calls in the exact client shape returned HTTP 200 with correct completions. No 400s, no prompt corruption.
- **Anthropic-native `/v1/messages` path: passthrough CONFIRMED end-to-end.** Two identical calls with a ~6k-token prefix and one `cache_control` block:
  - call 1 usage: `{"cache_creation_input_tokens": 6034, "input_tokens": 3, "output_tokens": 4}`
  - call 2 usage: `{"cache_read_input_tokens": 6034, "input_tokens": 3, "output_tokens": 4}`
- **OpenAI-format `/chat/completions` path (the path QuillCode uses): client markers are currently DROPPED by the deployed gateway.** Discriminating probe: a request with six `cache_control` blocks returned 200 on `/chat/completions`, while the identical six-marker request on `/v1/messages` returned Anthropic's own 400 (`"A maximum of 4 blocks with cache_control may be provided. Found 6."`, `source: provider`). A cross-format probe (write via chat/completions, read via an equivalent /messages request) also produced a cache MISS. Chat-path usage exposes no cache fields (`prompt_tokens` reported as the total both calls).

**Net:** this change is harmless today on every route (live-verified) and becomes the intended cost/latency win the moment the gateway forwards `cache_control` on the OpenAI→Anthropic translation — which its `/v1/messages` sibling already does. Command to re-verify once the gateway ships that: send the same streamed chat/completions request twice with a >2048-token prefix and a marked user message, and check the second call's usage/cost for cache-read accounting (script preserved in the probes below).

Note: the local `quill-router` control-plane checkout would pass user/assistant content (and markers) through verbatim — the deployed attested inference gateway at `api.trustedrouter.com` is a different binary (different error envelope; emits usage chunks the control-plane code doesn't), so the gateway-side fix belongs there.

## Tests

- 12 new tests in `TrustedRouterPromptCachingTests` — all assertions over the serialized request JSON: exactly-one-breakpoint-per-category placement, last-element targeting as history grows, turn-over-turn prefix stability (previously cached messages re-sent byte-identically), intra-turn tool-loop stability, system-message immunity, non-Anthropic byte-identity, `.disabled` opt-out, envelope regression (`stream`/`stream_options`/`response_format`/`model` untouched), whitespace/array/non-string content robustness.
- `swift test --filter QuillCodeAgentTests`: **276 passed, 0 failures**.
- Full `swift test`: **2339 passed, 1 skipped (pre-existing), 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)