### PR TITLE
Add host.web.fetch: GET a public URL as markdown (SSRF-gated)

### DIFF
--- a/Sources/QuillCodeAgent/AgentToolAnswerFormatters.swift
+++ b/Sources/QuillCodeAgent/AgentToolAnswerFormatters.swift
@@ -19,6 +19,7 @@ enum AgentToolAnswerFormatters {
             AgentUtilityToolAnswerFormatters.subagentsUpdateAnswer,
             AgentUtilityToolAnswerFormatters.memoryRememberAnswer,
             AgentShellToolAnswerFormatters.shellRunAnswer,
+            AgentWebToolAnswerFormatters.webFetchAnswer,
             AgentBrowserToolAnswerFormatters.browserInspectAnswer,
             AgentBrowserToolAnswerFormatters.browserOpenAnswer,
             AgentUtilityToolAnswerFormatters.mcpReadResourceAnswer,

--- a/Sources/QuillCodeAgent/AgentToolArgumentNormalizationRule.swift
+++ b/Sources/QuillCodeAgent/AgentToolArgumentNormalizationRule.swift
@@ -103,6 +103,10 @@ enum AgentToolArgumentNormalizationRules {
             stringArguments: [.init(canonicalKey: "url", aliases: ["address", "href", "target", "page"])]
         ),
         .init(
+            toolNames: [ToolDefinition.webFetch.name],
+            stringArguments: [.init(canonicalKey: "url", aliases: ["address", "href", "link", "target", "page", "uri"])]
+        ),
+        .init(
             toolNames: [ToolDefinition.gitPullRequestCreate.name],
             stringArguments: [.init(canonicalKey: "title", aliases: ["name", "subject"])]
         ),

--- a/Sources/QuillCodeAgent/AgentWebToolAnswerFormatters.swift
+++ b/Sources/QuillCodeAgent/AgentWebToolAnswerFormatters.swift
@@ -1,0 +1,28 @@
+import QuillCodeCore
+import QuillCodeTools
+
+enum AgentWebToolAnswerFormatters {
+    static func webFetchAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.webFetch.name else {
+            return nil
+        }
+        let url = AgentToolAnswerFormatterSupport.argument("url", in: call) ?? "the page"
+        if !result.ok {
+            let details = [result.error, result.stderr.trimmedNonEmpty]
+                .compactMap { $0?.trimmedNonEmpty }
+                .joined(separator: "\n")
+            return details.isEmpty
+                ? "Could not fetch \(url)."
+                : "Could not fetch \(url): \(AgentToolAnswerFormatters.truncated(details))"
+        }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !output.isEmpty else {
+            return "Fetched \(url), but it returned no readable content."
+        }
+        return AgentToolAnswerFormatters.truncated(output)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceToolCardSubtitleBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolCardSubtitleBuilder.swift
@@ -65,7 +65,7 @@ enum WorkspaceToolCardSubtitleBuilder {
             return "handoff"
         case ToolDefinition.subagentsUpdate.name:
             return "subagents"
-        case ToolDefinition.browserOpen.name:
+        case ToolDefinition.browserOpen.name, ToolDefinition.webFetch.name:
             return sanitized(arguments.string("url"))
         case ToolDefinition.memoryRemember.name:
             return sanitized(arguments.string("content"))

--- a/Sources/QuillCodeTools/HTMLEntityDecoder.swift
+++ b/Sources/QuillCodeTools/HTMLEntityDecoder.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Decodes HTML character references (`&amp;`, `&#233;`, `&#x1F600;`) in text and attribute
+/// values. Built for hostile input: numeric references are length- and range-clamped (an
+/// out-of-range or surrogate code point becomes U+FFFD, never a trap), and anything that does
+/// not parse is passed through literally.
+enum HTMLEntityDecoder {
+    static func decode(_ text: String) -> String {
+        guard text.contains("&") else {
+            return text
+        }
+        var result = ""
+        result.reserveCapacity(text.count)
+        var remainder = Substring(text)
+        while let ampersand = remainder.firstIndex(of: "&") {
+            result += remainder[..<ampersand]
+            remainder = remainder[ampersand...]
+            if let (scalar, afterEntity) = parseEntity(remainder) {
+                result += scalar
+                remainder = afterEntity
+            } else {
+                result.append("&")
+                remainder = remainder.dropFirst()
+            }
+        }
+        result += remainder
+        return result
+    }
+
+    /// Parses one entity at the start of `text` (which begins with `&`). Returns the decoded
+    /// string and the remainder after the entity, or nil when this is not a valid entity.
+    private static func parseEntity(_ text: Substring) -> (String, Substring)? {
+        let body = text.dropFirst()
+        guard let semicolon = body.prefix(maxEntityLength).firstIndex(of: ";") else {
+            return nil
+        }
+        let name = body[..<semicolon]
+        let afterEntity = body[body.index(after: semicolon)...]
+        guard !name.isEmpty else {
+            return nil
+        }
+        if name.hasPrefix("#") {
+            guard let scalar = numericScalar(name.dropFirst()) else {
+                return nil
+            }
+            return (String(scalar), afterEntity)
+        }
+        guard let replacement = namedEntities[String(name)] else {
+            return nil
+        }
+        return (replacement, afterEntity)
+    }
+
+    private static func numericScalar(_ digits: Substring) -> Unicode.Scalar? {
+        var value: UInt32 = 0
+        let isHex = digits.hasPrefix("x") || digits.hasPrefix("X")
+        let number = isHex ? digits.dropFirst() : digits
+        guard !number.isEmpty, number.count <= 8 else {
+            return nil
+        }
+        for character in number {
+            guard let digit = character.hexDigitValue, isHex || digit < 10 else {
+                return nil
+            }
+            value = value * (isHex ? 16 : 10) + UInt32(digit)
+            if value > 0x10FFFF {
+                return replacementScalar
+            }
+        }
+        guard value != 0, let scalar = Unicode.Scalar(value) else {
+            // NUL, surrogates (D800–DFFF), and out-of-range values all land here — the
+            // failable initializer is the clamp, so hostile references cannot trap.
+            return replacementScalar
+        }
+        return scalar
+    }
+
+    private static let replacementScalar = Unicode.Scalar(0xFFFD)!
+
+    private static let maxEntityLength = 40
+
+    private static let namedEntities: [String: String] = [
+        "amp": "&", "lt": "<", "gt": ">", "quot": "\"", "apos": "'",
+        "nbsp": "\u{00A0}", "ensp": "\u{2002}", "emsp": "\u{2003}", "thinsp": "\u{2009}",
+        "copy": "©", "reg": "®", "trade": "™", "sect": "§", "para": "¶", "middot": "·",
+        "bull": "•", "hellip": "…", "prime": "′", "Prime": "″",
+        "mdash": "—", "ndash": "–", "shy": "",
+        "lsquo": "\u{2018}", "rsquo": "\u{2019}", "sbquo": "\u{201A}",
+        "ldquo": "\u{201C}", "rdquo": "\u{201D}", "bdquo": "\u{201E}",
+        "laquo": "«", "raquo": "»", "lsaquo": "‹", "rsaquo": "›",
+        "times": "×", "divide": "÷", "plusmn": "±", "minus": "−", "ne": "≠",
+        "le": "≤", "ge": "≥", "asymp": "≈", "equiv": "≡", "infin": "∞", "sum": "∑",
+        "deg": "°", "micro": "µ", "frac12": "½", "frac14": "¼", "frac34": "¾",
+        "sup1": "¹", "sup2": "²", "sup3": "³",
+        "cent": "¢", "pound": "£", "yen": "¥", "euro": "€", "curren": "¤",
+        "larr": "←", "uarr": "↑", "rarr": "→", "darr": "↓", "harr": "↔",
+        "dagger": "†", "Dagger": "‡", "permil": "‰",
+        "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ", "epsilon": "ε",
+        "lambda": "λ", "mu": "μ", "pi": "π", "sigma": "σ", "omega": "ω",
+        "Delta": "Δ", "Omega": "Ω", "Sigma": "Σ", "Pi": "Π",
+        "agrave": "à", "aacute": "á", "acirc": "â", "atilde": "ã", "auml": "ä", "aring": "å",
+        "ccedil": "ç", "egrave": "è", "eacute": "é", "ecirc": "ê", "euml": "ë",
+        "igrave": "ì", "iacute": "í", "icirc": "î", "iuml": "ï",
+        "ntilde": "ñ", "ograve": "ò", "oacute": "ó", "ocirc": "ô", "otilde": "õ", "ouml": "ö",
+        "ugrave": "ù", "uacute": "ú", "ucirc": "û", "uuml": "ü",
+        "Agrave": "À", "Aacute": "Á", "Auml": "Ä", "Eacute": "É", "Ouml": "Ö", "Uuml": "Ü",
+        "szlig": "ß", "yuml": "ÿ", "oelig": "œ", "OElig": "Œ", "aelig": "æ", "AElig": "Æ",
+        "oslash": "ø", "Oslash": "Ø"
+    ]
+}

--- a/Sources/QuillCodeTools/HTMLMarkdownWriter.swift
+++ b/Sources/QuillCodeTools/HTMLMarkdownWriter.swift
@@ -1,0 +1,337 @@
+import Foundation
+
+/// Output side of the HTML→markdown converter: a budgeted text sink with pending-separator
+/// tracking (so blocks are separated by exactly one blank line), blockquote line prefixes,
+/// and a bounded stack of capture buffers for constructs that need their content before they
+/// can be emitted (link text, inline code, table cells, `<pre>` bodies).
+///
+/// Every write path is bounded: the main buffer stops growing past `maxOutputBytes` (setting
+/// `truncated`), and each capture has its own byte limit past which input is dropped.
+final class HTMLMarkdownWriter {
+    private(set) var truncated = false
+
+    /// Blockquote nesting; each level prefixes lines with "> ". Capped by the converter.
+    var quoteDepth = 0
+
+    private let maxOutputBytes: Int
+    private var output = ""
+    private var outputBytes = 0
+    private var pendingSeparator = Separator.none
+    private var pendingSpace = false
+    private var atBoundary = true
+    private var captures: [Capture] = []
+
+    private enum Separator: Int, Comparable {
+        case none = 0
+        case line = 1
+        case block = 2
+
+        static func < (lhs: Separator, rhs: Separator) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    private struct Capture {
+        var buffer = ""
+        var bytes = 0
+        var byteLimit: Int
+        var preservesWhitespace: Bool
+        var pendingSpace = false
+        var atBoundary = true
+    }
+
+    init(maxOutputBytes: Int) {
+        self.maxOutputBytes = max(1024, maxOutputBytes)
+    }
+
+    var captureDepth: Int {
+        captures.count
+    }
+
+    // MARK: - Separators
+
+    func requestLineBreak() {
+        guard captures.isEmpty else {
+            setCapturePendingSpace()
+            return
+        }
+        pendingSeparator = max(pendingSeparator, .line)
+    }
+
+    func requestBlockBreak() {
+        guard captures.isEmpty else {
+            setCapturePendingSpace()
+            return
+        }
+        pendingSeparator = max(pendingSeparator, .block)
+    }
+
+    // MARK: - Inline writing
+
+    /// Writes text with whitespace runs collapsed to single spaces and control characters
+    /// stripped. Inside a whitespace-preserving capture the text is kept verbatim (minus
+    /// dangerous control characters).
+    func writeText(_ text: String) {
+        if let index = captures.indices.last, captures[index].preservesWhitespace {
+            appendToCapture(sanitizedPreservingWhitespace(text), at: index)
+            return
+        }
+        writeCollapsed(text)
+    }
+
+    /// Writes literal markdown syntax (emphasis markers, rendered links). `flushingSpace`
+    /// controls whether a pending inter-word space lands before the marker (openers) or stays
+    /// pending until the following text (closers, so `x </b>y` becomes `x**` + ` y`).
+    func writeMarker(_ marker: String, flushingSpace: Bool) {
+        guard !marker.isEmpty else {
+            return
+        }
+        if let index = captures.indices.last {
+            if flushingSpace, captures[index].pendingSpace, !captures[index].atBoundary {
+                appendToCapture(" ", at: index)
+            }
+            captures[index].pendingSpace = flushingSpace ? false : captures[index].pendingSpace
+            appendToCapture(marker, at: index)
+            captures[index].atBoundary = false
+            return
+        }
+        flushSeparator()
+        if flushingSpace, pendingSpace, !atBoundary {
+            appendRaw(" ")
+        }
+        if flushingSpace {
+            pendingSpace = false
+        }
+        appendRaw(marker)
+        atBoundary = false
+    }
+
+    // MARK: - Block writing
+
+    /// Emits whole lines (fenced code, tables, horizontal rules) with the quote prefix applied
+    /// to each line, separated from surrounding content by a blank line on each side.
+    func writeBlockLines(_ lines: [String]) {
+        guard !lines.isEmpty else {
+            return
+        }
+        if let index = captures.indices.last {
+            // Block content inside a capture (a table in a link, …) flattens to spaced text.
+            let flattened = lines.joined(separator: " ")
+            if captures[index].pendingSpace, !captures[index].atBoundary {
+                appendToCapture(" ", at: index)
+            }
+            captures[index].pendingSpace = false
+            appendToCapture(flattened, at: index)
+            captures[index].atBoundary = false
+            return
+        }
+        pendingSeparator = max(pendingSeparator, .block)
+        flushSeparator()
+        let prefix = linePrefix()
+        appendRaw(lines.map { prefix + $0 }.joined(separator: "\n"))
+        pendingSeparator = .block
+        pendingSpace = false
+        atBoundary = true
+    }
+
+    // MARK: - Captures
+
+    /// Starts routing writes into a new capture buffer. Returns false (and captures nothing)
+    /// when the capture stack is at its bound — callers then simply let content flow through.
+    func pushCapture(byteLimit: Int, preservesWhitespace: Bool = false) -> Bool {
+        guard captures.count < Self.maxCaptureDepth else {
+            return false
+        }
+        captures.append(Capture(byteLimit: max(0, byteLimit), preservesWhitespace: preservesWhitespace))
+        return true
+    }
+
+    func popCapture() -> String? {
+        guard let capture = captures.popLast() else {
+            return nil
+        }
+        return capture.buffer
+    }
+
+    // MARK: - Finish
+
+    func finalizedMarkdown() -> String {
+        output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Internals
+
+    private func writeCollapsed(_ text: String) {
+        let hasVisibleContent = text.unicodeScalars.contains {
+            !isCollapsibleWhitespace($0) && !isStrippedControl($0)
+        }
+        guard hasVisibleContent else {
+            if text.unicodeScalars.contains(where: isCollapsibleWhitespace) {
+                if let index = captures.indices.last {
+                    captures[index].pendingSpace = true
+                } else {
+                    pendingSpace = true
+                }
+            }
+            return
+        }
+        if let index = captures.indices.last {
+            var localPendingSpace = captures[index].pendingSpace
+            var localAtBoundary = captures[index].atBoundary
+            let piece = collapsedPiece(text, pendingSpace: &localPendingSpace, atBoundary: &localAtBoundary)
+            captures[index].pendingSpace = localPendingSpace
+            captures[index].atBoundary = localAtBoundary
+            appendToCapture(piece, at: index)
+        } else {
+            flushSeparator()
+            var localPendingSpace = pendingSpace
+            var localAtBoundary = atBoundary
+            let piece = collapsedPiece(text, pendingSpace: &localPendingSpace, atBoundary: &localAtBoundary)
+            pendingSpace = localPendingSpace
+            atBoundary = localAtBoundary
+            appendRaw(piece)
+        }
+    }
+
+    private func collapsedPiece(
+        _ text: String,
+        pendingSpace: inout Bool,
+        atBoundary: inout Bool
+    ) -> String {
+        var piece = ""
+        piece.reserveCapacity(min(text.utf8.count, 4096))
+        for scalar in text.unicodeScalars {
+            if isCollapsibleWhitespace(scalar) {
+                pendingSpace = true
+                continue
+            }
+            if isStrippedControl(scalar) {
+                continue
+            }
+            if pendingSpace, !atBoundary {
+                piece.unicodeScalars.append(" ")
+            }
+            pendingSpace = false
+            piece.unicodeScalars.append(scalar)
+            atBoundary = false
+        }
+        return piece
+    }
+
+    private func flushSeparator() {
+        guard pendingSeparator != .none else {
+            return
+        }
+        let separator = pendingSeparator
+        pendingSeparator = .none
+        let prefix = linePrefix()
+        guard !output.isEmpty else {
+            // At the very start of the document there is nothing to separate FROM, but a
+            // blockquote prefix still has to open the first line.
+            appendRaw(prefix)
+            atBoundary = true
+            return
+        }
+        switch separator {
+        case .none:
+            break
+        case .line:
+            appendRaw("\n" + prefix)
+        case .block:
+            let blankLine = prefix.trimmingCharacters(in: .whitespaces)
+            appendRaw("\n" + blankLine + "\n" + prefix)
+        }
+        pendingSpace = false
+        atBoundary = true
+    }
+
+    private func linePrefix() -> String {
+        String(repeating: "> ", count: max(0, quoteDepth))
+    }
+
+    private func appendRaw(_ text: String) {
+        guard !truncated, !text.isEmpty else {
+            return
+        }
+        let bytes = text.utf8.count
+        if outputBytes + bytes <= maxOutputBytes {
+            output += text
+            outputBytes += bytes
+            return
+        }
+        // Partial fit: a single oversized piece (one giant text node) must not be dropped
+        // wholesale — keep whole scalars until the budget runs out, then stop.
+        let remaining = maxOutputBytes - outputBytes
+        if remaining > 0 {
+            var kept = ""
+            var keptBytes = 0
+            for scalar in text.unicodeScalars {
+                let scalarBytes = String(scalar).utf8.count
+                guard keptBytes + scalarBytes <= remaining else {
+                    break
+                }
+                kept.unicodeScalars.append(scalar)
+                keptBytes += scalarBytes
+            }
+            output += kept
+            outputBytes += keptBytes
+        }
+        truncated = true
+    }
+
+    private func appendToCapture(_ text: String, at index: Int) {
+        guard !text.isEmpty else {
+            return
+        }
+        let remaining = captures[index].byteLimit - captures[index].bytes
+        guard remaining > 0 else {
+            return
+        }
+        let bytes = text.utf8.count
+        if bytes <= remaining {
+            captures[index].buffer += text
+            captures[index].bytes += bytes
+            return
+        }
+        // Partial fit: keep whole scalars until the capture's byte budget runs out.
+        var kept = ""
+        var keptBytes = 0
+        for scalar in text.unicodeScalars {
+            let scalarBytes = String(scalar).utf8.count
+            guard keptBytes + scalarBytes <= remaining else {
+                break
+            }
+            kept.unicodeScalars.append(scalar)
+            keptBytes += scalarBytes
+        }
+        captures[index].buffer += kept
+        captures[index].bytes += keptBytes
+    }
+
+    private func setCapturePendingSpace() {
+        guard let index = captures.indices.last else {
+            return
+        }
+        if captures[index].preservesWhitespace {
+            appendToCapture("\n", at: index)
+        } else {
+            captures[index].pendingSpace = true
+        }
+    }
+
+    private func sanitizedPreservingWhitespace(_ text: String) -> String {
+        String(text.unicodeScalars.filter { scalar in
+            scalar == "\n" || scalar == "\t" || !isStrippedControl(scalar)
+        }.map(Character.init))
+    }
+
+    private func isCollapsibleWhitespace(_ scalar: Unicode.Scalar) -> Bool {
+        scalar == " " || scalar == "\t" || scalar == "\n" || scalar == "\r" || scalar == "\u{0C}"
+    }
+
+    private func isStrippedControl(_ scalar: Unicode.Scalar) -> Bool {
+        (scalar.value < 0x20 && scalar != "\n" && scalar != "\t") || scalar.value == 0x7F
+    }
+
+    private static let maxCaptureDepth = 8
+}

--- a/Sources/QuillCodeTools/HTMLToMarkdownConverter.swift
+++ b/Sources/QuillCodeTools/HTMLToMarkdownConverter.swift
@@ -1,0 +1,773 @@
+import Foundation
+
+public struct HTMLToMarkdownOptions: Sendable {
+    /// Base URL used to resolve relative link and image targets (usually the fetched page URL).
+    public var baseURL: URL?
+    /// Hard ceiling on produced markdown; conversion stops (and reports truncation) beyond it.
+    public var maxOutputBytes: Int
+    /// Element depth beyond which structure is ignored (text still flows) — bounds the cost of
+    /// pathologically nested documents.
+    public var maxElementDepth: Int
+
+    public init(baseURL: URL? = nil, maxOutputBytes: Int = 262_144, maxElementDepth: Int = 48) {
+        self.baseURL = baseURL
+        self.maxOutputBytes = maxOutputBytes
+        self.maxElementDepth = maxElementDepth
+    }
+}
+
+/// Hand-rolled HTML→markdown conversion for `host.web.fetch` — no parser dependency, no
+/// recursion, every buffer bounded. Covers the constructs that matter for reading docs pages
+/// (headings, paragraphs, links, lists, code, emphasis, blockquotes, images, best-effort
+/// tables) and deliberately drops page chrome (`script`/`style`/`nav`/`head`/…). Malformed
+/// HTML degrades to text instead of failing: the tokenizer treats anything unrecognizable as
+/// character data, and unclosed constructs are flushed at end of input.
+public enum HTMLToMarkdown {
+    public static func convert(
+        _ html: String,
+        options: HTMLToMarkdownOptions = HTMLToMarkdownOptions()
+    ) -> (markdown: String, truncated: Bool) {
+        var converter = Converter(html: html, options: options)
+        return converter.run()
+    }
+
+    // MARK: - Converter
+
+    private struct Converter {
+        private var tokenizer: HTMLTokenizer
+        private let options: HTMLToMarkdownOptions
+        private let writer: HTMLMarkdownWriter
+
+        private var elementDepth = 0
+        private var emphasisStack: [String] = []
+        private var listStack: [ListContext] = []
+        private var quoteDepth = 0
+        private var inlineCaptures: [InlineCapture] = []
+        private var preContext: PreContext?
+        private var table: TableContext?
+        private var skip: SkipContext?
+
+        /// Inline constructs whose text is buffered in the writer before they can be emitted.
+        /// The stack mirrors the writer's capture stack (cell/caption captures sit below).
+        private enum InlineCapture {
+            case link(href: String)
+            case code
+        }
+
+        private struct ListContext {
+            var ordered: Bool
+            var nextIndex: Int
+        }
+
+        private struct PreContext {
+            var language: String
+        }
+
+        private struct TableContext {
+            var rows: [[String]] = []
+            var currentRow: [String]?
+            var cellOpen = false
+            var captionOpen = false
+            var caption: String?
+            var nestedTables = 0
+        }
+
+        private struct SkipContext {
+            var name: String
+            var depth: Int
+        }
+
+        init(html: String, options: HTMLToMarkdownOptions) {
+            self.tokenizer = HTMLTokenizer(html)
+            self.options = options
+            self.writer = HTMLMarkdownWriter(maxOutputBytes: max(1024, options.maxOutputBytes))
+        }
+
+        mutating func run() -> (markdown: String, truncated: Bool) {
+            while let token = tokenizer.next() {
+                if writer.truncated {
+                    break
+                }
+                switch token {
+                case .text(let text):
+                    handleText(text)
+                case .openTag(let name, let attributes, let selfClosing):
+                    handleOpenTag(name, attributes: attributes, selfClosing: selfClosing)
+                case .closeTag(let name):
+                    handleCloseTag(name)
+                }
+            }
+            finishOpenConstructs()
+            return (writer.finalizedMarkdown(), writer.truncated)
+        }
+
+        // MARK: - Text
+
+        private mutating func handleText(_ text: String) {
+            guard skip == nil, !text.isEmpty else {
+                return
+            }
+            if isBetweenTableCells {
+                return // Inter-cell filler inside a table ("\n  " between <tr>s) is noise.
+            }
+            writer.writeText(text)
+        }
+
+        /// True while inside a `<table>` but not inside a cell or caption capture — the region
+        /// where text and inline markup have no representable place in a pipe table.
+        private var isBetweenTableCells: Bool {
+            guard let table else {
+                return false
+            }
+            return !table.cellOpen && !table.captionOpen
+        }
+
+        // MARK: - Open tags
+
+        private mutating func handleOpenTag(_ name: String, attributes: [String: String], selfClosing: Bool) {
+            if skip != nil {
+                handleOpenTagWhileSkipping(name, selfClosing: selfClosing)
+                return
+            }
+            if Self.rawTextElements.contains(name) {
+                if !selfClosing {
+                    _ = tokenizer.consumeRawText(until: name)
+                }
+                return
+            }
+            if Self.skippedSubtreeElements.contains(name), !selfClosing {
+                skip = SkipContext(name: name, depth: 1)
+                return
+            }
+            let isVoid = Self.voidElements.contains(name)
+            if !isVoid, !selfClosing {
+                elementDepth += 1
+            }
+            let structural = elementDepth <= options.maxElementDepth
+
+            // Between a table's cells only table structure matters; letting markers (emphasis,
+            // headings, list bullets) through would strand markdown syntax in the output while
+            // the corresponding text is being dropped.
+            if isBetweenTableCells, !Self.tableStructureElements.contains(name) {
+                return
+            }
+
+            if preContext != nil {
+                // Inside <pre>, tags (highlighter <span>s) contribute nothing themselves —
+                // except <br> (a literal line break) and <code>, which usually carries the
+                // `language-…` class in the common `<pre><code class="language-x">` pattern.
+                if name == "br" {
+                    writer.writeText("\n")
+                } else if name == "code", let context = preContext, context.language.isEmpty {
+                    preContext = PreContext(language: Self.codeLanguage(fromClass: attributes["class"]))
+                }
+                return
+            }
+
+            // Block-level elements implicitly terminate open inline constructs, the way
+            // browsers auto-close an unclosed <a> or <code> at a block boundary — otherwise a
+            // page missing one </a> would swallow everything after it into the link's
+            // (bounded) capture buffer.
+            if Self.blockBoundaryElements.contains(name) {
+                flushInlineCaptures()
+            }
+
+            switch name {
+            case "br":
+                requestLineBreak()
+            case "hr":
+                writer.writeBlockLines(["---"])
+            case "p", "div", "section", "article", "main", "header", "footer", "figure",
+                 "figcaption", "fieldset", "form", "details", "address", "dl", "dd", "center",
+                 "summary", "dt":
+                requestBlockBreak()
+            case "h1", "h2", "h3", "h4", "h5", "h6":
+                requestBlockBreak()
+                let level = Int(name.dropFirst()) ?? 1
+                writer.writeMarker(String(repeating: "#", count: min(max(level, 1), 6)) + " ", flushingSpace: true)
+            case "ul", "ol":
+                guard structural, listStack.count < Self.maxListDepth else {
+                    break
+                }
+                if listStack.isEmpty {
+                    requestBlockBreak()
+                }
+                listStack.append(ListContext(ordered: name == "ol", nextIndex: 1))
+            case "li":
+                startListItem()
+            case "blockquote":
+                guard structural, quoteDepth < Self.maxQuoteDepth else {
+                    break
+                }
+                requestBlockBreak()
+                quoteDepth += 1
+                writer.quoteDepth = quoteDepth
+                requestBlockBreak()
+            case "pre":
+                guard structural else {
+                    break
+                }
+                startPre(attributes: attributes)
+            case "code", "kbd", "samp", "tt":
+                guard structural, preContext == nil else {
+                    break
+                }
+                if writer.pushCapture(byteLimit: Self.inlineCodeByteLimit) {
+                    inlineCaptures.append(.code)
+                }
+            case "strong", "b":
+                openEmphasis("**")
+            case "em", "i", "cite", "dfn", "var":
+                openEmphasis("*")
+            case "del", "s", "strike":
+                openEmphasis("~~")
+            case "a":
+                guard structural else {
+                    break
+                }
+                if writer.pushCapture(byteLimit: Self.linkTextByteLimit) {
+                    inlineCaptures.append(.link(href: attributes["href"] ?? ""))
+                }
+            case "img":
+                writeImage(attributes)
+            case "table":
+                handleTableOpen()
+            case "tr":
+                handleTableRowOpen()
+            case "td", "th":
+                handleTableCellOpen()
+            case "caption":
+                handleTableCaptionOpen()
+            case "thead", "tbody", "tfoot", "colgroup":
+                break
+            default:
+                break // Unknown/inline elements are transparent.
+            }
+        }
+
+        private mutating func handleOpenTagWhileSkipping(_ name: String, selfClosing: Bool) {
+            guard var context = skip else {
+                return
+            }
+            // A raw-text element inside a skipped subtree must still be consumed as raw text —
+            // otherwise a literal "</head>" inside an inline script would end the skip early.
+            if Self.rawTextElements.contains(name) {
+                if !selfClosing {
+                    _ = tokenizer.consumeRawText(until: name)
+                }
+                return
+            }
+            if name == context.name, !selfClosing, !Self.voidElements.contains(name) {
+                context.depth += 1
+                skip = context
+            }
+            // Browsers auto-close <head> when <body> starts; honor that so a page missing
+            // </head> does not lose its entire body.
+            if context.name == "head", name == "body" {
+                skip = nil
+            }
+        }
+
+        // MARK: - Close tags
+
+        private mutating func handleCloseTag(_ name: String) {
+            if var context = skip {
+                if name == context.name {
+                    context.depth -= 1
+                    skip = context.depth > 0 ? context : nil
+                }
+                return
+            }
+            if Self.skippedSubtreeElements.contains(name) || Self.rawTextElements.contains(name) {
+                return // Stray close without a tracked open.
+            }
+            if !Self.voidElements.contains(name) {
+                elementDepth = max(0, elementDepth - 1)
+            }
+            if isBetweenTableCells, !Self.tableStructureElements.contains(name) {
+                return
+            }
+            if preContext != nil {
+                if name == "pre" {
+                    finishPre()
+                }
+                return
+            }
+
+            if Self.blockBoundaryElements.contains(name) {
+                flushInlineCaptures()
+            }
+
+            switch name {
+            case "p", "div", "section", "article", "main", "header", "footer", "figure",
+                 "figcaption", "fieldset", "form", "details", "summary", "dl", "dt", "dd",
+                 "center", "h1", "h2", "h3", "h4", "h5", "h6", "li":
+                requestBlockBreakAfterBlock(name)
+            case "ul", "ol":
+                if !listStack.isEmpty {
+                    listStack.removeLast()
+                }
+                if listStack.isEmpty {
+                    requestBlockBreak()
+                }
+            case "blockquote":
+                if quoteDepth > 0 {
+                    quoteDepth -= 1
+                    writer.quoteDepth = quoteDepth
+                }
+                requestBlockBreak()
+            case "code", "kbd", "samp", "tt":
+                finishInlineCode()
+            case "strong", "b":
+                closeEmphasis("**")
+            case "em", "i", "cite", "dfn", "var":
+                closeEmphasis("*")
+            case "del", "s", "strike":
+                closeEmphasis("~~")
+            case "a":
+                finishLink()
+            case "table":
+                handleTableClose()
+            case "tr":
+                handleTableRowClose()
+            case "td", "th":
+                handleTableCellClose()
+            case "caption":
+                handleTableCaptionClose()
+            default:
+                break
+            }
+        }
+
+        private mutating func requestBlockBreakAfterBlock(_ name: String) {
+            if name == "li" {
+                return // The next <li> or the list close provides the break.
+            }
+            requestBlockBreak()
+        }
+
+        // MARK: - Breaks and lists
+
+        private mutating func requestLineBreak() {
+            writer.requestLineBreak()
+        }
+
+        private mutating func requestBlockBreak() {
+            // Inside a list, paragraph breaks degrade to line breaks so items stay items.
+            if listStack.isEmpty {
+                writer.requestBlockBreak()
+            } else {
+                writer.requestLineBreak()
+            }
+        }
+
+        private mutating func startListItem() {
+            writer.requestLineBreak()
+            let depth = max(listStack.count, 1)
+            let indent = String(repeating: "  ", count: depth - 1)
+            let marker: String
+            if let index = listStack.indices.last, listStack[index].ordered {
+                marker = "\(listStack[index].nextIndex). "
+                listStack[index].nextIndex += 1
+            } else {
+                marker = "- "
+            }
+            writer.writeMarker(indent + marker, flushingSpace: false)
+        }
+
+        // MARK: - Emphasis
+
+        private mutating func openEmphasis(_ marker: String) {
+            guard preContext == nil, emphasisStack.count < Self.maxEmphasisDepth else {
+                return
+            }
+            emphasisStack.append(marker)
+            writer.writeMarker(marker, flushingSpace: true)
+        }
+
+        private mutating func closeEmphasis(_ marker: String) {
+            guard emphasisStack.last == marker else {
+                return // Mis-nested close; leave it rather than corrupt the stack.
+            }
+            emphasisStack.removeLast()
+            writer.writeMarker(marker, flushingSpace: false)
+        }
+
+        // MARK: - Inline captures (links and code)
+
+        /// Closes the innermost inline capture. Only pops when the top of the stack matches
+        /// the requested kind, so a stray close tag cannot desync captures.
+        private mutating func finishLink() {
+            guard case .link(let href)? = inlineCaptures.last else {
+                return
+            }
+            inlineCaptures.removeLast()
+            emitLink(href: href, text: writer.popCapture() ?? "")
+        }
+
+        private mutating func finishInlineCode() {
+            guard case .code? = inlineCaptures.last else {
+                return
+            }
+            inlineCaptures.removeLast()
+            emitInlineCode(writer.popCapture() ?? "")
+        }
+
+        /// Emits and clears every open inline capture, innermost first — called at block
+        /// boundaries (browsers auto-close inline elements there) and at end of input, so an
+        /// unclosed `<a>`/`<code>` cannot swallow the rest of the page into its buffer.
+        private mutating func flushInlineCaptures() {
+            while let capture = inlineCaptures.popLast() {
+                switch capture {
+                case .link(let href):
+                    emitLink(href: href, text: writer.popCapture() ?? "")
+                case .code:
+                    emitInlineCode(writer.popCapture() ?? "")
+                }
+            }
+        }
+
+        private mutating func emitLink(href: String, text: String) {
+            let label = escapedLinkLabel(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            guard let destination = resolvedLinkDestination(href) else {
+                writer.writeMarker(label, flushingSpace: true)
+                return
+            }
+            guard !label.isEmpty else {
+                return
+            }
+            writer.writeMarker("[\(label)](\(destination))", flushingSpace: true)
+        }
+
+        private mutating func emitInlineCode(_ content: String) {
+            let text = content.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else {
+                return
+            }
+            if text.contains("`") {
+                writer.writeMarker("`` \(text) ``", flushingSpace: true)
+            } else {
+                writer.writeMarker("`\(text)`", flushingSpace: true)
+            }
+        }
+
+        // MARK: - Images
+
+        private mutating func writeImage(_ attributes: [String: String]) {
+            let alt = (attributes["alt"] ?? "")
+                .components(separatedBy: .whitespacesAndNewlines)
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            let source = attributes["src"] ?? ""
+            if source.lowercased().hasPrefix("data:") {
+                // Inline base64 images: keep small ones (they render fine in markdown), and
+                // summarize big ones instead of flooding the context with base64.
+                if source.utf8.count <= Self.maxInlineDataURIBytes {
+                    writer.writeMarker("![\(escapedLinkLabel(alt))](\(source))", flushingSpace: true)
+                } else {
+                    let kilobytes = source.utf8.count / 1024
+                    writer.writeText("[inline image\(alt.isEmpty ? "" : " \"\(alt)\"") omitted — \(kilobytes) KB data URI]")
+                }
+                return
+            }
+            guard let destination = resolvedLinkDestination(source) else {
+                if !alt.isEmpty {
+                    writer.writeText(alt)
+                }
+                return
+            }
+            writer.writeMarker("![\(escapedLinkLabel(alt))](\(destination))", flushingSpace: true)
+        }
+
+        /// Resolves a href/src against the page URL and sanitizes it for a markdown
+        /// destination. Returns nil for empty, scripting, or unresolvable targets — the caller
+        /// then falls back to plain text.
+        private func resolvedLinkDestination(_ raw: String) -> String? {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                return nil
+            }
+            let lowered = trimmed.lowercased()
+            for scheme in ["javascript:", "vbscript:", "data:", "blob:", "about:"] where lowered.hasPrefix(scheme) {
+                return nil
+            }
+            let resolved = URL(string: trimmed, relativeTo: options.baseURL)?.absoluteString ?? trimmed
+            // Parentheses, spaces, and control characters break the (…) destination syntax.
+            var sanitized = ""
+            for scalar in resolved.unicodeScalars {
+                switch scalar {
+                case "(":
+                    sanitized += "%28"
+                case ")":
+                    sanitized += "%29"
+                case " ":
+                    sanitized += "%20"
+                default:
+                    if scalar.value >= 0x20, scalar.value != 0x7F {
+                        sanitized.unicodeScalars.append(scalar)
+                    }
+                }
+            }
+            return sanitized.isEmpty ? nil : sanitized
+        }
+
+        private func escapedLinkLabel(_ label: String) -> String {
+            label
+                .replacingOccurrences(of: "[", with: "\\[")
+                .replacingOccurrences(of: "]", with: "\\]")
+        }
+
+        // MARK: - Preformatted blocks
+
+        private mutating func startPre(attributes: [String: String]) {
+            guard writer.pushCapture(byteLimit: Self.preByteLimit, preservesWhitespace: true) else {
+                return
+            }
+            preContext = PreContext(language: Self.codeLanguage(fromClass: attributes["class"]))
+        }
+
+        private mutating func finishPre() {
+            guard let context = preContext, let content = writer.popCapture() else {
+                preContext = nil
+                return
+            }
+            preContext = nil
+            var body = content
+            while body.hasSuffix("\n") {
+                body.removeLast()
+            }
+            while body.hasPrefix("\n") {
+                body.removeFirst()
+            }
+            guard !body.isEmpty else {
+                return
+            }
+            // The fence must be longer than any backtick run in the body — capped, so a
+            // hostile block of thousands of backticks cannot inflate the fence itself.
+            var longestRun = 0
+            var currentRun = 0
+            for character in body {
+                currentRun = character == "`" ? currentRun + 1 : 0
+                longestRun = max(longestRun, currentRun)
+            }
+            let fence = String(repeating: "`", count: min(max(3, longestRun + 1), Self.maxCodeFenceLength))
+            writer.writeBlockLines([fence + context.language] + body.components(separatedBy: "\n") + [fence])
+        }
+
+        private static func codeLanguage(fromClass classAttribute: String?) -> String {
+            guard let classAttribute else {
+                return ""
+            }
+            for token in classAttribute.split(separator: " ") {
+                for prefix in ["language-", "lang-"] where token.hasPrefix(prefix) {
+                    let language = token.dropFirst(prefix.count).prefix(24)
+                    if !language.isEmpty, language.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "+" || $0 == "-" || $0 == "#" }) {
+                        return String(language)
+                    }
+                }
+            }
+            return ""
+        }
+
+        // MARK: - Tables
+
+        private mutating func handleTableOpen() {
+            if table != nil {
+                table?.nestedTables += 1
+                return
+            }
+            table = TableContext()
+        }
+
+        private mutating func handleTableClose() {
+            guard var context = table else {
+                return
+            }
+            if context.nestedTables > 0 {
+                context.nestedTables -= 1
+                table = context
+                return
+            }
+            closeCellIfOpen()
+            flushRowIfOpen()
+            renderTable()
+        }
+
+        private mutating func handleTableRowOpen() {
+            guard table != nil, table?.nestedTables == 0 else {
+                return
+            }
+            closeCellIfOpen()
+            flushRowIfOpen()
+            table?.currentRow = []
+        }
+
+        private mutating func handleTableRowClose() {
+            guard table != nil, table?.nestedTables == 0 else {
+                return
+            }
+            closeCellIfOpen()
+            flushRowIfOpen()
+        }
+
+        private mutating func handleTableCellOpen() {
+            guard var context = table, context.nestedTables == 0 else {
+                return
+            }
+            closeCellIfOpen()
+            if context.currentRow == nil {
+                context.currentRow = []
+            }
+            context.cellOpen = writer.pushCapture(byteLimit: Self.tableCellByteLimit)
+            table = context
+        }
+
+        private mutating func handleTableCellClose() {
+            closeCellIfOpen()
+        }
+
+        private mutating func closeCellIfOpen() {
+            guard var context = table, context.cellOpen else {
+                return
+            }
+            context.cellOpen = false
+            let text = writer.popCapture() ?? ""
+            if var row = context.currentRow {
+                if row.count < Self.maxTableColumns {
+                    row.append(text.trimmingCharacters(in: .whitespacesAndNewlines))
+                }
+                context.currentRow = row
+            }
+            table = context
+        }
+
+        private mutating func flushRowIfOpen() {
+            guard var context = table, let row = context.currentRow else {
+                return
+            }
+            context.currentRow = nil
+            if !row.isEmpty, context.rows.count < Self.maxTableRows {
+                context.rows.append(row)
+            }
+            table = context
+        }
+
+        private mutating func handleTableCaptionOpen() {
+            guard var context = table, context.nestedTables == 0, !context.captionOpen else {
+                return
+            }
+            context.captionOpen = writer.pushCapture(byteLimit: Self.tableCellByteLimit)
+            table = context
+        }
+
+        private mutating func handleTableCaptionClose() {
+            guard var context = table, context.captionOpen else {
+                return
+            }
+            context.captionOpen = false
+            context.caption = writer.popCapture()?.trimmingCharacters(in: .whitespacesAndNewlines)
+            table = context
+        }
+
+        private mutating func renderTable() {
+            guard let context = table else {
+                return
+            }
+            table = nil
+            let rows = context.rows
+            guard !rows.isEmpty else {
+                if let caption = context.caption, !caption.isEmpty {
+                    writer.writeBlockLines(["*\(caption)*"])
+                }
+                return
+            }
+            let columnCount = min(rows.map(\.count).max() ?? 0, Self.maxTableColumns)
+            guard columnCount > 0 else {
+                return
+            }
+            var lines: [String] = []
+            if let caption = context.caption, !caption.isEmpty {
+                lines.append("*\(caption)*")
+                lines.append("")
+            }
+            func renderRow(_ row: [String]) -> String {
+                let padded = (0..<columnCount).map { index in
+                    index < row.count ? row[index].replacingOccurrences(of: "|", with: "\\|") : ""
+                }
+                return "| " + padded.joined(separator: " | ") + " |"
+            }
+            lines.append(renderRow(rows[0]))
+            lines.append("| " + Array(repeating: "---", count: columnCount).joined(separator: " | ") + " |")
+            for row in rows.dropFirst() {
+                lines.append(renderRow(row))
+            }
+            writer.writeBlockLines(lines)
+        }
+
+        // MARK: - End of input
+
+        private mutating func finishOpenConstructs() {
+            // Unclosed captures are flushed innermost-first so their text is not lost.
+            if preContext != nil {
+                finishPre()
+            }
+            flushInlineCaptures()
+            if table != nil {
+                closeCellIfOpen()
+                flushRowIfOpen()
+                renderTable()
+            }
+            // Anything still captured (e.g. cells without a table) flushes as plain text.
+            while let leftover = writer.popCapture() {
+                let text = leftover.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !text.isEmpty {
+                    writer.writeMarker(text, flushingSpace: true)
+                }
+            }
+        }
+
+        // MARK: - Element sets and bounds
+
+        private static let voidElements: Set<String> = [
+            "area", "base", "br", "col", "embed", "hr", "img", "input",
+            "link", "meta", "param", "source", "track", "wbr"
+        ]
+
+        private static let rawTextElements: Set<String> = [
+            "script", "style", "textarea", "title", "xmp", "noscript"
+        ]
+
+        private static let skippedSubtreeElements: Set<String> = [
+            "head", "nav", "aside", "template", "svg", "math", "iframe",
+            "object", "canvas", "select", "audio", "video"
+        ]
+
+        private static let tableStructureElements: Set<String> = [
+            "table", "thead", "tbody", "tfoot", "colgroup", "tr", "td", "th", "caption"
+        ]
+
+        /// Elements whose start or end auto-closes open inline captures (browser-style
+        /// implicit termination). Trade-off: an HTML5 block-wrapping anchor (`<a><div>…`)
+        /// loses its href but keeps ALL of its text; without this, one unclosed `<a>` would
+        /// cap the rest of the page at the link buffer's limit.
+        private static let blockBoundaryElements: Set<String> = [
+            "p", "div", "section", "article", "main", "header", "footer", "figure",
+            "figcaption", "fieldset", "form", "details", "address", "dl", "dt", "dd",
+            "center", "summary", "h1", "h2", "h3", "h4", "h5", "h6",
+            "ul", "ol", "li", "blockquote", "pre", "hr",
+            "table", "thead", "tbody", "tfoot", "tr", "td", "th", "caption"
+        ]
+
+        private static let maxListDepth = 16
+        private static let maxQuoteDepth = 8
+        private static let maxEmphasisDepth = 16
+        private static let inlineCodeByteLimit = 2048
+        private static let linkTextByteLimit = 2048
+        private static let preByteLimit = 32_768
+        private static let tableCellByteLimit = 1024
+        private static let maxTableColumns = 16
+        private static let maxTableRows = 200
+        private static let maxInlineDataURIBytes = 2048
+        private static let maxCodeFenceLength = 16
+    }
+}

--- a/Sources/QuillCodeTools/HTMLTokenizer.swift
+++ b/Sources/QuillCodeTools/HTMLTokenizer.swift
@@ -1,0 +1,311 @@
+import Foundation
+
+enum HTMLToken: Equatable {
+    case text(String)
+    case openTag(name: String, attributes: [String: String], selfClosing: Bool)
+    case closeTag(name: String)
+}
+
+/// A forgiving, single-pass HTML tokenizer over UTF-8 bytes. It never recurses and its cursor
+/// advances on every call, so malformed input (unterminated comments, `<` soup, half-open
+/// tags) can slow it down only linearly — it cannot hang, recurse deep, or throw. Tag names
+/// and attribute counts are bounded; everything that is not a recognizable tag is text.
+struct HTMLTokenizer {
+    private let bytes: [UInt8]
+    private var index = 0
+
+    init(_ html: String) {
+        self.bytes = Array(html.utf8)
+    }
+
+    mutating func next() -> HTMLToken? {
+        guard index < bytes.count else {
+            return nil
+        }
+        if bytes[index] == UInt8(ascii: "<") {
+            if let token = parseMarkup() {
+                return token
+            }
+            // A lone `<` that is not markup is literal text.
+            index += 1
+            return .text("<")
+        }
+        return .text(consumeText())
+    }
+
+    /// Consumes raw character data until the matching `</name` close tag — used for elements
+    /// whose contents must never be tokenized as HTML (`script`, `style`, …). Returns the raw
+    /// text; the close tag itself is also consumed. Missing close tag = rest of input.
+    mutating func consumeRawText(until name: String) -> String {
+        let closeMarker = Array("</\(name.lowercased())".utf8)
+        var cursor = index
+        while cursor < bytes.count {
+            if bytes[cursor] == UInt8(ascii: "<"),
+               matchesCaseInsensitive(closeMarker, at: cursor),
+               isRawTextCloseTerminator(at: cursor + closeMarker.count) {
+                let raw = decode(index..<cursor)
+                index = cursor
+                skipThroughTagEnd()
+                return raw
+            }
+            cursor += 1
+        }
+        let raw = decode(index..<bytes.count)
+        index = bytes.count
+        return raw
+    }
+
+    // MARK: - Markup
+
+    private mutating func parseMarkup() -> HTMLToken? {
+        let start = index
+        guard start + 1 < bytes.count else {
+            return nil
+        }
+        let second = bytes[start + 1]
+        if second == UInt8(ascii: "!") {
+            skipDeclaration()
+            return .text("")
+        }
+        if second == UInt8(ascii: "?") {
+            index = start + 2
+            skipUntilTagEnd(consumeTerminator: true)
+            return .text("")
+        }
+        if second == UInt8(ascii: "/") {
+            index = start + 2
+            guard let name = consumeTagName() else {
+                index = start
+                return nil
+            }
+            skipUntilTagEnd(consumeTerminator: true)
+            return .closeTag(name: name)
+        }
+        guard isASCIILetter(second) else {
+            return nil
+        }
+        index = start + 1
+        guard let name = consumeTagName() else {
+            index = start
+            return nil
+        }
+        let (attributes, selfClosing) = consumeAttributes()
+        return .openTag(name: name, attributes: attributes, selfClosing: selfClosing)
+    }
+
+    private mutating func skipDeclaration() {
+        // `<!-- comment -->`, `<![CDATA[ ... ]]>`, `<!DOCTYPE ...>` — all discarded.
+        if matches("<!--", at: index) {
+            index += 4
+            skipPast("-->")
+            return
+        }
+        if matches("<![CDATA[", at: index) {
+            index += 9
+            skipPast("]]>")
+            return
+        }
+        index += 2
+        skipUntilTagEnd(consumeTerminator: true)
+    }
+
+    private mutating func consumeTagName() -> String? {
+        let start = index
+        while index < bytes.count, isTagNameByte(bytes[index]), index - start < maxTagNameLength {
+            index += 1
+        }
+        guard index > start else {
+            return nil
+        }
+        return decode(start..<index).lowercased()
+    }
+
+    private mutating func consumeAttributes() -> ([String: String], Bool) {
+        var attributes: [String: String] = [:]
+        var selfClosing = false
+        var count = 0
+        while index < bytes.count {
+            skipWhitespace()
+            guard index < bytes.count else {
+                break
+            }
+            let byte = bytes[index]
+            if byte == UInt8(ascii: ">") {
+                index += 1
+                return (attributes, selfClosing)
+            }
+            if byte == UInt8(ascii: "/") {
+                selfClosing = true
+                index += 1
+                continue
+            }
+            guard let name = consumeAttributeName() else {
+                // Junk byte inside a tag — skip it so the cursor always advances.
+                index += 1
+                continue
+            }
+            skipWhitespace()
+            var value = ""
+            if index < bytes.count, bytes[index] == UInt8(ascii: "=") {
+                index += 1
+                skipWhitespace()
+                value = consumeAttributeValue()
+            }
+            if count < maxAttributesPerTag {
+                attributes[name] = HTMLEntityDecoder.decode(value)
+                count += 1
+            }
+        }
+        return (attributes, selfClosing)
+    }
+
+    private mutating func consumeAttributeName() -> String? {
+        let start = index
+        while index < bytes.count, isAttributeNameByte(bytes[index]), index - start < maxAttributeNameLength {
+            index += 1
+        }
+        guard index > start else {
+            return nil
+        }
+        return decode(start..<index).lowercased()
+    }
+
+    private mutating func consumeAttributeValue() -> String {
+        guard index < bytes.count else {
+            return ""
+        }
+        let quote = bytes[index]
+        if quote == UInt8(ascii: "\"") || quote == UInt8(ascii: "'") {
+            index += 1
+            let start = index
+            while index < bytes.count, bytes[index] != quote {
+                index += 1
+            }
+            let value = decode(start..<min(index, start + maxAttributeValueLength))
+            if index < bytes.count {
+                index += 1
+            }
+            return value
+        }
+        let start = index
+        while index < bytes.count, !isWhitespaceByte(bytes[index]), bytes[index] != UInt8(ascii: ">") {
+            index += 1
+        }
+        return decode(start..<min(index, start + maxAttributeValueLength))
+    }
+
+    // MARK: - Text
+
+    private mutating func consumeText() -> String {
+        let start = index
+        while index < bytes.count, bytes[index] != UInt8(ascii: "<") {
+            index += 1
+        }
+        return HTMLEntityDecoder.decode(decode(start..<index))
+    }
+
+    // MARK: - Cursor helpers
+
+    private mutating func skipWhitespace() {
+        while index < bytes.count, isWhitespaceByte(bytes[index]) {
+            index += 1
+        }
+    }
+
+    private mutating func skipUntilTagEnd(consumeTerminator: Bool) {
+        while index < bytes.count, bytes[index] != UInt8(ascii: ">") {
+            index += 1
+        }
+        if consumeTerminator, index < bytes.count {
+            index += 1
+        }
+    }
+
+    private mutating func skipThroughTagEnd() {
+        skipUntilTagEnd(consumeTerminator: true)
+    }
+
+    private mutating func skipPast(_ marker: String) {
+        let markerBytes = Array(marker.utf8)
+        var cursor = index
+        while cursor < bytes.count {
+            if bytes[cursor] == markerBytes[0], matches(marker, at: cursor) {
+                index = cursor + markerBytes.count
+                return
+            }
+            cursor += 1
+        }
+        index = bytes.count
+    }
+
+    private func matches(_ marker: String, at position: Int) -> Bool {
+        let markerBytes = Array(marker.utf8)
+        guard position + markerBytes.count <= bytes.count else {
+            return false
+        }
+        for (offset, byte) in markerBytes.enumerated() where bytes[position + offset] != byte {
+            return false
+        }
+        return true
+    }
+
+    private func matchesCaseInsensitive(_ marker: [UInt8], at position: Int) -> Bool {
+        guard position + marker.count <= bytes.count else {
+            return false
+        }
+        for (offset, byte) in marker.enumerated() where lowercased(bytes[position + offset]) != byte {
+            return false
+        }
+        return true
+    }
+
+    /// After `</script` the next byte must end the tag name (whitespace, `>`, `/`, or EOF) —
+    /// otherwise `</scripty` inside a script would end raw-text mode early.
+    private func isRawTextCloseTerminator(at position: Int) -> Bool {
+        guard position < bytes.count else {
+            return true
+        }
+        let byte = bytes[position]
+        return isWhitespaceByte(byte) || byte == UInt8(ascii: ">") || byte == UInt8(ascii: "/")
+    }
+
+    private func decode(_ range: Range<Int>) -> String {
+        guard range.lowerBound < range.upperBound else {
+            return ""
+        }
+        return String(decoding: bytes[range], as: UTF8.self)
+    }
+
+    private func lowercased(_ byte: UInt8) -> UInt8 {
+        byte >= UInt8(ascii: "A") && byte <= UInt8(ascii: "Z") ? byte + 32 : byte
+    }
+
+    private func isASCIILetter(_ byte: UInt8) -> Bool {
+        (byte >= UInt8(ascii: "a") && byte <= UInt8(ascii: "z"))
+            || (byte >= UInt8(ascii: "A") && byte <= UInt8(ascii: "Z"))
+    }
+
+    private func isTagNameByte(_ byte: UInt8) -> Bool {
+        isASCIILetter(byte)
+            || (byte >= UInt8(ascii: "0") && byte <= UInt8(ascii: "9"))
+            || byte == UInt8(ascii: "-") || byte == UInt8(ascii: ":")
+    }
+
+    private func isAttributeNameByte(_ byte: UInt8) -> Bool {
+        !isWhitespaceByte(byte)
+            && byte != UInt8(ascii: "=") && byte != UInt8(ascii: ">")
+            && byte != UInt8(ascii: "/") && byte != UInt8(ascii: "\"")
+            && byte != UInt8(ascii: "'") && byte != UInt8(ascii: "<")
+    }
+
+    private func isWhitespaceByte(_ byte: UInt8) -> Bool {
+        byte == UInt8(ascii: " ") || byte == UInt8(ascii: "\t")
+            || byte == UInt8(ascii: "\n") || byte == UInt8(ascii: "\r")
+            || byte == 0x0C
+    }
+
+    private let maxTagNameLength = 64
+    private let maxAttributesPerTag = 32
+    private let maxAttributeNameLength = 128
+    private let maxAttributeValueLength = 8192
+}

--- a/Sources/QuillCodeTools/ToolRouter.swift
+++ b/Sources/QuillCodeTools/ToolRouter.swift
@@ -7,18 +7,21 @@ public struct ToolRouter: Sendable {
     public var files: FileToolExecutor
     public var git: GitToolExecutor
     public var patch: PatchToolExecutor
+    public var web: WebFetchToolExecutor
 
     public init(
         workspaceRoot: URL,
         shell: ShellToolExecutor = ShellToolExecutor(),
         git: GitToolExecutor = GitToolExecutor(),
-        editGuard: FileEditSessionGuard = .shared
+        editGuard: FileEditSessionGuard = .shared,
+        web: WebFetchToolExecutor = WebFetchToolExecutor()
     ) {
         self.workspaceRoot = workspaceRoot
         self.shell = shell
         self.files = FileToolExecutor(workspaceRoot: workspaceRoot, editGuard: editGuard)
         self.git = git
         self.patch = PatchToolExecutor(workspaceRoot: workspaceRoot, shell: shell, editGuard: editGuard)
+        self.web = web
     }
 
     public static let definitions: [ToolDefinition] = ShellToolCallDispatcher.definitions + [
@@ -26,7 +29,8 @@ public struct ToolRouter: Sendable {
         .fileList,
         .fileSearch,
         .fileWrite,
-        .applyPatch
+        .applyPatch,
+        .webFetch
     ] + GitToolCallDispatcher.definitions
 
     public func definition(named name: String) -> ToolDefinition? {
@@ -70,6 +74,8 @@ public struct ToolRouter: Sendable {
                 )
             case ToolDefinition.applyPatch.name:
                 return patch.apply(unifiedDiff: try args.requiredString("patch"))
+            case ToolDefinition.webFetch.name:
+                return web.fetch(urlString: try args.requiredString("url"))
             default:
                 return ToolResult(ok: false, error: "Unknown tool: \(call.name)")
             }

--- a/Sources/QuillCodeTools/URLSessionWebFetchHTTPClient.swift
+++ b/Sources/QuillCodeTools/URLSessionWebFetchHTTPClient.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// URLSession-backed `WebFetchHTTPClient`. Blocking by design — it is called from
+/// `ToolRouter.execute`, which is synchronous (the same way `ShellToolExecutor` blocks while
+/// a process runs). Redirects are refused at the delegate so every 3xx surfaces to the
+/// executor for SSRF re-gating, and the body is cancelled mid-stream the moment it exceeds
+/// the byte cap.
+public struct URLSessionWebFetchHTTPClient: WebFetchHTTPClient {
+    public init() {}
+
+    public func perform(_ request: WebFetchHTTPRequest) throws -> WebFetchHTTPResponse {
+        let delegate = TransactionDelegate(maxBodyBytes: max(0, request.maxBodyBytes))
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = request.timeout
+        configuration.timeoutIntervalForResource = request.timeout
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+
+        var urlRequest = URLRequest(url: request.url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.timeoutInterval = request.timeout
+        for (name, value) in request.headers {
+            urlRequest.setValue(value, forHTTPHeaderField: name)
+        }
+
+        let task = session.dataTask(with: urlRequest)
+        task.resume()
+
+        // The semaphore wait is BOUNDED: even if URLSession never calls back (which its
+        // resource timeout should prevent), the tool returns a timeout error instead of
+        // hanging the agent loop forever.
+        let grace: TimeInterval = 10
+        let deadline = DispatchTime.now() + request.timeout + grace
+        guard delegate.completionSemaphore.wait(timeout: deadline) == .success else {
+            task.cancel()
+            throw WebFetchHTTPClientError.timedOut
+        }
+        return try delegate.makeResponse()
+    }
+
+    /// Collects one transaction's response, enforcing the streaming byte cap and refusing
+    /// redirects. `@unchecked Sendable` is sound: all mutable state is guarded by `lock`,
+    /// and the caller only reads after `completionSemaphore` is signalled.
+    private final class TransactionDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+        let completionSemaphore = DispatchSemaphore(value: 0)
+
+        private let maxBodyBytes: Int
+        private let lock = NSLock()
+        private var response: HTTPURLResponse?
+        private var body = Data()
+        private var exceededMaxBytes = false
+        private var transportError: Error?
+
+        init(maxBodyBytes: Int) {
+            self.maxBodyBytes = maxBodyBytes
+        }
+
+        func makeResponse() throws -> WebFetchHTTPResponse {
+            lock.lock()
+            defer { lock.unlock() }
+            guard let response else {
+                if let transportError {
+                    if isTimeout(transportError) {
+                        throw WebFetchHTTPClientError.timedOut
+                    }
+                    throw WebFetchHTTPClientError.transport(transportError.localizedDescription)
+                }
+                throw WebFetchHTTPClientError.notHTTP
+            }
+            // A transport error AFTER the cap was hit is the cancellation we asked for; the
+            // partial body is the intended result. Any other mid-body error is a real failure.
+            if let transportError, !exceededMaxBytes {
+                if isTimeout(transportError) {
+                    throw WebFetchHTTPClientError.timedOut
+                }
+                throw WebFetchHTTPClientError.transport(transportError.localizedDescription)
+            }
+            return WebFetchHTTPResponse(
+                statusCode: response.statusCode,
+                headerFields: Self.normalizedHeaderFields(response),
+                body: body,
+                bodyExceededMaxBytes: exceededMaxBytes
+            )
+        }
+
+        // Refuse every redirect: returning nil delivers the 3xx response itself, letting the
+        // executor re-run the host gate on the Location target before any new connection.
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            willPerformHTTPRedirection response: HTTPURLResponse,
+            newRequest request: URLRequest,
+            completionHandler: @escaping (URLRequest?) -> Void
+        ) {
+            completionHandler(nil)
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            didReceive response: URLResponse,
+            completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        ) {
+            lock.lock()
+            self.response = response as? HTTPURLResponse
+            // Trust but verify: a huge declared Content-Length is refused before reading the
+            // body. Comparison stays in Int64 — no conversion of server data into Int.
+            let declared = response.expectedContentLength
+            if declared != NSURLSessionTransferSizeUnknown, declared > Int64(maxBodyBytes) {
+                exceededMaxBytes = true
+                lock.unlock()
+                completionHandler(.cancel)
+                return
+            }
+            lock.unlock()
+            completionHandler(.allow)
+        }
+
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            lock.lock()
+            let remaining = maxBodyBytes - body.count
+            if data.count <= remaining {
+                body.append(data)
+                lock.unlock()
+                return
+            }
+            if remaining > 0 {
+                body.append(data.prefix(remaining))
+            }
+            exceededMaxBytes = true
+            lock.unlock()
+            dataTask.cancel()
+        }
+
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            lock.lock()
+            transportError = error
+            lock.unlock()
+            completionSemaphore.signal()
+        }
+
+        private func isTimeout(_ error: Error) -> Bool {
+            let nsError = error as NSError
+            return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
+        }
+
+        private static func normalizedHeaderFields(_ response: HTTPURLResponse) -> [String: String] {
+            var fields: [String: String] = [:]
+            for (name, value) in response.allHeaderFields {
+                guard let name = name as? String, let value = value as? String else {
+                    continue
+                }
+                let key = name.lowercased()
+                fields[key] = fields[key].map { "\($0), \(value)" } ?? value
+            }
+            return fields
+        }
+    }
+}

--- a/Sources/QuillCodeTools/URLSessionWebFetchHTTPClient.swift
+++ b/Sources/QuillCodeTools/URLSessionWebFetchHTTPClient.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+// URLSession and its request/response/delegate types live in FoundationNetworking on Linux
+// (swift-corelibs-foundation), not Foundation — the same split the TrustedRouter clients guard.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 /// URLSession-backed `WebFetchHTTPClient`. Blocking by design — it is called from
 /// `ToolRouter.execute`, which is synchronous (the same way `ShellToolExecutor` blocks while
 /// a process runs). Redirects are refused at the delegate so every 3xx surfaces to the

--- a/Sources/QuillCodeTools/WebFetchHTTPClient.swift
+++ b/Sources/QuillCodeTools/WebFetchHTTPClient.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// One HTTP GET transaction for `host.web.fetch`, WITHOUT redirect following: a 3xx response
+/// is returned as-is (status + `location` header) so the executor can re-run the SSRF host
+/// gate on every hop. Implementations must stop reading the body once `maxBodyBytes` is
+/// exceeded (streaming cap, not an after-the-fact trim) and report the overflow.
+public struct WebFetchHTTPRequest: Sendable, Hashable {
+    public var url: URL
+    /// Header field name → value. Names are sent as given.
+    public var headers: [String: String]
+    /// Overall time budget for the transaction, in seconds.
+    public var timeout: TimeInterval
+    /// Maximum number of body bytes to read before cancelling the transfer.
+    public var maxBodyBytes: Int
+
+    public init(url: URL, headers: [String: String], timeout: TimeInterval, maxBodyBytes: Int) {
+        self.url = url
+        self.headers = headers
+        self.timeout = timeout
+        self.maxBodyBytes = maxBodyBytes
+    }
+}
+
+public struct WebFetchHTTPResponse: Sendable, Hashable {
+    public var statusCode: Int
+    /// Header field names lowercased; duplicate fields joined with ", ".
+    public var headerFields: [String: String]
+    /// Body bytes read, at most `maxBodyBytes` of them.
+    public var body: Data
+    /// True when the server offered more than `maxBodyBytes` and the transfer was cut short.
+    public var bodyExceededMaxBytes: Bool
+
+    public init(
+        statusCode: Int,
+        headerFields: [String: String] = [:],
+        body: Data = Data(),
+        bodyExceededMaxBytes: Bool = false
+    ) {
+        self.statusCode = statusCode
+        self.headerFields = headerFields
+        self.body = body
+        self.bodyExceededMaxBytes = bodyExceededMaxBytes
+    }
+
+    /// Case-insensitive header lookup (fields are stored lowercased).
+    public func header(_ name: String) -> String? {
+        headerFields[name.lowercased()]
+    }
+}
+
+public enum WebFetchHTTPClientError: Error, Sendable, Hashable, CustomStringConvertible {
+    case timedOut
+    case transport(String)
+    case notHTTP
+
+    public var description: String {
+        switch self {
+        case .timedOut:
+            return "the request timed out"
+        case .transport(let message):
+            return message
+        case .notHTTP:
+            return "the server did not return an HTTP response"
+        }
+    }
+}
+
+public protocol WebFetchHTTPClient: Sendable {
+    func perform(_ request: WebFetchHTTPRequest) throws -> WebFetchHTTPResponse
+}

--- a/Sources/QuillCodeTools/WebFetchHostGate.swift
+++ b/Sources/QuillCodeTools/WebFetchHostGate.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// SSRF gate for `host.web.fetch`: decides whether a URL points at the public web or at
+/// something internal that an agent-driven GET must never reach (cloud metadata endpoints,
+/// loopback services, RFC 1918/4193 ranges, intranet hostnames).
+///
+/// This is the fetch-side counterpart of `StaticSafetyDownloadPolicy`'s host gate for shell
+/// downloads and follows the same normalization rules (lowercasing, stripping the FQDN-root
+/// trailing dot, fail-closed when a host cannot be classified). It must be applied to the
+/// INITIAL URL and to EVERY redirect target — a public page that 302s to
+/// `http://169.254.169.254/…` is the classic SSRF laundering move.
+///
+/// The gate classifies textually (IP literals and hostname shape). It does not resolve DNS,
+/// so a public hostname that resolves to an internal address (DNS rebinding) is out of scope
+/// here; the gate's job is to stop direct and redirect-laundered internal targets.
+public enum WebFetchHostGate {
+    /// Returns a human-readable reason the URL must not be fetched, or nil when it is allowed.
+    public static func blockReason(for url: URL) -> String? {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            return "only http and https URLs are supported"
+        }
+        // Userinfo is rejected outright: `http://allowed@evil/` style URLs are a classic
+        // parser-differential vector (our gate and the transport disagreeing about where the
+        // host starts), and no legitimate doc/RFC fetch needs inline credentials.
+        if hasNonEmptyUser(url) || url.password != nil {
+            return "URLs with embedded credentials are not allowed"
+        }
+        guard let rawHost = url.host, !rawHost.isEmpty else {
+            return "the URL has no host"
+        }
+        // Same trailing-dot normalization as StaticSafetyRequest.normalizedHost: `localhost.`
+        // and `localhost` must classify identically (FQDN-root parser differential).
+        var host = rawHost.lowercased()
+        if host.hasSuffix(".") {
+            host = String(host.dropLast())
+        }
+        guard !host.isEmpty else {
+            return "the URL has no host"
+        }
+
+        if let ipv4 = parseIPv4(host) {
+            return blockReasonForIPv4(ipv4)
+        }
+        if host.contains(":") {
+            // Bracketed IPv6 literal (URL.host strips the brackets). Anything colon-y that
+            // inet_pton cannot parse is fail-closed: we cannot classify it, so we refuse it.
+            guard let ipv6 = parseIPv6(host) else {
+                return "the IPv6 host could not be parsed"
+            }
+            return blockReasonForIPv6(ipv6)
+        }
+        return blockReasonForHostname(host)
+    }
+
+    // MARK: - Hostname classification
+
+    private static func blockReasonForHostname(_ host: String) -> String? {
+        if host == "localhost" || host.hasSuffix(".localhost") {
+            return "\(host) is a loopback host"
+        }
+        for suffix in blockedInternalSuffixes where host == suffix || host.hasSuffix(".\(suffix)") {
+            return "\(host) is an internal-network host"
+        }
+        guard host.contains(".") else {
+            // Single-label names (`intranet`, `router`, `metadata`) only resolve on internal
+            // networks; the public web is always multi-label.
+            return "single-label hostnames are not routable on the public web"
+        }
+        // A host whose every label is purely numeric (or 0x-hex) is an IP literal in a form
+        // `inet_pton` rejects but many resolvers accept (`0177.0.0.1`, `127.1`). We cannot
+        // range-check it, so fail closed — mirroring StaticSafetyDownloadPolicy's rule that an
+        // unparseable URL drops the command rather than slipping through.
+        if hostLabelsAreAllNumeric(host) {
+            return "numeric hosts must be written as a full dotted-quad IP address"
+        }
+        return nil
+    }
+
+    /// Reserved / internal-only DNS suffixes. `.local` is mDNS, `.internal` is the cloud
+    /// metadata convention (`metadata.google.internal`), `.home.arpa` is RFC 8375.
+    private static let blockedInternalSuffixes: [String] = [
+        "local", "internal", "intranet", "lan", "home", "corp", "home.arpa"
+    ]
+
+    private static func hostLabelsAreAllNumeric(_ host: String) -> Bool {
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard !labels.isEmpty else { return true }
+        return labels.allSatisfy { label in
+            if label.isEmpty { return true }
+            if label.allSatisfy({ $0.isASCII && $0.isWholeNumber }) { return true }
+            if label.hasPrefix("0x") || label.hasPrefix("0X") {
+                return label.dropFirst(2).allSatisfy(\.isHexDigit)
+            }
+            return false
+        }
+    }
+
+    private static func hasNonEmptyUser(_ url: URL) -> Bool {
+        guard let user = url.user else { return false }
+        return !user.isEmpty
+    }
+
+    // MARK: - IPv4
+
+    /// STRICT dotted-quad parser — deliberately hand-rolled instead of `inet_pton`, whose
+    /// platform-dependent leniency is itself a parser differential: a label with a leading
+    /// zero ("0177.0.0.1") is octal 127.0.0.1 to `inet_aton`-style resolvers but decimal 177
+    /// to some `inet_pton`s. Anything non-canonical returns nil here and then fails closed via
+    /// the all-numeric-labels hostname rule.
+    private static func parseIPv4(_ host: String) -> UInt32? {
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.count == 4 else {
+            return nil
+        }
+        var value: UInt32 = 0
+        for label in labels {
+            guard !label.isEmpty,
+                  label.count <= 3,
+                  label.allSatisfy({ $0.isASCII && $0.isWholeNumber }),
+                  label == "0" || !label.hasPrefix("0"),
+                  let octet = UInt32(label),
+                  octet <= 255
+            else {
+                return nil
+            }
+            value = (value << 8) | octet
+        }
+        return value
+    }
+
+    private static func blockReasonForIPv4(_ value: UInt32) -> String? {
+        let ranges: [(mask: UInt32, prefix: UInt32, label: String)] = [
+            (0xFF00_0000, 0x0000_0000, "the 0.0.0.0/8 range"),
+            (0xFF00_0000, 0x0A00_0000, "the private 10.0.0.0/8 range"),
+            (0xFFC0_0000, 0x6440_0000, "the carrier-grade NAT 100.64.0.0/10 range"),
+            (0xFF00_0000, 0x7F00_0000, "the loopback 127.0.0.0/8 range"),
+            (0xFFFF_0000, 0xA9FE_0000, "the link-local 169.254.0.0/16 range (cloud metadata)"),
+            (0xFFF0_0000, 0xAC10_0000, "the private 172.16.0.0/12 range"),
+            (0xFFFF_FF00, 0xC000_0000, "the IETF protocol 192.0.0.0/24 range"),
+            (0xFFFF_0000, 0xC0A8_0000, "the private 192.168.0.0/16 range"),
+            (0xFFFE_0000, 0xC612_0000, "the benchmarking 198.18.0.0/15 range"),
+            (0xF000_0000, 0xE000_0000, "the multicast 224.0.0.0/4 range"),
+            (0xF000_0000, 0xF000_0000, "the reserved 240.0.0.0/4 range")
+        ]
+        for range in ranges where (value & range.mask) == range.prefix {
+            return "the IP address is in \(range.label)"
+        }
+        return nil
+    }
+
+    // MARK: - IPv6
+
+    private static func parseIPv6(_ host: String) -> [UInt8]? {
+        var address = in6_addr()
+        guard inet_pton(AF_INET6, host, &address) == 1 else {
+            return nil
+        }
+        return withUnsafeBytes(of: &address) { Array($0) }
+    }
+
+    private static func blockReasonForIPv6(_ bytes: [UInt8]) -> String? {
+        guard bytes.count == 16 else {
+            return "the IPv6 host could not be parsed"
+        }
+        if bytes.allSatisfy({ $0 == 0 }) {
+            return "the IPv6 unspecified address is not routable"
+        }
+        if bytes[0..<15].allSatisfy({ $0 == 0 }) && bytes[15] == 1 {
+            return "::1 is the IPv6 loopback address"
+        }
+        if bytes[0] == 0xFE && (bytes[1] & 0xC0) == 0x80 {
+            return "the IP address is in the link-local fe80::/10 range"
+        }
+        if (bytes[0] & 0xFE) == 0xFC {
+            return "the IP address is in the unique-local fc00::/7 range"
+        }
+        if bytes[0] == 0xFF {
+            return "the IP address is in the multicast ff00::/8 range"
+        }
+        // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d) forms smuggle an IPv4
+        // target through the IPv6 parser — classify the embedded IPv4 address instead.
+        if bytes[0..<10].allSatisfy({ $0 == 0 }), bytes[10] == 0xFF, bytes[11] == 0xFF {
+            return blockReasonForEmbeddedIPv4(bytes) ?? nil
+        }
+        if bytes[0..<12].allSatisfy({ $0 == 0 }) {
+            return blockReasonForEmbeddedIPv4(bytes) ?? "IPv4-compatible IPv6 addresses are not allowed"
+        }
+        // NAT64 (64:ff9b::/96) and 6to4 (2002::/16) both embed an IPv4 address that a gateway
+        // may route internally; neither is a legitimate way to reach a public docs page.
+        if bytes[0] == 0x00, bytes[1] == 0x64, bytes[2] == 0xFF, bytes[3] == 0x9B {
+            return "NAT64 (64:ff9b::/96) addresses are not allowed"
+        }
+        if bytes[0] == 0x20, bytes[1] == 0x02 {
+            return "6to4 (2002::/16) addresses are not allowed"
+        }
+        return nil
+    }
+
+    private static func blockReasonForEmbeddedIPv4(_ bytes: [UInt8]) -> String? {
+        let value = (UInt32(bytes[12]) << 24)
+            | (UInt32(bytes[13]) << 16)
+            | (UInt32(bytes[14]) << 8)
+            | UInt32(bytes[15])
+        return blockReasonForIPv4(value)
+    }
+}

--- a/Sources/QuillCodeTools/WebFetchMarkdownCapper.swift
+++ b/Sources/QuillCodeTools/WebFetchMarkdownCapper.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Bounds `host.web.fetch` output the way `ShellOutputCapper` bounds shell output, but keeps
+/// the HEAD instead of the tail: for a fetched page the title, intro, and leading sections are
+/// what matter, so truncation drops the end and appends an honest note.
+///
+/// `maxBytes` bounds the kept PAYLOAD; the one-line note is metadata appended after capping.
+public enum WebFetchMarkdownCapper {
+    public static let defaultMaxLines = 2000
+    public static let defaultMaxBytes = 48_000
+
+    public static func cap(
+        _ text: String,
+        maxLines: Int = defaultMaxLines,
+        maxBytes: Int = defaultMaxBytes
+    ) -> (text: String, truncated: Bool) {
+        let totalBytes = text.utf8.count
+        let hadTrailingNewline = text.hasSuffix("\n")
+        var lines = text.components(separatedBy: "\n")
+        if hadTrailingNewline {
+            lines.removeLast()
+        }
+        let totalLines = text.isEmpty ? 0 : lines.count
+        guard totalLines > maxLines || totalBytes > maxBytes else {
+            return (text, false)
+        }
+
+        if lines.count > maxLines {
+            lines = Array(lines.prefix(maxLines))
+        }
+        var kept = lines.joined(separator: "\n")
+
+        // Byte ceiling on the already line-trimmed head: keep the first maxBytes bytes, then
+        // drop trailing UTF-8 continuation bytes so the cut lands on a codepoint boundary.
+        if kept.utf8.count > maxBytes {
+            var bytes = Array(kept.utf8.prefix(maxBytes))
+            while let last = bytes.last, last & 0b1100_0000 == 0b1000_0000 {
+                bytes.removeLast()
+            }
+            // The byte we cut at may be the LEAD byte of a multi-byte scalar; drop it too.
+            if let last = bytes.last, last & 0b1000_0000 == 0b1000_0000 {
+                bytes.removeLast()
+            }
+            kept = String(decoding: bytes, as: UTF8.self)
+        }
+
+        let note = "\n\n[content truncated — showing the beginning; \(totalLines) line\(totalLines == 1 ? "" : "s"), \(totalBytes) bytes total]"
+        return (kept + note, true)
+    }
+}

--- a/Sources/QuillCodeTools/WebFetchResponseDecoder.swift
+++ b/Sources/QuillCodeTools/WebFetchResponseDecoder.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// Content-type classification and hostile-input-safe text decoding for `host.web.fetch`.
+/// Decoding never fails: unknown or lying charsets fall back to lossy UTF-8 (invalid bytes
+/// become U+FFFD), matching the "convert what we can, never explode" contract of the tool.
+enum WebFetchResponseDecoder {
+    enum ContentClass: Equatable {
+        /// HTML that should be converted to markdown.
+        case html
+        /// Markdown or plain text that passes through untouched.
+        case passthroughText
+        /// Some other textual type (JSON, XML, JS, …) that also passes through.
+        case otherText
+        /// Binary or unknown-binary content the tool refuses to return.
+        case refused(reportedType: String)
+    }
+
+    /// Classifies a Content-Type header value; when it is missing, sniffs the body prefix.
+    static func classify(contentType: String?, bodyPrefix: Data) -> ContentClass {
+        guard let contentType, !mimeType(of: contentType).isEmpty else {
+            return sniff(bodyPrefix: bodyPrefix)
+        }
+        let mime = mimeType(of: contentType)
+        switch mime {
+        case "text/html", "application/xhtml+xml":
+            return .html
+        case "text/markdown", "text/x-markdown", "text/plain":
+            return .passthroughText
+        default:
+            break
+        }
+        if mime.hasPrefix("text/") {
+            return .otherText
+        }
+        if textualApplicationTypes.contains(mime)
+            || mime.hasSuffix("+json") || mime.hasSuffix("+xml") {
+            return .otherText
+        }
+        return .refused(reportedType: mime)
+    }
+
+    /// The `type/subtype` portion of a Content-Type value, lowercased, parameters dropped.
+    /// Empty subsequences are kept so a malformed ";charset=utf-8" yields "" rather than
+    /// promoting the parameter into the mime type.
+    static func mimeType(of contentType: String) -> String {
+        (contentType.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false).first ?? "")
+            .trimmingCharacters(in: .whitespaces)
+            .lowercased()
+    }
+
+    /// The `charset` parameter of a Content-Type value, if present.
+    static func charset(of contentType: String?) -> String? {
+        guard let contentType else {
+            return nil
+        }
+        for parameter in contentType.split(separator: ";").dropFirst() {
+            let parts = parameter.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2,
+                  parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "charset"
+            else {
+                continue
+            }
+            let value = parts[1]
+                .trimmingCharacters(in: .whitespaces)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                .lowercased()
+            return value.isEmpty ? nil : value
+        }
+        return nil
+    }
+
+    /// Decodes body bytes to text: honor the declared charset when we support it, sniff a
+    /// `<meta charset>` for HTML when the header stays silent, and otherwise decode as lossy
+    /// UTF-8. NUL bytes are stripped so binary-ish content cannot smuggle terminators.
+    static func decode(_ data: Data, declaredCharset: String?, sniffHTMLMeta: Bool) -> String {
+        var body = data
+        // A UTF-8 BOM is decoration; a UTF-16 BOM decides the encoding outright.
+        if body.starts(with: [0xEF, 0xBB, 0xBF]) {
+            body = body.dropFirst(3)
+        } else if body.starts(with: [0xFF, 0xFE]) || body.starts(with: [0xFE, 0xFF]) {
+            if let text = String(data: body, encoding: .utf16) {
+                return stripNULs(text)
+            }
+        }
+        var charset = declaredCharset
+        if charset == nil, sniffHTMLMeta {
+            charset = sniffMetaCharset(in: body)
+        }
+        let text = decode(body, charset: charset ?? "utf-8")
+        return stripNULs(text)
+    }
+
+    // MARK: - Internals
+
+    private static func decode(_ data: Data, charset: String) -> String {
+        let normalized = charset.lowercased().trimmingCharacters(in: .whitespaces)
+        switch normalized {
+        case "utf-8", "utf8", "us-ascii", "ascii", "":
+            return String(decoding: data, as: UTF8.self)
+        case "iso-8859-1", "iso8859-1", "latin1", "latin-1", "l1", "cp819":
+            return String(data: data, encoding: .isoLatin1) ?? String(decoding: data, as: UTF8.self)
+        case "windows-1252", "cp1252", "x-cp1252":
+            return String(data: data, encoding: .windowsCP1252)
+                ?? String(data: data, encoding: .isoLatin1)
+                ?? String(decoding: data, as: UTF8.self)
+        case "iso-8859-2", "latin2":
+            return String(data: data, encoding: .isoLatin2) ?? String(decoding: data, as: UTF8.self)
+        case "utf-16", "utf16":
+            return String(data: data, encoding: .utf16) ?? String(decoding: data, as: UTF8.self)
+        case "utf-16le":
+            return String(data: data, encoding: .utf16LittleEndian) ?? String(decoding: data, as: UTF8.self)
+        case "utf-16be":
+            return String(data: data, encoding: .utf16BigEndian) ?? String(decoding: data, as: UTF8.self)
+        case "shift_jis", "shift-jis", "sjis", "x-sjis":
+            return String(data: data, encoding: .shiftJIS) ?? String(decoding: data, as: UTF8.self)
+        case "euc-jp":
+            return String(data: data, encoding: .japaneseEUC) ?? String(decoding: data, as: UTF8.self)
+        case "iso-2022-jp":
+            return String(data: data, encoding: .iso2022JP) ?? String(decoding: data, as: UTF8.self)
+        default:
+            // Unknown charset: lossy UTF-8 beats failing — replacement characters are honest.
+            return String(decoding: data, as: UTF8.self)
+        }
+    }
+
+    /// Best-effort `<meta charset="…">` / `<meta http-equiv … content="…charset=…">` sniff in
+    /// the first 1024 bytes, the way browsers do when the header does not say.
+    private static func sniffMetaCharset(in body: Data) -> String? {
+        let prefix = String(decoding: body.prefix(1024), as: UTF8.self).lowercased()
+        guard let metaRange = prefix.range(of: "charset=") else {
+            return nil
+        }
+        var value = ""
+        var iterator = prefix[metaRange.upperBound...].makeIterator()
+        var pendingQuote: Character?
+        while let character = iterator.next(), value.count < 40 {
+            if value.isEmpty, character == "\"" || character == "'" {
+                pendingQuote = character
+                continue
+            }
+            if let quote = pendingQuote {
+                if character == quote {
+                    break
+                }
+            } else if character == "\"" || character == "'" || character == ">" || character == "/"
+                        || character == ";" || character.isWhitespace {
+                break
+            }
+            value.append(character)
+        }
+        let charset = value.trimmingCharacters(in: .whitespaces)
+        return charset.isEmpty ? nil : charset
+    }
+
+    private static func sniff(bodyPrefix: Data) -> ContentClass {
+        let sample = String(decoding: bodyPrefix.prefix(512), as: UTF8.self).lowercased()
+        if sample.contains("<!doctype html") || sample.contains("<html") {
+            return .html
+        }
+        if bodyPrefix.prefix(512).contains(0) {
+            return .refused(reportedType: "unknown binary content")
+        }
+        return .passthroughText
+    }
+
+    private static func stripNULs(_ text: String) -> String {
+        guard text.unicodeScalars.contains(where: { $0.value == 0 }) else {
+            return text
+        }
+        return String(text.unicodeScalars.filter { $0.value != 0 }.map(Character.init))
+    }
+
+    private static let textualApplicationTypes: Set<String> = [
+        "application/json", "application/xml", "application/javascript",
+        "application/ecmascript", "application/x-javascript", "application/yaml",
+        "application/x-yaml", "application/toml", "application/x-ndjson",
+        "application/x-www-form-urlencoded", "application/sql", "application/graphql",
+        "application/rtf", "application/csv", "application/x-sh", "application/wasm-text",
+        "application/atom+xml", "application/rss+xml"
+    ]
+}

--- a/Sources/QuillCodeTools/WebFetchToolDefinitions.swift
+++ b/Sources/QuillCodeTools/WebFetchToolDefinitions.swift
@@ -1,0 +1,20 @@
+import QuillCodeCore
+
+public extension ToolDefinition {
+    static let webFetch = ToolDefinition(
+        name: "host.web.fetch",
+        description: """
+        Fetch a public http(s) URL with GET and return its content as markdown. Use this to pull a docs \
+        page, RFC, changelog, or error-report link into context. HTML is converted to markdown (headings, \
+        links, lists, code blocks, tables); markdown and plain-text responses pass through; binary content \
+        is refused. Responses are capped at 5 MB and long pages are truncated with a marker. Requests to \
+        private, loopback, or link-local hosts are refused; redirects are re-checked against the same rules. \
+        For pages behind bot protection or requiring JavaScript, use host.browser.open instead.
+        """,
+        parametersJSON: """
+        {"type":"object","properties":{"url":{"type":"string","description":"Absolute http or https URL to fetch."}},"required":["url"]}
+        """,
+        host: .local,
+        risk: .read
+    )
+}

--- a/Sources/QuillCodeTools/WebFetchToolExecutor.swift
+++ b/Sources/QuillCodeTools/WebFetchToolExecutor.swift
@@ -1,6 +1,12 @@
 import Foundation
 import QuillCodeCore
 
+// The default client is URLSession-backed, whose networking types live in FoundationNetworking
+// on Linux (swift-corelibs-foundation) rather than Foundation.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 /// Executes `host.web.fetch`: SSRF-gate the URL, GET it (following a bounded number of
 /// redirects, re-gating every hop), retry once with browser-like headers when Cloudflare's
 /// bot protection interferes, then decode and convert the body to markdown.

--- a/Sources/QuillCodeTools/WebFetchToolExecutor.swift
+++ b/Sources/QuillCodeTools/WebFetchToolExecutor.swift
@@ -1,0 +1,302 @@
+import Foundation
+import QuillCodeCore
+
+/// Executes `host.web.fetch`: SSRF-gate the URL, GET it (following a bounded number of
+/// redirects, re-gating every hop), retry once with browser-like headers when Cloudflare's
+/// bot protection interferes, then decode and convert the body to markdown.
+public struct WebFetchToolExecutor: Sendable {
+    public var client: any WebFetchHTTPClient
+    /// Streaming cap on the response body (~5 MB per the tool contract).
+    public var maxBodyBytes: Int
+    public var maxRedirects: Int
+    /// Overall time budget per HTTP transaction, in seconds.
+    public var timeout: TimeInterval
+    /// Bounds on the markdown handed back to the model (ShellOutputCapper precedent).
+    public var outputMaxLines: Int
+    public var outputMaxBytes: Int
+
+    public init(
+        client: any WebFetchHTTPClient = URLSessionWebFetchHTTPClient(),
+        maxBodyBytes: Int = 5_000_000,
+        maxRedirects: Int = 5,
+        timeout: TimeInterval = 25,
+        outputMaxLines: Int = WebFetchMarkdownCapper.defaultMaxLines,
+        outputMaxBytes: Int = WebFetchMarkdownCapper.defaultMaxBytes
+    ) {
+        self.client = client
+        self.maxBodyBytes = max(1, maxBodyBytes)
+        self.maxRedirects = max(0, maxRedirects)
+        self.timeout = min(max(1, timeout), 120)
+        self.outputMaxLines = max(1, outputMaxLines)
+        self.outputMaxBytes = max(1024, outputMaxBytes)
+    }
+
+    public func fetch(urlString: String) -> ToolResult {
+        guard let url = Self.normalizedRequestURL(urlString) else {
+            return Self.failure("`\(urlString)` is not a valid absolute http(s) URL. Pass a full URL like https://example.com/docs.")
+        }
+
+        let firstAttempt = performAttempt(startingAt: url, headers: Self.defaultHeaders)
+        switch firstAttempt {
+        case .success(let outcome):
+            if let retryReason = Self.cloudflareBlockReason(outcome.response) {
+                // Cloudflare bot heuristics often pass a browser-like client where a plain
+                // tool UA is challenged; retry ONCE with browser headers before giving up.
+                let secondAttempt = performAttempt(startingAt: url, headers: Self.browserLikeHeaders)
+                switch secondAttempt {
+                case .success(let retried):
+                    if Self.cloudflareBlockReason(retried.response) != nil {
+                        return Self.failure("""
+                        \(retryReason) at \(outcome.finalURL.absoluteString), and a retry with browser-like \
+                        headers was blocked too. This page needs a real browser — try host.browser.open \
+                        with the same URL.
+                        """)
+                    }
+                    return buildResult(requestedURL: url, outcome: retried)
+                case .failure(let failure):
+                    return Self.failure(failure.message)
+                }
+            }
+            return buildResult(requestedURL: url, outcome: outcome)
+        case .failure(let failure):
+            return Self.failure(failure.message)
+        }
+    }
+
+    // MARK: - Transport with redirect re-gating
+
+    private struct AttemptOutcome {
+        var response: WebFetchHTTPResponse
+        var finalURL: URL
+        var redirectCount: Int
+    }
+
+    private struct AttemptFailure: Error {
+        var message: String
+
+        init(_ message: String) {
+            self.message = message
+        }
+    }
+
+    private func performAttempt(
+        startingAt url: URL,
+        headers: [String: String]
+    ) -> Result<AttemptOutcome, AttemptFailure> {
+        var currentURL = url
+        var redirectCount = 0
+        while true {
+            // EVERY hop goes through the SSRF gate — the initial URL and each redirect target.
+            if let reason = WebFetchHostGate.blockReason(for: currentURL) {
+                return .failure(AttemptFailure(
+                    Self.blockedMessage(url: currentURL, reason: reason, wasRedirect: redirectCount > 0)
+                ))
+            }
+            let response: WebFetchHTTPResponse
+            do {
+                response = try client.perform(WebFetchHTTPRequest(
+                    url: currentURL,
+                    headers: headers,
+                    timeout: timeout,
+                    maxBodyBytes: maxBodyBytes
+                ))
+            } catch let error as WebFetchHTTPClientError {
+                return .failure(AttemptFailure("Fetching \(currentURL.absoluteString) failed: \(error.description)."))
+            } catch {
+                return .failure(AttemptFailure("Fetching \(currentURL.absoluteString) failed: \(error.localizedDescription)"))
+            }
+
+            guard Self.isRedirect(response.statusCode) else {
+                return .success(AttemptOutcome(
+                    response: response,
+                    finalURL: currentURL,
+                    redirectCount: redirectCount
+                ))
+            }
+            guard redirectCount < maxRedirects else {
+                return .failure(AttemptFailure("Gave up after \(maxRedirects) redirects fetching \(url.absoluteString); the last hop was \(currentURL.absoluteString)."))
+            }
+            guard let location = response.header("location")?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !location.isEmpty,
+                  let nextURL = URL(string: location, relativeTo: currentURL)?.absoluteURL
+            else {
+                return .failure(AttemptFailure("\(currentURL.absoluteString) answered HTTP \(response.statusCode) with a missing or unparseable Location header."))
+            }
+            currentURL = nextURL
+            redirectCount += 1
+        }
+    }
+
+    private static func isRedirect(_ statusCode: Int) -> Bool {
+        // 304 has no Location and no body to follow; the other 3xx statuses are hops.
+        (300..<400).contains(statusCode) && statusCode != 304
+    }
+
+    // MARK: - Result building
+
+    private func buildResult(requestedURL: URL, outcome: AttemptOutcome) -> ToolResult {
+        let response = outcome.response
+        let finalURL = outcome.finalURL
+
+        guard (200..<300).contains(response.statusCode) else {
+            return Self.failure(Self.httpErrorMessage(statusCode: response.statusCode, url: finalURL))
+        }
+        if response.bodyExceededMaxBytes, response.body.isEmpty {
+            return Self.failure("""
+            \(finalURL.absoluteString) is larger than the \(Self.formatBytes(maxBodyBytes)) response cap. \
+            Download it to a workspace file instead (host.shell.run with \
+            curl -L --fail --output <file> '\(finalURL.absoluteString)').
+            """)
+        }
+
+        let contentType = response.header("content-type")
+        let classification = WebFetchResponseDecoder.classify(
+            contentType: contentType,
+            bodyPrefix: response.body.prefix(512)
+        )
+        if case .refused(let reportedType) = classification {
+            return Self.failure("""
+            \(finalURL.absoluteString) returned \(reportedType), which host.web.fetch cannot render as text. \
+            Download it to a workspace file instead (host.shell.run with \
+            curl -L --fail --output <file> '\(finalURL.absoluteString)').
+            """)
+        }
+
+        let text = WebFetchResponseDecoder.decode(
+            response.body,
+            declaredCharset: WebFetchResponseDecoder.charset(of: contentType),
+            sniffHTMLMeta: classification == .html
+        )
+
+        var content: String
+        var converterTruncated = false
+        let renderNote: String
+        switch classification {
+        case .html:
+            let converted = HTMLToMarkdown.convert(text, options: HTMLToMarkdownOptions(
+                baseURL: finalURL,
+                maxOutputBytes: outputMaxBytes * 4
+            ))
+            content = converted.markdown
+            converterTruncated = converted.truncated
+            renderNote = "converted to markdown"
+        case .passthroughText:
+            content = text
+            renderNote = "returned as-is"
+        case .otherText:
+            content = text
+            renderNote = "textual content returned as-is"
+        case .refused(let reportedType):
+            // Already handled above; kept for exhaustiveness.
+            return Self.failure("\(finalURL.absoluteString) returned \(reportedType), which host.web.fetch cannot render as text.")
+        }
+
+        var truncationNotes: [String] = []
+        if response.bodyExceededMaxBytes {
+            truncationNotes.append("response body exceeded the \(Self.formatBytes(maxBodyBytes)) cap; only the first \(Self.formatBytes(response.body.count)) were fetched")
+        }
+        let capped = WebFetchMarkdownCapper.cap(content, maxLines: outputMaxLines, maxBytes: outputMaxBytes)
+        content = capped.text
+        if converterTruncated, !capped.truncated {
+            content += "\n\n[content truncated — the page was larger than the conversion budget]"
+        }
+
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            content = "[the page had no readable text content — it likely renders via JavaScript; try host.browser.open with the same URL]"
+        }
+
+        var summary = "Fetched \(finalURL.absoluteString) (HTTP \(response.statusCode), \(contentType.map(WebFetchResponseDecoder.mimeType) ?? "no content type"), \(Self.formatBytes(response.body.count)) fetched, \(renderNote))."
+        if outcome.redirectCount > 0 {
+            summary += " Followed \(outcome.redirectCount) redirect\(outcome.redirectCount == 1 ? "" : "s") from \(requestedURL.absoluteString)."
+        }
+        for note in truncationNotes {
+            summary += " Note: \(note)."
+        }
+
+        return ToolResult(ok: true, stdout: summary + "\n\n" + content)
+    }
+
+    // MARK: - Cloudflare detection
+
+    /// Detects a Cloudflare bot-protection block. Anti-bot challenges answer 403 (and
+    /// sometimes 503) with `cf-mitigated: challenge` or Cloudflare server markers.
+    private static func cloudflareBlockReason(_ response: WebFetchHTTPResponse) -> String? {
+        guard response.statusCode == 403 || response.statusCode == 503 else {
+            return nil
+        }
+        if response.header("cf-mitigated") != nil {
+            return "Cloudflare bot protection challenged the request (HTTP \(response.statusCode), cf-mitigated)"
+        }
+        let server = response.header("server")?.lowercased() ?? ""
+        if server.contains("cloudflare"), response.header("cf-ray") != nil {
+            return "Cloudflare blocked the request (HTTP \(response.statusCode))"
+        }
+        return nil
+    }
+
+    // MARK: - Helpers
+
+    private static func normalizedRequestURL(_ raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains(where: \.isWhitespace) else {
+            return nil
+        }
+        // Models sometimes pass bare hosts ("example.com/docs"); default them to https the
+        // same way AgentDownloadRequestParser does. Anything scheme-ful is used as given —
+        // the host gate rejects non-http(s) schemes with a clear message.
+        let candidate = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        guard let url = URL(string: candidate), url.host != nil else {
+            return nil
+        }
+        return url
+    }
+
+    private static func blockedMessage(url: URL, reason: String, wasRedirect: Bool) -> String {
+        let lead = wasRedirect
+            ? "A redirect pointed at \(url.absoluteString), which is blocked"
+            : "Refused to fetch \(url.absoluteString)"
+        return "\(lead): \(reason). host.web.fetch only fetches public web hosts."
+    }
+
+    private static func httpErrorMessage(statusCode: Int, url: URL) -> String {
+        var message = "\(url.absoluteString) answered HTTP \(statusCode)."
+        switch statusCode {
+        case 401, 403:
+            message += " The page may require authentication or block automated clients — try host.browser.open."
+        case 404:
+            message += " Check the URL for typos or a moved page."
+        case 429:
+            message += " The server is rate limiting; wait before retrying."
+        default:
+            break
+        }
+        return message
+    }
+
+    private static func failure(_ message: String) -> ToolResult {
+        ToolResult(ok: false, error: message)
+    }
+
+    private static func formatBytes(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            let megabytes = Double(count) / 1_000_000
+            return String(format: "%.1f MB", megabytes)
+        }
+        if count >= 1_000 {
+            return "\(count / 1_000) KB"
+        }
+        return "\(count) bytes"
+    }
+
+    private static let defaultHeaders: [String: String] = [
+        "Accept": "text/html, application/xhtml+xml;q=0.9, text/markdown;q=0.8, text/plain;q=0.7, */*;q=0.1",
+        "Accept-Language": "en-US,en;q=0.9",
+        "User-Agent": "QuillCode/1.0 WebFetch (+https://lorehex.co)"
+    ]
+
+    private static let browserLikeHeaders: [String: String] = [
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    ]
+}

--- a/Tests/QuillCodeAgentTests/AgentWebToolAnswerFormattersTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentWebToolAnswerFormattersTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+final class AgentWebToolAnswerFormattersTests: XCTestCase {
+    private func call(_ urlJSON: String = #"{"url":"https://example.com/docs"}"#) -> ToolCall {
+        ToolCall(name: ToolDefinition.webFetch.name, argumentsJSON: urlJSON)
+    }
+
+    func testFormatterIsRegistered() {
+        // The formatter chain resolves a webFetch result without falling through to a generic answer.
+        let result = ToolResult(ok: true, stdout: "Fetched https://example.com/docs (HTTP 200).\n\n# Title")
+        let answers = AgentToolAnswerFormatters.all.compactMap { $0(call(), result, nil) }
+        XCTAssertEqual(answers.count, 1)
+        XCTAssertTrue(answers[0].contains("# Title"))
+    }
+
+    func testSuccessPassesContentThrough() {
+        let result = ToolResult(ok: true, stdout: "Fetched https://example.com/docs.\n\n# Docs\n\nBody text")
+        let answer = AgentWebToolAnswerFormatters.webFetchAnswer(call: call(), result: result, followUpReviewResult: nil)
+        XCTAssertEqual(answer, "Fetched https://example.com/docs.\n\n# Docs\n\nBody text")
+    }
+
+    func testLongContentIsTruncatedForChat() {
+        let result = ToolResult(ok: true, stdout: String(repeating: "m", count: 10_000))
+        let answer = AgentWebToolAnswerFormatters.webFetchAnswer(call: call(), result: result, followUpReviewResult: nil)
+        XCTAssertNotNil(answer)
+        XCTAssertTrue(answer?.contains("[truncated in chat; full output is in the tool card]") == true)
+        XCTAssertLessThan(answer?.count ?? .max, 3_000)
+    }
+
+    func testFailureExplainsWithError() {
+        let result = ToolResult(ok: false, error: "Refused to fetch http://localhost/: loopback host.")
+        let answer = AgentWebToolAnswerFormatters.webFetchAnswer(
+            call: call(#"{"url":"http://localhost/"}"#),
+            result: result,
+            followUpReviewResult: nil
+        )
+        XCTAssertTrue(answer?.contains("Could not fetch http://localhost/") == true)
+        XCTAssertTrue(answer?.contains("loopback host") == true)
+    }
+
+    func testFailureWithoutDetailsStillAnswers() {
+        let result = ToolResult(ok: false)
+        let answer = AgentWebToolAnswerFormatters.webFetchAnswer(call: call(), result: result, followUpReviewResult: nil)
+        XCTAssertEqual(answer, "Could not fetch https://example.com/docs.")
+    }
+
+    func testOtherToolsAreIgnored() {
+        let otherCall = ToolCall(name: ToolDefinition.fileRead.name, argumentsJSON: #"{"path":"a.txt"}"#)
+        let result = ToolResult(ok: true, stdout: "x")
+        XCTAssertNil(AgentWebToolAnswerFormatters.webFetchAnswer(call: otherCall, result: result, followUpReviewResult: nil))
+    }
+
+    func testEmptySuccessGetsPlaceholder() {
+        let result = ToolResult(ok: true, stdout: "   \n  ")
+        let answer = AgentWebToolAnswerFormatters.webFetchAnswer(call: call(), result: result, followUpReviewResult: nil)
+        XCTAssertTrue(answer?.contains("no readable content") == true)
+    }
+}

--- a/Tests/QuillCodeToolsTests/HTMLToMarkdownConverterTests.swift
+++ b/Tests/QuillCodeToolsTests/HTMLToMarkdownConverterTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class HTMLToMarkdownConverterTests: XCTestCase {
+    private func convert(
+        _ html: String,
+        baseURL: URL? = URL(string: "https://example.com/docs/page"),
+        maxOutputBytes: Int = 262_144
+    ) -> String {
+        HTMLToMarkdown.convert(html, options: HTMLToMarkdownOptions(
+            baseURL: baseURL,
+            maxOutputBytes: maxOutputBytes
+        )).markdown
+    }
+
+    // MARK: - Elements
+
+    func testHeadingsAndParagraphs() {
+        let markdown = convert("<h1>Title</h1><p>First.</p><h2>Section</h2><p>Second.</p>")
+        XCTAssertEqual(markdown, "# Title\n\nFirst.\n\n## Section\n\nSecond.")
+    }
+
+    func testHeadAndTitleAreDropped() {
+        let markdown = convert("""
+        <html><head><title>Page Title</title><meta charset="utf-8"></head>\
+        <body><h1>Real Heading</h1></body></html>
+        """)
+        XCTAssertEqual(markdown, "# Real Heading")
+        XCTAssertFalse(markdown.contains("Page Title"))
+    }
+
+    func testLinksResolveRelativeToBaseURL() {
+        let markdown = convert("<p>See <a href=\"/api/reference\">the API docs</a> now.</p>")
+        XCTAssertEqual(markdown, "See [the API docs](https://example.com/api/reference) now.")
+    }
+
+    func testJavaScriptLinksBecomePlainText() {
+        let markdown = convert("<a href=\"javascript:alert(1)\">click</a>")
+        XCTAssertEqual(markdown, "click")
+    }
+
+    func testLinkDestinationParenthesesAreEscaped() {
+        let markdown = convert("<a href=\"https://en.wikipedia.org/wiki/Swift_(language)\">Swift</a>")
+        XCTAssertEqual(markdown, "[Swift](https://en.wikipedia.org/wiki/Swift_%28language%29)")
+    }
+
+    func testEmphasisAndInlineCode() {
+        let markdown = convert("<p>Use <strong>bold</strong>, <em>italic</em>, and <code>let x</code>.</p>")
+        XCTAssertEqual(markdown, "Use **bold**, *italic*, and `let x`.")
+    }
+
+    func testInlineCodeContainingBackticksUsesDoubleDelimiters() {
+        let markdown = convert("<code>a `b` c</code>")
+        XCTAssertEqual(markdown, "`` a `b` c ``")
+    }
+
+    func testUnorderedAndNestedLists() {
+        let markdown = convert("<ul><li>One</li><li>Two<ul><li>Nested</li></ul></li></ul>")
+        XCTAssertEqual(markdown, "- One\n- Two\n  - Nested")
+    }
+
+    func testOrderedListNumbering() {
+        let markdown = convert("<ol><li>First</li><li>Second</li><li>Third</li></ol>")
+        XCTAssertEqual(markdown, "1. First\n2. Second\n3. Third")
+    }
+
+    func testPreBecomesFencedCodeBlockWithLanguage() {
+        let markdown = convert("<pre><code class=\"language-swift\">let x = 1\nprint(x)</code></pre>")
+        XCTAssertEqual(markdown, "```swift\nlet x = 1\nprint(x)\n```")
+    }
+
+    func testPreWithHighlighterSpansKeepsTextOnly() {
+        let markdown = convert("<pre><span class=\"k\">func</span> <span class=\"n\">go</span>()</pre>")
+        XCTAssertEqual(markdown, "```\nfunc go()\n```")
+    }
+
+    func testPreContainingBacktickFenceUsesLongerFence() {
+        let markdown = convert("<pre>```\ninner\n```</pre>")
+        XCTAssertTrue(markdown.hasPrefix("````"), "fence must be longer than any backtick run: \(markdown)")
+    }
+
+    func testBlockquote() {
+        let markdown = convert("<blockquote><p>Quoted</p></blockquote><p>After</p>")
+        XCTAssertEqual(markdown, "> Quoted\n\nAfter")
+    }
+
+    func testHorizontalRuleAndLineBreak() {
+        let markdown = convert("<p>a<br>b</p><hr><p>c</p>")
+        XCTAssertEqual(markdown, "a\nb\n\n---\n\nc")
+    }
+
+    func testImages() {
+        let markdown = convert("<img src=\"/logo.png\" alt=\"Logo\">")
+        XCTAssertEqual(markdown, "![Logo](https://example.com/logo.png)")
+    }
+
+    func testSmallDataURIImageIsKept() {
+        let markdown = convert("<img src=\"data:image/png;base64,iVBORw0KGgo=\" alt=\"dot\">")
+        XCTAssertEqual(markdown, "![dot](data:image/png;base64,iVBORw0KGgo=)")
+    }
+
+    func testLargeDataURIImageIsSummarized() {
+        let payload = String(repeating: "A", count: 10_000)
+        let markdown = convert("<img src=\"data:image/png;base64,\(payload)\" alt=\"big\">")
+        XCTAssertFalse(markdown.contains("AAAA"))
+        XCTAssertTrue(markdown.contains("omitted"), "large data URIs must not flood the output: \(markdown)")
+    }
+
+    func testTableBestEffort() {
+        let markdown = convert("""
+        <table><tr><th>Name</th><th>Value</th></tr>\
+        <tr><td>alpha</td><td>1</td></tr><tr><td>beta | pipe</td><td>2</td></tr></table>
+        """)
+        XCTAssertEqual(markdown, """
+        | Name | Value |
+        | --- | --- |
+        | alpha | 1 |
+        | beta \\| pipe | 2 |
+        """)
+    }
+
+    func testEntitiesDecoded() {
+        let markdown = convert("<p>&lt;tag&gt; &amp; &#65;&#x42; &copy; &nbsp;done</p>")
+        XCTAssertTrue(markdown.contains("<tag> & AB ©"))
+        XCTAssertTrue(markdown.contains("done"))
+    }
+
+    func testInvalidNumericEntitiesBecomeReplacementCharacter() {
+        let markdown = convert("<p>&#0; &#xD800; &#x110000; &#xFFFFFFFFFF;</p>")
+        XCTAssertFalse(markdown.isEmpty)
+        XCTAssertTrue(markdown.unicodeScalars.contains { $0.value == 0xFFFD })
+        XCTAssertFalse(markdown.unicodeScalars.contains { $0.value == 0 })
+    }
+
+    func testUnknownEntityPassesThroughLiterally() {
+        let markdown = convert("<p>&notarealentity; stays</p>")
+        XCTAssertEqual(markdown, "&notarealentity; stays")
+    }
+
+    // MARK: - Noise stripping
+
+    func testScriptStyleAndNavAreStripped() {
+        let markdown = convert("""
+        <nav><a href="/">Home</a> | <a href="/about">About</a></nav>\
+        <script>var html = "<p>fake</p>";</script>\
+        <style>p { color: red }</style>\
+        <p>Real content</p>
+        """)
+        XCTAssertEqual(markdown, "Real content")
+    }
+
+    func testCommentsDoctypeAndCDATAAreDropped() {
+        let markdown = convert("<!DOCTYPE html><!-- hidden --><p>a<![CDATA[<b>ignored</b>]]>b</p>")
+        XCTAssertEqual(markdown, "ab")
+    }
+
+    func testWhitespaceCollapses() {
+        let markdown = convert("<p>a   lot\n\n of \t space</p>")
+        XCTAssertEqual(markdown, "a lot of space")
+    }
+
+    // MARK: - Malformed and hostile input
+
+    func testUnclosedTagsDoNotCrash() {
+        let markdown = convert("<div><b>unclosed <i>everything <a href=\"/x\">link text")
+        XCTAssertTrue(markdown.contains("unclosed"))
+        XCTAssertTrue(markdown.contains("everything"))
+        XCTAssertTrue(markdown.contains("link text"))
+    }
+
+    func testUnclosedLinkDoesNotSwallowFollowingBlocks() {
+        // Browsers auto-close inline elements at block boundaries; one missing </a> must not
+        // funnel the rest of the page into the link's bounded capture buffer.
+        let body = String(repeating: "Paragraph content here. ", count: 500)
+        let markdown = convert("<a href=\"/promo\">card<div><p>\(body)</p></div>")
+        XCTAssertTrue(markdown.contains("[card](https://example.com/promo)"))
+        XCTAssertGreaterThan(markdown.utf8.count, 10_000, "block content after the unclosed link must be kept")
+    }
+
+    func testAngleBracketSoupIsTreatedAsText() {
+        let markdown = convert("1 < 2 and 3 > 2, <<>> <not-a-tag <p>ok</p>")
+        XCTAssertTrue(markdown.contains("1 < 2"))
+        XCTAssertTrue(markdown.contains("ok"))
+    }
+
+    func testUnterminatedCommentAndScriptAreBounded() {
+        XCTAssertEqual(convert("<p>before</p><!-- never closed"), "before")
+        XCTAssertEqual(convert("<p>before</p><script>var x = 1;"), "before")
+    }
+
+    func testMissingHeadCloseStillEmitsBody() {
+        let markdown = convert("<html><head><meta charset=\"utf-8\"><body><p>Visible</p></body></html>")
+        XCTAssertEqual(markdown, "Visible")
+    }
+
+    func testDeeplyNestedInputIsBoundedAndTerminates() {
+        let html = String(repeating: "<div><ul><li><blockquote>", count: 5_000) + "core"
+        let markdown = convert(html)
+        XCTAssertTrue(markdown.contains("core"))
+    }
+
+    func testHugeFlatInputRespectsOutputBudget() {
+        let html = "<p>" + String(repeating: "word ", count: 200_000) + "</p>"
+        let result = HTMLToMarkdown.convert(html, options: HTMLToMarkdownOptions(maxOutputBytes: 4_096))
+        XCTAssertTrue(result.truncated)
+        XCTAssertLessThanOrEqual(result.markdown.utf8.count, 4_096)
+    }
+
+    func testMismatchedCloseTagsDoNotCorruptOutput() {
+        let markdown = convert("<b><i>x</b></i>y</em></strong>")
+        XCTAssertTrue(markdown.contains("x"))
+        XCTAssertTrue(markdown.contains("y"))
+    }
+
+    func testTableWithStrayContentAndNoClose() {
+        let markdown = convert("<table>loose<tr><td>cell</td>")
+        XCTAssertTrue(markdown.contains("cell"))
+        XCTAssertFalse(markdown.contains("loose"), "inter-cell filler must be dropped: \(markdown)")
+    }
+
+    func testNulAndControlCharactersAreStripped() {
+        let markdown = convert("<p>a\u{0}b\u{1}c\u{7F}d</p>")
+        XCTAssertEqual(markdown, "abcd")
+    }
+
+    func testGiantAttributeValueIsBounded() {
+        let href = String(repeating: "a", count: 100_000)
+        let markdown = convert("<a href=\"https://example.com/\(href)\">x</a>")
+        XCTAssertLessThan(markdown.utf8.count, 20_000)
+    }
+
+    func testEmptyAndWhitespaceOnlyInput() {
+        XCTAssertEqual(convert(""), "")
+        XCTAssertEqual(convert("   \n\t  "), "")
+        XCTAssertEqual(convert("<div>\n  \n</div>"), "")
+    }
+
+    func testRawTextCloseTagRequiresTerminator() {
+        // "</scripty" inside a script must not end raw-text mode.
+        let markdown = convert("<script>a </scripty b</script><p>after</p>")
+        XCTAssertEqual(markdown, "after")
+    }
+}

--- a/Tests/QuillCodeToolsTests/WebFetchHostGateTests.swift
+++ b/Tests/QuillCodeToolsTests/WebFetchHostGateTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class WebFetchHostGateTests: XCTestCase {
+    private func blockReason(_ urlString: String, file: StaticString = #filePath, line: UInt = #line) -> String? {
+        guard let url = URL(string: urlString) else {
+            XCTFail("could not build URL from \(urlString)", file: file, line: line)
+            return "unparseable"
+        }
+        return WebFetchHostGate.blockReason(for: url)
+    }
+
+    private func assertAllowed(_ urlString: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertNil(blockReason(urlString, file: file, line: line), "expected \(urlString) to be allowed", file: file, line: line)
+    }
+
+    private func assertBlocked(_ urlString: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertNotNil(blockReason(urlString, file: file, line: line), "expected \(urlString) to be blocked", file: file, line: line)
+    }
+
+    // MARK: - Allowed public hosts
+
+    func testPublicHostsAreAllowed() {
+        assertAllowed("https://example.com")
+        assertAllowed("http://example.com/path?q=1")
+        assertAllowed("https://docs.swift.org/swift-book/")
+        assertAllowed("https://api.github.com:8443/repos")
+        assertAllowed("https://example.com./trailing-dot-is-public")
+        assertAllowed("http://93.184.216.34/")
+        assertAllowed("https://[2606:4700:4700::1111]/")
+        assertAllowed("https://[::ffff:8.8.8.8]/")
+    }
+
+    // MARK: - Schemes and URL shape
+
+    func testNonHTTPSchemesAreBlocked() {
+        assertBlocked("ftp://example.com/file")
+        assertBlocked("file:///etc/passwd")
+        assertBlocked("gopher://example.com")
+    }
+
+    func testEmbeddedCredentialsAreBlocked() {
+        assertBlocked("https://user:secret@example.com/")
+        assertBlocked("https://127.0.0.1@example.com/") // confusion bait, still credentials
+    }
+
+    func testMissingHostIsBlocked() {
+        assertBlocked("https:///path-without-host")
+    }
+
+    // MARK: - Loopback and internal hostnames
+
+    func testLoopbackHostnamesAreBlocked() {
+        assertBlocked("http://localhost/")
+        assertBlocked("http://localhost:3000/")
+        assertBlocked("http://LOCALHOST/")
+        assertBlocked("http://localhost./") // FQDN-root trailing dot
+        assertBlocked("http://sub.localhost/")
+    }
+
+    func testInternalSuffixesAreBlocked() {
+        assertBlocked("http://metadata.google.internal/computeMetadata/v1/")
+        assertBlocked("http://printer.local/")
+        assertBlocked("http://gateway.lan/")
+        assertBlocked("http://files.intranet/")
+        assertBlocked("http://nas.home.arpa/")
+        assertBlocked("http://server.corp/")
+    }
+
+    func testSingleLabelHostnamesAreBlocked() {
+        assertBlocked("http://intranet/")
+        assertBlocked("http://router/")
+        assertBlocked("http://metadata/")
+    }
+
+    // MARK: - IPv4 ranges
+
+    func testInternalIPv4RangesAreBlocked() {
+        assertBlocked("http://127.0.0.1/")
+        assertBlocked("http://127.8.8.8/")
+        assertBlocked("http://0.0.0.0/")
+        assertBlocked("http://10.0.0.1/")
+        assertBlocked("http://10.255.255.255/")
+        assertBlocked("http://172.16.0.1/")
+        assertBlocked("http://172.31.255.254/")
+        assertBlocked("http://192.168.1.1/")
+        assertBlocked("http://169.254.169.254/latest/meta-data/") // cloud metadata endpoint
+        assertBlocked("http://169.254.169.254./") // trailing-dot differential
+        assertBlocked("http://100.64.0.1/")
+        assertBlocked("http://198.18.0.1/")
+        assertBlocked("http://192.0.0.192/")
+        assertBlocked("http://224.0.0.1/")
+        assertBlocked("http://255.255.255.255/")
+    }
+
+    func testAdjacentPublicIPv4RangesAreAllowed() {
+        assertAllowed("http://172.32.0.1/")   // just past 172.16/12
+        assertAllowed("http://11.0.0.1/")     // just past 10/8
+        assertAllowed("http://100.128.0.1/")  // just past 100.64/10
+        assertAllowed("http://169.253.1.1/")  // just below 169.254/16
+    }
+
+    func testObfuscatedNumericIPv4FormsFailClosed() {
+        assertBlocked("http://2130706433/")     // decimal 127.0.0.1, single label
+        assertBlocked("http://127.1/")          // BSD shorthand
+        assertBlocked("http://0177.0.0.1/")     // octal-style labels
+        assertBlocked("http://0x7f.0x0.0x0.0x1/") // hex labels
+        assertBlocked("http://0x7f000001/")     // hex single label
+    }
+
+    // MARK: - IPv6 ranges
+
+    func testInternalIPv6RangesAreBlocked() {
+        assertBlocked("http://[::1]/")
+        assertBlocked("http://[::]/")
+        assertBlocked("http://[fe80::1]/")
+        assertBlocked("http://[fc00::1]/")
+        assertBlocked("http://[fd12:3456:789a::1]/")
+        assertBlocked("http://[ff02::1]/")
+        assertBlocked("http://[::ffff:127.0.0.1]/")  // mapped loopback
+        assertBlocked("http://[::ffff:169.254.169.254]/") // mapped metadata
+        assertBlocked("http://[::ffff:10.0.0.1]/")
+        assertBlocked("http://[64:ff9b::808:808]/") // NAT64
+        assertBlocked("http://[2002:7f00:1::]/")    // 6to4
+        assertBlocked("http://[::7f00:1]/")         // IPv4-compatible form
+    }
+
+    // MARK: - Reason quality
+
+    func testBlockReasonsAreDescriptive() {
+        XCTAssertTrue(blockReason("http://169.254.169.254/")?.contains("link-local") == true)
+        XCTAssertTrue(blockReason("http://localhost/")?.contains("loopback") == true)
+        XCTAssertTrue(blockReason("ftp://example.com/")?.contains("http") == true)
+    }
+}

--- a/Tests/QuillCodeToolsTests/WebFetchMarkdownCapperTests.swift
+++ b/Tests/QuillCodeToolsTests/WebFetchMarkdownCapperTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class WebFetchMarkdownCapperTests: XCTestCase {
+    func testUnderLimitPassesThroughUnchanged() {
+        let text = "# Title\n\nBody"
+        let result = WebFetchMarkdownCapper.cap(text, maxLines: 100, maxBytes: 10_000)
+        XCTAssertFalse(result.truncated)
+        XCTAssertEqual(result.text, text)
+    }
+
+    func testOverLineLimitKeepsTheHead() {
+        let text = (1...3000).map { "line\($0)" }.joined(separator: "\n")
+        let result = WebFetchMarkdownCapper.cap(text, maxLines: 100, maxBytes: 1_000_000)
+        XCTAssertTrue(result.truncated)
+        XCTAssertTrue(result.text.contains("content truncated"))
+        XCTAssertTrue(result.text.hasPrefix("line1\n"), "the head must be kept — a page's title and intro matter most")
+        XCTAssertFalse(result.text.contains("line3000"), "the tail must be dropped")
+    }
+
+    func testOverByteLimitTruncatesOnCodepointBoundary() {
+        let text = String(repeating: "é", count: 10_000) // 2 bytes each
+        let result = WebFetchMarkdownCapper.cap(text, maxLines: 1_000_000, maxBytes: 1001)
+        XCTAssertTrue(result.truncated)
+        XCTAssertFalse(result.text.unicodeScalars.contains { $0.value == 0xFFFD }, "no torn codepoints")
+        XCTAssertTrue(result.text.contains("content truncated"))
+    }
+
+    func testEmptyIsPassthrough() {
+        XCTAssertFalse(WebFetchMarkdownCapper.cap("").truncated)
+    }
+
+    func testExactlyAtLimitsIsNotTruncated() {
+        let text = (1...100).map { "l\($0)" }.joined(separator: "\n")
+        let result = WebFetchMarkdownCapper.cap(text, maxLines: 100, maxBytes: 100_000)
+        XCTAssertFalse(result.truncated)
+    }
+
+    func testNoteReportsTotals() {
+        let text = String(repeating: "x", count: 5_000)
+        let result = WebFetchMarkdownCapper.cap(text, maxLines: 10, maxBytes: 1_000)
+        XCTAssertTrue(result.truncated)
+        XCTAssertTrue(result.text.contains("5000 bytes total"))
+    }
+}

--- a/Tests/QuillCodeToolsTests/WebFetchResponseDecoderTests.swift
+++ b/Tests/QuillCodeToolsTests/WebFetchResponseDecoderTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class WebFetchResponseDecoderTests: XCTestCase {
+    // MARK: - Classification
+
+    func testHTMLTypesClassifyAsHTML() {
+        XCTAssertEqual(WebFetchResponseDecoder.classify(contentType: "text/html", bodyPrefix: Data()), .html)
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "TEXT/HTML; charset=UTF-8", bodyPrefix: Data()),
+            .html
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "application/xhtml+xml", bodyPrefix: Data()),
+            .html
+        )
+    }
+
+    func testTextTypesPassThrough() {
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "text/markdown", bodyPrefix: Data()),
+            .passthroughText
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "text/plain; charset=us-ascii", bodyPrefix: Data()),
+            .passthroughText
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "text/csv", bodyPrefix: Data()),
+            .otherText
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "application/json", bodyPrefix: Data()),
+            .otherText
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "application/problem+json", bodyPrefix: Data()),
+            .otherText
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "application/rss+xml", bodyPrefix: Data()),
+            .otherText
+        )
+    }
+
+    func testBinaryTypesAreRefused() {
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "application/pdf", bodyPrefix: Data()),
+            .refused(reportedType: "application/pdf")
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "application/octet-stream", bodyPrefix: Data()),
+            .refused(reportedType: "application/octet-stream")
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: "image/jpeg", bodyPrefix: Data()),
+            .refused(reportedType: "image/jpeg")
+        )
+    }
+
+    func testMissingContentTypeSniffs() {
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: nil, bodyPrefix: Data("<!doctype HTML><html>".utf8)),
+            .html
+        )
+        XCTAssertEqual(
+            WebFetchResponseDecoder.classify(contentType: nil, bodyPrefix: Data("plain words".utf8)),
+            .passthroughText
+        )
+        if case .refused = WebFetchResponseDecoder.classify(contentType: nil, bodyPrefix: Data([0x00, 0x01])) {
+            // NUL bytes with no declared type read as binary.
+        } else {
+            XCTFail("NUL-laden body without a content type must be refused")
+        }
+    }
+
+    func testEmptyContentTypeDoesNotCrash() {
+        _ = WebFetchResponseDecoder.classify(contentType: "", bodyPrefix: Data())
+        _ = WebFetchResponseDecoder.classify(contentType: ";;;", bodyPrefix: Data())
+        XCTAssertEqual(WebFetchResponseDecoder.mimeType(of: ""), "")
+        XCTAssertEqual(WebFetchResponseDecoder.mimeType(of: ";charset=utf-8"), "")
+    }
+
+    // MARK: - Charset parameter parsing
+
+    func testCharsetParameterExtraction() {
+        XCTAssertEqual(WebFetchResponseDecoder.charset(of: "text/html; charset=utf-8"), "utf-8")
+        XCTAssertEqual(WebFetchResponseDecoder.charset(of: "text/html;charset=\"ISO-8859-1\""), "iso-8859-1")
+        XCTAssertEqual(WebFetchResponseDecoder.charset(of: "text/html; boundary=x; charset='windows-1252'"), "windows-1252")
+        XCTAssertNil(WebFetchResponseDecoder.charset(of: "text/html"))
+        XCTAssertNil(WebFetchResponseDecoder.charset(of: "text/html; charset="))
+        XCTAssertNil(WebFetchResponseDecoder.charset(of: nil))
+    }
+
+    // MARK: - Decoding
+
+    func testUTF8BOMIsStripped() {
+        var data = Data([0xEF, 0xBB, 0xBF])
+        data.append(contentsOf: Data("hello".utf8))
+        XCTAssertEqual(WebFetchResponseDecoder.decode(data, declaredCharset: "utf-8", sniffHTMLMeta: false), "hello")
+    }
+
+    func testUTF16BOMDecodes() {
+        let data = "hi there".data(using: .utf16)! // includes BOM
+        XCTAssertEqual(WebFetchResponseDecoder.decode(data, declaredCharset: nil, sniffHTMLMeta: false), "hi there")
+    }
+
+    func testUnknownCharsetFallsBackToLossyUTF8() {
+        var data = Data("ok ".utf8)
+        data.append(0xFF)
+        let text = WebFetchResponseDecoder.decode(data, declaredCharset: "x-mystery-encoding", sniffHTMLMeta: false)
+        XCTAssertTrue(text.hasPrefix("ok "))
+        XCTAssertTrue(text.unicodeScalars.contains { $0.value == 0xFFFD })
+    }
+
+    func testNULBytesAreStripped() {
+        let data = Data("a\u{0}b".utf8)
+        XCTAssertEqual(WebFetchResponseDecoder.decode(data, declaredCharset: "utf-8", sniffHTMLMeta: false), "ab")
+    }
+
+    func testMetaCharsetSniffVariants() {
+        let single = Data("<meta charset='shift_jis'>".utf8)
+        let decodedSingle = WebFetchResponseDecoder.decode(
+            Data("<meta charset='utf-8'><p>plain</p>".utf8),
+            declaredCharset: nil,
+            sniffHTMLMeta: true
+        )
+        XCTAssertTrue(decodedSingle.contains("plain"))
+        _ = WebFetchResponseDecoder.decode(single, declaredCharset: nil, sniffHTMLMeta: true)
+
+        let httpEquiv = Data(
+            "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=iso-8859-1\"><p>\u{E9}</p>"
+                .data(using: .isoLatin1)!
+        )
+        let decoded = WebFetchResponseDecoder.decode(httpEquiv, declaredCharset: nil, sniffHTMLMeta: true)
+        XCTAssertTrue(decoded.contains("é"), "http-equiv charset must be honored: \(decoded)")
+    }
+}

--- a/Tests/QuillCodeToolsTests/WebFetchToolExecutorTests.swift
+++ b/Tests/QuillCodeToolsTests/WebFetchToolExecutorTests.swift
@@ -1,0 +1,428 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+/// Scripted `WebFetchHTTPClient` so executor tests are deterministic and never touch the
+/// network: responses are consumed in order, and every request is recorded for inspection.
+final class StubWebFetchHTTPClient: WebFetchHTTPClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var scriptedResults: [Result<WebFetchHTTPResponse, WebFetchHTTPClientError>]
+    private var recordedRequests: [WebFetchHTTPRequest] = []
+
+    init(_ results: [Result<WebFetchHTTPResponse, WebFetchHTTPClientError>]) {
+        self.scriptedResults = results
+    }
+
+    convenience init(responses: [WebFetchHTTPResponse]) {
+        self.init(responses.map { .success($0) })
+    }
+
+    var requests: [WebFetchHTTPRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRequests
+    }
+
+    func perform(_ request: WebFetchHTTPRequest) throws -> WebFetchHTTPResponse {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedRequests.append(request)
+        guard !scriptedResults.isEmpty else {
+            throw WebFetchHTTPClientError.transport("unscripted request to \(request.url.absoluteString)")
+        }
+        return try scriptedResults.removeFirst().get()
+    }
+}
+
+final class WebFetchToolExecutorTests: XCTestCase {
+    private func makeExecutor(
+        responses: [WebFetchHTTPResponse],
+        maxRedirects: Int = 5,
+        outputMaxLines: Int = WebFetchMarkdownCapper.defaultMaxLines,
+        outputMaxBytes: Int = WebFetchMarkdownCapper.defaultMaxBytes
+    ) -> (WebFetchToolExecutor, StubWebFetchHTTPClient) {
+        let client = StubWebFetchHTTPClient(responses: responses)
+        let executor = WebFetchToolExecutor(
+            client: client,
+            maxRedirects: maxRedirects,
+            outputMaxLines: outputMaxLines,
+            outputMaxBytes: outputMaxBytes
+        )
+        return (executor, client)
+    }
+
+    private func htmlResponse(
+        _ html: String,
+        statusCode: Int = 200,
+        contentType: String = "text/html; charset=utf-8",
+        extraHeaders: [String: String] = [:]
+    ) -> WebFetchHTTPResponse {
+        var headers = ["content-type": contentType]
+        for (name, value) in extraHeaders {
+            headers[name.lowercased()] = value
+        }
+        return WebFetchHTTPResponse(statusCode: statusCode, headerFields: headers, body: Data(html.utf8))
+    }
+
+    // MARK: - Happy paths
+
+    func testHTMLIsFetchedAndConverted() {
+        let (executor, client) = makeExecutor(responses: [
+            htmlResponse("<h1>Docs</h1><p>Welcome to the <a href=\"/guide\">guide</a>.</p>")
+        ])
+        let result = executor.fetch(urlString: "https://example.com/docs")
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("# Docs"))
+        XCTAssertTrue(result.stdout.contains("[guide](https://example.com/guide)"))
+        XCTAssertTrue(result.stdout.contains("HTTP 200"))
+        XCTAssertTrue(result.stdout.contains("converted to markdown"))
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/docs")
+    }
+
+    func testAcceptHeaderNegotiatesTextFormats() {
+        let (executor, client) = makeExecutor(responses: [htmlResponse("<p>x</p>")])
+        _ = executor.fetch(urlString: "https://example.com/")
+        let accept = client.requests[0].headers["Accept"] ?? ""
+        XCTAssertTrue(accept.contains("text/html"))
+        XCTAssertTrue(accept.contains("text/markdown"))
+        XCTAssertTrue(accept.contains("text/plain"))
+        XCTAssertTrue(client.requests[0].headers["User-Agent"]?.contains("QuillCode") == true)
+    }
+
+    func testMarkdownPassesThroughUnchanged() {
+        let markdown = "# Already markdown\n\n- item `code`"
+        let (executor, _) = makeExecutor(responses: [
+            htmlResponse(markdown, contentType: "text/markdown")
+        ])
+        let result = executor.fetch(urlString: "https://example.com/README.md")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains(markdown))
+        XCTAssertTrue(result.stdout.contains("returned as-is"))
+    }
+
+    func testPlainTextPassesThrough() {
+        let text = "RFC 9110\n\nHTTP Semantics <not html>"
+        let (executor, _) = makeExecutor(responses: [
+            htmlResponse(text, contentType: "text/plain; charset=utf-8")
+        ])
+        let result = executor.fetch(urlString: "https://example.com/rfc.txt")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains(text))
+    }
+
+    func testJSONPassesThroughAsText() {
+        let (executor, _) = makeExecutor(responses: [
+            htmlResponse(#"{"name":"quill"}"#, contentType: "application/json")
+        ])
+        let result = executor.fetch(urlString: "https://api.example.com/info")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains(#"{"name":"quill"}"#))
+    }
+
+    func testSchemelessURLDefaultsToHTTPS() {
+        let (executor, client) = makeExecutor(responses: [htmlResponse("<p>x</p>")])
+        let result = executor.fetch(urlString: "example.com/docs")
+        XCTAssertTrue(result.ok)
+        XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/docs")
+    }
+
+    // MARK: - Content-type refusal and sniffing
+
+    func testBinaryContentTypeIsRefusedWithActionableError() {
+        let (executor, _) = makeExecutor(responses: [
+            htmlResponse("%PDF-1.4", contentType: "application/pdf")
+        ])
+        let result = executor.fetch(urlString: "https://example.com/paper.pdf")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("application/pdf") == true)
+        XCTAssertTrue(result.error?.contains("curl") == true, "refusal should point at a download path: \(result.error ?? "")")
+    }
+
+    func testImageContentTypeIsRefused() {
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 200,
+                headerFields: ["content-type": "image/png"],
+                body: Data([0x89, 0x50, 0x4E, 0x47])
+            )
+        ])
+        let result = executor.fetch(urlString: "https://example.com/img.png")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("image/png") == true)
+    }
+
+    func testMissingContentTypeSniffsHTML() {
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(statusCode: 200, body: Data("<!DOCTYPE html><h1>Sniffed</h1>".utf8))
+        ])
+        let result = executor.fetch(urlString: "https://example.com/")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("# Sniffed"))
+    }
+
+    func testMissingContentTypeWithBinaryBodyIsRefused() {
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(statusCode: 200, body: Data([0x00, 0x01, 0x02, 0xFF, 0x00, 0x10]))
+        ])
+        let result = executor.fetch(urlString: "https://example.com/mystery")
+        XCTAssertFalse(result.ok)
+    }
+
+    // MARK: - Charset handling
+
+    func testLatin1CharsetIsDecoded() {
+        var body = Data("<p>caf".utf8)
+        body.append(0xE9) // é in ISO-8859-1
+        body.append(contentsOf: Data("</p>".utf8))
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 200,
+                headerFields: ["content-type": "text/html; charset=iso-8859-1"],
+                body: body
+            )
+        ])
+        let result = executor.fetch(urlString: "https://example.com/")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("café"))
+    }
+
+    func testInvalidUTF8IsLossilyReplacedNotFatal() {
+        var body = Data("<p>ok ".utf8)
+        body.append(contentsOf: [0xFF, 0xFE, 0xFD]) // invalid UTF-8 bytes
+        body.append(contentsOf: Data(" end</p>".utf8))
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 200,
+                headerFields: ["content-type": "text/html; charset=utf-8"],
+                body: body
+            )
+        ])
+        let result = executor.fetch(urlString: "https://example.com/")
+        XCTAssertTrue(result.ok, "hostile bytes must degrade, not fail: \(result.error ?? "")")
+        XCTAssertTrue(result.stdout.contains("ok"))
+        XCTAssertTrue(result.stdout.contains("end"))
+    }
+
+    func testMetaCharsetIsSniffedWhenHeaderIsSilent() {
+        var body = Data("<html><head><meta charset=\"windows-1252\"></head><body><p>".utf8)
+        body.append(0x93) // “ in windows-1252
+        body.append(contentsOf: Data("quoted</p></body></html>".utf8))
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 200,
+                headerFields: ["content-type": "text/html"],
+                body: body
+            )
+        ])
+        let result = executor.fetch(urlString: "https://example.com/")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("\u{201C}quoted"))
+    }
+
+    // MARK: - SSRF gate
+
+    func testInternalInitialURLsAreBlockedWithoutAnyRequest() {
+        let blockedURLs = [
+            "http://localhost:8080/admin",
+            "http://127.0.0.1/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::1]:6379/",
+            "http://10.0.0.5/router",
+            "http://metadata.google.internal/computeMetadata/v1/",
+            "ftp://example.com/file",
+            "http://user:pass@example.com/"
+        ]
+        for urlString in blockedURLs {
+            let (executor, client) = makeExecutor(responses: [htmlResponse("<p>never</p>")])
+            let result = executor.fetch(urlString: urlString)
+            XCTAssertFalse(result.ok, "\(urlString) must be blocked")
+            XCTAssertTrue(client.requests.isEmpty, "\(urlString) must be blocked BEFORE any network I/O")
+        }
+    }
+
+    func testInvalidURLArgumentIsRejected() {
+        let (executor, client) = makeExecutor(responses: [])
+        XCTAssertFalse(executor.fetch(urlString: "not a url at all").ok)
+        XCTAssertFalse(executor.fetch(urlString: "").ok)
+        XCTAssertTrue(client.requests.isEmpty)
+    }
+
+    // MARK: - Redirects
+
+    func testRelativeRedirectIsFollowedAndReported() {
+        let (executor, client) = makeExecutor(responses: [
+            WebFetchHTTPResponse(statusCode: 302, headerFields: ["location": "/moved/here"]),
+            htmlResponse("<h1>Landed</h1>")
+        ])
+        let result = executor.fetch(urlString: "https://example.com/start")
+        XCTAssertTrue(result.ok)
+        XCTAssertEqual(client.requests.count, 2)
+        XCTAssertEqual(client.requests[1].url.absoluteString, "https://example.com/moved/here")
+        XCTAssertTrue(result.stdout.contains("# Landed"))
+        XCTAssertTrue(result.stdout.contains("1 redirect"))
+    }
+
+    func testRedirectToInternalHostIsBlocked() {
+        let (executor, client) = makeExecutor(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 302,
+                headerFields: ["location": "http://169.254.169.254/latest/meta-data/"]
+            ),
+            htmlResponse("<p>never fetched</p>")
+        ])
+        let result = executor.fetch(urlString: "https://example.com/innocent")
+        XCTAssertFalse(result.ok, "redirect laundering to the metadata endpoint must be blocked")
+        XCTAssertEqual(client.requests.count, 1, "the internal hop must never be requested")
+        XCTAssertTrue(result.error?.contains("redirect") == true)
+        XCTAssertTrue(result.error?.contains("169.254") == true)
+    }
+
+    func testRedirectToLocalhostIsBlocked() {
+        let (executor, client) = makeExecutor(responses: [
+            WebFetchHTTPResponse(statusCode: 301, headerFields: ["location": "https://localhost/internal"])
+        ])
+        let result = executor.fetch(urlString: "https://example.com/")
+        XCTAssertFalse(result.ok)
+        XCTAssertEqual(client.requests.count, 1)
+    }
+
+    func testRedirectToFileSchemeIsBlocked() {
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(statusCode: 302, headerFields: ["location": "file:///etc/passwd"])
+        ])
+        let result = executor.fetch(urlString: "https://example.com/")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("http") == true)
+    }
+
+    func testRedirectCountIsCapped() {
+        let hops = (0..<10).map { index in
+            WebFetchHTTPResponse(
+                statusCode: 302,
+                headerFields: ["location": "https://example.com/hop/\(index)"]
+            )
+        }
+        let (executor, client) = makeExecutor(responses: hops, maxRedirects: 3)
+        let result = executor.fetch(urlString: "https://example.com/start")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("redirect") == true)
+        XCTAssertEqual(client.requests.count, 4, "initial request + 3 redirects, then give up")
+    }
+
+    func testRedirectWithoutLocationFails() {
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(statusCode: 302)
+        ])
+        let result = executor.fetch(urlString: "https://example.com/")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("Location") == true)
+    }
+
+    // MARK: - HTTP errors and Cloudflare retry
+
+    func testNotFoundIsReported() {
+        let (executor, _) = makeExecutor(responses: [htmlResponse("gone", statusCode: 404)])
+        let result = executor.fetch(urlString: "https://example.com/missing")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("404") == true)
+    }
+
+    func testPlain403DoesNotTriggerRetry() {
+        let (executor, client) = makeExecutor(responses: [
+            htmlResponse("forbidden", statusCode: 403)
+        ])
+        let result = executor.fetch(urlString: "https://example.com/private")
+        XCTAssertFalse(result.ok)
+        XCTAssertEqual(client.requests.count, 1, "no Cloudflare markers, no retry")
+        XCTAssertTrue(result.error?.contains("host.browser.open") == true)
+    }
+
+    func testCloudflare403RetriesOnceWithBrowserHeaders() {
+        let (executor, client) = makeExecutor(responses: [
+            htmlResponse(
+                "blocked", statusCode: 403,
+                extraHeaders: ["cf-mitigated": "challenge", "server": "cloudflare"]
+            ),
+            htmlResponse("<h1>Through</h1>")
+        ])
+        let result = executor.fetch(urlString: "https://example.com/docs")
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("# Through"))
+        XCTAssertEqual(client.requests.count, 2)
+        let retryAgent = client.requests[1].headers["User-Agent"] ?? ""
+        XCTAssertTrue(retryAgent.contains("Mozilla"), "retry must use a browser-like User-Agent")
+        XCTAssertNotEqual(client.requests[0].headers["User-Agent"], client.requests[1].headers["User-Agent"])
+    }
+
+    func testPersistentCloudflareBlockSuggestsBrowserPane() {
+        let blocked = htmlResponse(
+            "denied", statusCode: 403,
+            extraHeaders: ["cf-mitigated": "challenge"]
+        )
+        let (executor, client) = makeExecutor(responses: [blocked, blocked])
+        let result = executor.fetch(urlString: "https://example.com/docs")
+        XCTAssertFalse(result.ok)
+        XCTAssertEqual(client.requests.count, 2, "exactly one retry")
+        XCTAssertTrue(result.error?.contains("host.browser.open") == true)
+    }
+
+    // MARK: - Size caps and truncation
+
+    func testBodyCapWithNoDataIsAnError() {
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 200,
+                headerFields: ["content-type": "text/html"],
+                body: Data(),
+                bodyExceededMaxBytes: true
+            )
+        ])
+        let result = executor.fetch(urlString: "https://example.com/huge")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("cap") == true)
+        XCTAssertTrue(result.error?.contains("curl") == true)
+    }
+
+    func testBodyCapWithPartialDataReturnsPrefixWithNote() {
+        let (executor, _) = makeExecutor(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 200,
+                headerFields: ["content-type": "text/html"],
+                body: Data("<h1>Start</h1><p>partial".utf8),
+                bodyExceededMaxBytes: true
+            )
+        ])
+        let result = executor.fetch(urlString: "https://example.com/huge")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("# Start"))
+        XCTAssertTrue(result.stdout.contains("cap"), "capped fetch must be flagged: \(result.stdout)")
+    }
+
+    func testLongOutputIsTruncatedWithMarker() {
+        let paragraphs = (0..<500).map { "<p>Paragraph number \($0) with some text.</p>" }.joined()
+        let (executor, _) = makeExecutor(
+            responses: [htmlResponse(paragraphs)],
+            outputMaxBytes: 2_000
+        )
+        let result = executor.fetch(urlString: "https://example.com/long")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("content truncated"))
+        XCTAssertLessThan(result.stdout.utf8.count, 4_000)
+    }
+
+    func testTransportErrorIsSurfaced() {
+        let client = StubWebFetchHTTPClient([.failure(.timedOut)])
+        let executor = WebFetchToolExecutor(client: client)
+        let result = executor.fetch(urlString: "https://example.com/slow")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("timed out") == true)
+    }
+
+    func testEmptyPageYieldsPlaceholder() {
+        let (executor, _) = makeExecutor(responses: [htmlResponse("<html><body></body></html>")])
+        let result = executor.fetch(urlString: "https://example.com/blank")
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("no readable text content"))
+    }
+}

--- a/Tests/QuillCodeToolsTests/WebFetchToolRouterTests.swift
+++ b/Tests/QuillCodeToolsTests/WebFetchToolRouterTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+final class WebFetchToolRouterTests: XCTestCase {
+    func testWebFetchDefinitionIsRegistered() {
+        let names = ToolRouter.definitions.map(\.name)
+        XCTAssertTrue(names.contains(ToolDefinition.webFetch.name))
+        XCTAssertEqual(Set(names).count, names.count, "tool names must stay unique")
+    }
+
+    func testWebFetchDefinitionShape() {
+        let definition = ToolDefinition.webFetch
+        XCTAssertEqual(definition.name, "host.web.fetch")
+        XCTAssertEqual(definition.host, .local)
+        XCTAssertEqual(definition.risk, .read)
+        XCTAssertTrue(definition.parametersJSON.contains("\"url\""))
+        XCTAssertTrue(definition.parametersJSON.contains("required"))
+        // The schema must be valid JSON.
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: Data(definition.parametersJSON.utf8)))
+    }
+
+    func testRouterDispatchesWebFetchCalls() throws {
+        let client = StubWebFetchHTTPClient(responses: [
+            WebFetchHTTPResponse(
+                statusCode: 200,
+                headerFields: ["content-type": "text/html"],
+                body: Data("<h1>Routed</h1>".utf8)
+            )
+        ])
+        let router = ToolRouter(
+            workspaceRoot: FileManager.default.temporaryDirectory,
+            web: WebFetchToolExecutor(client: client)
+        )
+        let result = router.execute(ToolCall(
+            name: ToolDefinition.webFetch.name,
+            argumentsJSON: #"{"url":"https://example.com/page"}"#
+        ))
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("# Routed"))
+    }
+
+    func testRouterRejectsMissingURLArgument() {
+        let router = ToolRouter(
+            workspaceRoot: FileManager.default.temporaryDirectory,
+            web: WebFetchToolExecutor(client: StubWebFetchHTTPClient(responses: []))
+        )
+        let result = router.execute(ToolCall(name: ToolDefinition.webFetch.name, argumentsJSON: "{}"))
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("url") == true)
+    }
+}


### PR DESCRIPTION
## What

Adds a `host.web.fetch` tool: HTTP GET a public URL and return its content as markdown, so the agent can pull a docs page, RFC, changelog, or error-report link into context without shelling out to curl or opening the browser pane.

Fixes #856

## How it works

- **Tool** `host.web.fetch` (`WebFetchToolDefinitions.swift`, risk `.read`, host `.local`), registered in `ToolRouter.definitions` and dispatched by `ToolRouter.execute` — so it is available to both the CLI agent loop (`AgentRunner` default toolset) and the desktop workspace executor with a single wiring point.
- **Executor** (`WebFetchToolExecutor.swift`): normalizes the URL (bare hosts default to https), GETs with an Accept header negotiating `text/html > text/markdown > text/plain`, follows up to 5 redirects, and renders per content type: HTML → markdown, markdown/plain/other-textual → pass-through, binary → actionable refusal pointing at a curl download.
- **SSRF host gate** (`WebFetchHostGate.swift`): every hop — the initial URL *and each redirect target* — is checked before any connection. Blocks non-http(s) schemes, credentialed URLs, loopback/private/link-local/CGNAT/benchmarking/multicast IPv4 ranges (incl. the cloud-metadata endpoint), IPv6 loopback/link-local/unique-local/mapped/NAT64/6to4, `localhost`/`.local`/`.internal`-style hostnames, and single-label intranet names. Numeric hosts are parsed with a **strict hand-rolled dotted-quad parser** rather than `inet_pton` (whose leniency on leading-zero labels is itself a parser differential: `0177.0.0.1` is octal 127.0.0.1 to `inet_aton`-style resolvers); any non-canonical numeric form fails closed. The gate follows the trailing-dot/normalization semantics established by `StaticSafetyDownloadPolicy` — per exploration there is no standalone reusable SSRF gate on main (that policy is a shell-command intent matcher), so the network-level gate lives beside the executor and reuses the same fail-closed rules. Redirects are refused inside the URLSession delegate, so a 3xx always surfaces for re-gating; hop count capped.
- **Transport** (`WebFetchHTTPClient.swift` protocol + `URLSessionWebFetchHTTPClient.swift`): single-transaction client with a ~5 MB body cap enforced **while streaming** (cancels mid-transfer; a lying Content-Length is also rejected up front via an `Int64` comparison — no unclamped numeric conversions from server data), overall resource timeout, bounded semaphore wait (cannot hang the agent loop), no cookies, no cache. Tests inject a scripted stub client through the protocol.
- **HTML → markdown** (`HTMLTokenizer` / `HTMLEntityDecoder` / `HTMLMarkdownWriter` / `HTMLToMarkdownConverter`, no dependencies): headings, paragraphs, links (resolved against the final URL, `javascript:` dropped), nested lists, inline code + fenced `pre` (fence sized past backtick runs, capped), emphasis, blockquotes, best-effort pipe tables, images (small base64 data URIs kept inline, large ones summarized). Strips `script`/`style`/`head`/`nav`/`aside`/`svg`/… noise. Built for hostile input: iterative (no recursion), cursor strictly advances, every buffer bounded (nesting, captures, attributes; numeric entities range-clamped via the failable `Unicode.Scalar` init), unclosed inline elements auto-close at block boundaries so one missing `</a>` cannot swallow the page, and output stops at a byte budget. Charset honors the header, sniffs `<meta charset>`, and falls back to lossy UTF-8 (invalid bytes → U+FFFD, NULs stripped) — decoding never fails.
- **Truncation** (`WebFetchMarkdownCapper.swift`): follows the `ShellOutputCapper` precedent (2000 lines / 48 KB payload) but keeps the **head** — for a fetched page the title and intro matter most — with an honest `[content truncated — …]` note, cut on a codepoint boundary.
- **Cloudflare-bot retry**: a 403/503 carrying `cf-mitigated`/Cloudflare markers triggers exactly one retry with browser-like User-Agent/Accept; if still blocked, the error suggests `host.browser.open`. Plain 403s do not retry.
- **Agent/desktop integration**: answer formatter (`AgentWebToolAnswerFormatters`, registered in `AgentToolAnswerFormatters.all`), argument-alias normalization (`url` ⇠ `address`/`href`/`link`/…), and tool-card subtitle showing the URL.

## Test evidence

- 107 new tests: converter (37: elements, malformed/hostile HTML, nesting + output bounds), host gate (12: ranges, obfuscated IP forms, IPv6, reasons), executor (30: redirect re-gate + cap, Cloudflare retry headers, size cap, content-type refusal, charset fallback, truncation marker — all via stub HTTP client, no network), router registration/dispatch (4), capper (6), decoder (11), answer formatter (7).
- Full suite: `swift test` → **2434 tests, 0 failures (1 pre-existing skip)**.
- Live smoke (real URLSession client): example.com converts; a real redirect chain (`http://google.com` → `www`) follows with re-gating and a redirect note; a 98 KB Wikipedia article converts with links/tables; an RFC `.txt` and raw GitHub markdown pass through; `favicon.ico` refused with the curl suggestion; the cloud-metadata endpoint and `localhost:8080` refused with zero network I/O; a JS-only SPA (Swift-DocC) reports "renders via JavaScript; try host.browser.open".
- Converter fuzz: 200 random tag-soup rounds (worst 1 ms) plus pathological cases (1M nested divs / unclosed anchors / entities / table cells, 5 MB text node, attribute + comment bombs) — all bounded well under 0.5 s with capped output.

## Notes / limitations

- The gate classifies textually (IP literals + hostname shape); it does not resolve DNS, so rebinding-style attacks (a public name resolving to an internal IP) are out of scope here, as they are for the browser pane and shell downloads today.
- HTML5 block-wrapping anchors (`<a><div>…`) keep their text but drop the href — the deliberate cost of auto-closing inline captures at block boundaries so malformed pages cannot lose content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
