### PR TITLE
Accept fenced Auto safety JSON

### DIFF
--- a/Sources/QuillCodeSafety/Safety.swift
+++ b/Sources/QuillCodeSafety/Safety.swift
@@ -252,7 +252,7 @@ public struct AutoSafetyReviewer: SafetyReviewer {
             var rationale: String
             var userIntentMatched: Bool
         }
-        let data = Data(json.trimmingCharacters(in: .whitespacesAndNewlines).utf8)
+        let data = Data(Self.reviewJSONPayload(from: json).utf8)
         let decoded = try JSONDecoder().decode(Wire.self, from: data)
         return SafetyReview(
             verdict: decoded.verdict,
@@ -260,6 +260,29 @@ public struct AutoSafetyReviewer: SafetyReviewer {
             reviewerModel: model,
             userIntentMatched: decoded.userIntentMatched
         )
+    }
+
+    private static func reviewJSONPayload(from response: String) -> String {
+        let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("```"), trimmed.hasSuffix("```") else {
+            return trimmed
+        }
+
+        var lines = trimmed.components(separatedBy: .newlines)
+        guard
+            let first = lines.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+            first == "```" || first.lowercased() == "```json",
+            let last = lines.last?.trimmingCharacters(in: .whitespacesAndNewlines),
+            last == "```"
+        else {
+            return trimmed
+        }
+
+        lines.removeFirst()
+        lines.removeLast()
+        return lines
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func combinedErrorSummary(primary: Error, fallback: Error) -> String {

--- a/Tests/QuillCodeSafetyTests/SafetyReviewerTelemetryTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyReviewerTelemetryTests.swift
@@ -37,6 +37,41 @@ final class SafetyReviewerTelemetryTests: SafetyPolicyTestCase {
         XCTAssertEqual(requestedModels, ["glm-5.2", "kimi-k2.6"])
     }
 
+    func testAutoReviewerAcceptsFencedJSONFromPrimaryModel() async {
+        let client = RecordingSafetyModelClient(outcomes: [
+            "glm-5.2": .success("""
+            ```json
+            {"verdict":"clarify","rationale":"missing target","userIntentMatched":false}
+            ```
+            """)
+        ])
+        let review = await reviewer(client: client).review(context(command: "whoami", userMessage: "run whoami"))
+
+        XCTAssertEqual(review.verdict, .clarify)
+        XCTAssertEqual(review.reviewerModel, "glm-5.2")
+        XCTAssertEqual(review.rationale, "missing target")
+        XCTAssertFalse(review.userIntentMatched)
+        XCTAssertEqual(review.reviewTelemetry?.source, .primaryModel)
+        let requestedModels = await client.requestedModels()
+        XCTAssertEqual(requestedModels, ["glm-5.2"])
+    }
+
+    func testAutoReviewerStillRejectsProseWrappedJSONAndFallsBack() async {
+        let client = RecordingSafetyModelClient(outcomes: [
+            "glm-5.2": .success("""
+            Here is my decision:
+            {"verdict":"deny","rationale":"unsafe","userIntentMatched":false}
+            """),
+            "kimi-k2.6": .failure("fallback unavailable")
+        ])
+        let review = await reviewer(client: client).review(context(command: "whoami", userMessage: "run whoami"))
+
+        XCTAssertEqual(review.verdict, .approve)
+        XCTAssertNil(review.reviewerModel)
+        XCTAssertEqual(review.reviewTelemetry?.source, .staticPolicy)
+        XCTAssertEqual(review.reviewTelemetry?.fallbackReason, .allModelsFailed)
+    }
+
     func testAutoReviewerRecordsStaticFallbackWhenAllModelsFail() async {
         let client = RecordingSafetyModelClient(outcomes: [
             "glm-5.2": .failure("primary unavailable"),

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,10 @@
   destruction, persistent security weakening, and irreversible disk/account changes. This keeps cheap reviewer models
   from over-blocking normal coding work while preserving the product rule that the tool call must match the user's
   latest request.
+- Auto safety reviewer parsing accepts only raw JSON or a whole-response fenced `json` block. Some cheap reviewer
+  models wrap otherwise valid strict JSON in Markdown fences despite the prompt, and treating that as malformed makes
+  Auto fall back to the static floor unnecessarily. The parser still rejects prose-wrapped JSON instead of scraping
+  arbitrary text because safety decisions should be deterministic and easy to audit.
 - Auto safety should approve common read-only diagnostics by command shape, not by broad shell trust.
   `StaticSafetyReadOnlyShellPolicy` now recognizes single-command requests for identity, date/time, hostname,
   OS/kernel, uptime, process listing, memory, and disk usage when the latest user request asks for that class of


### PR DESCRIPTION
## Summary
- accept whole-response fenced JSON from the Auto safety reviewer model
- keep prose-wrapped JSON rejected so safety parsing remains deterministic
- document the parser boundary in decisions

## Validation
- swift test --filter SafetyReviewerTelemetryTests
- git diff --check
- python3 scripts/grade-code-quality.py --root .