### PR TITLE
Add downloadable tester builds

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -1,0 +1,138 @@
+name: Download Builds
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  schedule:
+    - cron: "17 10 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: download-builds-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set build metadata
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "QUILLCODE_BUILD_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          else
+            echo "QUILLCODE_BUILD_VERSION=0.1.0" >> "$GITHUB_ENV"
+          fi
+          echo "QUILLCODE_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+      - name: Package macOS app and CLI
+        env:
+          QUILLCODE_DOWNLOAD_DIST_DIR: ${{ runner.temp }}/quillcode-macos-downloads
+        run: scripts/package-macos-downloads.sh
+      - name: Upload macOS downloads
+        uses: actions/upload-artifact@v4
+        with:
+          name: quillcode-macos-downloads
+          path: ${{ runner.temp }}/quillcode-macos-downloads/assets/*
+          if-no-files-found: error
+          retention-days: 14
+
+  linux:
+    runs-on: ubuntu-latest
+    container: swift:6.2-noble
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set build metadata
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "QUILLCODE_BUILD_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          else
+            echo "QUILLCODE_BUILD_VERSION=0.1.0" >> "$GITHUB_ENV"
+          fi
+          echo "QUILLCODE_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+      - name: Package Linux CLI
+        env:
+          QUILLCODE_DOWNLOAD_DIST_DIR: /tmp/quillcode-linux-downloads
+        run: scripts/package-linux-downloads.sh
+      - name: Upload Linux downloads
+        uses: actions/upload-artifact@v4
+        with:
+          name: quillcode-linux-downloads
+          path: /tmp/quillcode-linux-downloads/assets/*
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    needs: [macos, linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/downloaded-artifacts
+      - name: Prepare release assets
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-assets"
+          find "$RUNNER_TEMP/downloaded-artifacts" -maxdepth 3 -type f -print -exec cp {} "$RUNNER_TEMP/release-assets/" \;
+          (
+            cd "$RUNNER_TEMP/release-assets"
+            sha256sum * > SHASUMS256.txt
+          )
+          find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -print | sort
+      - name: Publish tester or tagged release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            RELEASE_TAG="${GITHUB_REF_NAME}"
+            RELEASE_TITLE="QuillCode ${GITHUB_REF_NAME}"
+            PRERELEASE_FLAG=()
+            LATEST_FLAG=(--latest)
+          else
+            RELEASE_TAG="tester-latest"
+            RELEASE_TITLE="QuillCode Tester Build"
+            PRERELEASE_FLAG=(--prerelease)
+            LATEST_FLAG=(--latest=false)
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -f "$RELEASE_TAG" "$GITHUB_SHA"
+            git push origin "refs/tags/$RELEASE_TAG" --force
+          fi
+
+          cat > "$RUNNER_TEMP/release-notes.md" <<NOTES
+          Automated QuillCode tester build.
+
+          Commit: \`${GITHUB_SHA}\`
+          Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          Downloads:
+          - \`QuillCode-macOS-*.zip\`: macOS app bundle for testers.
+          - \`quill-code-macOS-*.tar.gz\`: macOS CLI.
+          - \`quill-code-linux-*.tar.gz\`: Linux CLI.
+          - \`SHASUMS256.txt\`: checksum manifest for every asset.
+
+          macOS tester note: this build is ad-hoc signed but not notarized yet. If Gatekeeper blocks first launch, use right-click > Open. Computer Use still requires normal macOS Screen Recording and Accessibility permissions.
+          NOTES
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              "${PRERELEASE_FLAG[@]}"
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              --target "$GITHUB_SHA" \
+              "${PRERELEASE_FLAG[@]}" \
+              "${LATEST_FLAG[@]}"
+          fi
+
+          gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/* --clobber

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This initial repository contains the compile-stable foundation:
 
 ## Try It
 
+Download the latest automated tester build from
+[QuillCode Tester Build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest).
+The tester release is refreshed from `main`; see [Downloadable Builds](docs/DOWNLOADS.md).
+
 ```bash
 swift test
 ./scripts/smoke.sh
@@ -71,3 +75,4 @@ swift run quill-code auth clear
 - [Roadmap](docs/ROADMAP.md)
 - [Test Plan](docs/TEST_PLAN.md)
 - [Merge Train](docs/MERGE_TRAIN.md)
+- [Downloadable Builds](docs/DOWNLOADS.md)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,11 @@
 
 ## 2026-07-04
 
+- Tester distribution uses one moving GitHub prerelease, `tester-latest`, plus normal version tags. The **Download
+  Builds** workflow publishes macOS app, macOS CLI, and Linux CLI archives as short-retention workflow artifacts and
+  refreshes the stable tester release after successful `main` builds so early testers can use one download URL while
+  maintainers can still cut immutable `v*` releases for public announcements. The macOS tester app is ad-hoc signed
+  and explicitly not notarized until Apple signing/notarization credentials are configured.
 - QuillCode keeps TrustedRouter model-advisor guidance as a compact skill-backed pointer in the base prompt instead of
   carrying the full Lore-Hex/LLM-advisor playbook on every request. The prompt names the live-data-first behavior,
   concise 2-5 option recommendations, key privacy filters, and secret-handling guardrails; detailed model-selection

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -1,0 +1,53 @@
+# Downloadable Builds
+
+QuillCode publishes automated tester builds from GitHub Actions.
+
+## Tester Download
+
+Use the moving prerelease:
+
+- [QuillCode Tester Build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest)
+
+That release is refreshed after every successful push to `main`, on the nightly
+download-build schedule, and whenever a maintainer runs the **Download Builds**
+workflow manually.
+
+Assets:
+
+- `QuillCode-macOS-*.zip`: macOS app bundle.
+- `quill-code-macOS-*.tar.gz`: macOS CLI.
+- `quill-code-linux-*.tar.gz`: Linux CLI.
+- `SHASUMS256.txt`: checksums for all uploaded assets.
+
+The macOS tester app is ad-hoc signed but not notarized yet. Testers may need to
+right-click **Open** the first time. Computer Use still requires normal macOS
+Screen Recording and Accessibility permissions.
+
+## Versioned Releases
+
+Push a tag such as `v0.1.0` to create a versioned release with the same assets:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Use versioned releases for public announcements. Use `tester-latest` for quick
+iteration with early testers.
+
+## Local Packaging
+
+macOS app plus macOS CLI:
+
+```bash
+scripts/package-macos-downloads.sh
+```
+
+Linux CLI:
+
+```bash
+scripts/package-linux-downloads.sh
+```
+
+Both scripts write assets under `.build/downloads/.../assets` unless
+`QUILLCODE_DOWNLOAD_DIST_DIR` is set.

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -7,6 +7,8 @@ CONFIGURATION="${QUILLCODE_MACOS_APP_CONFIGURATION:-debug}"
 APP_NAME="${QUILLCODE_MACOS_APP_NAME:-QuillCode}"
 BUNDLE_ID="${QUILLCODE_MACOS_BUNDLE_ID:-co.lorehex.QuillCode}"
 MINIMUM_SYSTEM_VERSION="${QUILLCODE_MACOS_MINIMUM_SYSTEM_VERSION:-14.0}"
+VERSION="${QUILLCODE_MACOS_APP_VERSION:-0.1.0}"
+BUILD_NUMBER="${QUILLCODE_MACOS_BUILD_NUMBER:-1}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -82,9 +84,9 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>$VERSION</string>
   <key>CFBundleVersion</key>
-  <string>1</string>
+  <string>$BUILD_NUMBER</string>
   <key>LSMinimumSystemVersion</key>
   <string>$MINIMUM_SYSTEM_VERSION</string>
   <key>LSApplicationCategoryType</key>

--- a/scripts/package-linux-downloads.sh
+++ b/scripts/package-linux-downloads.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${QUILLCODE_DOWNLOAD_DIST_DIR:-$ROOT_DIR/.build/downloads/linux}"
+CONFIGURATION="${QUILLCODE_DOWNLOAD_CONFIGURATION:-release}"
+VERSION="${QUILLCODE_BUILD_VERSION:-0.1.0}"
+BUILD_NUMBER="${QUILLCODE_BUILD_NUMBER:-0}"
+ARCH="$(uname -m)"
+COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+ASSET_DIR="$DIST_DIR/assets"
+CLI_ROOT="$DIST_DIR/cli"
+CLI_DIR="$CLI_ROOT/quill-code-linux-$ARCH"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "package-linux-downloads.sh must run on Linux." >&2
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+rm -rf "$DIST_DIR"
+mkdir -p "$ASSET_DIR" "$CLI_DIR"
+
+echo "==> Packaging quill-code Linux CLI ($ARCH, version $VERSION build $BUILD_NUMBER)"
+swift build --configuration "$CONFIGURATION" --product quill-code >&2
+BIN_DIR="$(swift build --configuration "$CONFIGURATION" --product quill-code --show-bin-path)"
+cp "$BIN_DIR/quill-code" "$CLI_DIR/quill-code"
+chmod 755 "$CLI_DIR/quill-code"
+cat > "$CLI_DIR/README.txt" <<README
+QuillCode CLI for Linux $ARCH
+
+Install:
+  sudo install -m 755 quill-code /usr/local/bin/quill-code
+
+Smoke test:
+  quill-code "run whoami"
+README
+
+CLI_TARBALL="$ASSET_DIR/quill-code-linux-$ARCH.tar.gz"
+tar -C "$CLI_ROOT" -czf "$CLI_TARBALL" "$(basename "$CLI_DIR")"
+
+cat > "$ASSET_DIR/BUILD_INFO-linux-$ARCH.txt" <<INFO
+product=QuillCode
+platform=Linux
+arch=$ARCH
+version=$VERSION
+build=$BUILD_NUMBER
+commit=$COMMIT
+createdAt=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+configuration=$CONFIGURATION
+cli=quill-code-linux-$ARCH.tar.gz
+INFO
+
+(
+  cd "$ASSET_DIR"
+  sha256sum quill-code-linux-"$ARCH".tar.gz BUILD_INFO-linux-"$ARCH".txt \
+    > "quill-code-linux-$ARCH-SHASUMS256.txt"
+)
+
+echo "QuillCode Linux download assets:"
+find "$ASSET_DIR" -maxdepth 1 -type f -print | sort

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${QUILLCODE_DOWNLOAD_DIST_DIR:-$ROOT_DIR/.build/downloads/macos}"
+CONFIGURATION="${QUILLCODE_DOWNLOAD_CONFIGURATION:-release}"
+VERSION="${QUILLCODE_BUILD_VERSION:-0.1.0}"
+BUILD_NUMBER="${QUILLCODE_BUILD_NUMBER:-0}"
+ARCH="$(uname -m)"
+COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+ASSET_DIR="$DIST_DIR/assets"
+APP_OUTPUT_DIR="$DIST_DIR/app"
+CLI_ROOT="$DIST_DIR/cli"
+CLI_DIR="$CLI_ROOT/quill-code-macOS-$ARCH"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "package-macos-downloads.sh must run on macOS." >&2
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+rm -rf "$DIST_DIR"
+mkdir -p "$ASSET_DIR" "$CLI_DIR"
+
+echo "==> Packaging QuillCode macOS app ($ARCH, version $VERSION build $BUILD_NUMBER)"
+APP_BUNDLE="$(
+  QUILLCODE_MACOS_APP_VERSION="$VERSION" \
+  QUILLCODE_MACOS_BUILD_NUMBER="$BUILD_NUMBER" \
+  QUILLCODE_MACOS_ADHOC_CODESIGN="${QUILLCODE_MACOS_ADHOC_CODESIGN:-1}" \
+    "$ROOT_DIR/scripts/build-macos-app.sh" \
+      --configuration "$CONFIGURATION" \
+      --output "$APP_OUTPUT_DIR"
+)"
+
+APP_ZIP="$ASSET_DIR/QuillCode-macOS-$ARCH.zip"
+ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$APP_ZIP"
+
+echo "==> Packaging quill-code macOS CLI ($ARCH)"
+swift build --configuration "$CONFIGURATION" --product quill-code >&2
+BIN_DIR="$(swift build --configuration "$CONFIGURATION" --product quill-code --show-bin-path)"
+cp "$BIN_DIR/quill-code" "$CLI_DIR/quill-code"
+chmod 755 "$CLI_DIR/quill-code"
+cat > "$CLI_DIR/README.txt" <<README
+QuillCode CLI for macOS $ARCH
+
+Install:
+  sudo install -m 755 quill-code /usr/local/bin/quill-code
+
+Smoke test:
+  quill-code "run whoami"
+README
+
+CLI_TARBALL="$ASSET_DIR/quill-code-macOS-$ARCH.tar.gz"
+tar -C "$CLI_ROOT" -czf "$CLI_TARBALL" "$(basename "$CLI_DIR")"
+
+cat > "$ASSET_DIR/BUILD_INFO.txt" <<INFO
+product=QuillCode
+platform=macOS
+arch=$ARCH
+version=$VERSION
+build=$BUILD_NUMBER
+commit=$COMMIT
+createdAt=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+configuration=$CONFIGURATION
+app=QuillCode-macOS-$ARCH.zip
+cli=quill-code-macOS-$ARCH.tar.gz
+codesign=ad-hoc
+notarized=false
+INFO
+
+(
+  cd "$ASSET_DIR"
+  shasum -a 256 QuillCode-macOS-"$ARCH".zip quill-code-macOS-"$ARCH".tar.gz BUILD_INFO.txt \
+    > "QuillCode-macOS-$ARCH-SHASUMS256.txt"
+)
+
+echo "QuillCode macOS download assets:"
+find "$ASSET_DIR" -maxdepth 1 -type f -print | sort


### PR DESCRIPTION
## Summary
- Add a Download Builds workflow that packages macOS app, macOS CLI, and Linux CLI downloads.
- Publish successful main builds to a stable tester-latest prerelease and support versioned v* releases.
- Document tester download instructions and local packaging commands.

## Validation
- bash -n scripts/build-macos-app.sh scripts/package-macos-downloads.sh scripts/package-linux-downloads.sh
- ruby YAML parse for .github/workflows/download-builds.yml
- scripts/package-macos-downloads.sh produced QuillCode-macOS-arm64.zip and quill-code-macOS-arm64.tar.gz locally
- unzip -t QuillCode-macOS-arm64.zip
- codesign --verify --deep --strict QuillCode.app
- Docker swift:6.2-noble ran scripts/package-linux-downloads.sh and produced quill-code-linux-aarch64.tar.gz
- git diff --check
