### PR TITLE
Add support control slash commands

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4967,6 +4967,7 @@
       { usage: '/compact', title: 'Compact context', detail: 'Create a shorter continuation thread from the latest turns.', insertText: '/compact', aliases: ['compact-context', 'context-compact'] },
       { usage: '/stop', title: 'Stop active work', detail: 'Cancel the running agent turn, terminal command, or active extension work.', insertText: '/stop', aliases: ['cancel', 'abort'] },
       { usage: '/retry', title: 'Retry last turn', detail: 'Prepare the latest user request to run again.', insertText: '/retry', aliases: ['rerun', 'again', 'retry last'] },
+      { usage: '/disconnect', title: 'Disconnect all', detail: 'Stop active work and disconnect remote workspace or extension sessions.', insertText: '/disconnect', aliases: ['disconnect-all', 'disconnect all'] },
       { usage: '/back', title: 'Go back', detail: 'Return to the previous thread or project selection in workspace history.', insertText: '/back', aliases: ['previous', 'prev', 'history back'] },
       { usage: '/forward', title: 'Go forward', detail: 'Move to the next thread or project selection in workspace history.', insertText: '/forward', aliases: ['next', 'history forward'] },
       { usage: '/history back|forward', title: 'Navigate history', detail: 'Move through previous or next thread and project selections.', insertText: '/history ', aliases: ['history previous', 'history next'] },
@@ -4989,6 +4990,7 @@
       { usage: '/copy', title: 'Copy conversation', detail: 'Copy the visible conversation as Markdown.', insertText: '/copy', aliases: ['copy conversation', 'copy transcript'] },
       { usage: '/export', title: 'Export conversation', detail: 'Export the visible conversation as Markdown.', insertText: '/export', aliases: ['export markdown', 'export conversation', 'save transcript'] },
       { usage: '/settings', title: 'Settings', detail: 'Open TrustedRouter, Computer Use, browser, and notification settings.', insertText: '/settings', aliases: ['preferences', 'prefs'] },
+      { usage: '/computer-use', title: 'Computer Use setup', detail: 'Open Settings focused on Screen Recording and Accessibility setup.', insertText: '/computer-use', aliases: ['computer use', 'screen control', 'desktop control'] },
       { usage: '/shortcuts', title: 'Keyboard shortcuts', detail: 'Open the keyboard shortcut reference.', insertText: '/shortcuts', aliases: ['keyboard shortcuts', 'keys'] },
       { usage: '/commands', title: 'Command palette', detail: 'Open the searchable command palette.', insertText: '/commands', aliases: ['command-palette', 'palette'] },
       { usage: '/extensions', title: 'Toggle extensions', detail: 'Show or hide project plugins, skills, MCP servers, and marketplace entries.', insertText: '/extensions', aliases: ['plugins', 'skills'] },
@@ -16004,21 +16006,25 @@
         ? 'focus-composer'
         : /^\/(retry|rerun|again)\b/i.test(text)
           ? 'retry-last-turn'
-          : /^\/(back|previous|prev)\b/i.test(text)
-            ? 'workspace-back'
-            : /^\/history\s+(back|previous|prev)\b/i.test(text)
-              ? 'workspace-back'
-              : /^\/(forward|next)\b/i.test(text)
-              ? 'workspace-forward'
-                : /^\/history\s+(forward|next)\b/i.test(text)
+          : /^\/(disconnect|disconnect-all)\b/i.test(text)
+            ? 'disconnect-all'
+            : /^\/(computer-use|computer\s+use)\b/i.test(text)
+              ? 'computer-use-setup'
+              : /^\/(back|previous|prev)\b/i.test(text)
+                ? 'workspace-back'
+                : /^\/history\s+(back|previous|prev)\b/i.test(text)
+                  ? 'workspace-back'
+                  : /^\/(forward|next)\b/i.test(text)
                   ? 'workspace-forward'
-                  : /^\/(sidebar|toggle-sidebar)\b/i.test(text)
-                    ? 'toggle-sidebar'
-                    : /^\/(copy|copy-conversation)\b/i.test(text)
-                      ? 'copy-conversation'
-                      : /^\/(export|export-markdown|export-conversation-markdown)\b/i.test(text)
-                        ? 'export-conversation-markdown'
-                        : null;
+                    : /^\/history\s+(forward|next)\b/i.test(text)
+                      ? 'workspace-forward'
+                      : /^\/(sidebar|toggle-sidebar)\b/i.test(text)
+                        ? 'toggle-sidebar'
+                        : /^\/(copy|copy-conversation)\b/i.test(text)
+                          ? 'copy-conversation'
+                          : /^\/(export|export-markdown|export-conversation-markdown)\b/i.test(text)
+                            ? 'export-conversation-markdown'
+                            : null;
       if (!commandID) return false;
       runInstantSlashCommand(text, commandID);
       return true;

--- a/E2E/playwright/tests/composer-slash.spec.ts
+++ b/E2E/playwright/tests/composer-slash.spec.ts
@@ -126,6 +126,13 @@ test('mock harness opens utility surfaces from composer slash commands', async (
   await expect(message).toHaveValue('');
   await page.getByTestId('settings-cancel').click();
 
+  await message.fill('/computer-use');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('settings-panel')).toBeVisible();
+  await expect(page.getByTestId('computer-use-settings')).toBeVisible();
+  await expect(message).toHaveValue('');
+  await page.getByTestId('settings-cancel').click();
+
   await message.fill('/shortcuts');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('keyboard-shortcuts-panel')).toBeVisible();
@@ -182,6 +189,11 @@ test('mock harness routes control slash commands through existing stop and retry
   await expect(page.getByTestId('tool-card-title').filter({ hasText: 'host.shell.run' })).toHaveCount(shellCardCount + 1);
   await expect(page.getByTestId('message').last()).toContainText('mock-user');
   await expect(page.getByTestId('message').filter({ hasText: '/retry' })).toHaveCount(1);
+
+  await message.fill('/disconnect');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('agent-status')).toContainText('Stopped');
+  await expect(page.getByTestId('message').last()).toContainText('/disconnect');
 });
 
 test('mock harness routes history slash commands through workspace back and forward', async ({ page }) => {

--- a/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
+++ b/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
@@ -105,6 +105,12 @@ extension SlashCommandCatalog {
             aliases: ["rerun", "again", "retry last"]
         ),
         slashDefinition(
+            "/disconnect",
+            "Disconnect all",
+            "Stop active work and disconnect remote workspace or extension sessions.",
+            aliases: ["disconnect-all", "disconnect all"]
+        ),
+        slashDefinition(
             "/back",
             "Go back",
             "Return to the previous thread or project selection in workspace history.",
@@ -249,6 +255,12 @@ extension SlashCommandCatalog {
             "Settings",
             "Open TrustedRouter, Computer Use, browser, and notification settings.",
             aliases: ["preferences", "prefs"]
+        ),
+        slashDefinition(
+            "/computer-use",
+            "Computer Use setup",
+            "Open Settings focused on Screen Recording and Accessibility setup.",
+            aliases: ["computer use", "screen control", "desktop control"]
         ),
         slashDefinition(
             "/shortcuts",

--- a/Sources/QuillCodeApp/SlashWorkspaceCommandParser.swift
+++ b/Sources/QuillCodeApp/SlashWorkspaceCommandParser.swift
@@ -5,6 +5,7 @@ enum SlashWorkspaceCommandParser {
         switch normalizedName(name) {
         case "stop", "cancel", "abort",
              "retry", "rerun", "again",
+             "disconnect", "disconnect-all",
              "back", "previous", "prev",
              "forward", "next",
              "history",
@@ -14,6 +15,7 @@ enum SlashWorkspaceCommandParser {
              "copy", "copy-conversation",
              "export", "export-markdown", "export-conversation-markdown",
              "settings", "preferences", "prefs",
+             "computer-use",
              "shortcuts", "keyboard-shortcuts", "keys",
              "commands", "command-palette", "palette",
              "extensions", "plugins", "skills",
@@ -37,6 +39,8 @@ enum SlashWorkspaceCommandParser {
             return .workspaceCommand("stop-all")
         case "retry", "rerun", "again":
             return .workspaceCommand("retry-last-turn")
+        case "disconnect", "disconnect-all":
+            return .workspaceCommand("disconnect-all")
         case "back", "previous", "prev":
             return .workspaceCommand("workspace-back")
         case "forward", "next":
@@ -57,6 +61,8 @@ enum SlashWorkspaceCommandParser {
             return .workspaceCommand("find-in-chat")
         case "settings", "preferences", "prefs":
             return .workspaceCommand("settings")
+        case "computer-use":
+            return .workspaceCommand("computer-use-setup")
         case "shortcuts", "keyboard-shortcuts", "keys":
             return .workspaceCommand("keyboard-shortcuts")
         case "commands", "command-palette", "palette":

--- a/Tests/QuillCodeAppTests/SlashWorkspaceCommandParserTests.swift
+++ b/Tests/QuillCodeAppTests/SlashWorkspaceCommandParserTests.swift
@@ -9,6 +9,9 @@ final class SlashWorkspaceCommandParserTests: XCTestCase {
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("find"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("settings"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("preferences"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("computer-use"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("disconnect"))
+        XCTAssertTrue(SlashWorkspaceCommandParser.supports("disconnect-all"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("shortcuts"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("keyboard-shortcuts"))
         XCTAssertTrue(SlashWorkspaceCommandParser.supports("commands"))
@@ -46,8 +49,17 @@ final class SlashWorkspaceCommandParserTests: XCTestCase {
         XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "keyboard-shortcuts"), .workspaceCommand("keyboard-shortcuts"))
         XCTAssertEqual(SlashCommandParser.parse("/settings"), .workspaceCommand("settings"))
         XCTAssertEqual(SlashCommandParser.parse("/prefs"), .workspaceCommand("settings"))
+        XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "computer-use"), .workspaceCommand("computer-use-setup"))
+        XCTAssertEqual(SlashCommandParser.parse("/computer-use"), .workspaceCommand("computer-use-setup"))
         XCTAssertEqual(SlashCommandParser.parse("/shortcuts"), .workspaceCommand("keyboard-shortcuts"))
         XCTAssertEqual(SlashCommandParser.parse("/keys"), .workspaceCommand("keyboard-shortcuts"))
+    }
+
+    func testDisconnectAliasesRunExistingDisconnectAllCommand() {
+        XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "disconnect"), .workspaceCommand("disconnect-all"))
+        XCTAssertEqual(SlashWorkspaceCommandParser.parse(name: "disconnect-all"), .workspaceCommand("disconnect-all"))
+        XCTAssertEqual(SlashCommandParser.parse("/disconnect"), .workspaceCommand("disconnect-all"))
+        XCTAssertEqual(SlashCommandParser.parse("/disconnect-all"), .workspaceCommand("disconnect-all"))
     }
 
     func testCommandPaletteAliasesOpenExistingWorkspaceCommand() {


### PR DESCRIPTION
## Summary
- add /disconnect and /computer-use slash commands to native command catalog/parser
- route the same commands in the Playwright harness through existing workspace actions
- cover native parser/registry parity plus composer slash E2E behavior

## Validation
- swift test --filter SlashWorkspaceCommandParserTests --filter WorkspaceSlashRegistryHarnessParityTests
- npm test -- tests/composer-slash.spec.ts
- git diff --check
- python3 scripts/grade-code-quality.py --root .