### PR TITLE
Point TrustedRouter Swift dependency at Lore-Hex

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "389d35d9f96ceb765b4060d6dc9c07fe717e6d851aa0e2d3cf5a67f57ddda763",
+  "originHash" : "695f3f546179c353f8ec6810117a5a673c03ede3492d0b215859abb0d944cd4b",
   "pins" : [
     {
       "identity" : "trusted-router-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jperla/trusted-router-swift.git",
+      "location" : "https://github.com/Lore-Hex/trusted-router-swift.git",
       "state" : {
         "revision" : "410cb034ce5a20b62f209d03d46a256cafe7b54f",
         "version" : "0.4.1"

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/jperla/trusted-router-swift.git", from: "0.4.1")
+        .package(url: "https://github.com/Lore-Hex/trusted-router-swift.git", from: "0.4.1")
     ],
     targets: [
         .target(name: "QuillCodeCore"),


### PR DESCRIPTION
## Summary
- update SwiftPM TrustedRouter dependency URL from jperla/trusted-router-swift to Lore-Hex/trusted-router-swift
- refresh Package.resolved so the pin location matches the canonical Lore-Hex repo

## Verification
- swift package resolve
- swift build --target QuillCodeAgent
- swift test --filter QuillCodeAgentTests --skip-build