### PR TITLE
feat(worktree): wire /new-worktree trigger for the Worktree thread type

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4436,6 +4436,7 @@
       },
       commands: [
         { id: 'new-chat', title: 'New chat', shortcut: 'Cmd+N', category: 'Thread', keywords: ['thread', 'conversation'], isEnabled: true },
+        { id: 'thread-new-worktree', title: 'New worktree chat', shortcut: '', category: 'Thread', keywords: ['thread', 'worktree', 'branch', 'isolated', 'fork', 'parallel'], isEnabled: true },
         { id: 'cycle-mode', title: 'Cycle approval mode', shortcut: 'Shift+Tab', category: 'Workspace', keywords: ['mode', 'approval', 'auto', 'plan', 'review', 'read-only', 'safety', 'cycle'], isEnabled: true },
         { id: 'focus-composer', title: 'Focus message input', shortcut: 'Cmd+L', category: 'Workspace', keywords: ['focus', 'composer', 'message', 'input', 'prompt', 'type'], isEnabled: true },
         { id: 'toggle-sidebar', title: 'Toggle sidebar', shortcut: 'Cmd+B', category: 'Navigation', keywords: ['sidebar', 'navigation', 'hide', 'show', 'chats', 'projects'], isEnabled: true },
@@ -4960,6 +4961,7 @@
       { usage: '/undo', title: 'Undo latest edit', detail: 'Reverse the latest revertable file edits from the current thread.', insertText: '/undo', aliases: ['revert', 'revert-latest', 'undo-edit'] },
       { usage: '/rename title', title: 'Rename chat', detail: 'Rename the current thread.', insertText: '/rename ', aliases: ['rename-chat', 'title'] },
       { usage: '/duplicate', title: 'Duplicate chat', detail: 'Copy the current thread into a new one.', insertText: '/duplicate', aliases: ['duplicate-chat', 'copy-chat'] },
+      { usage: '/new-worktree', title: 'New worktree chat', detail: 'Start a new thread in a fresh git worktree off the current branch, isolated from the working tree.', insertText: '/new-worktree', aliases: ['worktree-chat', 'worktree-thread'] },
       { usage: '/pin', title: 'Pin chat', detail: 'Keep the current thread in the pinned section.', insertText: '/pin', aliases: ['pin-chat'] },
       { usage: '/unpin', title: 'Unpin chat', detail: 'Remove the current thread from the pinned section.', insertText: '/unpin', aliases: ['unpin-chat'] },
       { usage: '/archive', title: 'Archive chat', detail: 'Move the current thread out of the recent list.', insertText: '/archive', aliases: ['archive-chat'] },
@@ -13163,6 +13165,7 @@
       'thread-clear',
       'thread-delete',
       'thread-duplicate',
+      'thread-new-worktree',
       'thread-pin',
       'thread-revert-latest',
       'thread-rename',
@@ -13415,6 +13418,12 @@
       }
       if (commandID === 'thread-duplicate') {
         runSidebarThreadAction('duplicate', state.sidebar.selectedThreadID);
+        return;
+      }
+      if (commandID === 'thread-new-worktree') {
+        // Mock stand-in: the native model creates a fresh git worktree off the current branch and
+        // starts a thread bound to it. The harness has no git, so it just opens a new thread.
+        newChat();
         return;
       }
       if (commandID === 'thread-pin') {
@@ -16258,6 +16267,14 @@
         state.composer.isSending = false;
         state.topBar.agentStatus = 'Idle';
         addMessage('assistant', workspaceStatusText());
+      } else if (/^\/(new-worktree|worktree-chat|worktree-thread)\b/i.test(text)) {
+        // Must precede the /new branch: /new-worktree also matches /^\/(new)\b/. Mock stand-in for
+        // the native new-worktree thread type — the harness has no git, so it opens a new thread via
+        // the same command the palette runs, then notes the worktree intent.
+        state.composer.isSending = false;
+        runCommand('thread-new-worktree');
+        addMessage('assistant', 'Started a new chat in a fresh worktree off the current branch.');
+        return;
       } else if (/^\/(new|new-chat|newchat)\b/i.test(text)) {
         newChat();
         return;

--- a/E2E/playwright/tests/command-palette-core.spec.ts
+++ b/E2E/playwright/tests/command-palette-core.spec.ts
@@ -79,10 +79,15 @@ test('mock harness ranks and navigates command palette with keyboard', async ({ 
 
   await cmdP(page);
   await fillCommandPalette(page, '>worktree');
-  await expect(page.getByTestId('command-palette-group')).toHaveCount(1);
-  await expect(page.getByTestId('command-palette-group')).toContainText('Git');
-  await expectSelectedCommandPaletteResult(page, 'List worktrees');
+  // "worktree" surfaces the new-worktree-chat thread command (Thread group, ranked ahead of Git by
+  // category order) above the git-worktree tool commands (Git group).
+  await expect(page.getByTestId('command-palette-group')).toHaveCount(2);
+  await expect(page.getByTestId('command-palette-group').first()).toContainText('Thread');
+  await expect(page.getByTestId('command-palette-group').nth(1)).toContainText('Git');
+  await expectSelectedCommandPaletteResult(page, 'New worktree chat');
 
+  await down(page);
+  await expectSelectedCommandPaletteResult(page, 'List worktrees');
   await down(page);
   await expectSelectedCommandPaletteResult(page, 'Create worktree');
   await down(page);

--- a/E2E/playwright/tests/command-palette-worktrees.spec.ts
+++ b/E2E/playwright/tests/command-palette-worktrees.spec.ts
@@ -22,7 +22,8 @@ test('mock harness lists worktrees from the command palette', async ({ page }) =
   await openCommandPalette(page);
   await fillCommandPalette(page, '>worktree');
 
-  await expect(page.getByTestId('command-palette-result')).toHaveCount(5);
+  // Five git-worktree tool commands plus the new-worktree-chat thread command.
+  await expect(page.getByTestId('command-palette-result')).toHaveCount(6);
   await commandPaletteResult(page, 'git-worktree-list').click();
 
   await expectCommandPaletteClosed(page);

--- a/E2E/playwright/tests/composer-slash.spec.ts
+++ b/E2E/playwright/tests/composer-slash.spec.ts
@@ -225,6 +225,28 @@ test('mock harness routes history slash commands through workspace back and forw
   await expect(page.getByTestId('transcript-empty')).toBeVisible();
 });
 
+test('mock harness suggests and runs the new-worktree thread command', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  const message = page.getByLabel('Message');
+
+  // Suggestion: /new-w surfaces the new-worktree-chat command, distinct from /new.
+  await message.fill('/new-w');
+  await expect(page.getByTestId('slash-suggestion').first()).toContainText('/new-worktree');
+  await expect(page.getByTestId('slash-suggestion').first()).toContainText('New worktree chat');
+
+  // Execution: /new-worktree routes through the thread-new-worktree command (mock stand-in for the
+  // worktree-bound thread native creates) — NOT swallowed by /new, NOT sent as a chat prompt.
+  const before = await page.getByTestId('sidebar-thread-row').count();
+  await message.fill('/new-worktree');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('message').last())
+    .toContainText('Started a new chat in a fresh worktree off the current branch.');
+  await expect
+    .poll(async () => page.getByTestId('sidebar-thread-row').count())
+    .toBeGreaterThan(before);
+});
+
 test('mock harness suggests slash commands in the composer', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
+++ b/Sources/QuillCodeApp/QuillCodeCommandIconCatalog.swift
@@ -47,6 +47,8 @@ enum QuillCodeCommandIconCatalog {
             return "clear"
         case "thread-clear":
             return "text.badge.xmark"
+        case "thread-new-worktree":
+            return "plus.rectangle.on.folder"
         case "toggle-browser":
             return "globe"
         case "open-browser-session":

--- a/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
+++ b/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
@@ -43,6 +43,12 @@ extension SlashCommandCatalog {
             aliases: ["duplicate-chat", "copy-chat"]
         ),
         slashDefinition(
+            "/new-worktree",
+            "New worktree chat",
+            "Start a new thread in a fresh git worktree off the current branch, isolated from the working tree.",
+            aliases: ["worktree-chat", "worktree-thread"]
+        ),
+        slashDefinition(
             "/pin",
             "Pin chat",
             "Keep the current thread in the pinned section.",

--- a/Sources/QuillCodeApp/SlashThreadCommandParser.swift
+++ b/Sources/QuillCodeApp/SlashThreadCommandParser.swift
@@ -9,6 +9,7 @@ enum SlashThreadCommandParser {
              "compact", "compact-context", "context-compact",
              "rename", "rename-chat", "title",
              "duplicate", "duplicate-chat", "copy-chat",
+             "new-worktree", "worktree-chat", "worktree-thread",
              "fork", "fork-last", "fork-from-last",
              "fork-summary", "fork-with-summary",
              "fork-full", "fork-full-context",
@@ -40,6 +41,8 @@ enum SlashThreadCommandParser {
             return value.isEmpty ? .invalid("Usage: /rename New chat title") : .renameThread(value)
         case "duplicate", "duplicate-chat", "copy-chat":
             return .workspaceCommand("thread-duplicate")
+        case "new-worktree", "worktree-chat", "worktree-thread":
+            return .workspaceCommand("thread-new-worktree")
         case "fork":
             return parseFork(argument: value)
         case "fork-last", "fork-from-last":

--- a/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
@@ -82,6 +82,8 @@ extension QuillCodeWorkspaceModel {
             return removeProject(projectID)
         case .duplicateThread(let threadID):
             return duplicateThread(threadID) != nil
+        case .newWorktreeThread:
+            return newWorktreeThread() != nil
         case .setThreadPinned(let threadID, let isPinned):
             return setPinThread(threadID, isPinned: isPinned)
         case .clearThread(let threadID):

--- a/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionPlanner.swift
@@ -29,6 +29,7 @@ enum WorkspaceCommandActionEffect: Sendable, Hashable {
     case setDraft(String)
     case removeProject(projectID: UUID)
     case duplicateThread(threadID: UUID)
+    case newWorktreeThread
     case setThreadPinned(threadID: UUID, isPinned: Bool)
     case clearThread(threadID: UUID)
     case revertLatestTurn
@@ -111,6 +112,8 @@ struct WorkspaceCommandActionPlanner: Sendable, Hashable {
             return selectedThread.map { .setDraft("/rename \($0.title)") }
         case .threadDuplicate:
             return selectedThreadID.map { .duplicateThread(threadID: $0) }
+        case .threadNewWorktree:
+            return .newWorktreeThread
         case .threadPin:
             guard let selectedThreadID,
                   let selectedThread,

--- a/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlan.swift
@@ -247,6 +247,7 @@ enum WorkspaceCommandAction: String, Equatable {
     case projectRemove = "project-remove"
     case threadRename = "thread-rename"
     case threadDuplicate = "thread-duplicate"
+    case threadNewWorktree = "thread-new-worktree"
     case threadPin = "thread-pin"
     case threadUnpin = "thread-unpin"
     case threadClear = "thread-clear"

--- a/Sources/QuillCodeApp/WorkspaceThreadCommandCatalog.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadCommandCatalog.swift
@@ -34,6 +34,12 @@ enum WorkspaceThreadCommandCatalog {
                 category: WorkspaceCommandPalette.threadCategory,
                 keywords: ["thread", "conversation"]
             ),
+            WorkspaceCommandSurface(
+                id: "thread-new-worktree",
+                title: "New worktree chat",
+                category: WorkspaceCommandPalette.threadCategory,
+                keywords: ["thread", "worktree", "branch", "isolated", "fork", "parallel"]
+            ),
             savedFilterCommand(.all),
             savedFilterCommand(.pinned),
             savedFilterCommand(.recent),

--- a/Tests/QuillCodeAppTests/QuillCodeCommandIconCatalogTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeCommandIconCatalogTests.swift
@@ -16,6 +16,7 @@ final class QuillCodeCommandIconCatalogTests: XCTestCase {
             "project-rename": "text.cursor",
             "project-remove": "minus.circle",
             "thread-clear": "text.badge.xmark",
+            "thread-new-worktree": "plus.rectangle.on.folder",
             "toggle-terminal": "terminal",
             "terminal-clear": "clear",
             "toggle-browser": "globe",

--- a/Tests/QuillCodeAppTests/SlashThreadCommandParserTests.swift
+++ b/Tests/QuillCodeAppTests/SlashThreadCommandParserTests.swift
@@ -10,6 +10,9 @@ final class SlashThreadCommandParserTests: XCTestCase {
             "compact-context",
             "rename-chat",
             "copy-chat",
+            "new-worktree",
+            "worktree-chat",
+            "worktree-thread",
             "fork",
             "fork-summary",
             "fork-full-context",
@@ -89,6 +92,25 @@ final class SlashThreadCommandParserTests: XCTestCase {
             ("/unpin-chat", .workspaceCommand("thread-unpin")),
             ("/delete-chat", .workspaceCommand("thread-delete"))
         ])
+    }
+
+    func testWorktreeAliasesMapToNewWorktreeCommand() {
+        // The bare `/worktree` namespace stays owned by the git-worktree tool (list/create/open/…),
+        // so the new-worktree-chat thread command uses distinct, non-colliding aliases.
+        assertThreadParses([
+            ("new-worktree", "", .workspaceCommand("thread-new-worktree")),
+            ("worktree-chat", "", .workspaceCommand("thread-new-worktree")),
+            ("worktree-thread", "", .workspaceCommand("thread-new-worktree")),
+            // A trailing name argument is accepted (the branch name is auto-planned).
+            ("new-worktree", "login flow", .workspaceCommand("thread-new-worktree"))
+        ])
+        assertTopLevelParses([
+            ("/new-worktree", .workspaceCommand("thread-new-worktree")),
+            ("/worktree-chat", .workspaceCommand("thread-new-worktree"))
+        ])
+        // The git-worktree tool commands must NOT be hijacked by the thread parser.
+        XCTAssertFalse(SlashThreadCommandParser.supports("worktree"))
+        XCTAssertFalse(SlashThreadCommandParser.supports("worktrees"))
     }
 
     func testForkAliasesAndModesMapToWorkspaceCommands() {

--- a/Tests/QuillCodeAppTests/WorkspaceCommandActionPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandActionPlannerTests.swift
@@ -31,6 +31,8 @@ final class WorkspaceCommandActionPlannerTests: XCTestCase {
         XCTAssertEqual(planner.effect(for: .forkFullContext), .forkThread(.fullContext))
         XCTAssertEqual(planner.effect(for: .compactContext), .compactContext)
         XCTAssertEqual(planner.effect(for: .disconnectAll), .disconnectAll)
+        // New-worktree is context-free: the model resolves the selected project when it runs.
+        XCTAssertEqual(planner.effect(for: .threadNewWorktree), .newWorktreeThread)
     }
 
     func testProjectActionsRequireOnlyTheContextTheyUse() {

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
@@ -75,8 +75,14 @@ final class WorkspaceCommandPaletteRankerTests: XCTestCase {
         let commands = QuillCodeWorkspaceModel().surface().commands
         let groups = WorkspaceCommandPaletteRanker.groupedCommands(commands, matching: ">worktree")
 
-        XCTAssertEqual(groups.map(\.title), [WorkspaceCommandPalette.gitCategory])
-        XCTAssertEqual(groups.first?.commands.map(\.id), [
+        // The new-worktree-chat thread command matches "worktree" too; Thread sorts ahead of Git by
+        // palette category order, so it forms the first group above the git-worktree tool commands.
+        XCTAssertEqual(groups.map(\.title), [
+            WorkspaceCommandPalette.threadCategory,
+            WorkspaceCommandPalette.gitCategory
+        ])
+        XCTAssertEqual(groups.first?.commands.map(\.id), ["thread-new-worktree"])
+        XCTAssertEqual(groups.last?.commands.map(\.id), [
             "git-worktree-list",
             "git-worktree-create",
             "git-worktree-open",

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -64,6 +64,7 @@ final class WorkspaceSurfaceTests: XCTestCase {
         XCTAssertEqual(surface.composer.slashSuggestions, [])
         XCTAssertEqual(surface.commands.map(\.id), [
             "new-chat",
+            "thread-new-worktree",
             "sidebar-filter:all",
             "sidebar-filter:pinned",
             "sidebar-filter:recent",


### PR DESCRIPTION
Makes the merged slice-2 `newWorktreeThread()` model method actually invocable by a user. Before this, the "Worktree" thread type existed in the model and was unit-tested, but had no trigger on any surface.

## What this adds
A new **New worktree chat** command, wired through the full native command chain and mirrored in the HTML harness:
- **Command palette:** `thread-new-worktree` ("New worktree chat", Thread category)
- **Slash:** `/new-worktree` (aliases `worktree-chat`, `worktree-thread`)
- **Native chain:** `SlashThreadCommandParser` → `WorkspaceCommandAction.threadNewWorktree` → `WorkspaceCommandActionEffect.newWorktreeThread` → executor → `newWorktreeThread()`

Running it creates a fresh git worktree off the current branch and starts a new thread bound to it — isolated from the working tree, without minting a sibling project (the Codex Local-vs-Worktree choice at thread creation).

## Namespace collision, avoided deliberately
The git-worktree **tool** already owns the entire `/worktree` namespace (`/worktrees` list, `/worktree create|open|remove|prune`). This command uses distinct aliases only (`/new-worktree`, `worktree-chat`, `worktree-thread`) and a negative guard test asserts the thread parser never claims `worktree`/`worktrees`. A "worktree" palette search now surfaces **New worktree chat** (Thread group) ranked above the git-worktree tool commands (Git group).

## Tests
- **Unit:** parser aliases + negative guard, planner effect mapping, palette ranker grouping, icon catalog
- **Parity:** native↔harness slash-catalog usage parity (`/new-worktree` present on both)
- **Functional (harness):** routable-command set + `runCommand` handler + send-dispatch branch ordered before `/new` (which `/new-worktree` would otherwise match)
- **Playwright:** `/new-worktree` suggest + run, `>worktree` palette grouping, interaction-audit routability
- Full Swift suite green locally (3286 tests, 0 failures); all affected Playwright specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
