### PR TITLE
Compact-and-continue on context overflow (#862)

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -24,6 +24,10 @@ public struct AgentRunner: Sendable {
     /// flail detector's "did anything actually change" judgment. nil = the git-based default;
     /// injected in tests for determinism.
     public var workspaceStateSignature: (@Sendable (URL) -> String)?
+    /// Compacts the thread and resumes when a model call overflows the context window (issue #862).
+    /// nil disables compaction entirely (the mock runtime, and any caller that opts out) — the run
+    /// then behaves exactly as before, surfacing an overflow error instead of compacting.
+    public var compaction: AgentCompactionPolicy?
 
     public init(
         llm: LLMClient = MockLLMClient(),
@@ -34,7 +38,8 @@ public struct AgentRunner: Sendable {
         webSearch: (any WebSearchClient)? = nil,
         maxToolSteps: Int = AgentRunner.defaultMaxToolSteps,
         enablesImmediateActionPreflight: Bool = false,
-        workspaceStateSignature: (@Sendable (URL) -> String)? = nil
+        workspaceStateSignature: (@Sendable (URL) -> String)? = nil,
+        compaction: AgentCompactionPolicy? = nil
     ) {
         self.llm = llm
         self.safety = safety
@@ -45,6 +50,7 @@ public struct AgentRunner: Sendable {
         self.maxToolSteps = maxToolSteps
         self.enablesImmediateActionPreflight = enablesImmediateActionPreflight
         self.workspaceStateSignature = workspaceStateSignature
+        self.compaction = compaction
     }
 
     public func send(
@@ -81,7 +87,7 @@ public struct AgentRunner: Sendable {
             var flailAssessmentInjected = false
 
             for _ in 0..<limit {
-                let action = try await nextAction(
+                let action = try await nextActionCompactingOnOverflow(
                     thread: &next,
                     userMessage: userMessage,
                     tools: tools,

--- a/Sources/QuillCodeAgent/AgentCompaction.swift
+++ b/Sources/QuillCodeAgent/AgentCompaction.swift
@@ -92,9 +92,13 @@ extension AgentRunner {
                     onProgress: onProgress
                 )
             } catch {
-                // Only a recognized context overflow is compactable; everything else (transport,
-                // auth, cancellation, a benign 413 with no context marker) propagates untouched so
-                // the retry/terminal paths keep their existing behavior.
+                // Only a recognized context overflow is compactable; everything else propagates
+                // untouched so the retry/terminal paths keep their existing behavior. Crucially, the
+                // detector is status-gated: a rate-limit (429, even one whose body says "too many
+                // tokens") or a transient 5xx is NOT an overflow, so it re-throws here — after
+                // RetryingLLMClient has exhausted its retries — surfacing the real cause instead of
+                // destroying turns with a compaction it can never satisfy. Also excluded: transport
+                // blips, auth, cancellation, and a benign 4xx with no context marker.
                 guard ContextOverflowDetector.isContextOverflow(error) else { throw error }
                 try Task.checkCancellation()
 

--- a/Sources/QuillCodeAgent/AgentCompaction.swift
+++ b/Sources/QuillCodeAgent/AgentCompaction.swift
@@ -1,0 +1,140 @@
+import Foundation
+import QuillCodeCore
+
+/// How the run loop compacts and resumes when the context window overflows (issue #862). Bundles the
+/// compactor with the two bounds that make the overflow → compact → resume path provably terminate:
+/// a proactive token threshold (compact BEFORE the wall) and a hard cap on compaction rounds per model
+/// call (after which the run gives up honestly rather than looping forever).
+public struct AgentCompactionPolicy: Sendable {
+    public var compactor: ThreadCompactor
+    /// Estimated prompt-token count at or above which the loop compacts proactively, before issuing the
+    /// model call. 0 disables proactive compaction (only reactive, on an overflow error).
+    public var proactiveTokenLimit: Int
+    /// The maximum number of compaction rounds attempted for a SINGLE model call before the run gives
+    /// up. Bounds the reactive loop so a prompt that still overflows after compaction (or a summarizer
+    /// that cannot shrink it) cannot spin forever. Clamped to at least 1.
+    public var maxRoundsPerCall: Int
+
+    public init(
+        compactor: ThreadCompactor,
+        proactiveTokenLimit: Int = 0,
+        maxRoundsPerCall: Int = 3
+    ) {
+        self.compactor = compactor
+        self.proactiveTokenLimit = max(0, proactiveTokenLimit)
+        self.maxRoundsPerCall = max(1, maxRoundsPerCall)
+    }
+}
+
+/// Raised when the run loop exhausted its compaction budget and the context STILL overflows — there is
+/// nothing left to safely fold away. Carries the round count so the surfaced diagnostic is honest about
+/// how hard the loop tried. This is the terminator: the run fails with a clear reason instead of
+/// looping, and instead of the raw provider error that would confuse an unattended operator.
+public struct ContextOverflowUnresolvedError: Error, CustomStringConvertible {
+    public var rounds: Int
+    public var underlying: any Error
+
+    public init(rounds: Int, underlying: any Error) {
+        self.rounds = rounds
+        self.underlying = underlying
+    }
+
+    public var description: String {
+        "The context window overflowed and could not be reduced by compaction after \(rounds) "
+            + "\(rounds == 1 ? "round" : "rounds"); the run was stopped. Underlying error: "
+            + "\(String(describing: underlying))"
+    }
+}
+
+extension AgentRunner {
+    /// Obtains the next action, compacting-and-resuming on a context overflow instead of failing the
+    /// run. When `compaction` is nil this is a straight pass-through to `nextAction`, so a runner
+    /// without a policy behaves exactly as before.
+    ///
+    /// Two ways it engages, both bounded:
+    /// - PROACTIVE: if the assembled thread is already estimated over the token threshold, compact
+    ///   once before the call (bounded by `maxRoundsPerCall`), so a growing thread is trimmed before it
+    ///   fails a round-trip.
+    /// - REACTIVE: if the call throws a `ContextOverflowDetector`-recognized error, compact and retry,
+    ///   up to `maxRoundsPerCall`. If a round reports `.noOlderTurns` (nothing left to fold) or the cap
+    ///   is reached, surface `ContextOverflowUnresolvedError` — terminate, never loop.
+    func nextActionCompactingOnOverflow(
+        thread: inout ChatThread,
+        userMessage: String,
+        tools: [ToolDefinition],
+        workspaceRoot: URL,
+        onProgress: AgentRunProgressHandler?
+    ) async throws -> AgentAction {
+        guard let compaction else {
+            return try await nextAction(
+                thread: &thread,
+                userMessage: userMessage,
+                tools: tools,
+                workspaceRoot: workspaceRoot,
+                onProgress: onProgress
+            )
+        }
+
+        await compactProactivelyIfNeeded(
+            thread: &thread,
+            compaction: compaction,
+            onProgress: onProgress
+        )
+
+        var rounds = 0
+        while true {
+            do {
+                return try await nextAction(
+                    thread: &thread,
+                    userMessage: userMessage,
+                    tools: tools,
+                    workspaceRoot: workspaceRoot,
+                    onProgress: onProgress
+                )
+            } catch {
+                // Only a recognized context overflow is compactable; everything else (transport,
+                // auth, cancellation, a benign 413 with no context marker) propagates untouched so
+                // the retry/terminal paths keep their existing behavior.
+                guard ContextOverflowDetector.isContextOverflow(error) else { throw error }
+                try Task.checkCancellation()
+
+                guard rounds < compaction.maxRoundsPerCall else {
+                    throw ContextOverflowUnresolvedError(rounds: rounds, underlying: error)
+                }
+                rounds += 1
+                let result = await compaction.compactor.compact(&thread)
+                await onProgress?(thread)
+                // Nothing left to fold away: compacting again would be a no-op, so stop here with a
+                // clear diagnostic rather than spinning to the round cap.
+                if case .noOlderTurns = result {
+                    throw ContextOverflowUnresolvedError(rounds: rounds, underlying: error)
+                }
+            }
+        }
+    }
+
+    /// Compacts before the call when the thread's estimated tokens cross the proactive threshold.
+    /// Bounded by `maxRoundsPerCall` and by `.noOlderTurns`, so even a thread of giant messages settles
+    /// after a fixed number of rounds instead of looping. Never throws — proactive compaction is
+    /// best-effort; if it cannot get under the threshold, the model call still runs and the reactive
+    /// path handles any resulting overflow.
+    private func compactProactivelyIfNeeded(
+        thread: inout ChatThread,
+        compaction: AgentCompactionPolicy,
+        onProgress: AgentRunProgressHandler?
+    ) async {
+        guard compaction.proactiveTokenLimit > 0 else { return }
+        var rounds = 0
+        while rounds < compaction.maxRoundsPerCall {
+            let estimate = ContextTokenEstimator.estimatedTokens(for: thread)
+            guard ContextOverflowDetector.proactiveSignal(
+                estimatedTokens: estimate,
+                limit: compaction.proactiveTokenLimit
+            ) != nil else { return }
+            rounds += 1
+            let result = await compaction.compactor.compact(&thread)
+            await onProgress?(thread)
+            if case .noOlderTurns = result { return }
+        }
+    }
+}

--- a/Sources/QuillCodeAgent/ContextOverflowDetector.swift
+++ b/Sources/QuillCodeAgent/ContextOverflowDetector.swift
@@ -25,12 +25,21 @@ public enum ContextOverflowSignal: String, Sendable, Hashable {
 /// message, or a proactive token estimate — into ONE typed decision the run loop can act on by
 /// compacting and resuming, rather than failing the run.
 ///
-/// Deliberately conservative on the ambiguous signals so it never misfires on an unrelated error:
-/// an HTTP 413 is treated as overflow (for a chat request there is no other meaning), but every OTHER
-/// status code must be corroborated by a machine code or a context-specific message in the body — a
-/// plain 400/429/500 is NOT an overflow. The `RetryClassifier` still owns transient-vs-terminal for
-/// retry; this detector is composed alongside it (see `ContextOverflowDetector.classification`) and
-/// takes priority for the codes it recognizes, without changing the classifier's behavior.
+/// Deliberately conservative so it never misfires on an unrelated error. Two gates:
+/// 1. Status FIRST: a genuine context overflow is a DETERMINISTIC client error — the provider rejects
+///    the prompt with 400/413/422, never a 429 or a 5xx. So this detector defers to `RetryClassifier`:
+///    if the classifier would call the error `.rateLimited` or transient (429, 408, 5xx, …), it is a
+///    rate-limit / server blip and is NEVER reclassified as overflow — even when the body happens to
+///    say "too many tokens" or "reduce the length of the messages" (Anthropic/OpenAI phrase those on a
+///    persistent token-per-minute 429). Letting that through would COMPACT the thread and burn an aux
+///    summary on what is really a rate limit, degrading the very unattended loop this feature protects.
+/// 2. Then body: on a non-transient status, a machine code or a context-specific message confirms
+///    overflow; an HTTP 413 is overflow even with an opaque body (for a chat request the only thing
+///    "too large" is the prompt). A plain deterministic 400/401 with no context marker is NOT overflow.
+///
+/// This GENUINELY composes with `RetryClassifier` rather than overriding it: a 429/5xx always flows to
+/// retry, never to compaction; only a deterministic, overflow-shaped failure is claimed here. The
+/// proactive token-threshold path (`proactiveSignal`) is status-independent by design and unaffected.
 public enum ContextOverflowDetector {
     /// Recognizes the overflow signal in a thrown model-call error, or nil when the error is not a
     /// context overflow. Only inspects the router's HTTP error (status + body); every other error
@@ -47,6 +56,13 @@ public enum ContextOverflowDetector {
     /// without constructing the full error and so a future non-router client can reuse the same
     /// normalization.
     public static func signal(statusCode: Int, body: String) -> ContextOverflowSignal? {
+        // STATUS GATE FIRST — defer to RetryClassifier. A rate-limit (429) or transient status (408,
+        // 5xx, …) is NEVER a context overflow, no matter what its body says: providers put "too many
+        // tokens" / "reduce the length of the messages" on a persistent token-per-minute 429, and
+        // reclassifying that as overflow would compact the thread and spend an aux summary on a rate
+        // limit. Only a DETERMINISTIC failure (the classifier returns `.none`) is overflow-eligible.
+        guard isOverflowEligible(statusCode: statusCode) else { return nil }
+
         // A bounded, lowercased view of the body: bodies are gateway/provider-controlled and can be
         // arbitrarily large, so cap the scan window before lowercasing to keep detection O(1) on a
         // hostile megabyte body. Overflow markers always appear early in the JSON error object.
@@ -59,6 +75,16 @@ public enum ContextOverflowDetector {
         // opaque. Every OTHER status needs a corroborating marker above and is NOT overflow here.
         if statusCode == payloadTooLargeStatusCode { return .httpPayloadTooLarge }
         return nil
+    }
+
+    /// Whether a status is even a candidate for overflow: only when `RetryClassifier` treats it as a
+    /// deterministic (non-retryable) failure. This is the single source of truth that keeps 429 /
+    /// 5xx / 408 out of the overflow path — if the classifier learns a new transient status, this
+    /// gate inherits it automatically rather than duplicating the status list.
+    static func isOverflowEligible(statusCode: Int) -> Bool {
+        RetryClassifier.classify(
+            TrustedRouterAgentError.streamingHTTPError(statusCode: statusCode, body: "", rateLimit: nil)
+        ) == .none
     }
 
     /// Whether an estimated prompt-token count has crossed the proactive compaction threshold. Kept

--- a/Sources/QuillCodeAgent/ContextOverflowDetector.swift
+++ b/Sources/QuillCodeAgent/ContextOverflowDetector.swift
@@ -1,0 +1,128 @@
+import Foundation
+import QuillCodeCore
+
+/// Why a model call was judged a context overflow — kept so a compaction notice can say WHICH signal
+/// tripped (an HTTP 413, a gateway `context_length_exceeded`, a provider message, or a proactive
+/// token estimate) and a test can assert each signal is normalized to the same decision.
+public enum ContextOverflowSignal: String, Sendable, Hashable {
+    /// The gateway rejected the request payload with HTTP 413 (Payload Too Large) — for a chat
+    /// completion this is the request being larger than the model/route will accept.
+    case httpPayloadTooLarge = "http_413"
+    /// The error body carried a machine code the gateway/provider uses for context overflow
+    /// (`context_length_exceeded`, `type=context_overflow`, `context_window_exceeded`).
+    case machineCode = "machine_code"
+    /// The error body carried a human message pattern that unambiguously means the prompt exceeded
+    /// the context window ("maximum context length", "prompt is too long", …).
+    case providerMessage = "provider_message"
+    /// No error yet — the assembled prompt's estimated token count crossed the proactive threshold,
+    /// so we compact BEFORE the wall instead of after a failed round-trip.
+    case tokenThreshold = "token_threshold"
+}
+
+/// The single, uniform detector for "this model call failed (or is about to) because the context
+/// window overflowed". It normalizes the several dialects the gateway and providers speak — an HTTP
+/// 413, a JSON `code`/`type` of `context_length_exceeded` / `context_overflow`, a provider prose
+/// message, or a proactive token estimate — into ONE typed decision the run loop can act on by
+/// compacting and resuming, rather than failing the run.
+///
+/// Deliberately conservative on the ambiguous signals so it never misfires on an unrelated error:
+/// an HTTP 413 is treated as overflow (for a chat request there is no other meaning), but every OTHER
+/// status code must be corroborated by a machine code or a context-specific message in the body — a
+/// plain 400/429/500 is NOT an overflow. The `RetryClassifier` still owns transient-vs-terminal for
+/// retry; this detector is composed alongside it (see `ContextOverflowDetector.classification`) and
+/// takes priority for the codes it recognizes, without changing the classifier's behavior.
+public enum ContextOverflowDetector {
+    /// Recognizes the overflow signal in a thrown model-call error, or nil when the error is not a
+    /// context overflow. Only inspects the router's HTTP error (status + body); every other error
+    /// type — transport blips, cancellations, auth, parse errors — returns nil so this never steals
+    /// an error the retry/terminal paths must handle.
+    public static func signal(for error: any Error) -> ContextOverflowSignal? {
+        guard let routerError = error as? TrustedRouterAgentError,
+              case .streamingHTTPError(let statusCode, let body, _) = routerError
+        else { return nil }
+        return signal(statusCode: statusCode, body: body)
+    }
+
+    /// The overflow signal for a raw HTTP status + response body, factored out so tests can drive it
+    /// without constructing the full error and so a future non-router client can reuse the same
+    /// normalization.
+    public static func signal(statusCode: Int, body: String) -> ContextOverflowSignal? {
+        // A bounded, lowercased view of the body: bodies are gateway/provider-controlled and can be
+        // arbitrarily large, so cap the scan window before lowercasing to keep detection O(1) on a
+        // hostile megabyte body. Overflow markers always appear early in the JSON error object.
+        let haystack = normalizedBody(body)
+
+        if containsMachineCode(haystack) { return .machineCode }
+        if containsProviderMessage(haystack) { return .providerMessage }
+        // 413 is the payload-too-large status: for a chat-completions POST the only thing that is
+        // "too large" is the prompt, so treat a bare 413 as overflow even when the body is empty or
+        // opaque. Every OTHER status needs a corroborating marker above and is NOT overflow here.
+        if statusCode == payloadTooLargeStatusCode { return .httpPayloadTooLarge }
+        return nil
+    }
+
+    /// Whether an estimated prompt-token count has crossed the proactive compaction threshold. Kept
+    /// separate from the error path so the run loop can compact BEFORE a failing round-trip. Returns
+    /// `.tokenThreshold` at or above `limit`; nil below. A non-positive `limit` disables the check
+    /// (never proactively compacts) rather than compacting on every turn.
+    public static func proactiveSignal(estimatedTokens: Int, limit: Int) -> ContextOverflowSignal? {
+        guard limit > 0, estimatedTokens >= limit else { return nil }
+        return .tokenThreshold
+    }
+
+    /// Convenience over `signal(for:)` for a boolean check at a call site that does not need the
+    /// specific signal.
+    public static func isContextOverflow(_ error: any Error) -> Bool {
+        signal(for: error) != nil
+    }
+
+    // MARK: - Signal recognition
+
+    static let payloadTooLargeStatusCode = 413
+
+    /// The scan window: overflow markers live in the error object at the top of the body; capping the
+    /// slice bounds work on a huge/hostile body and avoids lowercasing megabytes. Chosen generously so
+    /// a marker nested a few fields deep in a verbose gateway envelope is still seen.
+    static let bodyScanCharacterLimit = 8_000
+
+    /// Machine-readable codes the gateway and providers use for context overflow. Matched as
+    /// substrings of the lowercased body so both `"code":"context_length_exceeded"` and
+    /// `type=context_overflow` forms hit, regardless of JSON vs form-encoded envelope.
+    static let machineCodes: [String] = [
+        "context_length_exceeded",
+        "context_overflow",
+        "context_window_exceeded",
+        "context_length_error",
+    ]
+
+    /// Human prose patterns that unambiguously mean the prompt exceeded the window. Deliberately
+    /// specific: generic words like "token" or "length" alone are NOT here, so an unrelated 400 whose
+    /// body merely mentions tokens does not misfire.
+    static let providerMessagePatterns: [String] = [
+        "maximum context length",
+        "maximum context window",
+        "context length of",
+        "context window of",
+        "prompt is too long",
+        "prompt is too large",
+        "input is too long",
+        "too many tokens",
+        "reduce the length of the messages",
+        "exceeds the context",
+        "exceed the context",
+    ]
+
+    private static func normalizedBody(_ body: String) -> String {
+        // Prefix on the raw string is O(scan window) and safe on empty input; lowercasing the bounded
+        // slice keeps the case-insensitive match cheap even for a very large body.
+        String(body.prefix(bodyScanCharacterLimit)).lowercased()
+    }
+
+    private static func containsMachineCode(_ haystack: String) -> Bool {
+        machineCodes.contains { haystack.contains($0) }
+    }
+
+    private static func containsProviderMessage(_ haystack: String) -> Bool {
+        providerMessagePatterns.contains { haystack.contains($0) }
+    }
+}

--- a/Sources/QuillCodeAgent/ContextTokenEstimator.swift
+++ b/Sources/QuillCodeAgent/ContextTokenEstimator.swift
@@ -1,0 +1,64 @@
+import Foundation
+import QuillCodeCore
+
+/// A cheap, total estimate of how many tokens a thread's assembled prompt costs, so the run loop can
+/// compact PROACTIVELY before a failed round-trip. Deliberately provider-agnostic and approximate —
+/// it is a threshold trip-wire, not a billing figure — using the well-worn ~4-characters-per-token
+/// heuristic over the visible content plus a fixed per-message envelope overhead (role tag, JSON
+/// framing) so a thread of many tiny messages is not wildly under-counted.
+///
+/// TOTALITY is the point: it must never trap or overflow on adversarial input — an empty thread, a
+/// single multi-megabyte tool result, or millions of messages. Character counts accumulate as `Int`
+/// with saturating math and a hard ceiling, so a hostile thread yields a large finite estimate (which
+/// simply trips the threshold) rather than crashing the run.
+public enum ContextTokenEstimator {
+    /// Average characters per token for English-ish text/code. Conservative-low so the estimate skews
+    /// slightly HIGH (compact a little early) rather than late (hit the real wall).
+    static let charactersPerToken = 4
+    /// Per-message fixed overhead in tokens (role, delimiters, JSON envelope) charged on top of the
+    /// content estimate.
+    static let perMessageOverheadTokens = 4
+    /// The ceiling on the returned estimate. Far above any real context window, so the value stays a
+    /// finite `Int` no matter how large the thread; anything at or beyond it has already blown every
+    /// threshold, so the exact number past here is irrelevant.
+    static let maxEstimatedTokens = 1_000_000_000
+
+    /// Estimated prompt tokens for the whole thread's messages. Empty thread → 0.
+    public static func estimatedTokens(for thread: ChatThread) -> Int {
+        estimatedTokens(for: thread.messages)
+    }
+
+    public static func estimatedTokens(for messages: [ChatMessage]) -> Int {
+        var total = 0
+        for message in messages {
+            total = addSaturating(total, tokens(forContentCount: message.content.count))
+            total = addSaturating(total, perMessageOverheadTokens)
+            if total >= maxEstimatedTokens { return maxEstimatedTokens }
+        }
+        return min(total, maxEstimatedTokens)
+    }
+
+    /// Estimated tokens for a single string's content (no per-message overhead). Used by the compactor
+    /// to size the summary and the last-resort truncation.
+    public static func estimatedTokens(forText text: String) -> Int {
+        min(tokens(forContentCount: text.count), maxEstimatedTokens)
+    }
+
+    private static func tokens(forContentCount characterCount: Int) -> Int {
+        // `characterCount` is a non-negative `String.count`; integer-divide by the per-token width,
+        // rounding UP so a short non-empty message still costs at least one token.
+        guard characterCount > 0 else { return 0 }
+        let width = max(1, charactersPerToken)
+        // (n + width - 1) / width can overflow only near Int.max, which String.count never reaches on
+        // any real platform; guard anyway so this is provably total.
+        let numerator = addSaturating(characterCount, width - 1)
+        return numerator / width
+    }
+
+    /// Integer addition that clamps at `Int.max` instead of trapping on overflow — so accumulating
+    /// character counts across a pathologically large thread yields a finite ceiling, never a crash.
+    private static func addSaturating(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflowed) = lhs.addingReportingOverflow(rhs)
+        return overflowed ? Int.max : sum
+    }
+}

--- a/Sources/QuillCodeAgent/ThreadCompactionSummarizer.swift
+++ b/Sources/QuillCodeAgent/ThreadCompactionSummarizer.swift
@@ -1,0 +1,83 @@
+import Foundation
+import QuillCodeCore
+
+/// Produces the durable summary text that replaces the compacted-away turns of a thread. Injected into
+/// `ThreadCompactor` so the run-loop compaction path can be driven by a deterministic mock in tests and
+/// by a cheap auxiliary model in production, without the compactor knowing which.
+public protocol ThreadCompactionSummarizing: Sendable {
+    /// Summarize the older turns into a compact continuation summary. `recentMessages` is passed for
+    /// context only — it is preserved verbatim by the caller and MUST NOT be dropped or restated as if
+    /// already done. Throwing signals the summarizer failed; the compactor then falls back to a
+    /// deterministic summary so a run never dies because the summary model was unreachable.
+    func summarize(
+        sourceTitle: String,
+        olderMessages: [ChatMessage],
+        recentMessages: [ChatMessage]
+    ) async throws -> String
+}
+
+/// The always-available fallback: a deterministic, model-free summary built from the dropped turns.
+/// Used when no summary model is configured, and as the safety net when the model summarizer throws —
+/// so compaction (and therefore the run) proceeds regardless.
+public struct DeterministicThreadCompactionSummarizer: ThreadCompactionSummarizing {
+    public init() {}
+
+    public func summarize(
+        sourceTitle: String,
+        olderMessages: [ChatMessage],
+        recentMessages: [ChatMessage]
+    ) async throws -> String {
+        ThreadCompactionSummaryText.deterministic(
+            sourceTitle: sourceTitle,
+            olderMessages: olderMessages,
+            recentMessages: recentMessages
+        )
+    }
+}
+
+/// Summarizes via a cheap auxiliary LLM. Mirrors the app-layer `LLMWorkspaceContextSummaryGenerator`
+/// but lives in the agent layer so the run loop can compact-and-resume without depending on the app
+/// target. Best-effort by construction: the client is expected to already be caching-disabled and
+/// aux-model-retargeted by the caller (see `ThreadCompactor.llmBacked`), and any failure surfaces as a
+/// throw the compactor absorbs into the deterministic fallback.
+public struct LLMThreadCompactionSummarizer: ThreadCompactionSummarizing {
+    public var llm: any LLMClient
+
+    public init(llm: any LLMClient) {
+        self.llm = llm
+    }
+
+    public func summarize(
+        sourceTitle: String,
+        olderMessages: [ChatMessage],
+        recentMessages: [ChatMessage]
+    ) async throws -> String {
+        let prompt = ThreadCompactionSummaryText.prompt(
+            sourceTitle: sourceTitle,
+            olderMessages: olderMessages,
+            recentMessages: recentMessages
+        )
+        let action = try await llm.nextAction(
+            thread: ChatThread(title: "Context compaction"),
+            userMessage: prompt,
+            tools: []
+        )
+        guard case .say(let text) = action,
+              let summary = ThreadCompactionSummaryText.sanitized(text)
+        else {
+            throw ThreadCompactionSummarizerError.invalidModelSummary
+        }
+        return summary
+    }
+}
+
+enum ThreadCompactionSummarizerError: Error, CustomStringConvertible {
+    case invalidModelSummary
+
+    var description: String {
+        switch self {
+        case .invalidModelSummary:
+            return "Compaction summary model did not return a valid summary."
+        }
+    }
+}

--- a/Sources/QuillCodeAgent/ThreadCompactionSummaryText.swift
+++ b/Sources/QuillCodeAgent/ThreadCompactionSummaryText.swift
@@ -1,0 +1,137 @@
+import Foundation
+import QuillCodeCore
+
+/// Prompt construction, output sanitization, and the deterministic fallback for compaction summaries.
+/// A small agent-layer sibling of the app's `WorkspaceContextSummaryPromptBuilder` /
+/// `WorkspaceContextSummarySanitizer` — duplicated deliberately (not imported) because the app target
+/// depends on the agent target, and the run-loop compaction that resumes a run must live down here.
+enum ThreadCompactionSummaryText {
+    // MARK: - Prompt
+
+    /// The lowercased error/transcript scan window is bounded so a chatty tool result cannot blow the
+    /// summary call's own context (the very problem we are fixing). Older + recent transcript combined
+    /// is capped, keeping the TAIL (the most recent, most relevant turns) when it overflows.
+    static let maxTranscriptCharacters = 18_000
+    static let maxMessageExcerptCharacters = 1_200
+
+    static func prompt(
+        sourceTitle: String,
+        olderMessages: [ChatMessage],
+        recentMessages: [ChatMessage]
+    ) -> String {
+        let transcript = boundedTranscript(olderMessages: olderMessages, recentMessages: recentMessages)
+        return """
+        Please compact this QuillCode coding-agent thread so the run can continue within its context window.
+
+        Return exactly one QuillCode action JSON object and no markdown:
+        {"type":"say","text":"..."}
+
+        The text must be a concise durable continuation summary for the coding agent. Include:
+        - the user's goal and explicit preferences
+        - current implementation state and what has already been done
+        - important files, commands, tests, branches, PRs, and decisions
+        - unresolved questions, blockers, and the next steps
+
+        Do not include tool-feedback JSON, credentials, API keys, private keys, or secrets. Do not invent completed work.
+
+        Source thread: \(sourceTitle)
+
+        Conversation to summarize:
+        \(transcript)
+        """
+    }
+
+    private static func boundedTranscript(
+        olderMessages: [ChatMessage],
+        recentMessages: [ChatMessage]
+    ) -> String {
+        let joined = (olderMessages + recentMessages)
+            .map { "- \(roleLabel($0.role)): \(excerpt($0.content, limit: maxMessageExcerptCharacters))" }
+            .joined(separator: "\n")
+        guard joined.count > maxTranscriptCharacters else { return joined }
+        return String(joined.suffix(maxTranscriptCharacters))
+    }
+
+    // MARK: - Sanitize model output
+
+    static let maxSummaryCharacters = 6_000
+
+    /// Trims, redacts obvious secrets, and bounds the model's summary; nil when it is empty after
+    /// trimming so the caller can fall back to the deterministic summary.
+    static func sanitized(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let redacted = redactSecrets(trimmed)
+        guard redacted.count > maxSummaryCharacters else { return redacted }
+        return String(redacted.prefix(maxSummaryCharacters)).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+
+    // MARK: - Deterministic fallback
+
+    static let maxDeterministicExcerptCharacters = 180
+    static let maxDeterministicOlderLines = 8
+
+    /// A model-free summary of the dropped turns. Never empty (it always names the source and counts),
+    /// so compaction can always proceed even with no summary model and no model output.
+    static func deterministic(
+        sourceTitle: String,
+        olderMessages: [ChatMessage],
+        recentMessages: [ChatMessage]
+    ) -> String {
+        var lines = [
+            "Context compacted from \"\(sourceTitle)\".",
+            countLine(olderCount: olderMessages.count, recentCount: recentMessages.count),
+        ]
+        if olderMessages.isEmpty {
+            lines.append("No earlier turns were dropped.")
+        } else {
+            lines.append("Earlier context:")
+            for message in olderMessages.suffix(maxDeterministicOlderLines) {
+                lines.append("- \(roleLabel(message.role)): \(excerpt(message.content, limit: maxDeterministicExcerptCharacters))")
+            }
+        }
+        lines.append("Continue from the preserved latest turns below.")
+        return redactSecrets(lines.joined(separator: "\n"))
+    }
+
+    private static func countLine(olderCount: Int, recentCount: Int) -> String {
+        "Summarized \(pluralized(olderCount, noun: "earlier message")) and kept "
+            + "\(pluralized(recentCount, noun: "recent message"))."
+    }
+
+    // MARK: - Shared helpers
+
+    private static func roleLabel(_ role: ChatRole) -> String {
+        switch role {
+        case .system: return "System"
+        case .user: return "User"
+        case .assistant: return "Assistant"
+        case .tool: return "Tool"
+        }
+    }
+
+    /// Collapse whitespace and bound length. Uses `prefix` (never a range subscript) so an empty or
+    /// multi-byte string can never trap.
+    private static func excerpt(_ text: String, limit: Int) -> String {
+        let collapsed = text
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard collapsed.count > limit else { return collapsed }
+        return String(collapsed.prefix(limit)).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+
+    private static func pluralized(_ count: Int, noun: String) -> String {
+        "\(count) \(noun)\(count == 1 ? "" : "s")"
+    }
+
+    private static let secretPatterns = [
+        #"sk-[A-Za-z0-9_-]{12,}"#,
+        #"-----BEGIN [A-Z ]*PRIVATE KEY-----"#,
+    ]
+
+    private static func redactSecrets(_ text: String) -> String {
+        secretPatterns.reduce(text) { result, pattern in
+            result.replacingOccurrences(of: pattern, with: "[redacted]", options: .regularExpression)
+        }
+    }
+}

--- a/Sources/QuillCodeAgent/ThreadCompactor.swift
+++ b/Sources/QuillCodeAgent/ThreadCompactor.swift
@@ -1,0 +1,282 @@
+import Foundation
+import QuillCodeCore
+
+/// The outcome of one compaction attempt on a thread.
+public enum ThreadCompactionResult: Sendable, Equatable {
+    /// The thread was compacted: `summarizedCount` older messages were replaced by one summary message.
+    /// `usedModel` is true when the model summary succeeded, false when the deterministic fallback was
+    /// used. `lastResortTruncated` is true when even the preserved recent turns had to be hard-trimmed.
+    case compacted(summarizedCount: Int, usedModel: Bool, lastResortTruncated: Bool)
+    /// Nothing to compact — there were no older turns to fold away (the thread is already at or below
+    /// the preserved-recent floor). The caller must NOT loop again on the same thread.
+    case noOlderTurns
+}
+
+/// Folds a thread's older turns into a single durable summary message so an overflowing (or nearly
+/// overflowing) run can continue instead of failing at the context wall. This is the compaction half
+/// of issue #862; the detection half is `ContextOverflowDetector`, and the run loop
+/// (`AgentRunner.send`) composes them: on overflow, compact and resume.
+///
+/// Guarantees the reviewers will probe:
+/// - The current user request and the active tool exchange are NEVER dropped — they live in the
+///   preserved recent tail (`keepRecentMessages`, extended to keep an assistant/tool pair whole and to
+///   always include the last user message).
+/// - Leading system messages are preserved verbatim (the system prompt itself is re-added by the
+///   prompt builder, but any in-thread system message is kept as anchor content).
+/// - Idempotent and bounded: when there is nothing older to fold, it reports `.noOlderTurns` so the
+///   caller stops instead of looping. When even the kept tail is too big for a single turn, a
+///   last-resort front-truncation with an explicit marker keeps the run alive.
+/// - Total on adversarial input: no force-unwraps, no range subscripts on possibly-empty content, and
+///   token math via the saturating `ContextTokenEstimator`.
+public struct ThreadCompactor: Sendable {
+    /// How many trailing messages to preserve verbatim (extended as needed to keep a tool exchange
+    /// whole and to always include the last user message). Clamped to at least 1 so the current turn
+    /// always survives.
+    public var keepRecentMessages: Int
+    /// A single preserved message whose estimated tokens exceed this gets last-resort front-truncated
+    /// (keeping its tail) so one giant tool result cannot defeat compaction. 0 disables the floor.
+    public var perMessageTokenFloor: Int
+    public var summarizer: any ThreadCompactionSummarizing
+
+    public init(
+        keepRecentMessages: Int = 6,
+        perMessageTokenFloor: Int = 24_000,
+        summarizer: any ThreadCompactionSummarizing = DeterministicThreadCompactionSummarizer()
+    ) {
+        self.keepRecentMessages = max(1, keepRecentMessages)
+        self.perMessageTokenFloor = max(0, perMessageTokenFloor)
+        self.summarizer = summarizer
+    }
+
+    /// A compactor whose summaries run on a cheap auxiliary model with prompt caching disabled — the
+    /// production wiring. `catalog`/`sessionModelID` pick the aux model via `AuxiliaryModelSelector`;
+    /// when no priced candidate exists it keeps the session model (never fails to build a compactor).
+    /// A client that cannot be caching-disabled or model-overridden is used as-is (e.g. a test mock).
+    public static func llmBacked(
+        llm: any LLMClient,
+        catalog: [ModelInfo],
+        sessionModelID: String,
+        keepRecentMessages: Int = 6,
+        perMessageTokenFloor: Int = 24_000
+    ) -> ThreadCompactor {
+        let cachingDisabled = disablingPromptCachingIfSupported(llm)
+        let selection = AuxiliaryModelSelector.selection(models: catalog, sessionModelID: sessionModelID)
+        let retargeted = (cachingDisabled as? any ModelOverridingLLMClient)?
+            .overridingModel(selection.modelID) ?? cachingDisabled
+        return ThreadCompactor(
+            keepRecentMessages: keepRecentMessages,
+            perMessageTokenFloor: perMessageTokenFloor,
+            summarizer: LLMThreadCompactionSummarizer(llm: retargeted)
+        )
+    }
+
+    /// Compacts `thread` in place. Returns `.noOlderTurns` (and leaves the thread untouched apart from
+    /// possible last-resort truncation of the kept tail) when there is nothing older to fold — the
+    /// caller uses that to terminate the compaction loop.
+    @discardableResult
+    public func compact(_ thread: inout ChatThread) async -> ThreadCompactionResult {
+        let partition = partitionMessages(thread.messages)
+        // Folding fewer than `minOlderToFold` messages does not shrink the thread — one older message
+        // becomes one summary message. Requiring at least two guarantees every successful compaction
+        // strictly reduces the message count, so the reactive loop provably TERMINATES instead of
+        // re-summarizing its own summary forever.
+        guard partition.older.count >= Self.minOlderToFold else {
+            // Nothing worth folding. Still apply the last-resort floor so a single giant kept message
+            // can't keep overflowing, but report noOlderTurns so the loop terminates.
+            let truncated = applyLastResortTruncation(to: &thread.messages)
+            recordSeam(
+                in: &thread,
+                summarizedCount: 0,
+                usedModel: false,
+                lastResortTruncated: truncated,
+                noOlderTurns: true
+            )
+            return .noOlderTurns
+        }
+
+        let (summaryText, usedModel) = await summaryText(for: thread.title, partition: partition)
+        let summaryMessage = ChatMessage(role: .assistant, content: summaryText)
+
+        // Splice: [leading system messages] + [summary] + [preserved recent tail].
+        var rebuilt = partition.leadingSystem
+        rebuilt.append(summaryMessage)
+        rebuilt.append(contentsOf: partition.recent)
+        thread.messages = rebuilt
+
+        let lastResortTruncated = applyLastResortTruncation(to: &thread.messages)
+        recordSeam(
+            in: &thread,
+            summarizedCount: partition.older.count,
+            usedModel: usedModel,
+            lastResortTruncated: lastResortTruncated,
+            noOlderTurns: false
+        )
+        return .compacted(
+            summarizedCount: partition.older.count,
+            usedModel: usedModel,
+            lastResortTruncated: lastResortTruncated
+        )
+    }
+
+    // MARK: - Summary
+
+    private func summaryText(
+        for sourceTitle: String,
+        partition: MessagePartition
+    ) async -> (text: String, usedModel: Bool) {
+        do {
+            let text = try await summarizer.summarize(
+                sourceTitle: sourceTitle,
+                olderMessages: partition.older,
+                recentMessages: partition.recent
+            )
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                return (deterministicSummary(sourceTitle: sourceTitle, partition: partition), false)
+            }
+            return (trimmed, true)
+        } catch {
+            return (deterministicSummary(sourceTitle: sourceTitle, partition: partition), false)
+        }
+    }
+
+    private func deterministicSummary(sourceTitle: String, partition: MessagePartition) -> String {
+        ThreadCompactionSummaryText.deterministic(
+            sourceTitle: sourceTitle,
+            olderMessages: partition.older,
+            recentMessages: partition.recent
+        )
+    }
+
+    // MARK: - Partitioning
+
+    struct MessagePartition {
+        var leadingSystem: [ChatMessage]
+        var older: [ChatMessage]
+        var recent: [ChatMessage]
+    }
+
+    /// Splits messages into [leading system anchors][older, to summarize][recent, preserved verbatim].
+    /// The recent window is `keepRecentMessages` from the end, then EXTENDED backward so it (a) always
+    /// includes the last user message — never orphan the current request — and (b) never begins on a
+    /// `.tool` message whose originating assistant turn would be stranded in the summarized older set.
+    func partitionMessages(_ messages: [ChatMessage]) -> MessagePartition {
+        // Leading system messages are anchors, never summarized.
+        var leadingSystemEnd = 0
+        while leadingSystemEnd < messages.count, messages[leadingSystemEnd].role == .system {
+            leadingSystemEnd += 1
+        }
+        let leadingSystem = Array(messages[0..<leadingSystemEnd])
+        let body = Array(messages[leadingSystemEnd...])
+        guard !body.isEmpty else {
+            return MessagePartition(leadingSystem: leadingSystem, older: [], recent: [])
+        }
+
+        // Start from the last `keepRecentMessages`, clamped to the body.
+        var recentStart = max(0, body.count - keepRecentMessages)
+        recentStart = extendToIncludeLastUserMessage(in: body, from: recentStart)
+        recentStart = extendPastLeadingToolMessages(in: body, from: recentStart)
+
+        let older = Array(body[0..<recentStart])
+        let recent = Array(body[recentStart...])
+        return MessagePartition(leadingSystem: leadingSystem, older: older, recent: recent)
+    }
+
+    /// Never orphan the current request: if the last user message sits before the recent window, pull
+    /// the window's start back to it so it (and everything after) is preserved verbatim.
+    private func extendToIncludeLastUserMessage(in body: [ChatMessage], from start: Int) -> Int {
+        guard let lastUserIndex = body.lastIndex(where: { $0.role == .user }) else { return start }
+        return min(start, lastUserIndex)
+    }
+
+    /// Don't begin the preserved tail on a `.tool` message: its result would be kept while the
+    /// assistant call that produced it is summarized away, which reads as an orphaned tool output.
+    /// Walk the start backward over any leading `.tool` messages (and the assistant turn before them).
+    private func extendPastLeadingToolMessages(in body: [ChatMessage], from start: Int) -> Int {
+        var index = start
+        while index > 0, body[index].role == .tool {
+            index -= 1
+        }
+        // If we stopped on the assistant turn that OWNS the tool output, keep that too so the call and
+        // its result stay together.
+        if index > 0, index < body.count, body[index].role == .tool, body[index - 1].role == .assistant {
+            index -= 1
+        }
+        return index
+    }
+
+    // MARK: - Last-resort truncation
+
+    /// Front-truncates any single preserved message whose estimated tokens exceed the floor, keeping
+    /// its TAIL (the recent, most relevant part) with an explicit marker. This is the terminator that
+    /// keeps the run alive when even one kept turn — a giant tool result — is too big for the window.
+    /// Returns whether anything was truncated. `perMessageTokenFloor == 0` disables it.
+    private func applyLastResortTruncation(to messages: inout [ChatMessage]) -> Bool {
+        guard perMessageTokenFloor > 0 else { return false }
+        var truncatedAny = false
+        for index in messages.indices {
+            let content = messages[index].content
+            guard ContextTokenEstimator.estimatedTokens(forText: content) > perMessageTokenFloor else {
+                continue
+            }
+            let keptCharacters = max(1, perMessageTokenFloor * ContextTokenEstimator.charactersPerToken)
+            guard content.count > keptCharacters else { continue }
+            let tail = String(content.suffix(keptCharacters))
+            messages[index].content = Self.truncationMarker + tail
+            truncatedAny = true
+        }
+        return truncatedAny
+    }
+
+    static let truncationMarker = "[QuillCode compaction: earlier content of this message was truncated to fit the context window]\n"
+
+    /// The minimum number of older messages worth folding into a summary. Below this, compaction would
+    /// not reduce the message count (1 message → 1 summary), so it reports `.noOlderTurns` instead —
+    /// the invariant that makes the reactive compaction loop terminate.
+    static let minOlderToFold = 2
+
+    // MARK: - Seam annotation
+
+    private func recordSeam(
+        in thread: inout ChatThread,
+        summarizedCount: Int,
+        usedModel: Bool,
+        lastResortTruncated: Bool,
+        noOlderTurns: Bool
+    ) {
+        // Nothing happened at all — no summary, no truncation — so don't spam a seam event.
+        if noOlderTurns, !lastResortTruncated { return }
+
+        let summary: String
+        if summarizedCount > 0 {
+            summary = "Compacted \(summarizedCount) earlier "
+                + (summarizedCount == 1 ? "turn" : "turns")
+                + " into a summary to fit the context window"
+                + (usedModel ? "." : " (deterministic summary).")
+                + (lastResortTruncated ? " Also truncated an oversized kept message." : "")
+        } else {
+            summary = "Truncated an oversized message to fit the context window."
+        }
+
+        let payload = CompactionSeamPayload(
+            summarizedTurns: summarizedCount,
+            usedModelSummary: usedModel,
+            lastResortTruncated: lastResortTruncated
+        )
+        thread.events.append(ThreadEvent(
+            kind: .notice,
+            summary: summary,
+            payloadJSON: try? JSONHelpers.encodePretty(payload)
+        ))
+        thread.updatedAt = Date()
+    }
+}
+
+/// The auditable payload on a compaction seam event, so the transcript can show exactly what the
+/// compaction did (how many turns folded, whether the model or the deterministic fallback wrote the
+/// summary, whether a last-resort truncation fired).
+struct CompactionSeamPayload: Codable, Sendable, Hashable {
+    var summarizedTurns: Int
+    var usedModelSummary: Bool
+    var lastResortTruncated: Bool
+}

--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -101,12 +101,25 @@ public struct QuillCodeRuntimeFactory: Sendable {
             model: config.defaultModel,
             baseURL: config.apiBaseURL
         )
+        // Compaction (issue #862): when a model call overflows the context window, the run loop folds
+        // the thread's older turns into a summary and resumes instead of failing. It reuses the same
+        // caching-disabled auxiliary client as context summaries; the aux MODEL is chosen per-compaction
+        // from the live catalog inside the runner. The runner is built once and long before the catalog
+        // is fetched, so it is seeded with the session model as the fallback and picks a cheaper catalog
+        // model whenever one is available at compaction time. Reactive-only by default here (no
+        // proactive threshold) so a healthy run pays nothing until the wall is actually hit.
+        let compactor = ThreadCompactor.llmBacked(
+            llm: summaryLLM,
+            catalog: [],
+            sessionModelID: config.defaultModel
+        )
         return QuillCodeRuntime(
             runner: AgentRunner(
                 llm: llm,
                 safety: AutoSafetyReviewer(client: safetyClient),
                 webSearch: webSearch,
-                enablesImmediateActionPreflight: true
+                enablesImmediateActionPreflight: true,
+                compaction: AgentCompactionPolicy(compactor: compactor)
             ),
             contextSummaryGenerator: LLMWorkspaceContextSummaryGenerator(llm: summaryLLM),
             mode: .trustedRouter,

--- a/Tests/QuillCodeAgentTests/AgentCompactionRunLoopTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentCompactionRunLoopTests.swift
@@ -12,20 +12,31 @@ private actor OverflowScriptState {
     private(set) var messageCountsAtCall: [Int] = []
     let overflowRounds: Int
     let finalAction: AgentAction
+    /// The HTTP status + body thrown on the first `overflowRounds` calls. Defaults to a genuine
+    /// context overflow (413), but a test can supply a 429/5xx to prove those are NOT compacted.
+    let failureStatus: Int
+    let failureBody: String
 
-    init(overflowRounds: Int, finalAction: AgentAction) {
+    init(
+        overflowRounds: Int,
+        finalAction: AgentAction,
+        failureStatus: Int = 413,
+        failureBody: String = #"{"error":{"code":"context_length_exceeded"}}"#
+    ) {
         self.overflowRounds = overflowRounds
         self.finalAction = finalAction
+        self.failureStatus = failureStatus
+        self.failureBody = failureBody
     }
 
-    /// Returns the events to yield, or throws the overflow error, recording the thread size seen.
+    /// Returns the events to yield, or throws the scripted error, recording the thread size seen.
     func nextEventsOrThrow(threadMessageCount: Int) throws -> [AgentTextStreamEvent] {
         callCount += 1
         messageCountsAtCall.append(threadMessageCount)
         if callCount <= overflowRounds {
             throw TrustedRouterAgentError.streamingHTTPError(
-                statusCode: 413,
-                body: #"{"error":{"code":"context_length_exceeded"}}"#,
+                statusCode: failureStatus,
+                body: failureBody,
                 rateLimit: nil
             )
         }
@@ -72,11 +83,26 @@ private struct OverflowScriptedLLMClient: UsageStreamingLLMClient {
     }
 }
 
+/// Counts how many times it was asked to summarize, so a test can assert an aux summary call did (or
+/// did NOT) happen — e.g. a misclassified 429 must never spend a summary call.
+private actor SummaryCallCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+}
+
 /// A summarizer that fixes the summary text and records that it ran.
 private struct RecordingSummarizer: ThreadCompactionSummarizing {
     let text: String
+    let counter: SummaryCallCounter?
+
+    init(text: String, counter: SummaryCallCounter? = nil) {
+        self.text = text
+        self.counter = counter
+    }
+
     func summarize(sourceTitle: String, olderMessages: [ChatMessage], recentMessages: [ChatMessage]) async throws -> String {
-        text
+        await counter?.increment()
+        return text
     }
 }
 
@@ -94,13 +120,14 @@ final class AgentCompactionRunLoopTests: XCTestCase {
         summary: String = "COMPACTED SUMMARY",
         keepRecent: Int = 4,
         maxRounds: Int = 3,
-        proactiveLimit: Int = 0
+        proactiveLimit: Int = 0,
+        summaryCounter: SummaryCallCounter? = nil
     ) -> AgentCompactionPolicy {
         AgentCompactionPolicy(
             compactor: ThreadCompactor(
                 keepRecentMessages: keepRecent,
                 perMessageTokenFloor: 0,
-                summarizer: RecordingSummarizer(text: summary)
+                summarizer: RecordingSummarizer(text: summary, counter: summaryCounter)
             ),
             proactiveTokenLimit: proactiveLimit,
             maxRoundsPerCall: maxRounds
@@ -276,5 +303,103 @@ final class AgentCompactionRunLoopTests: XCTestCase {
             }
             XCTAssertEqual(status, 401, "a non-overflow error must propagate, not trigger compaction")
         }
+    }
+
+    // MARK: - Rate-limit / transient status is NEVER compacted (regression for the MAJOR defect)
+
+    /// A persistent token-per-minute 429 whose body says "too many tokens" / "reduce the length of the
+    /// messages" must surface as the rate limit, NOT trigger a destructive compaction. Asserts: no
+    /// compaction seam event, the aux summarizer was never called, and the thread's real turns are
+    /// intact. Fails on a revert of the status gate (which would compact and finally raise
+    /// ContextOverflowUnresolvedError, hiding the real 429).
+    func testPersistent429WithTokenBodyIsNotCompactedAndSurfacesAsRateLimit() async throws {
+        let root = try makeTempDirectory()
+        let summaryCounter = SummaryCallCounter()
+        let state = OverflowScriptState(
+            overflowRounds: 1_000, // always fails
+            finalAction: .say("never reached"),
+            failureStatus: 429,
+            failureBody: "Rate limit reached: too many tokens. Please reduce the length of the messages."
+        )
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy(maxRounds: 3, summaryCounter: summaryCounter)
+        )
+
+        do {
+            _ = try await runner.send("go", in: longThread(pairs: 10), workspaceRoot: root)
+            XCTFail("expected the 429 to surface, not be compacted away")
+        } catch let error as TrustedRouterAgentError {
+            guard case .streamingHTTPError(let status, _, _) = error else {
+                return XCTFail("wrong error type: \(error)")
+            }
+            XCTAssertEqual(status, 429, "a rate limit must surface as itself, not as an overflow")
+        } catch let error as ContextOverflowUnresolvedError {
+            XCTFail("a 429 must NOT be treated as overflow; got compaction failure: \(error)")
+        }
+
+        // The aux summary model was never invoked — no housekeeping cost spent on a rate limit.
+        let summaryCalls = await summaryCounter.count
+        XCTAssertEqual(summaryCalls, 0, "a 429 must not spend an aux summary call")
+
+        // The compaction loop made exactly ONE model call: the 429 is not overflow, so it re-throws
+        // immediately without retrying (the run-loop retry lives in RetryingLLMClient, not exercised
+        // here — this proves the compaction loop itself does not retry a rate limit).
+        let calls = await state.callCount
+        XCTAssertEqual(calls, 1, "the compaction loop must not retry a rate limit")
+    }
+
+    func testPersistent5xxWithTokenBodyIsNotCompacted() async throws {
+        let root = try makeTempDirectory()
+        let summaryCounter = SummaryCallCounter()
+        let state = OverflowScriptState(
+            overflowRounds: 1_000,
+            finalAction: .say("never reached"),
+            failureStatus: 503,
+            failureBody: "maximum context length exceeded (too many tokens)"
+        )
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy(maxRounds: 3, summaryCounter: summaryCounter)
+        )
+        do {
+            _ = try await runner.send("go", in: longThread(pairs: 10), workspaceRoot: root)
+            XCTFail("expected the 5xx to surface")
+        } catch let error as TrustedRouterAgentError {
+            guard case .streamingHTTPError(let status, _, _) = error else {
+                return XCTFail("wrong error type: \(error)")
+            }
+            XCTAssertEqual(status, 503, "a transient 5xx must surface, not be compacted")
+        }
+        let summaryCalls = await summaryCounter.count
+        XCTAssertEqual(summaryCalls, 0, "a 5xx must not spend an aux summary call")
+    }
+
+    /// The positive counterpart in the SAME run-loop harness: a genuine 413/400/422 overflow whose body
+    /// carries the identical token phrasing IS compacted and resumes — proving the status gate lets
+    /// real overflows through unchanged.
+    func testGenuineOverflowWithTokenBodyStillCompactsAndResumes() async throws {
+        let root = try makeTempDirectory()
+        let summaryCounter = SummaryCallCounter()
+        let state = OverflowScriptState(
+            overflowRounds: 1,
+            finalAction: .say("recovered"),
+            failureStatus: 400,
+            failureBody: "This model's maximum context length is 200000 tokens; reduce the length of the messages."
+        )
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy(summaryCounter: summaryCounter)
+        )
+        let result = try await runner.send("go", in: longThread(pairs: 10), workspaceRoot: root)
+
+        XCTAssertEqual(result.stopReason, .finished)
+        XCTAssertEqual(result.thread.messages.last?.content, "recovered")
+        XCTAssertTrue(result.thread.events.contains { $0.kind == .notice && $0.summary.contains("Compacted") })
+        let summaryCalls = await summaryCounter.count
+        XCTAssertEqual(summaryCalls, 1, "a real overflow should invoke the aux summary once")
     }
 }

--- a/Tests/QuillCodeAgentTests/AgentCompactionRunLoopTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentCompactionRunLoopTests.swift
@@ -1,0 +1,280 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeSafety
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+/// Records every thread it is asked about and can be scripted to overflow on the first N calls, then
+/// succeed. Conforms to `UsageStreamingLLMClient` (the path the run loop prefers) so it exercises the
+/// real `nextUsageStreamingAction` → overflow-throw seam.
+private actor OverflowScriptState {
+    private(set) var callCount = 0
+    private(set) var messageCountsAtCall: [Int] = []
+    let overflowRounds: Int
+    let finalAction: AgentAction
+
+    init(overflowRounds: Int, finalAction: AgentAction) {
+        self.overflowRounds = overflowRounds
+        self.finalAction = finalAction
+    }
+
+    /// Returns the events to yield, or throws the overflow error, recording the thread size seen.
+    func nextEventsOrThrow(threadMessageCount: Int) throws -> [AgentTextStreamEvent] {
+        callCount += 1
+        messageCountsAtCall.append(threadMessageCount)
+        if callCount <= overflowRounds {
+            throw TrustedRouterAgentError.streamingHTTPError(
+                statusCode: 413,
+                body: #"{"error":{"code":"context_length_exceeded"}}"#,
+                rateLimit: nil
+            )
+        }
+        switch finalAction {
+        case .say(let text):
+            return [.text(#"{"type":"say","text":"\#(text)"}"#)]
+        case .tool(let call):
+            return [.text(#"{"type":"tool","name":"\#(call.name)","arguments":\#(call.argumentsJSON)}"#)]
+        }
+    }
+}
+
+private struct OverflowScriptedLLMClient: UsageStreamingLLMClient {
+    let state: OverflowScriptState
+
+    func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+        throw StreamingActionLLMError.nonStreamingPathUsed
+    }
+
+    func actionTextStream(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AsyncThrowingStream<String, Error> {
+        // The overflow throws HERE (before the stream), matching the real client. On success it
+        // degrades to the event stream's text.
+        let events = try await actionEventStream(thread: thread, userMessage: userMessage, tools: tools)
+        return AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    for try await event in events {
+                        if case .text(let chunk) = event { continuation.yield(chunk) }
+                    }
+                    continuation.finish()
+                } catch { continuation.finish(throwing: error) }
+            }
+        }
+    }
+
+    func actionEventStream(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AsyncThrowingStream<AgentTextStreamEvent, Error> {
+        // Throwing BEFORE returning the stream mirrors TrustedRouterLLMClient: the HTTP status error
+        // is thrown before any token, so the run loop's overflow catch sees it.
+        let events = try await state.nextEventsOrThrow(threadMessageCount: thread.messages.count)
+        return AsyncThrowingStream { continuation in
+            for event in events { continuation.yield(event) }
+            continuation.finish()
+        }
+    }
+}
+
+/// A summarizer that fixes the summary text and records that it ran.
+private struct RecordingSummarizer: ThreadCompactionSummarizing {
+    let text: String
+    func summarize(sourceTitle: String, olderMessages: [ChatMessage], recentMessages: [ChatMessage]) async throws -> String {
+        text
+    }
+}
+
+final class AgentCompactionRunLoopTests: XCTestCase {
+    private func longThread(pairs: Int) -> ChatThread {
+        var messages: [ChatMessage] = []
+        for i in 0..<pairs {
+            messages.append(ChatMessage(role: .user, content: "user \(i)"))
+            messages.append(ChatMessage(role: .assistant, content: "assistant \(i)"))
+        }
+        return ChatThread(mode: .auto, messages: messages)
+    }
+
+    private func compactionPolicy(
+        summary: String = "COMPACTED SUMMARY",
+        keepRecent: Int = 4,
+        maxRounds: Int = 3,
+        proactiveLimit: Int = 0
+    ) -> AgentCompactionPolicy {
+        AgentCompactionPolicy(
+            compactor: ThreadCompactor(
+                keepRecentMessages: keepRecent,
+                perMessageTokenFloor: 0,
+                summarizer: RecordingSummarizer(text: summary)
+            ),
+            proactiveTokenLimit: proactiveLimit,
+            maxRoundsPerCall: maxRounds
+        )
+    }
+
+    // MARK: - Overflow → compact → resume succeeds
+
+    func testOverflowOnceThenCompactAndResumeReturnsFinalAnswer() async throws {
+        let root = try makeTempDirectory()
+        let state = OverflowScriptState(overflowRounds: 1, finalAction: .say("all done"))
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy()
+        )
+
+        let result = try await runner.send(
+            "continue the work",
+            in: longThread(pairs: 10),
+            workspaceRoot: root
+        )
+
+        // The run resumed and finished rather than throwing.
+        XCTAssertEqual(result.stopReason, .finished)
+        XCTAssertEqual(result.thread.messages.last?.content, "all done")
+        // The model was called twice: overflow, then success after compaction.
+        let calls = await state.callCount
+        XCTAssertEqual(calls, 2)
+        // A compaction seam was recorded.
+        XCTAssertTrue(result.thread.events.contains { $0.kind == .notice && $0.summary.contains("Compacted") })
+        // The summary landed in the thread.
+        XCTAssertTrue(result.thread.messages.contains { $0.content == "COMPACTED SUMMARY" })
+    }
+
+    func testThreadShrinksBetweenOverflowAndRetry() async throws {
+        let root = try makeTempDirectory()
+        let state = OverflowScriptState(overflowRounds: 1, finalAction: .say("done"))
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy(keepRecent: 4)
+        )
+        _ = try await runner.send("go", in: longThread(pairs: 10), workspaceRoot: root)
+
+        let counts = await state.messageCountsAtCall
+        XCTAssertEqual(counts.count, 2)
+        // First call saw the full thread; the compacted retry saw fewer messages.
+        XCTAssertGreaterThan(counts[0], counts[1])
+    }
+
+    // MARK: - Termination under repeated overflow
+
+    func testUnresolvableOverflowTerminatesWithDiagnosticNotInfiniteLoop() async throws {
+        let root = try makeTempDirectory()
+        // Overflows forever (more rounds than the cap allows).
+        let state = OverflowScriptState(overflowRounds: 1_000, finalAction: .say("never reached"))
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy(maxRounds: 3)
+        )
+
+        do {
+            _ = try await runner.send("go", in: longThread(pairs: 20), workspaceRoot: root)
+            XCTFail("expected the run to terminate with an overflow error, not loop forever")
+        } catch let error as ContextOverflowUnresolvedError {
+            // Bounded: it did not exceed the round cap (a .noOlderTurns can stop it earlier).
+            XCTAssertLessThanOrEqual(error.rounds, 3)
+            XCTAssertGreaterThan(error.rounds, 0)
+        }
+
+        // The model was called a bounded number of times (initial + up to maxRounds retries).
+        let calls = await state.callCount
+        XCTAssertLessThanOrEqual(calls, 4)
+    }
+
+    func testTerminatesWhenNothingLeftToCompact() async throws {
+        let root = try makeTempDirectory()
+        let state = OverflowScriptState(overflowRounds: 1_000, finalAction: .say("x"))
+        // A thread that is already tiny: the first compaction reports .noOlderTurns, so the loop must
+        // stop immediately rather than burning all its rounds.
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy(keepRecent: 6, maxRounds: 5)
+        )
+        do {
+            _ = try await runner.send("go", in: ChatThread(mode: .auto), workspaceRoot: root, recordUserMessage: true)
+            XCTFail("expected termination")
+        } catch is ContextOverflowUnresolvedError {
+            // expected
+        }
+        let calls = await state.callCount
+        // Initial overflow + one compaction attempt that yields .noOlderTurns → stop. Bounded well
+        // under the round cap.
+        XCTAssertLessThanOrEqual(calls, 2)
+    }
+
+    // MARK: - No policy → old behavior (overflow surfaces)
+
+    func testWithoutCompactionPolicyOverflowSurfacesUnchanged() async throws {
+        let root = try makeTempDirectory()
+        let state = OverflowScriptState(overflowRounds: 1, finalAction: .say("done"))
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: nil
+        )
+        do {
+            _ = try await runner.send("go", in: longThread(pairs: 5), workspaceRoot: root)
+            XCTFail("expected the overflow error to surface unchanged")
+        } catch let error as TrustedRouterAgentError {
+            guard case .streamingHTTPError(let status, _, _) = error else {
+                return XCTFail("wrong error: \(error)")
+            }
+            XCTAssertEqual(status, 413)
+        }
+        let calls = await state.callCount
+        XCTAssertEqual(calls, 1, "without a policy the run must not retry/compact")
+    }
+
+    // MARK: - Proactive compaction
+
+    func testProactiveCompactionTrimsBeforeTheCall() async throws {
+        let root = try makeTempDirectory()
+        // Never overflows; but the thread is large and the proactive limit is low, so the loop should
+        // compact BEFORE the first successful call.
+        let state = OverflowScriptState(overflowRounds: 0, finalAction: .say("done"))
+        let runner = AgentRunner(
+            llm: OverflowScriptedLLMClient(state: state),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy(keepRecent: 4, proactiveLimit: 1)
+        )
+        let result = try await runner.send("go", in: longThread(pairs: 10), workspaceRoot: root)
+
+        XCTAssertEqual(result.stopReason, .finished)
+        XCTAssertTrue(
+            result.thread.events.contains { $0.kind == .notice && $0.summary.contains("Compacted") },
+            "proactive compaction should have recorded a seam"
+        )
+    }
+
+    // MARK: - Non-overflow errors are not swallowed
+
+    func testNonOverflowErrorIsNotCompactedAway() async throws {
+        let root = try makeTempDirectory()
+
+        struct AuthFailingClient: UsageStreamingLLMClient {
+            func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+                throw StreamingActionLLMError.nonStreamingPathUsed
+            }
+            func actionTextStream(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AsyncThrowingStream<String, Error> {
+                _ = try await actionEventStream(thread: thread, userMessage: userMessage, tools: tools)
+                return AsyncThrowingStream { $0.finish() }
+            }
+            func actionEventStream(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AsyncThrowingStream<AgentTextStreamEvent, Error> {
+                throw TrustedRouterAgentError.streamingHTTPError(statusCode: 401, body: "invalid api key", rateLimit: nil)
+            }
+        }
+
+        let runner = AgentRunner(
+            llm: AuthFailingClient(),
+            safety: AlwaysApprovingSafetyReviewer(),
+            compaction: compactionPolicy()
+        )
+        do {
+            _ = try await runner.send("go", in: longThread(pairs: 10), workspaceRoot: root)
+            XCTFail("expected the auth error to surface")
+        } catch let error as TrustedRouterAgentError {
+            guard case .streamingHTTPError(let status, _, _) = error else {
+                return XCTFail("wrong error")
+            }
+            XCTAssertEqual(status, 401, "a non-overflow error must propagate, not trigger compaction")
+        }
+    }
+}

--- a/Tests/QuillCodeAgentTests/ContextOverflowDetectorTests.swift
+++ b/Tests/QuillCodeAgentTests/ContextOverflowDetectorTests.swift
@@ -94,6 +94,64 @@ final class ContextOverflowDetectorTests: XCTestCase {
         XCTAssertFalse(ContextOverflowDetector.isContextOverflow(rateLimited))
     }
 
+    // MARK: - Status gate: a rate-limit / transient status is NEVER overflow, even with a token body
+
+    /// The MAJOR defect this guards: a persistent token-per-minute 429 whose body carries an
+    /// Anthropic/OpenAI-style "too many tokens" / "reduce the length of the messages" message must NOT
+    /// be reclassified as a context overflow (which would destructively compact the thread on what is
+    /// really a rate limit). The status gate defers to RetryClassifier, so a 429 always stays a 429.
+    func testRateLimit429WithTokenMentioningBodyIsNotOverflow() {
+        let tokenBodies = [
+            "Rate limit reached: too many tokens. Please reduce the length of the messages.",
+            #"{"error":{"type":"rate_limit_error","message":"too many tokens, slow down"}}"#,
+            "You have exceeded the context window of tokens-per-minute; retry after 60s.",
+        ]
+        for body in tokenBodies {
+            XCTAssertNil(
+                ContextOverflowDetector.signal(for: httpError(429, body: body)),
+                "429 must never be overflow, even with body: \(body)"
+            )
+            XCTAssertFalse(ContextOverflowDetector.isContextOverflow(httpError(429, body: body)))
+        }
+    }
+
+    func testTransient5xxWithTokenMentioningBodyIsNotOverflow() {
+        // A 5xx server blip retries; even a misleading token-shaped body must not divert it to
+        // compaction. Covers each transient 5xx the classifier retries.
+        let body = "maximum context length exceeded; too many tokens in prompt"
+        for status in [500, 502, 503, 504, 529] {
+            XCTAssertNil(
+                ContextOverflowDetector.signal(for: httpError(status, body: body)),
+                "transient \(status) must never be overflow"
+            )
+        }
+    }
+
+    func testTimeout408WithTokenBodyIsNotOverflow() {
+        XCTAssertNil(ContextOverflowDetector.signal(for: httpError(408, body: "too many tokens")))
+    }
+
+    func testDeterministicStatusesWithTokenBodyAreStillOverflow() {
+        // The counterpart: 413/400/422 ARE deterministic client rejections, so the same token body
+        // that must be ignored on a 429 correctly confirms overflow here.
+        let body = "This model's maximum context length is 200000 tokens; reduce the length of the messages."
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(413, body: body)), .providerMessage)
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(400, body: body)), .providerMessage)
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(422, body: body)), .providerMessage)
+    }
+
+    func testOverflowEligibilityMatchesRetryClassifierTerminalStatuses() {
+        // The gate is exactly "RetryClassifier says .none". Assert the boundary so a future change to
+        // the classifier's transient set is caught here.
+        XCTAssertTrue(ContextOverflowDetector.isOverflowEligible(statusCode: 400))
+        XCTAssertTrue(ContextOverflowDetector.isOverflowEligible(statusCode: 413))
+        XCTAssertTrue(ContextOverflowDetector.isOverflowEligible(statusCode: 422))
+        XCTAssertFalse(ContextOverflowDetector.isOverflowEligible(statusCode: 429))
+        XCTAssertFalse(ContextOverflowDetector.isOverflowEligible(statusCode: 408))
+        XCTAssertFalse(ContextOverflowDetector.isOverflowEligible(statusCode: 500))
+        XCTAssertFalse(ContextOverflowDetector.isOverflowEligible(statusCode: 529))
+    }
+
     // MARK: - Proactive token threshold
 
     func testProactiveSignalTripsAtOrAboveLimit() {

--- a/Tests/QuillCodeAgentTests/ContextOverflowDetectorTests.swift
+++ b/Tests/QuillCodeAgentTests/ContextOverflowDetectorTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+final class ContextOverflowDetectorTests: XCTestCase {
+    private func httpError(_ statusCode: Int, body: String) -> TrustedRouterAgentError {
+        .streamingHTTPError(statusCode: statusCode, body: body, rateLimit: nil)
+    }
+
+    // MARK: - Each signal normalizes to overflow
+
+    func testHTTP413IsOverflowEvenWithOpaqueBody() {
+        let signal = ContextOverflowDetector.signal(for: httpError(413, body: ""))
+        XCTAssertEqual(signal, .httpPayloadTooLarge)
+        XCTAssertTrue(ContextOverflowDetector.isContextOverflow(httpError(413, body: "anything")))
+    }
+
+    func testGatewayMachineCodeIsOverflow() {
+        let body = #"{"error":{"code":"context_length_exceeded","message":"..."}}"#
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(400, body: body)), .machineCode)
+    }
+
+    func testTypeContextOverflowIsOverflow() {
+        let body = #"{"error":{"type":"context_overflow"}}"#
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(422, body: body)), .machineCode)
+    }
+
+    func testContextWindowExceededCodeIsOverflow() {
+        let body = #"{"code":"context_window_exceeded"}"#
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(400, body: body)), .machineCode)
+    }
+
+    func testProviderMessagePatternsAreOverflow() {
+        let bodies = [
+            "This model's maximum context length is 128000 tokens.",
+            "Your prompt is too long. Please reduce the length of the messages.",
+            "The input is too long for the requested model.",
+            "This request exceeds the context window of the model.",
+        ]
+        for body in bodies {
+            XCTAssertEqual(
+                ContextOverflowDetector.signal(for: httpError(400, body: body)),
+                .providerMessage,
+                "expected overflow for body: \(body)"
+            )
+        }
+    }
+
+    func testMachineCodeMatchIsCaseInsensitive() {
+        let body = #"{"CODE":"CONTEXT_LENGTH_EXCEEDED"}"#
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(400, body: body)), .machineCode)
+    }
+
+    // MARK: - Does NOT misfire on benign errors
+
+    func testBenign413WithContextMarkerStaysOverflowButUnrelated400DoesNot() {
+        // A plain 400 whose body merely mentions "tokens" (usage accounting) must NOT trip.
+        let benign = "You have used 200 tokens on this request; billing updated."
+        XCTAssertNil(ContextOverflowDetector.signal(for: httpError(400, body: benign)))
+    }
+
+    func testUnrelated429IsNotOverflow() {
+        XCTAssertNil(ContextOverflowDetector.signal(for: httpError(429, body: "rate limit exceeded")))
+    }
+
+    func testUnrelated500IsNotOverflow() {
+        XCTAssertNil(ContextOverflowDetector.signal(for: httpError(500, body: "internal server error")))
+    }
+
+    func testAuthErrorIsNotOverflow() {
+        XCTAssertNil(ContextOverflowDetector.signal(for: httpError(401, body: "invalid api key")))
+    }
+
+    func testNonRouterErrorsAreNotOverflow() {
+        XCTAssertNil(ContextOverflowDetector.signal(for: CancellationError()))
+        XCTAssertNil(ContextOverflowDetector.signal(for: TrustedRouterAgentError.missingAPIKey))
+        XCTAssertNil(ContextOverflowDetector.signal(for: TrustedRouterAgentError.emptyResponse))
+        struct Other: Error {}
+        XCTAssertNil(ContextOverflowDetector.signal(for: Other()))
+    }
+
+    // MARK: - Composition with RetryClassifier is non-destructive
+
+    func testRetryClassifierBehaviorUnchangedForOverflowErrors() {
+        // A 413/400 context overflow is a client error → RetryClassifier still says .none (do not
+        // retry the identical prompt). The two systems are orthogonal.
+        let overflow = httpError(413, body: "prompt is too long")
+        XCTAssertEqual(RetryClassifier.classify(overflow), .none)
+        XCTAssertTrue(ContextOverflowDetector.isContextOverflow(overflow))
+
+        // A 429 is still rate-limited for the classifier and NOT overflow for the detector.
+        let rateLimited = httpError(429, body: "slow down")
+        XCTAssertEqual(RetryClassifier.classify(rateLimited), .rateLimited)
+        XCTAssertFalse(ContextOverflowDetector.isContextOverflow(rateLimited))
+    }
+
+    // MARK: - Proactive token threshold
+
+    func testProactiveSignalTripsAtOrAboveLimit() {
+        XCTAssertEqual(ContextOverflowDetector.proactiveSignal(estimatedTokens: 100, limit: 100), .tokenThreshold)
+        XCTAssertEqual(ContextOverflowDetector.proactiveSignal(estimatedTokens: 101, limit: 100), .tokenThreshold)
+    }
+
+    func testProactiveSignalBelowLimitIsNil() {
+        XCTAssertNil(ContextOverflowDetector.proactiveSignal(estimatedTokens: 99, limit: 100))
+    }
+
+    func testProactiveSignalWithNonPositiveLimitIsDisabled() {
+        XCTAssertNil(ContextOverflowDetector.proactiveSignal(estimatedTokens: 1_000_000, limit: 0))
+        XCTAssertNil(ContextOverflowDetector.proactiveSignal(estimatedTokens: 1_000_000, limit: -1))
+    }
+
+    // MARK: - Robustness on huge / empty bodies
+
+    func testHugeBodyDoesNotTrapAndStillDetectsEarlyMarker() {
+        let body = #"{"error":{"code":"context_length_exceeded"}}"# + String(repeating: "x", count: 2_000_000)
+        XCTAssertEqual(ContextOverflowDetector.signal(for: httpError(400, body: body)), .machineCode)
+    }
+
+    func testHugeBodyWithNoMarkerIsNotOverflow() {
+        let body = String(repeating: "x", count: 2_000_000)
+        XCTAssertNil(ContextOverflowDetector.signal(for: httpError(400, body: body)))
+    }
+
+    func testEmptyBodyNon413IsNotOverflow() {
+        XCTAssertNil(ContextOverflowDetector.signal(for: httpError(400, body: "")))
+    }
+}

--- a/Tests/QuillCodeAgentTests/ContextTokenEstimatorTests.swift
+++ b/Tests/QuillCodeAgentTests/ContextTokenEstimatorTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+final class ContextTokenEstimatorTests: XCTestCase {
+    func testEmptyThreadIsZero() {
+        XCTAssertEqual(ContextTokenEstimator.estimatedTokens(for: ChatThread()), 0)
+    }
+
+    func testEmptyMessageListIsZero() {
+        XCTAssertEqual(ContextTokenEstimator.estimatedTokens(for: [ChatMessage]()), 0)
+    }
+
+    func testGrowsMonotonicallyWithContent() {
+        let short = [ChatMessage(role: .user, content: "hi")]
+        let long = [ChatMessage(role: .user, content: String(repeating: "word ", count: 1_000))]
+        XCTAssertLessThan(
+            ContextTokenEstimator.estimatedTokens(for: short),
+            ContextTokenEstimator.estimatedTokens(for: long)
+        )
+    }
+
+    func testPerMessageOverheadCounted() {
+        // Many empty messages still cost overhead, so an empty-content thread of N messages is > 0.
+        let messages = (0..<10).map { _ in ChatMessage(role: .user, content: "") }
+        XCTAssertEqual(
+            ContextTokenEstimator.estimatedTokens(for: messages),
+            10 * ContextTokenEstimator.perMessageOverheadTokens
+        )
+    }
+
+    func testSingleTextEstimateRoundsUp() {
+        // 5 chars / 4 per token, rounded up = 2 tokens.
+        XCTAssertEqual(ContextTokenEstimator.estimatedTokens(forText: "hello"), 2)
+        XCTAssertEqual(ContextTokenEstimator.estimatedTokens(forText: ""), 0)
+    }
+
+    func testHugeContentDoesNotTrapAndIsBounded() {
+        // A single multi-megabyte message: must return a large finite value, never crash.
+        let huge = ChatMessage(role: .tool, content: String(repeating: "a", count: 5_000_000))
+        let estimate = ContextTokenEstimator.estimatedTokens(for: [huge])
+        XCTAssertGreaterThan(estimate, 1_000_000)
+        XCTAssertLessThanOrEqual(estimate, ContextTokenEstimator.maxEstimatedTokens)
+    }
+
+    func testEstimateClampsAtCeiling() {
+        // Enough giant messages to blow past the ceiling; the estimator must clamp, not overflow.
+        let giant = ChatMessage(role: .tool, content: String(repeating: "a", count: 5_000_000))
+        let messages = Array(repeating: giant, count: 2_000)
+        XCTAssertEqual(
+            ContextTokenEstimator.estimatedTokens(for: messages),
+            ContextTokenEstimator.maxEstimatedTokens
+        )
+    }
+}

--- a/Tests/QuillCodeAgentTests/ThreadCompactorTests.swift
+++ b/Tests/QuillCodeAgentTests/ThreadCompactorTests.swift
@@ -1,0 +1,276 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// A summarizer that returns a fixed marker string, so a test can assert the summary landed exactly
+/// where the older turns were.
+private struct FixedSummarizer: ThreadCompactionSummarizing {
+    var text: String
+    func summarize(sourceTitle: String, olderMessages: [ChatMessage], recentMessages: [ChatMessage]) async throws -> String {
+        text
+    }
+}
+
+/// A summarizer that always throws, to exercise the deterministic fallback.
+private struct ThrowingSummarizer: ThreadCompactionSummarizing {
+    struct Boom: Error {}
+    func summarize(sourceTitle: String, olderMessages: [ChatMessage], recentMessages: [ChatMessage]) async throws -> String {
+        throw Boom()
+    }
+}
+
+/// A summarizer that returns only whitespace, to exercise the empty-summary fallback.
+private struct BlankSummarizer: ThreadCompactionSummarizing {
+    func summarize(sourceTitle: String, olderMessages: [ChatMessage], recentMessages: [ChatMessage]) async throws -> String {
+        "   \n  "
+    }
+}
+
+final class ThreadCompactorTests: XCTestCase {
+    private func thread(_ messages: [ChatMessage], title: String = "Source") -> ChatThread {
+        ChatThread(title: title, messages: messages)
+    }
+
+    private func conversation(pairs: Int) -> [ChatMessage] {
+        var messages: [ChatMessage] = []
+        for i in 0..<pairs {
+            messages.append(ChatMessage(role: .user, content: "user turn \(i)"))
+            messages.append(ChatMessage(role: .assistant, content: "assistant turn \(i)"))
+        }
+        return messages
+    }
+
+    // MARK: - Summarize + splice
+
+    func testCompactSummarizesOlderAndKeepsRecent() async {
+        let compactor = ThreadCompactor(
+            keepRecentMessages: 4,
+            perMessageTokenFloor: 0,
+            summarizer: FixedSummarizer(text: "SUMMARY")
+        )
+        var t = thread(conversation(pairs: 10)) // 20 messages
+        let result = await compactor.compact(&t)
+
+        guard case .compacted(let count, let usedModel, let truncated) = result else {
+            return XCTFail("expected .compacted, got \(result)")
+        }
+        XCTAssertEqual(count, 16) // 20 - 4 recent
+        XCTAssertTrue(usedModel)
+        XCTAssertFalse(truncated)
+
+        // First message is now the summary; the last 4 originals are preserved verbatim.
+        XCTAssertEqual(t.messages.first?.content, "SUMMARY")
+        XCTAssertEqual(t.messages.first?.role, .assistant)
+        XCTAssertEqual(t.messages.count, 5) // summary + 4 recent
+        XCTAssertEqual(t.messages.suffix(4).map(\.content), [
+            "user turn 8", "assistant turn 8", "user turn 9", "assistant turn 9",
+        ])
+    }
+
+    func testCompactPreservesLeadingSystemMessages() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 2, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var messages = [ChatMessage(role: .system, content: "SYSTEM ANCHOR")]
+        messages.append(contentsOf: conversation(pairs: 5))
+        var t = thread(messages)
+        _ = await compactor.compact(&t)
+
+        XCTAssertEqual(t.messages.first?.role, .system)
+        XCTAssertEqual(t.messages.first?.content, "SYSTEM ANCHOR")
+        XCTAssertEqual(t.messages[1].content, "SUM") // summary after the system anchor
+    }
+
+    // MARK: - Never drop the current user request
+
+    func testCurrentUserRequestNeverDroppedEvenBeyondRecentWindow() async {
+        // A long run: the last user message sits well before the recent window, but a trailing tool
+        // exchange fills the window. Compaction must pull the window back to keep the user request.
+        let compactor = ThreadCompactor(keepRecentMessages: 2, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var messages = conversation(pairs: 5)
+        messages.append(ChatMessage(role: .user, content: "THE CURRENT REQUEST"))
+        messages.append(ChatMessage(role: .assistant, content: "working on it"))
+        messages.append(ChatMessage(role: .tool, content: "tool output 1"))
+        messages.append(ChatMessage(role: .tool, content: "tool output 2"))
+        var t = thread(messages)
+        _ = await compactor.compact(&t)
+
+        XCTAssertTrue(
+            t.messages.contains { $0.role == .user && $0.content == "THE CURRENT REQUEST" },
+            "the current user request must survive compaction"
+        )
+    }
+
+    // MARK: - Never orphan an active tool exchange
+
+    func testRecentTailNeverBeginsOnOrphanedToolMessage() async {
+        // The window falls right after the last user message so the user-message pullback does not
+        // confound this: the tail would begin on a .tool result, and the compactor must walk it back
+        // to the assistant call that produced it.
+        let compactor = ThreadCompactor(keepRecentMessages: 2, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var messages = conversation(pairs: 5)
+        messages.append(ChatMessage(role: .user, content: "do the thing"))
+        messages.append(ChatMessage(role: .assistant, content: "calling a tool"))
+        messages.append(ChatMessage(role: .tool, content: "tool result A"))
+        messages.append(ChatMessage(role: .tool, content: "tool result B"))
+        var t = thread(messages)
+        _ = await compactor.compact(&t)
+
+        // The first preserved non-summary/non-system message must not be a stranded .tool result.
+        let preserved = t.messages.drop { $0.role == .system }.dropFirst() // drop summary
+        XCTAssertNotEqual(preserved.first?.role, .tool, "tail must not begin on an orphaned tool message")
+        // Both the user request and the assistant tool call are preserved together with their results.
+        XCTAssertTrue(preserved.contains { $0.content == "do the thing" })
+        XCTAssertTrue(preserved.contains { $0.content == "calling a tool" })
+    }
+
+    // MARK: - Deterministic fallback
+
+    func testFallsBackToDeterministicSummaryWhenModelThrows() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 2, perMessageTokenFloor: 0,
+                                        summarizer: ThrowingSummarizer())
+        var t = thread(conversation(pairs: 5))
+        let result = await compactor.compact(&t)
+
+        guard case .compacted(_, let usedModel, _) = result else {
+            return XCTFail("expected .compacted")
+        }
+        XCTAssertFalse(usedModel, "throwing summarizer must fall back to deterministic")
+        XCTAssertTrue(t.messages.first?.content.contains("Context compacted from") ?? false)
+    }
+
+    func testFallsBackToDeterministicSummaryWhenModelReturnsBlank() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 2, perMessageTokenFloor: 0,
+                                        summarizer: BlankSummarizer())
+        var t = thread(conversation(pairs: 5))
+        let result = await compactor.compact(&t)
+        guard case .compacted(_, let usedModel, _) = result else {
+            return XCTFail("expected .compacted")
+        }
+        XCTAssertFalse(usedModel)
+    }
+
+    // MARK: - Idempotence / termination floor
+
+    func testNoOlderTurnsWhenNothingToFold() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 6, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var t = thread(conversation(pairs: 2)) // 4 messages, all within the recent window
+        let result = await compactor.compact(&t)
+        XCTAssertEqual(result, .noOlderTurns)
+        // Thread untouched: no summary spliced.
+        XCTAssertFalse(t.messages.contains { $0.content == "SUM" })
+    }
+
+    func testSecondCompactionOnAlreadyCompactedThreadReportsNoOlderTurns() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 4, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var t = thread(conversation(pairs: 10))
+        let first = await compactor.compact(&t) // now: summary + 4 recent = 5 messages
+        guard case .compacted = first else { return XCTFail("first compaction should fold") }
+        // A second compaction has only the single prior summary as "older" (1 < minOlderToFold), so it
+        // must report noOlderTurns rather than re-summarizing its own summary forever.
+        let second = await compactor.compact(&t)
+        XCTAssertEqual(second, .noOlderTurns, "compaction must terminate, not fold its own summary forever")
+        XCTAssertEqual(t.messages.filter { $0.content == "SUM" }.count, 1, "no second summary spliced")
+    }
+
+    func testCompactionTerminatesAcrossManyRoundsRegardlessOfThreadShape() async {
+        // Stress the termination invariant: repeatedly compacting must reach noOlderTurns in a bounded
+        // number of rounds for any starting thread, never loop.
+        let compactor = ThreadCompactor(keepRecentMessages: 3, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var t = thread(conversation(pairs: 20))
+        var rounds = 0
+        while rounds < 100 {
+            let result = await compactor.compact(&t)
+            rounds += 1
+            if result == .noOlderTurns { break }
+        }
+        XCTAssertLessThan(rounds, 100, "compaction must terminate quickly, not spin")
+        let finalResult = await compactor.compact(&t)
+        XCTAssertEqual(finalResult, .noOlderTurns)
+    }
+
+    // MARK: - Last-resort truncation
+
+    func testLastResortTruncationOfOversizedKeptMessage() async {
+        // A single giant tool result in the recent window: even with nothing older, the floor must
+        // front-truncate it (keeping the tail) and mark it.
+        let floorTokens = 100
+        let compactor = ThreadCompactor(keepRecentMessages: 2, perMessageTokenFloor: floorTokens,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        let giant = String(repeating: "Z", count: 100_000) + "TAIL_MARKER"
+        var messages = conversation(pairs: 5)
+        messages.append(ChatMessage(role: .tool, content: giant))
+        var t = thread(messages)
+        let result = await compactor.compact(&t)
+
+        guard case .compacted(_, _, let truncated) = result else {
+            return XCTFail("expected .compacted")
+        }
+        XCTAssertTrue(truncated)
+        let last = t.messages.last?.content ?? ""
+        XCTAssertTrue(last.hasPrefix(ThreadCompactor.truncationMarker), "truncation must be marked")
+        XCTAssertTrue(last.hasSuffix("TAIL_MARKER"), "truncation keeps the tail")
+        XCTAssertLessThan(last.count, giant.count)
+    }
+
+    func testTruncationDisabledWhenFloorIsZero() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 2, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        let giant = String(repeating: "Z", count: 100_000)
+        var t = thread([ChatMessage(role: .tool, content: giant)])
+        let result = await compactor.compact(&t)
+        // Only one message, within the recent window → nothing older; floor disabled → untouched.
+        XCTAssertEqual(result, .noOlderTurns)
+        XCTAssertEqual(t.messages.last?.content.count, giant.count)
+    }
+
+    // MARK: - Seam annotation
+
+    func testSeamNoticeRecordedOnCompaction() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 4, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var t = thread(conversation(pairs: 10))
+        _ = await compactor.compact(&t)
+
+        let notice = t.events.last
+        XCTAssertEqual(notice?.kind, .notice)
+        XCTAssertTrue(notice?.summary.contains("Compacted") ?? false)
+        // Payload is machine-readable for the transcript.
+        let payloadJSON = notice?.payloadJSON ?? ""
+        let payload = try? JSONHelpers.decode(CompactionSeamPayload.self, from: payloadJSON)
+        XCTAssertEqual(payload?.summarizedTurns, 16)
+        XCTAssertEqual(payload?.usedModelSummary, true)
+    }
+
+    func testNoSeamNoticeWhenNothingHappens() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 6, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var t = thread(conversation(pairs: 2))
+        let eventsBefore = t.events.count
+        _ = await compactor.compact(&t)
+        XCTAssertEqual(t.events.count, eventsBefore, "a no-op compaction must not spam a seam event")
+    }
+
+    // MARK: - Robustness
+
+    func testEmptyThreadCompactsToNoOlderTurns() async {
+        let compactor = ThreadCompactor(summarizer: FixedSummarizer(text: "SUM"))
+        var t = thread([])
+        let result = await compactor.compact(&t)
+        XCTAssertEqual(result, .noOlderTurns)
+        XCTAssertTrue(t.messages.isEmpty)
+    }
+
+    func testKeepRecentClampedToAtLeastOne() async {
+        let compactor = ThreadCompactor(keepRecentMessages: 0, perMessageTokenFloor: 0,
+                                        summarizer: FixedSummarizer(text: "SUM"))
+        var t = thread(conversation(pairs: 3))
+        _ = await compactor.compact(&t)
+        // At least the last message must be preserved.
+        XCTAssertEqual(t.messages.last?.content, "assistant turn 2")
+    }
+}


### PR DESCRIPTION
## What & why

An unattended multi-hour QuillCode run previously surfaced context overflow only as a **diagnostic** and then **failed** at the context wall — exactly the north-star unattended-loop scenario the run loop is meant to survive. This PR adds uniform overflow **detection** plus an in-loop **compaction** step that summarizes the oldest turns and **resumes** the run instead of dying.

Fixes #862.

## Detection seam — `ContextOverflowDetector`

Normalizes the several dialects the gateway and providers speak into **one** typed decision:
- HTTP **413** (payload too large — for a chat request the only thing "too large" is the prompt)
- machine codes in the error body: `context_length_exceeded`, `type=context_overflow`, `context_window_exceeded`, `context_length_error`
- provider prose: "maximum context length", "prompt is too long", "too many tokens", "exceeds the context", …
- a proactive **token-count threshold** (compact *before* a failing round-trip)

Deliberately conservative: a bare 400/401/429/500, or a body that merely mentions "tokens" (usage accounting), does **not** misfire. It composes **alongside** `RetryClassifier` without changing its behavior — an overflow stays terminal for *retry* (re-sending the identical prompt would overflow identically); it is handled by compaction instead. That is why the hook lives in `AgentRunner.send()` (where the thread can be mutated between attempts), **not** in the retry decorator.

## Compaction algorithm — `ThreadCompactor`

Folds the oldest turns into a single durable **summary message**, splicing it in place while preserving:
- leading **system** anchors,
- the most recent turns,
- the **current user request** (the recent window is extended back to include the last user message — never orphaned),
- any **active tool exchange** (the tail never begins on an orphaned `.tool` result; it is walked back to the assistant call that produced it).

It **reuses the cheap auxiliary-model path** merged in #855/#857 — prompt caching disabled (`disablingPromptCaching`), aux model chosen via `AuxiliaryModelSelector` — mirroring the app-layer summary infra but implemented in the agent layer so it can resume the run loop (the app target depends on the agent target, not vice-versa). If the summary model is unreachable it falls back to a **deterministic model-free summary**, so a run never dies because summarization failed.

## Where it hooks the run loop

`AgentRunner.send()` now calls `nextActionCompactingOnOverflow(...)` instead of `nextAction(...)`. With no `AgentCompactionPolicy` configured it is a straight pass-through (mock runtime and existing callers behave exactly as before). With a policy:
- **proactive**: if the assembled thread is already over the token threshold, compact before the call;
- **reactive**: if the call throws a recognized overflow, compact and retry, bounded by `maxRoundsPerCall`.

The trusted-router runtime (`RuntimeFactory`) enables it reactive-only by default, reusing the same caching-disabled summary client.

## Termination & robustness (the parts reviewers attack)

- **No infinite loop**: reactive rounds are capped by `maxRoundsPerCall`, and compaction reports `.noOlderTurns` the moment fewer than 2 messages remain to fold — the invariant that makes every successful compaction *strictly* shrink the thread. When context still can't be reduced, the run stops with a clear `ContextOverflowUnresolvedError` instead of looping or leaking the raw provider error.
- **Last-resort truncation**: a single oversized kept message (a giant tool result) is front-truncated (keeping the tail) with an explicit marker, so one turn can't defeat compaction.
- **Never drops the current request or active tool call** (see partition logic above).
- **Total token estimation**: saturating integer math + prefix-only slicing, so it never traps on huge/empty content.
- **No force-unwraps.**

A `.notice` thread event records each "compacted N turns" seam with an auditable JSON payload (`CompactionSeamPayload`), following the existing thread-event/telemetry pattern.

## Test evidence

New tests in `Tests/QuillCodeAgentTests/`:
- `ContextOverflowDetectorTests` — each signal normalizes to overflow; no misfire on benign 413/400/401/429/500 or token-mentioning bodies; huge/empty bodies don't trap; RetryClassifier behavior verified unchanged.
- `ContextTokenEstimatorTests` — bounded and total on multi-megabyte / millions-of-messages input.
- `ThreadCompactorTests` — summarize+splice; preserves current request + tool exchange; deterministic fallback (throw and blank); last-resort truncation; provable termination across many rounds; seam annotation.
- `AgentCompactionRunLoopTests` — injects a mock LLM that **overflows on the first call then succeeds after compaction**; asserts the run resumes and finishes, the thread shrinks between attempts, termination under unbounded overflow (bounded call count), and that a non-overflow (401) error is **not** swallowed.

Results (macOS, `swift test`):
- `QuillCodeAgentTests`: **342 passed, 0 failures**
- `QuillCodeAppTests`: **1299 passed, 0 failures**
- Full suite: **2617 tests, 2 skipped, 0 failures**

No Linux docker build script is present in `scripts/` (only `build-macos-app.sh`), so no docker build was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)