### PR TITLE
Publish tester download manifest

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -79,10 +79,25 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/release-assets"
           find "$RUNNER_TEMP/downloaded-artifacts" -maxdepth 3 -type f -print -exec cp {} "$RUNNER_TEMP/release-assets/" \;
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            RELEASE_TAG="${GITHUB_REF_NAME}"
+            RELEASE_CHANNEL="stable"
+          else
+            RELEASE_TAG="tester-latest"
+            RELEASE_CHANNEL="tester"
+          fi
           (
             cd "$RUNNER_TEMP/release-assets"
-            sha256sum * > SHASUMS256.txt
+            find . -maxdepth 1 -type f ! -name SHASUMS256.txt -printf '%P\0' | sort -z | xargs -0 sha256sum > SHASUMS256.txt
           )
+          scripts/build-download-manifest.py \
+            --assets-dir "$RUNNER_TEMP/release-assets" \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --channel "$RELEASE_CHANNEL" \
+            --commit "$GITHUB_SHA" \
+            --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --output "$RUNNER_TEMP/release-assets/latest-tester-build.json"
           find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -print | sort
       - name: Publish tester or tagged release
         env:
@@ -117,6 +132,7 @@ jobs:
           - \`quill-code-macOS-*.tar.gz\`: macOS CLI.
           - \`quill-code-linux-*.tar.gz\`: Linux CLI.
           - \`SHASUMS256.txt\`: checksum manifest for every asset.
+          - \`latest-tester-build.json\`: machine-readable build metadata, download URLs, sizes, and SHA-256 digests.
 
           macOS tester note: this build is ad-hoc signed but not notarized yet. If Gatekeeper blocks first launch, use right-click > Open. Computer Use still requires normal macOS Screen Recording and Accessibility permissions.
           NOTES

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This initial repository contains the compile-stable foundation:
 Download the latest automated tester build from
 [QuillCode Tester Build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest).
 The tester release is refreshed after every successful `main` push and nightly;
-see [Downloadable Builds](docs/DOWNLOADS.md) for direct app/CLI links and tester
-notes.
+see [Downloadable Builds](docs/DOWNLOADS.md) for direct app/CLI links, the
+machine-readable build manifest, and tester notes.
 
 ```bash
 swift test

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
+    func testDownloadManifestGeneratorWritesStableTesterMetadata() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-download-manifest-tests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try "product=QuillCode\nplatform=macOS\narch=arm64\nversion=0.2.0\nbuild=123\n"
+            .write(to: temporaryDirectory.appendingPathComponent("BUILD_INFO.txt"), atomically: true, encoding: .utf8)
+        try Data("mac app".utf8).write(to: temporaryDirectory.appendingPathComponent("QuillCode-macOS-arm64.zip"))
+        try Data("mac cli".utf8).write(to: temporaryDirectory.appendingPathComponent("quill-code-macOS-arm64.tar.gz"))
+        try Data("linux cli".utf8).write(to: temporaryDirectory.appendingPathComponent("quill-code-linux-x86_64.tar.gz"))
+        try "placeholder checksums\n"
+            .write(to: temporaryDirectory.appendingPathComponent("SHASUMS256.txt"), atomically: true, encoding: .utf8)
+
+        let manifestURL = temporaryDirectory.appendingPathComponent("latest-tester-build.json")
+        let script = Self.packageRoot()
+            .appendingPathComponent("scripts")
+            .appendingPathComponent("build-download-manifest.py")
+        let result = try Self.runPython(script, arguments: [
+            "--assets-dir", temporaryDirectory.path,
+            "--repo", "Lore-Hex/QuillCode",
+            "--tag", "tester-latest",
+            "--channel", "tester",
+            "--commit", "abc123",
+            "--workflow-run-url", "https://github.com/Lore-Hex/QuillCode/actions/runs/1",
+            "--generated-at", "2026-07-05T00:00:00Z",
+            "--output", manifestURL.path
+        ])
+        XCTAssertEqual(result.exitCode, 0, result.output)
+
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(manifest["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(manifest["product"] as? String, "QuillCode")
+        XCTAssertEqual(manifest["channel"] as? String, "tester")
+        XCTAssertEqual(manifest["tag"] as? String, "tester-latest")
+        XCTAssertEqual(manifest["releaseURL"] as? String, "https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest")
+        XCTAssertEqual(manifest["commit"] as? String, "abc123")
+        XCTAssertEqual(manifest["version"] as? String, "0.2.0")
+        XCTAssertEqual(manifest["build"] as? String, "123")
+        XCTAssertEqual(manifest["generatedAt"] as? String, "2026-07-05T00:00:00Z")
+        XCTAssertEqual(
+            manifest["workflowRunURL"] as? String,
+            "https://github.com/Lore-Hex/QuillCode/actions/runs/1"
+        )
+
+        let assets = try XCTUnwrap(manifest["assets"] as? [[String: Any]])
+        XCTAssertEqual(assets.count, 5)
+
+        let appAsset = try asset(named: "QuillCode-macOS-arm64.zip", in: assets)
+        XCTAssertEqual(appAsset["kind"] as? String, "app")
+        XCTAssertEqual(appAsset["platform"] as? String, "macOS")
+        XCTAssertEqual(appAsset["arch"] as? String, "arm64")
+        XCTAssertEqual(appAsset["install"] as? String, "zip-app")
+        XCTAssertEqual(appAsset["url"] as? String, "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/QuillCode-macOS-arm64.zip")
+        XCTAssertEqual(appAsset["sizeBytes"] as? Int, 7)
+        XCTAssertEqual((appAsset["sha256"] as? String)?.count, 64)
+
+        let linuxAsset = try asset(named: "quill-code-linux-x86_64.tar.gz", in: assets)
+        XCTAssertEqual(linuxAsset["kind"] as? String, "cli")
+        XCTAssertEqual(linuxAsset["platform"] as? String, "Linux")
+        XCTAssertEqual(linuxAsset["arch"] as? String, "x86_64")
+
+        let checksumAsset = try asset(named: "SHASUMS256.txt", in: assets)
+        XCTAssertEqual(checksumAsset["kind"] as? String, "checksum")
+    }
+
+    func testDownloadBuildWorkflowPublishesManifestWithReleaseAssets() throws {
+        let workflow = try Self.workflowText(named: "download-builds.yml")
+
+        Self.assertSource(workflow, containsAll: [
+            "scripts/build-download-manifest.py",
+            "--output \"$RUNNER_TEMP/release-assets/latest-tester-build.json\"",
+            "RELEASE_CHANNEL=\"tester\"",
+            "RELEASE_CHANNEL=\"stable\"",
+            "\\`latest-tester-build.json\\`: machine-readable build metadata",
+            "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/* --clobber"
+        ])
+    }
+
+    func testDownloadDocsExposeStableManifestLink() throws {
+        let downloads = try Self.docsText(named: "DOWNLOADS.md")
+        let readme = try String(contentsOf: Self.packageRoot().appendingPathComponent("README.md"), encoding: .utf8)
+
+        Self.assertSource(downloads, containsAll: [
+            "latest-tester-build.json",
+            "Build manifest",
+            "channel is `tester`",
+            "channel is `stable`"
+        ])
+        Self.assertSource(readme, contains: "machine-readable build manifest")
+    }
+
+    private func asset(named name: String, in assets: [[String: Any]]) throws -> [String: Any] {
+        try XCTUnwrap(assets.first { $0["name"] as? String == name })
+    }
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -12,6 +12,10 @@
   refreshes the stable tester release after successful `main` builds so early testers can use one download URL while
   maintainers can still cut immutable `v*` releases for public announcements. The macOS tester app is ad-hoc signed
   and explicitly not notarized until Apple signing/notarization credentials are configured.
+- Tester releases also publish `latest-tester-build.json` as a machine-readable download manifest. The manifest records
+  channel, tag, commit, workflow run, version/build metadata, and per-asset URL/size/platform/arch/SHA-256 fields so the
+  website, support scripts, and future in-app updater experiments can consume the same stable tester channel without
+  scraping GitHub release HTML.
 - QuillCode keeps TrustedRouter model-advisor guidance as a compact skill-backed pointer in the base prompt instead of
   carrying the full Lore-Hex/LLM-advisor playbook on every request. The prompt names the live-data-first behavior,
   concise 2-5 option recommendations, key privacy filters, and secret-handling guardrails; detailed model-selection

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -14,6 +14,12 @@ Direct asset links for the current tester channel:
 - [macOS CLI: `quill-code-macOS-arm64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-macOS-arm64.tar.gz)
 - [Linux CLI: `quill-code-linux-x86_64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-linux-x86_64.tar.gz)
 - [Checksums: `SHASUMS256.txt`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/SHASUMS256.txt)
+- [Build manifest: `latest-tester-build.json`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json)
+
+The build manifest is intended for the website, updater experiments, and support
+scripts. It records the build channel, tag, commit, workflow run URL, version,
+build number, and per-asset download URL, size, platform, architecture, and
+SHA-256 digest.
 
 ## Build Cadence
 
@@ -64,6 +70,10 @@ Then watch it:
 ```bash
 gh run list --repo Lore-Hex/QuillCode --workflow download-builds.yml --limit 1
 ```
+
+The workflow publishes the same `latest-tester-build.json` schema for manual,
+scheduled, `main`, and `v*` tag builds. For `v*` tags, the channel is `stable`;
+for `tester-latest`, the channel is `tester`.
 
 ## Local Packaging
 

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Build a machine-readable manifest for QuillCode download releases."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+
+SCHEMA_VERSION = 1
+PRODUCT = "QuillCode"
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Write latest-tester-build.json for QuillCode release assets."
+    )
+    parser.add_argument("--assets-dir", required=True, help="Directory containing release assets.")
+    parser.add_argument("--repo", required=True, help="GitHub repository, for example Lore-Hex/QuillCode.")
+    parser.add_argument("--tag", required=True, help="Release tag used in download URLs.")
+    parser.add_argument("--commit", required=True, help="Git commit SHA for this build.")
+    parser.add_argument("--workflow-run-url", required=True, help="GitHub Actions run URL.")
+    parser.add_argument("--channel", default="tester", help="Release channel label.")
+    parser.add_argument("--generated-at", help="UTC ISO timestamp override for tests.")
+    parser.add_argument("--output", required=True, help="Manifest JSON output path.")
+    return parser.parse_args()
+
+
+def sha256_hex(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_build_info(asset_directory: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for path in sorted(asset_directory.glob("BUILD_INFO*.txt")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            key, separator, value = line.partition("=")
+            if separator and key and key not in values:
+                values[key] = value
+    return values
+
+
+def classify_asset(name: str) -> dict[str, str]:
+    if name.startswith("QuillCode-macOS-") and name.endswith(".zip"):
+        arch = name.removeprefix("QuillCode-macOS-").removesuffix(".zip")
+        return {"kind": "app", "platform": "macOS", "arch": arch, "install": "zip-app"}
+    if name.startswith("quill-code-macOS-") and name.endswith(".tar.gz"):
+        arch = name.removeprefix("quill-code-macOS-").removesuffix(".tar.gz")
+        return {"kind": "cli", "platform": "macOS", "arch": arch, "install": "tarball"}
+    if name.startswith("quill-code-linux-") and name.endswith(".tar.gz"):
+        arch = name.removeprefix("quill-code-linux-").removesuffix(".tar.gz")
+        return {"kind": "cli", "platform": "Linux", "arch": arch, "install": "tarball"}
+    if name.startswith("BUILD_INFO"):
+        return {"kind": "metadata", "platform": "any", "arch": "any", "install": "text"}
+    if name.endswith("SHASUMS256.txt") or name == "SHASUMS256.txt":
+        return {"kind": "checksum", "platform": "any", "arch": "any", "install": "text"}
+    return {"kind": "asset", "platform": "any", "arch": "any", "install": "download"}
+
+
+def release_download_url(repo: str, tag: str, asset_name: str) -> str:
+    encoded_name = quote(asset_name, safe="")
+    encoded_tag = quote(tag, safe="")
+    return f"https://github.com/{repo}/releases/download/{encoded_tag}/{encoded_name}"
+
+
+def build_manifest(arguments: argparse.Namespace) -> dict[str, object]:
+    asset_directory = Path(arguments.assets_dir)
+    output_path = Path(arguments.output)
+    if not asset_directory.is_dir():
+        raise SystemExit(f"assets directory does not exist: {asset_directory}")
+
+    build_info = parse_build_info(asset_directory)
+    generated_at = arguments.generated_at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assets: list[dict[str, object]] = []
+    for path in sorted(asset_directory.iterdir(), key=lambda item: item.name):
+        if not path.is_file():
+            continue
+        if path.resolve() == output_path.resolve():
+            continue
+        classification = classify_asset(path.name)
+        assets.append(
+            {
+                "name": path.name,
+                "kind": classification["kind"],
+                "platform": classification["platform"],
+                "arch": classification["arch"],
+                "install": classification["install"],
+                "sizeBytes": path.stat().st_size,
+                "sha256": sha256_hex(path),
+                "url": release_download_url(arguments.repo, arguments.tag, path.name),
+            }
+        )
+
+    if not assets:
+        raise SystemExit(f"no release assets found in {asset_directory}")
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "product": PRODUCT,
+        "channel": arguments.channel,
+        "tag": arguments.tag,
+        "releaseURL": f"https://github.com/{arguments.repo}/releases/tag/{quote(arguments.tag, safe='')}",
+        "commit": arguments.commit,
+        "version": build_info.get("version", "unknown"),
+        "build": build_info.get("build", "unknown"),
+        "generatedAt": generated_at,
+        "workflowRunURL": arguments.workflow_run_url,
+        "assets": assets,
+    }
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    manifest = build_manifest(arguments)
+    output_path = Path(arguments.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/build-download-manifest.py` to produce a machine-readable release manifest for tester and tagged builds
- publish `latest-tester-build.json` from the Download Builds workflow with channel/tag/commit/build metadata plus per-asset URL, size, platform, arch, and SHA-256 fields
- document the stable manifest link and add a parity gate that exercises the generator against fake release assets

## Validation
- `swift test --filter ParityDownloadBuildsGateTests`
- `git diff --check --cached` before commit