### PR TITLE
Add prominent token budget meter

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -237,9 +237,15 @@
     .topbar-title-group {
       min-width: 0;
       display: flex;
-      align-items: baseline;
+      align-items: center;
       gap: 10px;
       text-align: left;
+    }
+    .topbar-title-copy {
+      flex: 1 1 220px;
+      min-width: 120px;
+      display: grid;
+      gap: 2px;
     }
     .topbar-branch-chip,
     .topbar-usage-chip,
@@ -258,8 +264,72 @@
       color: var(--green);
       background: rgba(66, 214, 119, 0.10);
     }
+    .topbar-token-budget {
+      flex: 0 0 min(260px, 28vw);
+      min-width: 210px;
+      display: grid;
+      gap: 5px;
+      padding: 7px 10px;
+      border-radius: 13px;
+      background: rgba(65, 184, 232, 0.11);
+      color: var(--text);
+      font-variant-numeric: tabular-nums;
+    }
+    .topbar-token-budget[data-tone="warning"] {
+      background: rgba(247, 184, 79, 0.13);
+    }
+    .topbar-token-budget[data-tone="critical"] {
+      background: rgba(255, 91, 82, 0.13);
+    }
+    .topbar-token-budget-row {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      min-width: 0;
+    }
+    .topbar-token-budget-label {
+      color: var(--muted);
+      font-size: 10px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+    .topbar-token-budget strong {
+      min-width: 0;
+      font-size: 12px;
+      font-weight: 800;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .topbar-token-budget-meter {
+      height: 4px;
+      overflow: hidden;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+    }
+    .topbar-token-budget-meter span {
+      display: block;
+      height: 100%;
+      border-radius: inherit;
+      background: var(--blue);
+    }
+    .topbar-token-budget[data-tone="warning"] .topbar-token-budget-meter span {
+      background: var(--yellow);
+    }
+    .topbar-token-budget[data-tone="critical"] .topbar-token-budget-meter span {
+      background: var(--red);
+    }
+    .topbar-token-budget p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 10px;
+      font-weight: 700;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     .topbar strong { font-size: 17px; }
-    .topbar-title-group strong {
+    .topbar-title-copy strong {
       flex: 0 1 auto;
       min-width: 0;
       overflow: hidden;
@@ -3641,6 +3711,7 @@
         subtitle: 'QuillCode - Not started',
         branchStatusLabel: null,
         usageStatusLabel: null,
+        tokenBudget: null,
         spendStatusLabel: null,
         spendStatusDetail: null,
         instructionLabel: '1 instruction file loaded',
@@ -4407,6 +4478,25 @@
       if (state.runtimeIssue?.severity === 'error') return 'error';
       if (state.runtimeIssue) return 'warning';
       return topBarStatusTone();
+    }
+
+    function renderTopBarTokenBudget() {
+      const budget = state.topBar.tokenBudget;
+      if (!budget) return '';
+      const usedPercent = Number(budget.usedPercent || 0);
+      const tone = usedPercent >= 100 ? 'critical' : usedPercent >= 80 ? 'warning' : 'normal';
+      const progressPercent = Math.max(0, Math.min(100, Number(budget.progressPercent || usedPercent || 0)));
+      return `
+        <section class="topbar-token-budget" data-testid="top-bar-token-budget" data-tone="${escapeHTML(tone)}" title="${escapeHTML(budget.detailLabel || '')}" aria-label="${escapeHTML(budget.detailLabel || '')}">
+          <div class="topbar-token-budget-row">
+            <span class="topbar-token-budget-label">Tokens</span>
+            <strong data-testid="top-bar-token-budget-primary">${escapeHTML(budget.primaryLabel || '')}</strong>
+          </div>
+          <div class="topbar-token-budget-meter" aria-hidden="true">
+            <span style="width: ${progressPercent}%"></span>
+          </div>
+          <p data-testid="top-bar-token-budget-secondary">${escapeHTML(budget.secondaryLabel || '')}</p>
+        </section>`;
     }
 
     function topBarOverflowTestID(commandID) {
@@ -6219,6 +6309,7 @@
       state.topBar.primaryTitle = 'QuillCode';
       state.topBar.subtitle = `${project.name} - Not started`;
       state.topBar.usageStatusLabel = null;
+      state.topBar.tokenBudget = null;
       state.topBar.spendStatusLabel = null;
       state.topBar.spendStatusDetail = null;
       emptyTranscriptSurface();
@@ -7539,11 +7630,14 @@
             </div>
             <div class="topbar-sidebar-slot">${topBarNavigation}</div>
             <div class="topbar-title-group" data-testid="top-bar-title-group">
-              <strong data-testid="top-bar-title">${escapeHTML(state.topBar.primaryTitle)}</strong>
-              <p class="topbar-context-label" data-testid="top-bar-subtitle">${escapeHTML(state.topBar.subtitle)}</p>
+              <div class="topbar-title-copy">
+                <strong data-testid="top-bar-title">${escapeHTML(state.topBar.primaryTitle)}</strong>
+                <p class="topbar-context-label" data-testid="top-bar-subtitle">${escapeHTML(state.topBar.subtitle)}</p>
+              </div>
               ${state.topBar.branchStatusLabel ? `<span class="topbar-branch-chip" data-testid="top-bar-branch" title="${escapeHTML(state.topBar.branchStatusLabel)}">${escapeHTML(state.topBar.branchStatusLabel)}</span>` : ''}
+              ${renderTopBarTokenBudget()}
               ${state.topBar.spendStatusLabel ? `<span class="topbar-spend-chip" data-testid="top-bar-spend" title="${escapeHTML(state.topBar.spendStatusDetail || state.topBar.spendStatusLabel)}">${escapeHTML(state.topBar.spendStatusLabel)}</span>` : ''}
-              ${!state.topBar.spendStatusLabel && state.topBar.usageStatusLabel ? `<span class="topbar-usage-chip" data-testid="top-bar-usage" title="${escapeHTML(state.topBar.usageStatusLabel)}">${escapeHTML(state.topBar.usageStatusLabel)}</span>` : ''}
+              ${!state.topBar.tokenBudget && !state.topBar.spendStatusLabel && state.topBar.usageStatusLabel ? `<span class="topbar-usage-chip" data-testid="top-bar-usage" title="${escapeHTML(state.topBar.usageStatusLabel)}">${escapeHTML(state.topBar.usageStatusLabel)}</span>` : ''}
             </div>
             <div class="topbar-clusters" data-testid="top-bar-clusters">
               <div class="topbar-cluster topbar-action-cluster" data-testid="top-bar-action-cluster">
@@ -10978,6 +11072,7 @@
       state.topBar.primaryTitle = 'QuillCode';
       // The usage chip is per-thread; a fresh thread has no usage until its first turn.
       state.topBar.usageStatusLabel = null;
+      state.topBar.tokenBudget = null;
       const selectedProject = state.projects.items.find(project => project.id === state.projects.selectedProjectID);
       state.topBar.subtitle = `${selectedProject?.name || 'No project'} - Not started`;
       recordWorkspaceNavigation(previousLocation);
@@ -15082,10 +15177,10 @@
       const halted = ['Failed', 'Stopped'].includes(state.topBar.agentStatus);
       if (!halted) {
         state.topBar.agentStatus = 'Idle';
-        // Mirrors native: the model reports token usage at the end of a turn, surfaced as
-        // the quiet top-bar usage chip. The chip is derived per-thread, so a fresh thread
-        // shows nothing until its first turn completes.
+        // Mirrors native: model usage is attached at turn end, then surfaced as a prominent
+        // per-thread token budget meter. A fresh thread stays empty until its first turn.
         state.topBar.usageStatusLabel = mockTokenUsageLabel();
+        state.topBar.tokenBudget = mockTokenBudget();
       }
       syncSelectedThreadSearchText();
       // Drain the next queued follow-up as the next turn — but only after a turn that finished
@@ -15114,9 +15209,7 @@
       return trim(Math.round((value / 1000000) * 10) / 10) + 'm';
     }
 
-    // A mock per-thread token-usage label estimated from the transcript (chars/4), formatted
-    // exactly like WorkspaceTokenUsageLabelBuilder.label (Swift): "<ctx> ctx · ↑<in> ↓<out>".
-    function mockTokenUsageLabel() {
+    function mockTokenCounts() {
       let prompt = 0;
       let completion = 0;
       for (const item of transcriptTimelineItems()) {
@@ -15128,8 +15221,46 @@
           prompt += Math.ceil((transcriptCopyText(item) || '').length / 4);
         }
       }
-      if (prompt + completion === 0) return null;
-      return `${abbreviateTokens(prompt + completion)} ctx · ↑${abbreviateTokens(prompt)} ↓${abbreviateTokens(completion)}`;
+      return { prompt, completion, total: prompt + completion };
+    }
+
+    // A mock per-thread token-usage label estimated from the transcript (chars/4), formatted
+    // exactly like WorkspaceTokenUsageLabelBuilder.label (Swift): "<ctx> ctx · ↑<in> ↓<out>".
+    function mockTokenUsageLabel() {
+      const counts = mockTokenCounts();
+      if (counts.total === 0) return null;
+      return `${abbreviateTokens(counts.total)} ctx · ↑${abbreviateTokens(counts.prompt)} ↓${abbreviateTokens(counts.completion)}`;
+    }
+
+    function decimalTokens(count) {
+      return String(Math.max(0, count)).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+
+    function selectedModelContextWindowTokens() {
+      const selectedModel = state.topBar.modelCategories
+        .flatMap(category => category.models || [])
+        .find(model => model.id === state.topBar.selectedModelID);
+      const tokens = selectedModel?.capabilities?.contextWindowTokens;
+      return Number.isFinite(tokens) && tokens > 0 ? tokens : 32000;
+    }
+
+    function mockTokenBudget() {
+      const counts = mockTokenCounts();
+      if (counts.total === 0) return null;
+      const limit = selectedModelContextWindowTokens();
+      const remaining = Math.max(0, limit - counts.total);
+      const usedPercent = Math.max(0, Math.round((counts.total / limit) * 100));
+      return {
+        usedTokens: counts.total,
+        limitTokens: limit,
+        remainingTokens: remaining,
+        usedPercent,
+        progressPercent: Math.max(0, Math.min(100, usedPercent)),
+        primaryLabel: `${abbreviateTokens(counts.total)} / ${abbreviateTokens(limit)} tokens`,
+        secondaryLabel: `${abbreviateTokens(remaining)} left · ${usedPercent}% · estimated`,
+        detailLabel: `Estimated token budget: ${decimalTokens(counts.total)} used of ${decimalTokens(limit)} · ${decimalTokens(remaining)} left · ${usedPercent}% used`,
+        sourceLabel: 'Estimated'
+      };
     }
 
     function completeMockAgentTurn(text) {

--- a/E2E/playwright/tests/core.spec.ts
+++ b/E2E/playwright/tests/core.spec.ts
@@ -86,6 +86,9 @@ test('mock harness executes simple command flow', async ({ page }) => {
   await expect(page.getByTestId('sidebar-item')).toContainText('z-ai/GLM 5.2');
   await expect(page.getByTestId('top-bar-title')).toHaveText('run whoami');
   await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode - Auto');
+  await expect(page.getByTestId('top-bar-token-budget')).toBeVisible();
+  await expect(page.getByTestId('top-bar-token-budget-primary')).toContainText(/\/ .* tokens/);
+  await expect(page.getByTestId('top-bar-token-budget-secondary')).toContainText(/left/);
   await expect(page.getByTestId('tool-card-title')).toHaveText('host.shell.run');
   await expect(page.getByTestId('tool-card')).toHaveAttribute('data-status', 'done');
   await expect(page.getByTestId('tool-card-subtitle')).toHaveText('Completed · whoami');

--- a/E2E/playwright/tests/status.spec.ts
+++ b/E2E/playwright/tests/status.spec.ts
@@ -57,23 +57,27 @@ test('mock harness surfaces the branch and ahead/behind chip after a git status'
   await expect(page.getByTestId('top-bar-branch')).toHaveCount(0);
 });
 
-test('mock harness surfaces the token-usage chip after a turn completes', async ({ page }) => {
+test('mock harness surfaces the prominent token budget meter after a turn completes', async ({ page }) => {
   await page.goto(harnessURL());
 
-  // No usage chip until a turn reports usage.
+  // No token budget meter until a thread exists and a turn reports usage.
+  await expect(page.getByTestId('top-bar-token-budget')).toHaveCount(0);
   await expect(page.getByTestId('top-bar-usage')).toHaveCount(0);
 
   await page.getByLabel('Message').fill('Run the tests');
   await page.getByRole('button', { name: 'Send' }).click();
 
-  await expect(page.getByTestId('top-bar-usage')).toBeVisible();
-  await expect(page.getByTestId('top-bar-usage')).toContainText('ctx');
-  await expect(page.getByTestId('top-bar-usage')).toContainText('↑');
+  await expect(page.getByTestId('top-bar-token-budget')).toBeVisible();
+  await expect(page.getByTestId('top-bar-token-budget-primary')).toContainText(/\/ .* tokens/);
+  await expect(page.getByTestId('top-bar-token-budget-secondary')).toContainText('left');
+  await expect(page.getByTestId('top-bar-token-budget-secondary')).toContainText('%');
+  await expect(page.getByTestId('top-bar-usage')).toHaveCount(0);
   // Additive: the existing subtitle is unchanged.
   await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode');
 
-  // The chip is per-thread, so a fresh thread shows nothing until its own first turn.
+  // The meter is per-thread, so a fresh thread shows nothing until its own first turn.
   await page.getByTestId('new-chat-button').click();
+  await expect(page.getByTestId('top-bar-token-budget')).toHaveCount(0);
   await expect(page.getByTestId('top-bar-usage')).toHaveCount(0);
 });
 

--- a/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
@@ -4,32 +4,43 @@ struct QuillCodeTopBarIdentityView: View {
     var topBar: TopBarSurface
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Text(topBar.primaryTitle)
-                .font(.headline.weight(.semibold))
-                .foregroundStyle(QuillCodePalette.text)
-                .lineLimit(1)
-                .truncationMode(.tail)
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(topBar.primaryTitle)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.text)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 
-            Text(topBar.subtitle)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(QuillCodePalette.muted)
-                .lineLimit(1)
-                .truncationMode(.middle)
+                Text(topBar.subtitle)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .layoutPriority(2)
 
             if let branchStatusLabel = topBar.branchStatusLabel {
                 statusChip(branchStatusLabel)
                     .accessibilityHidden(true)
             }
 
+            if let tokenBudget = topBar.tokenBudget {
+                tokenBudgetView(tokenBudget)
+                    .help(tokenBudget.detailLabel)
+                    .accessibilityLabel(tokenBudget.detailLabel)
+                    .layoutPriority(1)
+            } else if topBar.spendStatusLabel == nil,
+                      let usageStatusLabel = topBar.usageStatusLabel {
+                statusChip(usageStatusLabel)
+                    .help(usageStatusLabel)
+                    .accessibilityLabel("Token usage: \(usageStatusLabel)")
+            }
+
             if let spendStatusLabel = topBar.spendStatusLabel {
                 statusChip(spendStatusLabel, tint: QuillCodePalette.green)
                     .help(topBar.spendStatusDetail ?? spendStatusLabel)
                     .accessibilityLabel("Thread spend: \(spendStatusLabel)")
-            } else if let usageStatusLabel = topBar.usageStatusLabel {
-                statusChip(usageStatusLabel)
-                    .help(usageStatusLabel)
-                    .accessibilityLabel("Token usage: \(usageStatusLabel)")
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -47,5 +58,51 @@ struct QuillCodeTopBarIdentityView: View {
                 RoundedRectangle(cornerRadius: 7, style: .continuous)
                     .fill(tint.opacity(0.10))
             )
+    }
+
+    private func tokenBudgetView(_ budget: TokenBudgetSurface) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Tokens")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .textCase(.uppercase)
+                Text(budget.primaryLabel)
+                    .font(.caption.monospacedDigit().weight(.bold))
+                    .foregroundStyle(QuillCodePalette.text)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+            }
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(QuillCodePalette.panel.opacity(0.85))
+                    Capsule()
+                        .fill(tokenBudgetTint(for: budget).opacity(0.82))
+                        .frame(width: proxy.size.width * CGFloat(budget.progressPercent) / 100)
+                }
+            }
+            .frame(height: 4)
+
+            Text(budget.secondaryLabel)
+                .font(.caption2.monospacedDigit().weight(.semibold))
+                .foregroundStyle(QuillCodePalette.muted)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .frame(minWidth: 210, maxWidth: 260, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .fill(tokenBudgetTint(for: budget).opacity(0.11))
+        )
+    }
+
+    private func tokenBudgetTint(for budget: TokenBudgetSurface) -> Color {
+        if budget.usedPercent >= 100 { return QuillCodePalette.red }
+        if budget.usedPercent >= 80 { return QuillCodePalette.yellow }
+        return QuillCodePalette.blue
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeTopBarStatusPresentation.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarStatusPresentation.swift
@@ -82,6 +82,9 @@ extension TopBarSurface {
 
     var topBarHelpText: String {
         var parts = [subtitle, agentStatusPresentation.accessibilityLabel]
+        if let tokenBudget {
+            parts.append(tokenBudget.detailLabel)
+        }
         if let runtimeIssuePresentation {
             parts.append("Issue: \(runtimeIssuePresentation.label)")
         }
@@ -97,9 +100,12 @@ extension TopBarSurface {
         if let branchStatusLabel {
             parts.append("branch: \(branchStatusLabel)")
         }
+        if let tokenBudget {
+            parts.append("token budget: \(tokenBudget.detailLabel)")
+        }
         if let spendStatusLabel {
             parts.append("spend: \(spendStatusLabel)")
-        } else if let usageStatusLabel {
+        } else if tokenBudget == nil, let usageStatusLabel {
             parts.append("token usage: \(usageStatusLabel)")
         }
         if let runtimeIssuePresentation {

--- a/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
@@ -28,6 +28,9 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
     /// Pre-formatted token-usage chip (e.g. `847 ctx · ↑500 ↓347`), or nil when the model
     /// has not reported usage for this thread. Renderers display this string as-is.
     public var usageStatusLabel: String?
+    /// Prominent context-window budget meter. Uses provider-reported usage when available and
+    /// falls back to a local estimate so the user can see used/limit/left before the first reply.
+    public var tokenBudget: TokenBudgetSurface?
     /// Pre-formatted spend chip (e.g. `Spend $0.0050 / $1.00`), or nil when the thread has no
     /// priced provider usage. When present, renderers prefer this over the raw token-usage chip.
     public var spendStatusLabel: String?
@@ -59,6 +62,7 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
         showsComputerUseSetup: Bool,
         branchStatusLabel: String? = nil,
         usageStatusLabel: String? = nil,
+        tokenBudget: TokenBudgetSurface? = nil,
         spendStatusLabel: String? = nil,
         spendStatusDetail: String? = nil,
         canNavigateBack: Bool = false,
@@ -86,6 +90,7 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
         self.showsComputerUseSetup = showsComputerUseSetup
         self.branchStatusLabel = branchStatusLabel
         self.usageStatusLabel = usageStatusLabel
+        self.tokenBudget = tokenBudget
         self.spendStatusLabel = spendStatusLabel
         self.spendStatusDetail = spendStatusDetail
         self.canNavigateBack = canNavigateBack
@@ -94,6 +99,40 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
 
     public func filteredModelCategories(matching query: String) -> [ModelCategorySurface] {
         ModelCategorySearchFilter.filter(modelCategories, matching: query)
+    }
+}
+
+public struct TokenBudgetSurface: Codable, Sendable, Hashable {
+    public var usedTokens: Int
+    public var limitTokens: Int
+    public var remainingTokens: Int
+    public var usedPercent: Int
+    public var progressPercent: Int
+    public var primaryLabel: String
+    public var secondaryLabel: String
+    public var detailLabel: String
+    public var sourceLabel: String
+
+    public init(
+        usedTokens: Int,
+        limitTokens: Int,
+        remainingTokens: Int,
+        usedPercent: Int,
+        progressPercent: Int,
+        primaryLabel: String,
+        secondaryLabel: String,
+        detailLabel: String,
+        sourceLabel: String
+    ) {
+        self.usedTokens = max(0, usedTokens)
+        self.limitTokens = max(1, limitTokens)
+        self.remainingTokens = max(0, remainingTokens)
+        self.usedPercent = max(0, usedPercent)
+        self.progressPercent = min(100, max(0, progressPercent))
+        self.primaryLabel = primaryLabel
+        self.secondaryLabel = secondaryLabel
+        self.detailLabel = detailLabel
+        self.sourceLabel = sourceLabel
     }
 }
 

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -8,9 +8,12 @@ enum WorkspaceHTMLTopBarRenderer {
           <div class="topbar-sidebar-slot" aria-hidden="true"></div>
           \(renderNavigationControls(commands: commands))
           <div class="topbar-title-group" data-testid="top-bar-title-group">
-            <strong data-testid="top-bar-title">\(escape(topBar.primaryTitle))</strong>
-            <p class="topbar-context-label" data-testid="top-bar-subtitle">\(escape(topBar.subtitle))</p>
+            <div class="topbar-title-copy">
+              <strong data-testid="top-bar-title">\(escape(topBar.primaryTitle))</strong>
+              <p class="topbar-context-label" data-testid="top-bar-subtitle">\(escape(topBar.subtitle))</p>
+            </div>
             \(renderBranchStatus(topBar))
+            \(renderTokenBudget(topBar))
             \(renderSpendStatus(topBar))
             \(renderUsageStatus(topBar))
           </div>
@@ -41,10 +44,33 @@ enum WorkspaceHTMLTopBarRenderer {
     }
 
     private static func renderUsageStatus(_ topBar: TopBarSurface) -> String {
-        guard topBar.spendStatusLabel == nil,
+        guard topBar.tokenBudget == nil,
+              topBar.spendStatusLabel == nil,
               let usageStatusLabel = topBar.usageStatusLabel
         else { return "" }
         return #"<span class="topbar-usage-chip" data-testid="top-bar-usage" title="\#(escape(usageStatusLabel))">\#(escape(usageStatusLabel))</span>"#
+    }
+
+    private static func renderTokenBudget(_ topBar: TopBarSurface) -> String {
+        guard let budget = topBar.tokenBudget else { return "" }
+        return """
+        <section class="topbar-token-budget" data-testid="top-bar-token-budget" data-tone="\(escape(tokenBudgetTone(budget)))" title="\(escape(budget.detailLabel))" aria-label="\(escape(budget.detailLabel))">
+          <div class="topbar-token-budget-row">
+            <span class="topbar-token-budget-label">Tokens</span>
+            <strong data-testid="top-bar-token-budget-primary">\(escape(budget.primaryLabel))</strong>
+          </div>
+          <div class="topbar-token-budget-meter" aria-hidden="true">
+            <span style="width: \(budget.progressPercent)%"></span>
+          </div>
+          <p data-testid="top-bar-token-budget-secondary">\(escape(budget.secondaryLabel))</p>
+        </section>
+        """
+    }
+
+    private static func tokenBudgetTone(_ budget: TokenBudgetSurface) -> String {
+        if budget.usedPercent >= 100 { return "critical" }
+        if budget.usedPercent >= 80 { return "warning" }
+        return "normal"
     }
 
     private static func renderSpendStatus(_ topBar: TopBarSurface) -> String {

--- a/Sources/QuillCodeApp/WorkspaceTokenBudgetSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTokenBudgetSurfaceBuilder.swift
@@ -1,0 +1,90 @@
+import QuillCodeCore
+
+struct WorkspaceTokenBudgetSurfaceBuilder: Sendable, Hashable {
+    var thread: ChatThread?
+    var selectedModelID: String
+    var modelCatalog: [ModelInfo]
+    var fallbackTokenBudget: Int = WorkspaceContextBannerBuilder.defaultTokenBudget
+
+    func surface() -> TokenBudgetSurface? {
+        guard let thread else { return nil }
+        let usage = WorkspaceContextBannerBuilder.latestProviderUsage(for: thread)
+        let usedTokens = max(0, usage?.contextTokens ?? WorkspaceContextBannerBuilder.estimatedContextTokens(for: thread))
+        let limitTokens = contextWindowTokens() ?? max(1, fallbackTokenBudget)
+        let remainingTokens = max(0, limitTokens - usedTokens)
+        let usedPercent = Int((Double(usedTokens) / Double(limitTokens) * 100).rounded())
+        let sourceLabel = usage == nil ? "Estimated" : "Provider reported"
+        var secondaryParts = [
+            "\(WorkspaceTokenUsageLabelBuilder.abbreviate(remainingTokens)) left",
+            "\(max(0, usedPercent))%"
+        ]
+        if let usage {
+            secondaryParts.append(
+                "↑\(WorkspaceTokenUsageLabelBuilder.abbreviate(usage.promptTokens)) ↓\(WorkspaceTokenUsageLabelBuilder.abbreviate(usage.completionTokens))"
+            )
+        }
+        secondaryParts.append(
+            sourceLabel.lowercased()
+        )
+
+        return TokenBudgetSurface(
+            usedTokens: usedTokens,
+            limitTokens: limitTokens,
+            remainingTokens: remainingTokens,
+            usedPercent: max(0, usedPercent),
+            progressPercent: min(100, max(0, usedPercent)),
+            primaryLabel: "\(WorkspaceTokenUsageLabelBuilder.abbreviate(usedTokens)) / \(WorkspaceTokenUsageLabelBuilder.abbreviate(limitTokens)) tokens",
+            secondaryLabel: secondaryParts.joined(separator: " · "),
+            detailLabel: detailLabel(
+                usedTokens: usedTokens,
+                limitTokens: limitTokens,
+                remainingTokens: remainingTokens,
+                usedPercent: usedPercent,
+                usage: usage,
+                sourceLabel: sourceLabel
+            ),
+            sourceLabel: sourceLabel
+        )
+    }
+
+    private func contextWindowTokens() -> Int? {
+        let canonicalModelID = TrustedRouterDefaults.canonicalModelID(thread?.model ?? selectedModelID)
+        let model = TrustedRouterDefaults.normalizedModelCatalog(modelCatalog).first {
+            TrustedRouterDefaults.canonicalModelID($0.id) == canonicalModelID
+        }
+        guard let tokens = model?.capabilities.contextWindowTokens, tokens > 0 else { return nil }
+        return tokens
+    }
+
+    private func detailLabel(
+        usedTokens: Int,
+        limitTokens: Int,
+        remainingTokens: Int,
+        usedPercent: Int,
+        usage: ModelTokenUsage?,
+        sourceLabel: String
+    ) -> String {
+        var parts = [
+            "\(sourceLabel) token budget: \(decimal(usedTokens)) used of \(decimal(limitTokens))",
+            "\(decimal(remainingTokens)) left",
+            "\(max(0, usedPercent))% used"
+        ]
+        if let usage {
+            parts.append("input \(decimal(usage.promptTokens))")
+            parts.append("output \(decimal(usage.completionTokens))")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func decimal(_ value: Int) -> String {
+        let digits = String(max(0, value))
+        var output = ""
+        for (offset, character) in digits.reversed().enumerated() {
+            if offset > 0, offset.isMultiple(of: 3) {
+                output.append(",")
+            }
+            output.append(character)
+        }
+        return String(output.reversed())
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
@@ -32,6 +32,11 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
                 for: WorkspaceContextBannerBuilder.latestProviderUsage(for: thread)
             )
         }
+        let tokenBudget = WorkspaceTokenBudgetSurfaceBuilder(
+            thread: thread,
+            selectedModelID: topBarState.model,
+            modelCatalog: self.modelCatalog
+        ).surface()
         return TopBarSurface(
             appName: topBarState.appName,
             primaryTitle: thread?.title ?? "QuillCode",
@@ -61,6 +66,7 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
                 return label.isEmpty ? nil : label
             },
             usageStatusLabel: spendStatus == nil ? usageStatusLabel : nil,
+            tokenBudget: tokenBudget,
             spendStatusLabel: spendStatus?.label,
             spendStatusDetail: spendStatus?.detail,
             canNavigateBack: canNavigateBack,

--- a/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
@@ -333,6 +333,26 @@ final class QuillCodeTopBarSurfaceTests: XCTestCase {
             topBar.topBarHelpText,
             "Ready. Agent status: Running. Issue: Rate limited"
         )
+
+        topBar.tokenBudget = TokenBudgetSurface(
+            usedTokens: 42,
+            limitTokens: 32_000,
+            remainingTokens: 31_958,
+            usedPercent: 0,
+            progressPercent: 0,
+            primaryLabel: "42 / 32k tokens",
+            secondaryLabel: "32k left · 0% · estimated",
+            detailLabel: "Estimated token budget: 42 used of 32,000 · 31,958 left · 0% used",
+            sourceLabel: "Estimated"
+        )
+        XCTAssertEqual(
+            topBar.topBarAccessibilityLabel,
+            "Project, Ready, Agent status: Running, branch: main ↑2, token budget: Estimated token budget: 42 used of 32,000 · 31,958 left · 0% used, spend: Spend $0.0050 / $1.00, issue: Rate limited"
+        )
+        XCTAssertEqual(
+            topBar.topBarHelpText,
+            "Ready. Agent status: Running. Estimated token budget: 42 used of 32,000 · 31,958 left · 0% used. Issue: Rate limited"
+        )
     }
 
     private func filteredModelIDs(_ topBar: TopBarSurface, query: String) -> [String] {

--- a/Tests/QuillCodeAppTests/WorkspaceTokenBudgetSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenBudgetSurfaceBuilderTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import QuillCodeApp
+import QuillCodeCore
+
+final class WorkspaceTokenBudgetSurfaceBuilderTests: XCTestCase {
+    func testBuildsProviderReportedBudgetAgainstModelContextWindow() throws {
+        let thread = ChatThread(
+            title: "Work",
+            model: "trustedrouter/fast",
+            events: [
+                ModelTokenUsageEvent.event(usage: ModelTokenUsage(promptTokens: 500, completionTokens: 347))
+            ]
+        )
+
+        let budget = try XCTUnwrap(
+            WorkspaceTokenBudgetSurfaceBuilder(
+                thread: thread,
+                selectedModelID: "trustedrouter/fast",
+                modelCatalog: [model(id: "tr/fast", contextWindowTokens: 128_000)]
+            ).surface()
+        )
+
+        XCTAssertEqual(budget.usedTokens, 847)
+        XCTAssertEqual(budget.limitTokens, 128_000)
+        XCTAssertEqual(budget.remainingTokens, 127_153)
+        XCTAssertEqual(budget.usedPercent, 1)
+        XCTAssertEqual(budget.primaryLabel, "847 / 128k tokens")
+        XCTAssertEqual(budget.secondaryLabel, "127.2k left · 1% · ↑500 ↓347 · provider reported")
+        XCTAssertEqual(
+            budget.detailLabel,
+            "Provider reported token budget: 847 used of 128,000 · 127,153 left · 1% used · input 500 · output 347"
+        )
+    }
+
+    func testEstimatesBudgetBeforeProviderUsageArrives() throws {
+        let thread = ChatThread(
+            title: "Draft",
+            model: "trustedrouter/fast",
+            messages: [
+                ChatMessage(role: .user, content: String(repeating: "u", count: 76)),
+                ChatMessage(role: .assistant, content: String(repeating: "a", count: 76))
+            ]
+        )
+
+        let budget = try XCTUnwrap(
+            WorkspaceTokenBudgetSurfaceBuilder(
+                thread: thread,
+                selectedModelID: "trustedrouter/fast",
+                modelCatalog: [model(id: "trustedrouter/fast", contextWindowTokens: 1_000)]
+            ).surface()
+        )
+
+        XCTAssertEqual(budget.usedTokens, 50)
+        XCTAssertEqual(budget.limitTokens, 1_000)
+        XCTAssertEqual(budget.remainingTokens, 950)
+        XCTAssertEqual(budget.primaryLabel, "50 / 1k tokens")
+        XCTAssertEqual(budget.secondaryLabel, "950 left · 5% · estimated")
+        XCTAssertEqual(budget.sourceLabel, "Estimated")
+    }
+
+    func testUsesFallbackBudgetWhenCatalogHasNoContextWindow() throws {
+        let thread = ChatThread(
+            title: "Fallback",
+            events: [
+                ModelTokenUsageEvent.event(usage: ModelTokenUsage(promptTokens: 12, completionTokens: 8))
+            ]
+        )
+
+        let budget = try XCTUnwrap(
+            WorkspaceTokenBudgetSurfaceBuilder(
+                thread: thread,
+                selectedModelID: "missing/model",
+                modelCatalog: []
+            ).surface()
+        )
+
+        XCTAssertEqual(budget.limitTokens, WorkspaceContextBannerBuilder.defaultTokenBudget)
+        XCTAssertEqual(budget.primaryLabel, "20 / 32k tokens")
+        XCTAssertEqual(budget.secondaryLabel, "32k left · 0% · ↑12 ↓8 · provider reported")
+    }
+
+    func testReturnsNilWithoutASelectedThread() {
+        let budget = WorkspaceTokenBudgetSurfaceBuilder(
+            thread: nil,
+            selectedModelID: "trustedrouter/fast",
+            modelCatalog: []
+        ).surface()
+
+        XCTAssertNil(budget)
+    }
+
+    private func model(id: String, contextWindowTokens: Int) -> ModelInfo {
+        ModelInfo(
+            id: id,
+            provider: "TrustedRouter",
+            displayName: "Nike 1.0",
+            category: "Recommended",
+            capabilities: ModelCapabilities(contextWindowTokens: contextWindowTokens)
+        )
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
@@ -5,6 +5,7 @@ import QuillCodeCore
 final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
     private func makeTopBar(
         usageStatusLabel: String?,
+        tokenBudget: TokenBudgetSurface? = nil,
         spendStatusLabel: String? = nil,
         spendStatusDetail: String? = nil
     ) -> TopBarSurface {
@@ -24,8 +25,23 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
             computerUseLabel: "Computer Use unavailable",
             showsComputerUseSetup: false,
             usageStatusLabel: usageStatusLabel,
+            tokenBudget: tokenBudget,
             spendStatusLabel: spendStatusLabel,
             spendStatusDetail: spendStatusDetail
+        )
+    }
+
+    private func makeTokenBudget(usedPercent: Int = 3) -> TokenBudgetSurface {
+        TokenBudgetSurface(
+            usedTokens: 847,
+            limitTokens: 32_000,
+            remainingTokens: 31_153,
+            usedPercent: usedPercent,
+            progressPercent: min(100, max(0, usedPercent)),
+            primaryLabel: "847 / 32k tokens",
+            secondaryLabel: "31.2k left · \(max(0, usedPercent))% · provider reported",
+            detailLabel: "Provider reported token budget: 847 used of 32,000 · 31,153 left · \(max(0, usedPercent))% used",
+            sourceLabel: "Provider reported"
         )
     }
 
@@ -39,17 +55,32 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
         }
     }
 
+    func testTopBarRoundTripsTokenBudget() throws {
+        let topBar = makeTopBar(
+            usageStatusLabel: "847 ctx · ↑500 ↓347",
+            tokenBudget: makeTokenBudget()
+        )
+
+        let decoded = try JSONDecoder().decode(TopBarSurface.self, from: JSONEncoder().encode(topBar))
+
+        XCTAssertEqual(decoded.tokenBudget?.primaryLabel, "847 / 32k tokens")
+        XCTAssertEqual(decoded.tokenBudget?.remainingTokens, 31_153)
+        XCTAssertEqual(decoded.tokenBudget?.sourceLabel, "Provider reported")
+    }
+
     func testTopBarDecodesLegacyJSONWithoutUsageKey() throws {
         // A persisted top bar from before this field existed must still load (key absent -> nil).
         let encoded = try JSONEncoder().encode(makeTopBar(usageStatusLabel: "847 ctx · ↑500 ↓347"))
         var object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
         object.removeValue(forKey: "usageStatusLabel")
+        object.removeValue(forKey: "tokenBudget")
         object.removeValue(forKey: "spendStatusLabel")
         object.removeValue(forKey: "spendStatusDetail")
         let legacy = try JSONSerialization.data(withJSONObject: object)
 
         let decoded = try JSONDecoder().decode(TopBarSurface.self, from: legacy)
         XCTAssertNil(decoded.usageStatusLabel)
+        XCTAssertNil(decoded.tokenBudget)
         XCTAssertNil(decoded.spendStatusLabel)
         XCTAssertNil(decoded.spendStatusDetail)
     }
@@ -64,16 +95,48 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
         XCTAssertFalse(withoutUsage.contains(#"data-testid="top-bar-usage""#))
     }
 
+    func testHTMLRendererEmitsTokenBudgetInsteadOfCompactUsage() {
+        let html = WorkspaceHTMLTopBarRenderer.render(
+            makeTopBar(
+                usageStatusLabel: "847 ctx · ↑500 ↓347",
+                tokenBudget: makeTokenBudget()
+            ),
+            commands: []
+        )
+
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-token-budget""#))
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-token-budget-primary">847 / 32k tokens"#))
+        XCTAssertTrue(html.contains("31.2k left · 3% · provider reported"))
+        XCTAssertTrue(html.contains("topbar-token-budget"))
+        XCTAssertFalse(html.contains(#"data-testid="top-bar-usage""#))
+    }
+
+    func testHTMLRendererMarksTokenBudgetWarningAndCriticalTones() {
+        let warning = WorkspaceHTMLTopBarRenderer.render(
+            makeTopBar(usageStatusLabel: nil, tokenBudget: makeTokenBudget(usedPercent: 80)),
+            commands: []
+        )
+        let critical = WorkspaceHTMLTopBarRenderer.render(
+            makeTopBar(usageStatusLabel: nil, tokenBudget: makeTokenBudget(usedPercent: 100)),
+            commands: []
+        )
+
+        XCTAssertTrue(warning.contains(#"data-tone="warning""#))
+        XCTAssertTrue(critical.contains(#"data-tone="critical""#))
+    }
+
     func testHTMLRendererPrefersSpendChipOverUsageChip() {
         let html = WorkspaceHTMLTopBarRenderer.render(
             makeTopBar(
                 usageStatusLabel: "1.5k ctx · ↑1k ↓500",
+                tokenBudget: makeTokenBudget(),
                 spendStatusLabel: "Spend $0.0050 / $1.00",
                 spendStatusDetail: "$0.0050 across 1 model call · fuse $1.00. Latest usage: 1.5k ctx · ↑1k ↓500"
             ),
             commands: []
         )
 
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-token-budget""#))
         XCTAssertTrue(html.contains(#"data-testid="top-bar-spend""#))
         XCTAssertTrue(html.contains("Spend $0.0050 / $1.00"))
         XCTAssertTrue(html.contains("Latest usage: 1.5k ctx · ↑1k ↓500"))

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageIntegrationTests.swift
@@ -18,7 +18,11 @@ final class WorkspaceTokenUsageIntegrationTests: XCTestCase {
     func testUsageChipReflectsLatestProviderUsageOfSelectedThread() {
         let thread = ChatThread(title: "Work", events: [usageEvent(prompt: 500, completion: 347)])
         let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
-        XCTAssertEqual(model.surface().topBar.usageStatusLabel, "847 ctx · ↑500 ↓347")
+        let topBar = model.surface().topBar
+
+        XCTAssertEqual(topBar.usageStatusLabel, "847 ctx · ↑500 ↓347")
+        XCTAssertEqual(topBar.tokenBudget?.primaryLabel, "847 / 32k tokens")
+        XCTAssertEqual(topBar.tokenBudget?.secondaryLabel, "31.2k left · 3% · ↑500 ↓347 · provider reported")
     }
 
     func testUsesTheMostRecentUsageEvent() {
@@ -27,13 +31,20 @@ final class WorkspaceTokenUsageIntegrationTests: XCTestCase {
             usageEvent(prompt: 900, completion: 600)
         ])
         let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
-        XCTAssertEqual(model.surface().topBar.usageStatusLabel, "1.5k ctx · ↑900 ↓600")
+        let topBar = model.surface().topBar
+
+        XCTAssertEqual(topBar.usageStatusLabel, "1.5k ctx · ↑900 ↓600")
+        XCTAssertEqual(topBar.tokenBudget?.primaryLabel, "1.5k / 32k tokens")
     }
 
     func testNoUsageChipWithoutAUsageEvent() {
         let thread = ChatThread(title: "Fresh")
         let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id))
-        XCTAssertNil(model.surface().topBar.usageStatusLabel)
+        let topBar = model.surface().topBar
+
+        XCTAssertNil(topBar.usageStatusLabel)
+        XCTAssertEqual(topBar.tokenBudget?.primaryLabel, "0 / 32k tokens")
+        XCTAssertEqual(topBar.tokenBudget?.secondaryLabel, "32k left · 0% · estimated")
     }
 
     func testUsageChipIsDerivedPerThreadAndDoesNotBleed() {
@@ -43,10 +54,12 @@ final class WorkspaceTokenUsageIntegrationTests: XCTestCase {
             root: QuillCodeRootState(threads: [used, fresh], selectedThreadID: used.id)
         )
         XCTAssertEqual(model.surface().topBar.usageStatusLabel, "150 ctx · ↑100 ↓50")
+        XCTAssertEqual(model.surface().topBar.tokenBudget?.primaryLabel, "150 / 32k tokens")
 
         // Selecting the fresh thread shows no usage even though another thread has it.
         model.selectThread(fresh.id)
         XCTAssertNil(model.surface().topBar.usageStatusLabel)
+        XCTAssertEqual(model.surface().topBar.tokenBudget?.primaryLabel, "0 / 32k tokens")
     }
 
     func testActivityShowsPricedRunReceiptsFromModelCatalog() throws {
@@ -96,6 +109,8 @@ final class WorkspaceTokenUsageIntegrationTests: XCTestCase {
             "$0.0050 across 1 model call · fuse $1.00. Latest usage: 1.5k ctx · ↑1k ↓500"
         )
         XCTAssertNil(topBar.usageStatusLabel)
+        XCTAssertEqual(topBar.tokenBudget?.primaryLabel, "1.5k / 32k tokens")
+        XCTAssertEqual(topBar.tokenBudget?.secondaryLabel, "30.5k left · 5% · ↑1k ↓500 · provider reported")
     }
 
     func testActivityRunReceiptsFlagSpendFuseCrossing() {


### PR DESCRIPTION
## Summary
- add a first-class `TokenBudgetSurface` to the top bar with used/limit tokens, remaining tokens, percent used, and provider-vs-estimated source detail
- render the meter in SwiftUI and the HTML/E2E harness while keeping the old compact usage chip as a fallback
- add focused builder/render/integration tests plus a Playwright assertion in the core command flow

## Validation
- `swift test --filter WorkspaceTokenBudgetSurfaceBuilderTests`
- `swift test --filter WorkspaceTokenUsage`
- `swift test --filter QuillCodeTopBarSurfaceTests/testTopBarPresentationTextIncludesQuietMetadataOnce`
- `npm test -- --grep "mock harness executes simple command flow"` from `E2E/playwright`
- `npm test -- tests/workspace-chrome.spec.ts` from `E2E/playwright`
- `npm test -- tests/composer.spec.ts` from `E2E/playwright`
- `QUILLCODE_MACOS_APP_OUTPUT_DIR=/Users/jperla/Applications ./scripts/build-macos-app.sh --configuration debug`
- `swift test` (3186 tests, 2 skipped, 0 failures)

## Visual Check
- Relaunched `/Users/jperla/Applications/QuillCode.app`
- Captured screenshot: `/tmp/quillcode-token-budget.png`
