### PR TITLE
LSP tool + write-triggered diagnostics feedback + auto-format-on-save (#863)

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -28,6 +28,12 @@ public struct AgentRunner: Sendable {
     /// nil disables compaction entirely (the mock runtime, and any caller that opts out) — the run
     /// then behaves exactly as before, surfacing an overflow error instead of compacting.
     public var compaction: AgentCompactionPolicy?
+    /// LSP integration for the workspace (issue #863): after every write/apply_patch it feeds
+    /// project-wide diagnostics back to the model and (opt-in) auto-formats on save, and it backs the
+    /// `host.lsp.*` navigation tools. A single shared instance persists the language-server process
+    /// across tool steps. nil (the default, and the mock runtime) disables every LSP behavior — writes
+    /// behave exactly as before and the nav tools report "not available".
+    public var lsp: LSPCoordinator?
 
     public init(
         llm: LLMClient = MockLLMClient(),
@@ -39,7 +45,8 @@ public struct AgentRunner: Sendable {
         maxToolSteps: Int = AgentRunner.defaultMaxToolSteps,
         enablesImmediateActionPreflight: Bool = false,
         workspaceStateSignature: (@Sendable (URL) -> String)? = nil,
-        compaction: AgentCompactionPolicy? = nil
+        compaction: AgentCompactionPolicy? = nil,
+        lsp: LSPCoordinator? = nil
     ) {
         self.llm = llm
         self.safety = safety
@@ -51,6 +58,7 @@ public struct AgentRunner: Sendable {
         self.enablesImmediateActionPreflight = enablesImmediateActionPreflight
         self.workspaceStateSignature = workspaceStateSignature
         self.compaction = compaction
+        self.lsp = lsp
     }
 
     public func send(

--- a/Sources/QuillCodeAgent/AgentToolStepRunner.swift
+++ b/Sources/QuillCodeAgent/AgentToolStepRunner.swift
@@ -26,7 +26,7 @@ extension AgentRunner {
     ) async throws -> AgentToolStep {
         // The edit guard is scoped to THIS thread's model context: only files whose content
         // entered this thread (read or written here) may be overwritten/patched here.
-        let router = ToolRouter(workspaceRoot: workspaceRoot, editGuard: .session(for: thread.id))
+        let router = ToolRouter(workspaceRoot: workspaceRoot, editGuard: .session(for: thread.id), lsp: lsp)
         let definition = toolDefinitions.first { $0.name == call.name }
         await appendQueuedEvent(for: call, to: &thread, onProgress: onProgress)
 

--- a/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
@@ -62,7 +62,7 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
     }
 
     private var configuredRunner: AgentRunner {
-        WorkspaceAgentRunContextBuilder(
+        var runner = WorkspaceAgentRunContextBuilder(
             selectedProject: selectedProject,
             config: config,
             browser: browser,
@@ -74,5 +74,14 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
             sshRemoteShellExecutor: sshRemoteShellExecutor,
             permissionRules: permissionRules
         ).configuredRunner(from: baseRunner)
+        // Attach the (opt-in) per-workspace LSP coordinator so writes get diagnostics-after-write +
+        // format-on-save and the host.lsp.* tools work. The coordinator is cached per workspace so the
+        // language server persists across sends; nil (feature off / remote project) leaves the runner
+        // exactly as configured above.
+        runner.lsp = WorkspaceLSPCoordinatorProvider.shared.coordinator(
+            forWorkspace: workspaceRoot,
+            isRemote: selectedProject?.isRemote == true
+        )
+        return runner
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceLSPCoordinatorProvider.swift
+++ b/Sources/QuillCodeApp/WorkspaceLSPCoordinatorProvider.swift
@@ -1,0 +1,61 @@
+import Foundation
+import QuillCodeTools
+
+/// Process-wide, workspace-keyed cache of `LSPCoordinator`s. The coordinator holds a live
+/// language-server subprocess, so it MUST persist across the many per-send `AgentRunner`s a workspace
+/// produces — recreating it each send would relaunch sourcekit-lsp on every write. Keyed by the
+/// standardized workspace path; one coordinator (and thus one server) per workspace.
+///
+/// The whole LSP surface is opt-in: `coordinator(forWorkspace:)` returns `nil` unless the
+/// `QUILLCODE_LSP` environment flag is set, so the shipped default behavior is exactly as before
+/// until a user turns it on. `QUILLCODE_LSP_FORMAT` additionally enables auto-format-on-save.
+public final class WorkspaceLSPCoordinatorProvider: @unchecked Sendable {
+    public static let shared = WorkspaceLSPCoordinatorProvider()
+
+    private let lock = NSLock()
+    private var coordinators: [String: LSPCoordinator] = [:]
+    private let environment: [String: String]
+
+    public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.environment = environment
+    }
+
+    /// The coordinator for a workspace, or `nil` when the feature is disabled. Local (non-remote)
+    /// workspaces only — a remote project's files are not on this machine's filesystem, so a local
+    /// language server cannot see them.
+    public func coordinator(forWorkspace root: URL, isRemote: Bool) -> LSPCoordinator? {
+        guard isEnabled, !isRemote else { return nil }
+        let key = root.standardizedFileURL.path
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = coordinators[key] { return existing }
+        let coordinator = LSPCoordinator(workspaceRoot: root, formatOnSave: formatOnSave)
+        coordinators[key] = coordinator
+        return coordinator
+    }
+
+    /// Tears down every cached coordinator (and its server process). Call on app shutdown.
+    public func shutdownAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        for coordinator in coordinators.values {
+            coordinator.shutdown()
+        }
+        coordinators.removeAll()
+    }
+
+    private var isEnabled: Bool {
+        flag("QUILLCODE_LSP")
+    }
+
+    private var formatOnSave: Bool {
+        flag("QUILLCODE_LSP_FORMAT")
+    }
+
+    private func flag(_ name: String) -> Bool {
+        switch environment[name]?.lowercased() {
+        case "1", "true", "yes": return true
+        default: return false
+        }
+    }
+}

--- a/Sources/QuillCodeTools/LSPClient.swift
+++ b/Sources/QuillCodeTools/LSPClient.swift
@@ -1,0 +1,369 @@
+import Foundation
+
+/// A synchronous JSON-RPC 2.0 client for a single language-server process, speaking over an injected
+/// `LSPTransport`. Modeled on `MCPStdioProber`: one `NSLock` serializes every exchange, request ids
+/// increment monotonically, and responses are correlated by id with a wall-clock deadline so a
+/// silent server times out instead of hanging the agent.
+///
+/// The client is deliberately *blocking* — the tool router that drives it is itself synchronous, and
+/// LSP exchanges (definition, diagnostics) are short. Read loops always honor a deadline and treat
+/// EOF as a terminal `serverClosed` error, so there is no path that spins forever.
+///
+/// Notifications the server pushes unsolicited (chiefly `textDocument/publishDiagnostics`) are
+/// drained off the same stream while waiting for a response and stashed per-URI, so a later
+/// `diagnostics(for:)` call reads the latest set without another round trip.
+public final class LSPClient: @unchecked Sendable {
+    private let transport: LSPTransport
+    private let lock = NSLock()
+
+    private var buffer = Data()
+    private var nextID = 1
+    private var initialized = false
+    private var latestDiagnostics: [String: [LSPDiagnostic]] = [:]
+    /// Capabilities the server advertised at initialize, so we can skip requests it does not support
+    /// (e.g. formatting) instead of paying a round trip for a guaranteed "method not found".
+    private(set) var serverCapabilities: [String: Any] = [:]
+
+    public init(transport: LSPTransport) {
+        self.transport = transport
+    }
+
+    // MARK: Handshake
+
+    /// Performs the `initialize` / `initialized` handshake, advertising the workspace root and the
+    /// capabilities we actually use. Safe to call once; a second call is a no-op.
+    @discardableResult
+    public func initialize(workspaceRoot: URL, timeout: TimeInterval = 10.0) throws -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !initialized else { return serverCapabilities }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        let id = nextRequestID()
+        let rootURI = LSPURI.from(path: workspaceRoot.standardizedFileURL.path)
+        try writeRequest(id: id, method: "initialize", params: [
+            "processId": Int(ProcessInfo.processInfo.processIdentifier),
+            "rootUri": rootURI,
+            "workspaceFolders": [["uri": rootURI, "name": workspaceRoot.lastPathComponent]],
+            "capabilities": clientCapabilities(),
+            "clientInfo": ["name": "QuillCode", "version": "0.1.0"]
+        ])
+        let response = try awaitResponse(id: id, deadline: deadline)
+        let result = try resultObject(from: response)
+        serverCapabilities = (result["capabilities"] as? [String: Any]) ?? [:]
+        try writeNotification(method: "initialized", params: [:])
+        initialized = true
+        return serverCapabilities
+    }
+
+    /// Whether the server advertised `documentFormattingProvider`.
+    public var supportsFormatting: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return capabilityIsTrue(serverCapabilities["documentFormattingProvider"])
+    }
+
+    // MARK: Document lifecycle
+
+    /// Announces a document to the server. `didOpen` must precede any request that references it, and
+    /// resends on every write keep the server's view of the file current (`didChange` requires the
+    /// server to track incremental state; a fresh `didOpen` with the full text is simpler and equally
+    /// correct for our request/response usage).
+    public func didOpen(path: String, text: String, languageID: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        try writeNotification(method: "textDocument/didOpen", params: [
+            "textDocument": [
+                "uri": LSPURI.from(path: path),
+                "languageId": languageID,
+                "version": 1,
+                "text": text
+            ]
+        ])
+    }
+
+    /// Notifies the server the document was saved. Some servers only recompute diagnostics on save.
+    public func didSave(path: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        try writeNotification(method: "textDocument/didSave", params: [
+            "textDocument": ["uri": LSPURI.from(path: path)]
+        ])
+    }
+
+    // MARK: Requests
+
+    /// `textDocument/definition`.
+    public func definition(path: String, line: Int, character: Int, timeout: TimeInterval = 5.0) throws -> [LSPLocation] {
+        let result = try request(
+            method: "textDocument/definition",
+            params: positionParams(path: path, line: line, character: character),
+            timeout: timeout
+        )
+        return LSPLocation.parseList(result)
+    }
+
+    /// `textDocument/references`.
+    public func references(path: String, line: Int, character: Int, includeDeclaration: Bool = true, timeout: TimeInterval = 5.0) throws -> [LSPLocation] {
+        var params = positionParams(path: path, line: line, character: character)
+        params["context"] = ["includeDeclaration": includeDeclaration]
+        let result = try request(method: "textDocument/references", params: params, timeout: timeout)
+        return LSPLocation.parseList(result)
+    }
+
+    /// `textDocument/hover`, flattened to plain text.
+    public func hover(path: String, line: Int, character: Int, timeout: TimeInterval = 5.0) throws -> String? {
+        let result = try request(
+            method: "textDocument/hover",
+            params: positionParams(path: path, line: line, character: character),
+            timeout: timeout
+        )
+        return LSPHoverText.extract(from: result)
+    }
+
+    /// `textDocument/documentSymbol` — the symbols defined in one file.
+    public func documentSymbols(path: String, timeout: TimeInterval = 5.0) throws -> [LSPSymbol] {
+        let result = try request(
+            method: "textDocument/documentSymbol",
+            params: ["textDocument": ["uri": LSPURI.from(path: path)]],
+            timeout: timeout
+        )
+        return LSPSymbolParser.documentSymbols(from: result, uri: LSPURI.from(path: path))
+    }
+
+    /// `workspace/symbol` — project-wide symbol search by name.
+    public func workspaceSymbols(query: String, timeout: TimeInterval = 5.0) throws -> [LSPSymbol] {
+        let result = try request(method: "workspace/symbol", params: ["query": query], timeout: timeout)
+        return LSPSymbolParser.workspaceSymbols(from: result)
+    }
+
+    /// `textDocument/formatting`. Returns the ordered text edits the server would apply, or an empty
+    /// array when the file is already formatted. `nil` capability check is the caller's job via
+    /// `supportsFormatting`.
+    public func formatting(path: String, tabSize: Int = 4, insertSpaces: Bool = true, timeout: TimeInterval = 5.0) throws -> [LSPTextEdit] {
+        let result = try request(method: "textDocument/formatting", params: [
+            "textDocument": ["uri": LSPURI.from(path: path)],
+            "options": ["tabSize": tabSize, "insertSpaces": insertSpaces]
+        ], timeout: timeout)
+        return LSPTextEdit.parseList(result)
+    }
+
+    /// The most recent diagnostics the server published for a file, draining any pending
+    /// notifications up to `waitFor` first so freshly-computed diagnostics after a save are captured.
+    ///
+    /// To keep the after-write latency low, once the edited file receives a *fresh* publish (one that
+    /// arrived during this wait) we drain only a short additional grace window for project-wide
+    /// diagnostics that typically follow, rather than always blocking the full `waitFor`.
+    public func diagnostics(for path: String, waitFor: TimeInterval = 1.5) -> [LSPDiagnostic] {
+        lock.lock()
+        defer { lock.unlock() }
+        let uri = Self.canonicalKey(forPath: path)
+        let deadline = Date().addingTimeInterval(waitFor)
+        // A `nil` here means "no publish yet"; a value that changes marks a fresh publish for the file.
+        let baseline = latestDiagnostics[uri]
+        var graceDeadline: Date?
+        // Pump the stream for pending publishDiagnostics without blocking on a response id.
+        while Date() < deadline {
+            do {
+                guard try pumpOnce(deadline: deadline) else { break }
+            } catch {
+                break // stream error: return whatever we have; never propagate into a write result
+            }
+            // Once the edited file gets a fresh publish, allow a brief grace window for follow-on
+            // (cross-file) diagnostics, then stop early instead of waiting out the full deadline.
+            if graceDeadline == nil, freshlyPublished(uri, baseline: baseline) {
+                graceDeadline = min(deadline, Date().addingTimeInterval(0.3))
+            }
+            if let graceDeadline, Date() >= graceDeadline { break }
+        }
+        return latestDiagnostics[uri] ?? []
+    }
+
+    /// All diagnostics currently known, keyed by absolute file path. Used by diagnostics-after-write
+    /// to report *project-wide* breakage, not just the edited file.
+    public func allDiagnostics() -> [String: [LSPDiagnostic]] {
+        lock.lock()
+        defer { lock.unlock() }
+        // Keys are already canonical filesystem paths (see handleServerMessage).
+        return latestDiagnostics
+    }
+
+    /// Attempts a clean `shutdown`/`exit` handshake, then closes the transport so the child receives
+    /// EOF on stdin and its pipe fds are released. Best-effort — a crashed server just gets its process
+    /// killed by the session manager, and `closeTransport()` still frees our fds.
+    public func shutdown(timeout: TimeInterval = 2.0) {
+        lock.lock()
+        defer { lock.unlock() }
+        if initialized {
+            let id = nextRequestID()
+            try? writeRequest(id: id, method: "shutdown", params: [:])
+            _ = try? awaitResponse(id: id, deadline: Date().addingTimeInterval(timeout))
+            try? writeNotification(method: "exit", params: [:])
+            initialized = false
+        }
+        transport.close()
+    }
+
+    /// Closes the transport without the handshake — for a session being torn down because its process
+    /// already died (a clean shutdown would just time out). Releases our stdin/stdout fds.
+    public func closeTransport() {
+        lock.lock()
+        defer { lock.unlock() }
+        initialized = false
+        transport.close()
+    }
+
+    // MARK: Core request/response
+
+    private func request(method: String, params: [String: Any], timeout: TimeInterval) throws -> Any? {
+        lock.lock()
+        defer { lock.unlock() }
+        let deadline = Date().addingTimeInterval(timeout)
+        let id = nextRequestID()
+        try writeRequest(id: id, method: method, params: params)
+        let response = try awaitResponse(id: id, deadline: deadline)
+        return try resultValue(from: response)
+    }
+
+    /// Reads framed messages until the response for `id` arrives or the deadline passes. Server-push
+    /// notifications seen along the way are handled (diagnostics stashed) and skipped. EOF is a
+    /// terminal error; a timeout with no matching response is `LSPError.timeout`.
+    private func awaitResponse(id: Int, deadline: Date) throws -> [String: Any] {
+        while Date() < deadline {
+            if let message = try nextBufferedMessage() {
+                // A JSON-RPC RESPONSE has an `id` and no `method`. A server->client REQUEST also carries
+                // an `id` (from a SEPARATE id space that can numerically collide with ours), so match on
+                // "has our id AND is not a request" — otherwise a `workspace/configuration` request with
+                // id == ours would be mistaken for our response and yield an empty/garbage result.
+                if message["method"] == nil, let responseID = LSPJSON.int(message["id"]), responseID == id {
+                    return message
+                }
+                handleServerMessage(message)
+                continue
+            }
+            guard try fillBuffer(deadline: deadline) else {
+                throw LSPError.serverClosed("server closed the connection before responding to \(id)")
+            }
+        }
+        throw LSPError.timeout("no response to request \(id) within the deadline")
+    }
+
+    /// One non-blocking step of the read pump: parse a buffered message if present, else try to read
+    /// more. Returns `false` on EOF so a draining loop can stop. Used by `diagnostics(for:)`.
+    private func pumpOnce(deadline: Date) throws -> Bool {
+        if let message = try nextBufferedMessage() {
+            handleServerMessage(message)
+            return true
+        }
+        return try fillBuffer(deadline: deadline)
+    }
+
+    private func nextBufferedMessage() throws -> [String: Any]? {
+        guard let data = try LSPMessageCodec.nextMessage(from: &buffer) else { return nil }
+        return try LSPMessageCodec.decode(data)
+    }
+
+    /// Reads more bytes into the buffer, honoring the deadline. Returns `false` on EOF, `true`
+    /// otherwise (including an empty read on timeout, so the caller re-checks its own deadline).
+    private func fillBuffer(deadline: Date) throws -> Bool {
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { return true }
+        guard let data = try transport.receive(timeout: min(remaining, 0.25)) else {
+            return false // EOF
+        }
+        if !data.isEmpty { buffer.append(data) }
+        return true
+    }
+
+    /// Dispatches an inbound server-originated message. We only act on `publishDiagnostics`; other
+    /// server requests (e.g. `workspace/configuration`) are ignored — sourcekit-lsp tolerates a
+    /// client that does not answer optional server->client requests within our short-lived exchanges.
+    private func handleServerMessage(_ message: [String: Any]) {
+        guard message["method"] as? String == "textDocument/publishDiagnostics",
+              let params = message["params"] as? [String: Any],
+              let uri = params["uri"] as? String
+        else { return }
+        let raw = (params["diagnostics"] as? [[String: Any]]) ?? []
+        // Key by a canonical filesystem path, not the raw URI: a server may percent-encode or
+        // symlink-resolve URIs differently than we construct them (e.g. /private/var vs /var on macOS),
+        // and keying on the raw string would make `diagnostics(for:)` miss its own file.
+        latestDiagnostics[Self.canonicalKey(forURI: uri)] = raw.compactMap { LSPDiagnostic.parse($0) }
+    }
+
+    /// Canonical, symlink-resolved key for a `file://` URI (or the raw URI if it is not a file URL),
+    /// used so a diagnostics store keyed by the server's URI and a lookup keyed by our path agree.
+    private static func canonicalKey(forURI uri: String) -> String {
+        guard let path = LSPURI.path(from: uri) else { return uri }
+        return canonicalKey(forPath: path)
+    }
+
+    /// Canonical, symlink-resolved key for a filesystem path.
+    private static func canonicalKey(forPath path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    private func writeRequest(id: Int, method: String, params: [String: Any]) throws {
+        try transport.send(try LSPMessageCodec.encode([
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params
+        ]))
+    }
+
+    private func writeNotification(method: String, params: [String: Any]) throws {
+        try transport.send(try LSPMessageCodec.encode([
+            "jsonrpc": "2.0", "method": method, "params": params
+        ]))
+    }
+
+    private func resultObject(from response: [String: Any]) throws -> [String: Any] {
+        (try resultValue(from: response) as? [String: Any]) ?? [:]
+    }
+
+    private func resultValue(from response: [String: Any]) throws -> Any? {
+        if let error = response["error"] as? [String: Any] {
+            throw LSPError.serverError(
+                code: LSPJSON.int(error["code"]) ?? -1,
+                message: (error["message"] as? String) ?? "unknown server error"
+            )
+        }
+        return response["result"]
+    }
+
+    private func nextRequestID() -> Int {
+        defer { nextID += 1 }
+        return nextID
+    }
+
+    /// Whether `uri` has received a publish that differs from the `baseline` captured at the start of
+    /// a diagnostics wait — i.e. the server just recomputed diagnostics for the edited file.
+    private func freshlyPublished(_ uri: String, baseline: [LSPDiagnostic]?) -> Bool {
+        guard let current = latestDiagnostics[uri] else { return false }
+        return current != baseline
+    }
+
+    private func positionParams(path: String, line: Int, character: Int) -> [String: Any] {
+        [
+            "textDocument": ["uri": LSPURI.from(path: path)],
+            "position": LSPPosition(line: line, character: character).wire
+        ]
+    }
+
+    private func capabilityIsTrue(_ value: Any?) -> Bool {
+        if let bool = value as? Bool { return bool }
+        // Servers may advertise a provider as an options object rather than a bare `true`.
+        return value is [String: Any]
+    }
+
+    private func clientCapabilities() -> [String: Any] {
+        [
+            "textDocument": [
+                "publishDiagnostics": ["relatedInformation": false],
+                "definition": ["linkSupport": true],
+                "references": [:],
+                "hover": ["contentFormat": ["plaintext", "markdown"]],
+                "documentSymbol": ["hierarchicalDocumentSymbolSupport": true],
+                "formatting": [:]
+            ],
+            "workspace": ["symbol": [:]]
+        ]
+    }
+}

--- a/Sources/QuillCodeTools/LSPClient.swift
+++ b/Sources/QuillCodeTools/LSPClient.swift
@@ -20,12 +20,24 @@ public final class LSPClient: @unchecked Sendable {
     private var nextID = 1
     private var initialized = false
     private var latestDiagnostics: [String: [LSPDiagnostic]] = [:]
+    /// Set once a codec/decode error is hit on the read stream: the framing is desynced and the corrupt
+    /// bytes cannot be safely resynced, so the whole client is dead. The session manager checks this
+    /// (via `isHealthy`) and relaunches, rather than reusing a permanently-wedged client.
+    private var poisoned = false
     /// Capabilities the server advertised at initialize, so we can skip requests it does not support
     /// (e.g. formatting) instead of paying a round trip for a guaranteed "method not found".
     private(set) var serverCapabilities: [String: Any] = [:]
 
     public init(transport: LSPTransport) {
         self.transport = transport
+    }
+
+    /// Whether the client's read stream is still in sync. Once a malformed frame corrupts the framing
+    /// this is `false` forever — the caller must drop and relaunch the session.
+    public var isHealthy: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !poisoned
     }
 
     // MARK: Handshake
@@ -259,8 +271,17 @@ public final class LSPClient: @unchecked Sendable {
     }
 
     private func nextBufferedMessage() throws -> [String: Any]? {
-        guard let data = try LSPMessageCodec.nextMessage(from: &buffer) else { return nil }
-        return try LSPMessageCodec.decode(data)
+        do {
+            guard let data = try LSPMessageCodec.nextMessage(from: &buffer) else { return nil }
+            return try LSPMessageCodec.decode(data)
+        } catch {
+            // A codec/decode failure means the framing is out of sync — the corrupt bytes are still at
+            // the front of the buffer and every future read would re-hit them, permanently wedging the
+            // session. Per LSPMessageCodec's contract, treat the stream as corrupt: mark this client
+            // poisoned so the session manager evicts + relaunches it, and stop parsing.
+            poisoned = true
+            throw error
+        }
     }
 
     /// Reads more bytes into the buffer, honoring the deadline. Returns `false` on EOF, `true`

--- a/Sources/QuillCodeTools/LSPCoordinator.swift
+++ b/Sources/QuillCodeTools/LSPCoordinator.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// The outcome of the post-write LSP pass: an optional notice to append to the write result's
+/// `stdout` (diagnostics and/or a format notice, or a one-time "server unavailable"), and whether the
+/// on-disk file was rewritten by formatting.
+public struct LSPWriteFeedback: Sendable, Equatable {
+    /// Text to append to the tool result, or `nil` when there is nothing to say.
+    public var notice: String?
+    /// True when format-on-save rewrote the file (so the caller can refresh its read-set snapshot).
+    public var didFormat: Bool
+
+    public init(notice: String? = nil, didFormat: Bool = false) {
+        self.notice = notice
+        self.didFormat = didFormat
+    }
+
+    static let empty = LSPWriteFeedback()
+}
+
+/// Drives the two write-triggered LSP behaviors and backs the `host.lsp.*` navigation tool. Holds an
+/// `LSPSessionManager`, so a single coordinator serves an entire workspace across many tool steps.
+///
+/// Every entry point is failure-tolerant: an unavailable/slow/crashed server yields empty feedback
+/// (writes proceed untouched) rather than an error. Format-on-save is off by default and, when on,
+/// is crash-safe — a formatting failure keeps the original file.
+public final class LSPCoordinator: @unchecked Sendable {
+    private let workspaceRoot: URL
+    private let sessions: LSPSessionManager
+    /// Auto-format on save. Opt-in: `false` never touches file contents.
+    private let formatOnSave: Bool
+    /// How long to wait for diagnostics to settle after a save before reporting them.
+    private let diagnosticsWait: TimeInterval
+
+    public init(
+        workspaceRoot: URL,
+        sessions: LSPSessionManager? = nil,
+        formatOnSave: Bool = false,
+        diagnosticsWait: TimeInterval = 1.5
+    ) {
+        self.workspaceRoot = workspaceRoot.standardizedFileURL
+        self.sessions = sessions ?? LSPSessionManager(workspaceRoot: workspaceRoot)
+        self.formatOnSave = formatOnSave
+        self.diagnosticsWait = diagnosticsWait
+    }
+
+    /// Runs format-on-save (if enabled) then collects project-wide diagnostics for the file(s) just
+    /// written. `paths` are absolute paths inside the workspace. Never throws.
+    public func afterWrite(paths: [URL]) -> LSPWriteFeedback {
+        let supported = paths.filter { sessions.hasServer(forPath: $0.path) }
+        guard let primary = supported.first else {
+            return .empty
+        }
+
+        guard let client = sessions.client(forPath: primary.path) else {
+            // Server missing/disabled: emit the one-time notice (once per workspace run) and no-op.
+            let notice = sessions.consumeUnavailableNoticeIfNeeded(forPath: primary.path)
+            return LSPWriteFeedback(notice: notice)
+        }
+
+        var notices: [String] = []
+        var didFormat = false
+
+        for url in supported {
+            guard let languageID = sessions.languageID(forPath: url.path) else { continue }
+
+            // Format first so diagnostics reflect the formatted text the model will see.
+            if formatOnSave, client.supportsFormatting {
+                if let formatNotice = formatFile(url, client: client, languageID: languageID) {
+                    notices.append(formatNotice)
+                    didFormat = true
+                }
+            }
+
+            // Sync the (possibly reformatted) content to the server and prompt a diagnostics pass.
+            syncDocument(url, client: client, languageID: languageID)
+        }
+
+        // Let the server settle, then collect project-wide diagnostics capped at ≤5 files.
+        _ = client.diagnostics(for: primary.path, waitFor: diagnosticsWait)
+        let diagnostics = client.allDiagnostics()
+        if let block = LSPDiagnosticsFormatter.format(
+            diagnosticsByPath: diagnostics,
+            workspaceRoot: workspaceRoot,
+            editedPath: primary.path
+        ) {
+            notices.append(block)
+        }
+
+        let notice = notices.isEmpty ? nil : notices.joined(separator: "\n\n")
+        return LSPWriteFeedback(notice: notice, didFormat: didFormat)
+    }
+
+    /// The navigation tool's client + language for a path, or `nil` if unsupported/unavailable.
+    func navigationClient(forPath path: String) -> (client: LSPClient, languageID: String)? {
+        guard let languageID = sessions.languageID(forPath: path),
+              let client = sessions.client(forPath: path)
+        else { return nil }
+        // Make sure the server knows the file before a position-based request.
+        if let text = try? String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8) {
+            try? client.didOpen(path: path, text: text, languageID: languageID)
+        }
+        return (client, languageID)
+    }
+
+    public func shutdown() { sessions.shutdown() }
+
+    // MARK: Private
+
+    private func syncDocument(_ url: URL, client: LSPClient, languageID: String) {
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return }
+        try? client.didOpen(path: url.path, text: text, languageID: languageID)
+        try? client.didSave(path: url.path)
+    }
+
+    /// Formats one file crash-safely: request edits, apply them in-memory, and only write when the
+    /// result is a non-empty, changed, valid string. Any failure (server error, malformed edits,
+    /// empty output) leaves the file exactly as written. Returns a notice when the file changed.
+    private func formatFile(_ url: URL, client: LSPClient, languageID: String) -> String? {
+        guard let originalData = try? Data(contentsOf: url),
+              let original = String(data: originalData, encoding: .utf8)
+        else { return nil }
+        // The server needs the current text before it can format it.
+        try? client.didOpen(path: url.path, text: original, languageID: languageID)
+
+        let edits: [LSPTextEdit]
+        do {
+            edits = try client.formatting(path: url.path)
+        } catch {
+            return nil // server error/timeout: keep original
+        }
+        guard !edits.isEmpty,
+              let formatted = LSPEditApplier.apply(edits, to: original),
+              !formatted.isEmpty,
+              formatted != original
+        else { return nil }
+
+        // Preserve the file's existing BOM + line-ending style so formatting a CRLF/BOM file does not
+        // silently rewrite every line to bare UTF-8/LF — the same guarantee host.file.write gives.
+        let style = FileEncodingPreservation.detect(originalData)
+        let encoded = FileEncodingPreservation.apply(formatted, style: style)
+        // A no-op after re-encoding (formatting only changed the LF style we just restored) is not a
+        // real change — skip the write and the notice.
+        guard encoded != originalData else { return nil }
+
+        // Never truncate: an atomic write means readers see either the old or the new file, never a
+        // partial one. A write failure leaves the original in place.
+        do {
+            try encoded.write(to: url, options: .atomic)
+        } catch {
+            return nil
+        }
+        let relative = LSPDiagnosticsRelativePath.of(url.path, workspaceRoot: workspaceRoot)
+        return "Auto-formatted \(relative) on save."
+    }
+}
+
+/// Small shared relative-path helper (the formatter has its own private copy; this keeps the
+/// coordinator from importing it privately across files).
+enum LSPDiagnosticsRelativePath {
+    static func of(_ path: String, workspaceRoot: URL) -> String {
+        let root = workspaceRoot.standardizedFileURL.path
+        let prefix = root.hasSuffix("/") ? root : "\(root)/"
+        return path.hasPrefix(prefix) ? String(path.dropFirst(prefix.count)) : path
+    }
+}

--- a/Sources/QuillCodeTools/LSPCoordinator.swift
+++ b/Sources/QuillCodeTools/LSPCoordinator.swift
@@ -129,13 +129,18 @@ public final class LSPCoordinator: @unchecked Sendable {
             return nil // server error/timeout: keep original
         }
         guard !edits.isEmpty,
-              let formatted = LSPEditApplier.apply(edits, to: original),
-              !formatted.isEmpty,
-              formatted != original
+              let formattedRaw = LSPEditApplier.apply(edits, to: original),
+              !formattedRaw.isEmpty,
+              formattedRaw != original
         else { return nil }
 
         // Preserve the file's existing BOM + line-ending style so formatting a CRLF/BOM file does not
         // silently rewrite every line to bare UTF-8/LF — the same guarantee host.file.write gives.
+        // `String(data:encoding:.utf8)` decodes a leading BOM into a U+FEFF scalar that survives into
+        // the formatted text; strip it so `apply` re-adds exactly ONE BOM per the detected style rather
+        // than doubling it (which would compound on every subsequent format-on-save).
+        var formatted = formattedRaw
+        if formatted.first == "\u{FEFF}" { formatted.removeFirst() }
         let style = FileEncodingPreservation.detect(originalData)
         let encoded = FileEncodingPreservation.apply(formatted, style: style)
         // A no-op after re-encoding (formatting only changed the LF style we just restored) is not a

--- a/Sources/QuillCodeTools/LSPDiagnosticsFormatter.swift
+++ b/Sources/QuillCodeTools/LSPDiagnosticsFormatter.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Renders project-wide diagnostics into the concise `file:line: message` block that gets appended to
+/// a write result so the model sees its own breakage immediately. Errors are prioritized over
+/// warnings, and the output is capped to at most `maxFiles` files (issue #863: ≤5) and a bounded
+/// number of lines per file so a flood of diagnostics cannot blow up the model's context.
+public enum LSPDiagnosticsFormatter {
+    public static let maxFiles = 5
+    static let maxPerFile = 10
+
+    /// Formats diagnostics keyed by absolute path, relative to `workspaceRoot`. `editedPath` (if
+    /// given) is listed first so the file just written is always shown even when other files also have
+    /// issues. Returns `nil` when there are no errors or warnings to report.
+    public static func format(
+        diagnosticsByPath: [String: [LSPDiagnostic]],
+        workspaceRoot: URL,
+        editedPath: String? = nil
+    ) -> String? {
+        // Keep only errors and warnings; info/hints are not "did I break it" signal.
+        var relevant: [(path: String, diagnostics: [LSPDiagnostic])] = []
+        for (path, diagnostics) in diagnosticsByPath {
+            let filtered = diagnostics.filter { $0.severity == .error || $0.severity == .warning }
+            if !filtered.isEmpty {
+                relevant.append((path, filtered))
+            }
+        }
+        guard !relevant.isEmpty else { return nil }
+
+        // Order: the edited file first, then files with errors before files with only warnings, then
+        // by descending diagnostic count, then by path for determinism. Symlink-resolve so this matches
+        // the canonical, symlink-resolved keys the LSP client stores diagnostics under.
+        let editedResolved = editedPath.map {
+            URL(fileURLWithPath: $0).resolvingSymlinksInPath().standardizedFileURL.path
+        }
+        relevant.sort { lhs, rhs in
+            let lhsEdited = lhs.path == editedResolved
+            let rhsEdited = rhs.path == editedResolved
+            if lhsEdited != rhsEdited { return lhsEdited }
+            let lhsErrors = lhs.diagnostics.contains { $0.severity == .error }
+            let rhsErrors = rhs.diagnostics.contains { $0.severity == .error }
+            if lhsErrors != rhsErrors { return lhsErrors }
+            if lhs.diagnostics.count != rhs.diagnostics.count { return lhs.diagnostics.count > rhs.diagnostics.count }
+            return lhs.path < rhs.path
+        }
+
+        let shownFiles = relevant.prefix(maxFiles)
+        var lines: [String] = []
+        for entry in shownFiles {
+            let relativePath = Self.relativePath(entry.path, workspaceRoot: workspaceRoot)
+            // Within a file, errors before warnings, then by line.
+            let ordered = entry.diagnostics.sorted { lhs, rhs in
+                if lhs.severity != rhs.severity { return lhs.severity.rawValue < rhs.severity.rawValue }
+                return lhs.range.start.line < rhs.range.start.line
+            }
+            for diagnostic in ordered.prefix(maxPerFile) {
+                let line = diagnostic.range.start.line + 1 // 1-based for the model
+                let message = Self.singleLine(diagnostic.message)
+                lines.append("\(relativePath):\(line): \(diagnostic.severity.label): \(message)")
+            }
+            if ordered.count > maxPerFile {
+                lines.append("\(relativePath): (+\(ordered.count - maxPerFile) more)")
+            }
+        }
+
+        var header = "LSP diagnostics:"
+        if relevant.count > maxFiles {
+            header += " (showing \(maxFiles) of \(relevant.count) files with issues)"
+        }
+        return ([header] + lines).joined(separator: "\n")
+    }
+
+    private static func relativePath(_ path: String, workspaceRoot: URL) -> String {
+        let root = workspaceRoot.standardizedFileURL.path
+        let rootPrefix = root.hasSuffix("/") ? root : "\(root)/"
+        if path.hasPrefix(rootPrefix) {
+            return String(path.dropFirst(rootPrefix.count))
+        }
+        return path
+    }
+
+    /// Collapses a multi-line diagnostic message to one line and bounds its length so a pathological
+    /// message cannot dominate the block.
+    private static func singleLine(_ message: String) -> String {
+        let collapsed = message
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+        guard collapsed.count > 300 else { return collapsed }
+        return String(collapsed.prefix(300)) + "…"
+    }
+}

--- a/Sources/QuillCodeTools/LSPError.swift
+++ b/Sources/QuillCodeTools/LSPError.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Failure modes of the LSP subsystem. Every one is recoverable: the LSP features degrade to a
+/// no-op (writes still succeed, nav tool reports the reason) rather than propagating up and breaking
+/// the agent loop. The subsystem is a *correctness multiplier*, never a correctness *dependency*.
+public enum LSPError: Error, Equatable, CustomStringConvertible {
+    /// A response frame's Content-Length header was missing, negative, non-numeric, or oversized, or
+    /// the framed body was not a JSON object. The transport carries untrusted bytes from an external
+    /// subprocess, so a malformed frame must be reported, never force-unwrapped through.
+    case invalidMessage(String)
+    /// The server did not produce a response for a request id before the request's deadline. The
+    /// caller aborts the single request; it never spins forever on a silent server.
+    case timeout(String)
+    /// The server returned a JSON-RPC `error` object for a request (e.g. an unsupported method).
+    case serverError(code: Int, message: String)
+    /// No language server could be located for a file (none configured for its extension, or the
+    /// configured command was not found on PATH / via xcrun). The caller degrades gracefully.
+    case serverUnavailable(String)
+    /// The server subprocess exited / its stdout hit EOF while a request was outstanding.
+    case serverClosed(String)
+
+    public var description: String {
+        switch self {
+        case .invalidMessage(let detail):
+            return "LSP message error: \(detail)"
+        case .timeout(let detail):
+            return "LSP timeout: \(detail)"
+        case .serverError(let code, let message):
+            return "LSP server error \(code): \(message)"
+        case .serverUnavailable(let detail):
+            return "LSP unavailable: \(detail)"
+        case .serverClosed(let detail):
+            return "LSP server closed: \(detail)"
+        }
+    }
+}

--- a/Sources/QuillCodeTools/LSPJSON.swift
+++ b/Sources/QuillCodeTools/LSPJSON.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Defensive extractors for reading untrusted JSON values out of an LSP server's responses.
+/// `JSONSerialization` yields `NSNumber`s that bridge unpredictably to `Int`/`Double`, and a
+/// hostile or buggy server can put a string where a number belongs — these helpers normalize all of
+/// that to `nil` rather than trapping.
+enum LSPJSON {
+    /// An integer from a value that may be an `Int`, an `NSNumber`, or a numeric `String`.
+    static func int(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let number = value as? NSNumber { return number.intValue }
+        if let string = value as? String { return Int(string) }
+        return nil
+    }
+}
+
+/// Converts between filesystem paths and `file://` URIs the way LSP servers expect. LSP requires a
+/// properly percent-encoded `file://` URI; `URL(fileURLWithPath:)` handles the encoding, and we undo
+/// it on the way back.
+enum LSPURI {
+    /// A `file://` URI for an absolute filesystem path.
+    static func from(path: String) -> String {
+        URL(fileURLWithPath: path).absoluteString
+    }
+
+    /// The filesystem path for a `file://` URI, or `nil` for a non-file / unparseable URI.
+    static func path(from uri: String) -> String? {
+        guard let url = URL(string: uri), url.isFileURL else { return nil }
+        return url.path
+    }
+}

--- a/Sources/QuillCodeTools/LSPMessageCodec.swift
+++ b/Sources/QuillCodeTools/LSPMessageCodec.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Content-Length framing for JSON-RPC 2.0 over a byte stream — the base protocol of the Language
+/// Server Protocol (and of MCP-over-stdio, which frames identically). A message is a
+/// `Content-Length: N\r\n\r\n` header block followed by exactly N bytes of UTF-8 JSON.
+///
+/// Every byte handled here comes from an *untrusted* external subprocess, so parsing is bounded and
+/// defensive: a missing/negative/non-numeric length, an oversized body, or a non-object body is a
+/// thrown `LSPError.invalidMessage`, never a crash. Partial frames (a header without its full body,
+/// or a body split across reads) return `nil` so the caller reads more and retries — it never blocks
+/// waiting on bytes it already has.
+public enum LSPMessageCodec {
+    /// Upper bound on a single framed body. sourcekit-lsp can emit large `workspace/symbol` and
+    /// `documentSymbol` payloads, so this is generous, but still finite so a bogus `Content-Length`
+    /// can never make us allocate unboundedly.
+    public static let maxMessageBytes = 16_000_000
+
+    private static let headerSeparator = Data("\r\n\r\n".utf8)
+
+    /// Frames a JSON object as a Content-Length message ready to write to the server's stdin.
+    public static func encode(_ object: [String: Any]) throws -> Data {
+        guard JSONSerialization.isValidJSONObject(object) else {
+            throw LSPError.invalidMessage("outgoing message is not a valid JSON object")
+        }
+        let body = try JSONSerialization.data(withJSONObject: object, options: [])
+        var data = Data("Content-Length: \(body.count)\r\n\r\n".utf8)
+        data.append(body)
+        return data
+    }
+
+    /// Pulls the next complete message off the front of `buffer`, consuming its bytes, or returns
+    /// `nil` when the buffer does not yet hold a full header+body. Throws on a structurally invalid
+    /// frame (bad header, oversized length) — a caller that catches this should treat the stream as
+    /// corrupt and tear the server down rather than resync mid-stream.
+    public static func nextMessage(from buffer: inout Data) throws -> Data? {
+        guard let headerRange = buffer.firstRange(of: headerSeparator) else {
+            // Guard against a peer that never sends the separator: an unbounded header is an attack.
+            if buffer.count > maxMessageBytes {
+                throw LSPError.invalidMessage("header exceeded \(maxMessageBytes) bytes with no terminator")
+            }
+            return nil
+        }
+
+        let headerData = buffer[buffer.startIndex..<headerRange.lowerBound]
+        guard let header = String(data: headerData, encoding: .utf8) else {
+            throw LSPError.invalidMessage("message header is not UTF-8")
+        }
+        let length = try contentLength(from: header)
+        guard length <= maxMessageBytes else {
+            throw LSPError.invalidMessage("message body of \(length) bytes exceeds \(maxMessageBytes)")
+        }
+
+        let bodyStart = headerRange.upperBound
+        guard let bodyEnd = buffer.index(bodyStart, offsetBy: length, limitedBy: buffer.endIndex),
+              bodyEnd <= buffer.endIndex,
+              buffer.distance(from: bodyStart, to: buffer.endIndex) >= length
+        else {
+            return nil // body not fully arrived yet
+        }
+
+        let message = Data(buffer[bodyStart..<bodyEnd])
+        buffer.removeSubrange(buffer.startIndex..<bodyEnd)
+        return message
+    }
+
+    /// Parses a framed body into a JSON object, rejecting a body that is valid JSON but not an object
+    /// (e.g. a bare array or number) — a JSON-RPC message is always an object.
+    public static func decode(_ data: Data) throws -> [String: Any] {
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data, options: [])
+        } catch {
+            throw LSPError.invalidMessage("message body is not JSON: \(error.localizedDescription)")
+        }
+        guard let dictionary = object as? [String: Any] else {
+            throw LSPError.invalidMessage("message body is not a JSON object")
+        }
+        return dictionary
+    }
+
+    /// Extracts the `Content-Length` value from a header block, tolerating extra headers (e.g. the
+    /// optional `Content-Type`) and case-insensitive names, per the LSP spec.
+    private static func contentLength(from header: String) throws -> Int {
+        for line in header.components(separatedBy: "\r\n") {
+            let parts = line.split(separator: ":", maxSplits: 1).map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            guard parts.count == 2, parts[0].lowercased() == "content-length" else { continue }
+            guard let length = Int(parts[1]), length >= 0 else {
+                throw LSPError.invalidMessage("Content-Length value is not a non-negative integer")
+            }
+            return length
+        }
+        throw LSPError.invalidMessage("message is missing a Content-Length header")
+    }
+}

--- a/Sources/QuillCodeTools/LSPModels.swift
+++ b/Sources/QuillCodeTools/LSPModels.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// A 0-based line/character position, as LSP uses on the wire. The agent-facing tool speaks in
+/// 1-based lines (matching `host.file.read`'s numbering), so conversions live at the tool boundary,
+/// not here.
+public struct LSPPosition: Equatable, Sendable {
+    public var line: Int
+    public var character: Int
+
+    public init(line: Int, character: Int) {
+        self.line = line
+        self.character = character
+    }
+
+    /// The wire form. LSP positions are always 0-based.
+    public var wire: [String: Any] { ["line": line, "character": character] }
+
+    /// Parses a position out of an untrusted JSON object, defaulting missing/garbage fields to 0
+    /// rather than failing — a server that omits a field should not sink the whole response.
+    public static func parse(_ any: Any?) -> LSPPosition? {
+        guard let object = any as? [String: Any] else { return nil }
+        return LSPPosition(
+            line: LSPJSON.int(object["line"]) ?? 0,
+            character: LSPJSON.int(object["character"]) ?? 0
+        )
+    }
+}
+
+/// A `[start, end)` span within a document.
+public struct LSPRange: Equatable, Sendable {
+    public var start: LSPPosition
+    public var end: LSPPosition
+
+    public init(start: LSPPosition, end: LSPPosition) {
+        self.start = start
+        self.end = end
+    }
+
+    public var wire: [String: Any] { ["start": start.wire, "end": end.wire] }
+
+    public static func parse(_ any: Any?) -> LSPRange? {
+        guard let object = any as? [String: Any] else { return nil }
+        let start = LSPPosition.parse(object["start"]) ?? LSPPosition(line: 0, character: 0)
+        let end = LSPPosition.parse(object["end"]) ?? start
+        return LSPRange(start: start, end: end)
+    }
+}
+
+/// A resolved code location: a file plus a span. `path` is the workspace-relative path when the
+/// location falls inside the workspace, else the absolute path (locations can legitimately point at
+/// SDK/toolchain files outside the project).
+public struct LSPLocation: Equatable, Sendable {
+    public var uri: String
+    public var range: LSPRange
+
+    public init(uri: String, range: LSPRange) {
+        self.uri = uri
+        self.range = range
+    }
+
+    public static func parse(_ any: Any?) -> LSPLocation? {
+        guard let object = any as? [String: Any] else { return nil }
+        // Servers return either a `Location` (uri+range) or a `LocationLink` (targetUri+targetRange).
+        let uri = (object["uri"] as? String) ?? (object["targetUri"] as? String)
+        guard let uri, !uri.isEmpty else { return nil }
+        let range = LSPRange.parse(object["range"])
+            ?? LSPRange.parse(object["targetRange"])
+            ?? LSPRange(start: .init(line: 0, character: 0), end: .init(line: 0, character: 0))
+        return LSPLocation(uri: uri, range: range)
+    }
+
+    /// Parses a `Location | Location[] | LocationLink[] | null` response into a flat list.
+    public static func parseList(_ any: Any?) -> [LSPLocation] {
+        if let array = any as? [[String: Any]] {
+            return array.compactMap { parse($0) }
+        }
+        if let single = parse(any) {
+            return [single]
+        }
+        return []
+    }
+}
+
+/// Severity of a diagnostic, matching the LSP integer codes. Only errors and warnings are surfaced
+/// to the model after a write (info/hints are noise for the "did I break it" question).
+public enum LSPDiagnosticSeverity: Int, Sendable, Equatable {
+    case error = 1
+    case warning = 2
+    case information = 3
+    case hint = 4
+
+    var label: String {
+        switch self {
+        case .error: return "error"
+        case .warning: return "warning"
+        case .information: return "info"
+        case .hint: return "hint"
+        }
+    }
+}
+
+/// One diagnostic from `textDocument/publishDiagnostics`.
+public struct LSPDiagnostic: Equatable, Sendable {
+    public var range: LSPRange
+    public var severity: LSPDiagnosticSeverity
+    public var message: String
+
+    public init(range: LSPRange, severity: LSPDiagnosticSeverity, message: String) {
+        self.range = range
+        self.severity = severity
+        self.message = message
+    }
+
+    public static func parse(_ any: Any?) -> LSPDiagnostic? {
+        guard let object = any as? [String: Any] else { return nil }
+        let message = (object["message"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !message.isEmpty else { return nil }
+        let severity = LSPDiagnosticSeverity(rawValue: LSPJSON.int(object["severity"]) ?? 1) ?? .error
+        let range = LSPRange.parse(object["range"])
+            ?? LSPRange(start: .init(line: 0, character: 0), end: .init(line: 0, character: 0))
+        return LSPDiagnostic(range: range, severity: severity, message: message)
+    }
+}
+
+/// A symbol from `textDocument/documentSymbol` or `workspace/symbol`. Kept flat (name + kind + a
+/// single location) so the tool output is a concise list the model can scan.
+public struct LSPSymbol: Equatable, Sendable {
+    public var name: String
+    public var kind: Int
+    public var location: LSPLocation
+    public var containerName: String?
+
+    public init(name: String, kind: Int, location: LSPLocation, containerName: String? = nil) {
+        self.name = name
+        self.kind = kind
+        self.location = location
+        self.containerName = containerName
+    }
+
+    /// Human-readable name of the LSP `SymbolKind` integer.
+    public var kindLabel: String { LSPSymbolKind.label(for: kind) }
+}
+
+/// The subset of LSP `SymbolKind` names the tool prints. Unknown values fall back to "symbol" so a
+/// forward-compatible server never yields a blank kind.
+enum LSPSymbolKind {
+    private static let names: [Int: String] = [
+        1: "file", 2: "module", 3: "namespace", 4: "package", 5: "class", 6: "method",
+        7: "property", 8: "field", 9: "constructor", 10: "enum", 11: "interface",
+        12: "function", 13: "variable", 14: "constant", 15: "string", 16: "number",
+        17: "boolean", 18: "array", 19: "object", 20: "key", 21: "null", 22: "enum-member",
+        23: "struct", 24: "event", 25: "operator", 26: "type-parameter"
+    ]
+
+    static func label(for kind: Int) -> String { names[kind] ?? "symbol" }
+}

--- a/Sources/QuillCodeTools/LSPResponseParsers.swift
+++ b/Sources/QuillCodeTools/LSPResponseParsers.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Flattens the several shapes a `textDocument/hover` result can take (a `MarkupContent` object, a
+/// legacy `MarkedString`, or an array of either) into a single plain-text string. Returns `nil` for
+/// an empty/`null` hover so the tool can say "no hover info" rather than print an empty box.
+enum LSPHoverText {
+    static func extract(from any: Any?) -> String? {
+        guard let object = any as? [String: Any] else { return nil }
+        let contents = object["contents"]
+        let text = stringify(contents).trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+
+    private static func stringify(_ value: Any?) -> String {
+        switch value {
+        case let string as String:
+            return string
+        case let object as [String: Any]:
+            // `MarkupContent { kind, value }` or legacy `MarkedString { language, value }`.
+            return (object["value"] as? String) ?? ""
+        case let array as [Any]:
+            return array.map { stringify($0) }.filter { !$0.isEmpty }.joined(separator: "\n")
+        default:
+            return ""
+        }
+    }
+}
+
+/// Parses `documentSymbol` (both the flat `SymbolInformation[]` form and the nested
+/// `DocumentSymbol[]` tree) and `workspace/symbol` responses into a flat `[LSPSymbol]`.
+enum LSPSymbolParser {
+    /// `textDocument/documentSymbol` returns either `SymbolInformation[]` (each with its own
+    /// `location`) or a `DocumentSymbol[]` tree (with `range`/`selectionRange` and `children`). We
+    /// flatten the tree, attaching the file `uri` since tree nodes carry only ranges.
+    static func documentSymbols(from any: Any?, uri: String) -> [LSPSymbol] {
+        guard let array = any as? [[String: Any]] else { return [] }
+        var symbols: [LSPSymbol] = []
+        for node in array {
+            appendSymbols(from: node, uri: uri, container: nil, into: &symbols)
+        }
+        return symbols
+    }
+
+    /// `workspace/symbol` returns `SymbolInformation[]` (or `WorkspaceSymbol[]`), each carrying its
+    /// own `location`.
+    static func workspaceSymbols(from any: Any?) -> [LSPSymbol] {
+        guard let array = any as? [[String: Any]] else { return [] }
+        return array.compactMap { informationSymbol(from: $0) }
+    }
+
+    private static func appendSymbols(
+        from node: [String: Any],
+        uri: String,
+        container: String?,
+        into symbols: inout [LSPSymbol]
+    ) {
+        guard let name = (node["name"] as? String), !name.isEmpty else { return }
+        let kind = LSPJSON.int(node["kind"]) ?? 0
+
+        if let location = node["location"] {
+            // SymbolInformation shape.
+            if let parsed = LSPLocation.parse(location) {
+                symbols.append(LSPSymbol(name: name, kind: kind, location: parsed, containerName: node["containerName"] as? String))
+            }
+            return
+        }
+
+        // DocumentSymbol shape: use `selectionRange` (the identifier itself) for the reported location,
+        // not `range` (the whole declaration span, which for a symbol with leading doc-comments or
+        // attributes starts several lines above the declaration). Fall back to `range` then to origin.
+        let range = LSPRange.parse(node["selectionRange"])
+            ?? LSPRange.parse(node["range"])
+            ?? LSPRange(start: .init(line: 0, character: 0), end: .init(line: 0, character: 0))
+        symbols.append(LSPSymbol(
+            name: name,
+            kind: kind,
+            location: LSPLocation(uri: uri, range: range),
+            containerName: container
+        ))
+        if let children = node["children"] as? [[String: Any]] {
+            for child in children {
+                appendSymbols(from: child, uri: uri, container: name, into: &symbols)
+            }
+        }
+    }
+
+    private static func informationSymbol(from node: [String: Any]) -> LSPSymbol? {
+        guard let name = (node["name"] as? String), !name.isEmpty,
+              let location = LSPLocation.parse(node["location"])
+        else { return nil }
+        return LSPSymbol(
+            name: name,
+            kind: LSPJSON.int(node["kind"]) ?? 0,
+            location: location,
+            containerName: node["containerName"] as? String
+        )
+    }
+}

--- a/Sources/QuillCodeTools/LSPServerLauncher.swift
+++ b/Sources/QuillCodeTools/LSPServerLauncher.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// A launched language-server process: the transport to talk to it, plus a handle to observe/kill
+/// the underlying process. `isRunning` lets the session manager detect a crash; `terminate` tears it
+/// down on shutdown or restart.
+public struct LSPLaunchedServer: Sendable {
+    public var transport: LSPTransport
+    public var process: any LSPProcessControlling
+
+    public init(transport: LSPTransport, process: any LSPProcessControlling) {
+        self.transport = transport
+        self.process = process
+    }
+}
+
+/// Observable/terminable handle to a server process. Behind a protocol so a test can supply a fake
+/// process that pairs with an in-memory transport.
+public protocol LSPProcessControlling: AnyObject, Sendable {
+    var isRunning: Bool { get }
+    func terminate()
+}
+
+/// Spawns a language server and returns a stdio transport wired to it. Behind a protocol so the
+/// session manager can be tested with a launcher that hands back a scripted transport and a fake
+/// process, never touching a real subprocess.
+public protocol LSPServerLaunching: Sendable {
+    func launch(executable: String, arguments: [String], workspaceRoot: URL) throws -> LSPLaunchedServer
+}
+
+/// Production launcher: `Foundation.Process` with stdin/stdout pipes wired to an `LSPStdioTransport`,
+/// stderr drained so a chatty server cannot fill and block its pipe. Mirrors the MCP server launcher.
+public struct DefaultLSPServerLauncher: LSPServerLaunching {
+    public init() {}
+
+    public func launch(executable: String, arguments: [String], workspaceRoot: URL) throws -> LSPLaunchedServer {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.currentDirectoryURL = workspaceRoot
+
+        let standardInput = Pipe()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.standardInput = standardInput
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+
+        let controller = LSPFoundationProcessController(process: process, standardError: standardError)
+        do {
+            try process.run()
+        } catch {
+            throw LSPError.serverUnavailable("failed to launch \(executable): \(error.localizedDescription)")
+        }
+        // Drain stderr in the background; a full stderr pipe would otherwise deadlock the server.
+        standardError.fileHandleForReading.readabilityHandler = { handle in _ = handle.availableData }
+
+        let transport = LSPStdioTransport(
+            input: standardInput.fileHandleForWriting,
+            output: standardOutput.fileHandleForReading
+        )
+        return LSPLaunchedServer(transport: transport, process: controller)
+    }
+}
+
+private final class LSPFoundationProcessController: LSPProcessControlling, @unchecked Sendable {
+    private let process: Process
+    private let standardError: Pipe
+
+    init(process: Process, standardError: Pipe) {
+        self.process = process
+        self.standardError = standardError
+    }
+
+    var isRunning: Bool { process.isRunning }
+
+    func terminate() {
+        standardError.fileHandleForReading.readabilityHandler = nil
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+}

--- a/Sources/QuillCodeTools/LSPServerRegistry.swift
+++ b/Sources/QuillCodeTools/LSPServerRegistry.swift
@@ -105,12 +105,12 @@ public struct LSPCommandLocator: LSPCommandLocating {
         }
 
         // Drain both pipes concurrently so the child never blocks writing to a full, unread pipe.
-        let collected = NSMutableData()
+        let outputBuffer = LSPCommandOutputBuffer()
         let readerGroup = DispatchGroup()
         readerGroup.enter()
         DispatchQueue.global(qos: .utility).async {
             defer { readerGroup.leave() }
-            collected.append(output.fileHandleForReading.readDataToEndOfFile())
+            outputBuffer.append(output.fileHandleForReading.readDataToEndOfFile())
         }
         readerGroup.enter()
         DispatchQueue.global(qos: .utility).async {
@@ -128,7 +128,7 @@ public struct LSPCommandLocator: LSPCommandLocating {
         // The readers finish at EOF, which the child produces on exit.
         _ = readerGroup.wait(timeout: .now() + 1)
         guard process.terminationStatus == 0 else { return nil }
-        let path = String(decoding: collected as Data, as: UTF8.self)
+        let path = String(decoding: outputBuffer.snapshot(), as: UTF8.self)
             .split(separator: "\n").first.map { $0.trimmingCharacters(in: .whitespaces) } ?? ""
         guard !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) else { return nil }
         return path
@@ -136,5 +136,22 @@ public struct LSPCommandLocator: LSPCommandLocating {
 
     private func shellQuote(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+private final class LSPCommandOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = Data()
+
+    func append(_ data: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.append(data)
+    }
+
+    func snapshot() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
     }
 }

--- a/Sources/QuillCodeTools/LSPServerRegistry.swift
+++ b/Sources/QuillCodeTools/LSPServerRegistry.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// How to launch a language server for a family of file extensions, plus the LSP `languageId` to
+/// tag documents with. `command` is resolved on PATH (via `/usr/bin/env`) or, for the special value
+/// handled by discovery, located with `xcrun`.
+public struct LSPServerConfig: Sendable, Equatable {
+    /// Lowercased file extensions (no dot) this server handles.
+    public var fileExtensions: [String]
+    /// The LSP `languageId` for `didOpen` (e.g. "swift").
+    public var languageID: String
+    /// The executable name or absolute path. A bare name is resolved via `xcrun` (for the Swift
+    /// toolchain) or `env` on PATH.
+    public var command: String
+    /// Extra arguments to pass the server.
+    public var arguments: [String]
+
+    public init(fileExtensions: [String], languageID: String, command: String, arguments: [String] = []) {
+        self.fileExtensions = fileExtensions.map { $0.lowercased() }
+        self.languageID = languageID
+        self.command = command
+        self.arguments = arguments
+    }
+}
+
+/// The generic language → server table. sourcekit-lsp ships as the built-in default for Swift; other
+/// languages are added by extending `defaults` (or, in a follow-up, a workspace config file). The
+/// registry is pure data + discovery — it launches nothing itself.
+public struct LSPServerRegistry: Sendable {
+    public private(set) var configs: [LSPServerConfig]
+    private let commandLocator: LSPCommandLocating
+
+    public init(configs: [LSPServerConfig] = LSPServerRegistry.defaults, commandLocator: LSPCommandLocating = LSPCommandLocator()) {
+        self.configs = configs
+        self.commandLocator = commandLocator
+    }
+
+    /// The shipped default: sourcekit-lsp for Swift. Kept as a single-element table on purpose — the
+    /// mapping is the extension point, and QuillOS is a Swift project, so Swift is what we validate
+    /// end to end. Adding, say, `typescript-language-server` is one more entry here.
+    public static let defaults: [LSPServerConfig] = [
+        LSPServerConfig(fileExtensions: ["swift"], languageID: "swift", command: "sourcekit-lsp")
+    ]
+
+    /// The server config whose extensions include this path's extension, or `nil` if none.
+    public func config(forPath path: String) -> LSPServerConfig? {
+        let ext = (path as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty else { return nil }
+        return configs.first { $0.fileExtensions.contains(ext) }
+    }
+
+    /// Resolves a config's `command` to an absolute executable path, or `nil` if the server is not
+    /// installed. This is the single point where a *missing* language server is detected — every
+    /// caller degrades gracefully on `nil`.
+    public func resolveExecutable(for config: LSPServerConfig) -> String? {
+        commandLocator.locate(command: config.command)
+    }
+}
+
+/// Locates an executable by name. Behind a protocol so tests can inject a locator that reports a
+/// server present/absent without touching the real filesystem or spawning `xcrun`.
+public protocol LSPCommandLocating: Sendable {
+    func locate(command: String) -> String?
+}
+
+/// Default locator: an absolute path is used as-is if executable; otherwise the command is looked up
+/// first in the active Swift toolchain via `xcrun --find` (so sourcekit-lsp is found even when not on
+/// PATH), then on `PATH` via `/usr/bin/env`. All lookups are bounded with a short timeout so a
+/// hanging `xcrun` never stalls a write.
+public struct LSPCommandLocator: LSPCommandLocating {
+    public init() {}
+
+    public func locate(command: String) -> String? {
+        if command.hasPrefix("/") {
+            return FileManager.default.isExecutableFile(atPath: command) ? command : nil
+        }
+        #if os(macOS)
+        if let found = run(executable: "/usr/bin/xcrun", arguments: ["--find", command]) {
+            return found
+        }
+        #endif
+        // `command -v` respects PATH and resolves shell builtins/aliases the way a launch would.
+        if let found = run(executable: "/usr/bin/env", arguments: ["sh", "-c", "command -v \(shellQuote(command))"]) {
+            return found
+        }
+        return nil
+    }
+
+    /// Runs a short discovery command, returning its trimmed first line of stdout on a clean exit, or
+    /// `nil` on failure/timeout/non-executable-result. stdout and stderr are drained on background
+    /// queues *concurrently* with the wait, so a command that emits more than a pipe buffer (~64KB)
+    /// cannot deadlock (it never blocks on a write to a pipe no one is reading).
+    private func run(executable: String, arguments: [String]) -> String? {
+        guard FileManager.default.isExecutableFile(atPath: executable) else { return nil }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let output = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = output
+        process.standardError = errorPipe
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        // Drain both pipes concurrently so the child never blocks writing to a full, unread pipe.
+        let collected = NSMutableData()
+        let readerGroup = DispatchGroup()
+        readerGroup.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer { readerGroup.leave() }
+            collected.append(output.fileHandleForReading.readDataToEndOfFile())
+        }
+        readerGroup.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer { readerGroup.leave() }
+            _ = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in semaphore.signal() }
+        if semaphore.wait(timeout: .now() + 3) == .timedOut {
+            process.terminate()
+            _ = readerGroup.wait(timeout: .now() + 1)
+            return nil
+        }
+        // The readers finish at EOF, which the child produces on exit.
+        _ = readerGroup.wait(timeout: .now() + 1)
+        guard process.terminationStatus == 0 else { return nil }
+        let path = String(decoding: collected as Data, as: UTF8.self)
+            .split(separator: "\n").first.map { $0.trimmingCharacters(in: .whitespaces) } ?? ""
+        guard !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) else { return nil }
+        return path
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/QuillCodeTools/LSPSessionManager.swift
+++ b/Sources/QuillCodeTools/LSPSessionManager.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// Owns the running language-server sessions for one workspace and hands out a ready `LSPClient` for
+/// a given file, launching and initializing the server on first use. One session per server
+/// *command* (all `.swift` files share one sourcekit-lsp), keyed by the config's command.
+///
+/// Robustness is centered here:
+/// - **Missing server:** `client(forPath:)` returns `nil` and records a one-time notice; callers no-op.
+/// - **Crash:** a dead process is detected before reuse and relaunched, up to a bounded restart count
+///   with backoff, after which the language is disabled for the session (no infinite relaunch loop).
+/// - **Slow/hung:** every client call carries a deadline, so the manager itself never blocks unbounded.
+///
+/// Access is serialized by a lock; the manager is `@unchecked Sendable` and safe to share across the
+/// tool router instances created per tool step.
+public final class LSPSessionManager: @unchecked Sendable {
+    private struct Session {
+        var client: LSPClient
+        var process: any LSPProcessControlling
+        var config: LSPServerConfig
+        var restarts: Int
+    }
+
+    /// Max relaunches of a repeatedly-crashing server before its language is disabled for the run.
+    static let maxRestarts = 3
+
+    private let workspaceRoot: URL
+    private let registry: LSPServerRegistry
+    private let launcher: LSPServerLaunching
+    /// Upper bound on the `initialize` handshake. A server that does not complete it in this window is
+    /// treated as a failed launch (and, after `maxRestarts`, disabled) rather than blocking forever.
+    private let initializeTimeout: TimeInterval
+    private let lock = NSLock()
+
+    /// Keyed by server command. A `nil` value marks a command we know is unavailable (missing binary
+    /// or exhausted restarts) so we neither retry launching nor renotify.
+    private var sessions: [String: Session] = [:]
+    private var disabledCommands: Set<String> = []
+    private var emittedUnavailableNotice: Set<String> = []
+
+    public init(
+        workspaceRoot: URL,
+        registry: LSPServerRegistry = LSPServerRegistry(),
+        launcher: LSPServerLaunching = DefaultLSPServerLauncher(),
+        initializeTimeout: TimeInterval = 10.0
+    ) {
+        self.workspaceRoot = workspaceRoot.standardizedFileURL
+        self.registry = registry
+        self.launcher = launcher
+        self.initializeTimeout = initializeTimeout
+    }
+
+    /// Whether any language server is configured *and available* for this file's type. Cheap check
+    /// used to skip the diagnostics/format work entirely for unsupported files.
+    public func hasServer(forPath path: String) -> Bool {
+        registry.config(forPath: path) != nil
+    }
+
+    /// The `languageId` for a file, or `nil` if unsupported.
+    public func languageID(forPath path: String) -> String? {
+        registry.config(forPath: path)?.languageID
+    }
+
+    /// A ready, initialized client for the server that handles `path`, launching it if needed.
+    /// Returns `nil` (never throws) when the server is missing, disabled, or fails to start — the LSP
+    /// features are a multiplier, so their absence must be a silent no-op to the write path.
+    public func client(forPath path: String) -> LSPClient? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let config = registry.config(forPath: path) else { return nil }
+        let key = config.command
+
+        if disabledCommands.contains(key) { return nil }
+
+        // Reuse a live session; relaunch a crashed one within the restart budget.
+        if let existing = sessions[key] {
+            if existing.process.isRunning {
+                return existing.client
+            }
+            // The process died. Reap it AND close the transport so its stdin/stdout fds are not leaked
+            // across the relaunch.
+            existing.process.terminate()
+            existing.client.closeTransport()
+            sessions[key] = nil
+            guard existing.restarts < Self.maxRestarts else {
+                disabledCommands.insert(key)
+                return nil
+            }
+            return launchAndStore(config: config, key: key, restarts: existing.restarts + 1)
+        }
+
+        return launchAndStore(config: config, key: key, restarts: 0)
+    }
+
+    /// A one-time human-readable notice for a file whose server is unavailable, or `nil` if a server
+    /// is available or the notice was already emitted for this command. The write path shows this
+    /// once so the model knows why diagnostics are quiet, without repeating it on every write.
+    public func consumeUnavailableNoticeIfNeeded(forPath path: String) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let config = registry.config(forPath: path) else { return nil }
+        let key = config.command
+        // Only notice when we actually tried and failed (missing binary or disabled after crashes).
+        guard disabledCommands.contains(key) || registry.resolveExecutable(for: config) == nil else {
+            return nil
+        }
+        guard !emittedUnavailableNotice.contains(key) else { return nil }
+        emittedUnavailableNotice.insert(key)
+        return "Language server '\(config.command)' is not available; skipping diagnostics and formatting."
+    }
+
+    /// Terminates every running server. Call on workspace teardown.
+    public func shutdown() {
+        lock.lock()
+        defer { lock.unlock() }
+        for (_, session) in sessions {
+            session.client.shutdown()
+            session.process.terminate()
+        }
+        sessions.removeAll()
+    }
+
+    // MARK: Private
+
+    private func launchAndStore(config: LSPServerConfig, key: String, restarts: Int) -> LSPClient? {
+        guard let executable = registry.resolveExecutable(for: config) else {
+            disabledCommands.insert(key)
+            return nil
+        }
+        let launched: LSPLaunchedServer
+        do {
+            launched = try launcher.launch(
+                executable: executable,
+                arguments: config.arguments,
+                workspaceRoot: workspaceRoot
+            )
+        } catch {
+            if restarts >= Self.maxRestarts { disabledCommands.insert(key) }
+            return nil
+        }
+        let client = LSPClient(transport: launched.transport)
+        do {
+            // A failed handshake (timeout / EOF) counts as a launch failure — tear it down and, on
+            // repeated failure, disable rather than relaunch endlessly.
+            try client.initialize(workspaceRoot: workspaceRoot, timeout: initializeTimeout)
+            sessions[key] = Session(client: client, process: launched.process, config: config, restarts: restarts)
+            return client
+        } catch {
+            // Reap the process and close the transport so a failed handshake does not leak fds.
+            launched.process.terminate()
+            client.closeTransport()
+            if restarts >= Self.maxRestarts { disabledCommands.insert(key) }
+            return nil
+        }
+    }
+}

--- a/Sources/QuillCodeTools/LSPSessionManager.swift
+++ b/Sources/QuillCodeTools/LSPSessionManager.swift
@@ -71,13 +71,16 @@ public final class LSPSessionManager: @unchecked Sendable {
 
         if disabledCommands.contains(key) { return nil }
 
-        // Reuse a live session; relaunch a crashed one within the restart budget.
+        // Reuse a live session; relaunch a crashed OR poisoned one within the restart budget. A client
+        // whose read stream desynced on a malformed frame (`isHealthy == false`) is as unusable as a
+        // dead process — reusing it would replay the corrupt buffer on every request — so it is torn
+        // down and relaunched the same way.
         if let existing = sessions[key] {
-            if existing.process.isRunning {
+            if existing.process.isRunning && existing.client.isHealthy {
                 return existing.client
             }
-            // The process died. Reap it AND close the transport so its stdin/stdout fds are not leaked
-            // across the relaunch.
+            // The process died or the stream is corrupt. Reap it AND close the transport so its
+            // stdin/stdout fds are not leaked across the relaunch.
             existing.process.terminate()
             existing.client.closeTransport()
             sessions[key] = nil

--- a/Sources/QuillCodeTools/LSPTextEdit.swift
+++ b/Sources/QuillCodeTools/LSPTextEdit.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// A single `TextEdit` from a formatting response: replace the `range` with `newText`.
+public struct LSPTextEdit: Equatable, Sendable {
+    public var range: LSPRange
+    public var newText: String
+
+    public init(range: LSPRange, newText: String) {
+        self.range = range
+        self.newText = newText
+    }
+
+    public static func parse(_ any: Any?) -> LSPTextEdit? {
+        guard let object = any as? [String: Any],
+              let range = LSPRange.parse(object["range"]),
+              let newText = object["newText"] as? String
+        else { return nil }
+        return LSPTextEdit(range: range, newText: newText)
+    }
+
+    public static func parseList(_ any: Any?) -> [LSPTextEdit] {
+        guard let array = any as? [[String: Any]] else { return [] }
+        return array.compactMap { parse($0) }
+    }
+}
+
+/// Applies LSP text edits to a document string. LSP positions are 0-based `(line, UTF-16 code unit)`
+/// offsets; the spec guarantees edits within one response do not overlap, so we sort them
+/// end-to-start and splice each in turn — applying from the back keeps earlier positions valid.
+///
+/// Returns `nil` when any edit references a position outside the document (a malformed server
+/// response), so the caller keeps the original file untouched rather than writing corrupted text.
+public enum LSPEditApplier {
+    public static func apply(_ edits: [LSPTextEdit], to text: String) -> String? {
+        guard !edits.isEmpty else { return text }
+
+        // Precompute the UTF-16 start offset of each line so a (line, character) pair maps to a String
+        // index in one pass. LSP characters are UTF-16 code units — the same unit Swift's `utf16` view
+        // uses — so offsets line up exactly.
+        let utf16 = Array(text.utf16)
+        var lineStarts: [Int] = [0]
+        for (index, unit) in utf16.enumerated() where unit == 0x0A { // '\n'
+            lineStarts.append(index + 1)
+        }
+
+        func offset(of position: LSPPosition) -> Int? {
+            guard position.line >= 0, position.line < lineStarts.count else {
+                // A position on the line just past the last is valid only at character 0 (end of file).
+                if position.line == lineStarts.count, position.character == 0 { return utf16.count }
+                return nil
+            }
+            let lineStart = lineStarts[position.line]
+            let lineEnd = position.line + 1 < lineStarts.count ? lineStarts[position.line + 1] : utf16.count
+            let candidate = lineStart + max(0, position.character)
+            guard candidate <= lineEnd else { return nil }
+            return candidate
+        }
+
+        // Resolve every edit to a UTF-16 [start, end) range up front so a single bad edit aborts the
+        // whole apply before we mutate anything.
+        var resolved: [(start: Int, end: Int, text: String)] = []
+        for edit in edits {
+            guard let start = offset(of: edit.range.start),
+                  let end = offset(of: edit.range.end),
+                  start <= end, end <= utf16.count
+            else { return nil }
+            resolved.append((start, end, edit.newText))
+        }
+        // Apply from the back so an earlier splice never invalidates a later position. The LSP spec
+        // forbids overlapping edits in one response, but the server is untrusted: reject any overlap
+        // up front (return nil → keep the original file) rather than let `replaceSubrange` trap on a
+        // range past the shrinking array. After sorting descending by start, "no overlap" means each
+        // edit's end is at or before the previously-applied edit's start.
+        resolved.sort { $0.start > $1.start }
+        var previousStart = utf16.count
+        for edit in resolved {
+            guard edit.end <= previousStart else { return nil } // overlaps the edit applied before it
+            previousStart = edit.start
+        }
+
+        var units = utf16
+        for edit in resolved {
+            let replacement = Array(edit.text.utf16)
+            units.replaceSubrange(edit.start..<edit.end, with: replacement)
+        }
+        return String(utf16CodeUnits: units, count: units.count)
+    }
+}

--- a/Sources/QuillCodeTools/LSPToolCallDispatcher.swift
+++ b/Sources/QuillCodeTools/LSPToolCallDispatcher.swift
@@ -1,0 +1,196 @@
+import Foundation
+import QuillCodeCore
+
+/// Routes and executes the `host.lsp.*` navigation family against an `LSPCoordinator`. Returns
+/// concise, model-readable `ToolResult`s. When no coordinator/server is available every method
+/// returns a clear "not available" result rather than an error, so the tool degrades like the rest
+/// of the LSP surface.
+public struct LSPToolCallDispatcher: Sendable {
+    private let workspaceRoot: URL
+    private let coordinator: LSPCoordinator?
+    private let pathResolver: FileWorkspacePathResolver
+
+    public init(workspaceRoot: URL, coordinator: LSPCoordinator?) {
+        self.workspaceRoot = workspaceRoot.standardizedFileURL
+        self.coordinator = coordinator
+        self.pathResolver = FileWorkspacePathResolver(workspaceRoot: workspaceRoot)
+    }
+
+    public static let definitions: [ToolDefinition] = [
+        .lspDefinition,
+        .lspReferences,
+        .lspHover,
+        .lspDocumentSymbol,
+        .lspWorkspaceSymbol
+    ]
+
+    public static func handles(_ toolName: String) -> Bool {
+        definitions.contains { $0.name == toolName }
+    }
+
+    public func execute(name: String, arguments: ToolArguments) throws -> ToolResult {
+        guard let coordinator else {
+            return ToolResult(ok: false, error: "LSP navigation is not available in this workspace.")
+        }
+        switch name {
+        case ToolDefinition.lspDefinition.name:
+            return try location(name: name, arguments: arguments, coordinator: coordinator) { client, path, line, character in
+                try client.definition(path: path, line: line, character: character)
+            }
+        case ToolDefinition.lspReferences.name:
+            let includeDeclaration = arguments.bool("includeDeclaration") ?? true
+            return try location(name: name, arguments: arguments, coordinator: coordinator) { client, path, line, character in
+                try client.references(path: path, line: line, character: character, includeDeclaration: includeDeclaration)
+            }
+        case ToolDefinition.lspHover.name:
+            return try hover(arguments: arguments, coordinator: coordinator)
+        case ToolDefinition.lspDocumentSymbol.name:
+            return try documentSymbol(arguments: arguments, coordinator: coordinator)
+        case ToolDefinition.lspWorkspaceSymbol.name:
+            return try workspaceSymbol(arguments: arguments, coordinator: coordinator)
+        default:
+            return ToolResult(ok: false, error: "Unknown tool: \(name)")
+        }
+    }
+
+    // MARK: Handlers
+
+    private func location(
+        name: String,
+        arguments: ToolArguments,
+        coordinator: LSPCoordinator,
+        query: (LSPClient, String, Int, Int) throws -> [LSPLocation]
+    ) throws -> ToolResult {
+        let (path, url) = try resolvedPath(arguments)
+        let line = try oneBasedLine(arguments)
+        let character = arguments.int("character") ?? 0
+        guard let nav = coordinator.navigationClient(forPath: url.path) else {
+            return unavailable(forPath: path)
+        }
+        do {
+            let locations = try query(nav.client, url.path, line - 1, character)
+            return ToolResult(ok: true, stdout: renderLocations(locations))
+        } catch {
+            return errorResult(error)
+        }
+    }
+
+    private func hover(arguments: ToolArguments, coordinator: LSPCoordinator) throws -> ToolResult {
+        let (path, url) = try resolvedPath(arguments)
+        let line = try oneBasedLine(arguments)
+        let character = arguments.int("character") ?? 0
+        guard let nav = coordinator.navigationClient(forPath: url.path) else {
+            return unavailable(forPath: path)
+        }
+        do {
+            let text = try nav.client.hover(path: url.path, line: line - 1, character: character)
+            return ToolResult(ok: true, stdout: text ?? "No hover information at this position.\n")
+        } catch {
+            return errorResult(error)
+        }
+    }
+
+    private func documentSymbol(arguments: ToolArguments, coordinator: LSPCoordinator) throws -> ToolResult {
+        let (path, url) = try resolvedPath(arguments)
+        guard let nav = coordinator.navigationClient(forPath: url.path) else {
+            return unavailable(forPath: path)
+        }
+        do {
+            let symbols = try nav.client.documentSymbols(path: url.path)
+            return ToolResult(ok: true, stdout: renderSymbols(symbols))
+        } catch {
+            return errorResult(error)
+        }
+    }
+
+    private func workspaceSymbol(arguments: ToolArguments, coordinator: LSPCoordinator) throws -> ToolResult {
+        let query = try arguments.requiredString("query")
+        // Any supported file gives us a client; use a representative extension to route.
+        guard let nav = coordinator.navigationClient(forPath: representativeWorkspaceFile()?.path ?? "") else {
+            return ToolResult(ok: false, error: "LSP workspace symbol search is not available (no language server running).")
+        }
+        do {
+            let symbols = try nav.client.workspaceSymbols(query: query)
+            return ToolResult(ok: true, stdout: renderSymbols(symbols))
+        } catch {
+            return errorResult(error)
+        }
+    }
+
+    // MARK: Rendering
+
+    private func renderLocations(_ locations: [LSPLocation]) -> String {
+        guard !locations.isEmpty else { return "No locations found.\n" }
+        let lines = locations.prefix(50).map { location -> String in
+            let path = displayPath(forURI: location.uri)
+            let line = location.range.start.line + 1
+            let column = location.range.start.character + 1
+            return "\(path):\(line):\(column)"
+        }
+        var output = lines.joined(separator: "\n") + "\n"
+        if locations.count > 50 {
+            output += "(+\(locations.count - 50) more)\n"
+        }
+        return output
+    }
+
+    private func renderSymbols(_ symbols: [LSPSymbol]) -> String {
+        guard !symbols.isEmpty else { return "No symbols found.\n" }
+        let lines = symbols.prefix(100).map { symbol -> String in
+            let path = displayPath(forURI: symbol.location.uri)
+            let line = symbol.location.range.start.line + 1
+            let container = symbol.containerName.map { "\($0)." } ?? ""
+            return "\(symbol.kindLabel) \(container)\(symbol.name) — \(path):\(line)"
+        }
+        var output = lines.joined(separator: "\n") + "\n"
+        if symbols.count > 100 {
+            output += "(+\(symbols.count - 100) more)\n"
+        }
+        return output
+    }
+
+    // MARK: Helpers
+
+    /// A workspace-relative path for a `file://` URI inside the workspace, else the absolute path
+    /// (locations may point at SDK files outside the project).
+    private func displayPath(forURI uri: String) -> String {
+        guard let path = LSPURI.path(from: uri) else { return uri }
+        return LSPDiagnosticsRelativePath.of(path, workspaceRoot: workspaceRoot)
+    }
+
+    private func resolvedPath(_ arguments: ToolArguments) throws -> (relative: String, url: URL) {
+        let path = try arguments.requiredString("path")
+        let url = try pathResolver.resolve(path) // enforces the workspace boundary
+        return (path, url)
+    }
+
+    private func oneBasedLine(_ arguments: ToolArguments) throws -> Int {
+        let line = try arguments.requiredInt("line")
+        guard line >= 1 else {
+            throw ToolArgumentError.missingInteger("line (must be 1-based)")
+        }
+        return line
+    }
+
+    private func unavailable(forPath path: String) -> ToolResult {
+        ToolResult(ok: false, error: "No language server is available for \(path).")
+    }
+
+    private func errorResult(_ error: Error) -> ToolResult {
+        ToolResult(ok: false, error: "LSP request failed: \(String(describing: error))")
+    }
+
+    /// A representative existing file for workspace-wide requests that are not tied to a path. Picks
+    /// the first Swift file found so `workspace/symbol` routes to sourcekit-lsp.
+    private func representativeWorkspaceFile() -> URL? {
+        let enumerator = FileManager.default.enumerator(
+            at: workspaceRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        while let item = enumerator?.nextObject() as? URL {
+            if item.pathExtension.lowercased() == "swift" { return item }
+        }
+        return nil
+    }
+}

--- a/Sources/QuillCodeTools/LSPToolDefinitions.swift
+++ b/Sources/QuillCodeTools/LSPToolDefinitions.swift
@@ -1,0 +1,53 @@
+import QuillCodeCore
+
+public extension ToolDefinition {
+    static let lspDefinition = ToolDefinition(
+        name: "host.lsp.definition",
+        description: """
+        Jump to the definition of the symbol at a position, via the language server. \
+        `path` is a workspace file; `line` is 1-based (matching host.file.read numbering); \
+        `character` is the 0-based column. Returns the defining file:line locations.
+        """,
+        parametersJSON: #"{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer","description":"1-based line"},"character":{"type":"integer","description":"0-based column"}},"required":["path","line","character"]}"#,
+        host: .local,
+        risk: .read
+    )
+
+    static let lspReferences = ToolDefinition(
+        name: "host.lsp.references",
+        description: """
+        Find all references to the symbol at a position, project-wide, via the language server. \
+        `line` is 1-based; `character` is the 0-based column. Returns file:line locations.
+        """,
+        parametersJSON: #"{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer","description":"1-based line"},"character":{"type":"integer","description":"0-based column"},"includeDeclaration":{"type":"boolean"}},"required":["path","line","character"]}"#,
+        host: .local,
+        risk: .read
+    )
+
+    static let lspHover = ToolDefinition(
+        name: "host.lsp.hover",
+        description: """
+        Get hover info (type, signature, docs) for the symbol at a position, via the language \
+        server. `line` is 1-based; `character` is the 0-based column.
+        """,
+        parametersJSON: #"{"type":"object","properties":{"path":{"type":"string"},"line":{"type":"integer","description":"1-based line"},"character":{"type":"integer","description":"0-based column"}},"required":["path","line","character"]}"#,
+        host: .local,
+        risk: .read
+    )
+
+    static let lspDocumentSymbol = ToolDefinition(
+        name: "host.lsp.document_symbol",
+        description: "List the symbols (types, functions, properties) defined in a file, via the language server.",
+        parametersJSON: #"{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}"#,
+        host: .local,
+        risk: .read
+    )
+
+    static let lspWorkspaceSymbol = ToolDefinition(
+        name: "host.lsp.workspace_symbol",
+        description: "Search the whole project for symbols matching a name, via the language server.",
+        parametersJSON: #"{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}"#,
+        host: .local,
+        risk: .read
+    )
+}

--- a/Sources/QuillCodeTools/LSPTransport.swift
+++ b/Sources/QuillCodeTools/LSPTransport.swift
@@ -1,0 +1,94 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// The byte-level channel to a language server. Behind this protocol sits either a real subprocess's
+/// stdin/stdout (`LSPStdioTransport`) or a canned in-memory scripted server in tests — so the entire
+/// `LSPClient` runs deterministically without a real sourcekit-lsp.
+///
+/// Implementations must be `Sendable`; the client serializes access with its own lock, so a
+/// transport need not be internally concurrent, only safe to hand across the boundary.
+public protocol LSPTransport: Sendable {
+    /// Writes one already-framed message (header + body) to the server. Throws if the write fails
+    /// (e.g. the server's stdin is closed because it crashed).
+    func send(_ data: Data) throws
+
+    /// Blocks for up to `timeout` seconds for more bytes from the server, returning whatever arrived
+    /// (possibly empty on a spurious wakeup) or `nil` on end-of-stream (server exited). Throws only on
+    /// an unexpected OS error, never on a plain timeout — a timeout returns empty so the caller can
+    /// re-check its own deadline.
+    func receive(timeout: TimeInterval) throws -> Data?
+
+    /// Releases the underlying channel (closes the pipe file descriptors for a stdio transport).
+    /// Idempotent. Closing stdin signals EOF to the child so it can exit; not closing leaks fds and
+    /// can wedge the child. In-memory test transports may no-op.
+    func close()
+}
+
+public extension LSPTransport {
+    /// Default no-op so in-memory/scripted transports need not implement it.
+    func close() {}
+}
+
+/// A transport over a subprocess's stdin (write) and stdout (read) file handles. Reads use `poll(2)`
+/// with a bounded timeout so a silent server never wedges the calling thread — the exact pattern the
+/// MCP stdio prober uses. The caller owns the `Process`; this type only touches the handles.
+public final class LSPStdioTransport: LSPTransport, @unchecked Sendable {
+    private let input: FileHandle
+    private let output: FileHandle
+    private let writeLock = NSLock()
+    private var closed = false
+
+    public init(input: FileHandle, output: FileHandle) {
+        self.input = input
+        self.output = output
+    }
+
+    public func send(_ data: Data) throws {
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        guard !closed else { throw LSPError.serverClosed("transport is closed") }
+        // `write(contentsOf:)` throws instead of raising SIGPIPE-style traps when the pipe is broken,
+        // which is exactly what we want when the server has died mid-request.
+        try input.write(contentsOf: data)
+    }
+
+    /// Closes both pipe ends. Closing stdin sends EOF to the child so it can exit cleanly; closing
+    /// stdout releases the read fd. Idempotent and error-swallowing — a double close or an
+    /// already-broken pipe is not worth surfacing on a teardown path.
+    public func close() {
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        guard !closed else { return }
+        closed = true
+        try? input.close()
+        try? output.close()
+    }
+
+    public func receive(timeout: TimeInterval) throws -> Data? {
+        let milliseconds = Int32(max(0, min(timeout * 1000, Double(Int32.max))))
+        var descriptor = pollfd(fd: output.fileDescriptor, events: Int16(POLLIN), revents: 0)
+        let ready = poll(&descriptor, 1, milliseconds)
+        if ready == 0 {
+            return Data() // plain timeout — no bytes, not EOF
+        }
+        guard ready > 0 else {
+            if errno == EINTR { return Data() } // interrupted syscall — let the caller retry
+            throw LSPError.serverClosed("poll on server stdout failed with errno \(errno)")
+        }
+
+        var bytes = [UInt8](repeating: 0, count: 64 * 1024)
+        let count = read(descriptor.fd, &bytes, bytes.count)
+        if count == 0 {
+            return nil // EOF: the server closed its stdout / exited
+        }
+        guard count > 0 else {
+            if errno == EINTR || errno == EAGAIN { return Data() }
+            throw LSPError.serverClosed("read on server stdout failed with errno \(errno)")
+        }
+        return Data(bytes.prefix(count))
+    }
+}

--- a/Sources/QuillCodeTools/ToolRouter.swift
+++ b/Sources/QuillCodeTools/ToolRouter.swift
@@ -9,6 +9,10 @@ public struct ToolRouter: Sendable {
     public var patch: PatchToolExecutor
     public var web: WebFetchToolExecutor
     public var skill: SkillLoadToolExecutor
+    /// LSP integration. `nil` (the default) disables every LSP behavior: diagnostics-after-write and
+    /// format-on-save are skipped and `host.lsp.*` reports "not available". Injecting a coordinator
+    /// (e.g. from the desktop/CLI runtime) turns the features on without changing any existing tool.
+    public var lsp: LSPCoordinator?
 
     public init(
         workspaceRoot: URL,
@@ -16,7 +20,8 @@ public struct ToolRouter: Sendable {
         git: GitToolExecutor = GitToolExecutor(),
         editGuard: FileEditSessionGuard = .shared,
         web: WebFetchToolExecutor = WebFetchToolExecutor(),
-        skill: SkillLoadToolExecutor? = nil
+        skill: SkillLoadToolExecutor? = nil,
+        lsp: LSPCoordinator? = nil
     ) {
         self.workspaceRoot = workspaceRoot
         self.shell = shell
@@ -25,6 +30,7 @@ public struct ToolRouter: Sendable {
         self.patch = PatchToolExecutor(workspaceRoot: workspaceRoot, shell: shell, editGuard: editGuard)
         self.web = web
         self.skill = skill ?? SkillLoadToolExecutor.default(workspaceRoot: workspaceRoot)
+        self.lsp = lsp
     }
 
     public static let definitions: [ToolDefinition] = ShellToolCallDispatcher.definitions + [
@@ -36,7 +42,7 @@ public struct ToolRouter: Sendable {
         .webFetch,
         .webSearch,
         .skillLoad
-    ] + GitToolCallDispatcher.definitions
+    ] + GitToolCallDispatcher.definitions + LSPToolCallDispatcher.definitions
 
     public func definition(named name: String) -> ToolDefinition? {
         Self.definitions.first { $0.name == name }
@@ -51,6 +57,10 @@ public struct ToolRouter: Sendable {
             }
             if GitToolCallDispatcher.handles(call.name) {
                 return try GitToolCallDispatcher(workspaceRoot: workspaceRoot, git: git)
+                    .execute(name: call.name, arguments: args)
+            }
+            if LSPToolCallDispatcher.handles(call.name) {
+                return try LSPToolCallDispatcher(workspaceRoot: workspaceRoot, coordinator: lsp)
                     .execute(name: call.name, arguments: args)
             }
             switch call.name {
@@ -73,12 +83,17 @@ public struct ToolRouter: Sendable {
                     maxResults: args.int("maxResults")
                 )
             case ToolDefinition.fileWrite.name:
-                return files.write(
-                    path: try args.requiredString("path"),
+                let path = try args.requiredString("path")
+                let result = files.write(
+                    path: path,
                     content: try args.requiredString("content", allowingEmpty: true)
                 )
+                return withLSPFeedback(result, writtenPaths: [path])
             case ToolDefinition.applyPatch.name:
-                return patch.apply(unifiedDiff: try args.requiredString("patch"))
+                let patchText = try args.requiredString("patch")
+                let result = patch.apply(unifiedDiff: patchText)
+                let touched = PatchToolExecutor.targetPaths(in: patchText)
+                return withLSPFeedback(result, writtenPaths: touched)
             case ToolDefinition.webFetch.name:
                 return web.fetch(urlString: try args.requiredString("url"))
             case ToolDefinition.webSearch.name:
@@ -99,5 +114,24 @@ public struct ToolRouter: Sendable {
         } catch {
             return ToolResult(ok: false, error: String(describing: error))
         }
+    }
+
+    /// After a successful write/patch, run the LSP post-write pass (format-on-save + project-wide
+    /// diagnostics) and append its notice to the result's `stdout`. A no-op when no coordinator is
+    /// wired or the result already failed — the write's own behavior is never altered on failure.
+    private func withLSPFeedback(_ result: ToolResult, writtenPaths: [String]) -> ToolResult {
+        guard let lsp, result.ok, !writtenPaths.isEmpty else { return result }
+        // Resolve to absolute URLs inside the workspace; silently drop anything that fails the
+        // boundary check (a hostile path never reaches the LSP layer).
+        let resolver = FileWorkspacePathResolver(workspaceRoot: workspaceRoot)
+        let urls = writtenPaths.compactMap { try? resolver.resolve($0) }
+        guard !urls.isEmpty else { return result }
+
+        let feedback = lsp.afterWrite(paths: urls)
+        guard let notice = feedback.notice, !notice.isEmpty else { return result }
+        var updated = result
+        let separator = updated.stdout.isEmpty || updated.stdout.hasSuffix("\n") ? "" : "\n"
+        updated.stdout += "\(separator)\n\(notice)\n"
+        return updated
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceLSPCoordinatorProviderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceLSPCoordinatorProviderTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+@testable import QuillCodeApp
+
+final class WorkspaceLSPCoordinatorProviderTests: XCTestCase {
+    private let workspace = URL(fileURLWithPath: "/tmp/quillcode-lsp-provider")
+
+    func testDisabledByDefault() {
+        let provider = WorkspaceLSPCoordinatorProvider(environment: [:])
+        XCTAssertNil(provider.coordinator(forWorkspace: workspace, isRemote: false),
+                     "LSP must be off unless QUILLCODE_LSP is set")
+    }
+
+    func testEnabledByEnvironmentFlag() {
+        let provider = WorkspaceLSPCoordinatorProvider(environment: ["QUILLCODE_LSP": "1"])
+        XCTAssertNotNil(provider.coordinator(forWorkspace: workspace, isRemote: false))
+    }
+
+    func testRemoteWorkspaceHasNoCoordinatorEvenWhenEnabled() {
+        let provider = WorkspaceLSPCoordinatorProvider(environment: ["QUILLCODE_LSP": "1"])
+        XCTAssertNil(provider.coordinator(forWorkspace: workspace, isRemote: true),
+                     "a remote project's files are not on this machine, so a local server cannot see them")
+    }
+
+    func testCoordinatorIsCachedPerWorkspace() {
+        let provider = WorkspaceLSPCoordinatorProvider(environment: ["QUILLCODE_LSP": "true"])
+        let first = provider.coordinator(forWorkspace: workspace, isRemote: false)
+        let second = provider.coordinator(forWorkspace: workspace, isRemote: false)
+        XCTAssertNotNil(first)
+        XCTAssertTrue(first === second, "the same workspace must reuse one coordinator (and one server)")
+    }
+
+    func testDifferentWorkspacesGetDistinctCoordinators() {
+        let provider = WorkspaceLSPCoordinatorProvider(environment: ["QUILLCODE_LSP": "yes"])
+        let a = provider.coordinator(forWorkspace: URL(fileURLWithPath: "/tmp/ws-a"), isRemote: false)
+        let b = provider.coordinator(forWorkspace: URL(fileURLWithPath: "/tmp/ws-b"), isRemote: false)
+        XCTAssertNotNil(a)
+        XCTAssertNotNil(b)
+        XCTAssertFalse(a === b)
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPClientTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPClientTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import XCTest
+@testable import QuillCodeTools
+
+final class LSPClientTests: XCTestCase {
+    private let workspace = URL(fileURLWithPath: "/tmp/quillcode-lsp-test")
+
+    func testInitializeHandshakeSendsInitializeAndInitialized() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": ["documentFormattingProvider": true]])
+        let client = LSPClient(transport: transport)
+
+        let capabilities = try client.initialize(workspaceRoot: workspace)
+        XCTAssertTrue(client.supportsFormatting)
+        XCTAssertNotNil(capabilities["documentFormattingProvider"])
+
+        // The client must have sent an `initialize` request followed by an `initialized` notification.
+        let methods = transport.sentMessages.compactMap { $0["method"] as? String }
+        XCTAssertEqual(methods, ["initialize", "initialized"])
+        let initialize = try XCTUnwrap(transport.sentMessages.first)
+        XCTAssertEqual(initialize["id"] as? Int, 1)
+        let params = try XCTUnwrap(initialize["params"] as? [String: Any])
+        XCTAssertNotNil(params["rootUri"])
+    }
+
+    func testInitializeIsIdempotent() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+        try client.initialize(workspaceRoot: workspace) // second call is a no-op
+        XCTAssertEqual(transport.sentMessages.filter { $0["method"] as? String == "initialize" }.count, 1)
+    }
+
+    func testDefinitionParsesLocations() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        transport.enqueueResponse(id: 2, result: [[
+            "uri": "file:///tmp/quillcode-lsp-test/Foo.swift",
+            "range": ["start": ["line": 10, "character": 4], "end": ["line": 10, "character": 8]]
+        ]])
+        let locations = try client.definition(path: "/tmp/quillcode-lsp-test/Bar.swift", line: 3, character: 2)
+        XCTAssertEqual(locations.count, 1)
+        XCTAssertEqual(locations.first?.range.start.line, 10)
+        XCTAssertEqual(locations.first?.uri, "file:///tmp/quillcode-lsp-test/Foo.swift")
+    }
+
+    func testReferencesIncludesContext() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        transport.enqueueResponse(id: 2, result: [
+            ["uri": "file:///a.swift", "range": ["start": ["line": 1, "character": 0], "end": ["line": 1, "character": 3]]],
+            ["uri": "file:///b.swift", "range": ["start": ["line": 5, "character": 2], "end": ["line": 5, "character": 5]]]
+        ])
+        let refs = try client.references(path: "/tmp/quillcode-lsp-test/x.swift", line: 2, character: 1)
+        XCTAssertEqual(refs.count, 2)
+        let request = try XCTUnwrap(transport.sentMessages.last)
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        let context = try XCTUnwrap(params["context"] as? [String: Any])
+        XCTAssertEqual(context["includeDeclaration"] as? Bool, true)
+    }
+
+    func testHoverFlattensMarkupContent() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        transport.enqueueResponse(id: 2, result: ["contents": ["kind": "markdown", "value": "func foo() -> Int"]])
+        let hover = try client.hover(path: "/tmp/quillcode-lsp-test/x.swift", line: 1, character: 1)
+        XCTAssertEqual(hover, "func foo() -> Int")
+    }
+
+    func testDocumentSymbolFlattensTree() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        transport.enqueueResponse(id: 2, result: [[
+            "name": "Widget",
+            "kind": 5, // class
+            "range": ["start": ["line": 0, "character": 0], "end": ["line": 20, "character": 0]],
+            "selectionRange": ["start": ["line": 0, "character": 6], "end": ["line": 0, "character": 12]],
+            "children": [[
+                "name": "render",
+                "kind": 6, // method
+                "range": ["start": ["line": 2, "character": 4], "end": ["line": 4, "character": 4]],
+                "selectionRange": ["start": ["line": 2, "character": 9], "end": ["line": 2, "character": 15]]
+            ]]
+        ]])
+        let symbols = try client.documentSymbols(path: "/tmp/quillcode-lsp-test/Widget.swift")
+        XCTAssertEqual(symbols.map(\.name), ["Widget", "render"])
+        XCTAssertEqual(symbols.first?.kindLabel, "class")
+        XCTAssertEqual(symbols.last?.containerName, "Widget")
+    }
+
+    func testWorkspaceSymbolParsesInformation() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        transport.enqueueResponse(id: 2, result: [[
+            "name": "ToolRouter",
+            "kind": 23, // struct
+            "location": ["uri": "file:///tmp/quillcode-lsp-test/ToolRouter.swift", "range": ["start": ["line": 3, "character": 0], "end": ["line": 3, "character": 10]]]
+        ]])
+        let symbols = try client.workspaceSymbols(query: "ToolRouter")
+        XCTAssertEqual(symbols.first?.name, "ToolRouter")
+        XCTAssertEqual(symbols.first?.kindLabel, "struct")
+    }
+
+    func testDiagnosticsCollectedFromPublishNotification() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        let uri = "file:///tmp/quillcode-lsp-test/Broken.swift"
+        transport.enqueueDiagnostics(uri: uri, diagnostics: [[
+            "range": ["start": ["line": 4, "character": 0], "end": ["line": 4, "character": 5]],
+            "severity": 1,
+            "message": "cannot find 'foo' in scope"
+        ]])
+        let diagnostics = client.diagnostics(for: "/tmp/quillcode-lsp-test/Broken.swift", waitFor: 0.5)
+        XCTAssertEqual(diagnostics.count, 1)
+        XCTAssertEqual(diagnostics.first?.severity, .error)
+        XCTAssertEqual(diagnostics.first?.message, "cannot find 'foo' in scope")
+    }
+
+    func testServerErrorResponseThrows() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        transport.enqueueError(id: 2, code: -32601, message: "method not found")
+        XCTAssertThrowsError(try client.definition(path: "/tmp/quillcode-lsp-test/x.swift", line: 1, character: 0)) { error in
+            guard case LSPError.serverError(let code, _) = error else { return XCTFail("expected serverError") }
+            XCTAssertEqual(code, -32601)
+        }
+    }
+
+    func testTimeoutWhenServerNeverResponds() {
+        let transport = ScriptedLSPTransport() // never enqueues an initialize response
+        let client = LSPClient(transport: transport)
+        XCTAssertThrowsError(try client.initialize(workspaceRoot: workspace, timeout: 0.3)) { error in
+            guard case LSPError.timeout = error else { return XCTFail("expected timeout, got \(error)") }
+        }
+    }
+
+    func testEOFWhileAwaitingResponseThrowsServerClosed() {
+        let transport = ScriptedLSPTransport()
+        transport.close() // server exits immediately, no response
+        let client = LSPClient(transport: transport)
+        XCTAssertThrowsError(try client.initialize(workspaceRoot: workspace, timeout: 1.0)) { error in
+            guard case LSPError.serverClosed = error else { return XCTFail("expected serverClosed, got \(error)") }
+        }
+    }
+
+    func testServerRequestWithCollidingIdIsNotMistakenForResponse() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        // The server sends a REQUEST (has `method` AND `id`) whose id numerically equals our next
+        // request id (2), then the real response. The client must skip the request and return the
+        // actual response, not the request masquerading as one.
+        transport.enqueue([
+            "jsonrpc": "2.0",
+            "id": 2, // collides with our definition request id
+            "method": "workspace/configuration",
+            "params": ["items": []]
+        ])
+        transport.enqueueResponse(id: 2, result: [[
+            "uri": "file:///tmp/quillcode-lsp-test/real.swift",
+            "range": ["start": ["line": 7, "character": 0], "end": ["line": 7, "character": 4]]
+        ]])
+        let locations = try client.definition(path: "/tmp/quillcode-lsp-test/x.swift", line: 1, character: 0)
+        XCTAssertEqual(locations.count, 1, "the server request must not be consumed as our response")
+        XCTAssertEqual(locations.first?.range.start.line, 7)
+    }
+
+    func testOutOfOrderNotificationBeforeResponseIsHandled() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+
+        // A publishDiagnostics notification arrives before the definition response — the client must
+        // stash it and keep waiting for id 2, not mistake it for the response.
+        transport.enqueueDiagnostics(uri: "file:///tmp/quillcode-lsp-test/x.swift", diagnostics: [[
+            "range": ["start": ["line": 0, "character": 0], "end": ["line": 0, "character": 1]],
+            "severity": 2, "message": "warned"
+        ]])
+        transport.enqueueResponse(id: 2, result: [[
+            "uri": "file:///tmp/quillcode-lsp-test/y.swift",
+            "range": ["start": ["line": 1, "character": 0], "end": ["line": 1, "character": 1]]
+        ]])
+        let locations = try client.definition(path: "/tmp/quillcode-lsp-test/x.swift", line: 1, character: 0)
+        XCTAssertEqual(locations.count, 1)
+        // And the stashed diagnostic is available.
+        XCTAssertEqual(client.allDiagnostics().values.first?.first?.message, "warned")
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPClientTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPClientTests.swift
@@ -165,6 +165,26 @@ final class LSPClientTests: XCTestCase {
         }
     }
 
+    func testMalformedFramePoisonsClient() throws {
+        let transport = ScriptedLSPTransport()
+        transport.enqueueResponse(id: 1, result: ["capabilities": [:]])
+        let client = LSPClient(transport: transport)
+        try client.initialize(workspaceRoot: workspace)
+        XCTAssertTrue(client.isHealthy)
+
+        // The server leaks a non-protocol line to stdout (a bad Content-Length). The bytes stay at the
+        // front of the buffer, so the request throws — and the client must mark itself poisoned so the
+        // session is dropped rather than replaying the corrupt prefix on every future request.
+        transport.enqueueRaw(Data("Content-Length: not-a-number\r\n\r\n".utf8))
+        XCTAssertThrowsError(try client.definition(path: "/tmp/quillcode-lsp-test/x.swift", line: 1, character: 0))
+        XCTAssertFalse(client.isHealthy, "a codec error must poison the client so the manager relaunches it")
+
+        // Even a subsequently-queued valid response is unreachable — the client is dead until relaunch.
+        transport.enqueueResponse(id: 3, result: [])
+        XCTAssertThrowsError(try client.definition(path: "/tmp/quillcode-lsp-test/x.swift", line: 1, character: 0))
+        XCTAssertFalse(client.isHealthy)
+    }
+
     func testServerRequestWithCollidingIdIsNotMistakenForResponse() throws {
         let transport = ScriptedLSPTransport()
         transport.enqueueResponse(id: 1, result: ["capabilities": [:]])

--- a/Tests/QuillCodeToolsTests/LSPCoordinatorTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPCoordinatorTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+final class LSPCoordinatorTests: XCTestCase {
+    private var workspace: URL!
+
+    override func setUpWithError() throws {
+        workspace = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("quillcode-lsp-coord-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        // Resolve symlinks (/var -> /private/var on macOS) so on-disk paths match the coordinator's.
+        workspace = workspace.resolvingSymlinksInPath()
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: workspace)
+    }
+
+    private func registry(available: Bool) -> LSPServerRegistry {
+        LSPServerRegistry(
+            configs: LSPServerRegistry.defaults,
+            commandLocator: StubCommandLocator(resolvedPath: available ? "/usr/bin/sourcekit-lsp" : nil)
+        )
+    }
+
+    private func makeCoordinator(server: StubLanguageServer, available: Bool = true, formatOnSave: Bool = false) -> LSPCoordinator {
+        let launcher = StubLSPServerLauncher { server }
+        let sessions = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: available), launcher: launcher)
+        return LSPCoordinator(workspaceRoot: workspace, sessions: sessions, formatOnSave: formatOnSave, diagnosticsWait: 0.4)
+    }
+
+    private func writeFile(_ name: String, _ contents: String) throws -> URL {
+        let url = workspace.appendingPathComponent(name)
+        try Data(contents.utf8).write(to: url)
+        return url
+    }
+
+    func testDiagnosticsAfterWriteReportsErrors() throws {
+        let file = try writeFile("Broken.swift", "let x = \n")
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": [:]]
+        server.diagnosticsOnSave[LSPURI.from(path: file.path)] = [[
+            "range": ["start": ["line": 0, "character": 8], "end": ["line": 0, "character": 8]],
+            "severity": 1,
+            "message": "expected expression after '='"
+        ]]
+        let coordinator = makeCoordinator(server: server)
+
+        let feedback = coordinator.afterWrite(paths: [file])
+        let notice = try XCTUnwrap(feedback.notice)
+        XCTAssertTrue(notice.contains("Broken.swift:1:"), notice)
+        XCTAssertTrue(notice.contains("expected expression"), notice)
+        XCTAssertFalse(feedback.didFormat)
+    }
+
+    func testMissingServerDegradesGracefully() throws {
+        let file = try writeFile("A.swift", "let x = 1\n")
+        let server = StubLanguageServer()
+        let coordinator = makeCoordinator(server: server, available: false)
+
+        let feedback = coordinator.afterWrite(paths: [file])
+        // One-time notice about the missing server; never an error, never a crash.
+        XCTAssertNotNil(feedback.notice)
+        XCTAssertTrue(feedback.notice!.contains("not available"))
+        XCTAssertFalse(feedback.didFormat)
+        // Second write: no repeated notice.
+        XCTAssertNil(coordinator.afterWrite(paths: [file]).notice)
+    }
+
+    func testUnsupportedFileTypeIsNoOp() throws {
+        let file = try writeFile("notes.md", "# hi\n")
+        let server = StubLanguageServer()
+        let coordinator = makeCoordinator(server: server)
+        let feedback = coordinator.afterWrite(paths: [file])
+        XCTAssertNil(feedback.notice)
+        XCTAssertFalse(feedback.didFormat)
+    }
+
+    func testFormatOnSaveRewritesFileAndIsIdempotent() throws {
+        let messy = "let  x=1\n"
+        let clean = "let x = 1\n"
+        let file = try writeFile("Messy.swift", messy)
+
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": ["documentFormattingProvider": true]]
+        // The server returns a full-range edit replacing the document with the clean text.
+        server.resultsByMethod["textDocument/formatting"] = [[
+            "range": ["start": ["line": 0, "character": 0], "end": ["line": 1, "character": 0]],
+            "newText": clean
+        ]]
+        let coordinator = makeCoordinator(server: server, formatOnSave: true)
+
+        let feedback = coordinator.afterWrite(paths: [file])
+        XCTAssertTrue(feedback.didFormat)
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), clean)
+        XCTAssertTrue(feedback.notice?.contains("Auto-formatted") ?? false)
+
+        // Idempotence: reformatting already-clean content produces the same clean text. Point the
+        // server at an edit that yields the identical text -> no rewrite, no format notice.
+        server.resultsByMethod["textDocument/formatting"] = [[
+            "range": ["start": ["line": 0, "character": 0], "end": ["line": 1, "character": 0]],
+            "newText": clean
+        ]]
+        let second = coordinator.afterWrite(paths: [file])
+        XCTAssertFalse(second.didFormat, "no change means no rewrite")
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), clean)
+    }
+
+    func testFormatFailureKeepsOriginal() throws {
+        let original = "let  x=1\n"
+        let file = try writeFile("Keep.swift", original)
+
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": ["documentFormattingProvider": true]]
+        // A malformed edit (position past the end) must be rejected, leaving the file untouched.
+        server.resultsByMethod["textDocument/formatting"] = [[
+            "range": ["start": ["line": 99, "character": 0], "end": ["line": 99, "character": 5]],
+            "newText": "garbage"
+        ]]
+        let coordinator = makeCoordinator(server: server, formatOnSave: true)
+
+        let feedback = coordinator.afterWrite(paths: [file])
+        XCTAssertFalse(feedback.didFormat)
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), original, "malformed format edits must not corrupt the file")
+    }
+
+    func testFormatOnSavePreservesCRLFLineEndings() throws {
+        // A CRLF file must stay CRLF after formatting — format-on-save must not silently rewrite every
+        // line to LF (the same guarantee host.file.write gives via FileEncodingPreservation).
+        let messyCRLF = "let  x=1\r\n"
+        let cleanLF = "let x = 1\n" // sourcekit-lsp emits LF
+        let url = workspace.appendingPathComponent("CRLF.swift")
+        try Data(messyCRLF.utf8).write(to: url)
+
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": ["documentFormattingProvider": true]]
+        server.resultsByMethod["textDocument/formatting"] = [[
+            "range": ["start": ["line": 0, "character": 0], "end": ["line": 1, "character": 0]],
+            "newText": cleanLF
+        ]]
+        let coordinator = makeCoordinator(server: server, formatOnSave: true)
+
+        let feedback = coordinator.afterWrite(paths: [url])
+        XCTAssertTrue(feedback.didFormat)
+        let onDisk = try Data(contentsOf: url)
+        let text = String(decoding: onDisk, as: UTF8.self)
+        XCTAssertTrue(text.contains("\r\n"), "CRLF line endings must be preserved, got: \(text.debugDescription)")
+        XCTAssertEqual(text, "let x = 1\r\n")
+    }
+
+    func testFormatOffByDefaultLeavesFileUntouched() throws {
+        let original = "let  x=1\n"
+        let file = try writeFile("NoFormat.swift", original)
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": ["documentFormattingProvider": true]]
+        server.resultsByMethod["textDocument/formatting"] = [[
+            "range": ["start": ["line": 0, "character": 0], "end": ["line": 1, "character": 0]],
+            "newText": "let x = 1\n"
+        ]]
+        // formatOnSave defaults to false.
+        let coordinator = makeCoordinator(server: server, formatOnSave: false)
+        let feedback = coordinator.afterWrite(paths: [file])
+        XCTAssertFalse(feedback.didFormat)
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), original)
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPCoordinatorTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPCoordinatorTests.swift
@@ -150,6 +150,38 @@ final class LSPCoordinatorTests: XCTestCase {
         XCTAssertEqual(text, "let x = 1\r\n")
     }
 
+    func testFormatOnSaveDoesNotDoubleBOMAndIsIdempotent() throws {
+        // A UTF-8 BOM-prefixed file, formatted, must end with EXACTLY ONE BOM — not a doubled one —
+        // and a second format-on-save pass must be a byte-for-byte no-op.
+        let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
+        let url = workspace.appendingPathComponent("BOM.swift")
+        try Data(bom + Array("let  x=1\n".utf8)).write(to: url)
+
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": ["documentFormattingProvider": true]]
+        // The server sees the decoded text (with a leading U+FEFF scalar) and returns the formatted
+        // document, preserving that scalar the way a real server round-trips the file's leading BOM.
+        server.resultsByMethod["textDocument/formatting"] = [[
+            "range": ["start": ["line": 0, "character": 0], "end": ["line": 1, "character": 0]],
+            "newText": "\u{FEFF}let x = 1\n"
+        ]]
+        let coordinator = makeCoordinator(server: server, formatOnSave: true)
+
+        let feedback = coordinator.afterWrite(paths: [url])
+        XCTAssertTrue(feedback.didFormat)
+        let onDisk = [UInt8](try Data(contentsOf: url))
+        // Exactly one BOM at the front, and no second BOM immediately after it.
+        XCTAssertEqual(Array(onDisk.prefix(3)), bom, "must start with a single BOM")
+        XCTAssertNotEqual(Array(onDisk.dropFirst(3).prefix(3)), bom, "the BOM must not be doubled")
+        XCTAssertEqual(onDisk, bom + Array("let x = 1\n".utf8))
+
+        // Idempotence: a second pass over the already-formatted BOM file must not change any bytes.
+        let before = try Data(contentsOf: url)
+        let second = coordinator.afterWrite(paths: [url])
+        XCTAssertFalse(second.didFormat, "re-formatting an already-formatted BOM file must be a no-op")
+        XCTAssertEqual(try Data(contentsOf: url), before, "second pass must be byte-for-byte identical")
+    }
+
     func testFormatOffByDefaultLeavesFileUntouched() throws {
         let original = "let  x=1\n"
         let file = try writeFile("NoFormat.swift", original)

--- a/Tests/QuillCodeToolsTests/LSPDiagnosticsFormatterTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPDiagnosticsFormatterTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import XCTest
+@testable import QuillCodeTools
+
+final class LSPDiagnosticsFormatterTests: XCTestCase {
+    private let root = URL(fileURLWithPath: "/ws")
+
+    private func diagnostic(line: Int, severity: LSPDiagnosticSeverity, message: String) -> LSPDiagnostic {
+        LSPDiagnostic(
+            range: LSPRange(start: LSPPosition(line: line, character: 0), end: LSPPosition(line: line, character: 1)),
+            severity: severity,
+            message: message
+        )
+    }
+
+    func testNoErrorsOrWarningsReturnsNil() {
+        let diagnostics = ["/ws/A.swift": [diagnostic(line: 0, severity: .information, message: "note")]]
+        XCTAssertNil(LSPDiagnosticsFormatter.format(diagnosticsByPath: diagnostics, workspaceRoot: root))
+    }
+
+    func testFormatsErrorWithRelativePathAnd1BasedLine() throws {
+        let diagnostics = ["/ws/Sources/A.swift": [diagnostic(line: 4, severity: .error, message: "cannot find 'foo'")]]
+        let output = try XCTUnwrap(LSPDiagnosticsFormatter.format(diagnosticsByPath: diagnostics, workspaceRoot: root))
+        XCTAssertTrue(output.contains("Sources/A.swift:5: error: cannot find 'foo'"), output)
+    }
+
+    func testCapsAtFiveFiles() throws {
+        var diagnostics: [String: [LSPDiagnostic]] = [:]
+        for i in 0..<8 {
+            diagnostics["/ws/File\(i).swift"] = [diagnostic(line: 0, severity: .error, message: "boom \(i)")]
+        }
+        let output = try XCTUnwrap(LSPDiagnosticsFormatter.format(diagnosticsByPath: diagnostics, workspaceRoot: root))
+        let shownFiles = Set(output.split(separator: "\n").compactMap { line -> String? in
+            guard line.contains(".swift:") else { return nil }
+            return String(line.split(separator: ":").first ?? "")
+        })
+        XCTAssertEqual(shownFiles.count, LSPDiagnosticsFormatter.maxFiles)
+        XCTAssertTrue(output.contains("showing 5 of 8 files"), output)
+    }
+
+    func testEditedFileListedFirst() throws {
+        let diagnostics = [
+            "/ws/Zebra.swift": [diagnostic(line: 0, severity: .error, message: "z error")],
+            "/ws/Apple.swift": [diagnostic(line: 0, severity: .error, message: "a error")]
+        ]
+        let output = try XCTUnwrap(LSPDiagnosticsFormatter.format(
+            diagnosticsByPath: diagnostics,
+            workspaceRoot: root,
+            editedPath: "/ws/Zebra.swift"
+        ))
+        let firstFileLine = output.split(separator: "\n").first { $0.contains(".swift:") }
+        XCTAssertTrue(firstFileLine?.contains("Zebra.swift") ?? false, "edited file should be first: \(output)")
+    }
+
+    func testErrorsSortBeforeWarnings() throws {
+        let diagnostics = [
+            "/ws/A.swift": [
+                diagnostic(line: 10, severity: .warning, message: "a warning"),
+                diagnostic(line: 2, severity: .error, message: "an error")
+            ]
+        ]
+        let output = try XCTUnwrap(LSPDiagnosticsFormatter.format(diagnosticsByPath: diagnostics, workspaceRoot: root))
+        let errorIndex = output.range(of: "an error")?.lowerBound
+        let warningIndex = output.range(of: "a warning")?.lowerBound
+        XCTAssertNotNil(errorIndex)
+        XCTAssertNotNil(warningIndex)
+        XCTAssertTrue(errorIndex! < warningIndex!, "errors should be listed before warnings")
+    }
+
+    func testMultilineMessageCollapsedToOneLine() throws {
+        let diagnostics = ["/ws/A.swift": [diagnostic(line: 0, severity: .error, message: "line1\nline2")]]
+        let output = try XCTUnwrap(LSPDiagnosticsFormatter.format(diagnosticsByPath: diagnostics, workspaceRoot: root))
+        XCTAssertFalse(output.contains("line1\nline2"))
+        XCTAssertTrue(output.contains("line1 line2"))
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPMessageCodecTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPMessageCodecTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+@testable import QuillCodeTools
+
+final class LSPMessageCodecTests: XCTestCase {
+    func testEncodeDecodeRoundTrip() throws {
+        let object: [String: Any] = ["jsonrpc": "2.0", "id": 7, "method": "textDocument/definition"]
+        let encoded = try LSPMessageCodec.encode(object)
+        let header = String(decoding: encoded.prefix(40), as: UTF8.self)
+        XCTAssertTrue(header.hasPrefix("Content-Length: "))
+
+        var buffer = encoded
+        let message = try XCTUnwrap(LSPMessageCodec.nextMessage(from: &buffer))
+        XCTAssertTrue(buffer.isEmpty, "the full frame should have been consumed")
+        let decoded = try LSPMessageCodec.decode(message)
+        XCTAssertEqual(decoded["id"] as? Int, 7)
+        XCTAssertEqual(decoded["method"] as? String, "textDocument/definition")
+    }
+
+    func testTwoMessagesInOneBuffer() throws {
+        var buffer = Data()
+        buffer.append(try LSPMessageCodec.encode(["id": 1]))
+        buffer.append(try LSPMessageCodec.encode(["id": 2]))
+
+        let first = try LSPMessageCodec.decode(try XCTUnwrap(LSPMessageCodec.nextMessage(from: &buffer)))
+        let second = try LSPMessageCodec.decode(try XCTUnwrap(LSPMessageCodec.nextMessage(from: &buffer)))
+        XCTAssertEqual(first["id"] as? Int, 1)
+        XCTAssertEqual(second["id"] as? Int, 2)
+        XCTAssertNil(try LSPMessageCodec.nextMessage(from: &buffer))
+    }
+
+    func testPartialHeaderReturnsNilThenCompletes() throws {
+        let full = try LSPMessageCodec.encode(["id": 42])
+        // Split mid-header: only the first few bytes have arrived.
+        var buffer = full.prefix(10)
+        XCTAssertNil(try LSPMessageCodec.nextMessage(from: &buffer), "an incomplete header is not a message yet")
+        buffer.append(full.suffix(from: full.index(full.startIndex, offsetBy: 10)))
+        let message = try XCTUnwrap(LSPMessageCodec.nextMessage(from: &buffer))
+        XCTAssertEqual(try LSPMessageCodec.decode(message)["id"] as? Int, 42)
+    }
+
+    func testPartialBodyReturnsNilThenCompletes() throws {
+        let full = try LSPMessageCodec.encode(["method": "hello", "id": 3])
+        // Everything except the last byte of the body.
+        var buffer = full.prefix(full.count - 1)
+        XCTAssertNil(try LSPMessageCodec.nextMessage(from: &buffer), "an incomplete body is not a message yet")
+        buffer.append(full.suffix(1))
+        let message = try XCTUnwrap(LSPMessageCodec.nextMessage(from: &buffer))
+        XCTAssertEqual(try LSPMessageCodec.decode(message)["id"] as? Int, 3)
+    }
+
+    func testCaseInsensitiveHeaderAndExtraHeaders() throws {
+        let body = Data(#"{"id":9}"#.utf8)
+        var buffer = Data("content-length: \(body.count)\r\nContent-Type: application/vscode-jsonrpc\r\n\r\n".utf8)
+        buffer.append(body)
+        let message = try XCTUnwrap(LSPMessageCodec.nextMessage(from: &buffer))
+        XCTAssertEqual(try LSPMessageCodec.decode(message)["id"] as? Int, 9)
+    }
+
+    func testMissingContentLengthThrows() {
+        var buffer = Data("X-Whatever: 1\r\n\r\n{}".utf8)
+        XCTAssertThrowsError(try LSPMessageCodec.nextMessage(from: &buffer)) { error in
+            guard case LSPError.invalidMessage = error else { return XCTFail("expected invalidMessage") }
+        }
+    }
+
+    func testNegativeContentLengthThrows() {
+        var buffer = Data("Content-Length: -5\r\n\r\n".utf8)
+        XCTAssertThrowsError(try LSPMessageCodec.nextMessage(from: &buffer)) { error in
+            guard case LSPError.invalidMessage = error else { return XCTFail("expected invalidMessage") }
+        }
+    }
+
+    func testOversizedBodyThrows() {
+        var buffer = Data("Content-Length: \(LSPMessageCodec.maxMessageBytes + 1)\r\n\r\n".utf8)
+        buffer.append(Data(repeating: 0x20, count: 16)) // some body bytes so the header is complete
+        XCTAssertThrowsError(try LSPMessageCodec.nextMessage(from: &buffer)) { error in
+            guard case LSPError.invalidMessage = error else { return XCTFail("expected invalidMessage") }
+        }
+    }
+
+    func testNonObjectBodyIsRejected() {
+        let arrayBody = Data("[1,2,3]".utf8)
+        XCTAssertThrowsError(try LSPMessageCodec.decode(arrayBody)) { error in
+            guard case LSPError.invalidMessage = error else { return XCTFail("expected invalidMessage") }
+        }
+    }
+
+    func testGarbageBodyIsRejected() {
+        XCTAssertThrowsError(try LSPMessageCodec.decode(Data("not json".utf8))) { error in
+            guard case LSPError.invalidMessage = error else { return XCTFail("expected invalidMessage") }
+        }
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPSessionManagerTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPSessionManagerTests.swift
@@ -96,6 +96,36 @@ final class LSPSessionManagerTests: XCTestCase {
         XCTAssertTrue(box.server?.transportClosed ?? false, "shutdown must close each server's transport")
     }
 
+    func testPoisonedClientIsEvictedAndRelaunched() throws {
+        // Track every launched stub server so we can corrupt the first one's stream and assert the
+        // manager hands back a fresh, healthy client on the next request.
+        final class Box: @unchecked Sendable { var servers: [StubLanguageServer] = [] }
+        let box = Box()
+        let launcher = StubLSPServerLauncher {
+            let server = StubLanguageServer()
+            server.initializeResult = ["capabilities": [:]]
+            box.servers.append(server)
+            return server
+        }
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: launcher)
+
+        let first = try XCTUnwrap(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        XCTAssertTrue(first.isHealthy)
+        // Make the server leak a malformed frame on the next request, then make that request so the
+        // client poisons itself.
+        box.servers[0].corruptNextResponse = true
+        XCTAssertThrowsError(try first.definition(path: "/tmp/quillcode-lsp-sm/A.swift", line: 1, character: 0))
+        XCTAssertFalse(first.isHealthy)
+
+        // The manager must NOT hand back the poisoned client; it evicts + relaunches and returns a new,
+        // healthy one — nav recovers rather than being permanently broken.
+        let second = try XCTUnwrap(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        XCTAssertTrue(second.isHealthy)
+        XCTAssertFalse(second === first, "a fresh client must replace the poisoned one")
+        XCTAssertEqual(box.servers.count, 2, "the server was relaunched")
+        XCTAssertTrue(box.servers[0].transportClosed, "the poisoned session's transport must be closed")
+    }
+
     func testRepeatedCrashesDisableAfterMaxRestarts() {
         let launcher = handshakeLauncher()
         let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: launcher)

--- a/Tests/QuillCodeToolsTests/LSPSessionManagerTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPSessionManagerTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import XCTest
+@testable import QuillCodeTools
+
+final class LSPSessionManagerTests: XCTestCase {
+    private let workspace = URL(fileURLWithPath: "/tmp/quillcode-lsp-sm")
+
+    /// A registry whose command always resolves to a fixed availability.
+    private func registry(available: Bool) -> LSPServerRegistry {
+        LSPServerRegistry(
+            configs: LSPServerRegistry.defaults,
+            commandLocator: StubCommandLocator(resolvedPath: available ? "/usr/bin/sourcekit-lsp" : nil)
+        )
+    }
+
+    /// A launcher whose transport auto-answers `initialize` so the handshake succeeds.
+    private func handshakeLauncher() -> StubLSPServerLauncher {
+        StubLSPServerLauncher {
+            let server = StubLanguageServer()
+            server.initializeResult = ["capabilities": [:]]
+            return server
+        }
+    }
+
+    func testUnsupportedExtensionHasNoServer() {
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: handshakeLauncher())
+        XCTAssertFalse(manager.hasServer(forPath: "/tmp/quillcode-lsp-sm/readme.md"))
+        XCTAssertNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/readme.md"))
+    }
+
+    func testMissingServerReturnsNilAndOneTimeNotice() {
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: false), launcher: handshakeLauncher())
+        XCTAssertTrue(manager.hasServer(forPath: "/tmp/quillcode-lsp-sm/A.swift"), "config exists even though binary is missing")
+        XCTAssertNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+
+        let notice = manager.consumeUnavailableNoticeIfNeeded(forPath: "/tmp/quillcode-lsp-sm/A.swift")
+        XCTAssertNotNil(notice)
+        XCTAssertTrue(notice!.contains("not available"))
+        // Second call is suppressed (one-time).
+        XCTAssertNil(manager.consumeUnavailableNoticeIfNeeded(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+    }
+
+    func testAvailableServerLaunchesOnceAndIsReused() throws {
+        let launcher = handshakeLauncher()
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: launcher)
+        let first = manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift")
+        let second = manager.client(forPath: "/tmp/quillcode-lsp-sm/B.swift")
+        XCTAssertNotNil(first)
+        XCTAssertNotNil(second)
+        XCTAssertEqual(launcher.launchCount, 1, "the same sourcekit-lsp serves all .swift files")
+    }
+
+    func testCrashedServerIsRelaunched() throws {
+        let launcher = handshakeLauncher()
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: launcher)
+        XCTAssertNotNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        XCTAssertEqual(launcher.launchCount, 1)
+
+        // Simulate a crash: the launched process reports not running.
+        launcher.lastProcess?.running = false
+        XCTAssertNotNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        XCTAssertEqual(launcher.launchCount, 2, "a dead server should be relaunched")
+    }
+
+    func testCrashedServerTransportIsClosedOnRelaunch() throws {
+        // Track the transport handed to each launch so we can assert the dead one was closed (fds
+        // released) before the relaunch, not leaked.
+        final class Box: @unchecked Sendable { var servers: [StubLanguageServer] = [] }
+        let box = Box()
+        let launcher = StubLSPServerLauncher {
+            let server = StubLanguageServer()
+            server.initializeResult = ["capabilities": [:]]
+            box.servers.append(server)
+            return server
+        }
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: launcher)
+        XCTAssertNotNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        launcher.lastProcess?.running = false
+        XCTAssertNotNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        XCTAssertEqual(box.servers.count, 2)
+        XCTAssertTrue(box.servers[0].transportClosed, "the dead session's transport must be closed on relaunch")
+    }
+
+    func testShutdownClosesTransports() throws {
+        final class Box: @unchecked Sendable { var server: StubLanguageServer? }
+        let box = Box()
+        let launcher = StubLSPServerLauncher {
+            let server = StubLanguageServer()
+            server.initializeResult = ["capabilities": [:]]
+            box.server = server
+            return server
+        }
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: launcher)
+        XCTAssertNotNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        manager.shutdown()
+        XCTAssertTrue(box.server?.transportClosed ?? false, "shutdown must close each server's transport")
+    }
+
+    func testRepeatedCrashesDisableAfterMaxRestarts() {
+        let launcher = handshakeLauncher()
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: true), launcher: launcher)
+        // Each call: launch (or reuse), then kill it so the next call must relaunch.
+        for _ in 0...(LSPSessionManager.maxRestarts + 2) {
+            _ = manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift")
+            launcher.lastProcess?.running = false
+        }
+        // After exhausting the restart budget, the server is disabled: no further launches.
+        let before = launcher.launchCount
+        XCTAssertNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+        XCTAssertEqual(launcher.launchCount, before, "a repeatedly-crashing server is disabled, not relaunched forever")
+    }
+
+    func testFailedHandshakeDoesNotWedge() {
+        // Launcher whose transport never answers initialize -> handshake times out -> launch fails.
+        // A short initializeTimeout keeps the test fast while proving the manager gives up, not hangs.
+        let launcher = StubLSPServerLauncher { ScriptedLSPTransport() }
+        let manager = LSPSessionManager(
+            workspaceRoot: workspace,
+            registry: registry(available: true),
+            launcher: launcher,
+            initializeTimeout: 0.3
+        )
+        XCTAssertNil(manager.client(forPath: "/tmp/quillcode-lsp-sm/A.swift"))
+    }
+}
+
+final class LSPServerRegistryTests: XCTestCase {
+    func testSwiftIsTheShippedDefault() {
+        let registry = LSPServerRegistry(commandLocator: StubCommandLocator(resolvedPath: "/x"))
+        let config = registry.config(forPath: "/ws/Main.swift")
+        XCTAssertEqual(config?.command, "sourcekit-lsp")
+        XCTAssertEqual(config?.languageID, "swift")
+    }
+
+    func testUnknownExtensionHasNoConfig() {
+        let registry = LSPServerRegistry(commandLocator: StubCommandLocator(resolvedPath: "/x"))
+        XCTAssertNil(registry.config(forPath: "/ws/notes.txt"))
+        XCTAssertNil(registry.config(forPath: "/ws/noextension"))
+    }
+
+    func testResolveExecutableReflectsAvailability() {
+        let present = LSPServerRegistry(commandLocator: StubCommandLocator(resolvedPath: "/usr/bin/sourcekit-lsp"))
+        let absent = LSPServerRegistry(commandLocator: StubCommandLocator(resolvedPath: nil))
+        let config = LSPServerConfig(fileExtensions: ["swift"], languageID: "swift", command: "sourcekit-lsp")
+        XCTAssertEqual(present.resolveExecutable(for: config), "/usr/bin/sourcekit-lsp")
+        XCTAssertNil(absent.resolveExecutable(for: config))
+    }
+
+    func testGenericTableSupportsOtherLanguages() {
+        let registry = LSPServerRegistry(
+            configs: [LSPServerConfig(fileExtensions: ["ts", "tsx"], languageID: "typescript", command: "typescript-language-server")],
+            commandLocator: StubCommandLocator(resolvedPath: "/x")
+        )
+        XCTAssertEqual(registry.config(forPath: "/ws/app.tsx")?.languageID, "typescript")
+        XCTAssertNil(registry.config(forPath: "/ws/app.swift"))
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPSourceKitIntegrationTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPSourceKitIntegrationTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+@testable import QuillCodeTools
+
+/// End-to-end test against a REAL sourcekit-lsp. It is skipped (not failed) when sourcekit-lsp is not
+/// installed, so CI without a Swift toolchain LSP stays green — the deterministic stub tests carry
+/// the correctness load. Run locally with a toolchain present to exercise the real transport.
+final class LSPSourceKitIntegrationTests: XCTestCase {
+    private var workspace: URL!
+
+    override func setUpWithError() throws {
+        try XCTSkipUnless(sourceKitLSPAvailable, "sourcekit-lsp not found on PATH / via xcrun; skipping integration test")
+        workspace = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("quillcode-lsp-int-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        workspace = workspace.resolvingSymlinksInPath()
+    }
+
+    override func tearDownWithError() throws {
+        if let workspace { try? FileManager.default.removeItem(at: workspace) }
+    }
+
+    private var sourceKitLSPAvailable: Bool {
+        LSPCommandLocator().locate(command: "sourcekit-lsp") != nil
+    }
+
+    func testRealServerHandshakeAndDefinition() throws {
+        let registry = LSPServerRegistry()
+        let manager = LSPSessionManager(workspaceRoot: workspace, registry: registry)
+
+        let file = workspace.appendingPathComponent("Main.swift")
+        try Data("""
+        struct Point { var x: Int }
+        let p = Point(x: 1)
+        print(p.x)
+        """.utf8).write(to: file)
+
+        let client = try XCTUnwrap(manager.client(forPath: file.path), "server should launch and initialize")
+        try client.didOpen(path: file.path, text: try String(contentsOf: file, encoding: .utf8), languageID: "swift")
+        // A real server may take a moment; a bounded request must return without hanging the test.
+        let symbols = try client.documentSymbols(path: file.path, timeout: 15)
+        XCTAssertTrue(symbols.contains { $0.name == "Point" }, "expected the Point struct in document symbols")
+        manager.shutdown()
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPTestSupport.swift
+++ b/Tests/QuillCodeToolsTests/LSPTestSupport.swift
@@ -1,0 +1,189 @@
+import Foundation
+@testable import QuillCodeTools
+
+/// A deterministic in-memory `LSPTransport` for tests: the test writes framed JSON-RPC bytes the
+/// "server" will emit, and the client reads them through `receive`. `send` captures every outbound
+/// frame so a test can assert on the requests the client made. No process, no pipes, no real
+/// language server — the whole client runs in-process and deterministically.
+final class ScriptedLSPTransport: LSPTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var inbound = Data()
+    private var closed = false
+    private(set) var sentMessages: [[String: Any]] = []
+
+    /// Queues one server->client message (encoded with Content-Length framing).
+    func enqueue(_ object: [String: Any]) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let data = try? LSPMessageCodec.encode(object) {
+            inbound.append(data)
+        }
+    }
+
+    /// Queues a JSON-RPC response for a request id.
+    func enqueueResponse(id: Int, result: Any) {
+        enqueue(["jsonrpc": "2.0", "id": id, "result": result])
+    }
+
+    /// Queues a JSON-RPC error response for a request id.
+    func enqueueError(id: Int, code: Int, message: String) {
+        enqueue(["jsonrpc": "2.0", "id": id, "error": ["code": code, "message": message]])
+    }
+
+    /// Queues a `publishDiagnostics` notification.
+    func enqueueDiagnostics(uri: String, diagnostics: [[String: Any]]) {
+        enqueue([
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": ["uri": uri, "diagnostics": diagnostics]
+        ])
+    }
+
+    /// Appends raw bytes directly (for framing/partial-frame tests).
+    func enqueueRaw(_ data: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        inbound.append(data)
+    }
+
+    /// Simulates the server exiting: `receive` returns `nil` (EOF) once the buffer is drained.
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        closed = true
+    }
+
+    func send(_ data: Data) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        var buffer = data
+        while let message = try? LSPMessageCodec.nextMessage(from: &buffer),
+              let object = try? LSPMessageCodec.decode(message) {
+            sentMessages.append(object)
+        }
+    }
+
+    func receive(timeout: TimeInterval) throws -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        if !inbound.isEmpty {
+            let chunk = inbound
+            inbound.removeAll()
+            return chunk
+        }
+        if closed { return nil } // EOF after draining
+        return Data() // no data yet — a plain timeout
+    }
+}
+
+/// A canned server behavior that auto-responds to requests the way a real server would, so a test
+/// can drive an `LSPClient` end to end without hand-queuing every response. It inspects each sent
+/// request and enqueues a matching response on the transport.
+final class StubLanguageServer: LSPTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var inbound = Data()
+    private var closed = false
+    private(set) var transportClosed = false
+
+    /// Result to return for `initialize` (the `capabilities` object lives inside).
+    var initializeResult: [String: Any] = ["capabilities": ["documentFormattingProvider": true]]
+    /// Result for `textDocument/definition`, `references`, etc., keyed by method.
+    var resultsByMethod: [String: Any] = [:]
+    /// Diagnostics to publish for a URI right after `didSave` for it.
+    var diagnosticsOnSave: [String: [[String: Any]]] = [:]
+
+    func send(_ data: Data) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        var buffer = data
+        while let message = try? LSPMessageCodec.nextMessage(from: &buffer),
+              let object = try? LSPMessageCodec.decode(message) {
+            handle(object)
+        }
+    }
+
+    func receive(timeout: TimeInterval) throws -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        if !inbound.isEmpty {
+            let chunk = inbound
+            inbound.removeAll()
+            return chunk
+        }
+        if closed { return nil }
+        return Data()
+    }
+
+    func close() {
+        lock.lock(); defer { lock.unlock() }
+        closed = true
+        transportClosed = true
+    }
+
+    private func handle(_ object: [String: Any]) {
+        let method = object["method"] as? String
+        if let id = LSPJSON.int(object["id"]), let method {
+            let result: Any
+            if method == "initialize" {
+                result = initializeResult
+            } else {
+                result = resultsByMethod[method] ?? NSNull()
+            }
+            enqueue(["jsonrpc": "2.0", "id": id, "result": result])
+        }
+        // On save, publish the canned diagnostics for the saved URI.
+        if method == "textDocument/didSave",
+           let params = object["params"] as? [String: Any],
+           let doc = params["textDocument"] as? [String: Any],
+           let uri = doc["uri"] as? String,
+           let diagnostics = diagnosticsOnSave[uri] {
+            enqueue([
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": ["uri": uri, "diagnostics": diagnostics]
+            ])
+        }
+    }
+
+    private func enqueue(_ object: [String: Any]) {
+        if let data = try? LSPMessageCodec.encode(object) {
+            inbound.append(data)
+        }
+    }
+}
+
+/// A launcher that hands back a pre-built transport + a fake process, so `LSPSessionManager` can be
+/// tested without spawning anything. The `isRunning` flag is mutable so a test can simulate a crash.
+final class StubLSPServerLauncher: LSPServerLaunching, @unchecked Sendable {
+    final class FakeProcess: LSPProcessControlling, @unchecked Sendable {
+        var running: Bool
+        private(set) var terminated = false
+        init(running: Bool = true) { self.running = running }
+        var isRunning: Bool { running }
+        func terminate() { terminated = true; running = false }
+    }
+
+    private let makeTransport: @Sendable () -> LSPTransport
+    /// Set to a non-nil error to make the next launch throw (simulating a failed spawn).
+    var launchError: LSPError?
+    private(set) var launchCount = 0
+    private(set) var lastProcess: FakeProcess?
+
+    init(makeTransport: @escaping @Sendable () -> LSPTransport) {
+        self.makeTransport = makeTransport
+    }
+
+    func launch(executable: String, arguments: [String], workspaceRoot: URL) throws -> LSPLaunchedServer {
+        launchCount += 1
+        if let launchError { throw launchError }
+        let process = FakeProcess()
+        lastProcess = process
+        return LSPLaunchedServer(transport: makeTransport(), process: process)
+    }
+}
+
+/// A command locator that reports a fixed availability, for testing the missing-server path.
+struct StubCommandLocator: LSPCommandLocating {
+    let resolvedPath: String?
+    func locate(command: String) -> String? { resolvedPath }
+}

--- a/Tests/QuillCodeToolsTests/LSPTestSupport.swift
+++ b/Tests/QuillCodeToolsTests/LSPTestSupport.swift
@@ -91,6 +91,9 @@ final class StubLanguageServer: LSPTransport, @unchecked Sendable {
     var resultsByMethod: [String: Any] = [:]
     /// Diagnostics to publish for a URI right after `didSave` for it.
     var diagnosticsOnSave: [String: [[String: Any]]] = [:]
+    /// When true, the NEXT id-bearing request is answered with a malformed frame (a bad Content-Length)
+    /// instead of a valid response — simulating a server that leaks a non-protocol line to stdout.
+    var corruptNextResponse = false
 
     func send(_ data: Data) throws {
         lock.lock()
@@ -123,6 +126,11 @@ final class StubLanguageServer: LSPTransport, @unchecked Sendable {
     private func handle(_ object: [String: Any]) {
         let method = object["method"] as? String
         if let id = LSPJSON.int(object["id"]), let method {
+            if corruptNextResponse, method != "initialize" {
+                corruptNextResponse = false
+                inbound.append(Data("Content-Length: not-a-number\r\n\r\n".utf8))
+                return
+            }
             let result: Any
             if method == "initialize" {
                 result = initializeResult

--- a/Tests/QuillCodeToolsTests/LSPTextEditTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPTextEditTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+@testable import QuillCodeTools
+
+final class LSPTextEditTests: XCTestCase {
+    private func edit(_ sl: Int, _ sc: Int, _ el: Int, _ ec: Int, _ text: String) -> LSPTextEdit {
+        LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: sl, character: sc), end: LSPPosition(line: el, character: ec)),
+            newText: text
+        )
+    }
+
+    func testEmptyEditsAreIdentity() {
+        let text = "let x = 1\n"
+        XCTAssertEqual(LSPEditApplier.apply([], to: text), text)
+    }
+
+    func testWholeDocumentReplacement() {
+        let original = "let  x=1\n"
+        // sourcekit-lsp commonly returns a single full-range edit with the formatted document.
+        let formatted = "let x = 1\n"
+        let result = LSPEditApplier.apply([edit(0, 0, 1, 0, formatted)], to: original)
+        XCTAssertEqual(result, formatted)
+    }
+
+    func testMultipleNonOverlappingEditsApplyEndToStart() {
+        let original = "a\nb\nc\n"
+        // Replace line 0 "a" -> "A" and line 2 "c" -> "C"; order in the array is start-to-end.
+        let edits = [
+            edit(0, 0, 0, 1, "A"),
+            edit(2, 0, 2, 1, "C")
+        ]
+        XCTAssertEqual(LSPEditApplier.apply(edits, to: original), "A\nb\nC\n")
+    }
+
+    func testIdempotenceReapplyingFormattedTextYieldsSame() {
+        let formatted = "let x = 1\n"
+        // A formatter that returns the same text as a full-range edit must not change anything.
+        let result = LSPEditApplier.apply([edit(0, 0, 1, 0, formatted)], to: formatted)
+        XCTAssertEqual(result, formatted)
+    }
+
+    func testEditPastEndOfDocumentIsRejected() {
+        let original = "short\n"
+        // A start line far past the document is malformed — apply must refuse (return nil) so the
+        // caller keeps the original file.
+        let result = LSPEditApplier.apply([edit(99, 0, 99, 1, "x")], to: original)
+        XCTAssertNil(result)
+    }
+
+    func testEditWithEndBeforeStartIsRejected() {
+        let original = "abcdef\n"
+        let result = LSPEditApplier.apply([edit(0, 4, 0, 2, "x")], to: original)
+        XCTAssertNil(result)
+    }
+
+    func testUnicodeOffsetsUseUTF16CodeUnits() {
+        // "é" is one UTF-16 unit; an emoji is two. Editing after them must land correctly.
+        let original = "é😀X\n"
+        // Replace the "X" — it is at UTF-16 offset 3 (é=1, 😀=2).
+        let result = LSPEditApplier.apply([edit(0, 3, 0, 4, "Y")], to: original)
+        XCTAssertEqual(result, "é😀Y\n")
+    }
+
+    func testInsertionAtEndOfFile() {
+        let original = "line\n"
+        // Insert at the position just past the final newline (line 1, char 0).
+        let result = LSPEditApplier.apply([edit(1, 0, 1, 0, "added\n")], to: original)
+        XCTAssertEqual(result, "line\nadded\n")
+    }
+
+    func testOverlappingEditsAreRejectedNotCrashed() {
+        // An untrusted server violating the no-overlap guarantee must NOT crash the applier. Two edits
+        // whose ranges overlap (both valid against the original length) must return nil (keep original).
+        let original = "0123456789\n"
+        let edits = [
+            edit(0, 0, 0, 9, ""),   // delete [0,9)
+            edit(0, 3, 0, 10, "Z")  // overlaps the first edit's range
+        ]
+        XCTAssertNil(LSPEditApplier.apply(edits, to: original), "overlapping edits must be rejected, not crash")
+    }
+
+    func testAdjacentNonOverlappingEditsAreAccepted() {
+        // Edits that touch at a boundary ([0,3) and [3,6)) do NOT overlap and must apply.
+        let original = "aaabbb\n"
+        let edits = [
+            edit(0, 0, 0, 3, "X"),
+            edit(0, 3, 0, 6, "Y")
+        ]
+        XCTAssertEqual(LSPEditApplier.apply(edits, to: original), "XY\n")
+    }
+}

--- a/Tests/QuillCodeToolsTests/LSPToolRouterTests.swift
+++ b/Tests/QuillCodeToolsTests/LSPToolRouterTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+final class LSPToolRouterTests: XCTestCase {
+    private var workspace: URL!
+
+    override func setUpWithError() throws {
+        workspace = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("quillcode-lsp-router-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        workspace = workspace.resolvingSymlinksInPath()
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: workspace)
+    }
+
+    private func registry(available: Bool) -> LSPServerRegistry {
+        LSPServerRegistry(
+            configs: LSPServerRegistry.defaults,
+            commandLocator: StubCommandLocator(resolvedPath: available ? "/usr/bin/sourcekit-lsp" : nil)
+        )
+    }
+
+    private func coordinator(server: StubLanguageServer, available: Bool = true, formatOnSave: Bool = false) -> LSPCoordinator {
+        let launcher = StubLSPServerLauncher { server }
+        let sessions = LSPSessionManager(workspaceRoot: workspace, registry: registry(available: available), launcher: launcher)
+        return LSPCoordinator(workspaceRoot: workspace, sessions: sessions, formatOnSave: formatOnSave, diagnosticsWait: 0.4)
+    }
+
+    func testDefinitionsIncludeLSPNavTools() {
+        let names = ToolRouter.definitions.map(\.name)
+        XCTAssertTrue(names.contains("host.lsp.definition"))
+        XCTAssertTrue(names.contains("host.lsp.references"))
+        XCTAssertTrue(names.contains("host.lsp.hover"))
+        XCTAssertTrue(names.contains("host.lsp.document_symbol"))
+        XCTAssertTrue(names.contains("host.lsp.workspace_symbol"))
+    }
+
+    func testFileWriteWithoutLSPBehavesUnchanged() {
+        // No coordinator injected -> existing write behavior, no diagnostics text.
+        let router = ToolRouter(workspaceRoot: workspace, editGuard: FileEditSessionGuard())
+        let call = ToolCall(name: "host.file.write", argumentsJSON: ToolArguments.json([
+            "path": "A.swift", "content": "let x = 1\n"
+        ]))
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.hasPrefix("Wrote "))
+        XCTAssertFalse(result.stdout.contains("LSP diagnostics"))
+    }
+
+    func testFileWriteAppendsDiagnostics() throws {
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": [:]]
+        let uri = LSPURI.from(path: workspace.appendingPathComponent("A.swift").path)
+        server.diagnosticsOnSave[uri] = [[
+            "range": ["start": ["line": 2, "character": 0], "end": ["line": 2, "character": 3]],
+            "severity": 1,
+            "message": "type 'Foo' has no member 'bar'"
+        ]]
+        let router = ToolRouter(
+            workspaceRoot: workspace,
+            editGuard: FileEditSessionGuard(),
+            lsp: coordinator(server: server)
+        )
+        let call = ToolCall(name: "host.file.write", argumentsJSON: ToolArguments.json([
+            "path": "A.swift", "content": "struct Foo {}\nlet f = Foo()\nf.bar()\n"
+        ]))
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("Wrote "), result.stdout)
+        XCTAssertTrue(result.stdout.contains("LSP diagnostics"), result.stdout)
+        XCTAssertTrue(result.stdout.contains("A.swift:3: error: type 'Foo' has no member 'bar'"), result.stdout)
+    }
+
+    func testFileWriteMissingServerStillSucceeds() throws {
+        let server = StubLanguageServer()
+        let router = ToolRouter(
+            workspaceRoot: workspace,
+            editGuard: FileEditSessionGuard(),
+            lsp: coordinator(server: server, available: false)
+        )
+        let call = ToolCall(name: "host.file.write", argumentsJSON: ToolArguments.json([
+            "path": "A.swift", "content": "let x = 1\n"
+        ]))
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok, "a missing language server must never fail the write")
+        XCTAssertTrue(result.stdout.contains("Wrote "))
+        // The one-time "not available" notice is appended, but the write result is still ok.
+        XCTAssertTrue(result.stdout.contains("not available"))
+    }
+
+    func testNavToolWithoutCoordinatorReportsUnavailable() {
+        let router = ToolRouter(workspaceRoot: workspace, editGuard: FileEditSessionGuard())
+        let call = ToolCall(name: "host.lsp.definition", argumentsJSON: ToolArguments.json([
+            "path": "A.swift", "line": "1", "character": "0"
+        ]))
+        let result = router.execute(call)
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue((result.error ?? "").contains("not available"))
+    }
+
+    func testNavDefinitionReturnsLocations() throws {
+        _ = try Data("struct Foo {}\n".utf8).write(to: workspace.appendingPathComponent("A.swift"))
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": [:]]
+        server.resultsByMethod["textDocument/definition"] = [[
+            "uri": LSPURI.from(path: workspace.appendingPathComponent("A.swift").path),
+            "range": ["start": ["line": 0, "character": 7], "end": ["line": 0, "character": 10]]
+        ]]
+        let router = ToolRouter(
+            workspaceRoot: workspace,
+            editGuard: FileEditSessionGuard(),
+            lsp: coordinator(server: server)
+        )
+        let call = ToolCall(name: "host.lsp.definition", argumentsJSON: ToolArguments.json([
+            "path": "A.swift", "line": "1", "character": "8"
+        ]))
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        // Relative path + 1-based line/column.
+        XCTAssertTrue(result.stdout.contains("A.swift:1:8"), result.stdout)
+    }
+
+    func testNavHoverReturnsText() throws {
+        _ = try Data("let x = 1\n".utf8).write(to: workspace.appendingPathComponent("A.swift"))
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": [:]]
+        server.resultsByMethod["textDocument/hover"] = ["contents": ["kind": "plaintext", "value": "let x: Int"]]
+        let router = ToolRouter(
+            workspaceRoot: workspace,
+            editGuard: FileEditSessionGuard(),
+            lsp: coordinator(server: server)
+        )
+        let call = ToolCall(name: "host.lsp.hover", argumentsJSON: ToolArguments.json([
+            "path": "A.swift", "line": "1", "character": "4"
+        ]))
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("let x: Int"), result.stdout)
+    }
+
+    func testNavPathBoundaryEnforced() {
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": [:]]
+        let router = ToolRouter(
+            workspaceRoot: workspace,
+            editGuard: FileEditSessionGuard(),
+            lsp: coordinator(server: server)
+        )
+        let call = ToolCall(name: "host.lsp.definition", argumentsJSON: ToolArguments.json([
+            "path": "../../etc/passwd", "line": "1", "character": "0"
+        ]))
+        let result = router.execute(call)
+        XCTAssertFalse(result.ok, "a path escaping the workspace must be rejected")
+    }
+
+    func testApplyPatchAppendsDiagnostics() throws {
+        // Seed a git repo so apply_patch's `git apply` works.
+        let git = { (args: [String]) in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["git"] + args
+            process.currentDirectoryURL = self.workspace
+            process.standardOutput = Pipe()
+            process.standardError = Pipe()
+            try? process.run()
+            process.waitUntilExit()
+        }
+        git(["init"])
+        git(["config", "user.email", "t@t.co"])
+        git(["config", "user.name", "t"])
+        let target = workspace.appendingPathComponent("A.swift")
+        try Data("let x = 1\n".utf8).write(to: target)
+        git(["add", "."])
+        git(["commit", "-m", "init"])
+
+        let server = StubLanguageServer()
+        server.initializeResult = ["capabilities": [:]]
+        server.diagnosticsOnSave[LSPURI.from(path: target.path)] = [[
+            "range": ["start": ["line": 1, "character": 0], "end": ["line": 1, "character": 3]],
+            "severity": 1,
+            "message": "cannot find 'zzz' in scope"
+        ]]
+        let router = ToolRouter(
+            workspaceRoot: workspace,
+            editGuard: FileEditSessionGuard(),
+            lsp: coordinator(server: server)
+        )
+        // The edit guard requires the file be read in this session before it can be patched.
+        _ = router.execute(ToolCall(name: "host.file.read", argumentsJSON: ToolArguments.json(["path": "A.swift"])))
+        let patch = """
+        diff --git a/A.swift b/A.swift
+        index 0000000..1111111 100644
+        --- a/A.swift
+        +++ b/A.swift
+        @@ -1 +1,2 @@
+         let x = 1
+        +zzz
+        """
+        let call = ToolCall(name: "host.apply_patch", argumentsJSON: ToolArguments.json(["patch": patch]))
+        let result = router.execute(call)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains("LSP diagnostics"), result.stdout)
+        XCTAssertTrue(result.stdout.contains("cannot find 'zzz'"), result.stdout)
+    }
+}


### PR DESCRIPTION
## What & why

The single biggest correctness multiplier for an unattended agent: catch the model's own breakage the moment it writes, and let it navigate code semantically. QuillCode had **zero** LSP / formatting / diagnostics. This adds all three, riding **sourcekit-lsp** for Swift on QuillOS with a **generic** language→server table so other languages are one entry away.

Fixes #863.

## Design

**LSP client** (`Sources/QuillCodeTools/LSP*.swift`, many small files):
- `LSPMessageCodec` — Content-Length JSON-RPC framing (bounded, defensive; partial/oversized/non-object frames handled, never force-unwrapped).
- `LSPTransport` protocol + `LSPStdioTransport` (poll(2)-based reads, EOF-aware) — the injection seam. Tests drive a **scripted stub server**; no real sourcekit-lsp required.
- `LSPClient` — synchronous JSON-RPC engine: `initialize`/`initialized` handshake, `didOpen`/`didSave`, `textDocument/{definition,references,hover,documentSymbol,formatting}`, `workspace/symbol`, and `publishDiagnostics` collection. Request/response correlated by id **and** "is not a server request"; deadlines everywhere (a silent server times out, never hangs).
- `LSPServerRegistry` — language/extension → command table (**sourcekit-lsp** shipped default), with discovery via `xcrun --find` then `PATH`.
- `LSPServerLauncher` (spawns the subprocess; behind a protocol) and `LSPSessionManager` (one server per command per workspace, crash detection + bounded restart/backoff, graceful missing-server degradation).

**Three behaviors** (wired in `ToolRouter` at the write-result seam; a no-op when no coordinator is injected, so existing write/patch behavior is unchanged):
- **Diagnostics-after-write** — after `host.file.write` / `host.apply_patch` succeeds, project-wide errors+warnings are appended, capped to **≤5 files** (`file:line: severity: message`), edited file first.
- **Auto-format-on-save** — **opt-in**; crash-safe (atomic write; BOM/CRLF preserved via `FileEncodingPreservation`; malformed/overlapping edits keep the original file untouched).
- **`host.lsp.*` navigation tool** — `definition`/`references`/`hover`/`document_symbol`/`workspace_symbol`, concise `file:line:col` results, paths kept inside `WorkspaceBoundary`.

**Backend discovery:** `sourcekit-lsp` located via `xcrun --find` (Swift toolchain) or `PATH`; absolute paths used as-is. `#if os(macOS)` guards only the xcrun branch — Linux falls through to PATH (no app-level Linux conditionals).

**Live wiring:** opt-in behind `QUILLCODE_LSP` (and `QUILLCODE_LSP_FORMAT` for format-on-save), threaded as `AgentRunner.lsp` → `ToolRouter.lsp`. A process-wide, workspace-keyed `WorkspaceLSPCoordinatorProvider` cache persists the server across tool steps. Off by default → shipped behavior is byte-for-byte unchanged until a user turns it on.

## Robustness (attacked with an adversarial review)

- **Missing server** → feature disabled, one-time notice, writes still succeed.
- **Slow server** → per-request deadlines; handshake bounded and configurable.
- **Crashed server** → detected before reuse, relaunched up to a bounded budget, then disabled (no infinite relaunch). Transport fds **closed** on relaunch/shutdown/failed-handshake (no leak, child gets EOF).
- **Untrusted JSON-RPC** → bounded parsing, no force-unwraps, id **and** method correlation (a server→client request with a colliding id is not mistaken for our response), **overlapping-edit rejection** (a malformed formatting response can't crash or corrupt — it keeps the original), diagnostics keyed by canonical symlink-resolved paths so a `/var` vs `/private/var` URI mismatch doesn't drop diagnostics.
- **Command discovery** drains stdout/stderr concurrently (no pipe-buffer deadlock) with a timeout.

## Tests

Deterministic — a scripted/stub language server behind the transport protocol; no real sourcekit-lsp needed. Coverage: JSON-RPC framing round-trip (partial/oversized/case-insensitive/non-object), initialize handshake, each nav method mapping stub responses, diagnostics-after-write feeds capped errors, missing-server graceful degradation, format-on-save idempotence + failure-keeps-original + **CRLF preservation**, timeout/EOF/server-error/**id-collision**/out-of-order handling, crash→restart→disable + fd-close, path-boundary enforcement, and the opt-in provider gating. One **real sourcekit-lsp integration test**, gated to skip when the binary is absent.

- `swift build` — green (full package + `quill-code` product).
- Full `swift test` — **2769 tests, 0 failures, 2 skipped** (the 2 skips are pre-existing Linux-only platform gates; the real-sourcekit integration test *ran* here).
- CI gates verified locally: "no app-level Linux conditionals" passes.

## Deferred

- **Call-hierarchy** (`prepareCallHierarchy` + incoming/outgoing calls). Per the issue's guidance, I shipped the core navigation surface (definition/references/hover/documentSymbol/workspaceSymbol) solidly rather than a sprawling half-working set. Everything else in the issue is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)