### PR TITLE
Add slash aliases for settings and shortcuts

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4971,6 +4971,8 @@
       { usage: '/terminal clear', title: 'Clear terminal history', detail: 'Clear completed integrated-terminal history without resetting cwd or environment.', insertText: '/terminal clear', aliases: ['term clear', 'shell clear'] },
       { usage: '/search', title: 'Search chats', detail: 'Open global search across thread titles, transcript text, tools, models, and pinned or archived state.', insertText: '/search', aliases: ['global search', 'chat search'] },
       { usage: '/find', title: 'Find in chat', detail: 'Open the active chat finder with result count and next/previous navigation.', insertText: '/find', aliases: ['find in chat', 'transcript find'] },
+      { usage: '/settings', title: 'Settings', detail: 'Open TrustedRouter, Computer Use, browser, and notification settings.', insertText: '/settings', aliases: ['preferences', 'prefs'] },
+      { usage: '/shortcuts', title: 'Keyboard shortcuts', detail: 'Open the keyboard shortcut reference.', insertText: '/shortcuts', aliases: ['keyboard shortcuts', 'keys'] },
       { usage: '/browser', title: 'Toggle browser', detail: 'Show or hide the browser preview panel.', insertText: '/browser', aliases: ['preview'] },
       { usage: '/diff', title: 'Review diff', detail: 'Show the working-tree git diff in the review pane.', insertText: '/diff', aliases: ['changes', 'git diff'] },
       { usage: '/git-status', title: 'Git status', detail: 'Show the git status of the selected project.', insertText: '/git-status', aliases: ['gitstatus', 'git status'] },
@@ -16176,6 +16178,17 @@
       } else if (/^\/(find)\b/i.test(text)) {
         state.composer.isSending = false;
         openFindInChat();
+        return;
+      } else if (/^\/(settings|preferences|prefs)\b/i.test(text)) {
+        state.composer.isSending = false;
+        state.settings.isOpen = true;
+        state.settings.replacementAPIKey = '';
+        render();
+        return;
+      } else if (/^\/(shortcuts|keyboard-shortcuts|keys)\b/i.test(text)) {
+        state.composer.isSending = false;
+        state.shortcuts.isOpen = true;
+        render();
         return;
       } else if (/^\/plan\b/i.test(text)) {
         setModeLabel('Plan');

--- a/E2E/playwright/tests/composer-slash.spec.ts
+++ b/E2E/playwright/tests/composer-slash.spec.ts
@@ -91,6 +91,23 @@ test('mock harness opens search surfaces from composer slash commands', async ({
   await expect(page.getByTestId('find-status')).toContainText('1 of 1');
 });
 
+test('mock harness opens utility surfaces from composer slash commands', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  const message = page.getByLabel('Message');
+  await message.fill('/settings');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('settings-panel')).toBeVisible();
+  await expect(message).toHaveValue('');
+  await page.getByTestId('settings-cancel').click();
+
+  await message.fill('/shortcuts');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('keyboard-shortcuts-panel')).toBeVisible();
+  await expect(page.getByTestId('keyboard-shortcuts-list')).toContainText('Search');
+  await expect(message).toHaveValue('');
+});
+
 test('mock harness suggests slash commands in the composer', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
+++ b/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
@@ -184,6 +184,18 @@ extension SlashCommandCatalog {
             aliases: ["find in chat", "transcript find"]
         ),
         slashDefinition(
+            "/settings",
+            "Settings",
+            "Open TrustedRouter, Computer Use, browser, and notification settings.",
+            aliases: ["preferences", "prefs"]
+        ),
+        slashDefinition(
+            "/shortcuts",
+            "Keyboard shortcuts",
+            "Open the keyboard shortcut reference.",
+            aliases: ["keyboard shortcuts", "keys"]
+        ),
+        slashDefinition(
             "/browser",
             "Toggle browser",
             "Show or hide the browser preview panel.",

--- a/Sources/QuillCodeApp/SlashWorkspaceCommandParser.swift
+++ b/Sources/QuillCodeApp/SlashWorkspaceCommandParser.swift
@@ -4,6 +4,8 @@ enum SlashWorkspaceCommandParser {
     static func supports(_ name: String) -> Bool {
         switch normalizedName(name) {
         case "search", "find",
+             "settings", "preferences", "prefs",
+             "shortcuts", "keyboard-shortcuts", "keys",
              "browser", "preview",
              "diff", "changes",
              "git-status", "gitstatus",
@@ -23,6 +25,10 @@ enum SlashWorkspaceCommandParser {
             return .workspaceCommand("search")
         case "find":
             return .workspaceCommand("find-in-chat")
+        case "settings", "preferences", "prefs":
+            return .workspaceCommand("settings")
+        case "shortcuts", "keyboard-shortcuts", "keys":
+            return .workspaceCommand("keyboard-shortcuts")
         case "browser", "preview":
             return .workspaceCommand("toggle-browser")
         case "diff", "changes":

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -373,20 +373,35 @@ public struct QuillCodeWorkspaceView: View {
     private func handleComposerSend() {
         guard case .slash(.workspaceCommand(let commandID), _) =
             WorkspaceComposerSubmissionPlanner.plan(draft: draft),
-            commandID == "search" || commandID == "find-in-chat"
+            Self.composerPresentedCommandIDs.contains(commandID)
         else {
             actions.onSend()
             return
         }
 
         draft = ""
-        if commandID == "search" {
+        switch commandID {
+        case "search":
             searchQuery = ""
             isSearchPresented = true
-        } else {
+        case "find-in-chat":
             isFindPresented = true
+        case "settings":
+            settingsDraft = QuillCodeSettingsDraft(settings: surface.settings)
+            isSettingsPresented = true
+        case "keyboard-shortcuts":
+            isKeyboardShortcutsPresented = true
+        default:
+            break
         }
     }
+
+    private static let composerPresentedCommandIDs: Set<String> = [
+        "find-in-chat",
+        "keyboard-shortcuts",
+        "search",
+        "settings"
+    ]
 }
 
 extension AgentMode {

--- a/Tests/QuillCodeAppTests/SlashWorkspaceCommandParserTests.swift
+++ b/Tests/QuillCodeAppTests/SlashWorkspaceCommandParserTests.swift
@@ -7,6 +7,10 @@ final class SlashWorkspaceCommandParserTests: XCTestCase {
     func testSupportsWorkspaceAliases() {
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("search"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("find"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("settings"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("preferences"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("shortcuts"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("keyboard-shortcuts"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("browser"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("preview"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("diff"))
@@ -25,6 +29,17 @@ final class SlashWorkspaceCommandParserTests: XCTestCase {
         XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "find"), .workspaceCommand("find-in-chat"))
         XCTAssertEqual(SlashCommandParser.parse("/search"), .workspaceCommand("search"))
         XCTAssertEqual(SlashCommandParser.parse("/find"), .workspaceCommand("find-in-chat"))
+    }
+
+    func testSettingsAndShortcutAliasesOpenExistingWorkspaceCommands() {
+        XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "settings"), .workspaceCommand("settings"))
+        XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "preferences"), .workspaceCommand("settings"))
+        XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "shortcuts"), .workspaceCommand("keyboard-shortcuts"))
+        XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "keyboard-shortcuts"), .workspaceCommand("keyboard-shortcuts"))
+        XCTAssertEqual(SlashCommandParser.parse("/settings"), .workspaceCommand("settings"))
+        XCTAssertEqual(SlashCommandParser.parse("/prefs"), .workspaceCommand("settings"))
+        XCTAssertEqual(SlashCommandParser.parse("/shortcuts"), .workspaceCommand("keyboard-shortcuts"))
+        XCTAssertEqual(SlashCommandParser.parse("/keys"), .workspaceCommand("keyboard-shortcuts"))
     }
 
     func testBrowserAliasesToggleBrowserPane() {

--- a/Tests/QuillCodeAppTests/WorkspaceComposerSubmissionPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerSubmissionPlannerTests.swift
@@ -32,5 +32,13 @@ final class WorkspaceComposerSubmissionPlannerTests: XCTestCase {
             WorkspaceComposerSubmissionPlanner.plan(draft: "/find"),
             .slash(command: .workspaceCommand("find-in-chat"), originalPrompt: "/find")
         )
+        XCTAssertEqual(
+            WorkspaceComposerSubmissionPlanner.plan(draft: "/settings"),
+            .slash(command: .workspaceCommand("settings"), originalPrompt: "/settings")
+        )
+        XCTAssertEqual(
+            WorkspaceComposerSubmissionPlanner.plan(draft: "/shortcuts"),
+            .slash(command: .workspaceCommand("keyboard-shortcuts"), originalPrompt: "/shortcuts")
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Add /settings with preferences/prefs aliases for opening Settings from the composer
- Add /shortcuts with keyboard-shortcuts/keys aliases for opening keyboard shortcuts from the composer
- Keep SwiftUI and Playwright harness slash registries aligned with parser and UI coverage

## Validation
- swift test --filter SlashWorkspaceCommandParserTests --filter WorkspaceComposerSubmissionPlannerTests --filter WorkspaceSlashRegistryHarnessParityTests
- npm test -- tests/composer-slash.spec.ts
- git diff --check
- python3 scripts/grade-code-quality.py --root .