### PR TITLE
refactor(core): single-source spend-fuse epsilon + triage badge label

### DIFF
--- a/Sources/QuillCodeCore/MorningTriage.swift
+++ b/Sources/QuillCodeCore/MorningTriage.swift
@@ -43,14 +43,18 @@ public enum TriageVerdict: String, Codable, Sendable, Hashable, CaseIterable {
     /// run does not need the morning triage.
     public var needsAttention: Bool { self != .verified }
 
-    /// The badge text, matching the Run Integrity badge exactly.
-    public var badgeLabel: String {
+    /// The equivalent run-integrity verdict — the single source for badge text, so "matches the Run
+    /// Integrity badge exactly" is structural, not a hand-synced string table.
+    public var runIntegrityVerdict: RunIntegrityVerdict {
         switch self {
-        case .red: return "RED"
-        case .unverified: return "UNVERIFIED"
-        case .verified: return "VERIFIED"
+        case .red: return .red
+        case .unverified: return .unverified
+        case .verified: return .verified
         }
     }
+
+    /// The badge text, delegated to the Run Integrity badge so the two can never drift.
+    public var badgeLabel: String { runIntegrityVerdict.badgeLabel }
 
     public init(_ verdict: RunIntegrityVerdict) {
         switch verdict {

--- a/Sources/QuillCodeCore/RunSpendFusePolicy.swift
+++ b/Sources/QuillCodeCore/RunSpendFusePolicy.swift
@@ -14,9 +14,10 @@ public struct RunSpendFusePolicy: Sendable, Hashable {
 
     public func approvalState(for thread: ChatThread) -> RunSpendFuseApprovalState {
         let summary = spendSummary(for: thread)
-        guard summary.totalUSD + Self.epsilon >= fuseUSD else { return .allowed }
+        let epsilon = RunSpendLedger.spendComparisonEpsilon
+        guard summary.totalUSD + epsilon >= fuseUSD else { return .allowed }
 
-        let bucket = max(1, Int(floor((summary.totalUSD + Self.epsilon) / fuseUSD)))
+        let bucket = max(1, Int(floor((summary.totalUSD + epsilon) / fuseUSD)))
         guard !hasApprovedBucket(bucket, in: thread) else { return .allowed }
         if let existing = pendingRequestID(for: bucket, in: thread) {
             return .blocked(existingRequestID: existing)
@@ -120,6 +121,4 @@ public struct RunSpendFusePolicy: Sendable, Hashable {
     public static func costLabel(_ value: Double) -> String {
         RunSpendLedger.costLabel(value)
     }
-
-    private static let epsilon = 0.000_000_001
 }

--- a/Sources/QuillCodeCore/RunSpendLedger.swift
+++ b/Sources/QuillCodeCore/RunSpendLedger.swift
@@ -43,7 +43,7 @@ public struct RunSpendLedger: Sendable, Hashable {
 
     public var blocksNextRun: Bool {
         guard let fuseUSD else { return false }
-        return totalUSD + Self.epsilon >= fuseUSD
+        return totalUSD + Self.spendComparisonEpsilon >= fuseUSD
     }
 
     public var summary: RunSpendFuseSummary {
@@ -97,7 +97,9 @@ public struct RunSpendLedger: Sendable, Hashable {
         "\(value) \(singular)\(value == 1 ? "" : "s")"
     }
 
-    private static let epsilon = 0.000_000_001
+    /// Tolerance for the "spend has reached the fuse" float comparison. Shared with
+    /// `RunSpendFusePolicy` so the ledger's `blocksNextRun` and the policy's bucket math never drift.
+    static let spendComparisonEpsilon = 0.000_000_001
 }
 
 public struct RunSpendReceipt: Sendable, Hashable {


### PR DESCRIPTION
## What

Second slice of the semantic quality campaign — two **anti-drift DRY consolidations** in `QuillCodeCore`, behavior-identical.

1. **Spend-fuse epsilon** — `RunSpendLedger` and `RunSpendFusePolicy` each declared a private `epsilon = 0.000_000_001` and re-implemented the `total + epsilon >= fuse` threshold. The policy already delegates `costLabel`/`normalizedFuse` to the ledger, so the epsilon now lives once on the ledger (`spendComparisonEpsilon`) and the policy references it. The two copies can no longer silently drift apart.

2. **Triage badge label** — `MorningTriage.TriageVerdict.badgeLabel` hand-copied the `RED`/`UNVERIFIED`/`VERIFIED` string table from `RunIntegrityVerdict.badgeLabel` behind a doc comment promising it "matches the Run Integrity badge exactly". Made the promise structural: `TriageVerdict` maps 1:1 to `RunIntegrityVerdict` (it already has the reverse init), so `badgeLabel` now delegates through a new `runIntegrityVerdict` property — one source of badge text, no manual sync.

## Verification

Clean `swift build`; targeted + full `swift test` green. Independent of #1032 (touches disjoint files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)