### PR TITLE
Add host.web.search: web search routed through TrustedRouter

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -13,6 +13,11 @@ public struct AgentRunner: Sendable {
     public var baseToolDefinitions: [ToolDefinition]
     public var additionalToolDefinitions: [ToolDefinition]
     public var toolExecutionOverride: AgentToolExecutionOverride?
+    /// Backend for `host.web.search`. Injected (with TrustedRouter credentials) by the live
+    /// runtime; nil in mock/test runs, where the tool reports that search is unavailable. Kept as
+    /// a first-class runner dependency — rather than folded into `toolExecutionOverride` — so both
+    /// the CLI and desktop wire it through one place and `configuredRunner(from:)` preserves it.
+    public var webSearch: (any WebSearchClient)?
     public var maxToolSteps: Int
     public var enablesImmediateActionPreflight: Bool
     /// Computes an opaque signature of the workspace state, sampled around tool steps to feed the
@@ -26,6 +31,7 @@ public struct AgentRunner: Sendable {
         baseToolDefinitions: [ToolDefinition] = ToolRouter.definitions,
         additionalToolDefinitions: [ToolDefinition] = [],
         toolExecutionOverride: AgentToolExecutionOverride? = nil,
+        webSearch: (any WebSearchClient)? = nil,
         maxToolSteps: Int = AgentRunner.defaultMaxToolSteps,
         enablesImmediateActionPreflight: Bool = false,
         workspaceStateSignature: (@Sendable (URL) -> String)? = nil
@@ -35,6 +41,7 @@ public struct AgentRunner: Sendable {
         self.baseToolDefinitions = baseToolDefinitions
         self.additionalToolDefinitions = additionalToolDefinitions
         self.toolExecutionOverride = toolExecutionOverride
+        self.webSearch = webSearch
         self.maxToolSteps = maxToolSteps
         self.enablesImmediateActionPreflight = enablesImmediateActionPreflight
         self.workspaceStateSignature = workspaceStateSignature

--- a/Sources/QuillCodeAgent/AgentToolAnswerFormatters.swift
+++ b/Sources/QuillCodeAgent/AgentToolAnswerFormatters.swift
@@ -20,6 +20,7 @@ enum AgentToolAnswerFormatters {
             AgentUtilityToolAnswerFormatters.memoryRememberAnswer,
             AgentShellToolAnswerFormatters.shellRunAnswer,
             AgentWebToolAnswerFormatters.webFetchAnswer,
+            AgentWebToolAnswerFormatters.webSearchAnswer,
             AgentSkillToolAnswerFormatters.skillLoadAnswer,
             AgentBrowserToolAnswerFormatters.browserInspectAnswer,
             AgentBrowserToolAnswerFormatters.browserOpenAnswer,

--- a/Sources/QuillCodeAgent/AgentToolArgumentNormalizationRule.swift
+++ b/Sources/QuillCodeAgent/AgentToolArgumentNormalizationRule.swift
@@ -107,6 +107,18 @@ enum AgentToolArgumentNormalizationRules {
             stringArguments: [.init(canonicalKey: "url", aliases: ["address", "href", "link", "target", "page", "uri"])]
         ),
         .init(
+            toolNames: [ToolDefinition.webSearch.name],
+            stringArguments: [
+                .init(
+                    canonicalKey: "query",
+                    aliases: ["q", "term", "text", "search", "searchQuery", "search_query", "searchTerm", "search_term"]
+                )
+            ],
+            valueArguments: [
+                .init(canonicalKey: "maxResults", aliases: ["limit", "max", "count", "num", "numResults", "num_results", "max_results"])
+            ]
+        ),
+        .init(
             toolNames: [ToolDefinition.gitPullRequestCreate.name],
             stringArguments: [.init(canonicalKey: "title", aliases: ["name", "subject"])]
         ),

--- a/Sources/QuillCodeAgent/AgentToolStepRunner.swift
+++ b/Sources/QuillCodeAgent/AgentToolStepRunner.swift
@@ -119,10 +119,33 @@ extension AgentRunner {
     ) async throws -> ToolResult {
         await appendRunningEvent(for: call, to: &thread, onProgress: onProgress)
         try Task.checkCancellation()
-        let result = await toolExecutionOverride?(call, workspaceRoot) ?? router.execute(call)
+        let result: ToolResult
+        if let searchResult = await webSearchResult(for: call) {
+            result = searchResult
+        } else if let overrideResult = await toolExecutionOverride?(call, workspaceRoot) {
+            result = overrideResult
+        } else {
+            result = router.execute(call)
+        }
         try Task.checkCancellation()
         await appendResultEvent(for: call, result: result, to: &thread, onProgress: onProgress)
         return result
+    }
+
+    /// Dispatch `host.web.search` to the injected TrustedRouter-backed client. Returns nil for
+    /// every other tool (so the normal override/router path runs) and nil when no search client is
+    /// wired (so the router's own "not available" message is used). This is the single place the
+    /// async, credential-bearing search executor is invoked, shared by the CLI and desktop loops.
+    private func webSearchResult(for call: ToolCall) async -> ToolResult? {
+        guard call.name == ToolDefinition.webSearch.name, let webSearch else { return nil }
+        do {
+            let args = try ToolArguments(call.argumentsJSON)
+            let query = try args.requiredString("query")
+            return await WebSearchToolExecutor(client: webSearch)
+                .search(query: query, maxResults: args.int("maxResults"))
+        } catch {
+            return ToolResult(ok: false, error: String(describing: error))
+        }
     }
 
     private func runFollowUpReviewIfNeeded(

--- a/Sources/QuillCodeAgent/AgentWebToolAnswerFormatters.swift
+++ b/Sources/QuillCodeAgent/AgentWebToolAnswerFormatters.swift
@@ -25,4 +25,28 @@ enum AgentWebToolAnswerFormatters {
         }
         return AgentToolAnswerFormatters.truncated(output)
     }
+
+    static func webSearchAnswer(
+        call: ToolCall,
+        result: ToolResult,
+        followUpReviewResult _: ToolResult?
+    ) -> String? {
+        guard call.name == ToolDefinition.webSearch.name else {
+            return nil
+        }
+        let query = AgentToolAnswerFormatterSupport.argument("query", in: call) ?? "the query"
+        if !result.ok {
+            let details = [result.error, result.stderr.trimmedNonEmpty]
+                .compactMap { $0?.trimmedNonEmpty }
+                .joined(separator: "\n")
+            return details.isEmpty
+                ? "Could not search for \(query)."
+                : "Could not search for \(query): \(AgentToolAnswerFormatters.truncated(details))"
+        }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !output.isEmpty else {
+            return "Searched for \(query), but found no results."
+        }
+        return AgentToolAnswerFormatters.truncated(output)
+    }
 }

--- a/Sources/QuillCodeAgent/TrustedRouterWebSearchClient.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterWebSearchClient.swift
@@ -1,0 +1,146 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+import TrustedRouter
+
+/// `WebSearchClient` routed through TrustedRouter.
+///
+/// TrustedRouter has no dedicated web-search endpoint and its OpenAI-compatible passthrough does
+/// not forward provider-native search tools, so the reachable mechanism is a normal
+/// `/chat/completions` request: we ask a current-knowledge model to act as a search engine and
+/// return a strict JSON object of `{results: [{title, url, snippet}]}`. Provider selection stays
+/// gateway-side (per issue #861) — we send a TrustedRouter model id and the gateway routes it. The
+/// executor (`WebSearchToolExecutor`) then host-gates every returned URL and bounds the fields, so
+/// the model's output is treated as untrusted and can only surface fetchable public URLs.
+///
+/// This type performs no direct URLSession/URLRequest work of its own (the TrustedRouter SDK owns
+/// the transport), so it needs no FoundationNetworking import.
+public struct TrustedRouterWebSearchClient: WebSearchClient {
+    public var sessionStore: (any TrustedRouterSessionStore)?
+    public var apiKeyOverride: String?
+    public var model: String
+    public var baseURL: String
+
+    public init(
+        sessionStore: (any TrustedRouterSessionStore)? = nil,
+        apiKeyOverride: String? = nil,
+        model: String = TrustedRouterDefaults.defaultModel,
+        baseURL: String = TrustedRouterDefaults.defaultAPIBaseURL
+    ) {
+        self.sessionStore = sessionStore
+        self.apiKeyOverride = apiKeyOverride
+        self.model = model
+        self.baseURL = baseURL
+    }
+
+    public func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem] {
+        let apiKey: String
+        do {
+            apiKey = try configuredAPIKey()
+        } catch {
+            throw WebSearchClientError.missingAPIKey
+        }
+
+        let client: TrustedRouter
+        do {
+            client = try TrustedRouter(options: .init(apiKey: apiKey, baseUrl: baseURL))
+        } catch {
+            throw WebSearchClientError.transport(String(describing: error))
+        }
+
+        let completion: ChatCompletion
+        do {
+            completion = try await client.chatCompletions(
+                model: model,
+                messages: Self.messages(for: request),
+                params: TrustedRouterChatParameters.jsonObjectResponse
+            )
+        } catch {
+            throw WebSearchClientError.transport(String(describing: error))
+        }
+
+        guard let text = completion.choices.first?.message.content,
+              text.contains(where: { !$0.isWhitespace })
+        else {
+            throw WebSearchClientError.emptyResponse
+        }
+        return Self.parseResults(text)
+    }
+
+    private func configuredAPIKey() throws -> String {
+        try TrustedRouterAPIKeyResolver(
+            sessionStore: sessionStore,
+            apiKeyOverride: apiKeyOverride
+        ).configuredAPIKey()
+    }
+
+    // MARK: - Prompt
+
+    static func messages(for request: WebSearchRequest) -> [[String: Any]] {
+        let system = """
+        You are a web-search engine for a coding agent. For the user's query, return the most \
+        relevant, currently-known public web pages. Respond with ONLY a JSON object of the form \
+        {"results": [{"title": string, "url": string, "snippet": string}]}. Include at most \
+        \(request.maxResults) results, ordered most relevant first. Every "url" MUST be a full \
+        absolute https URL to a real public page (documentation, an official site, a reputable \
+        reference); never invent URLs, and never use internal, localhost, or private-network \
+        addresses. Keep each snippet to one or two sentences. If you do not know relevant pages, \
+        return {"results": []}.
+        """
+        return [
+            ["role": "system", "content": system],
+            ["role": "user", "content": "Search query: \(request.query)"]
+        ]
+    }
+
+    // MARK: - Parsing
+
+    /// Defensive parse of the model's JSON. Tolerates fenced code blocks and surrounding prose by
+    /// extracting the first balanced top-level object; missing/typo'd fields degrade to empty
+    /// strings rather than throwing. The executor does the real validation (host-gating, caps), so
+    /// this stays permissive and never force-unwraps.
+    static func parseResults(_ text: String) -> [WebSearchResultItem] {
+        guard let data = jsonObjectData(from: text),
+              let root = try? JSONSerialization.jsonObject(with: data),
+              let object = root as? [String: Any]
+        else {
+            return []
+        }
+        guard let rawResults = object["results"] as? [Any] else {
+            return []
+        }
+        var items: [WebSearchResultItem] = []
+        for entry in rawResults {
+            guard let dict = entry as? [String: Any] else { continue }
+            let url = stringField(dict, "url")
+            guard !url.isEmpty else { continue }
+            items.append(WebSearchResultItem(
+                title: stringField(dict, "title"),
+                url: url,
+                snippet: stringField(dict, "snippet")
+            ))
+        }
+        return items
+    }
+
+    private static func stringField(_ dict: [String: Any], _ key: String) -> String {
+        (dict[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    /// Extract the JSON-object substring: prefer the whole trimmed string, but if the model wrapped
+    /// it in ```json fences or prose, slice from the first `{` to the last `}`.
+    private static func jsonObjectData(from text: String) -> Data? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let data = trimmed.data(using: .utf8),
+           (try? JSONSerialization.jsonObject(with: data)) is [String: Any] {
+            return data
+        }
+        guard let open = trimmed.firstIndex(of: "{"),
+              let close = trimmed.lastIndex(of: "}"),
+              open < close
+        else {
+            return nil
+        }
+        return String(trimmed[open...close]).data(using: .utf8)
+    }
+}

--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -93,10 +93,19 @@ public struct QuillCodeRuntimeFactory: Sendable {
             apiKeyOverride: apiKey,
             baseURL: config.apiBaseURL
         )
+        // host.web.search routes through the same TrustedRouter credentials as the run loop, so the
+        // gateway selects the search provider (issue #861).
+        let webSearch = TrustedRouterWebSearchClient(
+            sessionStore: sessionStore,
+            apiKeyOverride: apiKey,
+            model: config.defaultModel,
+            baseURL: config.apiBaseURL
+        )
         return QuillCodeRuntime(
             runner: AgentRunner(
                 llm: llm,
                 safety: AutoSafetyReviewer(client: safetyClient),
+                webSearch: webSearch,
                 enablesImmediateActionPreflight: true
             ),
             contextSummaryGenerator: LLMWorkspaceContextSummaryGenerator(llm: summaryLLM),

--- a/Sources/QuillCodeApp/WorkspaceToolCardSubtitleBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolCardSubtitleBuilder.swift
@@ -31,7 +31,7 @@ enum WorkspaceToolCardSubtitleBuilder {
              ToolDefinition.gitPullRequestDiff.name, ToolDefinition.gitPullRequestReviewComment.name,
              ToolDefinition.gitWorktreeRemove.name:
             return sanitized(arguments.string("path"))
-        case ToolDefinition.fileSearch.name:
+        case ToolDefinition.fileSearch.name, ToolDefinition.webSearch.name:
             return sanitized(arguments.string("query"))
         case ToolDefinition.applyPatch.name:
             return "patch"

--- a/Sources/QuillCodeTools/ToolRouter.swift
+++ b/Sources/QuillCodeTools/ToolRouter.swift
@@ -34,6 +34,7 @@ public struct ToolRouter: Sendable {
         .fileWrite,
         .applyPatch,
         .webFetch,
+        .webSearch,
         .skillLoad
     ] + GitToolCallDispatcher.definitions
 
@@ -80,6 +81,16 @@ public struct ToolRouter: Sendable {
                 return patch.apply(unifiedDiff: try args.requiredString("patch"))
             case ToolDefinition.webFetch.name:
                 return web.fetch(urlString: try args.requiredString("url"))
+            case ToolDefinition.webSearch.name:
+                // `host.web.search` is async and routes through TrustedRouter, so the live agent
+                // loop dispatches it directly to a `WebSearchToolExecutor` (see AgentToolStepRunner)
+                // rather than through this synchronous router. Reaching here means no search client
+                // was wired (mock runtime, or a direct router call), so report it plainly instead of
+                // as an "unknown tool".
+                return ToolResult(
+                    ok: false,
+                    error: "Web search is not available in this workspace. Sign in to TrustedRouter or configure an API key."
+                )
             case ToolDefinition.skillLoad.name:
                 return skill.load(name: try args.requiredString("name"))
             default:

--- a/Sources/QuillCodeTools/WebSearchClient.swift
+++ b/Sources/QuillCodeTools/WebSearchClient.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// One web-search request: a normalized query plus the maximum number of results to return.
+/// The transport (see `WebSearchToolExecutor`) clamps `maxResults` into a sane band before it
+/// reaches here, so an implementation may trust the value is small and positive.
+public struct WebSearchRequest: Sendable, Hashable {
+    public var query: String
+    public var maxResults: Int
+
+    public init(query: String, maxResults: Int) {
+        self.query = query
+        self.maxResults = maxResults
+    }
+}
+
+/// A single search hit. `url` is an absolute http(s) URL the agent can hand straight to
+/// `host.web.fetch`; `snippet` is a short extract. Titles/snippets are model-authored text and
+/// are treated as untrusted display strings — the executor bounds their length.
+public struct WebSearchResultItem: Sendable, Hashable {
+    public var title: String
+    public var url: String
+    public var snippet: String
+
+    public init(title: String, url: String, snippet: String) {
+        self.title = title
+        self.url = url
+        self.snippet = snippet
+    }
+}
+
+public enum WebSearchClientError: Error, Sendable, CustomStringConvertible {
+    /// No TrustedRouter API key was configured, so the search route is unreachable.
+    case missingAPIKey
+    /// The gateway answered but returned nothing usable (empty body / unparseable results).
+    case emptyResponse
+    /// The transport failed (HTTP error, network, decode). `message` is already human-readable.
+    case transport(String)
+
+    public var description: String {
+        switch self {
+        case .missingAPIKey:
+            return "TrustedRouter is not configured. Sign in or set an API key to use web search."
+        case .emptyResponse:
+            return "the search provider returned no results"
+        case .transport(let message):
+            return message
+        }
+    }
+}
+
+/// A backend that turns a `WebSearchRequest` into a list of results. The concrete implementation
+/// (`TrustedRouterWebSearchClient` in QuillCodeAgent) routes the query through TrustedRouter so
+/// provider selection stays gateway-side; tests inject a scripted stub so the executor's parsing,
+/// clamping, and host-gating are verified without any network I/O.
+public protocol WebSearchClient: Sendable {
+    func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem]
+}

--- a/Sources/QuillCodeTools/WebSearchToolDefinitions.swift
+++ b/Sources/QuillCodeTools/WebSearchToolDefinitions.swift
@@ -1,0 +1,21 @@
+import QuillCodeCore
+
+public extension ToolDefinition {
+    static let webSearch = ToolDefinition(
+        name: "host.web.search",
+        description: """
+        Search the public web for a query and return a short, ranked list of results (title, URL, \
+        and a one- or two-line snippet). Use this to look up an API, an error message, a library \
+        version, changelog, or any current fact, then follow the most relevant result with \
+        host.web.fetch to read the full page. Provide a focused query the way you would type it \
+        into a search engine. Results are capped (up to 10) and routed through TrustedRouter, which \
+        selects the search provider. This does NOT return full page text — fetch a result URL for \
+        that. Prefer this over driving the browser pane for a quick lookup.
+        """,
+        parametersJSON: """
+        {"type":"object","properties":{"query":{"type":"string","description":"The search query, phrased as you would type it into a search engine."},"maxResults":{"type":"integer","description":"Maximum number of results to return (1-10, default 5)."}},"required":["query"]}
+        """,
+        host: .local,
+        risk: .read
+    )
+}

--- a/Sources/QuillCodeTools/WebSearchToolExecutor.swift
+++ b/Sources/QuillCodeTools/WebSearchToolExecutor.swift
@@ -1,0 +1,159 @@
+import Foundation
+import QuillCodeCore
+
+/// Executes `host.web.search`: normalize and clamp the query + result count, ask the injected
+/// `WebSearchClient` (TrustedRouter-backed in production), then defensively sanitize the results —
+/// drop entries whose URL is not a fetchable public http(s) target (reusing `WebFetchHostGate`,
+/// the same SSRF gate `host.web.fetch` applies), bound titles/snippets, de-duplicate by URL, and
+/// cap the count. The model gets a compact, numbered list it can hand straight to `host.web.fetch`.
+///
+/// The client is injected behind a protocol so this whole path is deterministic in tests with a
+/// scripted stub and never touches the network. Nothing here force-unwraps or does an unclamped
+/// numeric conversion, so a hostile/empty/oversized result set degrades to a clear message.
+public struct WebSearchToolExecutor: Sendable {
+    public var client: any WebSearchClient
+    /// Hard ceiling on results, independent of what the caller asks for or the provider returns.
+    public var maxResults: Int
+    /// Default result count when the caller omits `maxResults`.
+    public var defaultResults: Int
+    /// Longest query we forward; longer inputs are truncated so a runaway prompt can't be smuggled
+    /// through the search box.
+    public var maxQueryLength: Int
+    /// Per-field display caps for untrusted, model-authored title/snippet text.
+    public var maxTitleLength: Int
+    public var maxSnippetLength: Int
+
+    public init(
+        client: any WebSearchClient,
+        maxResults: Int = 10,
+        defaultResults: Int = 5,
+        maxQueryLength: Int = 400,
+        maxTitleLength: Int = 200,
+        maxSnippetLength: Int = 500
+    ) {
+        self.client = client
+        self.maxResults = max(1, maxResults)
+        self.defaultResults = min(max(1, defaultResults), max(1, maxResults))
+        self.maxQueryLength = max(1, maxQueryLength)
+        self.maxTitleLength = max(1, maxTitleLength)
+        self.maxSnippetLength = max(1, maxSnippetLength)
+    }
+
+    public func search(query rawQuery: String, maxResults requested: Int?) async -> ToolResult {
+        let query = Self.normalizedQuery(rawQuery, maxLength: maxQueryLength)
+        guard !query.isEmpty else {
+            return Self.failure("Provide a non-empty search query, e.g. \"URLSession follow redirects swift\".")
+        }
+        // Clamp the requested count into [1, maxResults] WITHOUT trusting the raw value: a negative
+        // or absurd number becomes the default / the ceiling, never a huge allocation request.
+        let count = Self.clampedCount(requested, defaultResults: defaultResults, maxResults: maxResults)
+
+        let items: [WebSearchResultItem]
+        do {
+            items = try await client.search(WebSearchRequest(query: query, maxResults: count))
+        } catch let error as WebSearchClientError {
+            return Self.failure("Web search for \"\(query)\" failed: \(error.description).")
+        } catch {
+            return Self.failure("Web search for \"\(query)\" failed: \(error.localizedDescription)")
+        }
+
+        let sanitized = Self.sanitize(
+            items,
+            limit: count,
+            maxTitleLength: maxTitleLength,
+            maxSnippetLength: maxSnippetLength
+        )
+        guard !sanitized.isEmpty else {
+            return Self.failure("""
+            Web search for \"\(query)\" returned no usable results. Try rephrasing the query, or open \
+            the browser pane with host.browser.open for an interactive search.
+            """)
+        }
+
+        return ToolResult(ok: true, stdout: Self.render(query: query, results: sanitized))
+    }
+
+    // MARK: - Input normalization
+
+    static func normalizedQuery(_ raw: String, maxLength: Int) -> String {
+        let collapsed = raw
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        guard collapsed.count > maxLength else { return collapsed }
+        let end = collapsed.index(collapsed.startIndex, offsetBy: maxLength)
+        return String(collapsed[..<end])
+    }
+
+    static func clampedCount(_ requested: Int?, defaultResults: Int, maxResults: Int) -> Int {
+        guard let requested else { return defaultResults }
+        return min(max(1, requested), maxResults)
+    }
+
+    // MARK: - Result sanitization
+
+    static func sanitize(
+        _ items: [WebSearchResultItem],
+        limit: Int,
+        maxTitleLength: Int,
+        maxSnippetLength: Int
+    ) -> [WebSearchResultItem] {
+        var seen = Set<String>()
+        var out: [WebSearchResultItem] = []
+        for item in items {
+            guard out.count < limit else { break }
+            guard let url = fetchableURL(item.url) else { continue }
+            let key = url.lowercased()
+            guard seen.insert(key).inserted else { continue }
+            out.append(WebSearchResultItem(
+                title: displayField(item.title, fallback: url, maxLength: maxTitleLength),
+                url: url,
+                snippet: displayField(item.snippet, fallback: "", maxLength: maxSnippetLength)
+            ))
+        }
+        return out
+    }
+
+    /// Accept only absolute http(s) URLs that pass the SAME SSRF gate `host.web.fetch` uses, so a
+    /// search hit can never surface (and then be fetched as) an internal/loopback/metadata target.
+    /// Bare hosts are defaulted to https the way `WebFetchToolExecutor.normalizedRequestURL` does.
+    static func fetchableURL(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains(where: \.isWhitespace) else { return nil }
+        let candidate = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        guard let url = URL(string: candidate), url.host != nil else { return nil }
+        guard WebFetchHostGate.blockReason(for: url) == nil else { return nil }
+        return url.absoluteString
+    }
+
+    static func displayField(_ raw: String, fallback: String, maxLength: Int) -> String {
+        let collapsed = raw
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        let text = collapsed.isEmpty ? fallback : collapsed
+        guard text.count > maxLength else { return text }
+        let end = text.index(text.startIndex, offsetBy: maxLength)
+        return String(text[..<end]) + "…"
+    }
+
+    // MARK: - Rendering
+
+    static func render(query: String, results: [WebSearchResultItem]) -> String {
+        var lines: [String] = []
+        lines.append("Search results for \"\(query)\" (\(results.count) result\(results.count == 1 ? "" : "s")). Use host.web.fetch on a URL to read the full page.")
+        lines.append("")
+        for (index, result) in results.enumerated() {
+            lines.append("\(index + 1). \(result.title)")
+            lines.append("   \(result.url)")
+            if !result.snippet.isEmpty {
+                lines.append("   \(result.snippet)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func failure(_ message: String) -> ToolResult {
+        ToolResult(ok: false, error: message)
+    }
+}

--- a/Sources/quill-code/main.swift
+++ b/Sources/quill-code/main.swift
@@ -93,9 +93,18 @@ struct QuillCodeCLI {
                 apiKeyOverride: key,
                 baseURL: baseURL
             )
+            // host.web.search routes through the same TrustedRouter credentials (gateway-side
+            // provider selection, issue #861).
+            let webSearch = TrustedRouterWebSearchClient(
+                sessionStore: sessionStore,
+                apiKeyOverride: key,
+                model: model,
+                baseURL: baseURL
+            )
             runner = AgentRunner(
                 llm: llm,
                 safety: AutoSafetyReviewer(client: safetyClient),
+                webSearch: webSearch,
                 enablesImmediateActionPreflight: true
             )
             thread.model = model

--- a/Tests/QuillCodeAgentTests/AgentWebSearchLoopTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentWebSearchLoopTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+/// Records the query it was asked and replays a fixed result set, so the agent-loop wiring test is
+/// deterministic and never touches the network.
+private final class RecordingWebSearchClient: WebSearchClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private let results: [WebSearchResultItem]
+    private(set) var lastQuery: String?
+    private(set) var lastMaxResults: Int?
+
+    init(results: [WebSearchResultItem]) {
+        self.results = results
+    }
+
+    func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem] {
+        lock.withLock {
+            lastQuery = request.query
+            lastMaxResults = request.maxResults
+        }
+        return results
+    }
+}
+
+final class AgentWebSearchLoopTests: XCTestCase {
+    func testAgentDispatchesWebSearchToInjectedClient() async throws {
+        let root = try makeTempDirectory()
+        let client = RecordingWebSearchClient(results: [
+            WebSearchResultItem(title: "URLSession docs", url: "https://developer.apple.com/urlsession", snippet: "The doc.")
+        ])
+        var runner = AgentRunner(
+            llm: FixedToolLLMClient(call: ToolCall(
+                name: ToolDefinition.webSearch.name,
+                argumentsJSON: #"{"query":"urlsession redirects","maxResults":3}"#
+            )),
+            safety: AlwaysApprovingSafetyReviewer()
+        )
+        runner.webSearch = client
+
+        let result = try await runner.send(
+            "how do redirects work",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        XCTAssertEqual(client.lastQuery, "urlsession redirects")
+        XCTAssertEqual(client.lastMaxResults, 3)
+        let first = try XCTUnwrap(result.toolResults.first)
+        XCTAssertTrue(first.ok, first.error ?? "")
+        XCTAssertTrue(first.stdout.contains("https://developer.apple.com/urlsession"))
+    }
+
+    func testAgentReportsSearchUnavailableWhenNoClientWired() async throws {
+        let root = try makeTempDirectory()
+        // No webSearch client on the runner (mock runtime), so the router's fallback message wins.
+        let runner = AgentRunner(
+            llm: FixedToolLLMClient(call: ToolCall(
+                name: ToolDefinition.webSearch.name,
+                argumentsJSON: #"{"query":"anything"}"#
+            )),
+            safety: AlwaysApprovingSafetyReviewer()
+        )
+
+        let result = try await runner.send(
+            "search for something",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        let first = try XCTUnwrap(result.toolResults.first)
+        XCTAssertFalse(first.ok)
+        XCTAssertTrue(first.error?.contains("not available") == true)
+    }
+}

--- a/Tests/QuillCodeAgentTests/AgentWebToolAnswerFormattersTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentWebToolAnswerFormattersTests.swift
@@ -58,4 +58,34 @@ final class AgentWebToolAnswerFormattersTests: XCTestCase {
         let answer = AgentWebToolAnswerFormatters.webFetchAnswer(call: call(), result: result, followUpReviewResult: nil)
         XCTAssertTrue(answer?.contains("no readable content") == true)
     }
+
+    // MARK: - Web search formatter
+
+    private func searchCall(_ json: String = #"{"query":"swift async"}"#) -> ToolCall {
+        ToolCall(name: ToolDefinition.webSearch.name, argumentsJSON: json)
+    }
+
+    func testSearchFormatterIsRegistered() {
+        let result = ToolResult(ok: true, stdout: "Search results for \"swift async\".\n\n1. Title\n   https://a.com")
+        let answers = AgentToolAnswerFormatters.all.compactMap { $0(searchCall(), result, nil) }
+        XCTAssertEqual(answers.count, 1)
+        XCTAssertTrue(answers[0].contains("https://a.com"))
+    }
+
+    func testSearchSuccessPassesResultsThrough() {
+        let result = ToolResult(ok: true, stdout: "Search results for \"swift async\".\n\n1. Title\n   https://a.com")
+        let answer = AgentWebToolAnswerFormatters.webSearchAnswer(call: searchCall(), result: result, followUpReviewResult: nil)
+        XCTAssertEqual(answer, "Search results for \"swift async\".\n\n1. Title\n   https://a.com")
+    }
+
+    func testSearchFailureExplainsWithError() {
+        let result = ToolResult(ok: false, error: "Web search for \"x\" failed: upstream 503.")
+        let answer = AgentWebToolAnswerFormatters.webSearchAnswer(call: searchCall(), result: result, followUpReviewResult: nil)
+        XCTAssertTrue(answer?.contains("Could not search for swift async") == true)
+        XCTAssertTrue(answer?.contains("upstream 503") == true)
+    }
+
+    func testSearchIgnoresOtherTools() {
+        XCTAssertNil(AgentWebToolAnswerFormatters.webSearchAnswer(call: call(), result: ToolResult(ok: true, stdout: "x"), followUpReviewResult: nil))
+    }
 }

--- a/Tests/QuillCodeAgentTests/TrustedRouterWebSearchClientTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterWebSearchClientTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+/// Parsing tests for the TrustedRouter-backed web-search client. These exercise the defensive JSON
+/// parse against clean, fenced, prose-wrapped, and hostile/malformed model output — no network.
+final class TrustedRouterWebSearchClientTests: XCTestCase {
+    func testCleanJSONObjectIsParsed() {
+        let json = #"{"results":[{"title":"A","url":"https://a.com","snippet":"one"},{"title":"B","url":"https://b.com","snippet":"two"}]}"#
+        let items = TrustedRouterWebSearchClient.parseResults(json)
+        XCTAssertEqual(items.count, 2)
+        XCTAssertEqual(items[0].title, "A")
+        XCTAssertEqual(items[0].url, "https://a.com")
+        XCTAssertEqual(items[1].snippet, "two")
+    }
+
+    func testFencedCodeBlockIsUnwrapped() {
+        let json = """
+        Here you go:
+        ```json
+        {"results":[{"title":"A","url":"https://a.com","snippet":"one"}]}
+        ```
+        """
+        let items = TrustedRouterWebSearchClient.parseResults(json)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].url, "https://a.com")
+    }
+
+    func testMissingFieldsDegradeToEmptyStrings() {
+        let json = #"{"results":[{"url":"https://a.com"}]}"#
+        let items = TrustedRouterWebSearchClient.parseResults(json)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].title, "")
+        XCTAssertEqual(items[0].snippet, "")
+    }
+
+    func testEntryWithoutURLIsSkipped() {
+        let json = #"{"results":[{"title":"no url"},{"title":"has url","url":"https://a.com"}]}"#
+        let items = TrustedRouterWebSearchClient.parseResults(json)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].title, "has url")
+    }
+
+    func testNonObjectEntriesAreIgnored() {
+        let json = #"{"results":["a string", 42, null, {"url":"https://a.com"}]}"#
+        let items = TrustedRouterWebSearchClient.parseResults(json)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].url, "https://a.com")
+    }
+
+    func testEmptyResultsArrayYieldsNoItems() {
+        XCTAssertTrue(TrustedRouterWebSearchClient.parseResults(#"{"results":[]}"#).isEmpty)
+    }
+
+    func testGarbageInputYieldsNoItemsInsteadOfCrashing() {
+        for hostile in ["", "not json at all", "{", "}", "[]", "null", #"{"results":"nope"}"#, #"{"wrong":[]}"#] {
+            XCTAssertTrue(
+                TrustedRouterWebSearchClient.parseResults(hostile).isEmpty,
+                "hostile input \(hostile) must degrade to no results"
+            )
+        }
+    }
+
+    func testResultsWrappedInProseAreExtracted() {
+        let text = "I found these: {\"results\":[{\"title\":\"A\",\"url\":\"https://a.com\",\"snippet\":\"s\"}]} — hope that helps!"
+        let items = TrustedRouterWebSearchClient.parseResults(text)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].url, "https://a.com")
+    }
+
+    func testPromptBoundsResultCountAndCarriesQuery() {
+        let messages = TrustedRouterWebSearchClient.messages(
+            for: WebSearchRequest(query: "swift concurrency", maxResults: 4)
+        )
+        XCTAssertEqual(messages.count, 2)
+        let system = messages[0]["content"] as? String ?? ""
+        XCTAssertTrue(system.contains("at most 4 results"))
+        let user = messages[1]["content"] as? String ?? ""
+        XCTAssertTrue(user.contains("swift concurrency"))
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -373,6 +373,14 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(
             WorkspaceToolCardSubtitleBuilder.subtitle(
                 stateLabel: "Completed",
+                toolName: "host.web.search",
+                inputJSON: ToolArguments.json(["query": "swift async await"])
+            ),
+            "Completed · swift async await"
+        )
+        XCTAssertEqual(
+            WorkspaceToolCardSubtitleBuilder.subtitle(
+                stateLabel: "Completed",
                 toolName: "host.git.pr.review_comment",
                 inputJSON: ToolArguments.json(["path": "Sources/App.swift", "line": 12, "body": "nit"])
             ),

--- a/Tests/QuillCodeToolsTests/WebSearchToolExecutorTests.swift
+++ b/Tests/QuillCodeToolsTests/WebSearchToolExecutorTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+/// Scripted `WebSearchClient` so executor tests are deterministic and never touch the network:
+/// it replays one scripted outcome and records the request it was handed for inspection.
+final class StubWebSearchClient: WebSearchClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private let outcome: Result<[WebSearchResultItem], WebSearchClientError>
+    private var recordedRequests: [WebSearchRequest] = []
+
+    init(_ outcome: Result<[WebSearchResultItem], WebSearchClientError>) {
+        self.outcome = outcome
+    }
+
+    convenience init(results: [WebSearchResultItem]) {
+        self.init(.success(results))
+    }
+
+    var requests: [WebSearchRequest] {
+        lock.withLock { recordedRequests }
+    }
+
+    func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem] {
+        lock.withLock { recordedRequests.append(request) }
+        return try outcome.get()
+    }
+}
+
+final class WebSearchToolExecutorTests: XCTestCase {
+    private func item(_ title: String, _ url: String, _ snippet: String = "snippet") -> WebSearchResultItem {
+        WebSearchResultItem(title: title, url: url, snippet: snippet)
+    }
+
+    // MARK: - Happy path
+
+    func testResultsAreRenderedWithNumberedURLs() async {
+        let client = StubWebSearchClient(results: [
+            item("Swift URLSession", "https://developer.apple.com/urlsession", "How to use URLSession."),
+            item("Follow redirects", "https://stackoverflow.com/q/123", "Redirect handling.")
+        ])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "urlsession redirects", maxResults: nil)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("1. Swift URLSession"))
+        XCTAssertTrue(result.stdout.contains("https://developer.apple.com/urlsession"))
+        XCTAssertTrue(result.stdout.contains("2. Follow redirects"))
+        XCTAssertTrue(result.stdout.contains("host.web.fetch"))
+        XCTAssertTrue(result.stdout.contains("urlsession redirects"))
+    }
+
+    func testDefaultResultCountIsForwardedWhenOmitted() async {
+        let client = StubWebSearchClient(results: [item("a", "https://a.com")])
+        let executor = WebSearchToolExecutor(client: client, defaultResults: 5)
+        _ = await executor.search(query: "hi", maxResults: nil)
+        XCTAssertEqual(client.requests.first?.maxResults, 5)
+    }
+
+    // MARK: - Query normalization
+
+    func testWhitespaceOnlyQueryIsRejectedWithoutCallingClient() async {
+        let client = StubWebSearchClient(results: [item("x", "https://x.com")])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "   \n\t ", maxResults: nil)
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(client.requests.isEmpty, "an empty query must not reach the search provider")
+    }
+
+    func testQueryWhitespaceIsCollapsed() async {
+        let client = StubWebSearchClient(results: [item("x", "https://x.com")])
+        let executor = WebSearchToolExecutor(client: client)
+        _ = await executor.search(query: "  swift   async   await\n", maxResults: nil)
+        XCTAssertEqual(client.requests.first?.query, "swift async await")
+    }
+
+    func testOverlongQueryIsTruncated() async {
+        let client = StubWebSearchClient(results: [item("x", "https://x.com")])
+        let executor = WebSearchToolExecutor(client: client, maxQueryLength: 10)
+        _ = await executor.search(query: String(repeating: "a", count: 500), maxResults: nil)
+        XCTAssertEqual(client.requests.first?.query.count, 10)
+    }
+
+    // MARK: - Result-count clamping
+
+    func testRequestedCountIsClampedToCeiling() async {
+        let client = StubWebSearchClient(results: [item("x", "https://x.com")])
+        let executor = WebSearchToolExecutor(client: client, maxResults: 10)
+        _ = await executor.search(query: "hi", maxResults: 9999)
+        XCTAssertEqual(client.requests.first?.maxResults, 10)
+    }
+
+    func testNegativeCountFallsBackToOne() async {
+        let client = StubWebSearchClient(results: [item("x", "https://x.com")])
+        let executor = WebSearchToolExecutor(client: client, maxResults: 10)
+        _ = await executor.search(query: "hi", maxResults: -5)
+        XCTAssertEqual(client.requests.first?.maxResults, 1)
+    }
+
+    func testResultsAreTrimmedToRequestedCount() async {
+        let client = StubWebSearchClient(results: (0..<10).map { item("t\($0)", "https://s\($0).com") })
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: 3)
+        XCTAssertTrue(result.stdout.contains("3. t2"))
+        XCTAssertFalse(result.stdout.contains("4. t3"), "must not render more than the requested count")
+    }
+
+    // MARK: - SSRF host gating of returned URLs
+
+    func testInternalAndNonHTTPResultURLsAreDropped() async {
+        let client = StubWebSearchClient(results: [
+            item("metadata", "http://169.254.169.254/latest/meta-data/"),
+            item("localhost", "http://localhost:8080/admin"),
+            item("private", "http://10.0.0.5/router"),
+            item("ftp", "ftp://example.com/file"),
+            item("creds", "http://user:pass@example.com/"),
+            item("good", "https://example.com/docs")
+        ])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: 10)
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("https://example.com/docs"))
+        XCTAssertFalse(result.stdout.contains("169.254"))
+        XCTAssertFalse(result.stdout.contains("localhost"))
+        XCTAssertFalse(result.stdout.contains("10.0.0.5"))
+        XCTAssertFalse(result.stdout.contains("ftp://"))
+        XCTAssertFalse(result.stdout.contains("user:pass"))
+    }
+
+    func testAllResultsGatedAwayYieldsNoUsableResultsError() async {
+        let client = StubWebSearchClient(results: [
+            item("bad", "http://127.0.0.1/"),
+            item("worse", "not a url")
+        ])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: 10)
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("no usable results") == true)
+    }
+
+    func testBareHostResultIsDefaultedToHTTPS() async {
+        let client = StubWebSearchClient(results: [item("bare", "example.com/docs")])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: 10)
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("https://example.com/docs"))
+    }
+
+    // MARK: - Dedup and field bounding
+
+    func testDuplicateURLsAreDeduplicated() async {
+        let client = StubWebSearchClient(results: [
+            item("first", "https://example.com/page"),
+            item("dup", "https://EXAMPLE.com/page"),
+            item("other", "https://example.com/other")
+        ])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: 10)
+        XCTAssertTrue(result.stdout.contains("1. first"))
+        XCTAssertTrue(result.stdout.contains("2. other"))
+        XCTAssertFalse(result.stdout.contains("dup"))
+    }
+
+    func testEmptyTitleFallsBackToURL() async {
+        let client = StubWebSearchClient(results: [item("", "https://example.com/x", "")])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: 10)
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("1. https://example.com/x"))
+    }
+
+    func testOverlongTitleAndSnippetAreBounded() async {
+        let client = StubWebSearchClient(results: [
+            item(String(repeating: "T", count: 1000), "https://example.com/x", String(repeating: "S", count: 1000))
+        ])
+        let executor = WebSearchToolExecutor(client: client, maxTitleLength: 20, maxSnippetLength: 30)
+        let result = await executor.search(query: "hi", maxResults: 10)
+        XCTAssertTrue(result.ok)
+        // Title capped at 20 chars + ellipsis; the 21st T must not appear as a run.
+        XCTAssertFalse(result.stdout.contains(String(repeating: "T", count: 21)))
+        XCTAssertFalse(result.stdout.contains(String(repeating: "S", count: 31)))
+        XCTAssertTrue(result.stdout.contains("…"))
+    }
+
+    // MARK: - Error mapping
+
+    func testMissingAPIKeyErrorIsSurfaced() async {
+        let client = StubWebSearchClient(.failure(.missingAPIKey))
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: nil)
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("not configured") == true)
+    }
+
+    func testTransportErrorIsSurfaced() async {
+        let client = StubWebSearchClient(.failure(.transport("upstream 503")))
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "hi", maxResults: nil)
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("upstream 503") == true)
+    }
+
+    func testEmptyResultListYieldsNoResultsMessage() async {
+        let client = StubWebSearchClient(results: [])
+        let executor = WebSearchToolExecutor(client: client)
+        let result = await executor.search(query: "obscure query", maxResults: nil)
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("no usable results") == true)
+        XCTAssertTrue(result.error?.contains("host.browser.open") == true)
+    }
+}

--- a/Tests/QuillCodeToolsTests/WebSearchToolRouterTests.swift
+++ b/Tests/QuillCodeToolsTests/WebSearchToolRouterTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+final class WebSearchToolRouterTests: XCTestCase {
+    func testWebSearchDefinitionIsRegistered() {
+        let names = ToolRouter.definitions.map(\.name)
+        XCTAssertTrue(names.contains(ToolDefinition.webSearch.name))
+        XCTAssertEqual(Set(names).count, names.count, "tool names must stay unique")
+    }
+
+    func testWebSearchDefinitionShape() {
+        let definition = ToolDefinition.webSearch
+        XCTAssertEqual(definition.name, "host.web.search")
+        XCTAssertEqual(definition.host, .local)
+        XCTAssertEqual(definition.risk, .read)
+        XCTAssertTrue(definition.parametersJSON.contains("\"query\""))
+        XCTAssertTrue(definition.parametersJSON.contains("required"))
+        // The schema must be valid JSON.
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: Data(definition.parametersJSON.utf8)))
+    }
+
+    /// The synchronous router has no search client (search is async and routes through
+    /// TrustedRouter in the agent loop), so a direct router dispatch must report search as
+    /// unavailable rather than falling through to "Unknown tool".
+    func testRouterReportsSearchUnavailableWithoutClient() {
+        let router = ToolRouter(workspaceRoot: FileManager.default.temporaryDirectory)
+        let result = router.execute(ToolCall(
+            name: ToolDefinition.webSearch.name,
+            argumentsJSON: #"{"query":"swift"}"#
+        ))
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("not available") == true)
+        XCTAssertFalse(result.error?.contains("Unknown tool") == true)
+    }
+}


### PR DESCRIPTION
## What
Adds a first-class **WebSearch** tool, `host.web.search`, so agents can look up an API, error message, or library version directly instead of driving the browser pane (far more token-efficient). It returns a short, ranked list of results (title, URL, one/two-line snippet) that the agent can then hand to `host.web.fetch` to read a full page.

Fixes #861

## Why / how routing works
**TrustedRouter has no first-class web-search API.** I verified this in the gateway (`quill-router`): the OpenAI-compatible passthrough forwards only `thinking` and `chat_template_kwargs` — it does **not** forward `tools`, `plugins`, or any `web_search` param to Anthropic/Gemini/OpenAI-compatible providers, so provider-native search cannot be reached through the SDK. Exa exists in the gateway but only inside internal fusion/DRACO **eval** harnesses, not as a routable endpoint.

So, per the issue's fallback guidance ("implement against the mechanism the codebase CAN reach; do NOT invent an unavailable endpoint"), search routes through the reachable path: a normal **`/chat/completions`** request (the same transport the agent loop already uses) that asks a current-knowledge model to return a strict JSON `{"results":[{title,url,snippet}]}` set. **Provider selection stays gateway-side** — a TrustedRouter model id is sent and the gateway routes it (issue requirement).

Because the URLs come from a model, they're treated as **untrusted**: the executor host-gates every returned URL through the existing `WebFetchHostGate` (the exact SSRF gate `host.web.fetch` uses), so a search hit can never surface — and then be fetched as — an internal/loopback/metadata target. Results are field-bounded, deduped by URL, and count-capped.

## Design (mirrors host.web.fetch)
- **`QuillCodeTools`** (network-free, fully testable): `ToolDefinition.webSearch` (`host.web.search`), a `WebSearchClient` protocol + result types, and `WebSearchToolExecutor` (clamps query/count, host-gates + bounds + dedupes results, renders a numbered list).
- **`QuillCodeAgent`**: `TrustedRouterWebSearchClient` — the routed implementation (`/chat/completions`, JSON-object response, defensive parse).
- **Wiring (one dispatch point):** new `AgentRunner.webSearch` dependency, dispatched in `AgentToolStepRunner` before the override/router. Constructed with the same TrustedRouter credentials in **both** the CLI loop (`quill-code/main.swift`) and the desktop runtime (`RuntimeFactory`). Registered the answer formatter, argument-alias normalization, and the tool-card subtitle. Mock/no-key runtimes report "web search is not available" cleanly.

## Robustness
No force-unwraps; clamped counts/sizes; overlong query and title/snippet truncation; SSRF host-gating of every result URL; dedup; defensive JSON parse that tolerates fenced/prose-wrapped model output and degrades hostile/garbage input to zero results rather than crashing; network injected behind a protocol so tests never touch the network.

## Test evidence
- **Full suite green: `swift test` → 2605 tests, 2 skipped, 0 failures.**
- New tests: `WebSearchToolExecutorTests` (17 — clamping, SSRF gating, dedup, field bounds, error mapping), `WebSearchToolRouterTests` (3 — registration/shape/unavailable), `TrustedRouterWebSearchClientTests` (9 — clean/fenced/prose/hostile JSON parsing), `AgentWebSearchLoopTests` (2 — end-to-end dispatch + unavailable), plus added web-search cases to the formatter and tool-card subtitle tests.
- Followed the repo's FoundationNetworking convention; the new files use only cross-platform `URL`/`URLComponents` (no URLSession/URLRequest types), so no `#if canImport(FoundationNetworking)` guard is required.

## Caveats
- **No first-class TrustedRouter search API** — confirmed gateway-side. Search quality therefore depends on the routed model's current knowledge; results should be verified via `host.web.fetch`, which the tool description and output both instruct. If the gateway later adds a real search endpoint/tool, only `TrustedRouterWebSearchClient` needs to change (the protocol/executor/wiring stay).
- **No Linux CI run**: `scripts/` has no docker Linux build helper, so Linux compilation was not verified locally. The FoundationNetworking convention was followed to keep Linux green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)