### PR TITLE
style: monospace code / path / command surfaces (Codex)

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -54,6 +54,9 @@
       color: var(--text);
     }
     h1, h2, h3, strong { text-wrap: balance; }
+    code, kbd, samp, pre, [data-testid="tool-card-title"], [data-testid="tool-card-subtitle"], [data-testid="review-file-path"] {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
     p, li, small, figcaption, .message { text-wrap: pretty; }
     [data-testid="agent-status"],
     [data-testid="context-banner-percent"],


### PR DESCRIPTION
From the design audit — Codex is monospace-forward. Added a base rule so `code`/`kbd`/`samp`/`pre` (which were inheriting sans) plus tool-card title/subtitle (tool IDs, paths, commands, branch refs) and review file paths render in `ui-monospace`; chat prose stays sans. Impact shows in populated states (tool cards, code, diffs). Playwright green. Follows #1049 + #1050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)