### PR TITLE
feat(worktree): 'Worktree' thread type — isolated-branch thread (slice 2)

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModelWorktrees.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelWorktrees.swift
@@ -27,6 +27,42 @@ extension QuillCodeWorkspaceModel {
         }
     }
 
+    /// The "Worktree" thread type (the Codex Local-vs-Worktree choice at thread creation): creates a
+    /// fresh worktree off the current branch and starts a NEW thread in the SAME project bound to it,
+    /// so it runs isolated without touching the current working tree — and without minting a sibling
+    /// project (unlike `createWorktree`, which is the standalone worktree-open flow). Returns the new
+    /// thread id, or nil if not on a local project or the worktree create failed.
+    @discardableResult
+    public func newWorktreeThread(name: String? = nil) -> UUID? {
+        guard let project = selectedProject, !project.isRemote else { return nil }
+        let projectRoot = URL(fileURLWithPath: project.path)
+        let baseBranch = selectedProjectBranch(project) ?? "HEAD"
+        let request = WorktreeThreadPlanner.plan(
+            projectRoot: projectRoot,
+            baseBranch: baseBranch,
+            name: name,
+            existingBranches: [baseBranch]
+        )
+        let result = runToolCall(
+            WorkspaceWorktreeToolCallPlanner.create(request),
+            workspaceRoot: projectRoot
+        )
+        guard result.ok, let worktreePath = result.artifacts.first else { return nil }
+        let threadID = newChat(projectID: project.id)
+        bindSelectedThreadToWorktree(path: worktreePath, branch: request.branch, base: baseBranch)
+        return threadID
+    }
+
+    private func selectedProjectBranch(_ project: ProjectRef) -> String? {
+        guard root.topBar.branchStatusProjectID == project.id,
+              let branch = root.topBar.branchStatus?.branch,
+              !branch.isEmpty
+        else {
+            return nil
+        }
+        return branch
+    }
+
     public func worktreeChoiceLoadRequest(workspaceRoot: URL) -> WorkspaceWorktreeChoiceLoadRequest {
         WorkspaceWorktreeChoiceLoadRequest(
             workspaceRoot: workspaceRoot,

--- a/Sources/QuillCodeApp/WorktreeThreadPlanner.swift
+++ b/Sources/QuillCodeApp/WorktreeThreadPlanner.swift
@@ -1,0 +1,50 @@
+import Foundation
+import QuillCodeCore
+
+/// Plans the git worktree for a new "Worktree" thread (the Codex Local-vs-Worktree choice): a
+/// collision-free branch off the current base and a sibling directory to check it out in. Pure so the
+/// naming is deterministic and unit-testable; the model runs the resulting create request.
+enum WorktreeThreadPlanner {
+    static func plan(
+        projectRoot: URL,
+        baseBranch: String,
+        name: String?,
+        existingBranches: [String]
+    ) -> WorkspaceWorktreeCreateRequest {
+        let slug = slug(from: name) ?? "work"
+        let branch = uniqueBranch(preferred: "quill/\(slug)", taken: Set(existingBranches))
+        // Sibling of the project root, named "<project>-<branch-leaf>", so worktrees sit next to the
+        // repo (the worktree tool already enforces sibling-in-parent).
+        let leaf = branch.split(separator: "/").last.map(String.init) ?? slug
+        let dirName = "\(projectRoot.lastPathComponent)-\(leaf)"
+        let path = projectRoot.deletingLastPathComponent().appendingPathComponent(dirName).path
+        return WorkspaceWorktreeCreateRequest(path: path, branch: branch, base: baseBranch)
+    }
+
+    /// Lowercased, hyphen-separated, alphanumerics-and-hyphens only; nil when nothing usable remains.
+    static func slug(from name: String?) -> String? {
+        guard let name else { return nil }
+        let lowered = name.lowercased()
+        var out = ""
+        var lastWasHyphen = false
+        for scalar in lowered.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                out.unicodeScalars.append(scalar)
+                lastWasHyphen = false
+            } else if !lastWasHyphen {
+                out.append("-")
+                lastWasHyphen = true
+            }
+        }
+        let trimmed = out.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return trimmed.isEmpty ? nil : String(trimmed.prefix(40))
+    }
+
+    /// `preferred`, else `preferred-2`, `-3`, … until it's not in `taken`.
+    static func uniqueBranch(preferred: String, taken: Set<String>) -> String {
+        guard taken.contains(preferred) else { return preferred }
+        var n = 2
+        while taken.contains("\(preferred)-\(n)") { n += 1 }
+        return "\(preferred)-\(n)"
+    }
+}

--- a/Tests/QuillCodeAppTests/WorktreeThreadTests.swift
+++ b/Tests/QuillCodeAppTests/WorktreeThreadTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+import Foundation
+import QuillCodeCore
+@testable import QuillCodeApp
+
+// MARK: - Unit: the pure planner
+
+final class WorktreeThreadPlannerTests: XCTestCase {
+    private let root = URL(fileURLWithPath: "/work/MyRepo")
+
+    func testSlugifies() {
+        XCTAssertEqual(WorktreeThreadPlanner.slug(from: "Add Login Flow!"), "add-login-flow")
+        XCTAssertEqual(WorktreeThreadPlanner.slug(from: "  spaced  out  "), "spaced-out")
+        XCTAssertNil(WorktreeThreadPlanner.slug(from: "  !!!  "))
+        XCTAssertNil(WorktreeThreadPlanner.slug(from: nil))
+    }
+
+    func testBranchAndSiblingPath() {
+        let req = WorktreeThreadPlanner.plan(projectRoot: root, baseBranch: "main", name: "Try It", existingBranches: [])
+        XCTAssertEqual(req.branch, "quill/try-it")
+        XCTAssertEqual(req.base, "main")
+        // sibling of the project root, named <project>-<leaf>
+        XCTAssertEqual(req.path, "/work/MyRepo-try-it")
+    }
+
+    func testDefaultNameWhenNil() {
+        let req = WorktreeThreadPlanner.plan(projectRoot: root, baseBranch: "main", name: nil, existingBranches: [])
+        XCTAssertEqual(req.branch, "quill/work")
+        XCTAssertEqual(req.path, "/work/MyRepo-work")
+    }
+
+    func testAvoidsBranchCollision() {
+        let req = WorktreeThreadPlanner.plan(
+            projectRoot: root, baseBranch: "main", name: "work",
+            existingBranches: ["quill/work", "quill/work-2"]
+        )
+        XCTAssertEqual(req.branch, "quill/work-3")
+        XCTAssertEqual(req.path, "/work/MyRepo-work-3")
+    }
+}
+
+// MARK: - Functional/integration: newWorktreeThread through the model against a real git repo
+
+@MainActor
+final class WorktreeThreadModelTests: XCTestCase {
+    private func makeGitRepo() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wtthread-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let shell = { (cmd: String) in
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/bin/sh")
+            p.arguments = ["-lc", cmd]
+            p.currentDirectoryURL = dir
+            let pipe = Pipe(); p.standardOutput = pipe; p.standardError = pipe
+            try? p.run(); p.waitUntilExit()
+        }
+        shell("git init -q && git config user.email t@t.co && git config user.name t && git config commit.gpgsign false")
+        try "hello\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        shell("git add -A && git commit -q -m init")
+        return dir
+    }
+
+    func testNewWorktreeThreadCreatesIsolatedBoundThreadInSameProject() throws {
+        let repo = try makeGitRepo()
+        let model = QuillCodeWorkspaceModel()
+        let projectID = model.addProject(path: repo, name: "Repo")
+        model.selectProject(projectID)
+        let localThread = model.newChat(projectID: projectID)
+
+        let worktreeThread = model.newWorktreeThread(name: "experiment")
+        XCTAssertNotNil(worktreeThread, "worktree thread should be created")
+        XCTAssertNotEqual(worktreeThread, localThread)
+
+        // The new thread stays in the SAME project but is bound to its own worktree directory.
+        XCTAssertEqual(model.selectedThread?.projectID, projectID)
+        let binding = model.selectedThread?.worktree
+        XCTAssertNotNil(binding)
+        XCTAssertEqual(binding?.branch, "quill/experiment")
+        XCTAssertTrue(binding.map(\.isResolvable) ?? false, "worktree dir should exist on disk")
+
+        // Isolation: the bound thread runs in the worktree; the local thread in the project root.
+        XCTAssertEqual(model.activeWorkspaceRoot?.standardizedFileURL,
+                       URL(fileURLWithPath: binding!.path).standardizedFileURL)
+        model.selectThread(localThread)
+        XCTAssertEqual(model.activeWorkspaceRoot?.standardizedFileURL, repo.standardizedFileURL)
+
+        // The real git worktree + branch exist.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: binding!.path))
+    }
+
+    func testNewWorktreeThreadIsNilWithoutLocalProject() throws {
+        let model = QuillCodeWorkspaceModel()
+        XCTAssertNil(model.newWorktreeThread(name: "x"), "no selected project → nil")
+    }
+}


### PR DESCRIPTION
## What

The Codex **Local-vs-Worktree choice** at thread creation. `newWorktreeThread()` spins a fresh worktree off the current branch and starts a **new thread in the same project bound to it** (via the slice-1 `WorktreeBinding`) — so it runs isolated without touching the working tree, and **without minting a sibling project** the way the standalone worktree-open flow does.

This matches how Codex keeps the two ideas orthogonal: **fork** = conversation copy (already in QuillCode via `WorkspaceThreadForkStrategy`), **worktree** = an isolated thread type. "Each fork is just a different session"; a worktree thread is a session with its own branch+folder.

## How (reuses everything)
- **`WorktreeThreadPlanner`** (pure): collision-free branch `quill/<slug>` off the base + a sibling `<project>-<leaf>` path. Deterministic, unit-tested.
- **`newWorktreeThread(name:)`**: plan → `host.git.worktree.create` (reused) → on ok, `newChat` in the same project + `bindSelectedThreadToWorktree`. No new git plumbing.

## Tests — pyramid
- **unit** — planner: slugify, branch + sibling path, default name, collision-avoidance.
- **functional + integration** — through the model against a **real git repo**: creates the worktree + branch on disk; the new thread stays in the same project, bound to it; `activeWorkspaceRoot` resolves to the worktree for the bound thread but the project root for a sibling local thread (**isolation proven end-to-end**); nil without a local project.
- **playwright** — N/A this slice: the `/worktree` command + native "New ▾ → Local/Worktree" affordance land in the immediate follow-up, with their DOM/Playwright coverage.

Follows #1052 (the binding primitive). Next: the trigger UI (slash + menu) then the worktree switcher + dirty/ahead-behind status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)