### PR TITLE
Show three spend periods in native top bar

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
@@ -128,7 +128,7 @@ struct QuillCodeTopBarIdentityView: View {
     }
 
     private func tokenBudgetQuotaLabel(_ budget: TokenBudgetSurface) -> String? {
-        let quotaSummary = budget.visibleQuotaLimits.prefix(2).map(\.compactLabel).joined(separator: " · ")
+        let quotaSummary = budget.visibleQuotaLimits.prefix(3).map(\.compactLabel).joined(separator: " · ")
         return quotaSummary.isEmpty ? nil : quotaSummary
     }
 

--- a/Tests/QuillCodeParityTests/ParityNativeTopBarChromeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityNativeTopBarChromeGateTests.swift
@@ -28,7 +28,8 @@ final class ParityNativeTopBarChromeGateTests: QuillCodeParityTestCase {
             "Text(\"Tokens\")",
             "font(.system(size: 16.5, weight: .semibold).monospacedDigit())",
             "font(.system(size: 14, weight: .medium).monospacedDigit())",
-            "tokenBudgetRemainingLabel"
+            "tokenBudgetRemainingLabel",
+            "visibleQuotaLimits.prefix(3)"
         ].forEach { Self.assertSource(identityText, contains: $0) }
         assertTopBarCompositionAvoidsBusyChrome(topBarViewText)
     }


### PR DESCRIPTION
## Summary
- show up to three quota/spend period labels in the native top-bar budget chip
- add a parity guard so Today/Week/Month spend visibility does not regress

## Validation
- swift test --filter ParityNativeTopBarChromeGateTests --filter WorkspaceTokenUsageIntegrationTests --filter WorkspaceTokenUsageChipRenderTests
- git diff --check