### PR TITLE
Harden command palette focus and click target tests

### DIFF
--- a/E2E/playwright/tests/harness-helpers.ts
+++ b/E2E/playwright/tests/harness-helpers.ts
@@ -68,15 +68,8 @@ export async function expectSelectedCommandPaletteResult(page: Page, label: stri
 export async function fillCommandPalette(page: Page, query: string) {
   const input = page.getByTestId('command-palette-input');
   await expect(input).toBeVisible();
-  await input.evaluate((element, nextQuery) => {
-    if (!(element instanceof HTMLInputElement)) return;
-    element.value = nextQuery;
-    element.dispatchEvent(new InputEvent('input', {
-      bubbles: true,
-      data: nextQuery,
-      inputType: 'insertReplacementText'
-    }));
-  }, query);
+  await expect(input).toBeFocused();
+  await input.fill(query);
   await expect(input).toHaveValue(query);
 }
 

--- a/E2E/playwright/tests/interaction-audit.spec.ts
+++ b/E2E/playwright/tests/interaction-audit.spec.ts
@@ -89,10 +89,23 @@ test('mock harness audits every visible interactive click target across workspac
   await page.getByTestId('search-close').click();
 
   await openTopBarOverflow(page);
-  await page.getByTestId('top-bar-overflow-command-palette').click();
+  await clickTargetInteriorPoint(
+    page.getByTestId('top-bar-overflow-command-palette'),
+    'top-bar command palette action trailing interior',
+    0.85,
+    0.5
+  );
   await expect(page.getByTestId('command-palette-panel')).toBeVisible();
   await expectInteractionTargetsClean(page, 'command palette');
-  await page.getByTestId('command-palette-close').click();
+  await fillCommandPalette(page, '>shortcuts');
+  await clickTargetInteriorPoint(
+    commandPaletteResult(page, 'keyboard-shortcuts'),
+    'command palette keyboard shortcuts result trailing interior',
+    0.85,
+    0.5
+  );
+  await expect(page.getByTestId('keyboard-shortcuts-panel')).toBeVisible();
+  await page.getByTestId('keyboard-shortcuts-close').click();
 
   await openTopBarOverflow(page);
   await page.getByTestId('top-bar-overflow-keyboard-shortcuts').click();

--- a/Tests/QuillCodeParityTests/ParityWorkspacePlaywrightInteractionSpecGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspacePlaywrightInteractionSpecGateTests.swift
@@ -66,6 +66,31 @@ final class ParityWorkspacePlaywrightInteractionSpecGateTests: QuillCodeParityTe
         XCTAssertFalse(coreSpecText.contains(shortcutFlowName), "\(shortcutFlowName) should not drift back into core.spec.ts.")
     }
 
+    func testCommandPaletteHelpersUseRealFocusedInputEvents() throws {
+        let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")
+        let helperText = try String(
+            contentsOf: testRoot.appendingPathComponent("harness-helpers.ts"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(
+            helperText.contains("await expect(input).toBeFocused()"),
+            "Command-palette tests should prove the palette can receive keyboard input before filling it."
+        )
+        XCTAssertTrue(
+            helperText.contains("await input.fill(query)"),
+            "Command-palette tests should use Playwright's real input path instead of mutating DOM values."
+        )
+        XCTAssertFalse(
+            helperText.contains("dispatchEvent(new InputEvent"),
+            "Command-palette helpers must not bypass app focus/input handling by dispatching synthetic InputEvents."
+        )
+        XCTAssertFalse(
+            helperText.contains("element.value = nextQuery"),
+            "Command-palette helpers must not bypass app focus/input handling by assigning DOM values directly."
+        )
+    }
+
 
     func testPlaywrightReviewFlowsStayInFocusedSpec() throws {
         let testRoot = Self.packageRoot().appendingPathComponent("E2E/playwright/tests")


### PR DESCRIPTION
## Summary
- require command-palette helpers to use focused, real Playwright input instead of DOM mutation
- expand the interaction audit to click command-palette actions/results from trailing interior target points
- add a Swift parity gate so future regressions cannot reintroduce synthetic input shortcuts

## Validation
- npm test -- tests/search.spec.ts tests/command-palette-core.spec.ts tests/interaction-audit.spec.ts
- env CLANG_MODULE_CACHE_PATH=/private/tmp/quillcode-clang-module-cache swift test --disable-sandbox --filter ParityWorkspacePlaywrightInteractionSpecGateTests
- git diff --check
- python3 scripts/grade-code-quality.py --root .
- npm test