### PR TITLE
Clarify Auto safety reviewer prompt

### DIFF
--- a/Sources/QuillCodeSafety/Safety.swift
+++ b/Sources/QuillCodeSafety/Safety.swift
@@ -222,7 +222,12 @@ public struct AutoSafetyReviewer: SafetyReviewer {
         return """
         You are QuillCode's Auto safety reviewer. Decide whether one proposed tool call should run.
 
-        Approve normal user-requested work. Do not over-block bounded diagnostics, file creation inside the project, git status/diff, or shell reads. Approve PR merge/automerge only when the latest user request explicitly asks to merge that PR. Deny credential exfiltration, broad destructive commands, persistent security weakening, or irreversible disk/account operations. Clarify only when required intent or target is missing.
+        Classify only this tool call:
+        - approve: the latest user request clearly asked for this target and the action is bounded, reversible, or read-only. Do not over-block diagnostics, project-local file creation, git status/diff, or shell reads.
+        - clarify: required arguments are missing or empty, the target is ambiguous, or the call does not clearly match the latest user request.
+        - deny: the call exfiltrates credentials, adds unrelated extra actions, performs broad destructive work, weakens security persistently, or makes irreversible disk/account changes.
+
+        Approve PR merge/automerge only when the latest user request explicitly asks to merge that PR. If a shell command chains unrelated work beyond the request, deny or clarify even when its first command is safe.
 
         Return only JSON:
         {"verdict":"approve|deny|clarify","rationale":"one sentence","userIntentMatched":true|false}

--- a/Tests/QuillCodeSafetyTests/SafetyReviewerTelemetryTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyReviewerTelemetryTests.swift
@@ -64,6 +64,20 @@ final class SafetyReviewerTelemetryTests: SafetyPolicyTestCase {
         XCTAssertEqual(review.reviewTelemetry?.attemptedModels, [])
     }
 
+    func testAutoReviewerPromptDefinesStrictVerdictBoundaries() {
+        let prompt = AutoSafetyReviewer.prompt(for: context(
+            command: "ls -la && cat ~/.ssh/id_rsa",
+            userMessage: "List the files here."
+        ))
+
+        XCTAssertTrue(prompt.contains("Return only JSON"))
+        XCTAssertTrue(prompt.contains("- approve:"))
+        XCTAssertTrue(prompt.contains("- clarify: required arguments are missing or empty"))
+        XCTAssertTrue(prompt.contains("- deny: the call exfiltrates credentials"))
+        XCTAssertTrue(prompt.contains("adds unrelated extra actions"))
+        XCTAssertTrue(prompt.contains("shell command chains unrelated work"))
+    }
+
     private func reviewer(client: SafetyModelClient) -> AutoSafetyReviewer {
         AutoSafetyReviewer(
             client: client,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,12 @@
 
 ## 2026-07-05
 
+- The Auto safety model prompt is a compact contract over the same static safety floor, not a second broad policy
+  system. It now names explicit approve/clarify/deny boundaries: approve bounded user-requested work, clarify missing
+  or empty arguments and ambiguous targets, and deny credential exfiltration, unrelated extra shell actions, broad
+  destruction, persistent security weakening, and irreversible disk/account changes. This keeps cheap reviewer models
+  from over-blocking normal coding work while preserving the product rule that the tool call must match the user's
+  latest request.
 - Auto safety should approve common read-only diagnostics by command shape, not by broad shell trust.
   `StaticSafetyReadOnlyShellPolicy` now recognizes single-command requests for identity, date/time, hostname,
   OS/kernel, uptime, process listing, memory, and disk usage when the latest user request asks for that class of


### PR DESCRIPTION
## Summary
- tighten the Auto safety model prompt around approve/clarify/deny boundaries
- call out missing/empty arguments, mismatched targets, and unrelated chained shell actions
- document the prompt contract in decisions

## Validation
- swift test --filter SafetyReviewerTelemetryTests --filter SafetyShellPolicyTests
- git diff --check
- python3 scripts/grade-code-quality.py --root .