### PR TITLE
Polish token budget and sidebar padding

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -26,7 +26,7 @@
       --hit-target: 44px;
       --hit-target-clearance: 8px;
       --control-cluster-gap: 10px;
-      --workspace-sidebar-width: 272px;
+      --workspace-sidebar-width: 280px;
     }
     * { box-sizing: border-box; }
     .visually-hidden {
@@ -265,12 +265,12 @@
       background: rgba(66, 214, 119, 0.10);
     }
     .topbar-token-budget {
-      flex: 0 0 min(260px, 28vw);
-      min-width: 210px;
+      flex: 0 0 min(286px, 30vw);
+      min-width: 226px;
       display: grid;
-      gap: 5px;
-      padding: 7px 10px;
-      border-radius: 13px;
+      gap: 6px;
+      padding: 8px 12px 9px;
+      border-radius: 16px;
       background: rgba(65, 184, 232, 0.11);
       color: var(--text);
       font-variant-numeric: tabular-nums;
@@ -327,6 +327,32 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+    .topbar-token-quota-row {
+      min-width: 0;
+      display: flex;
+      gap: 4px;
+      overflow: hidden;
+    }
+    .topbar-token-quota-row span {
+      min-width: 0;
+      padding: 2px 6px;
+      border-radius: 999px;
+      overflow: hidden;
+      color: var(--blue);
+      background: rgba(65, 184, 232, 0.12);
+      font-size: 10px;
+      font-weight: 800;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .topbar-token-budget[data-tone="warning"] .topbar-token-quota-row span {
+      color: var(--yellow);
+      background: rgba(247, 184, 79, 0.13);
+    }
+    .topbar-token-budget[data-tone="critical"] .topbar-token-quota-row span {
+      color: var(--red);
+      background: rgba(255, 91, 82, 0.13);
     }
     .topbar strong { font-size: 17px; }
     .topbar-title-copy strong {
@@ -911,7 +937,7 @@
       box-shadow: var(--shadow-border);
     }
     .sidebar {
-      padding: 8px 8px 8px 18px;
+      padding: 12px 14px;
       overflow: auto;
       border-right: 1px solid rgba(255,255,255,.07);
       display: flex;
@@ -4486,8 +4512,15 @@
       const usedPercent = Number(budget.usedPercent || 0);
       const tone = usedPercent >= 100 ? 'critical' : usedPercent >= 80 ? 'warning' : 'normal';
       const progressPercent = Math.max(0, Math.min(100, Number(budget.progressPercent || usedPercent || 0)));
+      const quotaLimits = Array.isArray(budget.quotaLimits) ? budget.quotaLimits.slice(0, 3) : [];
+      const quotaSummary = quotaLimits.map(limit => `${limit.periodLabel || ''} ${limit.usageLabel || ''}`.trim()).filter(Boolean).join(' · ');
+      const detailLabel = [budget.detailLabel || '', quotaSummary ? `Quota limits: ${quotaSummary}` : ''].filter(Boolean).join(' · ');
+      const quotaRow = quotaLimits.length ? `
+          <div class="topbar-token-quota-row" data-testid="top-bar-token-quota-limits">
+            ${quotaLimits.map(limit => `<span title="${escapeHTML(limit.detailLabel || '')}">${escapeHTML(`${limit.periodLabel || ''} ${limit.usageLabel || ''}`.trim())}</span>`).join('')}
+          </div>` : '';
       return `
-        <section class="topbar-token-budget" data-testid="top-bar-token-budget" data-tone="${escapeHTML(tone)}" title="${escapeHTML(budget.detailLabel || '')}" aria-label="${escapeHTML(budget.detailLabel || '')}">
+        <section class="topbar-token-budget" data-testid="top-bar-token-budget" data-tone="${escapeHTML(tone)}" title="${escapeHTML(detailLabel)}" aria-label="${escapeHTML(detailLabel)}">
           <div class="topbar-token-budget-row">
             <span class="topbar-token-budget-label">Tokens</span>
             <strong data-testid="top-bar-token-budget-primary">${escapeHTML(budget.primaryLabel || '')}</strong>
@@ -4496,6 +4529,7 @@
             <span style="width: ${progressPercent}%"></span>
           </div>
           <p data-testid="top-bar-token-budget-secondary">${escapeHTML(budget.secondaryLabel || '')}</p>
+          ${quotaRow}
         </section>`;
     }
 
@@ -15259,7 +15293,8 @@
         primaryLabel: `${abbreviateTokens(counts.total)} / ${abbreviateTokens(limit)} tokens`,
         secondaryLabel: `${abbreviateTokens(remaining)} left · ${usedPercent}% · estimated`,
         detailLabel: `Estimated token budget: ${decimalTokens(counts.total)} used of ${decimalTokens(limit)} · ${decimalTokens(remaining)} left · ${usedPercent}% used`,
-        sourceLabel: 'Estimated'
+        sourceLabel: 'Estimated',
+        quotaLimits: []
       };
     }
 

--- a/E2E/playwright/tests/harness-helpers.ts
+++ b/E2E/playwright/tests/harness-helpers.ts
@@ -40,6 +40,12 @@ export async function openSidebarTools(page: Page) {
 }
 
 export async function clickSidebarTool(page: Page, testID: string) {
+  const visibleSidebarTarget = page.getByTestId(testID).first();
+  if (await visibleSidebarTarget.isVisible().catch(() => false)) {
+    await visibleSidebarTarget.click();
+    return;
+  }
+
   await openSidebarTools(page);
   await page.getByTestId(testID).click();
 }

--- a/E2E/playwright/tests/status.spec.ts
+++ b/E2E/playwright/tests/status.spec.ts
@@ -71,6 +71,7 @@ test('mock harness surfaces the prominent token budget meter after a turn comple
   await expect(page.getByTestId('top-bar-token-budget-primary')).toContainText(/\/ .* tokens/);
   await expect(page.getByTestId('top-bar-token-budget-secondary')).toContainText('left');
   await expect(page.getByTestId('top-bar-token-budget-secondary')).toContainText('%');
+  await expect(page.getByTestId('top-bar-token-quota-limits')).toHaveCount(0);
   await expect(page.getByTestId('top-bar-usage')).toHaveCount(0);
   // Additive: the existing subtitle is unchanged.
   await expect(page.getByTestId('top-bar-subtitle')).toContainText('QuillCode');

--- a/E2E/playwright/tests/visual-polish.spec.ts
+++ b/E2E/playwright/tests/visual-polish.spec.ts
@@ -118,7 +118,7 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
     computedStyleProperties(page, '#message', ['transition-property']),
     computedStyleProperties(page, '[data-testid="top-bar-title"]', ['text-wrap']),
     computedStyleProperties(page, '[data-testid="agent-status"]', ['font-variant-numeric']),
-    computedStyleProperties(page, '[data-testid="sidebar"]', ['border-radius']),
+    computedStyleProperties(page, '[data-testid="sidebar"]', ['border-radius', 'padding-left', 'padding-right']),
     computedStyleProperties(page, '[data-testid="sidebar-tools-button"]', ['min-height', 'transition-property']),
     computedStyleProperties(page, '[data-testid="sidebar-search-button"]', ['min-height', 'transition-property']),
     computedStyleProperties(page, '[data-testid="settings-button"]', ['width', 'min-height']),
@@ -147,6 +147,8 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
     sidebarSettingsWidth: parseFloat(sidebarSettingsButtonStyle.width),
     sidebarSettingsMinHeight: parseFloat(sidebarSettingsButtonStyle['min-height']),
     sidebarRadius: parseFloat(sidebarStyle['border-radius']),
+    sidebarPaddingLeft: parseFloat(sidebarStyle['padding-left']),
+    sidebarPaddingRight: parseFloat(sidebarStyle['padding-right']),
     emptyStarterMinHeight: parseFloat(emptyStarterStyle['min-height']),
     emptyStarterTransitionProperty: emptyStarterStyle['transition-property'],
     emptyStarterRadius: parseFloat(emptyStarterStyle['border-radius'])
@@ -178,6 +180,8 @@ test('mock harness applies interface polish primitives', async ({ page }) => {
   expect(polish.titleTextWrap).toContain('balance');
   expect(polish.agentStatusNumbers).toContain('tabular-nums');
   expect(polish.sidebarRadius).toBeLessThanOrEqual(4);
+  expect(polish.sidebarPaddingLeft).toBe(14);
+  expect(polish.sidebarPaddingRight).toBe(14);
   expect(polish.emptyStarterMinHeight).toBeGreaterThanOrEqual(MINIMUM_HIT_TARGET);
   expect(polish.emptyStarterTransitionProperty).toContain('transform');
   expect(polish.emptyStarterTransitionProperty).toContain('box-shadow');

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -10,7 +10,15 @@ public enum QuillCodeMetrics {
     public static let controlClusterSpacing: CGFloat = 10
     public static let denseControlClusterSpacing: CGFloat = 8
     public static let topBarHeight: CGFloat = 44
+    public static let topBarTokenBudgetMinWidth: CGFloat = 226
+    public static let topBarTokenBudgetMaxWidth: CGFloat = 286
+    public static let topBarTokenBudgetHorizontalPadding: CGFloat = 12
+    public static let topBarTokenBudgetVerticalPadding: CGFloat = 8
     public static let sidebarWidth: CGFloat = 280
+    public static let sidebarLeadingInset: CGFloat = 14
+    public static let sidebarTrailingInset: CGFloat = 14
+    public static let sidebarVerticalInset: CGFloat = 12
+    public static let sidebarSectionSpacing: CGFloat = 10
     public static let composerSurfaceRadius: CGFloat = 12
     public static let composerControlRadius: CGFloat = 10
     public static let toolCardMinimumHeight: CGFloat = 74

--- a/Sources/QuillCodeApp/QuillCodeSidebarView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarView.swift
@@ -15,7 +15,7 @@ struct QuillCodeSidebarView: View {
     var onOpenAttentionDigest: (UUID) -> Void = { _ in }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: QuillCodeMetrics.sidebarSectionSpacing) {
             QuillCodeSidebarActionsView(commands: commands, onCommand: onCommand)
             if showsThreadHeader {
                 Divider()
@@ -63,7 +63,10 @@ struct QuillCodeSidebarView: View {
             Spacer(minLength: 0)
             QuillCodeSidebarUtilityActionsView(commands: commands, onCommand: onCommand)
         }
-        .padding(14)
+        .padding(.top, QuillCodeMetrics.sidebarVerticalInset)
+        .padding(.bottom, QuillCodeMetrics.sidebarVerticalInset)
+        .padding(.leading, QuillCodeMetrics.sidebarLeadingInset)
+        .padding(.trailing, QuillCodeMetrics.sidebarTrailingInset)
         .background(QuillCodePalette.sidebar)
     }
 

--- a/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
@@ -27,8 +27,8 @@ struct QuillCodeTopBarIdentityView: View {
 
             if let tokenBudget = topBar.tokenBudget {
                 tokenBudgetView(tokenBudget)
-                    .help(tokenBudget.detailLabel)
-                    .accessibilityLabel(tokenBudget.detailLabel)
+                    .help(tokenBudget.accessibilityLabel)
+                    .accessibilityLabel(tokenBudget.accessibilityLabel)
                     .layoutPriority(1)
             } else if topBar.spendStatusLabel == nil,
                       let usageStatusLabel = topBar.usageStatusLabel {
@@ -61,7 +61,7 @@ struct QuillCodeTopBarIdentityView: View {
     }
 
     private func tokenBudgetView(_ budget: TokenBudgetSurface) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text("Tokens")
                     .font(.caption2.weight(.bold))
@@ -90,12 +90,34 @@ struct QuillCodeTopBarIdentityView: View {
                 .foregroundStyle(QuillCodePalette.muted)
                 .lineLimit(1)
                 .minimumScaleFactor(0.82)
+
+            if !budget.visibleQuotaLimits.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(budget.visibleQuotaLimits.prefix(3), id: \.id) { quota in
+                        Text(quota.compactLabel)
+                            .font(.caption2.monospacedDigit().weight(.bold))
+                            .foregroundStyle(tokenBudgetTint(for: budget))
+                            .lineLimit(1)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule()
+                                    .fill(tokenBudgetTint(for: budget).opacity(0.12))
+                            )
+                    }
+                }
+                .lineLimit(1)
+            }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .frame(minWidth: 210, maxWidth: 260, alignment: .leading)
+        .padding(.horizontal, QuillCodeMetrics.topBarTokenBudgetHorizontalPadding)
+        .padding(.vertical, QuillCodeMetrics.topBarTokenBudgetVerticalPadding)
+        .frame(
+            minWidth: QuillCodeMetrics.topBarTokenBudgetMinWidth,
+            maxWidth: QuillCodeMetrics.topBarTokenBudgetMaxWidth,
+            alignment: .leading
+        )
         .background(
-            RoundedRectangle(cornerRadius: 13, style: .continuous)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(tokenBudgetTint(for: budget).opacity(0.11))
         )
     }

--- a/Sources/QuillCodeApp/QuillCodeTopBarStatusPresentation.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarStatusPresentation.swift
@@ -83,7 +83,7 @@ extension TopBarSurface {
     var topBarHelpText: String {
         var parts = [subtitle, agentStatusPresentation.accessibilityLabel]
         if let tokenBudget {
-            parts.append(tokenBudget.detailLabel)
+            parts.append(tokenBudget.accessibilityLabel)
         }
         if let runtimeIssuePresentation {
             parts.append("Issue: \(runtimeIssuePresentation.label)")
@@ -101,7 +101,7 @@ extension TopBarSurface {
             parts.append("branch: \(branchStatusLabel)")
         }
         if let tokenBudget {
-            parts.append("token budget: \(tokenBudget.detailLabel)")
+            parts.append("token budget: \(tokenBudget.accessibilityLabel)")
         }
         if let spendStatusLabel {
             parts.append("spend: \(spendStatusLabel)")

--- a/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
@@ -112,6 +112,9 @@ public struct TokenBudgetSurface: Codable, Sendable, Hashable {
     public var secondaryLabel: String
     public var detailLabel: String
     public var sourceLabel: String
+    /// Optional account/provider quota periods, such as day/week/month. The context-window budget
+    /// is always shown above; these only render when real quota data is supplied.
+    public var quotaLimits: [TokenQuotaLimitSurface]?
 
     public init(
         usedTokens: Int,
@@ -122,7 +125,8 @@ public struct TokenBudgetSurface: Codable, Sendable, Hashable {
         primaryLabel: String,
         secondaryLabel: String,
         detailLabel: String,
-        sourceLabel: String
+        sourceLabel: String,
+        quotaLimits: [TokenQuotaLimitSurface] = []
     ) {
         self.usedTokens = max(0, usedTokens)
         self.limitTokens = max(1, limitTokens)
@@ -133,6 +137,41 @@ public struct TokenBudgetSurface: Codable, Sendable, Hashable {
         self.secondaryLabel = secondaryLabel
         self.detailLabel = detailLabel
         self.sourceLabel = sourceLabel
+        self.quotaLimits = quotaLimits.isEmpty ? nil : quotaLimits
+    }
+
+    public var visibleQuotaLimits: [TokenQuotaLimitSurface] {
+        quotaLimits ?? []
+    }
+
+    public var quotaSummaryLabel: String? {
+        let summary = visibleQuotaLimits.map(\.compactLabel).joined(separator: " · ")
+        return summary.isEmpty ? nil : summary
+    }
+
+    public var accessibilityLabel: String {
+        var parts = [detailLabel]
+        if let quotaSummaryLabel {
+            parts.append("Quota limits: \(quotaSummaryLabel)")
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+public struct TokenQuotaLimitSurface: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { periodLabel }
+    public var periodLabel: String
+    public var usageLabel: String
+    public var detailLabel: String
+
+    public init(periodLabel: String, usageLabel: String, detailLabel: String) {
+        self.periodLabel = periodLabel
+        self.usageLabel = usageLabel
+        self.detailLabel = detailLabel
+    }
+
+    public var compactLabel: String {
+        "\(periodLabel) \(usageLabel)"
     }
 }
 

--- a/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLTopBarRenderer.swift
@@ -54,7 +54,7 @@ enum WorkspaceHTMLTopBarRenderer {
     private static func renderTokenBudget(_ topBar: TopBarSurface) -> String {
         guard let budget = topBar.tokenBudget else { return "" }
         return """
-        <section class="topbar-token-budget" data-testid="top-bar-token-budget" data-tone="\(escape(tokenBudgetTone(budget)))" title="\(escape(budget.detailLabel))" aria-label="\(escape(budget.detailLabel))">
+        <section class="topbar-token-budget" data-testid="top-bar-token-budget" data-tone="\(escape(tokenBudgetTone(budget)))" title="\(escape(budget.accessibilityLabel))" aria-label="\(escape(budget.accessibilityLabel))">
           <div class="topbar-token-budget-row">
             <span class="topbar-token-budget-label">Tokens</span>
             <strong data-testid="top-bar-token-budget-primary">\(escape(budget.primaryLabel))</strong>
@@ -63,8 +63,18 @@ enum WorkspaceHTMLTopBarRenderer {
             <span style="width: \(budget.progressPercent)%"></span>
           </div>
           <p data-testid="top-bar-token-budget-secondary">\(escape(budget.secondaryLabel))</p>
+          \(renderQuotaLimits(budget))
         </section>
         """
+    }
+
+    private static func renderQuotaLimits(_ budget: TokenBudgetSurface) -> String {
+        let quotaLimits = budget.visibleQuotaLimits.prefix(3)
+        guard !quotaLimits.isEmpty else { return "" }
+        let chips = quotaLimits.map { quota in
+            #"<span title="\#(escape(quota.detailLabel))">\#(escape(quota.compactLabel))</span>"#
+        }.joined(separator: "")
+        return #"<div class="topbar-token-quota-row" data-testid="top-bar-token-quota-limits">\#(chips)</div>"#
     }
 
     private static func tokenBudgetTone(_ budget: TokenBudgetSurface) -> String {

--- a/Tests/QuillCodeAppTests/WorkspaceTokenBudgetSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenBudgetSurfaceBuilderTests.swift
@@ -30,6 +30,8 @@ final class WorkspaceTokenBudgetSurfaceBuilderTests: XCTestCase {
             budget.detailLabel,
             "Provider reported token budget: 847 used of 128,000 · 127,153 left · 1% used · input 500 · output 347"
         )
+        XCTAssertTrue(budget.visibleQuotaLimits.isEmpty)
+        XCTAssertNil(budget.quotaSummaryLabel)
     }
 
     func testEstimatesBudgetBeforeProviderUsageArrives() throws {

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
@@ -31,7 +31,10 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
         )
     }
 
-    private func makeTokenBudget(usedPercent: Int = 3) -> TokenBudgetSurface {
+    private func makeTokenBudget(
+        usedPercent: Int = 3,
+        quotaLimits: [TokenQuotaLimitSurface] = []
+    ) -> TokenBudgetSurface {
         TokenBudgetSurface(
             usedTokens: 847,
             limitTokens: 32_000,
@@ -41,7 +44,8 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
             primaryLabel: "847 / 32k tokens",
             secondaryLabel: "31.2k left · \(max(0, usedPercent))% · provider reported",
             detailLabel: "Provider reported token budget: 847 used of 32,000 · 31,153 left · \(max(0, usedPercent))% used",
-            sourceLabel: "Provider reported"
+            sourceLabel: "Provider reported",
+            quotaLimits: quotaLimits
         )
     }
 
@@ -66,6 +70,36 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
         XCTAssertEqual(decoded.tokenBudget?.primaryLabel, "847 / 32k tokens")
         XCTAssertEqual(decoded.tokenBudget?.remainingTokens, 31_153)
         XCTAssertEqual(decoded.tokenBudget?.sourceLabel, "Provider reported")
+        XCTAssertTrue(decoded.tokenBudget?.visibleQuotaLimits.isEmpty == true)
+    }
+
+    func testTopBarRoundTripsTokenBudgetQuotaLimits() throws {
+        let topBar = makeTopBar(
+            usageStatusLabel: nil,
+            tokenBudget: makeTokenBudget(
+                quotaLimits: [
+                    TokenQuotaLimitSurface(
+                        periodLabel: "Day",
+                        usageLabel: "12k / 100k",
+                        detailLabel: "Daily quota: 12,000 used of 100,000"
+                    ),
+                    TokenQuotaLimitSurface(
+                        periodLabel: "Month",
+                        usageLabel: "$2 / $20",
+                        detailLabel: "Monthly spend: $2 used of $20"
+                    )
+                ]
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(TopBarSurface.self, from: JSONEncoder().encode(topBar))
+
+        XCTAssertEqual(decoded.tokenBudget?.visibleQuotaLimits.map(\.compactLabel), ["Day 12k / 100k", "Month $2 / $20"])
+        XCTAssertEqual(decoded.tokenBudget?.quotaSummaryLabel, "Day 12k / 100k · Month $2 / $20")
+        XCTAssertEqual(
+            decoded.tokenBudget?.accessibilityLabel,
+            "Provider reported token budget: 847 used of 32,000 · 31,153 left · 3% used · Quota limits: Day 12k / 100k · Month $2 / $20"
+        )
     }
 
     func testTopBarDecodesLegacyJSONWithoutUsageKey() throws {
@@ -108,7 +142,36 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="top-bar-token-budget-primary">847 / 32k tokens"#))
         XCTAssertTrue(html.contains("31.2k left · 3% · provider reported"))
         XCTAssertTrue(html.contains("topbar-token-budget"))
+        XCTAssertFalse(html.contains(#"data-testid="top-bar-token-quota-limits""#))
         XCTAssertFalse(html.contains(#"data-testid="top-bar-usage""#))
+    }
+
+    func testHTMLRendererEmitsQuotaLimitsWhenSupplied() {
+        let html = WorkspaceHTMLTopBarRenderer.render(
+            makeTopBar(
+                usageStatusLabel: nil,
+                tokenBudget: makeTokenBudget(
+                    quotaLimits: [
+                        TokenQuotaLimitSurface(
+                            periodLabel: "Day",
+                            usageLabel: "12k / 100k",
+                            detailLabel: "Daily quota: 12,000 used of 100,000"
+                        ),
+                        TokenQuotaLimitSurface(
+                            periodLabel: "Week",
+                            usageLabel: "$4 / $50",
+                            detailLabel: "Weekly spend: $4 used of $50"
+                        )
+                    ]
+                )
+            ),
+            commands: []
+        )
+
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-token-quota-limits""#))
+        XCTAssertTrue(html.contains("Day 12k / 100k"))
+        XCTAssertTrue(html.contains("Week $4 / $50"))
+        XCTAssertTrue(html.contains("Quota limits: Day 12k / 100k · Week $4 / $50"))
     }
 
     func testHTMLRendererMarksTokenBudgetWarningAndCriticalTones() {


### PR DESCRIPTION
## Summary
- Balance the top token budget tile padding and sidebar rail insets across SwiftUI and the HTML harness
- Add optional quota period chips for real day/week/month account limits when supplied, while hiding them when no quota data exists
- Cover quota rendering, hidden default behavior, and sidebar padding in Swift and Playwright tests

## Verification
- swift test --filter WorkspaceTokenBudgetSurfaceBuilderTests
- swift test --filter WorkspaceTokenUsageChipRenderTests
- swift test --filter QuillCodeTopBarSurfaceTests
- npm test -- status.spec.ts visual-polish.spec.ts sidebar.spec.ts
- npm test -- core.spec.ts
- npm test -- status.spec.ts visual-polish.spec.ts

Screenshot: /tmp/quillcode-padding-token-budget.png