### PR TITLE
fix(persistence): one corrupt thread file no longer empties the whole sidebar

### DIFF
--- a/Sources/QuillCodePersistence/ThreadStore.swift
+++ b/Sources/QuillCodePersistence/ThreadStore.swift
@@ -1,6 +1,19 @@
 import Foundation
 import QuillCodeCore
 
+/// Result of a best-effort thread listing: the healthy threads that decoded, plus the file URLs
+/// that could not be read (truncated, hand-edited, or schema-skewed) so callers can surface a
+/// self-healing notice instead of silently losing data.
+public struct ThreadListing: Sendable {
+    public var threads: [ChatThread]
+    public var unreadable: [URL]
+
+    public init(threads: [ChatThread], unreadable: [URL]) {
+        self.threads = threads
+        self.unreadable = unreadable
+    }
+}
+
 public struct JSONThreadStore: Sendable {
     public var directory: URL
 
@@ -31,16 +44,37 @@ public struct JSONThreadStore: Sendable {
     }
 
     public func list() throws -> [ChatThread] {
-        guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
-        let urls = try FileManager.default.contentsOfDirectory(
+        listing().threads
+    }
+
+    /// Best-effort listing that self-heals around damage: a single truncated (crash-mid-write),
+    /// hand-edited, or schema-skewed thread file must NOT empty the entire sidebar — every healthy
+    /// conversation still loads and the unreadable files are reported separately. `load(_:)` stays
+    /// strict, so a direct open of a named corrupt thread still surfaces the decode error.
+    public func listing() -> ThreadListing {
+        guard FileManager.default.fileExists(atPath: directory.path) else {
+            return ThreadListing(threads: [], unreadable: [])
+        }
+        guard let urls = try? FileManager.default.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: nil
-        ).filter { $0.pathExtension == "json" }
-        return try urls.map { url in
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            return try decoder.decode(ChatThread.self, from: Data(contentsOf: url))
-        }.sorted { $0.updatedAt > $1.updatedAt }
+        ).filter({ $0.pathExtension == "json" }) else {
+            return ThreadListing(threads: [], unreadable: [])
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        var threads: [ChatThread] = []
+        var unreadable: [URL] = []
+        for url in urls {
+            guard let data = try? Data(contentsOf: url),
+                  let thread = try? decoder.decode(ChatThread.self, from: data) else {
+                unreadable.append(url)
+                continue
+            }
+            threads.append(thread)
+        }
+        threads.sort { $0.updatedAt > $1.updatedAt }
+        return ThreadListing(threads: threads, unreadable: unreadable)
     }
 
     private func fileURL(for id: UUID) -> URL {

--- a/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
@@ -157,6 +157,25 @@ final class WorkspaceConfigurationIntegrationTests: XCTestCase {
         XCTAssertEqual(try ConfigStore(fileURL: paths.configFile).load(), nextConfig)
     }
 
+    func testBootstrapSurvivesACorruptThreadFileInsteadOfEmptyingTheSidebar() throws {
+        // End-to-end regression pin: a single truncated thread file (crash-mid-write) used to make
+        // threadStore.list() throw, aborting makeModel() and vanishing EVERY conversation. Bootstrap
+        // must now surface the surviving threads.
+        let root = try makeTempDirectory()
+        let paths = QuillCodePaths(home: root.appendingPathComponent(".quillcode"))
+        try paths.ensure()
+        let store = JSONThreadStore(directory: paths.threadsDirectory)
+        try store.save(ChatThread(title: "Survivor A", updatedAt: Date(timeIntervalSince1970: 1)))
+        try store.save(ChatThread(title: "Survivor B", updatedAt: Date(timeIntervalSince1970: 2)))
+        try Data("{ truncated mid-write".utf8)
+            .write(to: paths.threadsDirectory.appendingPathComponent("\(UUID().uuidString).json"))
+
+        let model = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
+
+        XCTAssertEqual(model.root.threads.map(\.title), ["Survivor B", "Survivor A"])
+        XCTAssertEqual(model.root.selectedThreadID, model.root.threads.first?.id)
+    }
+
     func testBootstrapPersistsAndClearsTrustedRouterAPIKey() throws {
         let paths = QuillCodePaths(home: try makeTempDirectory())
         let bootstrap = QuillCodeWorkspaceBootstrap(

--- a/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
@@ -64,6 +64,59 @@ final class JSONThreadStoreTests: PersistenceTestCase {
         XCTAssertNil(thread.composerDraft)
     }
 
+    func testListSkipsCorruptFilesAndKeepsHealthyThreads() throws {
+        // The catastrophic bug this guards: one truncated/hand-edited file must NOT empty the whole
+        // sidebar. A throwing map used to abort the entire load on a single bad file.
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        try store.save(ChatThread(title: "Alpha"))
+        try store.save(ChatThread(title: "Beta"))
+        // A truncated crash-mid-write file and a foreign-but-.json file.
+        try Data("{ not json".utf8).write(to: directory.appendingPathComponent("\(UUID().uuidString).json"))
+        try Data("{}".utf8).write(to: directory.appendingPathComponent("\(UUID().uuidString).json"))
+
+        let threads = try store.list()
+        XCTAssertEqual(Set(threads.map(\.title)), ["Alpha", "Beta"])
+    }
+
+    func testListingReportsUnreadableFilesWithoutLosingHealthyThreads() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        try store.save(ChatThread(title: "Healthy"))
+        let corrupt = directory.appendingPathComponent("\(UUID().uuidString).json")
+        try Data("garbage".utf8).write(to: corrupt)
+
+        let listing = store.listing()
+        XCTAssertEqual(listing.threads.map(\.title), ["Healthy"])
+        // Compare by filename: contentsOfDirectory resolves the macOS /var -> /private/var symlink,
+        // so raw URL equality is unreliable here.
+        XCTAssertEqual(listing.unreadable.map(\.lastPathComponent), [corrupt.lastPathComponent])
+    }
+
+    func testListToleratesSchemaIncompatibleFile() throws {
+        // A .json that is valid JSON but missing required ChatThread keys is skipped, not fatal.
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        try store.save(ChatThread(title: "Good"))
+        let incompatible = """
+        { "id": "\(UUID().uuidString)", "title": "No required fields" }
+        """
+        try Data(incompatible.utf8).write(to: directory.appendingPathComponent("\(UUID().uuidString).json"))
+
+        XCTAssertEqual(try store.list().map(\.title), ["Good"])
+        XCTAssertEqual(store.listing().unreadable.count, 1)
+    }
+
+    func testLoadStillThrowsOnCorruptNamedThread() throws {
+        // Only the LIST is best-effort; a direct open of a named corrupt thread must still report it.
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let id = UUID()
+        try Data("{ truncated".utf8).write(to: directory.appendingPathComponent("\(id.uuidString).json"))
+
+        XCTAssertThrowsError(try store.load(id))
+    }
+
     func testThreadWrittenBeforeQueueFieldDecodesToEmptyQueue() throws {
         // A thread JSON persisted before followUpQueue existed must still decode (queue = []).
         let json = """


### PR DESCRIPTION
## The bug (catastrophic, verified)
`JSONThreadStore.list()` decoded every `*.json` in the threads dir with a throwing `map`, so a SINGLE unreadable file — truncated by a crash-mid-write, hand-edited, or schema-skewed by a downgrade — made the whole call throw. `QuillCodeWorkspaceBootstrap.makeModel()` propagates that throw, so **one bad thread file emptied the entire sidebar on startup**: every healthy conversation vanished. Blast radius should be one thread; it was the whole workspace — the sharpest data-loss footgun in the app, on the core durability surface of a single-user local appliance.

## The fix
`list()` is now best-effort: it skips files it can't read and returns every healthy thread. `load(_:)` stays **strict** — a direct open of a named corrupt thread still surfaces the decode error (only the bulk list self-heals). A new `listing() -> ThreadListing` returns the healthy threads *and* the URLs it couldn't read, so damage is observable (a hook for a follow-up quarantine + self-healing notice) rather than silently swallowed. No on-disk format or encoder change; `list()` keeps its `throws` signature so no caller changes.

## Tests (full pyramid)
- **Unit** (`JSONThreadStoreTests`): 2 valid + a truncated `{ not json` + a `{}` file → `list()` returns exactly the 2 healthy threads and does not throw; `listing()` reports the unreadable file; a schema-incompatible-but-valid-JSON file is tolerated; `load(_:)` on a corrupt named thread **still throws** (strict path preserved).
- **Integration** (`WorkspaceConfigurationIntegrationTests`): a threads dir with 2 valid + 1 truncated file → `QuillCodeWorkspaceBootstrap.makeModel()` surfaces both survivors in `model.root.threads` (end-to-end regression pin) instead of an empty sidebar.
- No DOM surface, so no Playwright layer. Full Swift suite green locally.

Follow-up (separate increment): quarantine unreadable files (rename aside) + a self-healing startup notice using `ThreadListing.unreadable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
