### PR TITLE
Cover worktree top-bar status in HTML renderer

### DIFF
--- a/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
@@ -4,6 +4,13 @@ import QuillCodeCore
 
 @MainActor
 final class WorkspaceHTMLChromeRendererTests: XCTestCase {
+    private func makeTempDirectory(_ tag: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("html-\(tag)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
     func testHTMLRendererEscapesAndLabelsPrimaryRegions() {
         let project = ProjectRef(
             name: "Unsafe <project>",
@@ -125,6 +132,44 @@ final class WorkspaceHTMLChromeRendererTests: XCTestCase {
             )).surface()
         )
         XCTAssertTrue(remoteHTML.contains(#"data-testid="top-bar-overflow-disconnect-all""#))
+    }
+
+    func testHTMLRendererShowsWorktreeTopBarStatusAndDanglingWarning() throws {
+        let project = ProjectRef(name: "QuillCode", path: "/tmp/quillcode")
+        var thread = ChatThread(title: "Feature", projectID: project.id)
+        let worktree = try makeTempDirectory("worktree")
+        thread.worktree = WorktreeBinding(path: worktree.path, branch: "feature/ui", base: "main")
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            projects: [project],
+            selectedProjectID: project.id,
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="top-bar-worktree""#))
+        XCTAssertTrue(html.contains(#"data-tone="normal""#))
+        XCTAssertTrue(html.contains("Worktree feature/ui"))
+        XCTAssertTrue(html.contains("Base: main."))
+        XCTAssertTrue(html.contains(worktree.path))
+
+        var dangling = thread
+        dangling.worktree = WorktreeBinding(
+            path: "/tmp/quillcode-missing-\(UUID().uuidString)",
+            branch: "feature/gone"
+        )
+        let warningHTML = WorkspaceHTMLRenderer.render(QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            projects: [project],
+            selectedProjectID: project.id,
+            threads: [dangling],
+            selectedThreadID: dangling.id
+        )).surface())
+
+        XCTAssertTrue(warningHTML.contains(#"data-testid="top-bar-worktree""#))
+        XCTAssertTrue(warningHTML.contains(#"data-tone="warning""#))
+        XCTAssertTrue(warningHTML.contains("Worktree feature/gone"))
+        XCTAssertTrue(warningHTML.contains("runs fall back to the project root"))
     }
 
     func testHTMLRendererHidesSidebarAndExpandsWorkspaceGrid() {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -15462,3 +15462,15 @@ Validation:
 - `swift test --filter WorkspaceTopBarSurfaceBuilderTests` (6 tests, 0 failures)
 - `swift test --filter WorkspaceHTMLChromeRendererTests` (13 tests, 0 failures)
 - `git diff --check`
+
+## 2026-07-06 Worktree Top-Bar Harness Coverage
+
+Overall grade after this slice: **A+ static renderer parity coverage**.
+The worktree top-bar chip now has explicit static HTML coverage for both
+normal isolated worktrees and dangling bindings, matching the Playwright-facing
+surface instead of relying only on the Swift surface builder tests.
+
+Validation:
+
+- `swift test --filter WorkspaceHTMLChromeRendererTests` (14 tests, 0 failures)
+- `git diff --check`


### PR DESCRIPTION
## Summary
- add static HTML renderer coverage for the worktree top-bar chip
- assert both normal isolated worktree state and dangling-worktree warning state
- record the coverage slice in the quality audit

## Validation
- swift test --filter WorkspaceHTMLChromeRendererTests
- git diff --check