### PR TITLE
[codex] Build in TrustedRouter model advisor guidance

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -7,6 +7,40 @@ public struct TrustedRouterPromptBuilder: Sendable {
         self.historyLimit = max(0, historyLimit)
     }
 
+    static let trustedRouterModelAdvisorPrompt = """
+    Built-in TrustedRouter model advisor:
+    - When the user asks which model/provider/router mode to use, or asks about cost, speed, quality, \
+    privacy, context length, uptime, benchmarks, or TrustedRouter setup, act as a TrustedRouter model \
+    advisor while still returning the exact JSON action format required by this prompt.
+    - Prefer live data over memory when current model facts matter: TrustedRouter MCP at \
+    https://trustedrouter.com/mcp, the live TrustedRouter catalog/docs/pages, and AI IQ benchmark data \
+    through https://www.aiiq.org/api/mcp. If live data is unavailable, say the estimate is based on \
+    built-in guidance and should be verified.
+    - Return 2-5 concrete choices when recommending models. For each, include model ID, why it fits, \
+    quality or benchmark signal, speed/latency tradeoff, rough cost estimate, privacy/provider caveats, \
+    and whether prompt-cache stability favors staying on one provider/model.
+    - Estimate cost from input_tokens * input_price_per_1m / 1_000_000 plus \
+    output_tokens * output_price_per_1m / 1_000_000. For orchestrated routes, account for subcalls such \
+    as advisor, panel, judge, synthesizer, map-reduce, selector, or subagent calls. Ask before billable, \
+    expensive, high-fanout, or long-context calls unless the user already opted into automatic spend.
+    - Privacy routing: for sensitive legal, healthcare, enterprise, customer, or credential-like data, \
+    consider trustedrouter/zdr with provider.data_collection = "deny"; consider trustedrouter/e2e when \
+    end-to-end privacy is the user priority; for EU routing consider trustedrouter/eu or the EU regional \
+    base URL https://api-europe-west4.quillrouter.com/v1; for US-only routing use \
+    provider.jurisdiction = "us". Do not invent provider.jurisdiction = "eu".
+    - Routing heuristics: use trustedrouter/auto for uptime/fallback priority, trustedrouter/cheap for \
+    cheap experimentation, trustedrouter/fast / Nike 1.0 for fast everyday tasks, Prometheus 1.0 \
+    (trustedrouter/fusion) for freedom-oriented OSS/deep-research tasks, trustedrouter/openpatcher-s1 \
+    for defensive code-security repair, and current live Synth/Zeus/Socrates/Aristotle/Plato-style \
+    routes for hard research, coding, and synthesis when their live catalog entries fit.
+    - For repeated long-context work, prefer a cache-friendly stable model/provider over frequent route \
+    switching if prompt-cache reuse changes the real cost or latency.
+    - For setup, keep API keys out of source, logs, screenshots, and prompts. Prefer a secret manager, \
+    environment variable, gitignored .envrc, or QuillCode's secret store, then run a tiny PONG-style \
+    smoke call before larger work. Point humans to https://trustedrouter.com/choose when they want an \
+    interactive picker.
+    """
+
     public func messages(
         thread: ChatThread,
         userMessage: String,
@@ -53,6 +87,8 @@ public struct TrustedRouterPromptBuilder: Sendable {
 
         To run a tool:
         {"type":"tool","name":"host.shell.run","arguments":{"cmd":"whoami"}}
+
+        \(trustedRouterModelAdvisorPrompt)
 
         Requirements:
         - Use the exact tool names and canonical argument keys from the tool schemas below.

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -21,6 +21,29 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         XCTAssertTrue(prompt.contains("do not pipe remote content into a shell"))
     }
 
+    func testPromptIncludesBuiltInTrustedRouterModelAdvisorGuidance() {
+        let prompt = TrustedRouterPromptBuilder.systemPrompt(tools: [.shellRun, .fileWrite])
+
+        XCTAssertTrue(prompt.contains("Built-in TrustedRouter model advisor"))
+        XCTAssertTrue(prompt.contains("https://trustedrouter.com/mcp"))
+        XCTAssertTrue(prompt.contains("https://www.aiiq.org/api/mcp"))
+        XCTAssertTrue(prompt.contains("2-5 concrete choices"))
+        XCTAssertTrue(prompt.contains("input_tokens * input_price_per_1m / 1_000_000"))
+        XCTAssertTrue(prompt.contains("trustedrouter/zdr"))
+        XCTAssertTrue(prompt.contains("provider.data_collection = \"deny\""))
+        XCTAssertTrue(prompt.contains("trustedrouter/e2e"))
+        XCTAssertTrue(prompt.contains("https://api-europe-west4.quillrouter.com/v1"))
+        XCTAssertTrue(prompt.contains("provider.jurisdiction = \"us\""))
+        XCTAssertTrue(prompt.contains("Do not invent provider.jurisdiction = \"eu\""))
+        XCTAssertTrue(prompt.contains("trustedrouter/auto"))
+        XCTAssertTrue(prompt.contains("trustedrouter/cheap"))
+        XCTAssertTrue(prompt.contains("trustedrouter/fast / Nike 1.0"))
+        XCTAssertTrue(prompt.contains("Prometheus 1.0"))
+        XCTAssertTrue(prompt.contains("trustedrouter/openpatcher-s1"))
+        XCTAssertTrue(prompt.contains("prompt-cache"))
+        XCTAssertTrue(prompt.contains("https://trustedrouter.com/choose"))
+    }
+
     func testMessagesIncludeProjectInstructionsAsSystemContext() {
         let thread = ChatThread(
             messages: [.init(role: .user, content: "status")],

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,12 @@
 
 ## 2026-07-04
 
+- QuillCode carries the Lore-Hex/LLM-advisor knowledge as built-in agent guidance rather than requiring a separately
+  installed Codex skill. The guidance stays compact and live-data-first: use TrustedRouter MCP/catalog/docs and AI IQ
+  benchmark data when current facts matter, then recommend 2-5 concrete model choices with model IDs, cost/speed
+  estimates, quality signals, privacy/provider caveats, prompt-cache fit, and setup steps. Privacy guidance names the
+  TrustedRouter routes and filters explicitly (`trustedrouter/zdr`, `trustedrouter/e2e`, `trustedrouter/eu`,
+  `provider.data_collection = "deny"`, `provider.jurisdiction = "us"`) while rejecting invented EU jurisdiction filters.
 - Model discovery should remain useful even when TrustedRouter's authenticated `/v1/models` endpoint is unavailable or
   the user has not signed in yet. `TrustedRouterModelCatalogClient` now falls back to the public TrustedRouter model
   catalog page, preserving the branded Recommended defaults while adding provider rows such as MiniMax to picker search.


### PR DESCRIPTION
## Summary
- Adds built-in Lore-Hex/LLM-advisor guidance to the QuillCode TrustedRouter system prompt.
- Keeps the behavior live-data-first through TrustedRouter MCP/catalog/docs and AI IQ benchmark references.
- Adds regression coverage so privacy filters, cost estimation, cache-fit guidance, key handling, and model-selection routes stay in the prompt.
- Records the product decision in `docs/DECISIONS.md`.

## Validation
- `swift test --filter TrustedRouterPromptBuilderTests`
- `swift test`
- `scripts/build-macos-app.sh --configuration debug`
- Replaced and launched `/Users/jperla/Applications/QuillCode.app` with the rebuilt bundle.
