### PR TITLE
fix(harness): repoint 5 stale var(--accent) refs to the defined --blue token

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -598,7 +598,7 @@
     .model-panel p { margin: 0; }
     .model-panel .model-catalog-status,
     .model-panel .model-provider-health {
-      color: var(--accent);
+      color: var(--blue);
       font-size: 12px;
       font-weight: 650;
       line-height: 1.25;
@@ -860,7 +860,7 @@
       height: 14px;
       border-radius: 999px;
       border: 2px solid rgba(61,201,230,.22);
-      border-top-color: var(--accent);
+      border-top-color: var(--blue);
       animation: spin .85s linear infinite;
     }
     .dialog-choice {
@@ -1842,7 +1842,7 @@
       justify-content: center;
       border: 1px solid rgba(120, 220, 255, 0.24);
       background: rgba(31, 164, 219, 0.14);
-      color: var(--accent);
+      color: var(--blue);
       border-radius: 10px;
       font: 700 12px/1 var(--font-sans);
       letter-spacing: 0;
@@ -2360,7 +2360,7 @@
       border: 1px solid var(--line);
       border-radius: 999px;
       background: rgba(92, 200, 255, 0.12);
-      color: var(--accent);
+      color: var(--blue);
       padding: 0 12px;
       font: inherit;
       font-size: 13px;
@@ -2527,7 +2527,7 @@
     .tool-card-actions button:active { transform: scale(0.96); }
     .tool-card-actions button[data-action-style="primary"] {
       color: #fff;
-      background: var(--accent);
+      background: var(--blue);
       border-color: rgba(255,255,255,.14);
     }
     .tool-card-actions button[data-action-style="primary"] {

--- a/E2E/playwright/tests/visual-polish.spec.ts
+++ b/E2E/playwright/tests/visual-polish.spec.ts
@@ -39,6 +39,37 @@ test('mock harness avoids horizontal clipping in key desktop and mobile flows', 
   }
 });
 
+test('mock harness styles interactive accents with the defined cyan token, not a stale --accent', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  const audit = await page.evaluate(() => {
+    const rules: string[] = [];
+    for (const sheet of Array.from(document.styleSheets)) {
+      let cssRules: CSSRuleList | undefined;
+      try { cssRules = sheet.cssRules; } catch { continue; }
+      for (const rule of Array.from(cssRules || [])) rules.push(rule.cssText);
+    }
+    // The Codex theme renamed the accent token to --blue; any surviving var(--accent) is undefined
+    // and renders the referencing control unstyled (the primary tool-card action lost its fill).
+    const staleAccentRefs = rules.filter(text => text.includes('var(--accent)')).length;
+    const primaryActionRule = rules.find(text =>
+      text.includes('data-action-style') && text.includes('primary') && text.includes('background:'));
+
+    // Prove --blue actually resolves to the Codex cyan.
+    const probe = document.createElement('div');
+    probe.style.background = 'var(--blue)';
+    document.body.appendChild(probe);
+    const resolvedBlue = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+
+    return { staleAccentRefs, primaryActionRule, resolvedBlue };
+  });
+
+  expect(audit.staleAccentRefs).toBe(0);
+  expect(audit.primaryActionRule).toContain('var(--blue)');
+  expect(audit.resolvedBlue).toBe('rgb(61, 201, 230)');
+});
+
 test('mock harness keeps sidebar saved filters fully visible', async ({ page }) => {
   await page.goto(harnessURL());
   await page.getByLabel('Message').fill('run whoami');


### PR DESCRIPTION
## The bug (live visual regression, verified)
The Codex theme pass renamed the accent custom property to `--blue` (`#3dc9e6`) but left **5 `var(--accent)` references** in the harness — and `--accent` is defined nowhere. CSS resolves an undefined custom property to its initial value, so every one of these rendered wrong. The worst is the **primary tool-card action button** (`background: var(--accent)` → transparent): the single most important affordance in a transcript (approve/apply) lost its fill. Also affected: the model-catalog status text, the thinking spinner's leading edge, and an automation action.

## The fix
Repointed all 5 refs to the defined `var(--blue)` (the Codex cyan). The native mirror already uses `QuillCodePalette.blue` for the primary action (`QuillCodeToolCardControls.swift`), so this is a **harness-only** token repair — native and harness now agree.

## Tests
- **Playwright** (`visual-polish.spec.ts`): scans every loaded CSS rule and asserts **zero** `var(--accent)` references survive (permanent regression guard), that the primary-action rule references `var(--blue)`, and that `--blue` resolves to `rgb(61, 201, 230)`. Deterministic, no fragile fixture. Full Playwright suite green.

Part of the Codex-theme correctness sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
