### PR TITLE
fix(worktree): pass real branches to the planner so repeat /new-worktree names don't collide

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModelWorktrees.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelWorktrees.swift
@@ -41,7 +41,7 @@ extension QuillCodeWorkspaceModel {
             projectRoot: projectRoot,
             baseBranch: baseBranch,
             name: name,
-            existingBranches: [baseBranch]
+            existingBranches: existingLocalBranches(projectRoot: projectRoot, fallback: baseBranch)
         )
         let result = runToolCall(
             WorkspaceWorktreeToolCallPlanner.create(request),
@@ -51,6 +51,30 @@ extension QuillCodeWorkspaceModel {
         let threadID = newChat(projectID: project.id)
         bindSelectedThreadToWorktree(path: worktreePath, branch: request.branch, base: baseBranch)
         return threadID
+    }
+
+    /// The local branch names, so the planner picks a collision-free branch even when earlier
+    /// worktree threads already claimed `quill/<slug>`. Passing only the base branch (as before) let
+    /// two `/new-worktree experiment` calls both plan `quill/experiment`, and the second git worktree
+    /// create failed on the already-existing branch. Best-effort: any git failure falls back to the
+    /// base branch alone (the prior behavior).
+    private func existingLocalBranches(projectRoot: URL, fallback baseBranch: String) -> [String] {
+        let call = ToolCall(
+            name: ToolDefinition.gitBranchList.name,
+            argumentsJSON: ToolArguments.json(["includeRemote": false])
+        )
+        let result = runToolCall(call, workspaceRoot: projectRoot)
+        guard result.ok else { return [baseBranch] }
+        // Each line is "%(HEAD)\t%(refname:short)\t%(upstream:short)"; field 1 is the branch name.
+        let names = result.stdout
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { line -> String? in
+                let fields = line.split(separator: "\t", omittingEmptySubsequences: false)
+                guard fields.count >= 2 else { return nil }
+                let name = fields[1].trimmingCharacters(in: .whitespaces)
+                return name.isEmpty ? nil : name
+            }
+        return names.isEmpty ? [baseBranch] : names
     }
 
     private func selectedProjectBranch(_ project: ProjectRef) -> String? {

--- a/Tests/QuillCodeAppTests/WorktreeThreadTests.swift
+++ b/Tests/QuillCodeAppTests/WorktreeThreadTests.swift
@@ -93,4 +93,30 @@ final class WorktreeThreadModelTests: XCTestCase {
         let model = QuillCodeWorkspaceModel()
         XCTAssertNil(model.newWorktreeThread(name: "x"), "no selected project → nil")
     }
+
+    func testSecondWorktreeThreadWithSameNameGetsACollisionFreeBranch() throws {
+        let repo = try makeGitRepo()
+        let model = QuillCodeWorkspaceModel()
+        let projectID = model.addProject(path: repo, name: "Repo")
+        model.selectProject(projectID)
+
+        let first = model.newWorktreeThread(name: "experiment")
+        XCTAssertNotNil(first)
+        XCTAssertEqual(model.selectedThread?.worktree?.branch, "quill/experiment")
+        let firstPath = model.selectedThread?.worktree?.path
+
+        // A second worktree with the SAME requested name must NOT collide on the already-created
+        // quill/experiment branch: the planner enumerates real branches and picks quill/experiment-2.
+        // Before the fix it passed only [baseBranch], so the second create failed and returned nil.
+        let second = model.newWorktreeThread(name: "experiment")
+        XCTAssertNotNil(second, "second worktree thread must be created, not fail on branch collision")
+        XCTAssertNotEqual(second, first)
+        let secondBinding = model.selectedThread?.worktree
+        XCTAssertEqual(secondBinding?.branch, "quill/experiment-2")
+        XCTAssertTrue(secondBinding.map(\.isResolvable) ?? false, "second worktree dir should exist")
+
+        // The two bound worktrees are distinct directories on disk.
+        XCTAssertNotNil(firstPath)
+        XCTAssertNotEqual(firstPath, secondBinding?.path)
+    }
 }


### PR DESCRIPTION
## The bug (verified — regression from the new-worktree feature)
`newWorktreeThread` planned its branch by passing `existingBranches: [baseBranch]` to `WorktreeThreadPlanner`. The planner's collision avoidance (`quill/<slug>`, then `-2`, `-3`, …) therefore only ever knew about the base branch — never the `quill/*` branches earlier worktree threads had already created. So calling `/new-worktree experiment` twice both planned `quill/experiment`, and the second `git worktree add -b quill/experiment` failed on the existing branch and returned `nil` silently: the second attempt just did nothing.

## The fix
`newWorktreeThread` now enumerates the repo's real local branches (`git branch --format=…` through the existing sandboxed `runToolCall` path — the same infra the create uses) and feeds the full set to the planner, so it correctly picks `quill/experiment-2` for the second call. Best-effort: any git failure falls back to the prior `[baseBranch]` behavior.

## Tests (`WorktreeThreadModelTests`, real temp git repo)
- Call `newWorktreeThread(name: "experiment")` twice: the second now returns a non-nil thread bound to `quill/experiment-2` with a distinct, resolvable worktree directory (before the fix it returned nil). The existing single-call isolation test and the pure-planner unit tests still pass. Full Swift suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
