### PR TITLE
[codex] Classify download metadata by platform

### DIFF
--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -10,6 +10,12 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
 
         try "product=QuillCode\nplatform=macOS\narch=arm64\nversion=0.2.0\nbuild=123\n"
             .write(to: temporaryDirectory.appendingPathComponent("BUILD_INFO.txt"), atomically: true, encoding: .utf8)
+        try "product=QuillCode\nplatform=Linux\narch=x86_64\nversion=0.2.0\nbuild=123\n"
+            .write(
+                to: temporaryDirectory.appendingPathComponent("BUILD_INFO-linux-x86_64.txt"),
+                atomically: true,
+                encoding: .utf8
+            )
         try Data("mac app".utf8).write(to: temporaryDirectory.appendingPathComponent("QuillCode-macOS-arm64.zip"))
         try Data("mac cli".utf8).write(to: temporaryDirectory.appendingPathComponent("quill-code-macOS-arm64.tar.gz"))
         try Data("linux cli".utf8).write(to: temporaryDirectory.appendingPathComponent("quill-code-linux-x86_64.tar.gz"))
@@ -49,7 +55,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         )
 
         let assets = try XCTUnwrap(manifest["assets"] as? [[String: Any]])
-        XCTAssertEqual(assets.count, 5)
+        XCTAssertEqual(assets.count, 6)
 
         let appAsset = try asset(named: "QuillCode-macOS-arm64.zip", in: assets)
         XCTAssertEqual(appAsset["kind"] as? String, "app")
@@ -64,6 +70,16 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertEqual(linuxAsset["kind"] as? String, "cli")
         XCTAssertEqual(linuxAsset["platform"] as? String, "Linux")
         XCTAssertEqual(linuxAsset["arch"] as? String, "x86_64")
+
+        let macMetadata = try asset(named: "BUILD_INFO.txt", in: assets)
+        XCTAssertEqual(macMetadata["kind"] as? String, "metadata")
+        XCTAssertEqual(macMetadata["platform"] as? String, "macOS")
+        XCTAssertEqual(macMetadata["arch"] as? String, "any")
+
+        let linuxMetadata = try asset(named: "BUILD_INFO-linux-x86_64.txt", in: assets)
+        XCTAssertEqual(linuxMetadata["kind"] as? String, "metadata")
+        XCTAssertEqual(linuxMetadata["platform"] as? String, "Linux")
+        XCTAssertEqual(linuxMetadata["arch"] as? String, "x86_64")
 
         let checksumAsset = try asset(named: "SHASUMS256.txt", in: assets)
         XCTAssertEqual(checksumAsset["kind"] as? String, "checksum")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,24 @@
 # Code Quality Audit
 
+## 2026-07-05 Download Manifest Platform Metadata A+ Pass
+
+Overall grade after this slice: **A+ for tester-build manifest metadata precision**.
+The download manifest now classifies build-info assets by their actual platform
+and architecture, so support scripts and future updater surfaces can show the
+right metadata beside each downloadable package.
+
+Strict grades:
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Release architecture | A+ | The change stays inside the manifest classifier used by both tester and tagged release workflows. |
+| Supportability | A+ | macOS and Linux build-info files now carry distinct platform/arch fields instead of generic `any` metadata. |
+| Tests | A+ | The parity gate exercises macOS and Linux metadata entries in the generated manifest. |
+
+Validation:
+
+- `swift test --filter ParityDownloadBuildsGateTests`
+
 ## 2026-07-05 Read-Only Diagnostic Safety A+ Pass
 
 Overall grade after this slice: **A+ for bounded Auto-mode diagnostic approvals**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -16,6 +16,10 @@
   models wrap otherwise valid strict JSON in Markdown fences despite the prompt, and treating that as malformed makes
   Auto fall back to the static floor unnecessarily. The parser still rejects prose-wrapped JSON instead of scraping
   arbitrary text because safety decisions should be deterministic and easy to audit.
+- Download manifests should identify platform-specific metadata assets with the same platform/architecture semantics as
+  executable assets. `BUILD_INFO.txt` is emitted by the macOS packager and is therefore classified as macOS metadata,
+  while `BUILD_INFO-linux-<arch>.txt` is Linux metadata for that architecture. This keeps support scripts, website
+  download cards, and future updater experiments from treating build-info files as generic blobs.
 - Auto safety should approve common read-only diagnostics by command shape, not by broad shell trust.
   `StaticSafetyReadOnlyShellPolicy` now recognizes single-command requests for identity, date/time, hostname,
   OS/kernel, uptime, process listing, memory, and disk usage when the latest user request asks for that class of

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -58,6 +58,11 @@ def classify_asset(name: str) -> dict[str, str]:
     if name.startswith("quill-code-linux-") and name.endswith(".tar.gz"):
         arch = name.removeprefix("quill-code-linux-").removesuffix(".tar.gz")
         return {"kind": "cli", "platform": "Linux", "arch": arch, "install": "tarball"}
+    if name == "BUILD_INFO.txt":
+        return {"kind": "metadata", "platform": "macOS", "arch": "any", "install": "text"}
+    if name.startswith("BUILD_INFO-linux-") and name.endswith(".txt"):
+        arch = name.removeprefix("BUILD_INFO-linux-").removesuffix(".txt")
+        return {"kind": "metadata", "platform": "Linux", "arch": arch, "install": "text"}
     if name.startswith("BUILD_INFO"):
         return {"kind": "metadata", "platform": "any", "arch": "any", "install": "text"}
     if name.endswith("SHASUMS256.txt") or name == "SHASUMS256.txt":


### PR DESCRIPTION
## Summary
- Classify `BUILD_INFO.txt` as macOS metadata and `BUILD_INFO-linux-<arch>.txt` as Linux metadata in `latest-tester-build.json`.
- Extend the download-build parity gate so the generated manifest proves platform-specific metadata classification.
- Record the release-support decision and code-quality note.

## Validation
- `swift test --filter ParityDownloadBuildsGateTests` (4 tests, 0 failures)
- `python3 scripts/build-download-manifest.py --assets-dir /tmp --repo Lore-Hex/QuillCode --tag tester-latest --commit smoke --workflow-run-url https://github.com/Lore-Hex/QuillCode/actions/runs/0 --output /tmp/quillcode-manifest-smoke.json`
- `git diff --check`

## Release impact
- Future `tester-latest` and versioned release manifests will expose supportable platform/arch metadata for build-info assets.
