### PR TITLE
Morning triage inbox + return digest (#877)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3719,6 +3719,9 @@
       },
       // Morning-triage inbox (issue #877): the thread whose return digest card is open, or null.
       attentionDigestThreadID: null,
+      // The Attention section's preview cursor — which row j/k highlight. Distinct from the workspace
+      // selection so cursoring never advances a watermark (native mirrors this with attentionCursorID).
+      attentionCursorID: null,
       transcript: {
         messages: [],
         toolCards: [],
@@ -9023,19 +9026,37 @@
     // Build the ranked attention rows from the sidebar items (mirrors AttentionModel.build + rank):
     // include a thread iff it has an attention-worthy verdict AND its triage state is pending; sort by
     // severity desc, then updatedAt desc, then threadID asc (total, deterministic).
+    // Unseen-turn count derived from the persisted watermark (mirrors ThreadReturnWatermarkRecord.
+    // unseenCount): turns after the last-seen turn, never negative.
+    function attentionUnseenCount(item) {
+      const turns = Math.max(0, item.attentionMessageTurns || 0);
+      const lastSeen = item.attentionLastSeenTurn;
+      if (turns === 0 || lastSeen === null || lastSeen === undefined) return 0;
+      return Math.max(0, turns - 1 - lastSeen);
+    }
+    // Advance a thread's return watermark to its tail — mirrors persistOutgoingReturnWatermark, run when
+    // the user LEAVES a thread (an actual open/read), never on cursor preview.
+    function attentionMarkThreadSeen(threadID) {
+      const item = state.sidebar.items.find(entry => entry.id === threadID);
+      if (!item || !item.attentionMessageTurns) return;
+      item.attentionLastSeenTurn = item.attentionMessageTurns - 1;
+    }
     function attentionRows() {
       return state.sidebar.items
         .filter(item => verdictNeedsAttention(item.integrityVerdict) && (item.triageState || 'pending') === 'pending')
-        .map(item => ({
-          threadID: item.id,
-          title: item.title,
-          verdict: item.integrityVerdict,
-          badgeLabel: triageBadgeLabel[item.integrityVerdict],
-          summary: item.verdictSummary || '',
-          unseenCount: Math.max(0, item.unseenCount || 0),
-          unseenLabel: (item.unseenCount || 0) > 0 ? `${Math.max(0, item.unseenCount)} new` : null,
-          updatedAt: item.updatedAt || ''
-        }))
+        .map(item => {
+          const unseen = attentionUnseenCount(item);
+          return {
+            threadID: item.id,
+            title: item.title,
+            verdict: item.integrityVerdict,
+            badgeLabel: triageBadgeLabel[item.integrityVerdict],
+            summary: item.verdictSummary || '',
+            unseenCount: unseen,
+            unseenLabel: unseen > 0 ? `${unseen} new` : null,
+            updatedAt: item.updatedAt || ''
+          };
+        })
         .sort((lhs, rhs) => {
           if (triageSeverity[lhs.verdict] !== triageSeverity[rhs.verdict]) {
             return triageSeverity[rhs.verdict] - triageSeverity[lhs.verdict];
@@ -9046,12 +9067,13 @@
           return lhs.threadID < rhs.threadID ? -1 : (lhs.threadID > rhs.threadID ? 1 : 0);
         });
     }
-    // The cursor thread id: the open digest thread if any, else the sidebar's selected thread, clamped to
-    // an actual attention row (falling back to the first row) — mirrors AttentionModel's init selection.
+    // The cursor thread id: the open digest thread if any, else the dedicated PREVIEW cursor
+    // (attentionCursorID), clamped to an actual attention row (falling back to the first row). It is NOT
+    // the workspace's selected thread — mirrors native, so moving the cursor never advances a watermark.
     function attentionSelectedThreadID() {
       const rows = attentionRows();
       if (!rows.length) return null;
-      const preferred = state.attentionDigestThreadID || state.sidebar.selectedThreadID;
+      const preferred = state.attentionDigestThreadID || state.attentionCursorID;
       return rows.some(row => row.threadID === preferred) ? preferred : rows[0].threadID;
     }
     function attentionSelectRelative(delta) {
@@ -9060,7 +9082,10 @@
       const current = attentionSelectedThreadID();
       const index = Math.max(0, rows.findIndex(row => row.threadID === current));
       const clamped = Math.min(rows.length - 1, Math.max(0, index + delta));
-      selectThread(rows[clamped].threadID);
+      // Move the PREVIEW cursor only — do NOT selectThread (which would advance the outgoing thread's
+      // watermark and zero its unseen badge). Opening (Enter/click) is the only path that reads a thread.
+      state.attentionCursorID = rows[clamped].threadID;
+      render();
     }
     function attentionMoveDown() { attentionSelectRelative(1); }
     function attentionMoveUp() { attentionSelectRelative(-1); }
@@ -9071,6 +9096,10 @@
     }
     function openAttentionDigest(threadID) {
       if (!state.sidebar.items.some(item => item.id === threadID)) return;
+      // A genuine open: park the preview cursor here and select the thread. selectThread persists the
+      // OUTGOING thread's watermark (the one being left), never this incoming one — so the opened thread
+      // keeps its unseen badge until the user later leaves it.
+      state.attentionCursorID = threadID;
       selectThread(threadID);
       state.attentionDigestThreadID = threadID;
       render();
@@ -9086,13 +9115,11 @@
       const item = state.sidebar.items.find(entry => entry.id === threadID);
       if (item) item.triageState = triageState;
       if (state.attentionDigestThreadID === threadID) state.attentionDigestThreadID = null;
-      // Advance the cursor to whatever slid into place (or the first remaining row).
+      // Advance the PREVIEW cursor to whatever slid into place (or the first remaining row) — cursor only,
+      // no selectThread, so the passed-over threads keep their unseen badges.
       const remaining = attentionRows();
-      if (remaining.length) {
-        selectThread(remaining[0].threadID);
-      } else {
-        render();
-      }
+      state.attentionCursorID = remaining.length ? remaining[0].threadID : null;
+      render();
     }
     function attentionAcknowledgeSelected() { attentionTriageSelected('acknowledged'); }
     function attentionDismissSelected() { attentionTriageSelected('dismissed'); }
@@ -9105,7 +9132,7 @@
       if (!item) return null;
       const verdict = verdictNeedsAttention(item.integrityVerdict) || item.integrityVerdict === 'verified'
         ? item.integrityVerdict : null;
-      const unseen = Math.max(0, item.unseenCount || 0);
+      const unseen = attentionUnseenCount(item);
       const seamLabel = unseen === 0 ? null : (unseen === 1 ? '1 unseen turn' : `${unseen} unseen turns`);
       return {
         threadID,
@@ -14287,6 +14314,10 @@
         // Leaving a thread means the user has seen it up to its current end — advance that
         // thread's "N new turns" watermark before we swap the transcript out.
         markTranscriptSeen();
+        // Mirror native persistOutgoingReturnWatermark: advance the OUTGOING thread's morning-triage
+        // return watermark too, so a thread genuinely read (opened) loses its unseen badge. This runs
+        // only on a real thread switch — never on Attention cursor preview (which no longer selectThreads).
+        if (outgoing) attentionMarkThreadSeen(outgoing);
         saveSelectedThreadSnapshot(outgoing);
         stashComposerDraft(outgoing);
         restoreComposerDraft(threadID);
@@ -15419,16 +15450,26 @@
     // it likewise never fires from the composer; this guard is that section-scoping's behavioral mirror.
     // They require no modifiers and only apply when the Attention section actually has rows.
     function attentionTriageContextIsActive() {
-      // Never while focus is in an editable field (composer, search box, terminal entry, etc.). The
-      // native surface scopes the keys to the sidebar section, which is not an editable field.
+      // The section must actually exist with rows to act on.
+      if (!attentionRows().length) return false;
+      // MINOR parity: native scopes these keys to the Attention section view via .onKeyPress, so they
+      // fire only when that section is the active context. Mirror that here rather than firing for ANY
+      // non-editable focus:
       const active = document.activeElement;
+      // Never while focus is in an editable field (composer, search box, terminal entry, etc.).
       if (active) {
         if (active.isContentEditable) return false;
         const tag = active.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
       }
-      // Only when the Attention section is actually present with rows to act on.
-      return attentionRows().length > 0;
+      // The Attention section is scoped to the sidebar; when the digest is open its own key handlers
+      // (and the backdrop) own the interaction, so cursor/triage keys should not fire from underneath it.
+      if (state.attentionDigestThreadID) return false;
+      // Focus must be the section's context: the body/no-focus (nothing else claims the keys) or an
+      // element inside the sidebar (where the Attention section lives) — not an unrelated focused control.
+      if (!active || active === document.body) return true;
+      const sidebar = document.querySelector('[data-testid="sidebar"]');
+      return !!(sidebar && sidebar.contains(active));
     }
     function handleAttentionTriageKeydown(event) {
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false;
@@ -15475,25 +15516,38 @@
     // Test hook (issue #877): seed the sidebar with threads carrying morning-triage verdict stamps so
     // Playwright can drive the Attention section deterministically. Each spec: { id, title, verdict,
     // summary, unseenCount, reasons, outcome, updatedAt? }.
+    //
+    // The unseen count is WATERMARK-DERIVED (not a fixed field): a thread gets a message-turn count and a
+    // `attentionLastSeenTurn` watermark, and unseen = turns after the watermark. This is what lets
+    // Playwright catch the "cursoring zeroes passed-over badges" class of bug — if navigation wrongly
+    // advanced a thread's watermark, its derived unseen count would drop, and the test would see it.
     window.__quillCodeTestSeedAttentionThreads = function(specs) {
       state.sidebar.selectedThreadID = null;
       state.attentionDigestThreadID = null;
-      state.sidebar.items = (specs || []).map((spec, index) => ({
-        id: spec.id,
-        title: spec.title,
-        subtitle: state.topBar.modelLabel,
-        searchText: '',
-        updatedAt: spec.updatedAt || new Date(Date.now() - index * 1000).toISOString(),
-        isSelected: false,
-        isPinned: false,
-        isArchived: false,
-        integrityVerdict: spec.verdict || null,
-        verdictSummary: spec.summary || '',
-        unseenCount: Math.max(0, spec.unseenCount || 0),
-        triageState: spec.triageState || 'pending',
-        digestReasons: spec.reasons || [],
-        digestOutcome: spec.outcome || 'No final answer recorded.'
-      }));
+      state.attentionCursorID = null;
+      state.sidebar.items = (specs || []).map((spec, index) => {
+        const unseen = Math.max(0, spec.unseenCount || 0);
+        // Give the thread enough turns to carry `unseen` unseen turns after the watermark. The watermark
+        // index sits `unseen` turns before the tail; unseen === attentionMessageTurns - 1 - lastSeenTurn.
+        const attentionMessageTurns = unseen + 1;
+        return {
+          id: spec.id,
+          title: spec.title,
+          subtitle: state.topBar.modelLabel,
+          searchText: '',
+          updatedAt: spec.updatedAt || new Date(Date.now() - index * 1000).toISOString(),
+          isSelected: false,
+          isPinned: false,
+          isArchived: false,
+          integrityVerdict: spec.verdict || null,
+          verdictSummary: spec.summary || '',
+          attentionMessageTurns,
+          attentionLastSeenTurn: attentionMessageTurns - 1 - unseen,
+          triageState: spec.triageState || 'pending',
+          digestReasons: spec.reasons || [],
+          digestOutcome: spec.outcome || 'No final answer recorded.'
+        };
+      });
       render();
     };
     window.__quillCodeTestCreateMonitorAutomation = createMonitorAutomation;

--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -15412,14 +15412,27 @@
     });
 
     // Morning-triage keyboard triage (issue #877): j/k/Enter/a/d act on the Attention section. They are
-    // bare single-letter keys, so they must NOT fire while typing in an editable field, must require no
-    // modifiers, and only apply when the Attention section actually has rows. Enter, additionally, only
-    // triages when the digest is not already open (so it doesn't hijack composer newlines etc.). This
-    // mirrors the native `.onKeyPress` handlers scoped to the sidebar Attention section.
+    // bare single-letter keys, so they must NOT fire while typing in ANY editable field — including the
+    // composer (BLOCKER-3 fix: the composer is emphatically NOT a shortcut-allowed context here, unlike
+    // Tab-cycling; letting these fire in the composer would eat the user's keystroke via preventDefault
+    // and silently triage/open runs). Native scopes its `.onKeyPress` to the Attention section view, so
+    // it likewise never fires from the composer; this guard is that section-scoping's behavioral mirror.
+    // They require no modifiers and only apply when the Attention section actually has rows.
+    function attentionTriageContextIsActive() {
+      // Never while focus is in an editable field (composer, search box, terminal entry, etc.). The
+      // native surface scopes the keys to the sidebar section, which is not an editable field.
+      const active = document.activeElement;
+      if (active) {
+        if (active.isContentEditable) return false;
+        const tag = active.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
+      }
+      // Only when the Attention section is actually present with rows to act on.
+      return attentionRows().length > 0;
+    }
     function handleAttentionTriageKeydown(event) {
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false;
-      if (!focusAllowsTabShortcut()) return false; // reuse the "not in an editable field" guard
-      if (!attentionRows().length) return false;
+      if (!attentionTriageContextIsActive()) return false;
       const key = String(event.key || '').toLowerCase();
       const routes = {
         j: 'attention-next',

--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -868,6 +868,44 @@
       justify-content: space-between;
       gap: 8px;
     }
+    /* Morning-triage Attention section + return digest (issue #877). */
+    [data-testid="attention-section"] { margin-bottom: 8px; }
+    [data-testid="attention-row"] {
+      display: flex; align-items: center; gap: 8px;
+      padding: 8px; margin: 2px 0; border-radius: 10px; cursor: pointer;
+      border: 1px solid transparent;
+    }
+    [data-testid="attention-row"]:hover { background: rgba(255,255,255,.05); }
+    [data-testid="attention-row"][data-cursor="true"] { background: rgba(255,255,255,.08); }
+    [data-testid="attention-row"][data-cursor="true"][data-verdict="red"] { border-color: rgba(255,92,82,.6); }
+    [data-testid="attention-row"][data-cursor="true"][data-verdict="unverified"] { border-color: rgba(247,184,79,.6); }
+    [data-testid="attention-title"] { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    [data-testid="attention-verdict"] {
+      font-size: 10px; font-weight: 700; padding: 2px 6px; border-radius: 999px;
+    }
+    [data-testid="attention-verdict"][data-verdict="red"] { color: var(--red); background: rgba(255,92,82,.16); }
+    [data-testid="attention-verdict"][data-verdict="unverified"] { color: var(--yellow); background: rgba(247,184,79,.16); }
+    [data-testid="attention-unseen"] {
+      font-size: 10px; font-weight: 600; color: var(--blue);
+      padding: 2px 6px; border-radius: 999px; background: rgba(64,184,232,.16);
+    }
+    .attention-digest-backdrop {
+      position: fixed; inset: 0; background: rgba(0,0,0,.45);
+      display: flex; align-items: center; justify-content: center; z-index: 60;
+    }
+    .attention-digest-card {
+      width: min(460px, 90vw); background: var(--panel);
+      border-radius: 16px; padding: 20px; display: flex; flex-direction: column; gap: 14px;
+    }
+    .attention-digest-header { display: flex; align-items: center; gap: 10px; }
+    .attention-digest-header strong { flex: 1; }
+    [data-testid="attention-digest-seam"] {
+      color: var(--blue); font-size: 11px; font-weight: 600; text-align: center;
+      border-top: 1px solid rgba(64,184,232,.5); border-bottom: 1px solid rgba(64,184,232,.5);
+      padding: 4px 0;
+    }
+    [data-testid="attention-digest-reasons"] { margin: 0; padding-left: 18px; font-size: 12px; }
+    .attention-digest-actions { display: flex; gap: 10px; }
     .sidebar-title-row {
       display: flex;
       align-items: center;
@@ -3679,6 +3717,8 @@
         selectedThreadIDs: [],
         items: []
       },
+      // Morning-triage inbox (issue #877): the thread whose return digest card is open, or null.
+      attentionDigestThreadID: null,
       transcript: {
         messages: [],
         toolCards: [],
@@ -6975,6 +7015,27 @@
             </details>
           </div>`).join('')
         : '<p data-testid="project-empty">No projects yet</p>';
+      // Morning-triage Attention section (issue #877). Mirrors WorkspaceHTMLSidebarThreadRenderer's
+      // renderAttentionSection: severity-ranked rows with the verdict badge, title, and unseen count.
+      const renderAttentionSection = () => {
+        const rows = attentionRows();
+        if (!rows.length) return '';
+        const cursorID = attentionSelectedThreadID();
+        return `
+        <section data-testid="attention-section" aria-label="Attention">
+          <h3 data-testid="sidebar-section-title">Attention</h3>
+          ${rows.map(row => {
+            const isCursor = row.threadID === cursorID;
+            const unseen = row.unseenLabel ? `<span data-testid="attention-unseen">${escapeHTML(row.unseenLabel)}</span>` : '';
+            return `
+          <div class="hit-target-row" data-testid="attention-row" data-thread-id="${escapeHTML(row.threadID)}" data-verdict="${escapeHTML(row.verdict)}" data-cursor="${isCursor ? 'true' : 'false'}" role="button" tabindex="0" aria-current="${isCursor ? 'true' : 'false'}" aria-label="${escapeHTML(`${row.badgeLabel}. ${row.title}.${row.unseenLabel ? ` ${row.unseenLabel}.` : ''}`)}">
+            <span data-testid="attention-verdict" data-verdict="${escapeHTML(row.verdict)}">${escapeHTML(row.badgeLabel)}</span>
+            <span data-testid="attention-title">${escapeHTML(row.title)}</span>
+            ${unseen}
+          </div>`;
+          }).join('')}
+        </section>`;
+      };
       const renderSidebarSection = (title, items) => items.length ? `
         <section data-testid="sidebar-section">
           <h3 data-testid="sidebar-section-title">${escapeHTML(title)}</h3>
@@ -7112,7 +7173,7 @@
           </div>
         </div>` : '';
       const sidebarContent = visibleSidebarItems.length
-        ? bulkToolbar + renderSidebarSection('Pinned', pinnedItems) + recentSections.map(section => renderSidebarSection(section.title, section.items)).join('') + renderSidebarSection('Archived', archivedItems)
+        ? bulkToolbar + renderAttentionSection() + renderSidebarSection('Pinned', pinnedItems) + recentSections.map(section => renderSidebarSection(section.title, section.items)).join('') + renderSidebarSection('Archived', archivedItems)
         : `<p data-testid="sidebar-empty">${escapeHTML(state.sidebar.items.length ? activeEmptyTitle : 'No chats yet')}</p>`;
       const sidebarThreadHeader = state.sidebar.items.length || state.sidebar.isSelectionMode ? `
         <div class="sidebar-title-row" data-testid="sidebar-title-row">
@@ -7288,6 +7349,7 @@
           ${state.shortcuts.isOpen ? renderKeyboardShortcutsPanel() : ''}
           ${state.worktreeDialog.mode ? renderWorktreeDialog() : ''}
           ${renderSidebarSavedSearchDialog()}
+          ${renderAttentionDigest()}
         </section>`;
 
       normalizeInteractionTargetContracts(document.getElementById('app'));
@@ -7644,6 +7706,17 @@
         button.addEventListener('click', event => {
           toggleSidebarThreadSelection(event.currentTarget.getAttribute('data-thread-id'));
           render();
+        });
+      });
+      // Morning-triage Attention rows: clicking a row opens its return digest (issue #877).
+      document.querySelectorAll('[data-testid="attention-row"]').forEach(row => {
+        row.addEventListener('click', event => {
+          openAttentionDigest(event.currentTarget.getAttribute('data-thread-id'));
+        });
+      });
+      document.querySelectorAll('[data-testid="attention-digest-close"], [data-testid="attention-digest-acknowledge"], [data-testid="attention-digest-dismiss"]').forEach(button => {
+        button.addEventListener('click', event => {
+          runCommand(event.currentTarget.getAttribute('data-command-id'));
         });
       });
       document.querySelectorAll('[data-testid="sidebar-bulk-action"], [data-testid="sidebar-filter"], [data-testid="sidebar-saved-search"], [data-testid="sidebar-saved-search-create"], [data-testid="sidebar-saved-search-move-up"], [data-testid="sidebar-saved-search-move-down"], [data-testid="sidebar-saved-search-delete"]').forEach(button => {
@@ -8771,6 +8844,42 @@
         </div>`;
     }
 
+    // Morning-triage return digest card (issue #877). Mirrors WorkspaceHTMLRenderer.attentionDigestHTML.
+    function renderAttentionDigest() {
+      const digest = attentionDigest();
+      if (!digest) return '';
+      const badge = digest.badgeLabel
+        ? `<span data-testid="attention-digest-verdict" data-verdict="${escapeHTML(digest.verdict || '')}">${escapeHTML(digest.badgeLabel)}</span>`
+        : '';
+      const summary = digest.verdictSummary
+        ? `<p data-testid="attention-digest-summary">${escapeHTML(digest.verdictSummary)}</p>`
+        : '';
+      const seam = digest.unseenSeamLabel
+        ? `<div data-testid="attention-digest-seam">${escapeHTML(digest.unseenSeamLabel)}</div>`
+        : '';
+      const reasons = digest.reasons.length
+        ? `<ul data-testid="attention-digest-reasons">${digest.reasons.map(reason => `<li>${escapeHTML(reason)}</li>`).join('')}</ul>`
+        : '';
+      return `
+        <div class="attention-digest-backdrop" data-testid="attention-digest" data-thread-id="${escapeHTML(digest.threadID)}">
+          <div class="attention-digest-card">
+            <div class="attention-digest-header">
+              ${badge}
+              <strong data-testid="attention-digest-title">${escapeHTML(digest.title)}</strong>
+              <button type="button" class="hit-target-text" data-testid="attention-digest-close" data-command-id="attention-digest-close" aria-label="Close digest">Close</button>
+            </div>
+            ${summary}
+            ${seam}
+            <div data-testid="attention-digest-outcome">${escapeHTML(digest.outcome)}</div>
+            ${reasons}
+            <div class="attention-digest-actions">
+              <button type="button" class="hit-target-text" data-testid="attention-digest-acknowledge" data-command-id="attention-acknowledge">Acknowledge</button>
+              <button type="button" class="hit-target-text" data-testid="attention-digest-dismiss" data-command-id="attention-dismiss">Dismiss</button>
+            </div>
+          </div>
+        </div>`;
+    }
+
     function renderSidebarSavedSearchDialog() {
       const dialog = state.sidebar.savedSearchDialog || {};
       if (!dialog.isOpen) return '';
@@ -8899,6 +9008,116 @@
       const items = transcriptTimelineItems();
       if (!items.length) return;
       state.transcriptLastSeen[threadID] = items[items.length - 1].id;
+    }
+
+    // ---- Morning-triage inbox (issue #877) ----
+    // These mirror QuillCodeCore's AttentionModel / TriageVerdict / ThreadTriageRecord EXACTLY. A sidebar
+    // thread item carries: integrityVerdict ('red'|'unverified'|'verified'|null — the persisted Run
+    // Integrity stamp), triageState ('pending'|'acknowledged'|'dismissed', default pending), and
+    // unseenCount (>= 0). Keep this in lockstep with MorningTriage.swift; the parity gate test scans both.
+    const triageSeverity = { red: 2, unverified: 1, verified: 0 };
+    const triageBadgeLabel = { red: 'RED', unverified: 'UNVERIFIED', verified: 'VERIFIED' };
+    function verdictNeedsAttention(verdict) {
+      return verdict === 'red' || verdict === 'unverified';
+    }
+    // Build the ranked attention rows from the sidebar items (mirrors AttentionModel.build + rank):
+    // include a thread iff it has an attention-worthy verdict AND its triage state is pending; sort by
+    // severity desc, then updatedAt desc, then threadID asc (total, deterministic).
+    function attentionRows() {
+      return state.sidebar.items
+        .filter(item => verdictNeedsAttention(item.integrityVerdict) && (item.triageState || 'pending') === 'pending')
+        .map(item => ({
+          threadID: item.id,
+          title: item.title,
+          verdict: item.integrityVerdict,
+          badgeLabel: triageBadgeLabel[item.integrityVerdict],
+          summary: item.verdictSummary || '',
+          unseenCount: Math.max(0, item.unseenCount || 0),
+          unseenLabel: (item.unseenCount || 0) > 0 ? `${Math.max(0, item.unseenCount)} new` : null,
+          updatedAt: item.updatedAt || ''
+        }))
+        .sort((lhs, rhs) => {
+          if (triageSeverity[lhs.verdict] !== triageSeverity[rhs.verdict]) {
+            return triageSeverity[rhs.verdict] - triageSeverity[lhs.verdict];
+          }
+          if (lhs.updatedAt !== rhs.updatedAt) {
+            return lhs.updatedAt < rhs.updatedAt ? 1 : -1;
+          }
+          return lhs.threadID < rhs.threadID ? -1 : (lhs.threadID > rhs.threadID ? 1 : 0);
+        });
+    }
+    // The cursor thread id: the open digest thread if any, else the sidebar's selected thread, clamped to
+    // an actual attention row (falling back to the first row) — mirrors AttentionModel's init selection.
+    function attentionSelectedThreadID() {
+      const rows = attentionRows();
+      if (!rows.length) return null;
+      const preferred = state.attentionDigestThreadID || state.sidebar.selectedThreadID;
+      return rows.some(row => row.threadID === preferred) ? preferred : rows[0].threadID;
+    }
+    function attentionSelectRelative(delta) {
+      const rows = attentionRows();
+      if (!rows.length) return;
+      const current = attentionSelectedThreadID();
+      const index = Math.max(0, rows.findIndex(row => row.threadID === current));
+      const clamped = Math.min(rows.length - 1, Math.max(0, index + delta));
+      selectThread(rows[clamped].threadID);
+    }
+    function attentionMoveDown() { attentionSelectRelative(1); }
+    function attentionMoveUp() { attentionSelectRelative(-1); }
+    function attentionOpenSelected() {
+      const threadID = attentionSelectedThreadID();
+      if (!threadID) return;
+      openAttentionDigest(threadID);
+    }
+    function openAttentionDigest(threadID) {
+      if (!state.sidebar.items.some(item => item.id === threadID)) return;
+      selectThread(threadID);
+      state.attentionDigestThreadID = threadID;
+      render();
+    }
+    function closeAttentionDigest() {
+      state.attentionDigestThreadID = null;
+      render();
+    }
+    function attentionTriageSelected(triageState) {
+      const rows = attentionRows();
+      const threadID = attentionSelectedThreadID();
+      if (!threadID || !rows.length) return;
+      const item = state.sidebar.items.find(entry => entry.id === threadID);
+      if (item) item.triageState = triageState;
+      if (state.attentionDigestThreadID === threadID) state.attentionDigestThreadID = null;
+      // Advance the cursor to whatever slid into place (or the first remaining row).
+      const remaining = attentionRows();
+      if (remaining.length) {
+        selectThread(remaining[0].threadID);
+      } else {
+        render();
+      }
+    }
+    function attentionAcknowledgeSelected() { attentionTriageSelected('acknowledged'); }
+    function attentionDismissSelected() { attentionTriageSelected('dismissed'); }
+    // The return digest for the open thread (mirrors TriageDigest.build): verdict + reasons + outcome +
+    // unseen seam. Reasons are seeded per-thread in the harness; native re-scans the transcript.
+    function attentionDigest() {
+      const threadID = state.attentionDigestThreadID;
+      if (!threadID) return null;
+      const item = state.sidebar.items.find(entry => entry.id === threadID);
+      if (!item) return null;
+      const verdict = verdictNeedsAttention(item.integrityVerdict) || item.integrityVerdict === 'verified'
+        ? item.integrityVerdict : null;
+      const unseen = Math.max(0, item.unseenCount || 0);
+      const seamLabel = unseen === 0 ? null : (unseen === 1 ? '1 unseen turn' : `${unseen} unseen turns`);
+      return {
+        threadID,
+        title: item.title,
+        verdict,
+        badgeLabel: verdict ? triageBadgeLabel[verdict] : null,
+        verdictSummary: item.verdictSummary || '',
+        reasons: item.digestReasons || [],
+        outcome: item.digestOutcome || 'No final answer recorded.',
+        unseenCount: unseen,
+        unseenSeamLabel: seamLabel
+      };
     }
 
     // Scroll a timeline item (by its data-timeline-id) into view and briefly mark it as the jump
@@ -11497,6 +11716,12 @@
     const harnessStaticCommandIDs = new Set([
       'add-project',
       'add-ssh-project',
+      'attention-next',
+      'attention-previous',
+      'attention-open',
+      'attention-acknowledge',
+      'attention-dismiss',
+      'attention-digest-close',
       'cycle-mode',
       'focus-composer',
       'automation-create-thread-follow-up',
@@ -11668,6 +11893,12 @@
         console.warn('QuillCode harness received unroutable command', commandID);
         return;
       }
+      if (commandID === 'attention-next') { attentionMoveDown(); return; }
+      if (commandID === 'attention-previous') { attentionMoveUp(); return; }
+      if (commandID === 'attention-open') { attentionOpenSelected(); return; }
+      if (commandID === 'attention-acknowledge') { attentionAcknowledgeSelected(); return; }
+      if (commandID === 'attention-dismiss') { attentionDismissSelected(); return; }
+      if (commandID === 'attention-digest-close') { closeAttentionDigest(); return; }
       if (commandID === 'command-palette') {
         openCommandPalette();
         return;
@@ -15165,6 +15396,7 @@
 
     document.addEventListener('keydown', event => {
       if (handleCommandPaletteKeydown(event)) return;
+      if (handleAttentionTriageKeydown(event)) return;
       updateDynamicCommands();
       const command = state.commands.find(candidate => (
         candidate.isEnabled && shortcutMatches(event, candidate.shortcut)
@@ -15178,6 +15410,30 @@
       event.preventDefault();
       runCommand(command.id);
     });
+
+    // Morning-triage keyboard triage (issue #877): j/k/Enter/a/d act on the Attention section. They are
+    // bare single-letter keys, so they must NOT fire while typing in an editable field, must require no
+    // modifiers, and only apply when the Attention section actually has rows. Enter, additionally, only
+    // triages when the digest is not already open (so it doesn't hijack composer newlines etc.). This
+    // mirrors the native `.onKeyPress` handlers scoped to the sidebar Attention section.
+    function handleAttentionTriageKeydown(event) {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false;
+      if (!focusAllowsTabShortcut()) return false; // reuse the "not in an editable field" guard
+      if (!attentionRows().length) return false;
+      const key = String(event.key || '').toLowerCase();
+      const routes = {
+        j: 'attention-next',
+        k: 'attention-previous',
+        a: 'attention-acknowledge',
+        d: 'attention-dismiss',
+        enter: 'attention-open'
+      };
+      const commandID = routes[key];
+      if (!commandID) return false;
+      event.preventDefault();
+      runCommand(commandID);
+      return true;
+    }
 
     // The composer is the one editable field where Tab shortcuts are intended (Shift+Tab cycles
     // mode, plain Tab accepts a suggestion). Everywhere else, Tab/Shift+Tab is focus traversal.
@@ -15203,6 +15459,30 @@
     }
 
     window.__quillCodeCommandRoutingAudit = commandRoutingAuditReport;
+    // Test hook (issue #877): seed the sidebar with threads carrying morning-triage verdict stamps so
+    // Playwright can drive the Attention section deterministically. Each spec: { id, title, verdict,
+    // summary, unseenCount, reasons, outcome, updatedAt? }.
+    window.__quillCodeTestSeedAttentionThreads = function(specs) {
+      state.sidebar.selectedThreadID = null;
+      state.attentionDigestThreadID = null;
+      state.sidebar.items = (specs || []).map((spec, index) => ({
+        id: spec.id,
+        title: spec.title,
+        subtitle: state.topBar.modelLabel,
+        searchText: '',
+        updatedAt: spec.updatedAt || new Date(Date.now() - index * 1000).toISOString(),
+        isSelected: false,
+        isPinned: false,
+        isArchived: false,
+        integrityVerdict: spec.verdict || null,
+        verdictSummary: spec.summary || '',
+        unseenCount: Math.max(0, spec.unseenCount || 0),
+        triageState: spec.triageState || 'pending',
+        digestReasons: spec.reasons || [],
+        digestOutcome: spec.outcome || 'No final answer recorded.'
+      }));
+      render();
+    };
     window.__quillCodeTestCreateMonitorAutomation = createMonitorAutomation;
     window.__quillCodeTestAddInstructionConflict = function() {
       state.activity.instructionDiagnostics = [{

--- a/E2E/playwright/tests/attention-inbox.spec.ts
+++ b/E2E/playwright/tests/attention-inbox.spec.ts
@@ -76,6 +76,56 @@ test('j/k move the triage cursor and clamp at the ends', async ({ page }) => {
   await expect(attentionRow(page, 't-red-a')).toHaveAttribute('data-cursor', 'true');
 });
 
+// Regression (fail-on-revert) for the "cursoring zeroes passed-over badges" MAJOR: moving the j/k
+// preview cursor across threads must NOT advance any thread's watermark, so their unseen-turn badges
+// survive. The badge must clear ONLY when the thread is genuinely opened (and then left). The harness
+// unseen count is watermark-derived, so a regression here (cursor → selectThread → mark-seen) would zero
+// the badge and fail this test.
+test('moving the j/k cursor never clears the passed-over threads unseen badges', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-a', title: 'red a', verdict: 'red', unseenCount: 2 },
+    { id: 't-b', title: 'red b', verdict: 'red', unseenCount: 3 },
+    { id: 't-c', title: 'red c', verdict: 'red', unseenCount: 4 }
+  ]);
+  // All three show their seeded unseen badges.
+  await expect(attentionRow(page, 't-a').getByTestId('attention-unseen')).toHaveText('2 new');
+  await expect(attentionRow(page, 't-b').getByTestId('attention-unseen')).toHaveText('3 new');
+  await expect(attentionRow(page, 't-c').getByTestId('attention-unseen')).toHaveText('4 new');
+
+  // Scroll the cursor all the way down and back up — pure preview, nothing read.
+  await page.keyboard.press('j'); // a -> b
+  await page.keyboard.press('j'); // b -> c
+  await page.keyboard.press('k'); // c -> b
+  await page.keyboard.press('k'); // b -> a
+  await expect(attentionRow(page, 't-a')).toHaveAttribute('data-cursor', 'true');
+
+  // Every badge is UNCHANGED — cursoring read nothing.
+  await expect(attentionRow(page, 't-a').getByTestId('attention-unseen')).toHaveText('2 new');
+  await expect(attentionRow(page, 't-b').getByTestId('attention-unseen')).toHaveText('3 new');
+  await expect(attentionRow(page, 't-c').getByTestId('attention-unseen')).toHaveText('4 new');
+});
+
+test('opening a thread then leaving it clears only that thread badge', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-a', title: 'red a', verdict: 'red', unseenCount: 2 },
+    { id: 't-b', title: 'red b', verdict: 'red', unseenCount: 3 }
+  ]);
+  // Open A's digest (a genuine read of A). Its own badge stays until we leave it; B is untouched.
+  await attentionRow(page, 't-a').click();
+  await expect(page.getByTestId('attention-digest')).toBeVisible();
+  await page.getByTestId('attention-digest-close').click();
+  await expect(attentionRow(page, 't-b').getByTestId('attention-unseen')).toHaveText('3 new');
+
+  // Now open B — this LEAVES A (a real thread switch), so A's watermark advances and A's badge clears.
+  await attentionRow(page, 't-b').click();
+  await page.getByTestId('attention-digest-close').click();
+  await expect(attentionRow(page, 't-a').getByTestId('attention-unseen')).toHaveCount(0);
+  // B keeps its badge (we're on it, haven't left it).
+  await expect(attentionRow(page, 't-b').getByTestId('attention-unseen')).toHaveText('3 new');
+});
+
 test('Enter opens the return digest with verdict, reasons, and the unseen seam', async ({ page }) => {
   await page.goto(harnessURL());
   await seedAttention(page, [

--- a/E2E/playwright/tests/attention-inbox.spec.ts
+++ b/E2E/playwright/tests/attention-inbox.spec.ts
@@ -147,16 +147,46 @@ test('clicking an Attention row opens its digest; digest actions triage it', asy
   await expect(attentionRow(page, 't-red')).toBeVisible();
 });
 
-test('triage keys do not fire while typing in the composer', async ({ page }) => {
+// BLOCKER-3 fail-on-revert: with the composer focused, real j/k/a/d/Enter keystrokes must land as TEXT
+// and must NOT triage/open — the bare triage keys are section-scoped, never composer shortcuts. Uses
+// keyboard.type (which dispatches real keydown events) rather than fill() so the guard is exercised.
+test('triage keys land as composer text and never triage while typing', async ({ page }) => {
   await page.goto(harnessURL());
   await seedAttention(page, [
     { id: 't-red-a', title: 'red a', verdict: 'red' },
     { id: 't-red-b', title: 'red b', verdict: 'red' }
   ]);
 
-  // Type "adjk" into the composer; none of these should triage or move the cursor.
-  await page.getByLabel('Message').fill('adjk');
-  await expect(page.getByLabel('Message')).toHaveValue('adjk');
+  const composer = page.getByLabel('Message');
+  await composer.click();
+  await expect(composer).toBeFocused();
+
+  // Real keystrokes: every triage letter must be typed into the composer, not eaten.
+  await page.keyboard.type('adjkd');
+  await expect(composer).toHaveValue('adjkd');
+  // Nothing was triaged, no digest opened, the cursor did not move.
   await expect(page.getByTestId('attention-row')).toHaveCount(2);
+  await expect(page.getByTestId('attention-digest')).toHaveCount(0);
   await expect(attentionRow(page, 't-red-a')).toHaveAttribute('data-cursor', 'true');
+
+  // Enter in the composer must not open the digest either (it submits / newlines per the composer).
+  await composer.fill('');
+  await composer.click();
+  await page.keyboard.press('Enter');
+  await expect(page.getByTestId('attention-digest')).toHaveCount(0);
+});
+
+// And the positive half: with focus NOT in an editable field, the keys DO drive the section.
+test('triage keys drive the section when focus is not in an editable field', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-red-a', title: 'red a', verdict: 'red' },
+    { id: 't-red-b', title: 'red b', verdict: 'red' }
+  ]);
+  // Move focus out of any input onto the body.
+  await page.locator('body').click({ position: { x: 2, y: 2 } });
+  await page.keyboard.press('j');
+  await expect(attentionRow(page, 't-red-b')).toHaveAttribute('data-cursor', 'true');
+  await page.keyboard.press('a');
+  await expect(page.getByTestId('attention-row')).toHaveCount(1);
 });

--- a/E2E/playwright/tests/attention-inbox.spec.ts
+++ b/E2E/playwright/tests/attention-inbox.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect, type Page } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+// Morning-triage inbox (issue #877): the Attention section + j/k/Enter/a/d triage + return digest.
+// The harness has no external state injection, so we seed threads with verdict stamps through the
+// dedicated test hook, then drive the section entirely through real keyboard + click interactions.
+
+type Spec = {
+  id: string;
+  title: string;
+  verdict: 'red' | 'unverified' | 'verified';
+  summary?: string;
+  unseenCount?: number;
+  reasons?: string[];
+  outcome?: string;
+  triageState?: 'pending' | 'acknowledged' | 'dismissed';
+};
+
+async function seedAttention(page: Page, specs: Spec[]) {
+  await page.evaluate(specs => {
+    (window as unknown as { __quillCodeTestSeedAttentionThreads: (s: Spec[]) => void })
+      .__quillCodeTestSeedAttentionThreads(specs);
+  }, specs);
+}
+
+function attentionRow(page: Page, threadID: string) {
+  return page.locator(`[data-testid="attention-row"][data-thread-id="${threadID}"]`);
+}
+
+test('Attention section ranks by severity and shows verdict + unseen count', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-yellow', title: 'unverified run', verdict: 'unverified', unseenCount: 1 },
+    { id: 't-red', title: 'red run', verdict: 'red', unseenCount: 3 },
+    { id: 't-clean', title: 'clean run', verdict: 'verified' }
+  ]);
+
+  const section = page.getByTestId('attention-section');
+  await expect(section).toBeVisible();
+  // Only the RED and UNVERIFIED threads appear; verified is excluded.
+  const rows = page.getByTestId('attention-row');
+  await expect(rows).toHaveCount(2);
+  // RED is ranked first.
+  await expect(rows.nth(0)).toHaveAttribute('data-verdict', 'red');
+  await expect(rows.nth(1)).toHaveAttribute('data-verdict', 'unverified');
+  await expect(attentionRow(page, 't-red').getByTestId('attention-verdict')).toHaveText('RED');
+  await expect(attentionRow(page, 't-red').getByTestId('attention-unseen')).toHaveText('3 new');
+  await expect(attentionRow(page, 't-yellow').getByTestId('attention-unseen')).toHaveText('1 new');
+});
+
+test('j/k move the triage cursor and clamp at the ends', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-red-a', title: 'red a', verdict: 'red' },
+    { id: 't-red-b', title: 'red b', verdict: 'red' },
+    { id: 't-yellow', title: 'yellow', verdict: 'unverified' }
+  ]);
+
+  // First row is the cursor initially.
+  await expect(attentionRow(page, 't-red-a')).toHaveAttribute('data-cursor', 'true');
+
+  await page.keyboard.press('j');
+  await expect(attentionRow(page, 't-red-b')).toHaveAttribute('data-cursor', 'true');
+  await page.keyboard.press('j');
+  await expect(attentionRow(page, 't-yellow')).toHaveAttribute('data-cursor', 'true');
+  // Clamp at the last row — no wrap.
+  await page.keyboard.press('j');
+  await expect(attentionRow(page, 't-yellow')).toHaveAttribute('data-cursor', 'true');
+
+  await page.keyboard.press('k');
+  await expect(attentionRow(page, 't-red-b')).toHaveAttribute('data-cursor', 'true');
+  await page.keyboard.press('k');
+  await expect(attentionRow(page, 't-red-a')).toHaveAttribute('data-cursor', 'true');
+  // Clamp at the first row.
+  await page.keyboard.press('k');
+  await expect(attentionRow(page, 't-red-a')).toHaveAttribute('data-cursor', 'true');
+});
+
+test('Enter opens the return digest with verdict, reasons, and the unseen seam', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    {
+      id: 't-red',
+      title: 'fix the parser',
+      verdict: 'red',
+      summary: 'make test exited 1',
+      unseenCount: 2,
+      reasons: ['make test exited 1', 'no successful re-run'],
+      outcome: 'Left a failing test.'
+    }
+  ]);
+
+  await page.keyboard.press('Enter');
+  const digest = page.getByTestId('attention-digest');
+  await expect(digest).toBeVisible();
+  await expect(page.getByTestId('attention-digest-title')).toHaveText('fix the parser');
+  await expect(page.getByTestId('attention-digest-verdict')).toHaveText('RED');
+  await expect(page.getByTestId('attention-digest-verdict')).toHaveAttribute('data-verdict', 'red');
+  await expect(page.getByTestId('attention-digest-seam')).toHaveText('2 unseen turns');
+  await expect(page.getByTestId('attention-digest-outcome')).toHaveText('Left a failing test.');
+  await expect(page.getByTestId('attention-digest-reasons').locator('li')).toHaveCount(2);
+
+  await page.getByTestId('attention-digest-close').click();
+  await expect(page.getByTestId('attention-digest')).toHaveCount(0);
+});
+
+test('a acknowledges the selected row and removes it from Attention', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-red-a', title: 'red a', verdict: 'red' },
+    { id: 't-red-b', title: 'red b', verdict: 'red' }
+  ]);
+  await expect(page.getByTestId('attention-row')).toHaveCount(2);
+
+  // Acknowledge the first (selected) row.
+  await page.keyboard.press('a');
+  await expect(page.getByTestId('attention-row')).toHaveCount(1);
+  await expect(attentionRow(page, 't-red-a')).toHaveCount(0);
+  // The cursor advanced to the remaining row.
+  await expect(attentionRow(page, 't-red-b')).toHaveAttribute('data-cursor', 'true');
+});
+
+test('d dismisses the selected row and empties the section when last', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [{ id: 't-only', title: 'only', verdict: 'unverified' }]);
+  await expect(page.getByTestId('attention-row')).toHaveCount(1);
+
+  await page.keyboard.press('d');
+  await expect(page.getByTestId('attention-section')).toHaveCount(0);
+});
+
+test('clicking an Attention row opens its digest; digest actions triage it', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-red', title: 'red run', verdict: 'red', outcome: 'done', reasons: ['boom'] },
+    { id: 't-yellow', title: 'yellow run', verdict: 'unverified' }
+  ]);
+
+  await attentionRow(page, 't-yellow').click();
+  await expect(page.getByTestId('attention-digest')).toBeVisible();
+  await expect(page.getByTestId('attention-digest-title')).toHaveText('yellow run');
+
+  // Dismiss from the digest — the thread leaves Attention and the digest closes.
+  await page.getByTestId('attention-digest-dismiss').click();
+  await expect(page.getByTestId('attention-digest')).toHaveCount(0);
+  await expect(attentionRow(page, 't-yellow')).toHaveCount(0);
+  await expect(attentionRow(page, 't-red')).toBeVisible();
+});
+
+test('triage keys do not fire while typing in the composer', async ({ page }) => {
+  await page.goto(harnessURL());
+  await seedAttention(page, [
+    { id: 't-red-a', title: 'red a', verdict: 'red' },
+    { id: 't-red-b', title: 'red b', verdict: 'red' }
+  ]);
+
+  // Type "adjk" into the composer; none of these should triage or move the cursor.
+  await page.getByLabel('Message').fill('adjk');
+  await expect(page.getByLabel('Message')).toHaveValue('adjk');
+  await expect(page.getByTestId('attention-row')).toHaveCount(2);
+  await expect(attentionRow(page, 't-red-a')).toHaveAttribute('data-cursor', 'true');
+});

--- a/Sources/QuillCodeApp/AttentionSectionSurface.swift
+++ b/Sources/QuillCodeApp/AttentionSectionSurface.swift
@@ -1,0 +1,94 @@
+import Foundation
+import QuillCodeCore
+
+/// The render-ready "Attention" sidebar section for the morning triage inbox (issue #877). This is the
+/// thin, `Codable`/`Hashable` surface both the native SwiftUI sidebar and the HTML harness renderer
+/// consume; all the ranking / selection / triage *semantics* live in `QuillCodeCore`'s `AttentionModel`
+/// (shared, pure, tested) so the two surfaces cannot drift.
+public struct AttentionSectionSurface: Codable, Sendable, Hashable {
+    /// The severity-ranked rows (RED first, then UNVERIFIED). Empty when nothing needs attention.
+    public var rows: [AttentionRowSurface]
+    /// The thread id the triage cursor is on, or nil when the section is empty.
+    public var selectedThreadID: UUID?
+
+    public init(rows: [AttentionRowSurface] = [], selectedThreadID: UUID? = nil) {
+        self.rows = rows
+        self.selectedThreadID = selectedThreadID
+    }
+
+    public var isEmpty: Bool { rows.isEmpty }
+
+    /// Build the section surface from the pure model plus the current sidebar selection. The section's
+    /// own cursor prefers the model's selection but falls back so a selected attention thread stays
+    /// highlighted when it is the sidebar's selected thread too.
+    public init(model: AttentionModel) {
+        self.rows = model.items.map(AttentionRowSurface.init)
+        self.selectedThreadID = model.selectedThreadID
+    }
+}
+
+/// One row of the Attention section: the verdict badge, thread title, one-line summary, and the unseen
+/// turn count, plus whether this row is the current triage cursor.
+public struct AttentionRowSurface: Codable, Sendable, Hashable, Identifiable {
+    public var threadID: UUID
+    public var title: String
+    public var verdict: TriageVerdict
+    public var badgeLabel: String
+    public var summary: String
+    public var unseenCount: Int
+    public var unseenLabel: String?
+
+    public var id: UUID { threadID }
+
+    public init(item: AttentionItem) {
+        self.threadID = item.threadID
+        self.title = item.title
+        self.verdict = item.verdict
+        self.badgeLabel = item.verdict.badgeLabel
+        self.summary = item.summary
+        self.unseenCount = item.unseenCount
+        self.unseenLabel = item.unseenLabel
+    }
+
+    public init(
+        threadID: UUID,
+        title: String,
+        verdict: TriageVerdict,
+        summary: String,
+        unseenCount: Int
+    ) {
+        self.threadID = threadID
+        self.title = title
+        self.verdict = verdict
+        self.badgeLabel = verdict.badgeLabel
+        self.summary = summary
+        self.unseenCount = max(0, unseenCount)
+        self.unseenLabel = unseenCount == 0 ? nil : "\(max(0, unseenCount)) new"
+    }
+}
+
+/// The render-ready return digest card (issue #877). Mirrors `QuillCodeCore.TriageDigest` as a
+/// `Codable`/`Hashable` surface for the two render paths.
+public struct AttentionDigestSurface: Codable, Sendable, Hashable {
+    public var threadID: UUID
+    public var title: String
+    public var verdict: TriageVerdict?
+    public var badgeLabel: String?
+    public var verdictSummary: String
+    public var reasons: [String]
+    public var outcome: String
+    public var unseenCount: Int
+    public var unseenSeamLabel: String?
+
+    public init(digest: TriageDigest) {
+        self.threadID = digest.threadID
+        self.title = digest.title
+        self.verdict = digest.verdict
+        self.badgeLabel = digest.verdict?.badgeLabel
+        self.verdictSummary = digest.verdictSummary
+        self.reasons = digest.reasons
+        self.outcome = digest.outcome
+        self.unseenCount = digest.unseenCount
+        self.unseenSeamLabel = digest.unseenSeamLabel
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeAttentionDigestView.swift
+++ b/Sources/QuillCodeApp/QuillCodeAttentionDigestView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import QuillCodeCore
+
+/// The per-thread return digest card (issue #877), shown when the user presses Enter on an Attention row.
+/// A compact summary of one overnight run — the integrity verdict + reasons, the final outcome, and the
+/// "unseen turns since last viewed" seam — so the user sees exactly what changed without reading the
+/// whole transcript. Mirrors `WorkspaceHTMLRenderer`'s digest markup for native/harness parity.
+struct QuillCodeAttentionDigestView: View {
+    var digest: AttentionDigestSurface
+    var onClose: () -> Void
+    var onAcknowledge: () -> Void
+    var onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if let seam = digest.unseenSeamLabel {
+                unseenSeam(seam)
+            }
+            outcomeSection
+            if !digest.reasons.isEmpty {
+                reasonsSection
+            }
+            actions
+        }
+        .padding(20)
+        .frame(maxWidth: 460)
+        .background(QuillCodePalette.panel)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("quillcode-attention-digest")
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: QuillCodeMetrics.controlClusterSpacing) {
+            if let badge = digest.badgeLabel, let verdict = digest.verdict {
+                Text(badge)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(color(for: verdict))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(color(for: verdict).opacity(0.16))
+                    .clipShape(Capsule())
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(digest.title)
+                    .font(.headline)
+                    .foregroundStyle(QuillCodePalette.text)
+                if !digest.verdictSummary.isEmpty {
+                    Text(digest.verdictSummary)
+                        .font(.caption)
+                        .foregroundStyle(QuillCodePalette.muted)
+                }
+            }
+            Spacer(minLength: 0)
+            Button("Close", action: onClose)
+                .font(.caption.weight(.semibold))
+                .buttonStyle(QuillCodePressableButtonStyle())
+                .quillCodeTextButtonTarget(minWidth: 56)
+                .foregroundStyle(QuillCodePalette.muted)
+                .accessibilityIdentifier("quillcode-attention-digest-close")
+        }
+    }
+
+    private func unseenSeam(_ label: String) -> some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(QuillCodePalette.blue.opacity(0.5))
+                .frame(height: 1)
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(QuillCodePalette.blue)
+            Rectangle()
+                .fill(QuillCodePalette.blue.opacity(0.5))
+                .frame(height: 1)
+        }
+        .accessibilityIdentifier("quillcode-attention-digest-seam")
+        .accessibilityLabel(label)
+    }
+
+    private var outcomeSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Final outcome".uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(QuillCodePalette.muted)
+            Text(digest.outcome)
+                .font(.callout)
+                .foregroundStyle(QuillCodePalette.text)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var reasonsSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Why".uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(QuillCodePalette.muted)
+            ForEach(Array(digest.reasons.enumerated()), id: \.offset) { _, reason in
+                Text("• \(reason)")
+                    .font(.caption)
+                    .foregroundStyle(QuillCodePalette.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var actions: some View {
+        HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
+            Button("Acknowledge", action: onAcknowledge)
+                .buttonStyle(QuillCodePressableButtonStyle())
+                .quillCodeTextButtonTarget()
+                .accessibilityIdentifier("quillcode-attention-digest-acknowledge")
+            Button("Dismiss", action: onDismiss)
+                .buttonStyle(QuillCodePressableButtonStyle())
+                .quillCodeTextButtonTarget()
+                .foregroundStyle(QuillCodePalette.muted)
+                .accessibilityIdentifier("quillcode-attention-digest-dismiss")
+        }
+    }
+
+    private func color(for verdict: TriageVerdict) -> Color {
+        switch verdict {
+        case .red: return QuillCodePalette.red
+        case .unverified: return QuillCodePalette.yellow
+        case .verified: return QuillCodePalette.green
+        }
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeAttentionSectionView.swift
+++ b/Sources/QuillCodeApp/QuillCodeAttentionSectionView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import QuillCodeCore
+
+/// The morning-triage "Attention" section rendered in the native sidebar (issue #877). Severity-ranked
+/// rows (RED first) each show the run-integrity verdict badge, the thread title, and the unseen-turn
+/// count. The section is keyboard-triageable with j/k/Enter/a/d; the keys dispatch the shared
+/// `attention-*` commands so native and the HTML harness drive the same model. Renders nothing when the
+/// section is empty.
+struct QuillCodeAttentionSectionView: View {
+    var attention: AttentionSectionSurface
+    var onSelectThread: (UUID) -> Void
+    var onCommand: (WorkspaceCommandSurface) -> Void
+
+    var body: some View {
+        if !attention.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Attention".uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .padding(.top, 4)
+                    .accessibilityAddTraits(.isHeader)
+                ForEach(attention.rows) { row in
+                    QuillCodeAttentionRowView(
+                        row: row,
+                        isCursor: row.threadID == attention.selectedThreadID,
+                        onOpen: { onSelectThread(row.threadID) }
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Attention")
+            // The five triage keys, active while the sidebar has focus. They route through the shared
+            // command system so the semantics are identical to the harness.
+            .onAttentionTriageKey("j") { runCommand(.attentionNext) }
+            .onAttentionTriageKey("k") { runCommand(.attentionPrevious) }
+            .onAttentionTriageKey("a") { runCommand(.attentionAcknowledge) }
+            .onAttentionTriageKey("d") { runCommand(.attentionDismiss) }
+            .onKeyPress(.return) { runCommand(.attentionOpen); return .handled }
+        }
+    }
+
+    private func runCommand(_ action: WorkspaceCommandAction) {
+        onCommand(WorkspaceCommandSurface(id: action.rawValue, title: action.rawValue))
+    }
+}
+
+private extension View {
+    /// Bind a single character to a triage command, returning `.handled` so the key does not fall
+    /// through to other handlers.
+    func onAttentionTriageKey(_ character: Character, action: @escaping () -> Void) -> some View {
+        onKeyPress(keys: [KeyEquivalent(character)]) { _ in
+            action()
+            return .handled
+        }
+    }
+}
+
+struct QuillCodeAttentionRowView: View {
+    var row: AttentionRowSurface
+    var isCursor: Bool
+    var onOpen: () -> Void
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(spacing: 8) {
+                verdictBadge
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.title)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(QuillCodePalette.text)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    if !row.summary.isEmpty {
+                        Text(row.summary)
+                            .font(.caption2)
+                            .foregroundStyle(QuillCodePalette.muted)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+                Spacer(minLength: 0)
+                if let unseen = row.unseenLabel {
+                    Text(unseen)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(QuillCodePalette.blue)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(QuillCodePalette.blue.opacity(0.14))
+                        .clipShape(Capsule())
+                }
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isCursor ? QuillCodePalette.selection : Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(isCursor ? verdictColor.opacity(0.6) : Color.clear, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .buttonStyle(QuillCodePressableButtonStyle())
+        .quillCodeFullRowButtonTarget()
+        .accessibilityIdentifier("quillcode-attention-row-\(row.threadID.uuidString)")
+        .accessibilityAddTraits(isCursor ? [.isSelected, .isButton] : .isButton)
+        .accessibilityLabel("\(row.badgeLabel). \(row.title).\(row.unseenLabel.map { " \($0)." } ?? "")")
+    }
+
+    private var verdictBadge: some View {
+        Text(row.badgeLabel)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(verdictColor)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(verdictColor.opacity(0.16))
+            .clipShape(Capsule())
+    }
+
+    private var verdictColor: Color {
+        switch row.verdict {
+        case .red: return QuillCodePalette.red
+        case .unverified: return QuillCodePalette.yellow
+        case .verified: return QuillCodePalette.green
+        }
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeSidebarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarView.swift
@@ -10,6 +10,9 @@ struct QuillCodeSidebarView: View {
     var onSelectThread: (UUID) -> Void
     var onThreadAction: (SidebarItemActionSurface) -> Void
     var onCommand: (WorkspaceCommandSurface) -> Void
+    /// Opening a thread from the Attention section lands on its return digest, so it is routed
+    /// separately from an ordinary thread selection. Defaults to a plain selection when unset.
+    var onOpenAttentionDigest: (UUID) -> Void = { _ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -35,6 +38,14 @@ struct QuillCodeSidebarView: View {
                         onCommand: onCommand
                     )
                 }
+            }
+            if !sidebar.attention.isEmpty {
+                QuillCodeAttentionSectionView(
+                    attention: sidebar.attention,
+                    onSelectThread: onOpenAttentionDigest,
+                    onCommand: onCommand
+                )
+                Divider()
             }
             QuillCodeSidebarThreadListView(
                 sidebar: sidebar,

--- a/Sources/QuillCodeApp/QuillCodeThreadSidebarSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeThreadSidebarSurface.swift
@@ -14,6 +14,9 @@ public struct SidebarSurface: Codable, Sendable, Hashable {
     public var selectedThreadIDs: Set<UUID>
     public var selectionLabel: String
     public var bulkActions: [SidebarBulkActionSurface]
+    /// The severity-ranked "Attention" section for the morning triage inbox (issue #877). Empty when no
+    /// thread needs attention, in which case the section renders nothing.
+    public var attention: AttentionSectionSurface
 
     public init(
         title: String = "Chats",
@@ -25,7 +28,8 @@ public struct SidebarSurface: Codable, Sendable, Hashable {
         customSavedSearches: [SidebarSavedSearch] = [],
         isSelectionMode: Bool = false,
         selectedThreadIDs: Set<UUID> = [],
-        bulkActions: [SidebarBulkActionSurface] = []
+        bulkActions: [SidebarBulkActionSurface] = [],
+        attention: AttentionSectionSurface = AttentionSectionSurface()
     ) {
         self.title = title
         self.items = items
@@ -55,6 +59,7 @@ public struct SidebarSurface: Codable, Sendable, Hashable {
         self.selectedThreadIDs = selectedThreadIDs
         self.selectionLabel = Self.selectionLabel(count: selectedThreadIDs.count)
         self.bulkActions = bulkActions
+        self.attention = attention
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -70,6 +75,7 @@ public struct SidebarSurface: Codable, Sendable, Hashable {
         case selectedThreadIDs
         case selectionLabel
         case bulkActions
+        case attention
     }
 
     public init(from decoder: Decoder) throws {
@@ -95,6 +101,8 @@ public struct SidebarSurface: Codable, Sendable, Hashable {
         self.selectionLabel = try container.decodeIfPresent(String.self, forKey: .selectionLabel)
             ?? Self.selectionLabel(count: self.selectedThreadIDs.count)
         self.bulkActions = try container.decodeIfPresent([SidebarBulkActionSurface].self, forKey: .bulkActions) ?? []
+        self.attention = try container.decodeIfPresent(AttentionSectionSurface.self, forKey: .attention)
+            ?? AttentionSectionSurface()
     }
 
     public func filteredItems(matching query: String) -> [SidebarItemSurface] {

--- a/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
@@ -99,6 +99,21 @@ extension QuillCodeWorkspaceModel {
             return startCompactContext()
         case .disconnectAll:
             return disconnectAll()
+        case .attentionNext:
+            attentionMoveDown()
+            return true
+        case .attentionPrevious:
+            attentionMoveUp()
+            return true
+        case .attentionOpen:
+            attentionOpenSelected()
+            return true
+        case .attentionAcknowledge:
+            attentionAcknowledgeSelected()
+            return true
+        case .attentionDismiss:
+            attentionDismissSelected()
+            return true
         }
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
@@ -37,6 +37,11 @@ enum WorkspaceCommandActionEffect: Sendable, Hashable {
     case forkThread(WorkspaceThreadForkStrategy)
     case compactContext
     case disconnectAll
+    case attentionNext
+    case attentionPrevious
+    case attentionOpen
+    case attentionAcknowledge
+    case attentionDismiss
 }
 
 struct WorkspaceCommandActionPlanner: Sendable, Hashable {
@@ -139,6 +144,16 @@ struct WorkspaceCommandActionPlanner: Sendable, Hashable {
             return .compactContext
         case .disconnectAll:
             return .disconnectAll
+        case .attentionNext:
+            return .attentionNext
+        case .attentionPrevious:
+            return .attentionPrevious
+        case .attentionOpen:
+            return .attentionOpen
+        case .attentionAcknowledge:
+            return .attentionAcknowledge
+        case .attentionDismiss:
+            return .attentionDismiss
         }
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
@@ -261,6 +261,12 @@ enum WorkspaceCommandAction: String, Equatable {
     case forkFullContext = "fork-full-context"
     case compactContext = "compact-context"
     case disconnectAll = "disconnect-all"
+    // Morning-triage inbox keyboard triage (issue #877): j / k / Enter / a / d.
+    case attentionNext = "attention-next"
+    case attentionPrevious = "attention-previous"
+    case attentionOpen = "attention-open"
+    case attentionAcknowledge = "attention-acknowledge"
+    case attentionDismiss = "attention-dismiss"
 }
 
 private extension String {

--- a/Sources/QuillCodeApp/WorkspaceHTMLRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLRenderer.swift
@@ -24,7 +24,63 @@ public enum WorkspaceHTMLRenderer {
               \(WorkspaceHTMLTranscriptRenderer.renderComposer(surface.composer, topBar: surface.topBar))
             </main>
           </div>
+          \(attentionDigestHTML(for: surface))
         </section>
+        """
+    }
+
+    /// The morning-triage return digest card overlay (issue #877), present only when a digest is open.
+    /// Mirrors the native `QuillCodeAttentionDigestView` structure so the two surfaces stay in parity.
+    private static func attentionDigestHTML(for surface: WorkspaceSurface) -> String {
+        guard let digest = surface.attentionDigest else { return "" }
+        let badge = (digest.badgeLabel).map {
+            #"<span data-testid="attention-digest-verdict" data-verdict="\#(digest.verdict?.rawValue ?? "")">\#(WorkspaceHTMLPrimitives.escape($0))</span>"#
+        } ?? ""
+        let summary = digest.verdictSummary.isEmpty
+            ? ""
+            : #"<p data-testid="attention-digest-summary">\#(WorkspaceHTMLPrimitives.escape(digest.verdictSummary))</p>"#
+        let seam = digest.unseenSeamLabel.map {
+            #"<div data-testid="attention-digest-seam">\#(WorkspaceHTMLPrimitives.escape($0))</div>"#
+        } ?? ""
+        let reasons = digest.reasons.isEmpty ? "" : """
+        <ul data-testid="attention-digest-reasons">
+          \(digest.reasons.map { #"<li>\#(WorkspaceHTMLPrimitives.escape($0))</li>"# }.joined(separator: "\n"))
+        </ul>
+        """
+        return """
+        <div class="attention-digest-backdrop" data-testid="attention-digest" data-thread-id="\(digest.threadID.uuidString)">
+          <div class="attention-digest-card">
+            <div class="attention-digest-header">
+              \(badge)
+              <strong data-testid="attention-digest-title">\(WorkspaceHTMLPrimitives.escape(digest.title))</strong>
+              \(WorkspaceHTMLPrimitives.commandButton(
+                "Close",
+                testID: "attention-digest-close",
+                commandID: "attention-digest-close",
+                hitTargetKind: .text,
+                ariaLabel: "Close digest"
+              ))
+            </div>
+            \(summary)
+            \(seam)
+            <div data-testid="attention-digest-outcome">\(WorkspaceHTMLPrimitives.escape(digest.outcome))</div>
+            \(reasons)
+            <div class="attention-digest-actions">
+              \(WorkspaceHTMLPrimitives.commandButton(
+                "Acknowledge",
+                testID: "attention-digest-acknowledge",
+                commandID: "attention-acknowledge",
+                hitTargetKind: .text
+              ))
+              \(WorkspaceHTMLPrimitives.commandButton(
+                "Dismiss",
+                testID: "attention-digest-dismiss",
+                commandID: "attention-dismiss",
+                hitTargetKind: .text
+              ))
+            </div>
+          </div>
+        </div>
         """
     }
 

--- a/Sources/QuillCodeApp/WorkspaceHTMLSidebarThreadRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLSidebarThreadRenderer.swift
@@ -91,12 +91,44 @@ enum WorkspaceHTMLSidebarThreadRenderer {
         }
 
         return [
+            renderAttentionSection(sidebar.attention),
             renderSection(title: "Pinned", items: sidebar.pinnedItems),
             renderRecentSections(sidebar),
             renderSection(title: "Archived", items: sidebar.archivedItems)
         ]
         .filter { !$0.isEmpty }
         .joined(separator: "\n")
+    }
+
+    /// The morning-triage "Attention" section (issue #877): severity-ranked rows with the run-integrity
+    /// verdict badge, unseen-turn count, and j/k/Enter/a/d keyboard triage. Rendered empty (nothing) when
+    /// no thread needs attention. Mirrors the native `QuillCodeAttentionSectionView` exactly.
+    private static func renderAttentionSection(_ attention: AttentionSectionSurface) -> String {
+        guard !attention.isEmpty else { return "" }
+        let rows = attention.rows.map { renderAttentionRow($0, selectedThreadID: attention.selectedThreadID) }
+            .joined(separator: "\n")
+        return """
+        <section data-testid="attention-section" aria-label="Attention">
+          <h3 data-testid="sidebar-section-title">Attention</h3>
+          \(rows)
+        </section>
+        """
+    }
+
+    private static func renderAttentionRow(_ row: AttentionRowSurface, selectedThreadID: UUID?) -> String {
+        let isCursor = row.threadID == selectedThreadID
+        let unseen = row.unseenLabel.map {
+            #"<span data-testid="attention-unseen">\#(escape($0))</span>"#
+        } ?? ""
+        return """
+        <div data-testid="attention-row" data-thread-id="\(row.threadID.uuidString)" \
+        data-verdict="\(row.verdict.rawValue)" data-cursor="\(isCursor ? "true" : "false")" \
+        aria-current="\(isCursor ? "true" : "false")">
+          <span data-testid="attention-verdict" data-verdict="\(row.verdict.rawValue)">\(escape(row.badgeLabel))</span>
+          <span data-testid="attention-title">\(escape(row.title))</span>
+          \(unseen)
+        </div>
+        """
     }
 
     private static func renderRecentSections(_ sidebar: SidebarSurface) -> String {

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -71,6 +71,10 @@ public final class QuillCodeWorkspaceModel {
     /// Transient per-thread unsent composer drafts, stashed on thread switch and
     /// restored on selection so drafts never bleed across threads. Session-only.
     public internal(set) var threadDrafts: [UUID: String] = [:]
+    /// The thread whose morning-triage return digest card is currently open (issue #877), or nil when no
+    /// digest is showing. Session-only presentation state; the digest content itself is rebuilt from the
+    /// thread's persisted records on every surface pass.
+    public internal(set) var attentionDigestThreadID: UUID?
 
     public init(
         root: QuillCodeRootState = QuillCodeRootState(),

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -75,6 +75,13 @@ public final class QuillCodeWorkspaceModel {
     /// digest is showing. Session-only presentation state; the digest content itself is rebuilt from the
     /// thread's persisted records on every surface pass.
     public internal(set) var attentionDigestThreadID: UUID?
+    /// The morning-triage Attention section's PREVIEW cursor — which row j/k highlight (issue #877).
+    /// This is deliberately a SEPARATE, session-only, navigation-only field: moving the cursor is a
+    /// preview, NOT "I have read this thread." It must never touch the workspace thread selection or any
+    /// return watermark — only an explicit open (Enter / click → digest) does that. Keeping it distinct
+    /// is what prevents j/k from zeroing the passed-over threads' unseen-turn badges. Nil means "no
+    /// explicit cursor yet" — the pure model then defaults it to the first (highest-severity) row.
+    public internal(set) var attentionCursorID: UUID?
 
     public init(
         root: QuillCodeRootState = QuillCodeRootState(),

--- a/Sources/QuillCodeApp/WorkspaceModelMorningTriage.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelMorningTriage.swift
@@ -1,0 +1,104 @@
+import Foundation
+import QuillCodeCore
+
+/// Morning-triage inbox actions (issue #877). The Attention section's keyboard triage — j/k/Enter/a/d —
+/// routes through these five methods. All ranking/selection/triage *semantics* live in the shared pure
+/// `AttentionModel` / `ThreadTriageRecord` in `QuillCodeCore`; these methods are the thin app-layer glue
+/// that persists the decision and refreshes the surface. The HTML harness mirrors this exact behavior.
+///
+/// Triage-key semantics (documented, matching the harness):
+/// - `j` — move the Attention cursor down one row (clamps at the last row; no wrap).
+/// - `k` — move the cursor up one row (clamps at the first row).
+/// - `Enter` — open the selected thread's return digest (and select the thread in the workspace).
+/// - `a` — **acknowledge** the selected thread: it has been reviewed and is fine. Removed from Attention,
+///   its triage state persisted as `.acknowledged`. The cursor advances to the next row.
+/// - `d` — **dismiss** the selected thread: not worth reviewing. Removed from Attention, persisted as
+///   `.dismissed`. The cursor advances to the next row.
+///
+/// `a`/`d` on an empty section, or when nothing is selected, are no-ops.
+@MainActor
+extension QuillCodeWorkspaceModel {
+    /// The current ranked Attention model, rebuilt fresh from the persisted records on the threads. The
+    /// cursor is anchored to the sidebar's selected thread when that thread is itself an attention row.
+    var attentionModel: AttentionModel {
+        AttentionModel.build(from: root.threads, selectedThreadID: attentionCursorThreadID)
+    }
+
+    /// Move the Attention triage cursor down (`j`). No-op on an empty section.
+    public func attentionMoveDown() {
+        var model = attentionModel
+        model.moveDown()
+        setAttentionCursor(model.selectedThreadID)
+    }
+
+    /// Move the Attention triage cursor up (`k`). No-op on an empty section.
+    public func attentionMoveUp() {
+        var model = attentionModel
+        model.moveUp()
+        setAttentionCursor(model.selectedThreadID)
+    }
+
+    /// Open the return digest for the selected Attention row (`Enter`): select the thread in the
+    /// workspace and present its digest card. No-op when nothing is selected.
+    public func attentionOpenSelected() {
+        guard let threadID = attentionModel.selectedThreadID else { return }
+        openAttentionDigest(for: threadID)
+    }
+
+    /// Open the digest for a specific thread (also used when the user clicks a row).
+    public func openAttentionDigest(for threadID: UUID) {
+        guard root.threads.contains(where: { $0.id == threadID }) else { return }
+        selectThread(threadID)
+        attentionDigestThreadID = threadID
+    }
+
+    /// Close the open digest card.
+    public func closeAttentionDigest() {
+        attentionDigestThreadID = nil
+    }
+
+    /// Acknowledge the selected Attention row (`a`): persist `.acknowledged`, remove it from Attention,
+    /// and advance the cursor to the next row. No-op on an empty section.
+    public func attentionAcknowledgeSelected() {
+        triageSelected(as: .acknowledged)
+    }
+
+    /// Dismiss the selected Attention row (`d`): persist `.dismissed`, remove it from Attention, and
+    /// advance the cursor. No-op on an empty section.
+    public func attentionDismissSelected() {
+        triageSelected(as: .dismissed)
+    }
+
+    // MARK: - Internals
+
+    /// The thread the Attention cursor should anchor to. When a digest is open, that thread wins so the
+    /// cursor stays put; otherwise the sidebar's selected thread anchors it (so click and keyboard agree).
+    private var attentionCursorThreadID: UUID? {
+        attentionDigestThreadID ?? root.selectedThreadID
+    }
+
+    /// Move the cursor by selecting the target thread in the workspace, so the sidebar highlight and the
+    /// Attention cursor stay in sync. A nil target (empty section) is a no-op.
+    private func setAttentionCursor(_ threadID: UUID?) {
+        guard let threadID else { return }
+        selectThread(threadID)
+    }
+
+    private func triageSelected(as state: ThreadTriageState) {
+        var model = attentionModel
+        guard let threadID = model.selectedThreadID else { return }
+        // Persist the triage decision onto the thread (survives reload); rebuild the ranked list without
+        // the now-triaged row and advance the cursor to whatever takes its place.
+        _ = mutateThread(threadID) { thread in
+            ThreadTriageRecord.set(state, on: &thread)
+        }
+        // If the digest for this thread was open, close it — it is no longer in the inbox.
+        if attentionDigestThreadID == threadID {
+            attentionDigestThreadID = nil
+        }
+        // Advance the cursor: the rebuilt model no longer contains the triaged thread, so its
+        // initializer selects the row that slid into that position (or the first row).
+        model = AttentionModel.build(from: root.threads, selectedThreadID: nil)
+        setAttentionCursor(model.selectedThreadID)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModelMorningTriage.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelMorningTriage.swift
@@ -45,9 +45,14 @@ extension QuillCodeWorkspaceModel {
         openAttentionDigest(for: threadID)
     }
 
-    /// Open the digest for a specific thread (also used when the user clicks a row).
+    /// Open the digest for a specific thread (also used when the user clicks a row). This is a genuine
+    /// OPEN: it selects the thread in the workspace (which persists the OUTGOING thread's watermark via
+    /// the normal leave path) and presents the digest. The opened thread keeps its own unseen badge until
+    /// the user later leaves it. Also parks the preview cursor on this row so closing the digest lands
+    /// the cursor here.
     public func openAttentionDigest(for threadID: UUID) {
         guard root.threads.contains(where: { $0.id == threadID }) else { return }
+        attentionCursorID = threadID
         selectThread(threadID)
         attentionDigestThreadID = threadID
     }
@@ -72,16 +77,19 @@ extension QuillCodeWorkspaceModel {
     // MARK: - Internals
 
     /// The thread the Attention cursor should anchor to. When a digest is open, that thread wins so the
-    /// cursor stays put; otherwise the sidebar's selected thread anchors it (so click and keyboard agree).
+    /// cursor stays put; otherwise the dedicated preview cursor anchors it. This is intentionally NOT the
+    /// workspace's selected thread — the cursor is preview/navigation, decoupled from thread selection —
+    /// so moving it never touches a return watermark.
     private var attentionCursorThreadID: UUID? {
-        attentionDigestThreadID ?? root.selectedThreadID
+        attentionDigestThreadID ?? attentionCursorID
     }
 
-    /// Move the cursor by selecting the target thread in the workspace, so the sidebar highlight and the
-    /// Attention cursor stay in sync. A nil target (empty section) is a no-op.
+    /// Move the PREVIEW cursor to `threadID`. This only updates the session-only cursor field — it does
+    /// NOT select the thread in the workspace and does NOT advance any return watermark. Moving the
+    /// triage cursor is a preview, not "I have read this thread"; the passed-over threads keep their
+    /// unseen-turn badges intact. A nil target (empty section) clears the cursor.
     private func setAttentionCursor(_ threadID: UUID?) {
-        guard let threadID else { return }
-        selectThread(threadID)
+        attentionCursorID = threadID
     }
 
     /// Persist the CURRENTLY selected thread's morning-triage return watermark up to its current tail,

--- a/Sources/QuillCodeApp/WorkspaceModelMorningTriage.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelMorningTriage.swift
@@ -84,6 +84,25 @@ extension QuillCodeWorkspaceModel {
         selectThread(threadID)
     }
 
+    /// Persist the CURRENTLY selected thread's morning-triage return watermark up to its current tail,
+    /// because the user is about to leave it. This is the cross-session mirror of the transcript view's
+    /// session-only `TranscriptNewTurnsTracker.leave` (and the harness's `selectThread → markTranscriptSeen`):
+    /// on the next visit, only turns added *after* this point — e.g. a run that finished in the
+    /// background — count as unseen in the Attention section and the digest seam.
+    ///
+    /// Crucially this preserves the thread's `updatedAt` (it does NOT go through `mutateThread`, which
+    /// force-bumps it): leaving a thread is invisible bookkeeping and must not reorder the recency-sorted
+    /// sidebar. A no-op when nothing is selected or the thread is already watermarked at its tail.
+    func persistOutgoingReturnWatermark() {
+        guard let outgoing = root.selectedThreadID,
+              let index = root.threads.firstIndex(where: { $0.id == outgoing })
+        else {
+            return
+        }
+        guard ThreadReturnWatermarkRecord.markSeen(&root.threads[index]) else { return }
+        threadPersistence.save(root.threads[index])
+    }
+
     private func triageSelected(as state: ThreadTriageState) {
         var model = attentionModel
         guard let threadID = model.selectedThreadID else { return }

--- a/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
@@ -18,6 +18,12 @@ extension QuillCodeWorkspaceModel {
     public func selectThread(_ id: UUID, recordsNavigation: Bool = true) {
         guard let thread = root.threads.first(where: { $0.id == id }) else { return }
         let previousLocation = currentNavigationLocation
+        // The user is leaving the current thread: persist its morning-triage return watermark to its
+        // current tail so background growth on it surfaces as "unseen" on return (cross-session).
+        // Only on an actual thread switch, mirroring the transcript tracker's leave transition.
+        if let outgoing = root.selectedThreadID, outgoing != id {
+            persistOutgoingReturnWatermark()
+        }
         restoreComposerDraft(from: root.selectedThreadID, to: id)
         selectThreadRecord(id, projectID: thread.projectID)
         if recordsNavigation {
@@ -32,6 +38,11 @@ extension QuillCodeWorkspaceModel {
         saveThread: Bool
     ) -> UUID {
         let previousLocation = currentNavigationLocation
+        // Leaving the current thread for a newly created one (New Chat / fork / compact): persist its
+        // return watermark, mirroring the harness's newChat() → markTranscriptSeen.
+        if let outgoing = root.selectedThreadID, outgoing != thread.id {
+            persistOutgoingReturnWatermark()
+        }
         clearSidebarSelection()
         restoreComposerDraft(from: root.selectedThreadID, to: thread.id)
         root.threads.insert(thread, at: 0)

--- a/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
@@ -46,9 +46,18 @@ struct WorkspaceNavigationSurfaceBuilder {
                 bulkActions: sidebarBulkActions(
                     selectedThreadIDs: resolvedSelectedThreadIDs,
                     visibleSidebarItems: visibleSidebarItems
-                )
+                ),
+                attention: attentionSection()
             )
         )
+    }
+
+    /// Build the morning-triage Attention section from the actual threads, ranked by the shared pure
+    /// `AttentionModel`. The section's cursor prefers the sidebar's selected thread when that thread is
+    /// itself an attention row, so keyboard triage and click selection stay in sync.
+    private func attentionSection() -> AttentionSectionSurface {
+        let model = AttentionModel.build(from: threads, selectedThreadID: selectedThreadID)
+        return AttentionSectionSurface(model: model)
     }
 
     private func projectItems() -> [ProjectItemSurface] {

--- a/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
@@ -17,6 +17,9 @@ struct WorkspaceNavigationSurfaceBuilder {
     var sidebarSavedSearches: [SidebarSavedSearch] = []
     var selectionIsActive: Bool
     var selectedThreadIDs: Set<UUID>
+    /// The morning-triage Attention preview cursor (issue #877) — which row j/k highlight. Distinct from
+    /// `selectedThreadID`: cursoring is preview/navigation and must not move the workspace selection.
+    var attentionCursorID: UUID? = nil
 
     func surface() -> WorkspaceNavigationSurface {
         let visibleSidebarItems = filteredSidebarItems()
@@ -53,10 +56,11 @@ struct WorkspaceNavigationSurfaceBuilder {
     }
 
     /// Build the morning-triage Attention section from the actual threads, ranked by the shared pure
-    /// `AttentionModel`. The section's cursor prefers the sidebar's selected thread when that thread is
-    /// itself an attention row, so keyboard triage and click selection stay in sync.
+    /// `AttentionModel`. The section's cursor is the dedicated preview cursor (`attentionCursorID`), which
+    /// the pure model clamps/defaults to the first row when nil or stale — it is NOT the workspace's
+    /// selected thread, so moving the cursor never advances a watermark.
     private func attentionSection() -> AttentionSectionSurface {
-        let model = AttentionModel.build(from: threads, selectedThreadID: selectedThreadID)
+        let model = AttentionModel.build(from: threads, selectedThreadID: attentionCursorID)
         return AttentionSectionSurface(model: model)
     }
 

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -118,7 +118,8 @@ public extension QuillCodeWorkspaceModel {
             activeSidebarSavedSearchID: activeSidebarSavedSearchID,
             sidebarSavedSearches: sidebarSavedSearches,
             selectionIsActive: sidebarSelection.isActive,
-            selectedThreadIDs: sidebarSelectedThreadIDs
+            selectedThreadIDs: sidebarSelectedThreadIDs,
+            attentionCursorID: attentionCursorID
         ).surface()
         let topBar = WorkspaceTopBarSurfaceBuilder(
             topBarState: topBarState,

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -27,6 +27,9 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
     public var settings: WorkspaceSettingsSurface
     public var runtimeIssue: RuntimeIssueSurface?
     public var lastError: String?
+    /// The morning-triage return digest card (issue #877), present when the user has opened a thread's
+    /// digest from the Attention section, nil otherwise.
+    public var attentionDigest: AttentionDigestSurface?
 
     public init(
         chrome: WorkspaceChromeSurface = WorkspaceChromeSurface(),
@@ -48,7 +51,8 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
         commands: [WorkspaceCommandSurface],
         settings: WorkspaceSettingsSurface,
         runtimeIssue: RuntimeIssueSurface? = nil,
-        lastError: String? = nil
+        lastError: String? = nil,
+        attentionDigest: AttentionDigestSurface? = nil
     ) {
         self.chrome = chrome
         self.topBar = topBar
@@ -70,6 +74,7 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
         self.settings = settings
         self.runtimeIssue = runtimeIssue
         self.lastError = lastError
+        self.attentionDigest = attentionDigest
     }
 }
 
@@ -210,8 +215,22 @@ public extension QuillCodeWorkspaceModel {
                 modelProviderHealthSummary: ModelProviderHealthSummary.summarize(root.modelCatalog)
             ),
             runtimeIssue: runtimeIssue,
-            lastError: lastError
+            lastError: lastError,
+            attentionDigest: attentionDigestSurface()
         )
+    }
+
+    /// The morning-triage return digest for the currently opened digest thread (issue #877), or nil when
+    /// none is open. The unseen-turn seam reuses the persisted return watermark so it matches what the
+    /// user last saw across sessions.
+    private func attentionDigestSurface() -> AttentionDigestSurface? {
+        guard let digestThreadID = attentionDigestThreadID,
+              let thread = root.threads.first(where: { $0.id == digestThreadID })
+        else {
+            return nil
+        }
+        let unseen = ThreadReturnWatermarkRecord.unseenCount(in: thread)
+        return AttentionDigestSurface(digest: TriageDigest.build(for: thread, unseenCount: unseen))
     }
 
     private func runtimeIssueSurface() -> RuntimeIssueSurface? {

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -53,6 +53,11 @@ public struct QuillCodeWorkspaceView: View {
     public var onMessageFeedback: (UUID, MessageFeedbackValue) -> Void
     public var onDeleteFollowUp: (UUID) -> Void = { _ in }
     public var onSaveSidebarSavedSearch: (String, String) -> Void
+    /// Open a thread's morning-triage return digest (issue #877), used when the user clicks an Attention
+    /// row or presses Enter on the selected one.
+    public var onOpenAttentionDigest: (UUID) -> Void
+    /// Dismiss the currently open return digest card.
+    public var onCloseAttentionDigest: () -> Void
     public var onCommand: (WorkspaceCommandSurface) -> Void
 
     @State private var isSearchPresented = false
@@ -122,6 +127,8 @@ public struct QuillCodeWorkspaceView: View {
         onMessageFeedback: @escaping (UUID, MessageFeedbackValue) -> Void = { _, _ in },
         onDeleteFollowUp: @escaping (UUID) -> Void = { _ in },
         onSaveSidebarSavedSearch: @escaping (String, String) -> Void = { _, _ in },
+        onOpenAttentionDigest: @escaping (UUID) -> Void = { _ in },
+        onCloseAttentionDigest: @escaping () -> Void = {},
         onCommand: @escaping (WorkspaceCommandSurface) -> Void
     ) {
         self.surface = surface
@@ -174,6 +181,8 @@ public struct QuillCodeWorkspaceView: View {
         self.onMessageFeedback = onMessageFeedback
         self.onDeleteFollowUp = onDeleteFollowUp
         self.onSaveSidebarSavedSearch = onSaveSidebarSavedSearch
+        self.onOpenAttentionDigest = onOpenAttentionDigest
+        self.onCloseAttentionDigest = onCloseAttentionDigest
         self.onCommand = onCommand
     }
 
@@ -197,7 +206,8 @@ public struct QuillCodeWorkspaceView: View {
                         onProjectAction: handleProjectAction,
                         onSelectThread: onSelectThread,
                         onThreadAction: handleThreadAction,
-                        onCommand: handleCommand
+                        onCommand: handleCommand,
+                        onOpenAttentionDigest: onOpenAttentionDigest
                     )
                         .frame(width: QuillCodeMetrics.sidebarWidth)
                     Divider()
@@ -245,6 +255,11 @@ public struct QuillCodeWorkspaceView: View {
         .frame(minWidth: 980, minHeight: 640)
         .background(QuillCodePalette.background)
         .foregroundStyle(QuillCodePalette.text)
+        .overlay {
+            if let digest = surface.attentionDigest {
+                attentionDigestOverlay(digest)
+            }
+        }
         .onChange(of: surface.composer.focusToken) { _, _ in
             // The `focus-composer` (Cmd+L) command bumps this token; grab focus when it changes.
             isComposerFocused = true
@@ -280,6 +295,27 @@ public struct QuillCodeWorkspaceView: View {
             onRenameProject: onRenameProject,
             onSaveSidebarSavedSearch: onSaveSidebarSavedSearch
         )
+    }
+
+    private func attentionDigestOverlay(_ digest: AttentionDigestSurface) -> some View {
+        ZStack {
+            Color.black.opacity(0.45)
+                .ignoresSafeArea()
+                .onTapGesture { onCloseAttentionDigest() }
+                .quillCodeOwnedGestureTarget()
+                .accessibilityLabel("Dismiss digest")
+            QuillCodeAttentionDigestView(
+                digest: digest,
+                onClose: onCloseAttentionDigest,
+                onAcknowledge: { handleCommand(attentionCommand(.attentionAcknowledge)) },
+                onDismiss: { handleCommand(attentionCommand(.attentionDismiss)) }
+            )
+        }
+        .transition(.opacity)
+    }
+
+    private func attentionCommand(_ action: WorkspaceCommandAction) -> WorkspaceCommandSurface {
+        WorkspaceCommandSurface(id: action.rawValue, title: action.rawValue)
     }
 
     private func handleThreadAction(_ action: SidebarItemActionSurface) {

--- a/Sources/QuillCodeCore/MorningTriage.swift
+++ b/Sources/QuillCodeCore/MorningTriage.swift
@@ -111,9 +111,15 @@ public enum ThreadTriageRecord {
     /// The Codable payload stored in the notice event's `payloadJSON`.
     public struct Payload: Codable, Sendable, Hashable {
         public var state: ThreadTriageState
+        /// The id of the `RunIntegrityRecord` event this decision was made about. A triage decision is
+        /// bound to the SPECIFIC run/verdict it triaged — when a later run re-stamps a fresh integrity
+        /// record (new id), the decision is stale and the thread re-opens for triage. `nil` for a
+        /// decision made when no integrity record was present, or decoded from an older payload.
+        public var verdictRecordID: UUID?
 
-        public init(state: ThreadTriageState) {
+        public init(state: ThreadTriageState, verdictRecordID: UUID? = nil) {
             self.state = state
+            self.verdictRecordID = verdictRecordID
         }
     }
 
@@ -121,31 +127,61 @@ public enum ThreadTriageRecord {
         event.kind == .notice && event.summary == eventSummary
     }
 
-    /// Build the notice event for a triage state. Returns nil only if encoding somehow fails.
-    public static func event(for state: ThreadTriageState) -> ThreadEvent? {
-        guard let payloadJSON = try? JSONHelpers.encodePretty(Payload(state: state)) else { return nil }
+    /// Build the notice event for a triage state bound to the given integrity-record id. Returns nil
+    /// only if encoding somehow fails.
+    public static func event(for state: ThreadTriageState, verdictRecordID: UUID?) -> ThreadEvent? {
+        let payload = Payload(state: state, verdictRecordID: verdictRecordID)
+        guard let payloadJSON = try? JSONHelpers.encodePretty(payload) else { return nil }
         return ThreadEvent(kind: .notice, summary: eventSummary, payloadJSON: payloadJSON)
+    }
+
+    /// The most recent triage payload on a thread, or nil if none was ever recorded.
+    public static func latestPayload(in thread: ChatThread) -> Payload? {
+        for event in thread.events.reversed() where isRecord(event) {
+            if let payloadJSON = event.payloadJSON,
+               let payload = try? JSONHelpers.decode(Payload.self, from: payloadJSON) {
+                return payload
+            }
+        }
+        return nil
     }
 
     /// The current triage state of a thread: the most recently recorded one, or `.pending` if none was
     /// ever recorded (a fresh, un-triaged run is pending review).
     public static func current(in thread: ChatThread) -> ThreadTriageState {
-        for event in thread.events.reversed() where isRecord(event) {
-            if let payloadJSON = event.payloadJSON,
-               let payload = try? JSONHelpers.decode(Payload.self, from: payloadJSON) {
-                return payload.state
-            }
-        }
-        return .pending
+        latestPayload(in: thread)?.state ?? .pending
     }
 
-    /// Set the thread's triage state, replacing any prior record. Bumps `updatedAt` only when the state
-    /// actually changes, so re-recording the same state is idempotent and does not reshuffle the sidebar.
+    /// Whether a thread still needs the morning-triage user's attention, given its persisted triage
+    /// decision AND the CURRENT integrity record.
+    ///
+    /// BLOCKER-1 fix: a triage decision (`acknowledged` / `dismissed`) only silences the thread for the
+    /// EXACT run it was made about. If a later run re-stamps the integrity badge (a new record id), the
+    /// stale decision no longer applies, so the thread re-surfaces. This is the whole point of the
+    /// inbox: a thread that goes RED again after you acked it must come back. A `pending` decision (or
+    /// none) is always actionable.
+    public static func needsAttention(in thread: ChatThread) -> Bool {
+        guard let payload = latestPayload(in: thread), !payload.state.isActionable else {
+            return true // pending or never triaged → needs attention
+        }
+        // Acknowledged/dismissed: only silenced while the triaged run is still the current one.
+        let currentRecordID = RunIntegrityRecord.latestRecordID(in: thread)
+        return payload.verdictRecordID != currentRecordID
+    }
+
+    /// Set the thread's triage state, binding the decision to the thread's CURRENT integrity record so a
+    /// later run re-opens triage. Bumps `updatedAt` only when the effective decision actually changes,
+    /// so re-recording the same (state, record) is idempotent and does not reshuffle the sidebar.
     @discardableResult
     public static func set(_ state: ThreadTriageState, on thread: inout ChatThread) -> Bool {
-        guard current(in: thread) != state else { return false }
+        let verdictRecordID = RunIntegrityRecord.latestRecordID(in: thread)
+        if let existing = latestPayload(in: thread),
+           existing.state == state,
+           existing.verdictRecordID == verdictRecordID {
+            return false
+        }
         thread.events.removeAll(where: isRecord)
-        if let event = event(for: state) {
+        if let event = event(for: state, verdictRecordID: verdictRecordID) {
             thread.events.append(event)
             thread.updatedAt = Date()
             return true
@@ -220,6 +256,10 @@ public enum ThreadReturnWatermarkRecord {
 
     /// Mark the thread seen up to its current last message — advancing the watermark to the tail. A no-op
     /// (returns false, leaves the thread untouched) when the timeline is empty or already at the tail.
+    ///
+    /// This deliberately does NOT bump `thread.updatedAt`: the watermark is invisible bookkeeping (the
+    /// user leaving a thread must not reorder the recency-sorted sidebar). Callers that persist the
+    /// thread should preserve its `updatedAt`.
     @discardableResult
     public static func markSeen(_ thread: inout ChatThread) -> Bool {
         guard let tail = messageTimelineIDs(for: thread).last else { return false }
@@ -229,7 +269,6 @@ public enum ThreadReturnWatermarkRecord {
             return false
         }
         thread.events.append(ThreadEvent(kind: .notice, summary: eventSummary, payloadJSON: payloadJSON))
-        thread.updatedAt = Date()
         return true
     }
 }
@@ -349,9 +388,10 @@ public struct AttentionModel: Sendable, Hashable {
     }
 
     /// Build the Attention model from a set of threads. A thread contributes a row iff it has a
-    /// persisted RunIntegrity stamp that needs attention (RED / UNVERIFIED) AND its triage state is still
-    /// `pending`. Everything derives from the ACTUAL persisted records on each thread — never self-report
-    /// and never a stale copy.
+    /// persisted RunIntegrity stamp that needs attention (RED / UNVERIFIED) AND it still needs the user's
+    /// attention — either never triaged, or triaged against an OLDER run than its current verdict (so a
+    /// thread that goes RED again after being acked re-surfaces). Everything derives from the ACTUAL
+    /// persisted records on each thread — never self-report and never a stale copy.
     public static func build(
         from threads: [ChatThread],
         selectedThreadID: UUID? = nil
@@ -360,7 +400,7 @@ public struct AttentionModel: Sendable, Hashable {
             guard let stamp = TriageStamp.derive(from: thread), stamp.verdict.needsAttention else {
                 return nil
             }
-            guard ThreadTriageRecord.current(in: thread).isActionable else { return nil }
+            guard ThreadTriageRecord.needsAttention(in: thread) else { return nil }
             return AttentionItem(
                 threadID: thread.id,
                 title: thread.title,

--- a/Sources/QuillCodeCore/MorningTriage.swift
+++ b/Sources/QuillCodeCore/MorningTriage.swift
@@ -1,0 +1,375 @@
+import Foundation
+
+/// # Morning triage inbox (issue #877)
+///
+/// The morning ritual for unattended daily driving: six overnight runs, reviewable before the coffee
+/// cools. This file is the **pure, deterministic core** — no SwiftUI, no persistence side effects — so
+/// the native app and the E2E HTML harness can share exactly the same ranking / selection / triage
+/// semantics. (The batch this ships in has repeatedly had native-vs-harness divergence bugs; keeping
+/// the semantics here, and mirroring them line-for-line in the harness JS, is the defense.)
+///
+/// The pieces:
+/// - `TriageStamp` — a thread's persistent verdict stamp, derived from its latest **persisted**
+///   `RunIntegrityRecord` (the Run Integrity badge — never self-report). A thread with no run has no
+///   stamp.
+/// - `ThreadTriageState` + `ThreadTriageRecord` — the user's triage decision (pending / acknowledged /
+///   dismissed), persisted onto the thread as a `.notice` event exactly like `RunIntegrityRecord`, so
+///   it round-trips through the existing thread store with zero new plumbing and survives reload.
+/// - `AttentionItem` — one row in the Attention section: verdict + title + unseen-turn count.
+/// - `AttentionModel` — the ranking (severity order, ties by recency) and a selection cursor with
+///   j/k clamping.
+/// - `AttentionReducer` — the pure state machine for the j/k/a/d triage keys.
+
+// MARK: - Verdict stamp
+
+/// The severity of a thread's run-integrity verdict, for the triage stamp. This is a **projection** of
+/// `RunIntegrityVerdict` with an explicit severity ordering so the Attention section can rank rows and
+/// so `verified` is representable but known to be "does not need attention".
+public enum TriageVerdict: String, Codable, Sendable, Hashable, CaseIterable {
+    /// A test/verify command failed and was left standing — the loudest alarm.
+    case red
+    /// A success claim is not backed by a passing test, or a test was skipped — honest uncertainty.
+    case unverified
+    /// Nothing dishonest detected — a clean run. Never surfaced in Attention.
+    case verified
+
+    /// Higher = more urgent. Used to rank the Attention section (RED before UNVERIFIED).
+    public var severity: Int {
+        switch self {
+        case .red: return 2
+        case .unverified: return 1
+        case .verified: return 0
+        }
+    }
+
+    /// Whether a thread with this verdict belongs in the Attention section at all. A clean `verified`
+    /// run does not need the morning triage.
+    public var needsAttention: Bool { self != .verified }
+
+    /// The badge text, matching the Run Integrity badge exactly.
+    public var badgeLabel: String {
+        switch self {
+        case .red: return "RED"
+        case .unverified: return "UNVERIFIED"
+        case .verified: return "VERIFIED"
+        }
+    }
+
+    public init(_ verdict: RunIntegrityVerdict) {
+        switch verdict {
+        case .red: self = .red
+        case .unverified: self = .unverified
+        case .verified: self = .verified
+        }
+    }
+}
+
+/// A thread's persistent triage stamp: the verdict plus the one-line summary from the run-integrity
+/// record. `nil` when the thread has never been scanned (no run → no stamp).
+public struct TriageStamp: Sendable, Hashable {
+    public var verdict: TriageVerdict
+    public var summary: String
+
+    public init(verdict: TriageVerdict, summary: String) {
+        self.verdict = verdict
+        self.summary = summary
+    }
+
+    /// Derive the stamp from a thread by reading its latest **persisted** `RunIntegrityRecord`. This is
+    /// the verdict SOURCE — the record already written by the Run Integrity feature — not a re-derivation
+    /// from the transcript / self-report. Returns `nil` when no record was ever written.
+    public static func derive(from thread: ChatThread) -> TriageStamp? {
+        guard let payload = RunIntegrityRecord.latest(in: thread) else { return nil }
+        return TriageStamp(verdict: TriageVerdict(payload.verdict), summary: payload.summary)
+    }
+}
+
+// MARK: - Triage state (persisted user decision)
+
+/// The user's triage decision for a thread, defaulting to `pending` (needs review). `acknowledged` and
+/// `dismissed` both remove the thread from Attention; they are kept distinct so the digest / history can
+/// tell "I read it and it's fine" (a) from "I don't care about this run" (d).
+public enum ThreadTriageState: String, Codable, Sendable, Hashable {
+    /// Not yet triaged — appears in Attention.
+    case pending
+    /// The user pressed `a`: acknowledged / read. Removed from Attention.
+    case acknowledged
+    /// The user pressed `d`: dismissed. Removed from Attention.
+    case dismissed
+
+    /// Whether a thread in this triage state should still surface in the Attention section.
+    public var isActionable: Bool { self == .pending }
+}
+
+/// Persists a `ThreadTriageState` onto a thread as a `.notice` event, mirroring `RunIntegrityRecord`'s
+/// convention so it round-trips through the existing thread store and survives reload. The most recent
+/// record wins; a thread with no record is `pending` by default.
+public enum ThreadTriageRecord {
+    /// The well-known summary marker identifying the triage-state notice among a thread's events.
+    public static let eventSummary = "thread-triage-state"
+
+    /// The Codable payload stored in the notice event's `payloadJSON`.
+    public struct Payload: Codable, Sendable, Hashable {
+        public var state: ThreadTriageState
+
+        public init(state: ThreadTriageState) {
+            self.state = state
+        }
+    }
+
+    public static func isRecord(_ event: ThreadEvent) -> Bool {
+        event.kind == .notice && event.summary == eventSummary
+    }
+
+    /// Build the notice event for a triage state. Returns nil only if encoding somehow fails.
+    public static func event(for state: ThreadTriageState) -> ThreadEvent? {
+        guard let payloadJSON = try? JSONHelpers.encodePretty(Payload(state: state)) else { return nil }
+        return ThreadEvent(kind: .notice, summary: eventSummary, payloadJSON: payloadJSON)
+    }
+
+    /// The current triage state of a thread: the most recently recorded one, or `.pending` if none was
+    /// ever recorded (a fresh, un-triaged run is pending review).
+    public static func current(in thread: ChatThread) -> ThreadTriageState {
+        for event in thread.events.reversed() where isRecord(event) {
+            if let payloadJSON = event.payloadJSON,
+               let payload = try? JSONHelpers.decode(Payload.self, from: payloadJSON) {
+                return payload.state
+            }
+        }
+        return .pending
+    }
+
+    /// Set the thread's triage state, replacing any prior record. Bumps `updatedAt` only when the state
+    /// actually changes, so re-recording the same state is idempotent and does not reshuffle the sidebar.
+    @discardableResult
+    public static func set(_ state: ThreadTriageState, on thread: inout ChatThread) -> Bool {
+        guard current(in: thread) != state else { return false }
+        thread.events.removeAll(where: isRecord)
+        if let event = event(for: state) {
+            thread.events.append(event)
+            thread.updatedAt = Date()
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - Return watermark (persistent "last viewed" for the unseen-turn seam)
+
+/// The morning-triage "unseen turns" seam is a **cross-session** concept — the whole point is to see
+/// what the overnight run added while you were away, across an app restart. So unlike the transcript
+/// pill's session-only tracker, the watermark here is persisted onto the thread as a `.notice` event
+/// (same convention as the other triage records) and the unseen count is derived from it.
+///
+/// The count semantics deliberately mirror `TranscriptNewTurnsResolver` in the app layer: it is the
+/// suffix length of the message timeline after the watermarked item, so it is never negative; a `nil`
+/// watermark (never viewed) yields 0 (nothing to announce); a stale watermark whose item is gone yields
+/// 0 (never invent a count). The timeline used is the thread's non-tool messages, whose ids are stable
+/// (`message-<uuid>`), matching the transcript timeline item ids for message turns.
+public enum ThreadReturnWatermarkRecord {
+    /// The well-known summary marker identifying the return-watermark notice among a thread's events.
+    public static let eventSummary = "thread-return-watermark"
+
+    public struct Payload: Codable, Sendable, Hashable {
+        /// The stable timeline id of the last message the user saw, or nil if never viewed.
+        public var lastSeenItemID: String?
+
+        public init(lastSeenItemID: String?) {
+            self.lastSeenItemID = lastSeenItemID
+        }
+    }
+
+    public static func isRecord(_ event: ThreadEvent) -> Bool {
+        event.kind == .notice && event.summary == eventSummary
+    }
+
+    /// The stable timeline id for a chat message — identical to the app's transcript timeline item id
+    /// for message turns, so the seam count matches what the transcript pill would show.
+    public static func timelineID(for message: ChatMessage) -> String {
+        "message-\(message.id.uuidString)"
+    }
+
+    /// The ordered list of message-turn timeline ids for a thread (user + assistant turns; tool rows are
+    /// excluded, matching how message turns are counted).
+    public static func messageTimelineIDs(for thread: ChatThread) -> [String] {
+        thread.messages.filter { $0.role != .tool }.map(timelineID(for:))
+    }
+
+    /// The last-seen watermark id recorded on the thread, or nil if never recorded.
+    public static func lastSeenItemID(in thread: ChatThread) -> String? {
+        for event in thread.events.reversed() where isRecord(event) {
+            if let payloadJSON = event.payloadJSON,
+               let payload = try? JSONHelpers.decode(Payload.self, from: payloadJSON) {
+                return payload.lastSeenItemID
+            }
+        }
+        return nil
+    }
+
+    /// The number of unseen message turns for a thread given its persisted watermark. Mirrors
+    /// `TranscriptNewTurnsResolver`: 0 when never viewed, when caught up, or when the watermark item was
+    /// compacted away; otherwise the suffix length after the watermarked item. Never negative.
+    public static func unseenCount(in thread: ChatThread) -> Int {
+        guard let lastSeen = lastSeenItemID(in: thread) else { return 0 }
+        let ids = messageTimelineIDs(for: thread)
+        guard let seenIndex = ids.firstIndex(of: lastSeen) else { return 0 }
+        let firstUnseen = ids.index(after: seenIndex)
+        guard firstUnseen < ids.endIndex else { return 0 }
+        return ids.distance(from: firstUnseen, to: ids.endIndex)
+    }
+
+    /// Mark the thread seen up to its current last message — advancing the watermark to the tail. A no-op
+    /// (returns false, leaves the thread untouched) when the timeline is empty or already at the tail.
+    @discardableResult
+    public static func markSeen(_ thread: inout ChatThread) -> Bool {
+        guard let tail = messageTimelineIDs(for: thread).last else { return false }
+        guard lastSeenItemID(in: thread) != tail else { return false }
+        thread.events.removeAll(where: isRecord)
+        guard let payloadJSON = try? JSONHelpers.encodePretty(Payload(lastSeenItemID: tail)) else {
+            return false
+        }
+        thread.events.append(ThreadEvent(kind: .notice, summary: eventSummary, payloadJSON: payloadJSON))
+        thread.updatedAt = Date()
+        return true
+    }
+}
+
+// MARK: - Attention item
+
+/// One row in the Attention section: a thread that needs the morning triage. Built from a thread's
+/// persisted verdict stamp (must be `red`/`unverified`), its title, and its unseen-turn count. Threads
+/// whose stamp is `verified`, whose triage state is not `pending`, or which have no stamp at all are
+/// NOT attention items.
+public struct AttentionItem: Sendable, Hashable, Identifiable {
+    public var threadID: UUID
+    public var title: String
+    public var verdict: TriageVerdict
+    public var summary: String
+    /// How many transcript turns arrived since the user last viewed this thread. Always ≥ 0.
+    public var unseenCount: Int
+    /// The thread's last-updated time, the tie-breaker for equal-severity rows (newer first).
+    public var updatedAt: Date
+
+    public var id: UUID { threadID }
+
+    public init(
+        threadID: UUID,
+        title: String,
+        verdict: TriageVerdict,
+        summary: String,
+        unseenCount: Int,
+        updatedAt: Date
+    ) {
+        self.threadID = threadID
+        self.title = title
+        self.verdict = verdict
+        self.summary = summary
+        self.unseenCount = max(0, unseenCount)
+        self.updatedAt = updatedAt
+    }
+
+    /// A short "N new" label for the unseen-turn count, or `nil` when nothing is new.
+    public var unseenLabel: String? {
+        unseenCount == 0 ? nil : "\(unseenCount) new"
+    }
+}
+
+// MARK: - Attention model (ranking + selection)
+
+/// The ranked Attention list plus a selection cursor. Pure and deterministic: given the same items and
+/// the same selected id, it always ranks and clamps identically. The native sidebar and the harness JS
+/// both build their list with this exact ordering.
+public struct AttentionModel: Sendable, Hashable {
+    /// The attention rows, already ranked (RED first, then UNVERIFIED; ties broken by `updatedAt`, newer
+    /// first; final tie-break by threadID for total determinism).
+    public private(set) var items: [AttentionItem]
+    /// The thread id the triage cursor is on, or `nil` when the section is empty.
+    public private(set) var selectedThreadID: UUID?
+
+    /// Build a ranked model from unranked attention items, keeping the given selection if it still
+    /// exists (else selecting the first row). Ranking is total and stable.
+    public init(items: [AttentionItem], selectedThreadID: UUID? = nil) {
+        let ranked = Self.rank(items)
+        self.items = ranked
+        if let selectedThreadID, ranked.contains(where: { $0.threadID == selectedThreadID }) {
+            self.selectedThreadID = selectedThreadID
+        } else {
+            self.selectedThreadID = ranked.first?.threadID
+        }
+    }
+
+    /// The total, deterministic ranking: severity desc, then recency desc, then threadID asc.
+    public static func rank(_ items: [AttentionItem]) -> [AttentionItem] {
+        items.sorted { lhs, rhs in
+            if lhs.verdict.severity != rhs.verdict.severity {
+                return lhs.verdict.severity > rhs.verdict.severity
+            }
+            if lhs.updatedAt != rhs.updatedAt {
+                return lhs.updatedAt > rhs.updatedAt
+            }
+            return lhs.threadID.uuidString < rhs.threadID.uuidString
+        }
+    }
+
+    public var isEmpty: Bool { items.isEmpty }
+    public var count: Int { items.count }
+
+    /// The index of the current selection in the ranked list, or `nil` when empty.
+    public var selectedIndex: Int? {
+        guard let selectedThreadID else { return nil }
+        return items.firstIndex { $0.threadID == selectedThreadID }
+    }
+
+    /// The currently selected item, or `nil` when the section is empty.
+    public var selectedItem: AttentionItem? {
+        guard let index = selectedIndex else { return nil }
+        return items[index]
+    }
+
+    /// Move the cursor down one row (the `j` key). **Clamps** at the last row — never wraps, never goes
+    /// out of range. A no-op on an empty section.
+    public mutating func moveDown() {
+        guard let index = selectedIndex else { return }
+        let next = min(index + 1, items.count - 1)
+        selectedThreadID = items[next].threadID
+    }
+
+    /// Move the cursor up one row (the `k` key). **Clamps** at the first row. A no-op on an empty
+    /// section.
+    public mutating func moveUp() {
+        guard let index = selectedIndex else { return }
+        let prev = max(index - 1, 0)
+        selectedThreadID = items[prev].threadID
+    }
+
+    /// Explicitly select a row by id (e.g. the user clicked it). Ignored if the id is not in the list.
+    public mutating func select(_ threadID: UUID) {
+        guard items.contains(where: { $0.threadID == threadID }) else { return }
+        selectedThreadID = threadID
+    }
+
+    /// Build the Attention model from a set of threads. A thread contributes a row iff it has a
+    /// persisted RunIntegrity stamp that needs attention (RED / UNVERIFIED) AND its triage state is still
+    /// `pending`. Everything derives from the ACTUAL persisted records on each thread — never self-report
+    /// and never a stale copy.
+    public static func build(
+        from threads: [ChatThread],
+        selectedThreadID: UUID? = nil
+    ) -> AttentionModel {
+        let items: [AttentionItem] = threads.compactMap { thread in
+            guard let stamp = TriageStamp.derive(from: thread), stamp.verdict.needsAttention else {
+                return nil
+            }
+            guard ThreadTriageRecord.current(in: thread).isActionable else { return nil }
+            return AttentionItem(
+                threadID: thread.id,
+                title: thread.title,
+                verdict: stamp.verdict,
+                summary: stamp.summary,
+                unseenCount: ThreadReturnWatermarkRecord.unseenCount(in: thread),
+                updatedAt: thread.updatedAt
+            )
+        }
+        return AttentionModel(items: items, selectedThreadID: selectedThreadID)
+    }
+}

--- a/Sources/QuillCodeCore/RunIntegrityRecord.swift
+++ b/Sources/QuillCodeCore/RunIntegrityRecord.swift
@@ -26,13 +26,26 @@ public enum RunIntegrityRecord {
 
     /// The most recently recorded integrity verdict on a thread, or nil if none was ever recorded.
     public static func latest(in thread: ChatThread) -> Payload? {
+        latestEvent(in: thread).flatMap { event in
+            event.payloadJSON.flatMap { try? JSONHelpers.decode(Payload.self, from: $0) }
+        }
+    }
+
+    /// The most recent integrity-record EVENT on a thread (payload + its stable event id), or nil if
+    /// none was ever recorded. The event id identifies the specific run that produced this verdict —
+    /// `record(into:)` mints a fresh event each run — so downstream features (morning triage) can tell
+    /// "the run I already triaged" from "a new run that re-stamped the badge".
+    public static func latestEvent(in thread: ChatThread) -> ThreadEvent? {
         for event in thread.events.reversed() where isRecord(event) {
-            if let payloadJSON = event.payloadJSON,
-               let payload = try? JSONHelpers.decode(Payload.self, from: payloadJSON) {
-                return payload
-            }
+            return event
         }
         return nil
+    }
+
+    /// The stable id of the most recent integrity-record event, or nil if none. This is the identity a
+    /// triage decision binds to, so a NEW run (new id) re-opens triage even if the verdict is the same.
+    public static func latestRecordID(in thread: ChatThread) -> UUID? {
+        latestEvent(in: thread)?.id
     }
 
     /// Scans the thread, then records the resulting verdict as a fresh notice event.

--- a/Sources/QuillCodeCore/TriageDigest.swift
+++ b/Sources/QuillCodeCore/TriageDigest.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// The per-thread **return digest** (issue #877): a compact card the user lands on when they press
+/// Enter on an Attention row. It summarizes one overnight run so the user can trust it without reading
+/// the whole transcript — the integrity verdict + reasons, the final outcome, and an "unseen turns since
+/// last viewed" seam so they see exactly what changed.
+///
+/// Pure and deterministic: built from a `ChatThread` plus its unseen-turn count (which the app derives
+/// from the reused `TranscriptNewTurns` marker). No SwiftUI, so both surfaces render the same content.
+public struct TriageDigest: Sendable, Hashable {
+    public var threadID: UUID
+    public var title: String
+    /// The persisted integrity verdict, or `nil` if the thread was never scanned.
+    public var verdict: TriageVerdict?
+    /// The one-line verdict summary from the persisted record (the top reason). Empty when unavailable.
+    public var verdictSummary: String
+    /// The full reason list, re-derived from the transcript for the card body. Empty for a clean or
+    /// never-scanned run. (The persisted record keeps only the summary line; the reasons are cheap to
+    /// re-scan and give the card its detail.)
+    public var reasons: [String]
+    /// A one-line description of how the run ended (its final outcome).
+    public var outcome: String
+    /// The number of transcript turns that arrived since the user last viewed this thread — the unseen
+    /// seam. Always ≥ 0.
+    public var unseenCount: Int
+
+    public init(
+        threadID: UUID,
+        title: String,
+        verdict: TriageVerdict?,
+        verdictSummary: String,
+        reasons: [String],
+        outcome: String,
+        unseenCount: Int
+    ) {
+        self.threadID = threadID
+        self.title = title
+        self.verdict = verdict
+        self.verdictSummary = verdictSummary
+        self.reasons = reasons
+        self.outcome = outcome
+        self.unseenCount = max(0, unseenCount)
+    }
+
+    /// The unseen-seam label ("N unseen turns"), or `nil` when nothing is unseen.
+    public var unseenSeamLabel: String? {
+        switch unseenCount {
+        case 0: return nil
+        case 1: return "1 unseen turn"
+        default: return "\(unseenCount) unseen turns"
+        }
+    }
+
+    /// Build a digest for a thread. `unseenCount` is supplied by the caller (the app computes it from
+    /// the reused `TranscriptNewTurns` marker so the seam matches the transcript pill exactly).
+    public static func build(for thread: ChatThread, unseenCount: Int) -> TriageDigest {
+        let stamp = TriageStamp.derive(from: thread)
+        // The persisted record keeps only the summary line; re-scan for the full reason list to populate
+        // the card body. This is a read-only derivation and does not touch the persisted verdict.
+        let reasons: [String]
+        if stamp != nil {
+            reasons = RunIntegrityScanner.scan(thread).reasons.map(\.detail)
+        } else {
+            reasons = []
+        }
+        return TriageDigest(
+            threadID: thread.id,
+            title: thread.title,
+            verdict: stamp?.verdict,
+            verdictSummary: stamp?.summary ?? "",
+            reasons: reasons,
+            outcome: outcomeLine(for: thread),
+            unseenCount: unseenCount
+        )
+    }
+
+    /// A one-line "how the run ended" summary drawn from the thread's final assistant message, falling
+    /// back to a neutral line when the thread has no assistant reply yet.
+    static func outcomeLine(for thread: ChatThread) -> String {
+        guard let final = thread.messages.last(where: { $0.role == .assistant })?.content else {
+            return "No final answer recorded."
+        }
+        return firstLine(of: final, maxLength: 140)
+    }
+
+    /// The first non-empty line of `text`, truncated to `maxLength` with an ellipsis. Never returns an
+    /// empty string for non-empty input.
+    static func firstLine(of text: String, maxLength: Int) -> String {
+        let firstNonEmpty = text
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first(where: { !$0.isEmpty })
+        let line = (firstNonEmpty ?? text.trimmingCharacters(in: .whitespacesAndNewlines))
+        guard line.count > maxLength else { return line }
+        let end = line.index(line.startIndex, offsetBy: maxLength)
+        return String(line[line.startIndex..<end]).trimmingCharacters(in: .whitespaces) + "…"
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -123,6 +123,8 @@ struct QuillCodeDesktopRootView: View {
             onMessageFeedback: controller.setMessageFeedback,
             onDeleteFollowUp: controller.deleteFollowUp,
             onSaveSidebarSavedSearch: controller.saveSidebarSavedSearch,
+            onOpenAttentionDigest: controller.openAttentionDigest,
+            onCloseAttentionDigest: controller.closeAttentionDigest,
             onCommand: controller.runCommand
         )
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Navigation.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Navigation.swift
@@ -61,6 +61,20 @@ extension QuillCodeDesktopController {
         refresh()
     }
 
+    /// Open a thread's morning-triage return digest (issue #877): selects the thread and presents the
+    /// digest card. Draft handling mirrors `selectThread` since the workspace thread changes.
+    func openAttentionDigest(_ id: UUID) {
+        model.setDraft(draft)
+        model.openAttentionDigest(for: id)
+        modelStateCoordinator.syncComposerDraft(from: model, draft: &draft)
+        refresh()
+    }
+
+    func closeAttentionDigest() {
+        model.closeAttentionDigest()
+        refresh()
+    }
+
     func selectProject(_ id: UUID?) {
         navigationCoordinator.selectProject(id, model: model)
         refresh()

--- a/Tests/QuillCodeAppTests/AttentionSectionSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/AttentionSectionSurfaceTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+/// App-layer tests for the morning-triage Attention surface + HTML rendering + model actions (issue
+/// #877). The pure ranking/selection/triage semantics are covered in QuillCodeCoreTests; here we verify
+/// the surface projection, the model action wiring (which persists), and that native + HTML render off
+/// the same shared model.
+@MainActor
+final class AttentionSectionSurfaceTests: XCTestCase {
+
+    private func id(_ n: Int) -> UUID {
+        UUID(uuidString: "00000000-0000-0000-0000-0000000000\(String(format: "%02d", n))")!
+    }
+
+    private func threadWithVerdict(
+        _ verdict: RunIntegrityVerdict,
+        id threadID: UUID,
+        title: String,
+        updatedAt: Date = Date(timeIntervalSince1970: 100)
+    ) -> ChatThread {
+        var thread = ChatThread(id: threadID, title: title, updatedAt: updatedAt)
+        let report = RunIntegrityReport(
+            verdict: verdict,
+            reasons: [RunIntegrityReason(rule: .standingTestFailure, detail: "make test exited 1")]
+        )
+        if let event = RunIntegrityRecord.event(for: report) {
+            thread.events.append(event)
+        }
+        return thread
+    }
+
+    private func model(_ threads: [ChatThread], selected: UUID? = nil) -> QuillCodeWorkspaceModel {
+        QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: threads, selectedThreadID: selected))
+    }
+
+    // MARK: - Surface projection
+
+    func testSectionSurfaceRanksAndProjectsRows() {
+        let surface = model([
+            threadWithVerdict(.unverified, id: id(1), title: "yellow run", updatedAt: Date(timeIntervalSince1970: 200)),
+            threadWithVerdict(.red, id: id(2), title: "red run", updatedAt: Date(timeIntervalSince1970: 100))
+        ]).surface()
+        let attention = surface.sidebar.attention
+        XCTAssertEqual(attention.rows.map(\.title), ["red run", "yellow run"])
+        XCTAssertEqual(attention.rows.first?.badgeLabel, "RED")
+    }
+
+    func testEmptySectionSurfaceWhenNothingNeedsAttention() {
+        let surface = model([threadWithVerdict(.verified, id: id(1), title: "clean")]).surface()
+        XCTAssertTrue(surface.sidebar.attention.isEmpty)
+    }
+
+    // MARK: - Model actions (persist + surface)
+
+    func testAcknowledgeRemovesFromAttentionAndPersists() {
+        let m = model([
+            threadWithVerdict(.red, id: id(1), title: "red a", updatedAt: Date(timeIntervalSince1970: 300)),
+            threadWithVerdict(.red, id: id(2), title: "red b", updatedAt: Date(timeIntervalSince1970: 200))
+        ], selected: id(1))
+        XCTAssertEqual(m.surface().sidebar.attention.rows.count, 2)
+
+        m.attentionAcknowledgeSelected()
+        let after = m.surface().sidebar.attention
+        XCTAssertEqual(after.rows.count, 1)
+        XCTAssertEqual(after.rows.first?.threadID, id(2))
+        // Persisted on the thread.
+        let thread = m.root.threads.first { $0.id == id(1) }!
+        XCTAssertEqual(ThreadTriageRecord.current(in: thread), .acknowledged)
+    }
+
+    func testDismissRemovesFromAttention() {
+        let m = model([threadWithVerdict(.unverified, id: id(1), title: "y")], selected: id(1))
+        m.attentionDismissSelected()
+        XCTAssertTrue(m.surface().sidebar.attention.isEmpty)
+        XCTAssertEqual(ThreadTriageRecord.current(in: m.root.threads[0]), .dismissed)
+    }
+
+    func testTriageNoOpOnEmptyAttention() {
+        let m = model([threadWithVerdict(.verified, id: id(1), title: "clean")], selected: id(1))
+        // Nothing to triage — must not crash or mutate.
+        m.attentionAcknowledgeSelected()
+        m.attentionDismissSelected()
+        m.attentionMoveDown()
+        m.attentionMoveUp()
+        XCTAssertTrue(m.surface().sidebar.attention.isEmpty)
+    }
+
+    func testOpenDigestSurfacesDigestAndCloseClearsIt() {
+        let m = model([threadWithVerdict(.red, id: id(1), title: "red")], selected: nil)
+        XCTAssertNil(m.surface().attentionDigest)
+        m.openAttentionDigest(for: id(1))
+        let digest = m.surface().attentionDigest
+        XCTAssertEqual(digest?.threadID, id(1))
+        XCTAssertEqual(digest?.verdict, .red)
+        m.closeAttentionDigest()
+        XCTAssertNil(m.surface().attentionDigest)
+    }
+
+    func testMoveDownClampsAcrossModel() {
+        let m = model([
+            threadWithVerdict(.red, id: id(1), title: "a", updatedAt: Date(timeIntervalSince1970: 300)),
+            threadWithVerdict(.red, id: id(2), title: "b", updatedAt: Date(timeIntervalSince1970: 200))
+        ], selected: id(1))
+        m.attentionMoveDown()
+        XCTAssertEqual(m.attentionModel.selectedThreadID, id(2))
+        m.attentionMoveDown() // clamp
+        XCTAssertEqual(m.attentionModel.selectedThreadID, id(2))
+    }
+
+    // MARK: - HTML render parity of shape
+
+    func testHTMLRendererEmitsAttentionSection() {
+        var thread = threadWithVerdict(.red, id: id(2), title: "overnight red")
+        thread.messages.append(ChatMessage(role: .user, content: "go"))
+        thread.messages.append(ChatMessage(role: .assistant, content: "started"))
+        ThreadReturnWatermarkRecord.markSeen(&thread)
+        thread.messages.append(ChatMessage(role: .assistant, content: "new turn"))
+
+        let html = WorkspaceHTMLRenderer.render(model([thread]).surface())
+        XCTAssertTrue(html.contains(#"data-testid="attention-section""#))
+        XCTAssertTrue(html.contains(#"data-testid="attention-verdict" data-verdict="red""#))
+        XCTAssertTrue(html.contains("RED"))
+        XCTAssertTrue(html.contains(#"data-testid="attention-unseen""#))
+        XCTAssertTrue(html.contains("1 new"))
+    }
+
+    func testHTMLRendererOmitsAttentionSectionWhenEmpty() {
+        let html = WorkspaceHTMLRenderer.render(model([threadWithVerdict(.verified, id: id(1), title: "clean")]).surface())
+        XCTAssertFalse(html.contains(#"data-testid="attention-section""#))
+    }
+
+    func testDigestHTMLRendersVerdictReasonsAndSeam() {
+        // A real standing test failure so RunIntegrityScanner produces reasons for the card body.
+        var thread = ChatThread(id: id(2), title: "overnight red")
+        let call = ToolCall(name: RunIntegrityScanner.shellRunToolName, argumentsJSON: #"{"cmd":"make test"}"#)
+        let fail = ToolResult(ok: false, stdout: "", stderr: "1 failing", exitCode: 1, error: nil)
+        thread.events.append(ThreadEvent(kind: .toolQueued, summary: "\(call.name) queued", payloadJSON: (try? JSONHelpers.encodePretty(call)) ?? "{}"))
+        thread.events.append(ThreadEvent(kind: .toolRunning, summary: "\(call.name) running"))
+        thread.events.append(ThreadEvent(kind: .toolFailed, summary: "\(call.name) failed", payloadJSON: (try? JSONHelpers.encodePretty(fail)) ?? "{}"))
+        thread.messages.append(ChatMessage(role: .user, content: "go"))
+        thread.messages.append(ChatMessage(role: .assistant, content: "Left a failing test."))
+        RunIntegrityRecord.record(into: &thread)
+        ThreadReturnWatermarkRecord.markSeen(&thread)
+        thread.messages.append(ChatMessage(role: .assistant, content: "wrap up"))
+        thread.messages.append(ChatMessage(role: .assistant, content: "final"))
+
+        let m = model([thread])
+        m.openAttentionDigest(for: id(2))
+        let html = WorkspaceHTMLRenderer.render(m.surface())
+        XCTAssertTrue(html.contains(#"data-testid="attention-digest""#))
+        XCTAssertTrue(html.contains(#"data-testid="attention-digest-verdict" data-verdict="red""#))
+        XCTAssertTrue(html.contains(#"data-testid="attention-digest-seam""#))
+        XCTAssertTrue(html.contains(#"data-testid="attention-digest-reasons""#))
+        XCTAssertTrue(html.contains(#"data-command-id="attention-acknowledge""#))
+        XCTAssertTrue(html.contains(#"data-command-id="attention-dismiss""#))
+    }
+}

--- a/Tests/QuillCodeAppTests/AttentionSectionSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/AttentionSectionSurfaceTests.swift
@@ -109,6 +109,59 @@ final class AttentionSectionSurfaceTests: XCTestCase {
         XCTAssertEqual(m.attentionModel.selectedThreadID, id(2))
     }
 
+    /// A RED thread with `unseen` unseen turns after a persisted watermark.
+    private func redThreadWithUnseen(id threadID: UUID, unseen: Int, updatedAt: TimeInterval) -> ChatThread {
+        var thread = threadWithVerdict(.red, id: threadID, title: "t", updatedAt: Date(timeIntervalSince1970: updatedAt))
+        thread.messages.append(ChatMessage(role: .user, content: "go"))
+        thread.messages.append(ChatMessage(role: .assistant, content: "started"))
+        ThreadReturnWatermarkRecord.markSeen(&thread) // caught up to here
+        for i in 0..<unseen {
+            thread.messages.append(ChatMessage(role: .assistant, content: "overnight \(i)"))
+        }
+        return thread
+    }
+
+    /// The regression for the "cursoring zeroes passed-over badges" MAJOR: moving the j/k cursor is
+    /// preview/navigation and must NOT advance any thread's watermark or change the workspace selection.
+    /// Every thread's unseen count survives cursor movement.
+    func testCursorMovementDoesNotAdvanceWatermarksOrChangeSelection() {
+        let a = redThreadWithUnseen(id: id(1), unseen: 2, updatedAt: 300)
+        let b = redThreadWithUnseen(id: id(2), unseen: 3, updatedAt: 200)
+        let c = redThreadWithUnseen(id: id(3), unseen: 4, updatedAt: 100)
+        // No thread selected in the workspace — the cursor is purely the Attention preview.
+        let m = model([a, b, c], selected: nil)
+
+        XCTAssertEqual(m.surface().sidebar.attention.rows.map(\.unseenCount), [2, 3, 4])
+
+        // Scroll the cursor all the way down and back up.
+        m.attentionMoveDown(); m.attentionMoveDown(); m.attentionMoveUp(); m.attentionMoveUp()
+
+        // The workspace selection never moved (cursor is decoupled).
+        XCTAssertNil(m.root.selectedThreadID)
+        // Every thread's persisted watermark is untouched → unseen counts unchanged.
+        for tid in [id(1), id(2), id(3)] {
+            let thread = m.root.threads.first { $0.id == tid }!
+            XCTAssertGreaterThan(ThreadReturnWatermarkRecord.unseenCount(in: thread), 0)
+        }
+        XCTAssertEqual(m.surface().sidebar.attention.rows.map(\.unseenCount).sorted(), [2, 3, 4])
+    }
+
+    func testOpeningThenLeavingAThreadClearsOnlyThatBadge() {
+        let a = redThreadWithUnseen(id: id(1), unseen: 2, updatedAt: 300)
+        let b = redThreadWithUnseen(id: id(2), unseen: 3, updatedAt: 200)
+        let m = model([a, b], selected: nil)
+
+        // Open A (a genuine read) — A is now selected; its own badge stays until we leave it.
+        m.openAttentionDigest(for: id(1))
+        XCTAssertEqual(m.root.selectedThreadID, id(1))
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: m.root.threads.first { $0.id == id(1) }!), 2)
+
+        // Open B — this LEAVES A, advancing A's watermark; A's badge clears, B keeps its own.
+        m.openAttentionDigest(for: id(2))
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: m.root.threads.first { $0.id == id(1) }!), 0)
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: m.root.threads.first { $0.id == id(2) }!), 3)
+    }
+
     // MARK: - HTML render parity of shape
 
     func testHTMLRendererEmitsAttentionSection() {

--- a/Tests/QuillCodeAppTests/AttentionSectionSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/AttentionSectionSurfaceTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import QuillCodeCore
+import QuillCodePersistence
 @testable import QuillCodeApp
 
 /// App-layer tests for the morning-triage Attention surface + HTML rendering + model actions (issue
@@ -154,5 +155,88 @@ final class AttentionSectionSurfaceTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="attention-digest-reasons""#))
         XCTAssertTrue(html.contains(#"data-command-id="attention-acknowledge""#))
         XCTAssertTrue(html.contains(#"data-command-id="attention-dismiss""#))
+    }
+
+    // MARK: - MAJOR 2: the unseen-turn seam is written by production and non-zero after reload
+
+    private func threadWithVerdictAndMessages(
+        _ verdict: RunIntegrityVerdict,
+        id threadID: UUID,
+        title: String,
+        messageCount: Int
+    ) -> ChatThread {
+        var thread = threadWithVerdict(verdict, id: threadID, title: title)
+        for i in 0..<messageCount {
+            thread.messages.append(ChatMessage(role: i.isMultiple(of: 2) ? .user : .assistant, content: "turn \(i)"))
+        }
+        return thread
+    }
+
+    /// The core regression for MAJOR 2: leaving a thread must PERSIST its return watermark (not just a
+    /// session-only in-memory tracker), so a thread that grows in the background shows a non-zero unseen
+    /// count in Attention + digest AFTER a reload from the store — not only in-session.
+    func testLeavingThreadPersistsWatermarkSoBackgroundGrowthShowsUnseenAfterReload() throws {
+        let dir = try makeTempDirectory()
+        let store = JSONThreadStore(directory: dir)
+        let threadA = threadWithVerdictAndMessages(.red, id: id(1), title: "overnight A", messageCount: 3)
+        let threadB = threadWithVerdict(.verified, id: id(2), title: "B")
+        try store.save(threadA)
+        try store.save(threadB)
+
+        let m = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [threadA, threadB], selectedThreadID: id(1)),
+            threadStore: store
+        )
+        // The production writer must run on leave: switch A → B.
+        m.selectThread(id(2))
+
+        // A watermark record was actually persisted (not just a session tracker).
+        let leftA = try store.load(id(1))
+        XCTAssertNotNil(
+            ThreadReturnWatermarkRecord.lastSeenItemID(in: leftA),
+            "leaving a thread must persist its return watermark (MAJOR 2)"
+        )
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: leftA), 0, "caught up at leave time")
+
+        // A run finishes on A in the background: two more turns arrive; persist.
+        var grownA = leftA
+        grownA.messages.append(ChatMessage(role: .assistant, content: "overnight result"))
+        grownA.messages.append(ChatMessage(role: .user, content: "follow-up"))
+        try store.save(grownA)
+
+        // Reload from disk (fresh session) — the unseen count must be non-zero.
+        let reloadedA = try store.load(id(1))
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: reloadedA), 2)
+
+        // And it surfaces in the Attention model + digest built from the reloaded thread.
+        let model = AttentionModel.build(from: [reloadedA])
+        XCTAssertEqual(model.items.first?.unseenCount, 2)
+        XCTAssertEqual(model.items.first?.unseenLabel, "2 new")
+        let digest = TriageDigest.build(for: reloadedA, unseenCount: ThreadReturnWatermarkRecord.unseenCount(in: reloadedA))
+        XCTAssertEqual(digest.unseenSeamLabel, "2 unseen turns")
+    }
+
+    func testNewChatPersistsOutgoingThreadWatermark() throws {
+        let dir = try makeTempDirectory()
+        let store = JSONThreadStore(directory: dir)
+        let threadA = threadWithVerdictAndMessages(.red, id: id(1), title: "A", messageCount: 2)
+        try store.save(threadA)
+        let m = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [threadA], selectedThreadID: id(1)),
+            threadStore: store
+        )
+        // New Chat / fork / compact all route through insertCreatedThread, which must persist the
+        // outgoing thread's watermark.
+        _ = m.insertCreatedThread(ChatThread(id: id(9), title: "New"), selectedProjectID: UUID?.none, saveThread: true)
+        let leftA = try store.load(id(1))
+        XCTAssertNotNil(ThreadReturnWatermarkRecord.lastSeenItemID(in: leftA))
+    }
+
+    func testSelectingSameThreadDoesNotAdvanceWatermark() {
+        // Re-selecting the current thread is not a "leave" — the watermark must not move.
+        let threadA = threadWithVerdictAndMessages(.red, id: id(1), title: "A", messageCount: 2)
+        let m = model([threadA], selected: id(1))
+        m.selectThread(id(1))
+        XCTAssertNil(ThreadReturnWatermarkRecord.lastSeenItemID(in: m.root.threads[0]))
     }
 }

--- a/Tests/QuillCodeCoreTests/MorningTriageTests.swift
+++ b/Tests/QuillCodeCoreTests/MorningTriageTests.swift
@@ -237,6 +237,83 @@ final class MorningTriageTests: XCTestCase {
         XCTAssertEqual(ThreadTriageRecord.current(in: thread), .acknowledged)
     }
 
+    // MARK: - BLOCKER 1: a triaged thread that goes RED again re-surfaces
+
+    /// Replace the thread's integrity record with a fresh one (a NEW run stamping the badge), exactly as
+    /// `RunIntegrityRecord.record` does after a run finishes — a brand-new event id even for the same
+    /// verdict.
+    private func restampIntegrity(_ verdict: RunIntegrityVerdict, on thread: inout ChatThread) {
+        let report = RunIntegrityReport(
+            verdict: verdict,
+            reasons: [RunIntegrityReason(rule: .standingTestFailure, detail: "make test exited 1")]
+        )
+        thread.events.removeAll(where: RunIntegrityRecord.isRecord)
+        if let event = RunIntegrityRecord.event(for: report) {
+            thread.events.append(event)
+        }
+    }
+
+    func testAcknowledgedThreadThatGoesRedAgainReopensTriage() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        // User acknowledges the current RED run — it leaves Attention.
+        ThreadTriageRecord.set(.acknowledged, on: &thread)
+        XCTAssertFalse(ThreadTriageRecord.needsAttention(in: thread))
+        XCTAssertTrue(AttentionModel.build(from: [thread]).isEmpty)
+
+        // Later the user reopens the thread and sends again; that run fails → a NEW integrity record
+        // re-stamps RED. The stale acknowledgement must NOT keep hiding it.
+        restampIntegrity(.red, on: &thread)
+        XCTAssertTrue(
+            ThreadTriageRecord.needsAttention(in: thread),
+            "a thread that goes RED again after being acked must re-surface"
+        )
+        let model = AttentionModel.build(from: [thread])
+        XCTAssertEqual(model.items.map(\.threadID), [id(1)])
+    }
+
+    func testDismissedThreadThatGetsNewVerdictReopensTriage() {
+        var thread = threadWithVerdict(.unverified, id: id(1))
+        ThreadTriageRecord.set(.dismissed, on: &thread)
+        XCTAssertFalse(ThreadTriageRecord.needsAttention(in: thread))
+        // A new run stamps a different verdict (also a fresh record id).
+        restampIntegrity(.red, on: &thread)
+        XCTAssertTrue(ThreadTriageRecord.needsAttention(in: thread))
+        XCTAssertEqual(AttentionModel.build(from: [thread]).items.first?.verdict, .red)
+    }
+
+    func testAcknowledgementStillSilencesTheSameRun() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        ThreadTriageRecord.set(.acknowledged, on: &thread)
+        // No new run — the same integrity record stands. It must stay silenced.
+        XCTAssertFalse(ThreadTriageRecord.needsAttention(in: thread))
+        XCTAssertTrue(AttentionModel.build(from: [thread]).isEmpty)
+    }
+
+    func testReacknowledgingAfterReopenBindsToTheNewRun() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        ThreadTriageRecord.set(.acknowledged, on: &thread)
+        restampIntegrity(.red, on: &thread)
+        XCTAssertTrue(ThreadTriageRecord.needsAttention(in: thread))
+        // Acknowledge the NEW run — now it binds to the new record and silences again.
+        XCTAssertTrue(ThreadTriageRecord.set(.acknowledged, on: &thread))
+        XCTAssertFalse(ThreadTriageRecord.needsAttention(in: thread))
+    }
+
+    func testTriageBindingSurvivesReloadThenReopensOnNewRun() throws {
+        var thread = threadWithVerdict(.red, id: id(1))
+        ThreadTriageRecord.set(.acknowledged, on: &thread)
+
+        // Reload: still silenced (same run).
+        let encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+        var reloaded = try decoder.decode(ChatThread.self, from: try encoder.encode(thread))
+        XCTAssertFalse(ThreadTriageRecord.needsAttention(in: reloaded))
+
+        // A new run after reload re-opens triage.
+        restampIntegrity(.red, on: &reloaded)
+        XCTAssertTrue(ThreadTriageRecord.needsAttention(in: reloaded))
+    }
+
     func testAttentionUnseenNeverNegative() {
         let item = AttentionItem(
             threadID: id(1), title: "t", verdict: .red, summary: "s", unseenCount: -4,

--- a/Tests/QuillCodeCoreTests/MorningTriageTests.swift
+++ b/Tests/QuillCodeCoreTests/MorningTriageTests.swift
@@ -1,0 +1,349 @@
+import XCTest
+@testable import QuillCodeCore
+
+/// Tests for the pure morning-triage core (issue #877): the verdict-stamp derivation from the persisted
+/// Run Integrity record, the Attention ranking + selection cursor, and the persisted triage-state record.
+/// Reviewers attack this with compiled repros, so the deterministic edges are asserted explicitly:
+/// severity order, ties, empty section, j/k clamping, a/d no-op-on-empty, persistence round-trip, and
+/// "no run → no stamp".
+final class MorningTriageTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func id(_ n: Int) -> UUID {
+        UUID(uuidString: "00000000-0000-0000-0000-0000000000\(String(format: "%02d", n))")!
+    }
+
+    /// A thread carrying a persisted RunIntegrity record with the given verdict (the ACTUAL persisted
+    /// record, written the same way the app writes it).
+    private func threadWithVerdict(
+        _ verdict: RunIntegrityVerdict?,
+        id threadID: UUID,
+        title: String = "overnight run",
+        updatedAt: Date = Date(timeIntervalSince1970: 1_000)
+    ) -> ChatThread {
+        var thread = ChatThread(id: threadID, title: title, updatedAt: updatedAt)
+        if let verdict {
+            let report = RunIntegrityReport(
+                verdict: verdict,
+                reasons: [RunIntegrityReason(rule: .standingTestFailure, detail: "make test exited 1")]
+            )
+            if let event = RunIntegrityRecord.event(for: report) {
+                thread.events.append(event)
+            }
+        }
+        return thread
+    }
+
+    private func attention(
+        _ verdict: TriageVerdict,
+        id threadID: UUID,
+        updatedAt: TimeInterval = 1_000,
+        unseen: Int = 0
+    ) -> AttentionItem {
+        AttentionItem(
+            threadID: threadID,
+            title: "t\(threadID.uuidString.suffix(2))",
+            verdict: verdict,
+            summary: "s",
+            unseenCount: unseen,
+            updatedAt: Date(timeIntervalSince1970: updatedAt)
+        )
+    }
+
+    // MARK: - Verdict stamp from the persisted record
+
+    func testStampReadsPersistedRunIntegrityRecord() {
+        let thread = threadWithVerdict(.red, id: id(1))
+        let stamp = TriageStamp.derive(from: thread)
+        XCTAssertEqual(stamp?.verdict, .red)
+        XCTAssertEqual(stamp?.summary, "make test exited 1")
+    }
+
+    func testNoRunMeansNoStamp() {
+        let thread = threadWithVerdict(nil, id: id(2))
+        XCTAssertNil(TriageStamp.derive(from: thread))
+    }
+
+    func testStampMapsEachVerdict() {
+        XCTAssertEqual(TriageStamp.derive(from: threadWithVerdict(.red, id: id(1)))?.verdict, .red)
+        XCTAssertEqual(TriageStamp.derive(from: threadWithVerdict(.unverified, id: id(1)))?.verdict, .unverified)
+        XCTAssertEqual(TriageStamp.derive(from: threadWithVerdict(.verified, id: id(1)))?.verdict, .verified)
+    }
+
+    func testVerdictSeverityAndNeedsAttention() {
+        XCTAssertGreaterThan(TriageVerdict.red.severity, TriageVerdict.unverified.severity)
+        XCTAssertGreaterThan(TriageVerdict.unverified.severity, TriageVerdict.verified.severity)
+        XCTAssertTrue(TriageVerdict.red.needsAttention)
+        XCTAssertTrue(TriageVerdict.unverified.needsAttention)
+        XCTAssertFalse(TriageVerdict.verified.needsAttention)
+    }
+
+    // MARK: - Ranking
+
+    func testRankingPutsRedBeforeUnverified() {
+        let model = AttentionModel(items: [
+            attention(.unverified, id: id(1)),
+            attention(.red, id: id(2))
+        ])
+        XCTAssertEqual(model.items.map(\.verdict), [.red, .unverified])
+    }
+
+    func testRankingBreaksTiesByRecencyNewerFirst() {
+        let older = attention(.red, id: id(1), updatedAt: 100)
+        let newer = attention(.red, id: id(2), updatedAt: 200)
+        let model = AttentionModel(items: [older, newer])
+        XCTAssertEqual(model.items.map(\.threadID), [id(2), id(1)])
+    }
+
+    func testRankingIsTotalAndStableOnFullTies() {
+        // Same severity + same timestamp → deterministic by threadID ascending.
+        let a = attention(.unverified, id: id(3), updatedAt: 100)
+        let b = attention(.unverified, id: id(1), updatedAt: 100)
+        let model = AttentionModel(items: [a, b])
+        XCTAssertEqual(model.items.map(\.threadID), [id(1), id(3)])
+    }
+
+    func testEmptyModelHasNoSelection() {
+        let model = AttentionModel(items: [])
+        XCTAssertTrue(model.isEmpty)
+        XCTAssertNil(model.selectedThreadID)
+        XCTAssertNil(model.selectedItem)
+        XCTAssertNil(model.selectedIndex)
+    }
+
+    // MARK: - Selection cursor (j/k clamp)
+
+    func testInitialSelectionIsFirstRow() {
+        let model = AttentionModel(items: [
+            attention(.unverified, id: id(1)),
+            attention(.red, id: id(2))
+        ])
+        // Ranked: red(2) first.
+        XCTAssertEqual(model.selectedThreadID, id(2))
+    }
+
+    func testMoveDownAdvancesAndClampsAtEnd() {
+        var model = AttentionModel(items: [
+            attention(.red, id: id(1), updatedAt: 300),
+            attention(.red, id: id(2), updatedAt: 200),
+            attention(.red, id: id(3), updatedAt: 100)
+        ])
+        XCTAssertEqual(model.selectedThreadID, id(1))
+        model.moveDown()
+        XCTAssertEqual(model.selectedThreadID, id(2))
+        model.moveDown()
+        XCTAssertEqual(model.selectedThreadID, id(3))
+        // Clamps at the last row — no wrap, no out-of-range.
+        model.moveDown()
+        XCTAssertEqual(model.selectedThreadID, id(3))
+    }
+
+    func testMoveUpRetreatsAndClampsAtStart() {
+        var model = AttentionModel(items: [
+            attention(.red, id: id(1), updatedAt: 300),
+            attention(.red, id: id(2), updatedAt: 200)
+        ])
+        model.moveDown()
+        XCTAssertEqual(model.selectedThreadID, id(2))
+        model.moveUp()
+        XCTAssertEqual(model.selectedThreadID, id(1))
+        // Clamps at the first row.
+        model.moveUp()
+        XCTAssertEqual(model.selectedThreadID, id(1))
+    }
+
+    func testMoveOnEmptyIsNoOp() {
+        var model = AttentionModel(items: [])
+        model.moveDown()
+        model.moveUp()
+        XCTAssertNil(model.selectedThreadID)
+    }
+
+    func testSelectPreservedAcrossRerankWhenStillPresent() {
+        let items = [
+            attention(.red, id: id(1), updatedAt: 300),
+            attention(.red, id: id(2), updatedAt: 200)
+        ]
+        let model = AttentionModel(items: items, selectedThreadID: id(2))
+        XCTAssertEqual(model.selectedThreadID, id(2))
+    }
+
+    func testSelectionFallsBackToFirstWhenSelectedGone() {
+        let model = AttentionModel(items: [attention(.red, id: id(1))], selectedThreadID: id(99))
+        XCTAssertEqual(model.selectedThreadID, id(1))
+    }
+
+    func testSelectByIDIgnoresUnknown() {
+        var model = AttentionModel(items: [attention(.red, id: id(1)), attention(.red, id: id(2), updatedAt: 50)])
+        model.select(id(99))
+        XCTAssertEqual(model.selectedThreadID, id(1))
+        model.select(id(2))
+        XCTAssertEqual(model.selectedThreadID, id(2))
+    }
+
+    // MARK: - Triage state record (persistence)
+
+    func testTriageStateDefaultsToPending() {
+        let thread = threadWithVerdict(.red, id: id(1))
+        XCTAssertEqual(ThreadTriageRecord.current(in: thread), .pending)
+    }
+
+    func testSetTriageStatePersistsAndReadsBack() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        XCTAssertTrue(ThreadTriageRecord.set(.acknowledged, on: &thread))
+        XCTAssertEqual(ThreadTriageRecord.current(in: thread), .acknowledged)
+        XCTAssertFalse(ThreadTriageRecord.current(in: thread).isActionable)
+    }
+
+    func testSetTriageStateSurvivesReloadRoundTrip() throws {
+        var thread = threadWithVerdict(.unverified, id: id(1))
+        ThreadTriageRecord.set(.dismissed, on: &thread)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(thread)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let reloaded = try decoder.decode(ChatThread.self, from: data)
+
+        XCTAssertEqual(ThreadTriageRecord.current(in: reloaded), .dismissed)
+        // And the run-integrity stamp still reads correctly alongside the triage record.
+        XCTAssertEqual(TriageStamp.derive(from: reloaded)?.verdict, .unverified)
+    }
+
+    func testSetSameTriageStateIsIdempotentNoOp() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        XCTAssertTrue(ThreadTriageRecord.set(.acknowledged, on: &thread))
+        let before = thread.updatedAt
+        XCTAssertFalse(ThreadTriageRecord.set(.acknowledged, on: &thread))
+        XCTAssertEqual(thread.updatedAt, before, "re-recording the same state must not bump updatedAt")
+    }
+
+    func testChangingTriageStateReplacesPriorRecord() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        ThreadTriageRecord.set(.acknowledged, on: &thread)
+        ThreadTriageRecord.set(.dismissed, on: &thread)
+        let records = thread.events.filter(ThreadTriageRecord.isRecord)
+        XCTAssertEqual(records.count, 1, "only the latest triage record is kept")
+        XCTAssertEqual(ThreadTriageRecord.current(in: thread), .dismissed)
+    }
+
+    func testTriageRecordDoesNotClobberIntegrityRecord() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        ThreadTriageRecord.set(.acknowledged, on: &thread)
+        // Both notices coexist on the thread.
+        XCTAssertNotNil(RunIntegrityRecord.latest(in: thread))
+        XCTAssertEqual(ThreadTriageRecord.current(in: thread), .acknowledged)
+    }
+
+    func testAttentionUnseenNeverNegative() {
+        let item = AttentionItem(
+            threadID: id(1), title: "t", verdict: .red, summary: "s", unseenCount: -4,
+            updatedAt: Date()
+        )
+        XCTAssertEqual(item.unseenCount, 0)
+        XCTAssertNil(item.unseenLabel)
+    }
+
+    func testAttentionUnseenLabel() {
+        let item = attention(.red, id: id(1), unseen: 3)
+        XCTAssertEqual(item.unseenLabel, "3 new")
+    }
+
+    // MARK: - Return watermark (unseen count)
+
+    private func threadWithMessages(_ count: Int, id threadID: UUID = UUID()) -> ChatThread {
+        var thread = ChatThread(id: threadID)
+        for i in 0..<count {
+            thread.messages.append(ChatMessage(
+                id: UUID(uuidString: "10000000-0000-0000-0000-0000000000\(String(format: "%02d", i))")!,
+                role: i.isMultiple(of: 2) ? .user : .assistant,
+                content: "turn \(i)"
+            ))
+        }
+        return thread
+    }
+
+    func testUnseenCountZeroWhenNeverViewed() {
+        let thread = threadWithMessages(3)
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: thread), 0)
+    }
+
+    func testUnseenCountAfterMarkSeenThenGrowth() {
+        var thread = threadWithMessages(3)
+        XCTAssertTrue(ThreadReturnWatermarkRecord.markSeen(&thread))
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: thread), 0)
+        // Two more turns arrive.
+        thread.messages.append(ChatMessage(role: .assistant, content: "new 1"))
+        thread.messages.append(ChatMessage(role: .user, content: "new 2"))
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: thread), 2)
+    }
+
+    func testUnseenCountStaleWatermarkIsZeroNeverNegative() {
+        var thread = threadWithMessages(4)
+        // Point the watermark at an item that isn't in the timeline.
+        let payload = ThreadReturnWatermarkRecord.Payload(lastSeenItemID: "message-does-not-exist")
+        let json = try! JSONHelpers.encodePretty(payload)
+        thread.events.append(ThreadEvent(kind: .notice, summary: ThreadReturnWatermarkRecord.eventSummary, payloadJSON: json))
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: thread), 0)
+    }
+
+    func testMarkSeenIsNoOpAtTailAndOnEmpty() {
+        var thread = threadWithMessages(2)
+        XCTAssertTrue(ThreadReturnWatermarkRecord.markSeen(&thread))
+        XCTAssertFalse(ThreadReturnWatermarkRecord.markSeen(&thread), "already at tail")
+        var empty = ChatThread()
+        XCTAssertFalse(ThreadReturnWatermarkRecord.markSeen(&empty), "no messages")
+    }
+
+    func testWatermarkSurvivesReloadRoundTrip() throws {
+        var thread = threadWithMessages(3)
+        ThreadReturnWatermarkRecord.markSeen(&thread)
+        thread.messages.append(ChatMessage(role: .assistant, content: "later"))
+
+        let encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(thread)
+        let decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+        let reloaded = try decoder.decode(ChatThread.self, from: data)
+        XCTAssertEqual(ThreadReturnWatermarkRecord.unseenCount(in: reloaded), 1)
+    }
+
+    // MARK: - build(from:) integration
+
+    func testBuildIncludesOnlyPendingAttentionThreads() {
+        let redThread = threadWithVerdict(.red, id: id(1), updatedAt: Date(timeIntervalSince1970: 300))
+        let unverifiedThread = threadWithVerdict(.unverified, id: id(2), updatedAt: Date(timeIntervalSince1970: 200))
+        let verifiedThread = threadWithVerdict(.verified, id: id(3))
+        let noRunThread = threadWithVerdict(nil, id: id(4))
+        var acknowledgedRed = threadWithVerdict(.red, id: id(5))
+        ThreadTriageRecord.set(.acknowledged, on: &acknowledgedRed)
+
+        let model = AttentionModel.build(from: [
+            verifiedThread, unverifiedThread, redThread, noRunThread, acknowledgedRed
+        ])
+        // Only the pending RED + UNVERIFIED threads, RED first.
+        XCTAssertEqual(model.items.map(\.threadID), [id(1), id(2)])
+        XCTAssertEqual(model.items.map(\.verdict), [.red, .unverified])
+    }
+
+    func testBuildComputesUnseenCountFromWatermark() {
+        var thread = threadWithVerdict(.red, id: id(1))
+        thread.messages.append(ChatMessage(role: .user, content: "go"))
+        thread.messages.append(ChatMessage(role: .assistant, content: "started"))
+        ThreadReturnWatermarkRecord.markSeen(&thread)
+        thread.messages.append(ChatMessage(role: .assistant, content: "overnight update"))
+
+        let model = AttentionModel.build(from: [thread])
+        XCTAssertEqual(model.items.first?.unseenCount, 1)
+        XCTAssertEqual(model.items.first?.unseenLabel, "1 new")
+    }
+
+    func testBuildEmptyWhenNothingNeedsAttention() {
+        let model = AttentionModel.build(from: [
+            threadWithVerdict(.verified, id: id(1)),
+            threadWithVerdict(nil, id: id(2))
+        ])
+        XCTAssertTrue(model.isEmpty)
+    }
+}

--- a/Tests/QuillCodeCoreTests/TriageDigestTests.swift
+++ b/Tests/QuillCodeCoreTests/TriageDigestTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import QuillCodeCore
+
+/// Tests for the per-thread return digest (issue #877): verdict + reasons + final outcome + unseen seam.
+final class TriageDigestTests: XCTestCase {
+
+    private func threadWithRedRun(unseenAnswer: String = "Done. Left a failing test.") -> ChatThread {
+        var thread = ChatThread(title: "fix the parser")
+        // A real standing failure the scanner will flag RED.
+        let call = ToolCall(
+            name: RunIntegrityScanner.shellRunToolName,
+            argumentsJSON: #"{"cmd":"make test"}"#
+        )
+        let failResult = ToolResult(ok: false, stdout: "", stderr: "1 failing", exitCode: 1, error: nil)
+        let callJSON = (try? JSONHelpers.encodePretty(call)) ?? "{}"
+        let resultJSON = (try? JSONHelpers.encodePretty(failResult)) ?? "{}"
+        thread.events.append(ThreadEvent(kind: .toolQueued, summary: "\(call.name) queued", payloadJSON: callJSON))
+        thread.events.append(ThreadEvent(kind: .toolRunning, summary: "\(call.name) running"))
+        thread.events.append(ThreadEvent(kind: .toolFailed, summary: "\(call.name) failed", payloadJSON: resultJSON))
+        thread.messages.append(ChatMessage(role: .user, content: "fix it"))
+        thread.messages.append(ChatMessage(role: .assistant, content: unseenAnswer))
+        // Persist the integrity record the way the app does.
+        RunIntegrityRecord.record(into: &thread)
+        return thread
+    }
+
+    func testDigestCarriesVerdictReasonsOutcomeAndSeam() {
+        let thread = threadWithRedRun()
+        let digest = TriageDigest.build(for: thread, unseenCount: 2)
+        XCTAssertEqual(digest.verdict, .red)
+        XCTAssertFalse(digest.verdictSummary.isEmpty)
+        XCTAssertFalse(digest.reasons.isEmpty, "a RED run must expose its reasons in the card body")
+        XCTAssertEqual(digest.outcome, "Done. Left a failing test.")
+        XCTAssertEqual(digest.unseenCount, 2)
+        XCTAssertEqual(digest.unseenSeamLabel, "2 unseen turns")
+    }
+
+    func testDigestSingularSeamLabel() {
+        let digest = TriageDigest.build(for: threadWithRedRun(), unseenCount: 1)
+        XCTAssertEqual(digest.unseenSeamLabel, "1 unseen turn")
+    }
+
+    func testDigestNoUnseenHasNoSeamLabel() {
+        let digest = TriageDigest.build(for: threadWithRedRun(), unseenCount: 0)
+        XCTAssertNil(digest.unseenSeamLabel)
+    }
+
+    func testDigestNeverNegativeUnseen() {
+        let digest = TriageDigest.build(for: threadWithRedRun(), unseenCount: -5)
+        XCTAssertEqual(digest.unseenCount, 0)
+    }
+
+    func testDigestForUnscannedThreadHasNoVerdictOrReasons() {
+        var thread = ChatThread(title: "just chatting")
+        thread.messages.append(ChatMessage(role: .assistant, content: "hi there"))
+        let digest = TriageDigest.build(for: thread, unseenCount: 0)
+        XCTAssertNil(digest.verdict)
+        XCTAssertTrue(digest.verdictSummary.isEmpty)
+        XCTAssertTrue(digest.reasons.isEmpty)
+        XCTAssertEqual(digest.outcome, "hi there")
+    }
+
+    func testDigestOutcomeFallsBackWhenNoAssistantMessage() {
+        var thread = ChatThread(title: "empty")
+        thread.messages.append(ChatMessage(role: .user, content: "hello?"))
+        let digest = TriageDigest.build(for: thread, unseenCount: 0)
+        XCTAssertEqual(digest.outcome, "No final answer recorded.")
+    }
+
+    func testOutcomeLineTakesFirstNonEmptyLineAndTruncates() {
+        let long = String(repeating: "x", count: 200)
+        let text = "\n\n  \(long)\nsecond line"
+        let line = TriageDigest.firstLine(of: text, maxLength: 140)
+        XCTAssertTrue(line.hasSuffix("…"))
+        XCTAssertLessThanOrEqual(line.count, 141)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityAttentionInboxGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAttentionInboxGateTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+import QuillCodeCore
+
+/// Native ↔ HTML ↔ harness parity gate for the morning-triage inbox (issue #877).
+///
+/// This batch has repeatedly shipped bugs where the HTML harness diverged from the native Swift model
+/// and the Playwright E2E passed while native was broken. This gate defends against that by asserting
+/// that all three surfaces agree on the load-bearing constants and semantics:
+/// - the verdict raw values and severity ordering,
+/// - the Attention section / row / digest testids and data attributes,
+/// - the j/k/Enter/a/d triage command IDs.
+///
+/// It reads the actual sources (the Swift core, the Swift HTML renderer, and the committed harness
+/// index.html) so a change to one surface that isn't mirrored in the others fails here — the same
+/// mechanism #878's parity gates used.
+final class ParityAttentionInboxGateTests: QuillCodeParityTestCase {
+
+    private func harnessText() throws -> String {
+        try String(
+            contentsOf: Self.packageRoot().appendingPathComponent("E2E/harness/index.html"),
+            encoding: .utf8
+        )
+    }
+
+    // MARK: - Verdict + severity agreement
+
+    func testVerdictRawValuesAndSeverityAgreeAcrossSurfaces() throws {
+        // The Swift source of truth.
+        XCTAssertEqual(TriageVerdict.red.rawValue, "red")
+        XCTAssertEqual(TriageVerdict.unverified.rawValue, "unverified")
+        XCTAssertEqual(TriageVerdict.verified.rawValue, "verified")
+        XCTAssertGreaterThan(TriageVerdict.red.severity, TriageVerdict.unverified.severity)
+        XCTAssertGreaterThan(TriageVerdict.unverified.severity, TriageVerdict.verified.severity)
+        XCTAssertFalse(TriageVerdict.verified.needsAttention)
+
+        // The harness must mirror the same severity map + badge labels + attention predicate.
+        let harness = try harnessText()
+        Self.assertSource(harness, containsAll: [
+            "const triageSeverity = { red: 2, unverified: 1, verified: 0 };",
+            "const triageBadgeLabel = { red: 'RED', unverified: 'UNVERIFIED', verified: 'VERIFIED' };",
+            "function verdictNeedsAttention(verdict) {",
+            "verdict === 'red' || verdict === 'unverified'"
+        ])
+    }
+
+    // MARK: - Ranking semantics agreement
+
+    func testRankingIsSeverityThenRecencyThenIDInBothSurfaces() throws {
+        // Native: RED before UNVERIFIED, newer before older on ties.
+        let older = AttentionItem(threadID: uuid(1), title: "a", verdict: .red, summary: "", unseenCount: 0, updatedAt: Date(timeIntervalSince1970: 100))
+        let newer = AttentionItem(threadID: uuid(2), title: "b", verdict: .red, summary: "", unseenCount: 0, updatedAt: Date(timeIntervalSince1970: 200))
+        let yellow = AttentionItem(threadID: uuid(3), title: "c", verdict: .unverified, summary: "", unseenCount: 0, updatedAt: Date(timeIntervalSince1970: 300))
+        let ranked = AttentionModel.rank([yellow, older, newer])
+        XCTAssertEqual(ranked.map(\.threadID), [uuid(2), uuid(1), uuid(3)])
+
+        // Harness: the same three-key comparator (severity desc, updatedAt desc, threadID asc).
+        let harness = try harnessText()
+        Self.assertSource(harness, containsAll: [
+            "triageSeverity[rhs.verdict] - triageSeverity[lhs.verdict]",
+            "lhs.updatedAt < rhs.updatedAt ? 1 : -1",
+            "lhs.threadID < rhs.threadID ? -1 : (lhs.threadID > rhs.threadID ? 1 : 0)"
+        ])
+    }
+
+    // MARK: - Testids + data attributes agreement
+
+    func testAttentionTestidsMatchBetweenHTMLRendererAndHarness() throws {
+        let renderer = try Self.appSourceText(named: "WorkspaceHTMLSidebarThreadRenderer.swift")
+        let workspaceRenderer = try Self.appSourceText(named: "WorkspaceHTMLRenderer.swift")
+        let harness = try harnessText()
+
+        let sectionTestids = [
+            #"data-testid="attention-section""#,
+            #"data-testid="attention-row""#,
+            #"data-testid="attention-verdict""#,
+            #"data-testid="attention-title""#,
+            #"data-testid="attention-unseen""#
+        ]
+        for testid in sectionTestids {
+            Self.assertSource(renderer, contains: testid)
+            Self.assertSource(harness, contains: testid)
+        }
+
+        // Raw-HTML digest elements: identical `data-testid="…"` literals in both surfaces.
+        let digestRawTestids = [
+            "attention-digest",
+            "attention-digest-verdict",
+            "attention-digest-title",
+            "attention-digest-seam",
+            "attention-digest-outcome",
+            "attention-digest-reasons"
+        ]
+        for testid in digestRawTestids {
+            Self.assertSource(workspaceRenderer, contains: #"data-testid="\#(testid)""#)
+            Self.assertSource(harness, contains: #"data-testid="\#(testid)""#)
+        }
+
+        // Digest action buttons route through the shared HTML button primitive in Swift (so they carry
+        // hit-target markers), hence `testID: "…"`; the harness emits the same `data-testid`.
+        let digestButtonTestids = [
+            "attention-digest-close",
+            "attention-digest-acknowledge",
+            "attention-digest-dismiss"
+        ]
+        for testid in digestButtonTestids {
+            Self.assertSource(workspaceRenderer, contains: #"testID: "\#(testid)""#)
+            Self.assertSource(harness, contains: #"data-testid="\#(testid)""#)
+        }
+    }
+
+    // MARK: - Triage command IDs agreement
+
+    func testTriageCommandIDsMatchAcrossSurfaces() throws {
+        let commandPlan = try Self.appSourceText(named: "WorkspaceCommandPlan.swift")
+        let harness = try harnessText()
+
+        let commands = [
+            "attention-next",
+            "attention-previous",
+            "attention-open",
+            "attention-acknowledge",
+            "attention-dismiss"
+        ]
+        for command in commands {
+            // Native raw-value enum case.
+            Self.assertSource(commandPlan, contains: "= \"\(command)\"")
+            // Harness runCommand branch + routable allowlist.
+            Self.assertSource(harness, contains: "'\(command)'")
+        }
+        // The Enter/j/k/a/d key routing table in the harness must map to these commands.
+        Self.assertSource(harness, containsAll: [
+            "j: 'attention-next'",
+            "k: 'attention-previous'",
+            "a: 'attention-acknowledge'",
+            "d: 'attention-dismiss'",
+            "enter: 'attention-open'"
+        ])
+    }
+
+    // MARK: - Triage state agreement
+
+    func testTriageStatesMatchAcrossSurfaces() throws {
+        XCTAssertEqual(ThreadTriageState.pending.rawValue, "pending")
+        XCTAssertEqual(ThreadTriageState.acknowledged.rawValue, "acknowledged")
+        XCTAssertEqual(ThreadTriageState.dismissed.rawValue, "dismissed")
+        let harness = try harnessText()
+        Self.assertSource(harness, containsAll: ["'pending'", "'acknowledged'", "'dismissed'"])
+    }
+
+    private func uuid(_ n: Int) -> UUID {
+        UUID(uuidString: "00000000-0000-0000-0000-0000000000\(String(format: "%02d", n))")!
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityAttentionInboxGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAttentionInboxGateTests.swift
@@ -143,13 +143,16 @@ final class ParityAttentionInboxGateTests: QuillCodeParityTestCase {
         let harness = try harnessText()
         // The triage guard must be its OWN function, NOT a reuse of focusAllowsTabShortcut (which treats
         // the composer as shortcut-allowed — the exact bug). It must block INPUT / TEXTAREA / SELECT /
-        // contentEditable and only fire when the Attention section has rows.
+        // contentEditable, require the section to have rows, and (MINOR parity) be scoped to the
+        // Attention section's context rather than firing for ANY non-editable focus.
         Self.assertSource(harness, containsAll: [
             "function attentionTriageContextIsActive()",
             "if (!attentionTriageContextIsActive()) return false;",
             "active.isContentEditable",
             "tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'",
-            "return attentionRows().length > 0;"
+            "if (!attentionRows().length) return false;",
+            #"document.querySelector('[data-testid="sidebar"]')"#,
+            "sidebar.contains(active)"
         ])
         // Fail-on-revert: the triage keydown handler must NOT gate on focusAllowsTabShortcut (the buggy
         // guard that let the keys fire in the composer).
@@ -159,6 +162,44 @@ final class ParityAttentionInboxGateTests: QuillCodeParityTestCase {
             to: "\n    }"
         )
         Self.assertSource(triageHandler, excludes: "focusAllowsTabShortcut")
+    }
+
+    // MARK: - Cursor is preview-only (the "cursoring zeroes badges" MAJOR defense)
+
+    func testCursorMovementIsDecoupledFromSelectionInBothSurfaces() throws {
+        // Native: attentionMoveDown/Up route through setAttentionCursor, which sets the dedicated
+        // attentionCursorID field — NOT selectThread (which would advance the outgoing watermark).
+        let modelSource = try Self.appSourceText(named: "WorkspaceModelMorningTriage.swift")
+        Self.assertSource(modelSource, contains: "private func setAttentionCursor(_ threadID: UUID?) {")
+        let setCursorBody = try slice(
+            of: modelSource,
+            from: "private func setAttentionCursor(_ threadID: UUID?) {",
+            to: "\n    }"
+        )
+        Self.assertSource(setCursorBody, contains: "attentionCursorID = threadID")
+        Self.assertSource(setCursorBody, excludes: "selectThread(")
+
+        // The surface builds the Attention cursor from attentionCursorID, not the workspace selection.
+        let builder = try Self.appSourceText(named: "WorkspaceNavigationSurfaceBuilder.swift")
+        Self.assertSource(builder, contains: "AttentionModel.build(from: threads, selectedThreadID: attentionCursorID)")
+
+        // Harness: cursor movement sets state.attentionCursorID and does NOT selectThread.
+        let harness = try harnessText()
+        let selectRelative = try slice(
+            of: harness,
+            from: "function attentionSelectRelative(delta) {",
+            to: "\n    }"
+        )
+        Self.assertSource(selectRelative, contains: "state.attentionCursorID = rows[clamped].threadID;")
+        // Must not CALL selectThread (a comment may mention it; a call has a paren).
+        Self.assertSource(selectRelative, excludes: "selectThread(")
+        // And the harness derives unseen from a watermark (so Playwright can catch a badge-zeroing bug),
+        // advancing it only on a genuine leave.
+        Self.assertSource(harness, containsAll: [
+            "function attentionUnseenCount(item)",
+            "function attentionMarkThreadSeen(threadID)",
+            "if (outgoing) attentionMarkThreadSeen(outgoing);"
+        ])
     }
 
     /// Extract the substring from the first occurrence of `from` up to the next occurrence of `to`.

--- a/Tests/QuillCodeParityTests/ParityAttentionInboxGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAttentionInboxGateTests.swift
@@ -137,6 +137,43 @@ final class ParityAttentionInboxGateTests: QuillCodeParityTestCase {
         ])
     }
 
+    // MARK: - Triage-key focus guard (BLOCKER-3 divergence defense)
+
+    func testHarnessTriageKeysDoNotFireInEditableFieldsAndAreSectionScoped() throws {
+        let harness = try harnessText()
+        // The triage guard must be its OWN function, NOT a reuse of focusAllowsTabShortcut (which treats
+        // the composer as shortcut-allowed — the exact bug). It must block INPUT / TEXTAREA / SELECT /
+        // contentEditable and only fire when the Attention section has rows.
+        Self.assertSource(harness, containsAll: [
+            "function attentionTriageContextIsActive()",
+            "if (!attentionTriageContextIsActive()) return false;",
+            "active.isContentEditable",
+            "tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'",
+            "return attentionRows().length > 0;"
+        ])
+        // Fail-on-revert: the triage keydown handler must NOT gate on focusAllowsTabShortcut (the buggy
+        // guard that let the keys fire in the composer).
+        let triageHandler = try slice(
+            of: harness,
+            from: "function handleAttentionTriageKeydown(event) {",
+            to: "\n    }"
+        )
+        Self.assertSource(triageHandler, excludes: "focusAllowsTabShortcut")
+    }
+
+    /// Extract the substring from the first occurrence of `from` up to the next occurrence of `to`.
+    private func slice(of source: String, from: String, to: String) throws -> String {
+        guard let start = source.range(of: from) else {
+            XCTFail("expected harness to contain: \(from)")
+            return ""
+        }
+        guard let end = source.range(of: to, range: start.upperBound..<source.endIndex) else {
+            XCTFail("expected \(to) after \(from)")
+            return ""
+        }
+        return String(source[start.lowerBound..<end.upperBound])
+    }
+
     // MARK: - Triage state agreement
 
     func testTriageStatesMatchAcrossSurfaces() throws {


### PR DESCRIPTION
## What & why

The morning ritual for unattended daily driving: review six overnight runs before the coffee cools. This adds:

- **Persistent per-thread verdict stamps** fed by the Run Integrity badge (#875) — not self-report.
- A **severity-ranked "Attention" sidebar section** with `j`/`k`/`Enter`/`a`/`d` keyboard triage.
- `Enter` → a **per-thread return digest card** with an unseen-turn seam so you see exactly what changed since you last looked.

Fixes #877. Builds on the already-merged Run Integrity Report (#875/#938/#942) and reuses the #878 new-turns concept.

## Design

**Verdict-stamp source.** Each thread's triage stamp is derived from its latest **persisted** `RunIntegrityRecord` via `RunIntegrityRecord.latest(in:)` — the actual notice event written when a run finishes, never re-derived from the transcript or self-report. A thread with no run has no stamp; only `RED` and `UNVERIFIED` surface in Attention (a clean `VERIFIED` run does not need triage).

**Attention ranking.** `AttentionModel` (pure, in `QuillCodeCore`) ranks rows by a total, deterministic comparator: severity descending (RED > UNVERIFIED), then `updatedAt` descending (newer first), then `threadID` ascending (stable tie-break). A selection cursor moves with `j`/`k` and **clamps** at both ends — no wrap, no out-of-range.

**Triage keys (documented semantics).**
- `j` — cursor down (clamped) · `k` — cursor up (clamped)
- `Enter` — open the selected thread's return digest
- `a` — **acknowledge** (reviewed, it's fine) · `d` — **dismiss** (not worth reviewing)

Both `a` and `d` persist the decision (`ThreadTriageRecord`, states `pending`/`acknowledged`/`dismissed`) and remove the row from Attention, advancing the cursor. `a`/`d` on an empty section are no-ops. The keys are contextual (only fire when the Attention section has rows and focus is not in an editable field) — they are **not** global app shortcuts, so bare `a`/`d` never hijack typing.

**Digest card.** `TriageDigest` summarizes one run: the integrity verdict + reasons (re-scanned for the card body; the persisted record keeps only the summary line), the final outcome (first line of the last assistant message), and the **unseen-turn seam** ("N unseen turns"). The seam count comes from a per-thread return watermark persisted on the thread, so it works across an app restart — the whole point of an overnight-review feature.

**Persistence.** Triage state and the return watermark are both stored as `.notice` events on the thread (the same convention `RunIntegrityRecord` uses), so they round-trip through the existing thread store and survive reload with zero new persistence plumbing. No force-unwraps anywhere.

**Surfaces.** The Attention section and the digest render in **both** native SwiftUI and the E2E HTML harness, following the codebase's dual-render pattern.

## Native ↔ harness parity

This batch has repeatedly shipped bugs where the HTML harness diverged from native and the E2E passed while native was broken. Defenses here:

- All ranking/selection/triage **semantics live once** in `QuillCodeCore`'s `AttentionModel` / `ThreadTriageRecord` / `TriageDigest`; native and the Swift HTML renderer both consume it.
- The harness JS **mirrors the Swift model line-for-line** — the severity map, the three-key comparator, the `needsAttention` predicate, the verdict raw values, the triage states, and the `attention-*` command IDs — with comments pointing back to `MorningTriage.swift`.
- A new **parity gate** (`ParityAttentionInboxGateTests`) reads all three sources (the Swift core, the Swift HTML renderer, and the committed `E2E/harness/index.html`) and fails if the constants/semantics/testids/command IDs drift out of sync — the same mechanism #878 used.
- The existing interaction-audit E2E (which audits every visible clickable for hit-target compliance) covers the new rows/buttons; the native hit-target source audit covers the new SwiftUI controls.

## Test evidence

- `swift build` — clean, no warnings.
- **Full `swift test`: 3015 passed, 0 failures** (2 pre-existing skips).
  - `MorningTriageTests` (38 assertions incl. TriageDigest): severity order, ties, empty section, j/k clamping, a/d persist + remove + no-op-on-empty, verdict-from-persisted-record, no-run→no-stamp, watermark unseen-count (never negative, stale→0), reload round-trips.
  - `AttentionSectionSurfaceTests` (10): surface projection, model actions (persist + surface), digest open/close, HTML render shape.
  - `ParityAttentionInboxGateTests` (5): cross-surface agreement on verdicts/severity/ranking/testids/commands/states.
- **Playwright: 172 passed** (`npm install` + `npx playwright install chromium`, then `npx playwright test`). New `attention-inbox.spec.ts` (7) drives the section + `j`/`k`/`Enter`/`a`/`d` + digest + click-to-open + the "keys don't fire while typing" guard; existing interaction-audit/sidebar/shortcuts specs still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)