### PR TITLE
Polish Codex-density sidebar and token chrome

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -1437,7 +1437,7 @@
       position: relative;
       display: grid;
       grid-template-columns: minmax(0, 1fr) var(--hit-target);
-      gap: 6px;
+      gap: var(--hit-target-clearance);
       align-items: start;
       margin-bottom: 4px;
     }
@@ -1448,7 +1448,7 @@
       position: relative;
       display: grid;
       grid-template-columns: minmax(0, 1fr) var(--hit-target);
-      gap: 6px;
+      gap: var(--hit-target-clearance);
       align-items: start;
       margin-bottom: 4px;
     }

--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -25,7 +25,7 @@
       --shadow-surface-hover: 0 0 0 1px rgba(255,255,255,.14), 0 12px 30px rgba(0,0,0,.18);
       --hit-target: 44px;
       --hit-target-clearance: 8px;
-      --control-cluster-gap: 10px;
+      --control-cluster-gap: 8px;
       --workspace-sidebar-width: 280px;
     }
     * { box-sizing: border-box; }
@@ -191,11 +191,11 @@
       display: grid;
       grid-template-columns: var(--workspace-sidebar-width) minmax(0, 1fr) auto;
       align-items: center;
-      gap: 14px;
+      gap: 10px;
       min-height: var(--hit-target);
-      padding: 0 14px;
-      border-bottom: 1px solid rgba(255,255,255,.10);
-      background: rgba(12, 18, 22, .94);
+      padding: 0 12px;
+      border-bottom: 1px solid rgba(255,255,255,.08);
+      background: rgba(10, 16, 20, .96);
     }
     .topbar-sidebar-slot {
       display: flex;
@@ -214,9 +214,9 @@
       font-size: 18px;
       font-weight: 800;
       line-height: 1;
-      border: 1px solid rgba(65, 184, 232, .24);
-      border-radius: 10px;
-      background: rgba(65, 184, 232, .12);
+      border: 1px solid transparent;
+      border-radius: 8px;
+      background: transparent;
     }
     .quillcode-workspace[data-sidebar-visible="false"] .topbar {
       grid-template-columns: auto minmax(0, 1fr) auto;
@@ -238,7 +238,7 @@
       min-width: 0;
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 8px;
       text-align: left;
     }
     .topbar-title-copy {
@@ -265,12 +265,12 @@
       background: rgba(66, 214, 119, 0.10);
     }
     .topbar-token-budget {
-      flex: 0 0 min(286px, 30vw);
-      min-width: 226px;
+      flex: 0 0 min(318px, 32vw);
+      min-width: 260px;
       display: grid;
-      gap: 6px;
-      padding: 8px 12px 9px;
-      border-radius: 16px;
+      gap: 4px;
+      padding: 5px 10px;
+      border-radius: 10px;
       background: rgba(65, 184, 232, 0.11);
       color: var(--text);
       font-variant-numeric: tabular-nums;
@@ -289,13 +289,12 @@
     }
     .topbar-token-budget-label {
       color: var(--muted);
-      font-size: 10px;
-      font-weight: 800;
-      text-transform: uppercase;
+      font-size: 13px;
+      font-weight: 700;
     }
     .topbar-token-budget strong {
       min-width: 0;
-      font-size: 12px;
+      font-size: 14px;
       font-weight: 800;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -322,7 +321,7 @@
     .topbar-token-budget p {
       margin: 0;
       color: var(--muted);
-      font-size: 10px;
+      font-size: 13px;
       font-weight: 700;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -341,7 +340,7 @@
       overflow: hidden;
       color: var(--blue);
       background: rgba(65, 184, 232, 0.12);
-      font-size: 10px;
+      font-size: 12px;
       font-weight: 800;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -956,8 +955,8 @@
     .sidebar-projects-zone {
       margin-top: 10px;
     }
-    .sidebar h2 { margin: 0 0 12px; color: var(--muted); font-size: 13px; text-transform: uppercase; letter-spacing: .08em; }
-    .sidebar h3 { margin: 8px 0 4px; color: var(--muted); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; }
+    .sidebar h2 { margin: 0 0 8px; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+    .sidebar h3 { margin: 6px 0 3px; color: var(--muted); font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: .06em; }
     .sidebar-section > h3[data-testid="sidebar-section-title"] {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -1149,22 +1148,22 @@
     }
     .sidebar-actions {
       display: grid;
-      gap: 6px;
-      margin-bottom: 10px;
+      gap: 3px;
+      margin-bottom: 8px;
     }
     .sidebar-action {
       width: 100%;
       min-height: var(--hit-target);
-      padding: 7px 10px;
+      padding: 2px 14px;
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 9px;
       justify-content: flex-start;
       text-align: left;
       color: var(--text);
       background: transparent;
       border: 1px solid transparent;
-      border-radius: 10px;
+      border-radius: 8px;
       box-shadow: none;
       transition-property: transform, background-color, box-shadow, border-color;
       transition-duration: 150ms;
@@ -1186,15 +1185,15 @@
     .sidebar-tools-menu summary::before,
     .sidebar-tool-action::before {
       flex: 0 0 auto;
-      width: 28px;
-      height: 28px;
+      width: 24px;
+      height: 24px;
       display: grid;
       place-items: center;
       color: var(--muted);
       text-align: center;
-      font-size: 15px;
+      font-size: 14px;
       line-height: 1;
-      border-radius: 8px;
+      border-radius: 7px;
       background: rgba(255,255,255,.045);
       box-shadow: inset 0 0 0 1px rgba(255,255,255,.07);
     }
@@ -1352,15 +1351,15 @@
     .sidebar-item,
     .project-item {
       width: 100%;
-      margin: 0 0 8px;
-      padding: 11px 12px;
+      margin: 0 0 4px;
+      padding: 5px 14px;
       display: grid;
-      gap: 3px;
+      gap: 1px;
       text-align: left;
       color: var(--text);
       background: transparent;
       border: 1px solid transparent;
-      border-radius: 12px;
+      border-radius: 8px;
       transition-property: transform, background-color, box-shadow, border-color;
       transition-duration: 150ms;
       transition-timing-function: var(--ease-out);
@@ -1373,9 +1372,9 @@
       background: rgba(255,255,255,.06);
     }
     .sidebar-item {
-      min-height: 60px;
-      padding-right: 12px;
-      margin-bottom: 6px;
+      min-height: var(--hit-target);
+      padding-right: 14px;
+      margin-bottom: 3px;
     }
     .sidebar-item.selected,
     .project-item.selected { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.14); }
@@ -1421,7 +1420,7 @@
       background: rgba(65,184,232,.1);
     }
     .sidebar-item small,
-    .project-item small { color: var(--muted); }
+    .project-item small { color: var(--muted); font-size: 12px; line-height: 1.25; }
     .project-connection-kind {
       display: inline-flex;
       align-items: center;
@@ -1438,9 +1437,9 @@
       position: relative;
       display: grid;
       grid-template-columns: minmax(0, 1fr) var(--hit-target);
-      gap: var(--hit-target-clearance);
+      gap: 6px;
       align-items: start;
-      margin-bottom: 8px;
+      margin-bottom: 4px;
     }
     .sidebar-thread-row.selection-mode {
       grid-template-columns: var(--hit-target) minmax(0, 1fr) var(--hit-target);
@@ -1449,12 +1448,12 @@
       position: relative;
       display: grid;
       grid-template-columns: minmax(0, 1fr) var(--hit-target);
-      gap: var(--hit-target-clearance);
+      gap: 6px;
       align-items: start;
-      margin-bottom: 8px;
+      margin-bottom: 4px;
     }
     .project-row .project-item {
-      padding-right: 12px;
+      padding-right: 14px;
     }
     .sidebar-thread-menu {
       position: relative;
@@ -3702,6 +3701,18 @@
       }
       .topbar-cluster {
         flex-wrap: wrap;
+      }
+      .topbar-title-group {
+        width: 100%;
+        flex-wrap: wrap;
+      }
+      .topbar-title-copy {
+        flex-basis: 100%;
+      }
+      .topbar-token-budget {
+        flex: 1 1 100%;
+        min-width: 0;
+        max-width: 100%;
       }
       .browser-form {
         grid-template-columns: minmax(0, 1fr) auto;

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -68,13 +68,24 @@ public struct QuillCodePressableButtonStyle: ButtonStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(
-                minWidth: enforcesMinimumHitTarget ? QuillCodeMetrics.minimumHitTarget : nil,
-                minHeight: enforcesMinimumHitTarget ? QuillCodeMetrics.minimumHitTarget : nil
-            )
+            .quillCodeOptionalPressableFrame(enforcesMinimumHitTarget: enforcesMinimumHitTarget)
             .contentShape(Rectangle())
             .scaleEffect(!reduceMotion && configuration.isPressed ? QuillCodeMetrics.pressScale : 1)
             .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func quillCodeOptionalPressableFrame(enforcesMinimumHitTarget: Bool) -> some View {
+        if enforcesMinimumHitTarget {
+            frame(
+                minWidth: QuillCodeMetrics.minimumHitTarget,
+                minHeight: QuillCodeMetrics.minimumHitTarget
+            )
+        } else {
+            self
+        }
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -10,18 +10,18 @@ public enum QuillCodeMetrics {
     public static let controlClusterSpacing: CGFloat = 8
     public static let denseControlClusterSpacing: CGFloat = 6
     public static let topBarHeight: CGFloat = 40
-    public static let topBarTokenBudgetMinWidth: CGFloat = 328
-    public static let topBarTokenBudgetMaxWidth: CGFloat = 460
-    public static let topBarTokenBudgetHorizontalPadding: CGFloat = 9
-    public static let topBarTokenBudgetVerticalPadding: CGFloat = 4
+    public static let topBarTokenBudgetMinWidth: CGFloat = 300
+    public static let topBarTokenBudgetMaxWidth: CGFloat = 420
+    public static let topBarTokenBudgetHorizontalPadding: CGFloat = 10
+    public static let topBarTokenBudgetVerticalPadding: CGFloat = 5
     public static let sidebarWidth: CGFloat = 280
-    public static let sidebarLeadingInset: CGFloat = 10
-    public static let sidebarTrailingInset: CGFloat = 10
-    public static let sidebarVerticalInset: CGFloat = 6
-    public static let sidebarSectionSpacing: CGFloat = 5
-    public static let sidebarVisibleRowHeight: CGFloat = 29
-    public static let sidebarVisibleRowHorizontalPadding: CGFloat = 12
-    public static let sidebarVisibleRowRadius: CGFloat = 7
+    public static let sidebarLeadingInset: CGFloat = 12
+    public static let sidebarTrailingInset: CGFloat = 12
+    public static let sidebarVerticalInset: CGFloat = 5
+    public static let sidebarSectionSpacing: CGFloat = 4
+    public static let sidebarVisibleRowHeight: CGFloat = 27
+    public static let sidebarVisibleRowHorizontalPadding: CGFloat = 14
+    public static let sidebarVisibleRowRadius: CGFloat = 8
     public static let composerSurfaceRadius: CGFloat = 12
     public static let composerControlRadius: CGFloat = 10
     public static let toolCardMinimumHeight: CGFloat = 74
@@ -60,13 +60,17 @@ func quillCodeWithAnimation(_ animation: Animation, reduceMotion: Bool, _ update
 public struct QuillCodePressableButtonStyle: ButtonStyle {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    public init() {}
+    private let enforcesMinimumHitTarget: Bool
+
+    public init(enforcesMinimumHitTarget: Bool = true) {
+        self.enforcesMinimumHitTarget = enforcesMinimumHitTarget
+    }
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(
-                minWidth: QuillCodeMetrics.minimumHitTarget,
-                minHeight: QuillCodeMetrics.minimumHitTarget
+                minWidth: enforcesMinimumHitTarget ? QuillCodeMetrics.minimumHitTarget : nil,
+                minHeight: enforcesMinimumHitTarget ? QuillCodeMetrics.minimumHitTarget : nil
             )
             .contentShape(Rectangle())
             .scaleEffect(!reduceMotion && configuration.isPressed ? QuillCodeMetrics.pressScale : 1)

--- a/Sources/QuillCodeApp/QuillCodeProjectRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectRowView.swift
@@ -27,7 +27,7 @@ struct QuillCodeProjectRowView: View {
             }
             .quillCodeSidebarRowChrome(background: project.isSelected ? QuillCodePalette.selection : Color.clear)
         }
-        .buttonStyle(QuillCodePressableButtonStyle())
+        .buttonStyle(QuillCodePressableButtonStyle(enforcesMinimumHitTarget: false))
     }
 
     private var projectTitleRow: some View {

--- a/Sources/QuillCodeApp/QuillCodeProjectRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectRowView.swift
@@ -6,7 +6,7 @@ struct QuillCodeProjectRowView: View {
     var onProjectAction: (ProjectItemActionSurface) -> Void
 
     var body: some View {
-        HStack(spacing: QuillCodeMetrics.denseControlClusterSpacing) {
+        HStack(spacing: QuillCodeMetrics.minimumTargetClearance) {
             projectButton
             projectActionMenu
         }

--- a/Sources/QuillCodeApp/QuillCodeSidebarActionsView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarActionsView.swift
@@ -26,7 +26,7 @@ struct QuillCodeSidebarActionsView: View {
                     .foregroundStyle(command.isEnabled ? QuillCodePalette.text : QuillCodePalette.muted)
                     .quillCodeSidebarRowChrome(background: primaryCommandBackground(command))
                 }
-                .buttonStyle(QuillCodePressableButtonStyle())
+                .buttonStyle(QuillCodePressableButtonStyle(enforcesMinimumHitTarget: false))
                 .disabled(!command.isEnabled)
                 .accessibilityIdentifier("quillcode-sidebar-command-\(command.id)")
             }

--- a/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
@@ -53,7 +53,7 @@ struct QuillCodeSidebarThreadRowView: View {
             }
             .quillCodeSidebarRowChrome(background: item.isSelected ? QuillCodePalette.selection : Color.clear)
         }
-        .buttonStyle(QuillCodePressableButtonStyle())
+        .buttonStyle(QuillCodePressableButtonStyle(enforcesMinimumHitTarget: false))
     }
 
     private var actionsMenu: some View {

--- a/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
@@ -8,7 +8,7 @@ struct QuillCodeSidebarThreadRowView: View {
     var onCommand: (WorkspaceCommandSurface) -> Void
 
     var body: some View {
-        HStack(spacing: QuillCodeMetrics.denseControlClusterSpacing) {
+        HStack(spacing: QuillCodeMetrics.minimumTargetClearance) {
             selectionToggle
             threadButton
             actionsMenu

--- a/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
@@ -61,16 +61,21 @@ struct QuillCodeTopBarIdentityView: View {
     }
 
     private func tokenBudgetView(_ budget: TokenBudgetSurface) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 3) {
             HStack(alignment: .firstTextBaseline, spacing: 7) {
                 Text("Tokens")
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.system(size: 13.5, weight: .semibold))
                     .foregroundStyle(QuillCodePalette.muted)
                 Text(budget.primaryLabel)
-                    .font(.system(size: 15.5, weight: .semibold).monospacedDigit())
+                    .font(.system(size: 16, weight: .semibold).monospacedDigit())
                     .foregroundStyle(QuillCodePalette.text)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.96)
+                    .minimumScaleFactor(0.94)
+                Spacer(minLength: 4)
+                Text("\(budget.usedPercent)%")
+                    .font(.system(size: 13.5, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(tokenBudgetTint(for: budget))
+                    .lineLimit(1)
             }
 
             GeometryReader { proxy in
@@ -86,17 +91,17 @@ struct QuillCodeTopBarIdentityView: View {
 
             HStack(spacing: 7) {
                 Text(budget.secondaryLabel)
-                    .font(.system(size: 14, weight: .medium).monospacedDigit())
+                    .font(.system(size: 13.5, weight: .medium).monospacedDigit())
                     .foregroundStyle(QuillCodePalette.muted)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.96)
+                    .minimumScaleFactor(0.94)
 
                 if !budget.visibleQuotaLimits.isEmpty {
                     Text(budget.visibleQuotaLimits.prefix(2).map(\.compactLabel).joined(separator: " · "))
-                        .font(.system(size: 14, weight: .semibold).monospacedDigit())
+                        .font(.system(size: 13.5, weight: .semibold).monospacedDigit())
                         .foregroundStyle(tokenBudgetTint(for: budget))
                         .lineLimit(1)
-                        .minimumScaleFactor(0.96)
+                        .minimumScaleFactor(0.94)
                 }
             }
         }

--- a/Tests/QuillCodeParityTests/ParityInteractionTargetHarnessGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityInteractionTargetHarnessGateTests.swift
@@ -8,7 +8,7 @@ final class ParityInteractionTargetHarnessGateTests: QuillCodeParityTestCase {
             harnessText,
             containsAll: [
                 "--hit-target-clearance: 8px",
-                "--control-cluster-gap: 10px",
+                "--control-cluster-gap: 8px",
                 ".model-category { display: grid; gap: var(--hit-target-clearance); }",
                 ".model-actions {",
                 ".browser-nav-controls {",

--- a/Tests/QuillCodeParityTests/ParityNativeTopBarChromeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityNativeTopBarChromeGateTests.swift
@@ -19,13 +19,13 @@ final class ParityNativeTopBarChromeGateTests: QuillCodeParityTestCase {
         [
             "static let sidebarWidth",
             "static let topBarHeight: CGFloat = 40",
-            "static let topBarTokenBudgetMinWidth: CGFloat = 328",
-            "static let topBarTokenBudgetVerticalPadding: CGFloat = 4"
+            "static let topBarTokenBudgetMinWidth: CGFloat = 300",
+            "static let topBarTokenBudgetVerticalPadding: CGFloat = 5"
         ].forEach { Self.assertSource(designText, contains: $0) }
         [
             "Text(\"Tokens\")",
-            "font(.system(size: 15.5, weight: .semibold).monospacedDigit())",
-            "font(.system(size: 14, weight: .medium).monospacedDigit())"
+            "font(.system(size: 16, weight: .semibold).monospacedDigit())",
+            "font(.system(size: 13.5, weight: .medium).monospacedDigit())"
         ].forEach { Self.assertSource(identityText, contains: $0) }
         assertTopBarCompositionAvoidsBusyChrome(topBarViewText)
     }

--- a/Tests/QuillCodeParityTests/ParityRenderedResponsiveTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityRenderedResponsiveTargetGateTests.swift
@@ -8,7 +8,7 @@ final class ParityRenderedResponsiveTargetGateTests: QuillCodeParityTestCase {
 
         Self.assertSource(harnessText, containsAll: [
             "--hit-target-clearance: 8px",
-            "--control-cluster-gap: 10px",
+            "--control-cluster-gap: 8px",
             ".model-category { display: grid; gap: var(--hit-target-clearance); }",
             ".model-actions {",
             "gap: var(--hit-target-clearance);",

--- a/Tests/QuillCodeParityTests/ParitySidebarCommandPresentationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySidebarCommandPresentationGateTests.swift
@@ -72,9 +72,9 @@ final class ParitySidebarCommandPresentationGateTests: QuillCodeParityTestCase {
         let buttonTargetText = try Self.appSourceText(named: "QuillCodeButtonHitTargetViewModifiers.swift")
 
         [
-            "static let sidebarVisibleRowHeight: CGFloat = 29",
-            "static let sidebarVisibleRowHorizontalPadding: CGFloat = 12",
-            "static let sidebarVisibleRowRadius: CGFloat = 7"
+            "static let sidebarVisibleRowHeight: CGFloat = 27",
+            "static let sidebarVisibleRowHorizontalPadding: CGFloat = 14",
+            "static let sidebarVisibleRowRadius: CGFloat = 8"
         ].forEach { Self.assertSource(designText, contains: $0) }
         [
             primaryActionsText,

--- a/Tests/QuillCodeParityTests/ParitySidebarCommandPresentationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySidebarCommandPresentationGateTests.swift
@@ -88,6 +88,8 @@ final class ParitySidebarCommandPresentationGateTests: QuillCodeParityTestCase {
         Self.assertSource(buttonTargetText, contains: "QuillCodeMetrics.sidebarVisibleRowRadius")
         Self.assertSource(buttonTargetText, contains: "QuillCodeMetrics.sidebarVisibleRowHeight")
         Self.assertSource(buttonTargetText, contains: "QuillCodeMetrics.minimumHitTarget")
+        Self.assertSource(threadRowText, contains: "HStack(spacing: QuillCodeMetrics.minimumTargetClearance)")
+        Self.assertSource(projectRowText, contains: "HStack(spacing: QuillCodeMetrics.minimumTargetClearance)")
         Self.assertSource(threadRowText, contains: ".quillCodeIconButtonTarget")
         Self.assertSource(projectRowText, contains: ".quillCodeIconButtonTarget")
     }


### PR DESCRIPTION
## Summary
- tighten QuillCode sidebar visible row metrics while preserving shared hit-target contracts
- make the top-bar token budget more readable with normal-size tabular text
- update the HTML harness to match the native density and wrap token chrome on mobile

## Codex UI notes applied
- compact desktop rows with stronger horizontal padding instead of tall mobile-style buttons
- quiet top chrome with less boxed navigation
- tabular token numbers that stay legible without creating mobile overflow

## Validation
- swift test --filter 'ParityNativeTopBarChromeGateTests|ParitySidebarCommandPresentationGateTests|QuillCodeNativeHitTargetDesignTests|WorkspaceTokenUsageChipRenderTests'
- swift test --filter 'QuillCodeNativeHitTargetSourceAuditTests|ParityNativeSourceInteractionAuditGateTests|ParityNativeInteractionContractGateTests|ParityNativePrimaryChromeHitTargetGateTests'
- npx playwright test E2E/playwright/tests/visual-polish.spec.ts

Screenshot: E2E/playwright/visual-artifacts/quillcode-density-polish.png