### PR TITLE
Tighten slash init harness parity

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4654,6 +4654,7 @@
       { usage: '/workspace-check when', title: 'Schedule workspace check', detail: 'Create a scheduled check for the selected project, for example in 1 hour, Friday morning, next Monday at noon, or every 2 hours.', insertText: '/workspace-check in ', aliases: ['workspace schedule', 'schedule workspace', 'project check', 'repo check', 'automation workspace'] },
       { usage: '/project new', title: 'Project new chat', detail: 'Start a new thread in the selected project.', insertText: '/project new', aliases: ['project chat'] },
       { usage: '/project refresh', title: 'Refresh project context', detail: 'Reload instructions, local actions, extensions, and memories.', insertText: '/project refresh', aliases: ['project reload', 'project context'] },
+      { usage: '/init', title: 'Initialize AGENTS.md', detail: 'Scaffold a starter AGENTS.md for the project from its build and test commands.', insertText: '/init', aliases: ['init-project', 'scaffold', 'agents'] },
       { usage: '/project rename name', title: 'Rename project', detail: 'Rename the selected project in QuillCode.', insertText: '/project rename ', aliases: ['project title'] },
       { usage: '/project remove', title: 'Remove project', detail: 'Forget the selected project from the sidebar without deleting files.', insertText: '/project remove', aliases: ['project forget'] },
       { usage: '/ssh user@host:/path', title: 'Add SSH Remote', detail: 'Register an SSH Remote workspace in the project sidebar.', insertText: '/ssh ', aliases: ['remote', 'ssh project'] },

--- a/Tests/QuillCodeAppTests/WorkspaceSlashRegistryHarnessParityTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSlashRegistryHarnessParityTests.swift
@@ -12,12 +12,11 @@ final class WorkspaceSlashRegistryHarnessParityTests: XCTestCase {
     // MARK: - Command set parity
 
     /// The PR sub-catalog is enumerated per-subcommand natively but collapsed to a single `/pr` row
-    /// in the harness; `/init`, `/subagents`, and `/env schedule` are native-only local commands the
-    /// mock harness does not model. These are long-standing, PRE-EXISTING divergences — every OTHER
-    /// command must match one-for-one between the two surfaces so a new registry entry (like the
-    /// #879 `/model` and `/skill` rows) can never land on only one side unnoticed.
+    /// in the harness; `/subagents` and `/env schedule` are native-only local commands the mock
+    /// harness does not model. These are long-standing, PRE-EXISTING divergences — every OTHER command
+    /// must match one-for-one between the two surfaces so a new registry entry (like the #879 `/model`
+    /// and `/skill` rows) can never land on only one side unnoticed.
     private static let nativeOnlyUsages: Set<String> = [
-        "/init",
         "/subagents objective | Name: role",
         "/env schedule name when"
     ]


### PR DESCRIPTION
## Summary
- Register `/init` in the HTML/Playwright harness slash command catalog now that the harness already executes it.
- Remove `/init` from the native-only slash registry exception list so future drift fails CI.

## Validation
- `swift test --filter WorkspaceSlashRegistryHarnessParityTests`
- `npm test -- tests/init.spec.ts` from `E2E/playwright`
- `npm test -- tests/composer-slash.spec.ts` from `E2E/playwright`
- `git diff --check`