### PR TITLE
[codex] Document tester download builds

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -125,6 +125,7 @@ jobs:
             gh release edit "$RELEASE_TAG" \
               --title "$RELEASE_TITLE" \
               --notes-file "$RUNNER_TEMP/release-notes.md" \
+              --target "$GITHUB_SHA" \
               "${PRERELEASE_FLAG[@]}"
           else
             gh release create "$RELEASE_TAG" \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # QuillCode
 
+[![CI](https://github.com/Lore-Hex/QuillCode/actions/workflows/ci.yml/badge.svg)](https://github.com/Lore-Hex/QuillCode/actions/workflows/ci.yml)
+[![Download Builds](https://github.com/Lore-Hex/QuillCode/actions/workflows/download-builds.yml/badge.svg)](https://github.com/Lore-Hex/QuillCode/actions/workflows/download-builds.yml)
+[Download tester build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest)
+
 QuillCode is a Swift and QuillUI coding agent inspired by Codex workflows and backed by TrustedRouter. The long-term target is a public, cross-platform macOS/Linux app with local project chat, tool execution, Computer Use, worktrees, plugins, automations, and browser-assisted development.
 
 This initial repository contains the compile-stable foundation:
@@ -20,7 +24,9 @@ This initial repository contains the compile-stable foundation:
 
 Download the latest automated tester build from
 [QuillCode Tester Build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest).
-The tester release is refreshed from `main`; see [Downloadable Builds](docs/DOWNLOADS.md).
+The tester release is refreshed after every successful `main` push and nightly;
+see [Downloadable Builds](docs/DOWNLOADS.md) for direct app/CLI links and tester
+notes.
 
 ```bash
 swift test

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -2,26 +2,42 @@
 
 QuillCode publishes automated tester builds from GitHub Actions.
 
-## Tester Download
+## What To Send Testers
 
-Use the moving prerelease:
+Send testers this moving prerelease link:
 
 - [QuillCode Tester Build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest)
 
-That release is refreshed after every successful push to `main`, on the nightly
-download-build schedule, and whenever a maintainer runs the **Download Builds**
-workflow manually.
+Direct asset links for the current tester channel:
 
-Assets:
+- [macOS app: `QuillCode-macOS-arm64.zip`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/QuillCode-macOS-arm64.zip)
+- [macOS CLI: `quill-code-macOS-arm64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-macOS-arm64.tar.gz)
+- [Linux CLI: `quill-code-linux-x86_64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-linux-x86_64.tar.gz)
+- [Checksums: `SHASUMS256.txt`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/SHASUMS256.txt)
 
-- `QuillCode-macOS-*.zip`: macOS app bundle.
-- `quill-code-macOS-*.tar.gz`: macOS CLI.
-- `quill-code-linux-*.tar.gz`: Linux CLI.
-- `SHASUMS256.txt`: checksums for all uploaded assets.
+## Build Cadence
+
+The tester release is refreshed:
+
+- after every successful push to `main`
+- every night from the scheduled **Download Builds** workflow
+- whenever a maintainer runs **Download Builds** manually from GitHub Actions
+
+The workflow updates the stable `tester-latest` tag and replaces release assets
+in place, so the links above do not change as new builds are published.
+
+## Tester Install Notes
 
 The macOS tester app is ad-hoc signed but not notarized yet. Testers may need to
 right-click **Open** the first time. Computer Use still requires normal macOS
 Screen Recording and Accessibility permissions.
+
+The app is still a tester build, so ask testers to include:
+
+- their operating system and CPU architecture
+- the `BUILD_INFO.txt` or `BUILD_INFO-linux-*.txt` asset contents
+- what they clicked or typed before the issue
+- a screenshot when the issue is visual
 
 ## Versioned Releases
 
@@ -34,6 +50,20 @@ git push origin v0.1.0
 
 Use versioned releases for public announcements. Use `tester-latest` for quick
 iteration with early testers.
+
+## Manual Build Refresh
+
+Maintainers can refresh the tester channel without a code change:
+
+```bash
+gh workflow run download-builds.yml --repo Lore-Hex/QuillCode --ref main
+```
+
+Then watch it:
+
+```bash
+gh run list --repo Lore-Hex/QuillCode --workflow download-builds.yml --limit 1
+```
 
 ## Local Packaging
 


### PR DESCRIPTION
## Summary
- make the tester download path visible from the README with workflow badges and the stable release link
- expand `docs/DOWNLOADS.md` with direct tester asset links, cadence, install notes, feedback details, and manual refresh commands
- update the download-build workflow so existing `tester-latest` releases point at the exact commit that produced the assets

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/download-builds.yml"); puts "download-builds.yml parses"'`
- release docs/workflow text assertions for `tester-latest`
