### PR TITLE
Refresh tester builds after train merges

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -43,5 +43,5 @@ jobs:
           MERGE_TRAIN_DELETE_BRANCH: "true"
           MERGE_TRAIN_UPDATE_BEHIND_BRANCHES: "false"
           MERGE_TRAIN_IGNORED_CHECK_RE: "^(Merge Train|train)$"
-          MERGE_TRAIN_POST_MERGE_WORKFLOW: ci.yml
+          MERGE_TRAIN_POST_MERGE_WORKFLOWS: ci.yml download-builds.yml
         run: ./scripts/merge-train.sh

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -95,6 +95,26 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         Self.assertSource(readme, contains: "machine-readable build manifest")
     }
 
+    func testMergeTrainRefreshesTesterDownloadsAfterMerges() throws {
+        let workflow = try Self.workflowText(named: "merge-train.yml")
+        let script = try String(
+            contentsOf: Self.packageRoot().appendingPathComponent("scripts/merge-train.sh"),
+            encoding: .utf8
+        )
+        let docs = try Self.docsText(named: "MERGE_TRAIN.md")
+
+        Self.assertSource(workflow, contains: "MERGE_TRAIN_POST_MERGE_WORKFLOWS: ci.yml download-builds.yml")
+        Self.assertSource(script, containsAll: [
+            "MERGE_TRAIN_POST_MERGE_WORKFLOWS",
+            "MERGE_TRAIN_POST_MERGE_WORKFLOW",
+            "gh workflow run \"$post_merge_workflow\" --repo \"$repo\" --ref \"$base_branch\""
+        ])
+        Self.assertSource(docs, containsAll: [
+            "`CI` and `Download Builds` workflows",
+            "refreshes the `tester-latest` download release"
+        ])
+    }
+
     private func asset(named name: String, in assets: [[String: Any]]) throws -> [String: Any] {
         try XCTUnwrap(assets.first { $0["name"] as? String == name })
     }

--- a/Tests/QuillCodeParityTests/ParityMergeTrainGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityMergeTrainGateTests.swift
@@ -18,13 +18,29 @@ final class ParityMergeTrainGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(result.ghLog.contains("pr update-branch 42 --repo Lore-Hex/QuillCode"))
     }
 
+    func testMergedPullRequestDispatchesAllConfiguredPostMergeWorkflows() throws {
+        let result = try runMergeTrain(
+            pullRequestJSON: readyCleanPullRequestJSON,
+            postMergeWorkflows: "ci.yml download-builds.yml"
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.ghLog.contains("pr merge 42 --repo Lore-Hex/QuillCode --squash --delete-branch"))
+        XCTAssertTrue(result.ghLog.contains("workflow run ci.yml --repo Lore-Hex/QuillCode --ref main"))
+        XCTAssertTrue(result.ghLog.contains("workflow run download-builds.yml --repo Lore-Hex/QuillCode --ref main"))
+    }
+
     private struct MergeTrainResult {
         let exitCode: Int32
         let output: String
         let ghLog: String
     }
 
-    private func runMergeTrain(updateBehindBranches: String?) throws -> MergeTrainResult {
+    private func runMergeTrain(
+        pullRequestJSON: String? = nil,
+        updateBehindBranches: String? = nil,
+        postMergeWorkflows: String? = nil
+    ) throws -> MergeTrainResult {
         let temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("quillcode-merge-train-tests")
             .appendingPathComponent(UUID().uuidString)
@@ -36,7 +52,7 @@ final class ParityMergeTrainGateTests: QuillCodeParityTestCase {
         let prJSONURL = temporaryDirectory.appendingPathComponent("prs.json")
         let fakeGHURL = binDirectory.appendingPathComponent("gh")
 
-        try readyBehindPullRequestJSON.write(to: prJSONURL, atomically: true, encoding: .utf8)
+        try (pullRequestJSON ?? readyBehindPullRequestJSON).write(to: prJSONURL, atomically: true, encoding: .utf8)
         try fakeGHScript.write(to: fakeGHURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeGHURL.path)
 
@@ -56,6 +72,11 @@ final class ParityMergeTrainGateTests: QuillCodeParityTestCase {
             environment["MERGE_TRAIN_UPDATE_BEHIND_BRANCHES"] = updateBehindBranches
         } else {
             environment.removeValue(forKey: "MERGE_TRAIN_UPDATE_BEHIND_BRANCHES")
+        }
+        if let postMergeWorkflows {
+            environment["MERGE_TRAIN_POST_MERGE_WORKFLOWS"] = postMergeWorkflows
+        } else {
+            environment.removeValue(forKey: "MERGE_TRAIN_POST_MERGE_WORKFLOWS")
         }
         process.environment = environment
 
@@ -91,6 +112,30 @@ final class ParityMergeTrainGateTests: QuillCodeParityTestCase {
         """
     }
 
+    private var readyCleanPullRequestJSON: String {
+        """
+        [
+          {
+            "number": 42,
+            "title": "Ready clean PR",
+            "url": "https://github.com/Lore-Hex/QuillCode/pull/42",
+            "isDraft": false,
+            "createdAt": "2026-06-29T00:00:00Z",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [
+              {"name": "swift", "status": "COMPLETED", "conclusion": "SUCCESS"},
+              {"name": "linux-swift", "status": "COMPLETED", "conclusion": "SUCCESS"},
+              {"name": "playwright", "status": "COMPLETED", "conclusion": "SUCCESS"},
+              {"name": "smoke", "status": "COMPLETED", "conclusion": "SUCCESS"}
+            ],
+            "labels": [{"name": "merge-train"}],
+            "headRefName": "feature",
+            "headRepositoryOwner": {"login": "Lore-Hex"}
+          }
+        ]
+        """
+    }
+
     private var fakeGHScript: String {
         """
         #!/usr/bin/env bash
@@ -101,6 +146,12 @@ final class ParityMergeTrainGateTests: QuillCodeParityTestCase {
           exit 0
         fi
         if [[ "$1" == "pr" && "$2" == "update-branch" ]]; then
+          exit 0
+        fi
+        if [[ "$1" == "pr" && "$2" == "merge" ]]; then
+          exit 0
+        fi
+        if [[ "$1" == "workflow" && "$2" == "run" ]]; then
           exit 0
         fi
         echo "unexpected gh invocation: $*" >&2

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,10 @@
 
 ## 2026-07-05
 
+- Merge-train merges use GitHub Actions' `GITHUB_TOKEN`, so GitHub does not enqueue normal push-triggered
+  workflows afterward. The train therefore dispatches both `ci.yml` and `download-builds.yml` explicitly after a
+  successful merge. This keeps `main` validated and refreshes `tester-latest` without requiring a maintainer to
+  remember a manual tester-build run after agent PRs land.
 - Project `.quillcode/config.toml` starts as a bounded source-derived configuration layer, not another persisted app-state
   object. `WorkspaceProjectConfigurationLoader` currently lets repositories add local action directories and cap discovered
   local actions while keeping `.quillcode/actions` and `.quillcode/local-env` enabled by default. Unsafe, absolute, parent

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -26,6 +26,7 @@ SHA-256 digest.
 The tester release is refreshed:
 
 - after every successful push to `main`
+- after merge-train PR merges, which explicitly dispatch **Download Builds**
 - every night from the scheduled **Download Builds** workflow
 - whenever a maintainer runs **Download Builds** manually from GitHub Actions
 

--- a/docs/MERGE_TRAIN.md
+++ b/docs/MERGE_TRAIN.md
@@ -20,7 +20,7 @@ The train processes only the oldest eligible PR at a time. It ignores draft PRs 
 - Only one train run can execute at a time.
 
 When the train head is ready, it merges with a squash merge and deletes the source branch.
-After a successful merge, the train dispatches the `CI` workflow on `main` explicitly. GitHub does not automatically create a normal push-triggered run for merges performed with `GITHUB_TOKEN`, so this keeps the latest `main` state visibly validated in Actions.
+After a successful merge, the train dispatches the `CI` and `Download Builds` workflows on `main` explicitly. GitHub does not automatically create normal push-triggered runs for merges performed with `GITHUB_TOKEN`, so this keeps the latest `main` state visibly validated in Actions and refreshes the `tester-latest` download release for early users.
 
 The train intentionally does not update behind PR branches by default. Branch updates made by GitHub Actions' `GITHUB_TOKEN` do not reliably create normal `pull_request` CI checks, which can leave the PR with no completed checks for the train to trust. `MERGE_TRAIN_UPDATE_BEHIND_BRANCHES=true` is available only for installations using a token that can trigger the required PR checks.
 

--- a/scripts/merge-train.sh
+++ b/scripts/merge-train.sh
@@ -9,7 +9,7 @@ block_label="${MERGE_TRAIN_BLOCK_LABEL:-do-not-merge}"
 merge_method="${MERGE_TRAIN_METHOD:-squash}"
 delete_branch="${MERGE_TRAIN_DELETE_BRANCH:-true}"
 ignored_check_re="${MERGE_TRAIN_IGNORED_CHECK_RE:-^(Merge Train|train)$}"
-post_merge_workflow="${MERGE_TRAIN_POST_MERGE_WORKFLOW:-}"
+post_merge_workflows_raw="${MERGE_TRAIN_POST_MERGE_WORKFLOWS:-${MERGE_TRAIN_POST_MERGE_WORKFLOW:-}}"
 dry_run="${MERGE_TRAIN_DRY_RUN:-false}"
 update_behind_branches="${MERGE_TRAIN_UPDATE_BEHIND_BRANCHES:-false}"
 
@@ -145,11 +145,18 @@ else
   gh "${merge_args[@]}"
 fi
 
-if [[ -n "$post_merge_workflow" ]]; then
-  echo "Dispatching post-merge workflow $post_merge_workflow on $base_branch."
-  if [[ "$dry_run" == "true" ]]; then
-    echo "DRY RUN: gh workflow run $post_merge_workflow --repo $repo --ref $base_branch"
-  else
-    gh workflow run "$post_merge_workflow" --repo "$repo" --ref "$base_branch"
-  fi
+if [[ -n "$post_merge_workflows_raw" ]]; then
+  IFS=$' \t\n,' read -r -a post_merge_workflows <<<"$post_merge_workflows_raw"
+  for post_merge_workflow in "${post_merge_workflows[@]}"; do
+    if [[ -z "$post_merge_workflow" ]]; then
+      continue
+    fi
+
+    echo "Dispatching post-merge workflow $post_merge_workflow on $base_branch."
+    if [[ "$dry_run" == "true" ]]; then
+      echo "DRY RUN: gh workflow run $post_merge_workflow --repo $repo --ref $base_branch"
+    else
+      gh workflow run "$post_merge_workflow" --repo "$repo" --ref "$base_branch"
+    fi
+  done
 fi


### PR DESCRIPTION
## Summary
- dispatch both CI and Download Builds after a successful merge-train merge
- keep the legacy single post-merge workflow env var as a fallback while adding multi-workflow support
- document that tester-latest is refreshed after merge-train PR merges

## Validation
- swift test --filter 'ParityMergeTrainGateTests|ParityDownloadBuildsGateTests'
- swift test
- git diff --check