### PR TITLE
Clarify skill load schema

### DIFF
--- a/Sources/QuillCodeTools/SkillToolDefinitions.swift
+++ b/Sources/QuillCodeTools/SkillToolDefinitions.swift
@@ -13,7 +13,17 @@ public extension ToolDefinition {
         does not run any skill code.
         """,
         parametersJSON: """
-        {"type":"object","properties":{"name":{"type":"string","description":"The bare name of the skill to load, e.g. code-review. Not a path; no slashes or ..."}},"required":["name"]}
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The bare name of the skill to load, e.g. code-review. Not a path; no slashes or .. segments."
+            }
+          },
+          "required": ["name"]
+        }
         """,
         host: .local,
         risk: .read

--- a/Tests/QuillCodeToolsTests/SkillToolRouterTests.swift
+++ b/Tests/QuillCodeToolsTests/SkillToolRouterTests.swift
@@ -29,6 +29,8 @@ final class SkillToolRouterTests: XCTestCase {
         XCTAssertEqual(definition.host, .local)
         XCTAssertEqual(definition.risk, .read)
         XCTAssertTrue(definition.parametersJSON.contains("\"name\""))
+        XCTAssertTrue(definition.parametersJSON.contains("\"minLength\": 1"))
+        XCTAssertTrue(definition.parametersJSON.contains("no slashes or .. segments"))
         XCTAssertTrue(definition.parametersJSON.contains("required"))
         XCTAssertNoThrow(try JSONSerialization.jsonObject(with: Data(definition.parametersJSON.utf8)))
     }


### PR DESCRIPTION
## Summary
- make host.skill.load advertise non-empty skill names with minLength
- fix the bare-name schema wording to say no slashes or .. segments
- expand the schema to readable JSON and cover it in router tests

## Validation
- swift test --filter SkillToolRouterTests
- git diff --check
- python3 scripts/grade-code-quality.py --root .