### PR TITLE
[opencode] Make skills executable: add host.skill.load (Skill tool)

### DIFF
--- a/Sources/QuillCodeAgent/AgentSkillToolAnswerFormatters.swift
+++ b/Sources/QuillCodeAgent/AgentSkillToolAnswerFormatters.swift
@@ -1,0 +1,28 @@
+import QuillCodeCore
+import QuillCodeTools
+
+enum AgentSkillToolAnswerFormatters {
+    static func skillLoadAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.skillLoad.name else {
+            return nil
+        }
+        let name = AgentToolAnswerFormatterSupport.argument("name", in: call) ?? "the skill"
+        if !result.ok {
+            let details = [result.error, result.stderr.trimmedNonEmpty]
+                .compactMap { $0?.trimmedNonEmpty }
+                .joined(separator: "\n")
+            return details.isEmpty
+                ? "Could not load skill `\(name)`."
+                : "Could not load skill `\(name)`: \(AgentToolAnswerFormatters.truncated(details))"
+        }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !output.isEmpty else {
+            return "Loaded skill `\(name)`, but it had no content."
+        }
+        return AgentToolAnswerFormatters.truncated(output)
+    }
+}

--- a/Sources/QuillCodeAgent/AgentToolAnswerFormatters.swift
+++ b/Sources/QuillCodeAgent/AgentToolAnswerFormatters.swift
@@ -20,6 +20,7 @@ enum AgentToolAnswerFormatters {
             AgentUtilityToolAnswerFormatters.memoryRememberAnswer,
             AgentShellToolAnswerFormatters.shellRunAnswer,
             AgentWebToolAnswerFormatters.webFetchAnswer,
+            AgentSkillToolAnswerFormatters.skillLoadAnswer,
             AgentBrowserToolAnswerFormatters.browserInspectAnswer,
             AgentBrowserToolAnswerFormatters.browserOpenAnswer,
             AgentUtilityToolAnswerFormatters.mcpReadResourceAnswer,

--- a/Sources/QuillCodeTools/SkillLoadToolExecutor.swift
+++ b/Sources/QuillCodeTools/SkillLoadToolExecutor.swift
@@ -1,0 +1,199 @@
+import Foundation
+import QuillCodeCore
+
+/// Executes `host.skill.load`: resolve a skill name (user shadows builtin), read its `SKILL.md`, and
+/// return a `<skill_content>` block carrying the skill's base directory (absolute), a listing of the
+/// files inside it, and the `SKILL.md` body. The model then references those files by absolute path
+/// with the ordinary file tools.
+///
+/// This tool LOADS skill content into context — it does not execute any skill code. It is `risk: .read`.
+public struct SkillLoadToolExecutor: Sendable {
+    public var resolver: SkillResolver
+    /// Byte ceiling on the injected `SKILL.md` body (ShellOutputCapper precedent).
+    public var manifestMaxBytes: Int
+    /// Line ceiling on the injected `SKILL.md` body.
+    public var manifestMaxLines: Int
+    /// Cap on how many files are listed under the skill directory, to keep the block bounded.
+    public var maxListedFiles: Int
+
+    public init(
+        resolver: SkillResolver,
+        manifestMaxBytes: Int = SkillLoadToolExecutor.defaultManifestMaxBytes,
+        manifestMaxLines: Int = SkillLoadToolExecutor.defaultManifestMaxLines,
+        maxListedFiles: Int = SkillLoadToolExecutor.defaultMaxListedFiles
+    ) {
+        self.resolver = resolver
+        self.manifestMaxBytes = max(1024, manifestMaxBytes)
+        self.manifestMaxLines = max(1, manifestMaxLines)
+        self.maxListedFiles = max(1, maxListedFiles)
+    }
+
+    public static let defaultManifestMaxBytes = 48_000
+    public static let defaultManifestMaxLines = 2_000
+    public static let defaultMaxListedFiles = 200
+
+    /// Convenience for the default project + home roots.
+    public static func `default`(
+        workspaceRoot: URL,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> SkillLoadToolExecutor {
+        SkillLoadToolExecutor(resolver: .default(workspaceRoot: workspaceRoot, homeDirectory: homeDirectory))
+    }
+
+    public func load(name: String) -> ToolResult {
+        let skill: ResolvedSkill
+        do {
+            skill = try resolver.resolve(name: name)
+        } catch let error as SkillResolutionError {
+            return ToolResult(ok: false, error: Self.message(for: error))
+        } catch {
+            return ToolResult(ok: false, error: String(describing: error))
+        }
+
+        // Read the manifest. A directory-with-SKILL.md that is unreadable (permissions) or invalid
+        // UTF-8 is an actionable failure, not a crash.
+        guard let data = try? Data(contentsOf: skill.skillFile) else {
+            return ToolResult(ok: false, error: """
+            Found skill `\(skill.name)` at \(skill.baseDirectory.path) but could not read its \
+            \(SkillResolver.manifestFileName). Check the file's permissions.
+            """)
+        }
+        guard let rawBody = String(data: data, encoding: .utf8) else {
+            return ToolResult(ok: false, error: """
+            Skill `\(skill.name)`'s \(SkillResolver.manifestFileName) at \(skill.skillFile.path) is not \
+            valid UTF-8 text and cannot be loaded.
+            """)
+        }
+
+        // Keep the HEAD of SKILL.md — its title, purpose, and leading instructions are what matter;
+        // WebFetchMarkdownCapper is the head-keeping capper (ShellOutputCapper keeps the tail).
+        let capped = WebFetchMarkdownCapper.cap(rawBody, maxLines: manifestMaxLines, maxBytes: manifestMaxBytes)
+        let listing = fileListing(for: skill.baseDirectory)
+
+        let content = Self.renderSkillContent(
+            skill: skill,
+            manifestBody: capped.text,
+            manifestTruncated: capped.truncated,
+            files: listing.files,
+            fileCountTruncated: listing.truncated,
+            totalFileCount: listing.total
+        )
+
+        let sourceLabel = skill.kind == .user ? "user" : "builtin"
+        let summary = "Loaded \(sourceLabel) skill `\(skill.name)` from \(skill.baseDirectory.path)."
+        return ToolResult(ok: true, stdout: summary + "\n\n" + content)
+    }
+
+    // MARK: - File listing
+
+    private struct FileListing {
+        var files: [String]
+        var total: Int
+        var truncated: Bool
+    }
+
+    /// Files under the skill's base directory, as paths relative to that directory, sorted, capped.
+    /// A deterministic recursive walk (skipping hidden entries) so the model sees exactly what it can
+    /// then read by absolute path. Symlinks are listed by name but not followed.
+    private func fileListing(for baseDirectory: URL) -> FileListing {
+        let fileManager = FileManager.default
+        var relativePaths: [String] = []
+        var total = 0
+        let basePath = baseDirectory.standardizedFileURL.path
+        let prefix = basePath.hasSuffix("/") ? basePath : basePath + "/"
+
+        guard let enumerator = fileManager.enumerator(
+            at: baseDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in true }
+        ) else {
+            return FileListing(files: [], total: 0, truncated: false)
+        }
+
+        for case let fileURL as URL in enumerator {
+            let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            guard values?.isRegularFile == true else { continue }
+            total += 1
+            guard relativePaths.count < maxListedFiles else { continue }
+            let path = fileURL.standardizedFileURL.path
+            let relative = path.hasPrefix(prefix) ? String(path.dropFirst(prefix.count)) : fileURL.lastPathComponent
+            relativePaths.append(relative)
+        }
+
+        relativePaths.sort()
+        return FileListing(files: relativePaths, total: total, truncated: total > relativePaths.count)
+    }
+
+    // MARK: - Rendering
+
+    /// Builds the `<skill_content>` block: base dir (absolute) + file listing + the `SKILL.md` body.
+    static func renderSkillContent(
+        skill: ResolvedSkill,
+        manifestBody: String,
+        manifestTruncated: Bool,
+        files: [String],
+        fileCountTruncated: Bool,
+        totalFileCount: Int
+    ) -> String {
+        var lines: [String] = []
+        lines.append("<skill_content name=\"\(skill.name)\" source=\"\(skill.kind.rawValue)\">")
+        lines.append("Base directory (absolute): \(skill.baseDirectory.path)")
+        lines.append("Reference any file below by its absolute path, e.g. \(skill.baseDirectory.path)/<relative-path>.")
+        lines.append("")
+        if files.isEmpty {
+            lines.append("Files: (none besides \(SkillResolver.manifestFileName))")
+        } else {
+            let shown = files.count
+            let header = fileCountTruncated
+                ? "Files (\(shown) of \(totalFileCount), relative to the base directory):"
+                : "Files (\(totalFileCount), relative to the base directory):"
+            lines.append(header)
+            for file in files {
+                lines.append("- \(file)")
+            }
+            if fileCountTruncated {
+                lines.append("- … \(totalFileCount - shown) more (list \(skill.baseDirectory.path) for the rest)")
+            }
+        }
+        lines.append("")
+        lines.append("--- \(SkillResolver.manifestFileName) ---")
+        lines.append(manifestBody)
+        if manifestTruncated {
+            lines.append("")
+            lines.append("[\(SkillResolver.manifestFileName) truncated — read \(skill.skillFile.path) directly for the full text]")
+        }
+        lines.append("</skill_content>")
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Errors
+
+    static func message(for error: SkillResolutionError) -> String {
+        switch error {
+        case .invalidName(let name):
+            return """
+            `\(name)` is not a valid skill name. Pass a bare skill name (letters, digits, `.`, `-`, `_`) \
+            such as `code-review` — not a path, and no `/` or `..`.
+            """
+        case .notFound(let requested, let available):
+            if available.isEmpty {
+                return """
+                No skill named `\(requested)` is available, and no skills are installed. Add a skill under \
+                .quillcode/skills/<name>/\(SkillResolver.manifestFileName).
+                """
+            }
+            let suggestions = FilePathSuggester.suggest(missing: requested, candidates: available, limit: 3)
+            let suggestionText: String
+            if suggestions.isEmpty {
+                suggestionText = ""
+            } else {
+                let quoted = suggestions.map { "`\($0)`" }.joined(separator: ", ")
+                suggestionText = " Did you mean \(quoted)?"
+            }
+            let listed = available.prefix(20).map { "`\($0)`" }.joined(separator: ", ")
+            let more = available.count > 20 ? ", … (\(available.count - 20) more)" : ""
+            return "No skill named `\(requested)`.\(suggestionText) Available skills: \(listed)\(more)."
+        }
+    }
+}

--- a/Sources/QuillCodeTools/SkillResolver.swift
+++ b/Sources/QuillCodeTools/SkillResolver.swift
@@ -1,0 +1,185 @@
+import Foundation
+import QuillCodeCore
+
+/// Where a resolved skill came from. `user` roots shadow `builtin` roots of the same name, so the
+/// caller orders `SkillResolver.roots` user-first and the resolver returns the first match.
+public enum SkillRootKind: String, Sendable, Hashable {
+    /// A project (or otherwise user-owned) skills directory — e.g. `<workspace>/.quillcode/skills`.
+    case user
+    /// A shared/global skills directory — e.g. `~/.quillcode/skills`.
+    case builtin
+}
+
+/// One skills directory to search, and what kind it is. Ordering in `SkillResolver.roots` is the
+/// precedence: earlier roots win, so a user root placed before a builtin root shadows it.
+public struct SkillRoot: Sendable, Hashable {
+    public var kind: SkillRootKind
+    public var url: URL
+
+    public init(kind: SkillRootKind, url: URL) {
+        self.kind = kind
+        self.url = url
+    }
+}
+
+/// A skill successfully resolved on disk: its canonical directory, the `SKILL.md` inside it, and
+/// which root it came from.
+public struct ResolvedSkill: Sendable, Hashable {
+    /// The canonical (symlink-resolved) name — the skill's directory basename.
+    public var name: String
+    public var kind: SkillRootKind
+    /// Absolute path to the skill's base directory.
+    public var baseDirectory: URL
+    /// Absolute path to `SKILL.md` inside the base directory.
+    public var skillFile: URL
+
+    public init(name: String, kind: SkillRootKind, baseDirectory: URL, skillFile: URL) {
+        self.name = name
+        self.kind = kind
+        self.baseDirectory = baseDirectory
+        self.skillFile = skillFile
+    }
+}
+
+/// Why a skill name could not be resolved. Carries enough context for an actionable tool error.
+public enum SkillResolutionError: Error, Sendable, Equatable {
+    /// The name was empty, or contained a path separator / `..` / other unsafe component. The name is
+    /// model-controlled, so this is the gate that keeps resolution inside the known skill roots.
+    case invalidName(String)
+    /// No skill directory with a readable `SKILL.md` matched, across every configured root. Carries
+    /// the sorted list of available skill names so the caller can offer "did you mean" suggestions.
+    case notFound(requested: String, available: [String])
+}
+
+/// Resolves a model-controlled skill *name* to an on-disk skill with user-shadows-builtin precedence.
+///
+/// The name is untrusted, so this is deliberately strict: a skill name is a single path component
+/// (`^[A-Za-z0-9._-]+$`, no `/`, no `\`, not `.`/`..`), it is joined onto each known root, and the
+/// resolved directory must still live *inside* that root (a symlink pointing out is rejected via
+/// `WorkspaceBoundary`). There is no way for a name to escape the configured roots — absolute paths,
+/// `../`, and separator injection are all refused before any filesystem access that could leave a root.
+public struct SkillResolver: Sendable {
+    /// Search roots in precedence order — earlier wins. A user root before a builtin root shadows it.
+    public var roots: [SkillRoot]
+    /// The manifest file every skill directory must contain.
+    public static let manifestFileName = "SKILL.md"
+
+    public init(roots: [SkillRoot]) {
+        self.roots = roots
+    }
+
+    /// The default roots for a workspace: the project `.quillcode/skills` (user, wins) then
+    /// `~/.quillcode/skills` (builtin/global, shadowed). Missing directories are harmless — they
+    /// simply contribute no skills.
+    public static func defaultRoots(
+        workspaceRoot: URL,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> [SkillRoot] {
+        [
+            SkillRoot(
+                kind: .user,
+                url: workspaceRoot
+                    .appendingPathComponent(".quillcode", isDirectory: true)
+                    .appendingPathComponent("skills", isDirectory: true)
+            ),
+            SkillRoot(
+                kind: .builtin,
+                url: homeDirectory
+                    .appendingPathComponent(".quillcode", isDirectory: true)
+                    .appendingPathComponent("skills", isDirectory: true)
+            )
+        ]
+    }
+
+    public static func `default`(
+        workspaceRoot: URL,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> SkillResolver {
+        SkillResolver(roots: defaultRoots(workspaceRoot: workspaceRoot, homeDirectory: homeDirectory))
+    }
+
+    /// Resolves `name` to the first root (in precedence order) that holds a skill directory with a
+    /// readable `SKILL.md`. Throws `SkillResolutionError` on an unsafe name or a miss.
+    public func resolve(name rawName: String) throws -> ResolvedSkill {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isSafeSkillName(name) else {
+            throw SkillResolutionError.invalidName(rawName)
+        }
+
+        for root in roots {
+            let rootURL = root.url.standardizedFileURL
+            let candidate = rootURL.appendingPathComponent(name, isDirectory: true).standardizedFileURL
+            // The joined directory must still live inside its root — a symlink named like a skill that
+            // points outside the root is not a skill of this root.
+            guard WorkspaceBoundary.isWithin(candidate, root: rootURL) else {
+                continue
+            }
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else {
+                continue
+            }
+            let manifest = candidate.appendingPathComponent(Self.manifestFileName, isDirectory: false)
+            var manifestIsDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: manifest.path, isDirectory: &manifestIsDirectory),
+                  !manifestIsDirectory.boolValue,
+                  // The manifest itself must resolve inside the root too (defends against a symlinked
+                  // SKILL.md pointing at an arbitrary file on disk).
+                  WorkspaceBoundary.isWithin(manifest, root: rootURL)
+            else {
+                continue
+            }
+            return ResolvedSkill(
+                name: name,
+                kind: root.kind,
+                baseDirectory: candidate,
+                skillFile: manifest
+            )
+        }
+
+        throw SkillResolutionError.notFound(requested: name, available: availableSkillNames())
+    }
+
+    /// Every skill name available across all roots, de-duplicated (a name present in several roots is
+    /// listed once) and sorted. Used for "did you mean" suggestions and empty-state messaging.
+    public func availableSkillNames() -> [String] {
+        var names: Set<String> = []
+        for root in roots {
+            let rootURL = root.url.standardizedFileURL
+            let entries = (try? FileManager.default.contentsOfDirectory(
+                at: rootURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            for entry in entries {
+                let dir = entry.standardizedFileURL
+                guard WorkspaceBoundary.isWithin(dir, root: rootURL) else { continue }
+                var isDirectory: ObjCBool = false
+                guard FileManager.default.fileExists(atPath: dir.path, isDirectory: &isDirectory),
+                      isDirectory.boolValue
+                else {
+                    continue
+                }
+                let manifest = dir.appendingPathComponent(Self.manifestFileName, isDirectory: false)
+                if FileManager.default.fileExists(atPath: manifest.path) {
+                    names.insert(dir.lastPathComponent)
+                }
+            }
+        }
+        return names.sorted()
+    }
+
+    /// A skill name is exactly one safe path component: non-empty, not `.`/`..`, no path separators,
+    /// no NUL, and only ASCII letters/digits and `._-`. This is the choke point that keeps a
+    /// model-controlled name from ever naming a path outside a root.
+    public static func isSafeSkillName(_ name: String) -> Bool {
+        guard !name.isEmpty, name.count <= 128 else { return false }
+        guard name != ".", name != ".." else { return false }
+        guard !name.contains("/"), !name.contains("\\"), !name.contains("\0") else { return false }
+        return name.allSatisfy { character in
+            character.isASCII &&
+                (character.isLetter || character.isNumber || character == "." || character == "-" || character == "_")
+        }
+    }
+}

--- a/Sources/QuillCodeTools/SkillToolDefinitions.swift
+++ b/Sources/QuillCodeTools/SkillToolDefinitions.swift
@@ -1,0 +1,21 @@
+import QuillCodeCore
+
+public extension ToolDefinition {
+    static let skillLoad = ToolDefinition(
+        name: "host.skill.load",
+        description: """
+        Load an installed skill into context by name. Skills are listed in the extensions pane; this \
+        tool reads the skill's SKILL.md and returns a <skill_content> block with the skill's base \
+        directory (absolute path), a listing of its files, and the SKILL.md body. After loading, follow \
+        the instructions in the body and read any referenced skill files by their absolute path with \
+        host.file.read. A user skill (in the project's .quillcode/skills) shadows a builtin skill of the \
+        same name. Pass a bare skill name, e.g. `code-review` — not a path. This loads skill content; it \
+        does not run any skill code.
+        """,
+        parametersJSON: """
+        {"type":"object","properties":{"name":{"type":"string","description":"The bare name of the skill to load, e.g. code-review. Not a path; no slashes or ..."}},"required":["name"]}
+        """,
+        host: .local,
+        risk: .read
+    )
+}

--- a/Sources/QuillCodeTools/ToolRouter.swift
+++ b/Sources/QuillCodeTools/ToolRouter.swift
@@ -8,13 +8,15 @@ public struct ToolRouter: Sendable {
     public var git: GitToolExecutor
     public var patch: PatchToolExecutor
     public var web: WebFetchToolExecutor
+    public var skill: SkillLoadToolExecutor
 
     public init(
         workspaceRoot: URL,
         shell: ShellToolExecutor = ShellToolExecutor(),
         git: GitToolExecutor = GitToolExecutor(),
         editGuard: FileEditSessionGuard = .shared,
-        web: WebFetchToolExecutor = WebFetchToolExecutor()
+        web: WebFetchToolExecutor = WebFetchToolExecutor(),
+        skill: SkillLoadToolExecutor? = nil
     ) {
         self.workspaceRoot = workspaceRoot
         self.shell = shell
@@ -22,6 +24,7 @@ public struct ToolRouter: Sendable {
         self.git = git
         self.patch = PatchToolExecutor(workspaceRoot: workspaceRoot, shell: shell, editGuard: editGuard)
         self.web = web
+        self.skill = skill ?? SkillLoadToolExecutor.default(workspaceRoot: workspaceRoot)
     }
 
     public static let definitions: [ToolDefinition] = ShellToolCallDispatcher.definitions + [
@@ -30,7 +33,8 @@ public struct ToolRouter: Sendable {
         .fileSearch,
         .fileWrite,
         .applyPatch,
-        .webFetch
+        .webFetch,
+        .skillLoad
     ] + GitToolCallDispatcher.definitions
 
     public func definition(named name: String) -> ToolDefinition? {
@@ -76,6 +80,8 @@ public struct ToolRouter: Sendable {
                 return patch.apply(unifiedDiff: try args.requiredString("patch"))
             case ToolDefinition.webFetch.name:
                 return web.fetch(urlString: try args.requiredString("url"))
+            case ToolDefinition.skillLoad.name:
+                return skill.load(name: try args.requiredString("name"))
             default:
                 return ToolResult(ok: false, error: "Unknown tool: \(call.name)")
             }

--- a/Tests/QuillCodeAgentTests/AgentSkillToolAnswerFormattersTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentSkillToolAnswerFormattersTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+final class AgentSkillToolAnswerFormattersTests: XCTestCase {
+    private func call(_ json: String = #"{"name":"code-review"}"#) -> ToolCall {
+        ToolCall(name: ToolDefinition.skillLoad.name, argumentsJSON: json)
+    }
+
+    func testFormatterIsRegistered() {
+        // The formatter chain resolves a skillLoad result without falling through to a generic answer.
+        let result = ToolResult(ok: true, stdout: "Loaded user skill `code-review`.\n\n<skill_content>…</skill_content>")
+        let answers = AgentToolAnswerFormatters.all.compactMap { $0(call(), result, nil) }
+        XCTAssertEqual(answers.count, 1)
+        XCTAssertTrue(answers[0].contains("skill_content"))
+    }
+
+    func testSuccessPassesContentThrough() {
+        let result = ToolResult(ok: true, stdout: "Loaded builtin skill `code-review`.\n\n<skill_content>body</skill_content>")
+        let answer = AgentSkillToolAnswerFormatters.skillLoadAnswer(call: call(), result: result, followUpReviewResult: nil)
+        XCTAssertEqual(answer, "Loaded builtin skill `code-review`.\n\n<skill_content>body</skill_content>")
+    }
+
+    func testFailureExplainsWithError() {
+        let result = ToolResult(ok: false, error: "No skill named `code-reviw`. Did you mean `code-review`?")
+        let answer = AgentSkillToolAnswerFormatters.skillLoadAnswer(
+            call: call(#"{"name":"code-reviw"}"#),
+            result: result,
+            followUpReviewResult: nil
+        )
+        XCTAssertTrue(answer?.contains("Could not load skill `code-reviw`") == true, answer ?? "")
+        XCTAssertTrue(answer?.contains("Did you mean `code-review`?") == true, answer ?? "")
+    }
+
+    func testFailureWithoutDetailsStillAnswers() {
+        let result = ToolResult(ok: false)
+        let answer = AgentSkillToolAnswerFormatters.skillLoadAnswer(call: call(), result: result, followUpReviewResult: nil)
+        XCTAssertEqual(answer, "Could not load skill `code-review`.")
+    }
+
+    func testOtherToolsAreIgnored() {
+        let otherCall = ToolCall(name: ToolDefinition.fileRead.name, argumentsJSON: #"{"path":"a.txt"}"#)
+        let result = ToolResult(ok: true, stdout: "x")
+        XCTAssertNil(AgentSkillToolAnswerFormatters.skillLoadAnswer(call: otherCall, result: result, followUpReviewResult: nil))
+    }
+}

--- a/Tests/QuillCodeToolsTests/SkillLoadToolExecutorTests.swift
+++ b/Tests/QuillCodeToolsTests/SkillLoadToolExecutorTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+final class SkillLoadToolExecutorTests: XCTestCase {
+    private var tempRoot: URL!
+    private var userRoot: URL!
+    private var builtinRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("skill-exec-\(UUID().uuidString)", isDirectory: true)
+        userRoot = tempRoot.appendingPathComponent("user", isDirectory: true)
+        builtinRoot = tempRoot.appendingPathComponent("builtin", isDirectory: true)
+        try FileManager.default.createDirectory(at: userRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: builtinRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+    }
+
+    private func makeSkill(
+        in root: URL,
+        name: String,
+        manifest: String,
+        extraFiles: [String: String] = [:]
+    ) throws {
+        let dir = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try manifest.write(to: dir.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
+        for (relative, contents) in extraFiles {
+            let fileURL = dir.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func executor(
+        manifestMaxBytes: Int = SkillLoadToolExecutor.defaultManifestMaxBytes,
+        maxListedFiles: Int = SkillLoadToolExecutor.defaultMaxListedFiles
+    ) -> SkillLoadToolExecutor {
+        SkillLoadToolExecutor(
+            resolver: SkillResolver(roots: [
+                SkillRoot(kind: .user, url: userRoot),
+                SkillRoot(kind: .builtin, url: builtinRoot)
+            ]),
+            manifestMaxBytes: manifestMaxBytes,
+            maxListedFiles: maxListedFiles
+        )
+    }
+
+    // MARK: - Happy path
+
+    func testLoadInjectsBaseDirFileListAndBody() throws {
+        try makeSkill(
+            in: builtinRoot,
+            name: "reviewer",
+            manifest: "# Reviewer\nInspect the diff.\n",
+            extraFiles: [
+                "checklist.md": "1. correctness\n",
+                "scripts/run.sh": "#!/bin/sh\necho hi\n"
+            ]
+        )
+
+        let result = executor().load(name: "reviewer")
+        XCTAssertTrue(result.ok, result.error ?? "")
+        let out = result.stdout
+
+        // <skill_content> wrapper with source label.
+        XCTAssertTrue(out.contains("<skill_content name=\"reviewer\" source=\"builtin\">"))
+        XCTAssertTrue(out.contains("</skill_content>"))
+
+        // Absolute base directory.
+        let expectedBase = builtinRoot.appendingPathComponent("reviewer").standardizedFileURL.path
+        XCTAssertTrue(out.contains("Base directory (absolute): \(expectedBase)"), out)
+
+        // File listing (relative), excluding directories, including nested files.
+        XCTAssertTrue(out.contains("- SKILL.md"))
+        XCTAssertTrue(out.contains("- checklist.md"))
+        XCTAssertTrue(out.contains("- scripts/run.sh"))
+
+        // Manifest body injected.
+        XCTAssertTrue(out.contains("# Reviewer"))
+        XCTAssertTrue(out.contains("Inspect the diff."))
+    }
+
+    func testUserSkillShadowsBuiltinInLoad() throws {
+        try makeSkill(in: userRoot, name: "dup", manifest: "# From user\n")
+        try makeSkill(in: builtinRoot, name: "dup", manifest: "# From builtin\n")
+
+        let result = executor().load(name: "dup")
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("source=\"user\""))
+        XCTAssertTrue(result.stdout.contains("# From user"))
+        XCTAssertFalse(result.stdout.contains("# From builtin"))
+    }
+
+    // MARK: - Errors
+
+    func testMissingSkillGivesActionableErrorWithSuggestion() throws {
+        try makeSkill(in: userRoot, name: "code-review", manifest: "# CR\n")
+
+        // Close typo -> "did you mean".
+        let result = executor().load(name: "code-reviw")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("code-reviw") == true)
+        XCTAssertTrue(result.error?.contains("code-review") == true, result.error ?? "")
+    }
+
+    func testMissingSkillWithNoSkillsInstalled() {
+        let result = executor().load(name: "anything")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("no skills are installed") == true, result.error ?? "")
+    }
+
+    func testPathTraversalNameRejected() {
+        let result = executor().load(name: "../../etc/passwd")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("not a valid skill name") == true, result.error ?? "")
+    }
+
+    func testEmptyNameRejected() {
+        let result = executor().load(name: "   ")
+        XCTAssertFalse(result.ok)
+    }
+
+    // MARK: - Capping
+
+    func testOversizedManifestIsCapped() throws {
+        let big = String(repeating: "line of skill text\n", count: 5_000)
+        try makeSkill(in: builtinRoot, name: "huge", manifest: big)
+
+        let result = executor(manifestMaxBytes: 2_048).load(name: "huge")
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("truncated"), "expected a truncation marker")
+        // The tool output must be far smaller than the raw manifest.
+        XCTAssertLessThan(result.stdout.utf8.count, big.utf8.count / 2)
+        // The truncation note points at the on-disk file for the full text.
+        XCTAssertTrue(result.stdout.contains("SKILL.md"))
+    }
+
+    func testFileListIsCappedWithMoreMarker() throws {
+        var extra: [String: String] = [:]
+        for index in 0..<50 {
+            extra["file-\(String(format: "%03d", index)).txt"] = "x"
+        }
+        try makeSkill(in: builtinRoot, name: "manyfiles", manifest: "# many\n", extraFiles: extra)
+
+        let result = executor(maxListedFiles: 10).load(name: "manyfiles")
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("more"), "expected a truncated-file-list marker")
+    }
+
+    func testInvalidUTF8ManifestGivesActionableError() throws {
+        let dir = builtinRoot.appendingPathComponent("binary", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // Bytes that are not valid UTF-8.
+        try Data([0xFF, 0xFE, 0xFD]).write(to: dir.appendingPathComponent("SKILL.md"))
+
+        let result = executor().load(name: "binary")
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("valid UTF-8") == true, result.error ?? "")
+    }
+}

--- a/Tests/QuillCodeToolsTests/SkillResolverTests.swift
+++ b/Tests/QuillCodeToolsTests/SkillResolverTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+final class SkillResolverTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("skill-resolver-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+    }
+
+    // MARK: - Fixture helpers
+
+    private func makeSkill(
+        in root: URL,
+        name: String,
+        manifest: String = "# Skill\n",
+        extraFiles: [String: String] = [:]
+    ) throws {
+        let dir = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try manifest.write(to: dir.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
+        for (relative, contents) in extraFiles {
+            let fileURL = dir.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func resolver(user: URL? = nil, builtin: URL? = nil) -> SkillResolver {
+        var roots: [SkillRoot] = []
+        if let user { roots.append(SkillRoot(kind: .user, url: user)) }
+        if let builtin { roots.append(SkillRoot(kind: .builtin, url: builtin)) }
+        return SkillResolver(roots: roots)
+    }
+
+    // MARK: - Resolution
+
+    func testResolvesBuiltinSkill() throws {
+        let builtin = tempRoot.appendingPathComponent("builtin", isDirectory: true)
+        try makeSkill(in: builtin, name: "code-review", manifest: "# Code Review\nDo the thing.\n")
+
+        let resolved = try resolver(user: tempRoot.appendingPathComponent("user"), builtin: builtin)
+            .resolve(name: "code-review")
+
+        XCTAssertEqual(resolved.name, "code-review")
+        XCTAssertEqual(resolved.kind, .builtin)
+        XCTAssertEqual(
+            resolved.baseDirectory.standardizedFileURL.path,
+            builtin.appendingPathComponent("code-review").standardizedFileURL.path
+        )
+        XCTAssertEqual(resolved.skillFile.lastPathComponent, "SKILL.md")
+    }
+
+    func testUserSkillShadowsBuiltinOfSameName() throws {
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        let builtin = tempRoot.appendingPathComponent("builtin", isDirectory: true)
+        try makeSkill(in: user, name: "review", manifest: "# User review\n")
+        try makeSkill(in: builtin, name: "review", manifest: "# Builtin review\n")
+
+        let resolved = try resolver(user: user, builtin: builtin).resolve(name: "review")
+
+        XCTAssertEqual(resolved.kind, .user, "user root wins because it is ordered first")
+        XCTAssertEqual(
+            resolved.baseDirectory.standardizedFileURL.path,
+            user.appendingPathComponent("review").standardizedFileURL.path
+        )
+    }
+
+    func testFallsThroughToBuiltinWhenUserMissing() throws {
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        let builtin = tempRoot.appendingPathComponent("builtin", isDirectory: true)
+        try FileManager.default.createDirectory(at: user, withIntermediateDirectories: true)
+        try makeSkill(in: builtin, name: "only-builtin")
+
+        let resolved = try resolver(user: user, builtin: builtin).resolve(name: "only-builtin")
+        XCTAssertEqual(resolved.kind, .builtin)
+    }
+
+    // MARK: - Missing / invalid
+
+    func testMissingSkillThrowsNotFoundWithAvailableList() throws {
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        try makeSkill(in: user, name: "alpha")
+        try makeSkill(in: user, name: "beta")
+
+        XCTAssertThrowsError(try resolver(user: user).resolve(name: "gamma")) { error in
+            guard case let SkillResolutionError.notFound(requested, available) = error else {
+                return XCTFail("expected notFound, got \(error)")
+            }
+            XCTAssertEqual(requested, "gamma")
+            XCTAssertEqual(available, ["alpha", "beta"])
+        }
+    }
+
+    func testAvailableSkillNamesDeduplicatesAcrossRoots() throws {
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        let builtin = tempRoot.appendingPathComponent("builtin", isDirectory: true)
+        try makeSkill(in: user, name: "shared")
+        try makeSkill(in: builtin, name: "shared")
+        try makeSkill(in: builtin, name: "extra")
+
+        XCTAssertEqual(resolver(user: user, builtin: builtin).availableSkillNames(), ["extra", "shared"])
+    }
+
+    func testDirectoryWithoutManifestIsNotASkill() throws {
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        let dir = user.appendingPathComponent("no-manifest", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "not a manifest".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        XCTAssertThrowsError(try resolver(user: user).resolve(name: "no-manifest"))
+        XCTAssertFalse(resolver(user: user).availableSkillNames().contains("no-manifest"))
+    }
+
+    // MARK: - Path-traversal / injection defense
+
+    func testRejectsPathTraversalNames() {
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        let resolver = resolver(user: user)
+        for name in ["../secret", "..", ".", "a/b", "foo/../bar", "sub/skill", "a\\b", "with space"] {
+            XCTAssertThrowsError(try resolver.resolve(name: name), "should reject \(name)") { error in
+                guard case SkillResolutionError.invalidName = error else {
+                    return XCTFail("expected invalidName for \(name), got \(error)")
+                }
+            }
+        }
+    }
+
+    func testRejectsAbsolutePathName() {
+        let resolver = resolver(user: tempRoot.appendingPathComponent("user"))
+        XCTAssertThrowsError(try resolver.resolve(name: "/etc/passwd")) { error in
+            guard case SkillResolutionError.invalidName = error else {
+                return XCTFail("expected invalidName, got \(error)")
+            }
+        }
+    }
+
+    func testAbsoluteTraversalNameCannotEscapeRoot() throws {
+        // Place a "secret" SKILL.md OUTSIDE the user root; a crafted name must never reach it.
+        let outside = tempRoot.appendingPathComponent("outside", isDirectory: true)
+        try makeSkill(in: outside, name: "loot", manifest: "# secret\n")
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        try FileManager.default.createDirectory(at: user, withIntermediateDirectories: true)
+
+        // Even URL-ish traversal attempts are rejected at the name gate before any filesystem walk.
+        XCTAssertThrowsError(try resolver(user: user).resolve(name: "../outside/loot"))
+    }
+
+    func testSymlinkedSkillDirectoryPointingOutsideRootIsRejected() throws {
+        let user = tempRoot.appendingPathComponent("user", isDirectory: true)
+        try FileManager.default.createDirectory(at: user, withIntermediateDirectories: true)
+        let outside = tempRoot.appendingPathComponent("outside-skill", isDirectory: true)
+        try makeSkill(in: outside.deletingLastPathComponent(), name: "outside-skill")
+
+        // A symlink INSIDE the root, named like a skill, pointing at a real skill dir outside the root.
+        let link = user.appendingPathComponent("escape", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        XCTAssertThrowsError(try resolver(user: user).resolve(name: "escape")) { error in
+            guard case SkillResolutionError.notFound = error else {
+                return XCTFail("expected notFound (symlink rejected), got \(error)")
+            }
+        }
+    }
+
+    func testIsSafeSkillName() {
+        XCTAssertTrue(SkillResolver.isSafeSkillName("code-review"))
+        XCTAssertTrue(SkillResolver.isSafeSkillName("my_skill.v2"))
+        XCTAssertTrue(SkillResolver.isSafeSkillName("Skill123"))
+        XCTAssertFalse(SkillResolver.isSafeSkillName(""))
+        XCTAssertFalse(SkillResolver.isSafeSkillName("."))
+        XCTAssertFalse(SkillResolver.isSafeSkillName(".."))
+        XCTAssertFalse(SkillResolver.isSafeSkillName("a/b"))
+        XCTAssertFalse(SkillResolver.isSafeSkillName("a b"))
+        XCTAssertFalse(SkillResolver.isSafeSkillName("a\u{0}b"))
+        XCTAssertFalse(SkillResolver.isSafeSkillName(String(repeating: "a", count: 129)))
+    }
+}

--- a/Tests/QuillCodeToolsTests/SkillToolRouterTests.swift
+++ b/Tests/QuillCodeToolsTests/SkillToolRouterTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+final class SkillToolRouterTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("skill-router-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+    }
+
+    func testSkillLoadDefinitionIsRegistered() {
+        let names = ToolRouter.definitions.map(\.name)
+        XCTAssertTrue(names.contains(ToolDefinition.skillLoad.name))
+        XCTAssertEqual(Set(names).count, names.count, "tool names must stay unique")
+    }
+
+    func testSkillLoadDefinitionShape() throws {
+        let definition = ToolDefinition.skillLoad
+        XCTAssertEqual(definition.name, "host.skill.load")
+        XCTAssertEqual(definition.host, .local)
+        XCTAssertEqual(definition.risk, .read)
+        XCTAssertTrue(definition.parametersJSON.contains("\"name\""))
+        XCTAssertTrue(definition.parametersJSON.contains("required"))
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: Data(definition.parametersJSON.utf8)))
+    }
+
+    func testRouterDispatchesSkillLoadCalls() throws {
+        // Skill lives in the project's .quillcode/skills — the default user root.
+        let skillsDir = tempRoot
+            .appendingPathComponent(".quillcode", isDirectory: true)
+            .appendingPathComponent("skills", isDirectory: true)
+            .appendingPathComponent("demo", isDirectory: true)
+        try FileManager.default.createDirectory(at: skillsDir, withIntermediateDirectories: true)
+        try "# Demo skill\nHello from the skill.\n".write(
+            to: skillsDir.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let router = ToolRouter(
+            workspaceRoot: tempRoot,
+            skill: SkillLoadToolExecutor(resolver: SkillResolver(roots: [
+                SkillRoot(kind: .user, url: tempRoot
+                    .appendingPathComponent(".quillcode", isDirectory: true)
+                    .appendingPathComponent("skills", isDirectory: true))
+            ]))
+        )
+        let result = router.execute(ToolCall(
+            name: ToolDefinition.skillLoad.name,
+            argumentsJSON: #"{"name":"demo"}"#
+        ))
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("<skill_content"))
+        XCTAssertTrue(result.stdout.contains("Hello from the skill."))
+    }
+
+    func testRouterRejectsMissingNameArgument() {
+        let router = ToolRouter(workspaceRoot: tempRoot)
+        let result = router.execute(ToolCall(name: ToolDefinition.skillLoad.name, argumentsJSON: "{}"))
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("name") == true, result.error ?? "")
+    }
+
+    func testDefaultResolverUsesProjectSkillsDirectory() throws {
+        // The default ToolRouter wires SkillLoadToolExecutor.default(workspaceRoot:), whose user root
+        // is <workspace>/.quillcode/skills. Prove a skill placed there resolves without a custom executor.
+        let skillsDir = tempRoot
+            .appendingPathComponent(".quillcode", isDirectory: true)
+            .appendingPathComponent("skills", isDirectory: true)
+            .appendingPathComponent("wired", isDirectory: true)
+        try FileManager.default.createDirectory(at: skillsDir, withIntermediateDirectories: true)
+        try "# Wired\n".write(
+            to: skillsDir.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let router = ToolRouter(workspaceRoot: tempRoot)
+        let result = router.execute(ToolCall(
+            name: ToolDefinition.skillLoad.name,
+            argumentsJSON: #"{"name":"wired"}"#
+        ))
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("source=\"user\""))
+    }
+}


### PR DESCRIPTION
## What

Adds `host.skill.load`, a Skill tool that loads an installed skill's `SKILL.md` into context. Skills were previously only listed manifests in the extensions pane — discoverable but inert. Now the model can load a skill by name and follow its instructions.

Given a skill name, the tool resolves it (user skills shadow builtin ones), reads its `SKILL.md`, and returns a `<skill_content>` block containing:
- the skill's **base directory** (absolute path),
- a **listing of the skill's files** (relative to the base dir), and
- the **`SKILL.md` body**.

The model then reads any referenced skill file by its absolute path with `host.file.read`. This tool **loads content only — it never runs skill code** (`risk: .read`), per the issue.

## Why

Fixes #860. Skills are shipped as manifests but there was no way to actually use one — this makes them executable in the OpenCode sense: inject the manifest body + base dir + file list, and let the model reference files by absolute path afterward.

## Design

- **Tool name:** `host.skill.load` — matches the repo's `host.<category>.<action>` convention (`host.web.fetch`, `host.memory.remember`).
- **Resolution & precedence (`SkillResolver`):** an ordered list of roots, earlier wins. The default roots are `<workspace>/.quillcode/skills` (**user**, shadows) then `~/.quillcode/skills` (**builtin/global**, shadowed) — a user skill overrides a builtin of the same name. A skill is a directory containing `SKILL.md`.
- **Safety (name is model-controlled):** a name must be a single safe path component — non-empty, ≤128 chars, not `.`/`..`, no `/`/`\`/NUL, ASCII `[A-Za-z0-9._-]` only. It is joined onto each root and the resolved directory (and the manifest) must still live *inside* that root via the existing `WorkspaceBoundary` gate, so `../` traversal, absolute-path injection, and symlinked skill dirs pointing outside a root are all refused. No force-unwraps.
- **`<skill_content>` contents:** `name` + `source` (user/builtin) attributes, absolute base directory, a capped/sorted recursive file listing (hidden files skipped, directories excluded), and the `SKILL.md` body. Oversized manifests are head-capped (reusing the `WebFetchMarkdownCapper` precedent — the head of a SKILL.md is what matters) with an honest truncation note pointing at the on-disk file; the file list is bounded with a "… N more" marker.
- **Errors:** invalid name → actionable message; missing skill → lists available skills and offers `FilePathSuggester` "did you mean" suggestions; unreadable / non-UTF-8 `SKILL.md` → graceful actionable error.
- **Integration:** registered in `ToolRouter.definitions` and dispatched in `ToolRouter.execute`, so **both** the CLI agent loop (`Agent.baseToolDefinitions = ToolRouter.definitions`) and the desktop workspace executor (`WorkspaceToolRunCoordinator` → `ToolRouter`) get it. A chat answer formatter (`AgentSkillToolAnswerFormatters.skillLoadAnswer`) is registered in `AgentToolAnswerFormatters.all`.

### Files
- `Sources/QuillCodeTools/SkillResolver.swift` — safe name gate + user-shadows-builtin resolution
- `Sources/QuillCodeTools/SkillLoadToolExecutor.swift` — reads SKILL.md, builds `<skill_content>`, caps
- `Sources/QuillCodeTools/SkillToolDefinitions.swift` — `host.skill.load` definition
- `Sources/QuillCodeTools/ToolRouter.swift` — registration + dispatch
- `Sources/QuillCodeAgent/AgentSkillToolAnswerFormatters.swift` + `AgentToolAnswerFormatters.swift` — chat formatter

## Test evidence

`swift build`: clean. Full `swift test`: **2600 tests, 2 skipped, 0 failures**.

New deterministic tests (temp skills-dir fixtures):
- `SkillResolverTests` — builtin resolution, user-overrides-builtin, fall-through, missing→notFound with available list, dedup across roots, dir-without-manifest ignored, path-traversal / absolute / `..` / separator / space names rejected, symlinked-skill-dir-pointing-outside-root rejected, `isSafeSkillName` matrix.
- `SkillLoadToolExecutorTests` — injects base dir + file list (incl. nested) + body, user shadows builtin, missing-skill "did you mean", no-skills-installed message, path-traversal rejected, oversized manifest capped, file list capped with "more" marker, invalid-UTF-8 handled.
- `SkillToolRouterTests` — definition registered + unique + valid JSON schema, router dispatches a real load, missing-`name` rejected, default resolver uses `<workspace>/.quillcode/skills`.
- `AgentSkillToolAnswerFormattersTests` — formatter registered in the chain, success passthrough, failure messaging, other tools ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)