### PR TITLE
Load public TrustedRouter model catalog

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -3667,6 +3667,12 @@
               // No price — proves the `/model` popup renders a model gracefully without a price line.
               { id: 'moonshotai/kimi-k2.6', provider: 'moonshotai', displayName: 'Kimi K2.6', isSelected: false, isFavorite: false, badges: [], capabilities: {} }
             ]
+          },
+          {
+            category: 'minimax',
+            models: [
+              { id: 'minimax/minimax-m3', provider: 'minimax', displayName: 'MiniMax M3', isSelected: false, isFavorite: false, badges: [], capabilities: { contextWindowTokens: 200000 } }
+            ]
           }
         ],
         modeLabel: 'Auto',

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -31,7 +31,7 @@ test('mock harness executes simple command flow', async ({ page }) => {
   const modeButtonBounds = await elementRect(page, '[data-testid="mode-picker-button"]');
   expect(modeButtonBounds.left - modelButtonBounds.right).toBeGreaterThanOrEqual(8);
   await page.getByTestId('model-picker-button').click();
-  await expect(page.getByTestId('model-category')).toHaveCount(2);
+  await expect(page.getByTestId('model-category')).toHaveCount(3);
   await page.getByTestId('model-picker-button').click();
   await expect(page.getByTestId('send-button')).toBeDisabled();
 

--- a/E2E/playwright/tests/model-picker.spec.ts
+++ b/E2E/playwright/tests/model-picker.spec.ts
@@ -8,7 +8,7 @@ test('mock harness searches and selects models from the composer', async ({ page
   await expect(page.getByTestId('model-browser')).toBeVisible();
   await expect(page.getByTestId('model-catalog-status')).toHaveText('Bundled catalog');
   await expect(page.getByTestId('model-provider-health')).toHaveText('Provider health unavailable');
-  await expect(page.getByTestId('model-result-count')).toHaveText('8 models available');
+  await expect(page.getByTestId('model-result-count')).toHaveText('9 models available');
   await expect(page.getByTestId('model-option').first()).toContainText('Nike 1.0');
   await expect(page.getByTestId('model-option-summary').first()).toContainText('Fast everyday agent');
   await expect(page.getByTestId('model-detail-button').nth(0)).toHaveAttribute('aria-expanded', 'true');
@@ -16,7 +16,7 @@ test('mock harness searches and selects models from the composer', async ({ page
   await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'trustedrouter/fast' })).toBeVisible();
   await expect(page.getByTestId('model-metadata-row').filter({ hasText: 'Current, Default, Recommended' }))
     .toBeVisible();
-  await expect(page.getByTestId('model-option')).toHaveCount(8);
+  await expect(page.getByTestId('model-option')).toHaveCount(9);
 
   await page.getByTestId('model-detail-button').nth(3).click();
   await expect(page.getByTestId('model-detail-button').nth(3)).toHaveAttribute('aria-expanded', 'true');
@@ -37,7 +37,7 @@ test('mock harness searches and selects models from the composer', async ({ page
   await page.getByTestId('model-favorite-button').nth(1).click();
   await expect(page.getByTestId('model-browser')).toBeVisible();
   await expect(page.getByTestId('model-category').first()).toContainText('Favorites');
-  await expect(page.getByTestId('model-option')).toHaveCount(9);
+  await expect(page.getByTestId('model-option')).toHaveCount(10);
   await expect(page.getByTestId('model-favorite-button').first())
     .toHaveAttribute('aria-label', 'Remove favorite model');
 
@@ -50,6 +50,12 @@ test('mock harness searches and selects models from the composer', async ({ page
   await expect(page.getByTestId('model-option')).toHaveCount(1);
   await expect(page.getByTestId('model-option')).toContainText('moonshotai/Kimi K2.6');
 
+  await page.getByTestId('model-search').fill('minimax');
+  await expect(page.getByTestId('model-result-count')).toHaveText('1 model for "minimax"');
+  await expect(page.getByTestId('model-option')).toHaveCount(1);
+  await expect(page.getByTestId('model-option')).toContainText('MiniMax M3');
+
+  await page.getByTestId('model-search').fill('moon k2');
   await page.getByTestId('model-option').click();
   await expect(page.getByTestId('model-picker-button')).toHaveText('moonshotai/Kimi K2.6');
   await expect(page.getByTestId('mode-pill')).toHaveText('Auto');
@@ -61,7 +67,7 @@ test('mock harness searches and selects models from the composer', async ({ page
   await expect(page.getByTestId('model-empty')).toBeVisible();
   await page.getByTestId('model-clear-search').first().click();
   await expect(page.getByTestId('model-search')).toBeFocused();
-  await expect(page.getByTestId('model-result-count')).toHaveText('9 models available');
+  await expect(page.getByTestId('model-result-count')).toHaveText('10 models available');
 });
 
 test('mock harness supports keyboard navigation in the model picker', async ({ page }) => {

--- a/Sources/QuillCodeAgent/TrustedRouterIntegration.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterIntegration.swift
@@ -46,6 +46,13 @@ public struct TrustedRouterModelCatalog: Sendable {
 }
 
 public struct TrustedRouterModelCatalogClient: Sendable {
+    private static let publicCatalogURL = URL(string: "https://trustedrouter.com/models")!
+    private static let publicCatalogExcludedModelIDs: Set<String> = [
+        "trustedrouter/synth",
+        "trustedrouter/synth-code",
+        "trustedrouter/fusion-code"
+    ]
+
     public var apiKey: String?
     public var baseURL: String
     public var urlSession: URLSession
@@ -61,6 +68,19 @@ public struct TrustedRouterModelCatalogClient: Sendable {
     }
 
     public func fetch() async throws -> TrustedRouterModelCatalog {
+        if apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+            return try await fetchPublicCatalog(note: nil)
+        }
+        do {
+            return try await fetchAuthenticatedCatalog()
+        } catch {
+            return try await fetchPublicCatalog(
+                note: "Authenticated JSON catalog failed: \(String(describing: error))"
+            )
+        }
+    }
+
+    private func fetchAuthenticatedCatalog() async throws -> TrustedRouterModelCatalog {
         let client = try TrustedRouter(options: .init(apiKey: apiKey, baseUrl: baseURL, urlSession: urlSession))
         let data: Data = try await client.request(method: "GET", path: "/models")
         let response = try JSONDecoder().decode(TrustedRouterCatalogModelsResponse.self, from: data)
@@ -83,6 +103,64 @@ public struct TrustedRouterModelCatalogClient: Sendable {
         return TrustedRouterModelCatalog(models: models, status: .liveTrustedRouter())
     }
 
+    private func fetchPublicCatalog(note: String?) async throws -> TrustedRouterModelCatalog {
+        let (data, response) = try await urlSession.data(from: Self.publicCatalogURL)
+        if let response = response as? HTTPURLResponse,
+           !(200..<300).contains(response.statusCode) {
+            throw TrustedRouterPublicCatalogError.httpStatus(response.statusCode)
+        }
+        guard let html = String(data: data, encoding: .utf8) else {
+            throw TrustedRouterPublicCatalogError.invalidUTF8
+        }
+        let models = Self.publicCatalogModels(fromHTML: html)
+        guard !models.isEmpty else {
+            throw TrustedRouterPublicCatalogError.emptyCatalog
+        }
+        return TrustedRouterModelCatalog(
+            models: models,
+            status: .publicTrustedRouter(note: note)
+        )
+    }
+
+    static func publicCatalogModels(fromHTML html: String) -> [QuillCodeCore.ModelInfo] {
+        let pattern = #""url":"https://trustedrouter\.com/models/([^"]+)","name":"([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(html.startIndex..<html.endIndex, in: html)
+        var seen = Set<String>()
+        return regex.matches(in: html, range: range).compactMap { match in
+            guard match.numberOfRanges == 3,
+                  let idRange = Range(match.range(at: 1), in: html),
+                  let nameRange = Range(match.range(at: 2), in: html) else {
+                return nil
+            }
+            let id = Self.jsonStringFragment(String(html[idRange]))
+            let displayName = Self.jsonStringFragment(String(html[nameRange]))
+            let canonicalID = TrustedRouterDefaults.canonicalModelID(id)
+            guard canonicalID.contains("/"),
+                  !Self.publicCatalogExcludedModelIDs.contains(canonicalID),
+                  seen.insert(canonicalID).inserted else {
+                return nil
+            }
+            let provider = Self.provider(from: canonicalID)
+            return QuillCodeCore.ModelInfo(
+                id: canonicalID,
+                provider: provider,
+                displayName: displayName.isEmpty ? Self.displayName(from: canonicalID) : displayName,
+                category: Self.category(for: canonicalID, provider: provider)
+            )
+        }
+    }
+
+    private static func jsonStringFragment(_ value: String) -> String {
+        let data = Data("\"\(value)\"".utf8)
+        if let decoded = try? JSONDecoder().decode(String.self, from: data) {
+            return decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return value
+            .replacingOccurrences(of: #"\/"#, with: "/")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     public static func provider(from modelID: String) -> String {
         TrustedRouterDefaults.provider(fromModelID: modelID)
     }
@@ -93,6 +171,23 @@ public struct TrustedRouterModelCatalogClient: Sendable {
 
     public static func category(for modelID: String, provider: String) -> String {
         TrustedRouterDefaults.category(forModelID: modelID, provider: provider)
+    }
+}
+
+private enum TrustedRouterPublicCatalogError: Error, CustomStringConvertible {
+    case httpStatus(Int)
+    case invalidUTF8
+    case emptyCatalog
+
+    var description: String {
+        switch self {
+        case .httpStatus(let statusCode):
+            return "TrustedRouter public catalog returned HTTP \(statusCode)."
+        case .invalidUTF8:
+            return "TrustedRouter public catalog was not UTF-8."
+        case .emptyCatalog:
+            return "TrustedRouter public catalog did not contain any model rows."
+        }
     }
 }
 

--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -4,6 +4,10 @@ import QuillCodeCore
 import QuillCodePersistence
 import QuillCodeSafety
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 public enum QuillCodeRuntimeMode: String, Codable, Sendable, Hashable {
     case mock
     case trustedRouter
@@ -37,13 +41,16 @@ public struct QuillCodeRuntime: Sendable {
 public struct QuillCodeRuntimeFactory: Sendable {
     public var paths: QuillCodePaths
     public var environment: [String: String]
+    public var modelCatalogURLSession: URLSession
 
     public init(
         paths: QuillCodePaths = QuillCodePaths(),
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        modelCatalogURLSession: URLSession = .shared
     ) {
         self.paths = paths
         self.environment = environment
+        self.modelCatalogURLSession = modelCatalogURLSession
     }
 
     public func makeRuntime(config: AppConfig) -> QuillCodeRuntime {
@@ -135,13 +142,11 @@ public struct QuillCodeRuntimeFactory: Sendable {
             return TrustedRouterModelCatalog()
         }
         let key = configuredAPIKey() ?? (try? sessionStore().apiKey())
-        guard key?.isEmpty == false else {
-            return TrustedRouterModelCatalog()
-        }
         do {
             return try await TrustedRouterModelCatalogClient(
                 apiKey: key,
-                baseURL: config.apiBaseURL
+                baseURL: config.apiBaseURL,
+                urlSession: modelCatalogURLSession
             ).fetch()
         } catch {
             return TrustedRouterModelCatalog(status: .fallbackAfterFailure(String(describing: error)))
@@ -164,7 +169,23 @@ public struct QuillCodeRuntimeFactory: Sendable {
         if let key, !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return key
         }
+        if let key = configuredAPIKeyFileContents() {
+            return key
+        }
         return nil
+    }
+
+    private func configuredAPIKeyFileContents() -> String? {
+        let explicitPath = environment["QUILLCODE_API_KEY_FILE"] ?? environment["QUILLCODE_LIVE_KEY_FILE"]
+        let fileURL: URL
+        if let explicitPath, !explicitPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            fileURL = URL(fileURLWithPath: explicitPath.expandingTildeInPath)
+        } else {
+            fileURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".quill.code.keyfile")
+        }
+        guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else { return nil }
+        let key = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        return key.isEmpty ? nil : key
     }
 
     private func sessionStore() -> SecretTrustedRouterSessionStore {
@@ -181,5 +202,11 @@ public struct QuillCodeRuntimeFactory: Sendable {
             mode: .mock,
             statusLabel: status
         )
+    }
+}
+
+private extension String {
+    var expandingTildeInPath: String {
+        NSString(string: self).expandingTildeInPath
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceModelCatalogRefreshPolicy.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelCatalogRefreshPolicy.swift
@@ -18,11 +18,12 @@ public struct WorkspaceModelCatalogRefreshPolicy: Sendable, Hashable {
         hasTrustedRouterAPIKey: Bool,
         now: Date = Date()
     ) -> Bool {
-        guard hasTrustedRouterAPIKey else { return false }
         switch status.source {
         case .bundled:
             return true
         case .liveTrustedRouter:
+            return hasTrustedRouterAPIKey && isStale(status.fetchedAt, now: now, threshold: staleAfter)
+        case .publicTrustedRouter:
             return isStale(status.fetchedAt, now: now, threshold: staleAfter)
         case .fallbackAfterFailure:
             return isStale(status.fetchedAt, now: now, threshold: retryAfterFailure)

--- a/Sources/QuillCodeCore/ModelCatalogStatus.swift
+++ b/Sources/QuillCodeCore/ModelCatalogStatus.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum ModelCatalogSource: String, Codable, Sendable, Hashable {
     case bundled
     case liveTrustedRouter
+    case publicTrustedRouter
     case fallbackAfterFailure
 }
 
@@ -27,6 +28,13 @@ public struct ModelCatalogStatus: Codable, Sendable, Hashable {
         ModelCatalogStatus(source: .liveTrustedRouter, fetchedAt: fetchedAt)
     }
 
+    public static func publicTrustedRouter(
+        fetchedAt: Date = Date(),
+        note: String? = nil
+    ) -> ModelCatalogStatus {
+        ModelCatalogStatus(source: .publicTrustedRouter, fetchedAt: fetchedAt, failureMessage: note)
+    }
+
     public static func fallbackAfterFailure(
         _ failureMessage: String?,
         fetchedAt: Date = Date()
@@ -44,6 +52,8 @@ public struct ModelCatalogStatus: Codable, Sendable, Hashable {
             return "Bundled catalog"
         case .liveTrustedRouter:
             return "Live TrustedRouter catalog · \(freshnessLabel(now: now, staleAfter: staleAfter))"
+        case .publicTrustedRouter:
+            return "Public TrustedRouter catalog · \(freshnessLabel(now: now, staleAfter: staleAfter))"
         case .fallbackAfterFailure:
             return "Bundled fallback · refresh failed"
         }
@@ -55,6 +65,9 @@ public struct ModelCatalogStatus: Codable, Sendable, Hashable {
             return "Using QuillCode's built-in recommended models until TrustedRouter sign-in refreshes the catalog."
         case .liveTrustedRouter:
             return "Provider, pricing, modality, and health metadata last refreshed \(freshnessLabel(now: now, staleAfter: staleAfter))."
+        case .publicTrustedRouter:
+            let suffix = failureMessage.map { " \($0)" } ?? ""
+            return "Loaded the public TrustedRouter model catalog \(freshnessLabel(now: now, staleAfter: staleAfter)).\(suffix)"
         case .fallbackAfterFailure:
             let suffix = failureMessage.map { ": \($0)" } ?? "."
             return "The latest TrustedRouter model refresh failed\(suffix)"

--- a/Tests/QuillCodeAgentTests/TrustedRouterModelCatalogTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterModelCatalogTests.swift
@@ -134,6 +134,70 @@ final class TrustedRouterModelCatalogTests: XCTestCase {
         XCTAssertNil(brokenModel.capabilities.releaseDate)
     }
 
+    func testPublicCatalogParserIncludesMiniMaxAndExcludesSyntheticRoutes() throws {
+        let html = """
+        <script type="application/ld+json">
+        {"@type":"ItemList","itemListElement":[
+        {"url":"https://trustedrouter.com/models/minimax/minimax-m3","name":"MiniMax M3"},
+        {"url":"https://trustedrouter.com/models/minimax/minimax-m3","name":"MiniMax M3 Duplicate"},
+        {"url":"https://trustedrouter.com/models/trustedrouter/synth","name":"Synth"},
+        {"url":"https://trustedrouter.com/models/trustedrouter/synth-code","name":"Synth Code"},
+        {"url":"https://trustedrouter.com/models/trustedrouter/fusion-code","name":"Fusion Code"},
+        {"url":"https://trustedrouter.com/models/z-ai/glm-5.2","name":"GLM 5.2"}
+        ]}
+        </script>
+        """
+
+        let models = TrustedRouterModelCatalogClient.publicCatalogModels(fromHTML: html)
+
+        let miniMax = try XCTUnwrap(models.first { $0.id == "minimax/minimax-m3" })
+        XCTAssertEqual(miniMax.displayName, "MiniMax M3")
+        XCTAssertEqual(miniMax.provider, "minimax")
+        XCTAssertEqual(miniMax.category, "minimax")
+        XCTAssertEqual(models.filter { $0.id == "minimax/minimax-m3" }.count, 1)
+        XCTAssertTrue(models.contains { $0.id == "z-ai/glm-5.2" })
+        XCTAssertFalse(models.contains { $0.id == "trustedrouter/synth" })
+        XCTAssertFalse(models.contains { $0.id == "trustedrouter/synth-code" })
+        XCTAssertFalse(models.contains { $0.id == "trustedrouter/fusion-code" })
+    }
+
+    func testCatalogFetchFallsBackToPublicTrustedRouterCatalogWhenJSONEndpointFails() async throws {
+        ModelCatalogURLProtocol.handler = { request in
+            if request.url?.host == "api.trustedrouter.test" {
+                XCTAssertEqual(request.url?.path, "/v1/models")
+                return (
+                    HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!,
+                    Data(#"{"error":{"message":"route not found"}}"#.utf8)
+                )
+            }
+            XCTAssertEqual(request.url?.absoluteString, "https://trustedrouter.com/models")
+            return (
+                HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                Data("""
+                <script type="application/ld+json">
+                {"@type":"ItemList","itemListElement":[
+                {"url":"https://trustedrouter.com/models/minimax/minimax-m3","name":"MiniMax M3"},
+                {"url":"https://trustedrouter.com/models/openai/gpt-5.5","name":"GPT 5.5"}
+                ]}
+                </script>
+                """.utf8)
+            )
+        }
+        let client = TrustedRouterModelCatalogClient(
+            apiKey: "sk-test",
+            baseURL: "https://api.trustedrouter.test/v1",
+            urlSession: ModelCatalogURLProtocol.session()
+        )
+
+        let catalog = try await client.fetch()
+
+        XCTAssertEqual(catalog.status.source, .publicTrustedRouter)
+        XCTAssertTrue(catalog.status.failureMessage?.contains("Authenticated JSON catalog failed") == true)
+        XCTAssertTrue(catalog.models.contains { $0.id == "minimax/minimax-m3" })
+        XCTAssertTrue(catalog.models.contains { $0.id == "openai/gpt-5.5" })
+        XCTAssertEqual(catalog.models.prefix(TrustedRouterDefaults.recommendedModelIDs.count).map(\.id), TrustedRouterDefaults.recommendedModelIDs)
+    }
+
     func testNormalizedCatalogBackfillsLiveCapabilitiesIntoBundledEntries() throws {
         // The bundled curated entries (empty capabilities) dedup-shadow same-canonical-ID live rows.
         // The live row's capabilities must be backfilled, or canonical models — including the default

--- a/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
@@ -159,7 +159,13 @@ final class WorkspaceConfigurationIntegrationTests: XCTestCase {
 
     func testBootstrapPersistsAndClearsTrustedRouterAPIKey() throws {
         let paths = QuillCodePaths(home: try makeTempDirectory())
-        let bootstrap = QuillCodeWorkspaceBootstrap(paths: paths)
+        let bootstrap = QuillCodeWorkspaceBootstrap(
+            paths: paths,
+            runtimeFactory: QuillCodeRuntimeFactory(
+                paths: paths,
+                environment: ["QUILLCODE_API_KEY_FILE": paths.home.appendingPathComponent("missing.key").path]
+            )
+        )
 
         XCTAssertFalse(bootstrap.hasTrustedRouterAPIKey())
         try bootstrap.saveTrustedRouterAPIKey("  sk-tr-v1-test  ")

--- a/Tests/QuillCodeAppTests/WorkspaceModelCatalogRefreshPolicyTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceModelCatalogRefreshPolicyTests.swift
@@ -5,16 +5,21 @@ import QuillCodeCore
 final class WorkspaceModelCatalogRefreshPolicyTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 2_000)
 
-    func testDoesNotRefreshWithoutTrustedRouterKey() {
+    func testRefreshesBundledAndPublicCatalogsWithoutTrustedRouterKey() {
         let policy = WorkspaceModelCatalogRefreshPolicy()
 
-        XCTAssertFalse(policy.shouldRefresh(
+        XCTAssertTrue(policy.shouldRefresh(
             status: .bundled,
             hasTrustedRouterAPIKey: false,
             now: now
         ))
         XCTAssertFalse(policy.shouldRefresh(
             status: .liveTrustedRouter(fetchedAt: now.addingTimeInterval(-7_200)),
+            hasTrustedRouterAPIKey: false,
+            now: now
+        ))
+        XCTAssertTrue(policy.shouldRefresh(
+            status: .publicTrustedRouter(fetchedAt: now.addingTimeInterval(-7_200)),
             hasTrustedRouterAPIKey: false,
             now: now
         ))
@@ -43,6 +48,16 @@ final class WorkspaceModelCatalogRefreshPolicyTests: XCTestCase {
             hasTrustedRouterAPIKey: true,
             now: now
         ))
+        XCTAssertFalse(policy.shouldRefresh(
+            status: .publicTrustedRouter(fetchedAt: now.addingTimeInterval(-59)),
+            hasTrustedRouterAPIKey: false,
+            now: now
+        ))
+        XCTAssertTrue(policy.shouldRefresh(
+            status: .publicTrustedRouter(fetchedAt: now.addingTimeInterval(-60)),
+            hasTrustedRouterAPIKey: false,
+            now: now
+        ))
     }
 
     func testRetriesFailedRefreshAfterShortBackoff() {
@@ -69,6 +84,11 @@ final class WorkspaceModelCatalogRefreshPolicyTests: XCTestCase {
             now: now
         ))
         XCTAssertTrue(policy.shouldRefresh(
+            status: ModelCatalogStatus(source: .publicTrustedRouter),
+            hasTrustedRouterAPIKey: false,
+            now: now
+        ))
+        XCTAssertTrue(policy.shouldRefresh(
             status: ModelCatalogStatus(source: .fallbackAfterFailure, failureMessage: "timeout"),
             hasTrustedRouterAPIKey: true,
             now: now
@@ -79,6 +99,11 @@ final class WorkspaceModelCatalogRefreshPolicyTests: XCTestCase {
         XCTAssertTrue(WorkspaceModelCatalogRefreshPolicy(staleAfter: -Double.infinity).shouldRefresh(
             status: .liveTrustedRouter(fetchedAt: now),
             hasTrustedRouterAPIKey: true,
+            now: now
+        ))
+        XCTAssertTrue(WorkspaceModelCatalogRefreshPolicy(staleAfter: -Double.infinity).shouldRefresh(
+            status: .publicTrustedRouter(fetchedAt: now),
+            hasTrustedRouterAPIKey: false,
             now: now
         ))
         XCTAssertTrue(WorkspaceModelCatalogRefreshPolicy(retryAfterFailure: Double.nan).shouldRefresh(
@@ -94,6 +119,11 @@ final class WorkspaceModelCatalogRefreshPolicyTests: XCTestCase {
         XCTAssertFalse(policy.shouldRefresh(
             status: .liveTrustedRouter(fetchedAt: now.addingTimeInterval(1)),
             hasTrustedRouterAPIKey: true,
+            now: now
+        ))
+        XCTAssertFalse(policy.shouldRefresh(
+            status: .publicTrustedRouter(fetchedAt: now.addingTimeInterval(1)),
+            hasTrustedRouterAPIKey: false,
             now: now
         ))
         XCTAssertFalse(policy.shouldRefresh(

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeFactoryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeFactoryTests.swift
@@ -3,7 +3,16 @@ import QuillCodeCore
 import QuillCodePersistence
 @testable import QuillCodeApp
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 final class WorkspaceRuntimeFactoryTests: XCTestCase {
+    override func tearDown() {
+        RuntimeFactoryCatalogURLProtocol.reset()
+        super.tearDown()
+    }
+
     func testUsesTrustedRouterWhenEnvironmentKeyExists() throws {
         let paths = QuillCodePaths(home: try makeQuillCodeTestDirectory())
         try paths.ensure()
@@ -28,6 +37,21 @@ final class WorkspaceRuntimeFactoryTests: XCTestCase {
         )
 
         XCTAssertTrue(runtimeFactory.hasTrustedRouterAPIKey())
+    }
+
+    func testKeyFileCountsAsTrustedRouterCredential() throws {
+        let paths = QuillCodePaths(home: try makeQuillCodeTestDirectory())
+        try paths.ensure()
+        let keyFile = paths.home.appendingPathComponent("trustedrouter.key")
+        try "sk-test-from-file\n".write(to: keyFile, atomically: true, encoding: .utf8)
+
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_API_KEY_FILE": keyFile.path]
+        )
+
+        XCTAssertTrue(runtimeFactory.hasTrustedRouterAPIKey())
+        XCTAssertEqual(runtimeFactory.makeRuntime(config: AppConfig()).mode, .trustedRouter)
     }
 
     func testUsesTrustedRouterWhenSecretExists() throws {
@@ -63,17 +87,73 @@ final class WorkspaceRuntimeFactoryTests: XCTestCase {
         XCTAssertFalse(runtime.contextSummaryGenerator.isModelBacked)
     }
 
-    func testModelCatalogFallsBackWithoutKey() async throws {
+    func testModelCatalogFetchesPublicCatalogWithoutKey() async throws {
         let paths = QuillCodePaths(home: try makeQuillCodeTestDirectory())
         try paths.ensure()
+        RuntimeFactoryCatalogURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://trustedrouter.com/models")
+            return (
+                HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                Data("""
+                <script type="application/ld+json">
+                {"@type":"ItemList","itemListElement":[
+                {"url":"https://trustedrouter.com/models/minimax/minimax-m3","name":"MiniMax M3"},
+                {"url":"https://trustedrouter.com/models/anthropic/claude-sonnet-5","name":"Claude Sonnet 5"}
+                ]}
+                </script>
+                """.utf8)
+            )
+        }
 
-        let catalog = await QuillCodeRuntimeFactory(paths: paths, environment: [:])
-            .fetchModelCatalog(config: AppConfig())
+        let catalog = await QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_API_KEY_FILE": paths.home.appendingPathComponent("missing.key").path],
+            modelCatalogURLSession: RuntimeFactoryCatalogURLProtocol.session()
+        ).fetchModelCatalog(config: AppConfig())
 
         XCTAssertEqual(catalog.defaultModelID, TrustedRouterDefaults.defaultModel)
-        XCTAssertEqual(catalog.status.source, .bundled)
+        XCTAssertEqual(catalog.status.source, .publicTrustedRouter)
         XCTAssertTrue(catalog.models.contains { $0.id == "trustedrouter/fast" })
         XCTAssertTrue(catalog.models.contains { $0.id == TrustedRouterDefaults.prometheusModel })
-        XCTAssertTrue(catalog.models.contains { $0.id == "z-ai/glm-5.2" })
+        XCTAssertTrue(catalog.models.contains { $0.id == "minimax/minimax-m3" })
     }
+}
+
+private final class RuntimeFactoryCatalogURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RuntimeFactoryCatalogURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    static func reset() {
+        handler = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/Tests/QuillCodeCoreTests/ModelCatalogCoreTests.swift
+++ b/Tests/QuillCodeCoreTests/ModelCatalogCoreTests.swift
@@ -232,6 +232,10 @@ final class ModelCatalogCoreTests: XCTestCase {
         let immediate = ModelCatalogStatus.liveTrustedRouter(fetchedAt: now.addingTimeInterval(-30))
         let fresh = ModelCatalogStatus.liveTrustedRouter(fetchedAt: now.addingTimeInterval(-120))
         let stale = ModelCatalogStatus.liveTrustedRouter(fetchedAt: now.addingTimeInterval(-7_200))
+        let publicCatalog = ModelCatalogStatus.publicTrustedRouter(
+            fetchedAt: now.addingTimeInterval(-120),
+            note: "Authenticated JSON catalog failed."
+        )
         let fallback = ModelCatalogStatus.fallbackAfterFailure(
             "  HTTP 500\nprovider down  ",
             fetchedAt: now
@@ -240,6 +244,11 @@ final class ModelCatalogCoreTests: XCTestCase {
         XCTAssertEqual(immediate.statusLabel(now: now), "Live TrustedRouter catalog · just now")
         XCTAssertEqual(fresh.statusLabel(now: now), "Live TrustedRouter catalog · 2m ago")
         XCTAssertEqual(stale.statusLabel(now: now), "Live TrustedRouter catalog · stale 2h ago")
+        XCTAssertEqual(publicCatalog.statusLabel(now: now), "Public TrustedRouter catalog · 2m ago")
+        XCTAssertEqual(
+            publicCatalog.detailLabel(now: now),
+            "Loaded the public TrustedRouter model catalog 2m ago. Authenticated JSON catalog failed."
+        )
         XCTAssertEqual(fallback.statusLabel(now: now), "Bundled fallback · refresh failed")
         XCTAssertEqual(
             fallback.detailLabel(now: now),

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopModelCatalogRefreshCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopModelCatalogRefreshCoordinatorTests.swift
@@ -46,7 +46,7 @@ final class QuillCodeDesktopModelCatalogRefreshCoordinatorTests: XCTestCase {
         XCTAssertEqual(refreshCount, 1)
     }
 
-    func testRefreshDoesNotFetchWithoutTrustedRouterKey() async throws {
+    func testRefreshFetchesPublicCatalogWithoutTrustedRouterKey() async throws {
         let paths = QuillCodePaths(home: try makeTempDirectory())
         try paths.ensure()
         let recorder = CatalogFetchRecorder()
@@ -67,9 +67,9 @@ final class QuillCodeDesktopModelCatalogRefreshCoordinatorTests: XCTestCase {
         await coordinator.refreshIfNeeded(on: model, refresh: { refreshCount += 1 })
 
         let fetchCount = await recorder.fetchCount()
-        XCTAssertEqual(fetchCount, 0)
-        XCTAssertEqual(refreshCount, 0)
-        XCTAssertEqual(model.root.modelCatalogStatus.source, .bundled)
+        XCTAssertEqual(fetchCount, 1)
+        XCTAssertEqual(refreshCount, 1)
+        XCTAssertEqual(model.root.modelCatalogStatus.source, .liveTrustedRouter)
     }
 
     private func makeTempDirectory() throws -> URL {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,13 @@
 # QuillCode Decisions
 
+## 2026-07-04
+
+- Model discovery should remain useful even when TrustedRouter's authenticated `/v1/models` endpoint is unavailable or
+  the user has not signed in yet. `TrustedRouterModelCatalogClient` now falls back to the public TrustedRouter model
+  catalog page, preserving the branded Recommended defaults while adding provider rows such as MiniMax to picker search.
+  The desktop runtime also reads `~/.quill.code.keyfile` and explicit key-file environment variables for local smoke
+  testing, so a developer can chat live and refresh the model catalog without re-entering credentials in Settings.
+
 ## 2026-07-02
 
 - Context summary progress is derived from thread notices instead of stored as a separate workspace flag.


### PR DESCRIPTION
## Summary
- fall back to the public TrustedRouter model catalog when authenticated /v1/models is unavailable or no key is configured
- read local TrustedRouter key files for desktop smoke testing, including ~/.quill.code.keyfile
- add MiniMax coverage in Swift catalog tests and the Playwright model picker harness

## Verification
- swift test --filter 'WorkspaceConfigurationIntegrationTests/testBootstrapPersistsAndClearsTrustedRouterAPIKey|TrustedRouterModelCatalogTests|WorkspaceRuntimeFactoryTests|WorkspaceModelCatalogRefreshPolicyTests|QuillCodeDesktopModelCatalogRefreshCoordinatorTests|ModelCatalogCoreTests'
- swift test --quiet
- npx playwright test tests/model-picker.spec.ts
- scripts/build-macos-app.sh --configuration debug
