### PR TITLE
fix(persistence): ConfigStore round-trips newlines losslessly instead of bricking all settings

### DIFF
--- a/Sources/QuillCodePersistence/ConfigStore.swift
+++ b/Sources/QuillCodePersistence/ConfigStore.swift
@@ -207,9 +207,14 @@ public struct ConfigStore: Sendable {
     }
 
     private static func quote(_ value: String) -> String {
+        // Escape backslash FIRST, then the chars that would break the flat key=value line format.
+        // Newlines especially: an unescaped '\n' splits the value across physical lines, and load()
+        // then rejects the '=' -less fragment — corrupting the ENTIRE config, not just this value.
         let escaped = value
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
         return "\"\(escaped)\""
     }
 
@@ -223,7 +228,14 @@ public struct ConfigStore: Sendable {
         var isEscaping = false
         for character in inner {
             if isEscaping {
-                output.append(character)
+                // Decode the escape sequences quote() emits: \n -> newline, \r -> CR, and
+                // \\ / \" -> the literal char (default). Without the n/r cases a round-tripped
+                // newline would silently decode back to the literal letter 'n'.
+                switch character {
+                case "n": output.append("\n")
+                case "r": output.append("\r")
+                default: output.append(character)
+                }
                 isEscaping = false
             } else if character == "\\" {
                 isEscaping = true

--- a/Tests/QuillCodePersistenceTests/ConfigStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/ConfigStoreTests.swift
@@ -140,6 +140,33 @@ final class ConfigStoreTests: PersistenceTestCase {
         XCTAssertTrue(stored.contains("automation_notifications_enabled = true"))
     }
 
+    func testConfigRoundTripsValuesContainingNewlinesAndEscapes() throws {
+        // Regression: a value with a newline was written as a PHYSICAL line break, so load() hit an
+        // '='-less fragment and threw invalidLine — discarding the ENTIRE config (model, mode, auth,
+        // account, notification prefs). Now newline/CR/quote/backslash round-trip losslessly.
+        let store = try makeConfigStore()
+        let gnarly = "line1\nline2\r\ttab \"quoted\" back\\slash \\n literal"
+        let config = AppConfig(
+            defaultModel: TrustedRouterDefaults.prometheusModel,
+            apiBaseURL: gnarly,
+            authMode: .oauth,
+            trustedRouterAccount: TrustedRouterAccountProfile(userID: "u", subject: gnarly)
+        )
+
+        try store.save(config)
+        let loaded = try store.load()
+
+        XCTAssertEqual(loaded.apiBaseURL, gnarly)
+        XCTAssertEqual(loaded.trustedRouterAccount?.subject, gnarly)
+        XCTAssertEqual(loaded, config)
+
+        // On disk the value stays on one logical line (newline escaped as \n), so no '='-less
+        // fragment can ever brick the parser again.
+        let stored = try String(contentsOf: store.fileURL, encoding: .utf8)
+        XCTAssertTrue(stored.contains(#"api_base_url = "line1\nline2"#))
+        XCTAssertFalse(stored.contains("line1\nline2"))
+    }
+
     func testExplicitAuthModeWinsOverLegacyDeveloperOverrideFlag() throws {
         let fileURL = try makeTempDirectory().appendingPathComponent("config.toml")
         try """


### PR DESCRIPTION
## The bug (verified)
`ConfigStore.quote()` escaped only `\` and `"` — **not newline/CR**. So any config value containing a newline (a pasted `api_base_url`, `favorite_model`, `browser_allowed_domain`, or a TrustedRouter account field) was written as a physical line break in the flat `key = "value"` file. On the next `load()`, the value's second line has no `=`, so `parts.count != 2` and load throws `invalidLine` — discarding the **entire** config: default model, mode, auth mode, TrustedRouter account, notification prefs, everything.

A second latent bug: `unquote()`'s escape branch appended the escaped char verbatim, so even a correctly-escaped `\n` would decode back to the literal letter `n`. `save`/`load` are meant to be a lossless pair and weren't.

## The fix
- `quote()` now also escapes `\n` → `\n` and `\r` → `\r` (after the backslash pass, so a literal backslash-n stays distinct from a real newline).
- `unquote()` now decodes `\n` → newline and `\r` → CR (and still `\\` → `\`, `\"` → `"` via the default case).

Result: `load(save(config)) == config` for any value, and a value with a newline can never again split the file and brick every setting. No format change; `load()` behavior for existing well-formed files is unchanged.

## Tests
- **Unit** (`ConfigStoreTests`): round-trips a config whose `api_base_url` and account `subject` contain a newline + CR + tab + `"quoted"` + `back\slash` + a literal `\n` together → all fields equal, whole config equal; and asserts the on-disk value stays on one logical line (`api_base_url = "line1\nline2…"` with **no raw newline** inside the value). Full Swift suite green.

Part of the persistence-durability sweep (sibling of the JSONThreadStore resilience fix, #1056).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
