### PR TITLE
Enforce period spend caps

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -253,15 +253,22 @@ public struct AgentRunner: Sendable {
         case .blocked(let existingRequestID):
             thread.events.append(.init(
                 kind: .notice,
-                summary: "Spend fuse is waiting on approval \(existingRequestID)."
+                summary: "Spend limit is waiting on approval \(existingRequestID)."
             ))
             thread.updatedAt = Date()
             await onProgress?(thread)
             let summary = runSpendFusePolicy.spendSummary(for: thread)
-            return .spendFuseApprovalRequired(totalUSD: summary.totalUSD, fuseUSD: runSpendFusePolicy.fuseUSD)
+            return .spendFuseApprovalRequired(totalUSD: summary.totalUSD, fuseUSD: runSpendFusePolicy.fuseUSD ?? 0)
         case .request(let request):
-            let summary = runSpendFusePolicy.spendSummary(for: thread)
-            let text = "Thread spend reached \(RunSpendFusePolicy.costLabel(summary.totalUSD)). "
+            let payload = try? JSONHelpers.decode(
+                RunSpendFuseApprovalPayload.self,
+                from: request.toolCall.argumentsJSON
+            )
+            let limitLabel = payload?.approvalLimitKind == .threadFuse
+                ? "Thread spend"
+                : payload?.approvalLimitKind.label.capitalized ?? "Spend limit"
+            let spend = RunSpendFusePolicy.costLabel(payload?.totalUSD ?? 0)
+            let text = "\(limitLabel) reached \(spend). "
                 + "Approve to continue this run."
             thread.events.append(.init(
                 kind: .approvalRequested,
@@ -272,13 +279,9 @@ public struct AgentRunner: Sendable {
             thread.events.append(.init(kind: .message, summary: text))
             thread.updatedAt = Date()
             await onProgress?(thread)
-            let payload = try? JSONHelpers.decode(
-                RunSpendFuseApprovalPayload.self,
-                from: request.toolCall.argumentsJSON
-            )
             return .spendFuseApprovalRequired(
                 totalUSD: payload?.totalUSD ?? 0,
-                fuseUSD: payload?.fuseUSD ?? runSpendFusePolicy.fuseUSD
+                fuseUSD: payload?.fuseUSD ?? runSpendFusePolicy.fuseUSD ?? 0
             )
         }
     }

--- a/Sources/QuillCodeApp/WorkspaceAgentRunContextBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentRunContextBuilder.swift
@@ -9,6 +9,7 @@ struct WorkspaceAgentRunContextBuilder: Sendable {
     var selectedProject: ProjectRef?
     var config: AppConfig = AppConfig()
     var modelCatalog: [ModelInfo] = []
+    var spendPeriodThreads: [ChatThread] = []
     var browser: BrowserState
     var browserToolOverride: AgentToolExecutionOverride? = nil
     var computerUseBackend: (any ComputerUseBackend)?
@@ -33,6 +34,8 @@ struct WorkspaceAgentRunContextBuilder: Sendable {
         activeRunner.toolExecutionOverride = toolExecutionOverride
         activeRunner.runSpendFusePolicy = RunSpendFusePolicy(
             fuseUSD: config.runSpendFuseUSD,
+            periodLimits: config.runSpendPeriodLimits,
+            periodThreads: spendPeriodThreads,
             modelCatalog: modelCatalog
         )
         if let permissionRules {

--- a/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSessionFactory.swift
@@ -10,6 +10,7 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
     private let selectedProject: ProjectRef?
     private let config: AppConfig
     private let modelCatalog: [ModelInfo]
+    private let spendPeriodThreads: [ChatThread]
     private let browser: BrowserState
     private let browserToolOverride: AgentToolExecutionOverride?
     private let computerUseBackend: (any ComputerUseBackend)?
@@ -25,6 +26,7 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
         selectedProject: ProjectRef?,
         config: AppConfig,
         modelCatalog: [ModelInfo] = [],
+        spendPeriodThreads: [ChatThread] = [],
         browser: BrowserState,
         browserToolOverride: AgentToolExecutionOverride?,
         computerUseBackend: (any ComputerUseBackend)?,
@@ -39,6 +41,7 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
         self.selectedProject = selectedProject
         self.config = config
         self.modelCatalog = modelCatalog
+        self.spendPeriodThreads = spendPeriodThreads
         self.browser = browser
         self.browserToolOverride = browserToolOverride
         self.computerUseBackend = computerUseBackend
@@ -76,6 +79,7 @@ struct WorkspaceAgentSendSessionFactory: Sendable {
             selectedProject: selectedProject,
             config: config,
             modelCatalog: modelCatalog,
+            spendPeriodThreads: spendPeriodThreads,
             browser: browser,
             browserToolOverride: browserToolOverride,
             computerUseBackend: computerUseBackend,

--- a/Sources/QuillCodeApp/WorkspaceModelAgentSession.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelAgentSession.swift
@@ -59,6 +59,7 @@ extension QuillCodeWorkspaceModel {
             selectedProject: selectedProject,
             config: root.config,
             modelCatalog: root.modelCatalog,
+            spendPeriodThreads: root.threads,
             browser: browser,
             browserToolOverride: WorkspaceBrowserAgentToolOverride.make { [weak self] call, workspaceRoot in
                 guard let self else { return nil }

--- a/Sources/QuillCodeApp/WorkspaceSpendHistoryQuotaBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceSpendHistoryQuotaBuilder.swift
@@ -43,25 +43,11 @@ struct WorkspaceSpendHistoryQuotaBuilder: Sendable, Hashable {
     }
 
     private func spendSince(_ start: Date) -> Double {
-        threads.reduce(0) { total, thread in
-            let periodThread = ChatThread(
-                id: thread.id,
-                title: thread.title,
-                projectID: thread.projectID,
-                mode: thread.mode,
-                model: thread.model,
-                messages: [],
-                events: thread.events.filter { $0.createdAt >= start && $0.createdAt <= now },
-                createdAt: thread.createdAt,
-                updatedAt: thread.updatedAt,
-                instructions: thread.instructions,
-                memories: thread.memories,
-                composerDraft: thread.composerDraft,
-                followUpQueue: thread.followUpQueue
-            )
-            let ledger = RunSpendLedger(thread: periodThread, modelCatalog: modelCatalog, fuseUSD: nil)
-            return total + ledger.totalUSD
-        }
+        RunSpendPeriodLedger(
+            threads: threads,
+            modelCatalog: modelCatalog,
+            now: now
+        ).spendUSD(since: start)
     }
 
     private func startOfCurrentWeek() -> Date {

--- a/Sources/QuillCodeCore/RunSpendFuseModels.swift
+++ b/Sources/QuillCodeCore/RunSpendFuseModels.swift
@@ -6,25 +6,48 @@ public enum RunSpendFuseApprovalState: Sendable, Hashable {
     case request(ApprovalRequest)
 }
 
+public enum RunSpendLimitKind: String, Codable, Sendable, Hashable {
+    case threadFuse = "thread_fuse"
+    case daily = "daily"
+    case weekly = "weekly"
+    case monthly = "monthly"
+
+    public var label: String {
+        switch self {
+        case .threadFuse: return "thread fuse"
+        case .daily: return "daily cap"
+        case .weekly: return "weekly cap"
+        case .monthly: return "monthly cap"
+        }
+    }
+}
+
 public struct RunSpendFuseApprovalPayload: Codable, Sendable, Hashable {
     public var totalUSD: Double
     public var fuseUSD: Double
     public var bucket: Int
     public var pricedCallCount: Int
     public var unpricedCallCount: Int
+    public var limitKind: RunSpendLimitKind?
 
     public init(
         totalUSD: Double,
         fuseUSD: Double,
         bucket: Int,
         pricedCallCount: Int,
-        unpricedCallCount: Int
+        unpricedCallCount: Int,
+        limitKind: RunSpendLimitKind? = nil
     ) {
         self.totalUSD = max(0, totalUSD)
         self.fuseUSD = max(0, fuseUSD)
         self.bucket = max(1, bucket)
         self.pricedCallCount = max(0, pricedCallCount)
         self.unpricedCallCount = max(0, unpricedCallCount)
+        self.limitKind = limitKind
+    }
+
+    public var approvalLimitKind: RunSpendLimitKind {
+        limitKind ?? .threadFuse
     }
 }
 

--- a/Sources/QuillCodeCore/RunSpendFusePolicy.swift
+++ b/Sources/QuillCodeCore/RunSpendFusePolicy.swift
@@ -3,26 +3,39 @@ import Foundation
 public struct RunSpendFusePolicy: Sendable, Hashable {
     public static let toolName = "host.run.spend_fuse"
 
-    public var fuseUSD: Double
+    public var fuseUSD: Double?
+    public var periodLimits: RunSpendPeriodLimits
+    public var periodThreads: [ChatThread]
     public var modelCatalog: [ModelInfo]
+    public var calendar: Calendar
+    public var now: Date
 
-    public init?(fuseUSD: Double?, modelCatalog: [ModelInfo]) {
-        guard let fuseUSD = RunSpendLedger.normalizedFuse(fuseUSD) else { return nil }
-        self.fuseUSD = fuseUSD
+    public init?(
+        fuseUSD: Double?,
+        periodLimits: RunSpendPeriodLimits = RunSpendPeriodLimits(),
+        periodThreads: [ChatThread] = [],
+        modelCatalog: [ModelInfo],
+        calendar: Calendar = .current,
+        now: Date = Date()
+    ) {
+        let normalizedFuse = RunSpendLedger.normalizedFuse(fuseUSD)
+        guard normalizedFuse != nil || periodLimits.hasAnyLimit else { return nil }
+        self.fuseUSD = normalizedFuse
+        self.periodLimits = periodLimits
+        self.periodThreads = periodThreads
         self.modelCatalog = modelCatalog
+        self.calendar = calendar
+        self.now = now
     }
 
     public func approvalState(for thread: ChatThread) -> RunSpendFuseApprovalState {
-        let summary = spendSummary(for: thread)
-        let epsilon = RunSpendLedger.spendComparisonEpsilon
-        guard summary.totalUSD + epsilon >= fuseUSD else { return .allowed }
+        guard let breach = firstBreach(for: thread) else { return .allowed }
 
-        let bucket = max(1, Int(floor((summary.totalUSD + epsilon) / fuseUSD)))
-        guard !hasApprovedBucket(bucket, in: thread) else { return .allowed }
-        if let existing = pendingRequestID(for: bucket, in: thread) {
+        guard !hasApprovedBucket(breach.bucket, kind: breach.kind, in: thread) else { return .allowed }
+        if let existing = pendingRequestID(for: breach.bucket, kind: breach.kind, in: thread) {
             return .blocked(existingRequestID: existing)
         }
-        return .request(approvalRequest(summary: summary, bucket: bucket))
+        return .request(approvalRequest(breach: breach))
     }
 
     public func spendSummary(for thread: ChatThread) -> RunSpendFuseSummary {
@@ -33,30 +46,32 @@ public struct RunSpendFusePolicy: Sendable, Hashable {
         ).summary
     }
 
-    private func approvalRequest(summary: RunSpendFuseSummary, bucket: Int) -> ApprovalRequest {
+    private func approvalRequest(breach: SpendLimitBreach) -> ApprovalRequest {
         let payload = RunSpendFuseApprovalPayload(
-            totalUSD: summary.totalUSD,
-            fuseUSD: fuseUSD,
-            bucket: bucket,
-            pricedCallCount: summary.pricedCallCount,
-            unpricedCallCount: summary.unpricedCallCount
+            totalUSD: breach.summary.totalUSD,
+            fuseUSD: breach.limitUSD,
+            bucket: breach.bucket,
+            pricedCallCount: breach.summary.pricedCallCount,
+            unpricedCallCount: breach.summary.unpricedCallCount,
+            limitKind: breach.kind
         )
         let argumentsJSON = (try? JSONHelpers.encodePretty(payload)) ?? "{}"
         return ApprovalRequest(
-            id: "approval-spend-fuse-\(bucket)-\(UUID().uuidString)",
+            id: "approval-spend-\(breach.kind.rawValue)-\(breach.bucket)-\(UUID().uuidString)",
             scope: .runSpendFuse,
             toolCall: ToolCall(
-                id: "tool-spend-fuse-\(bucket)-\(UUID().uuidString)",
+                id: "tool-spend-\(breach.kind.rawValue)-\(breach.bucket)-\(UUID().uuidString)",
                 name: Self.toolName,
                 argumentsJSON: argumentsJSON
             ),
             toolDefinition: nil,
-            reason: "Thread spend reached \(Self.costLabel(summary.totalUSD)) against the \(Self.costLabel(fuseUSD)) fuse.",
+            reason: "\(breach.kind.label.capitalized) reached \(Self.costLabel(breach.summary.totalUSD)) "
+                + "against the \(Self.costLabel(breach.limitUSD)) local limit.",
             recommendedVerdict: .clarify
         )
     }
 
-    private func hasApprovedBucket(_ bucket: Int, in thread: ChatThread) -> Bool {
+    private func hasApprovedBucket(_ bucket: Int, kind: RunSpendLimitKind, in thread: ChatThread) -> Bool {
         let requests = spendFuseRequests(in: thread)
         return thread.events.contains { event in
             guard event.kind == .approvalDecided,
@@ -67,11 +82,11 @@ public struct RunSpendFusePolicy: Sendable, Hashable {
             else {
                 return false
             }
-            return payload.bucket >= bucket
+            return payload.approvalLimitKind == kind && payload.bucket >= bucket
         }
     }
 
-    private func pendingRequestID(for bucket: Int, in thread: ChatThread) -> String? {
+    private func pendingRequestID(for bucket: Int, kind: RunSpendLimitKind, in thread: ChatThread) -> String? {
         let decidedIDs = Set(thread.events.compactMap { event -> String? in
             guard event.kind == .approvalDecided,
                   let decision = decodeApprovalDecision(event)
@@ -86,7 +101,9 @@ public struct RunSpendFusePolicy: Sendable, Hashable {
                   let request = try? JSONHelpers.decode(ApprovalRequest.self, from: payloadJSON),
                   request.scope == .runSpendFuse,
                   !decidedIDs.contains(request.id),
-                  spendFusePayload(in: request)?.bucket == bucket
+                  let payload = spendFusePayload(in: request),
+                  payload.approvalLimitKind == kind,
+                  payload.bucket == bucket
             else {
                 return nil
             }
@@ -121,4 +138,65 @@ public struct RunSpendFusePolicy: Sendable, Hashable {
     public static func costLabel(_ value: Double) -> String {
         RunSpendLedger.costLabel(value)
     }
+
+    private func firstBreach(for thread: ChatThread) -> SpendLimitBreach? {
+        let threadSummary = spendSummary(for: thread)
+        if let fuseUSD,
+           let breach = breach(kind: .threadFuse, summary: threadSummary, limitUSD: fuseUSD) {
+            return breach
+        }
+        return periodSpecs.compactMap { spec in
+            periodBreach(spec: spec, replacing: thread)
+        }.first
+    }
+
+    private var periodSpecs: [SpendLimitPeriodSpec] {
+        [
+            SpendLimitPeriodSpec(kind: .daily, start: calendar.startOfDay(for: now), limitUSD: periodLimits.dailyUSD),
+            SpendLimitPeriodSpec(kind: .weekly, start: startOfCurrentWeek(), limitUSD: periodLimits.weeklyUSD),
+            SpendLimitPeriodSpec(kind: .monthly, start: startOfCurrentMonth(), limitUSD: periodLimits.monthlyUSD)
+        ]
+    }
+
+    private func periodBreach(spec: SpendLimitPeriodSpec, replacing thread: ChatThread) -> SpendLimitBreach? {
+        guard let limitUSD = spec.limitUSD else { return nil }
+        let summary = RunSpendPeriodLedger(
+            threads: periodThreads,
+            modelCatalog: modelCatalog,
+            now: now
+        ).summary(since: spec.start, replacing: thread)
+        return breach(kind: spec.kind, summary: summary, limitUSD: limitUSD)
+    }
+
+    private func breach(
+        kind: RunSpendLimitKind,
+        summary: RunSpendFuseSummary,
+        limitUSD: Double
+    ) -> SpendLimitBreach? {
+        let epsilon = RunSpendLedger.spendComparisonEpsilon
+        guard summary.totalUSD + epsilon >= limitUSD else { return nil }
+        let bucket = max(1, Int(floor((summary.totalUSD + epsilon) / limitUSD)))
+        return SpendLimitBreach(kind: kind, summary: summary, limitUSD: limitUSD, bucket: bucket)
+    }
+
+    private func startOfCurrentWeek() -> Date {
+        calendar.dateInterval(of: .weekOfYear, for: now)?.start ?? calendar.startOfDay(for: now)
+    }
+
+    private func startOfCurrentMonth() -> Date {
+        calendar.dateInterval(of: .month, for: now)?.start ?? calendar.startOfDay(for: now)
+    }
+}
+
+private struct SpendLimitBreach: Sendable, Hashable {
+    var kind: RunSpendLimitKind
+    var summary: RunSpendFuseSummary
+    var limitUSD: Double
+    var bucket: Int
+}
+
+private struct SpendLimitPeriodSpec: Sendable, Hashable {
+    var kind: RunSpendLimitKind
+    var start: Date
+    var limitUSD: Double?
 }

--- a/Sources/QuillCodeCore/RunSpendPeriodLedger.swift
+++ b/Sources/QuillCodeCore/RunSpendPeriodLedger.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+public struct RunSpendPeriodLedger: Sendable, Hashable {
+    public var threads: [ChatThread]
+    public var modelCatalog: [ModelInfo]
+    public var now: Date
+
+    public init(
+        threads: [ChatThread],
+        modelCatalog: [ModelInfo],
+        now: Date = Date()
+    ) {
+        self.threads = threads
+        self.modelCatalog = modelCatalog
+        self.now = now
+    }
+
+    public func spendUSD(since start: Date, replacing replacement: ChatThread? = nil) -> Double {
+        summary(since: start, replacing: replacement).totalUSD
+    }
+
+    public func summary(since start: Date, replacing replacement: ChatThread? = nil) -> RunSpendFuseSummary {
+        threads(replacing: replacement).reduce(RunSpendFuseSummary()) { total, thread in
+            let summary = RunSpendLedger(
+                thread: periodThread(thread, since: start),
+                modelCatalog: modelCatalog,
+                fuseUSD: nil
+            ).summary
+            return RunSpendFuseSummary(
+                totalUSD: total.totalUSD + summary.totalUSD,
+                pricedCallCount: total.pricedCallCount + summary.pricedCallCount,
+                unpricedCallCount: total.unpricedCallCount + summary.unpricedCallCount
+            )
+        }
+    }
+
+    private func threads(replacing replacement: ChatThread?) -> [ChatThread] {
+        guard let replacement else { return threads }
+        var replaced = false
+        let updated = threads.map { thread -> ChatThread in
+            guard thread.id == replacement.id else { return thread }
+            replaced = true
+            return replacement
+        }
+        return replaced ? updated : updated + [replacement]
+    }
+
+    private func periodThread(_ thread: ChatThread, since start: Date) -> ChatThread {
+        ChatThread(
+            id: thread.id,
+            title: thread.title,
+            projectID: thread.projectID,
+            mode: thread.mode,
+            model: thread.model,
+            messages: [],
+            events: thread.events.filter { $0.createdAt >= start && $0.createdAt <= now },
+            createdAt: thread.createdAt,
+            updatedAt: thread.updatedAt,
+            instructions: thread.instructions,
+            memories: thread.memories,
+            composerDraft: thread.composerDraft,
+            followUpQueue: thread.followUpQueue
+        )
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceAgentRunContextBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentRunContextBuilderTests.swift
@@ -107,6 +107,39 @@ final class WorkspaceAgentRunContextBuilderTests: XCTestCase {
         XCTAssertEqual(policy?.modelCatalog.map(\.id), ["trustedrouter/fast"])
     }
 
+    func testConfiguredRunnerWiresSpendPeriodLimitsAndThreadSnapshot() {
+        let thread = ChatThread(title: "Existing spend")
+        let runner = WorkspaceAgentRunContextBuilder(
+            selectedProject: nil,
+            config: AppConfig(
+                runSpendFuseUSD: nil,
+                runSpendPeriodLimits: RunSpendPeriodLimits(dailyUSD: 1, weeklyUSD: 5, monthlyUSD: 20)
+            ),
+            modelCatalog: [
+                ModelInfo(
+                    id: "trustedrouter/fast",
+                    provider: "trustedrouter",
+                    displayName: "Nike 1.0",
+                    category: "Fast"
+                )
+            ],
+            spendPeriodThreads: [thread],
+            browser: BrowserState(),
+            computerUseBackend: nil,
+            globalMemoryDirectory: nil,
+            mcpToolDefinitions: [],
+            mcpToolExecutionOverride: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor()
+        ).configuredRunner(from: AgentRunner(baseToolDefinitions: [], additionalToolDefinitions: []))
+
+        let policy = runner.runSpendFusePolicy
+        XCTAssertNil(policy?.fuseUSD)
+        XCTAssertEqual(policy?.periodLimits.dailyUSD, 1)
+        XCTAssertEqual(policy?.periodLimits.weeklyUSD, 5)
+        XCTAssertEqual(policy?.periodLimits.monthlyUSD, 20)
+        XCTAssertEqual(policy?.periodThreads.map(\.id), [thread.id])
+    }
+
     func testOverrideHandlesPlanBrowserAndMemoryTools() async throws {
         let memoryDirectory = try makeQuillCodeTestDirectory()
         let runner = WorkspaceAgentRunContextBuilder(

--- a/Tests/QuillCodeCoreTests/RunSpendFusePolicyTests.swift
+++ b/Tests/QuillCodeCoreTests/RunSpendFusePolicyTests.swift
@@ -78,6 +78,120 @@ final class RunSpendFusePolicyTests: XCTestCase {
         XCTAssertEqual(payload.bucket, 2)
     }
 
+    func testPeriodCapRequestsApprovalWithoutThreadFuse() throws {
+        let now = Date(timeIntervalSince1970: 1_735_257_600)
+        let thread = ChatThread(title: "Today", model: "acme/agent", events: [
+            usageEvent(prompt: 2_000, completion: 1_000, createdAt: now)
+        ])
+        let policy = try XCTUnwrap(RunSpendFusePolicy(
+            fuseUSD: nil,
+            periodLimits: RunSpendPeriodLimits(dailyUSD: 0.01),
+            periodThreads: [thread],
+            modelCatalog: [pricedModel()],
+            calendar: utcCalendar(),
+            now: now
+        ))
+
+        guard case .request(let request) = policy.approvalState(for: thread) else {
+            return XCTFail("Expected daily spend-cap approval request.")
+        }
+
+        let payload = try JSONHelpers.decode(
+            RunSpendFuseApprovalPayload.self,
+            from: request.toolCall.argumentsJSON
+        )
+        XCTAssertEqual(policy.fuseUSD, nil)
+        XCTAssertEqual(payload.approvalLimitKind, .daily)
+        XCTAssertEqual(payload.fuseUSD, 0.01)
+        XCTAssertEqual(payload.totalUSD, 0.01, accuracy: 0.000_001)
+        XCTAssertTrue(request.reason.contains("Daily Cap reached $0.01"))
+    }
+
+    func testPeriodCapCombinesOtherThreadsAndReplacesActiveThreadSnapshot() throws {
+        let now = Date(timeIntervalSince1970: 1_735_257_600)
+        let activeSnapshot = ChatThread(title: "Active", model: "acme/agent")
+        var active = activeSnapshot
+        active.events = [usageEvent(prompt: 1_000, completion: 500, createdAt: now)]
+        let other = ChatThread(title: "Other", model: "acme/agent", events: [
+            usageEvent(prompt: 1_000, completion: 500, createdAt: now)
+        ])
+        let policy = try XCTUnwrap(RunSpendFusePolicy(
+            fuseUSD: nil,
+            periodLimits: RunSpendPeriodLimits(dailyUSD: 0.01),
+            periodThreads: [activeSnapshot, other],
+            modelCatalog: [pricedModel()],
+            calendar: utcCalendar(),
+            now: now
+        ))
+
+        guard case .request(let request) = policy.approvalState(for: active) else {
+            return XCTFail("Expected daily cap to include other threads and live active-thread progress.")
+        }
+
+        let payload = try JSONHelpers.decode(
+            RunSpendFuseApprovalPayload.self,
+            from: request.toolCall.argumentsJSON
+        )
+        XCTAssertEqual(payload.approvalLimitKind, .daily)
+        XCTAssertEqual(payload.totalUSD, 0.01, accuracy: 0.000_001)
+        XCTAssertEqual(payload.pricedCallCount, 2)
+    }
+
+    func testPeriodApprovalDoesNotSatisfyThreadFuseBucket() throws {
+        let now = Date(timeIntervalSince1970: 1_735_257_600)
+        let policy = try XCTUnwrap(RunSpendFusePolicy(
+            fuseUSD: 0.01,
+            periodLimits: RunSpendPeriodLimits(dailyUSD: 0.01),
+            modelCatalog: [pricedModel()],
+            calendar: utcCalendar(),
+            now: now
+        ))
+        var thread = ChatThread(title: "Cost", model: "acme/agent", events: [
+            usageEvent(prompt: 2_000, completion: 1_000, createdAt: now)
+        ])
+        let dailyPayload = RunSpendFuseApprovalPayload(
+            totalUSD: 0.01,
+            fuseUSD: 0.01,
+            bucket: 1,
+            pricedCallCount: 1,
+            unpricedCallCount: 0,
+            limitKind: .daily
+        )
+        let request = ApprovalRequest(
+            id: "approval-daily",
+            scope: .runSpendFuse,
+            toolCall: ToolCall(
+                name: RunSpendFusePolicy.toolName,
+                argumentsJSON: try JSONHelpers.encodePretty(dailyPayload)
+            ),
+            toolDefinition: nil,
+            reason: "daily"
+        )
+        thread.events.append(ThreadEvent(
+            kind: .approvalRequested,
+            summary: request.reason,
+            payloadJSON: try JSONHelpers.encodePretty(request)
+        ))
+        thread.events.append(ThreadEvent(
+            kind: .approvalDecided,
+            summary: "approve daily",
+            payloadJSON: try JSONHelpers.encodePretty(ApprovalDecision(
+                requestID: request.id,
+                verdict: .approve,
+                rationale: "daily only"
+            ))
+        ))
+
+        guard case .request(let nextRequest) = policy.approvalState(for: thread) else {
+            return XCTFail("Expected thread-fuse request to remain distinct from daily approval.")
+        }
+        let payload = try JSONHelpers.decode(
+            RunSpendFuseApprovalPayload.self,
+            from: nextRequest.toolCall.argumentsJSON
+        )
+        XCTAssertEqual(payload.approvalLimitKind, .threadFuse)
+    }
+
     func testLegacyToolApprovalRequestsDecodeAsToolScope() throws {
         let request = ApprovalRequest(
             id: "approval-legacy",
@@ -107,5 +221,20 @@ final class RunSpendFusePolicyTests: XCTestCase {
                 outputPricePerMillionTokens: 6.0
             )
         )
+    }
+
+    private func usageEvent(prompt: Int, completion: Int, createdAt: Date) -> ThreadEvent {
+        var event = ModelTokenUsageEvent.event(
+            usage: ModelTokenUsage(promptTokens: prompt, completionTokens: completion),
+            modelID: "acme/agent"
+        )
+        event.createdAt = createdAt
+        return event
+    }
+
+    private func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
     }
 }

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -72,7 +72,10 @@
   `RunSpendLedger`. Agent runs now hard-pause after a priced model call crosses
   the configured spend-fuse bucket, render a focused Spend Review tool card with
   Continue/Stop actions, and resume only after the user approves the next spend
-  bucket.
+  bucket. Optional local day/week/month spend caps now use the same Spend Review
+  approval path: the runner combines the live active thread with the workspace
+  thread snapshot, pauses when a configured period cap is reached, and tracks
+  thread-fuse/daily/weekly/monthly approvals as distinct buckets.
 - Project run hooks now execute local project scripts before and after each
   agent run through the normal `host.shell.run` tool-card path. Hooks are
   discovered from `.quillcode/hooks/before-agent-run/*.sh` and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -74,7 +74,10 @@
 - Day/week/month spend rows are local QuillCode caps until TrustedRouter exposes account-history or quota APIs. Optional
   `run_spend_daily_limit_usd`, `run_spend_weekly_limit_usd`, and `run_spend_monthly_limit_usd` config keys render
   `$spent / $cap` in the existing token-budget popover even at zero spend, while uncapped periods continue to appear only
-  after priced model receipts exist. Provider quota rows still come only from provider errors, not guesses.
+  after priced model receipts exist. Provider quota rows still come only from provider errors, not guesses. Period caps
+  also enforce through the same Spend Review pause as the thread fuse: the app passes a start-of-run workspace thread
+  snapshot into the runner, the runner replaces the active thread with live progress while evaluating caps, and approval
+  payloads include a limit kind so daily/weekly/monthly approvals cannot satisfy thread-fuse buckets.
 - Model discovery should remain useful even when TrustedRouter's authenticated `/v1/models` endpoint is unavailable or
   the user has not signed in yet. `TrustedRouterModelCatalogClient` now falls back to the public TrustedRouter model
   catalog page, preserving the branded Recommended defaults while adding provider rows such as MiniMax to picker search.


### PR DESCRIPTION
## Summary
- enforce local daily, weekly, and monthly spend caps through the existing Spend Review approval path
- share period spend accounting between the top-bar quota display and runtime enforcement via RunSpendPeriodLedger
- tag spend approval payloads with the breached limit kind so thread-fuse, daily, weekly, and monthly approvals stay distinct

## Verification
- swift test --filter RunSpendFusePolicyTests
- swift test --filter WorkspaceAgentRunContextBuilderTests
- swift test --filter WorkspaceTokenUsageIntegrationTests
- swift test --filter AgentStreamingTests
- git diff --check
- python3 scripts/grade-code-quality.py --root .