### PR TITLE
Clarify period spend review copy

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceApprovalActionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceApprovalActionPlanner.swift
@@ -90,12 +90,13 @@ enum WorkspaceApprovalActionPlanner {
         action: ToolCardActionSurface,
         request: ApprovalRequest
     ) -> WorkspaceApprovalActionPlan? {
+        let label = spendLimitLabel(for: request)
         switch action.kind {
         case .approve:
             return decisionPlan(
                 request: request,
                 verdict: .approve,
-                rationale: "Approved spend-fuse continuation from the tool card.",
+                rationale: "Approved \(label) continuation from the tool card.",
                 shouldRunTool: false,
                 assistantNotice: nil
             )
@@ -103,13 +104,43 @@ enum WorkspaceApprovalActionPlanner {
             return decisionPlan(
                 request: request,
                 verdict: .deny,
-                rationale: "Stopped at the spend fuse from the tool card.",
+                rationale: "Stopped at the \(label) from the tool card.",
                 shouldRunTool: false,
-                assistantNotice: "Stopped before spending more on this thread."
+                assistantNotice: stopNotice(for: request)
             )
         case .edit, .approveAlways, .denyAlways:
             return nil
         }
+    }
+
+    private static func spendLimitLabel(for request: ApprovalRequest) -> String {
+        switch spendLimitKind(for: request) {
+        case .threadFuse:
+            return "thread spend fuse"
+        case .daily:
+            return "daily spend cap"
+        case .weekly:
+            return "weekly spend cap"
+        case .monthly:
+            return "monthly spend cap"
+        }
+    }
+
+    private static func stopNotice(for request: ApprovalRequest) -> String {
+        switch spendLimitKind(for: request) {
+        case .threadFuse:
+            return "Stopped before spending more on this thread."
+        case .daily:
+            return "Stopped before crossing the daily spend cap."
+        case .weekly:
+            return "Stopped before crossing the weekly spend cap."
+        case .monthly:
+            return "Stopped before crossing the monthly spend cap."
+        }
+    }
+
+    private static func spendLimitKind(for request: ApprovalRequest) -> RunSpendLimitKind {
+        decode(RunSpendFuseApprovalPayload.self, from: request.toolCall.argumentsJSON)?.approvalLimitKind ?? .threadFuse
     }
 
     static func pendingRequest(id: String, in thread: ChatThread?) -> ApprovalRequest? {

--- a/Sources/QuillCodeApp/WorkspaceToolCardProjection.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolCardProjection.swift
@@ -170,9 +170,40 @@ enum WorkspaceToolCardProjection {
 
     private static func approvalTitle(request: ApprovalRequest?, fallback: ToolCardState?) -> String {
         if request?.scope == .runSpendFuse {
-            return "Spend Review"
+            return spendReviewTitle(for: request)
         }
         return request?.toolCall.name ?? fallback?.title ?? "Approval needed"
+    }
+
+    private static func spendReviewTitle(for request: ApprovalRequest?) -> String {
+        guard let kind = spendLimitKind(in: request),
+              kind != .threadFuse
+        else {
+            return "Spend Review"
+        }
+        return "\(spendLimitName(kind)) Spend Review"
+    }
+
+    private static func spendLimitName(_ kind: RunSpendLimitKind) -> String {
+        switch kind {
+        case .threadFuse:
+            return "Thread"
+        case .daily:
+            return "Daily"
+        case .weekly:
+            return "Weekly"
+        case .monthly:
+            return "Monthly"
+        }
+    }
+
+    private static func spendLimitKind(in request: ApprovalRequest?) -> RunSpendLimitKind? {
+        guard let request,
+              request.scope == .runSpendFuse
+        else {
+            return nil
+        }
+        return decode(RunSpendFuseApprovalPayload.self, request.toolCall.argumentsJSON)?.approvalLimitKind
     }
 
     private static func approvalSubtitle(

--- a/Tests/QuillCodeAppTests/WorkspaceApprovalActionPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceApprovalActionPlannerTests.swift
@@ -74,6 +74,48 @@ final class WorkspaceApprovalActionPlannerTests: XCTestCase {
         XCTAssertEqual(decision.rationale, "Skipped from the tool card.")
     }
 
+    func testPeriodSpendCapDenyPlanUsesSpecificAuditCopy() throws {
+        let payload = RunSpendFuseApprovalPayload(
+            totalUSD: 5,
+            fuseUSD: 5,
+            bucket: 1,
+            pricedCallCount: 4,
+            unpricedCallCount: 0,
+            limitKind: .weekly
+        )
+        let request = ApprovalRequest(
+            id: "approval-weekly-spend",
+            scope: .runSpendFuse,
+            toolCall: ToolCall(
+                name: RunSpendFusePolicy.toolName,
+                argumentsJSON: try JSONHelpers.encodePretty(payload)
+            ),
+            toolDefinition: nil,
+            reason: "Weekly Cap reached $5.00 against the $5.00 local limit.",
+            recommendedVerdict: .clarify
+        )
+        let thread = ChatThread(events: [try approvalRequestedEvent(request)])
+
+        let plan = try XCTUnwrap(WorkspaceApprovalActionPlanner.plan(
+            action: ToolCardActionSurface(
+                title: "Stop",
+                kind: .deny,
+                requestID: "approval-weekly-spend",
+                style: .secondary
+            ),
+            thread: thread
+        ))
+        let decision = try JSONHelpers.decode(
+            ApprovalDecision.self,
+            from: try XCTUnwrap(plan.decisionEvent?.payloadJSON)
+        )
+
+        XCTAssertFalse(plan.shouldRunTool)
+        XCTAssertEqual(plan.assistantNotice, "Stopped before crossing the weekly spend cap.")
+        XCTAssertEqual(plan.decisionEvent?.summary, "deny: Stopped at the weekly spend cap from the tool card.")
+        XCTAssertEqual(decision.rationale, "Stopped at the weekly spend cap from the tool card.")
+    }
+
     func testEditPlanLoadsShellCommandDraftWithoutRecordingDecision() throws {
         let request = approvalRequest(
             id: "approval-edit",

--- a/Tests/QuillCodeAppTests/WorkspaceToolCardIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceToolCardIntegrationTests.swift
@@ -90,6 +90,41 @@ final class WorkspaceToolCardIntegrationTests: XCTestCase {
         XCTAssertTrue(cards[0].subtitle.contains("Thread spend reached $0.01"))
     }
 
+    func testToolCardsRepresentPeriodSpendCapReviewWithSpecificTitle() throws {
+        let request = ApprovalRequest(
+            id: "daily-spend-review",
+            scope: .runSpendFuse,
+            toolCall: ToolCall(
+                name: RunSpendFusePolicy.toolName,
+                argumentsJSON: try JSONHelpers.encodePretty(RunSpendFuseApprovalPayload(
+                    totalUSD: 0.50,
+                    fuseUSD: 0.50,
+                    bucket: 1,
+                    pricedCallCount: 3,
+                    unpricedCallCount: 0,
+                    limitKind: .daily
+                ))
+            ),
+            toolDefinition: nil,
+            reason: "Daily Cap reached $0.50 against the $0.50 local limit.",
+            recommendedVerdict: .clarify
+        )
+        let thread = ChatThread(events: [
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: request.reason,
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )
+        ])
+
+        let cards = WorkspaceTranscriptSurfaceBuilder(thread: thread).toolCards()
+
+        XCTAssertEqual(cards.count, 1)
+        XCTAssertEqual(cards[0].title, "Daily Spend Review")
+        XCTAssertEqual(cards[0].actions.map(\.title), ["Continue", "Stop"])
+        XCTAssertTrue(cards[0].subtitle.contains("Daily Cap reached $0.50"))
+    }
+
     func testToolCardApprovalActionRecordsDecisionAndRunsTool() throws {
         let root = try makeTempDirectory()
         let call = ToolCall(
@@ -333,6 +368,57 @@ final class WorkspaceToolCardIntegrationTests: XCTestCase {
         XCTAssertTrue(events.contains { $0.kind == .approvalDecided })
         XCTAssertFalse(events.contains { $0.kind == .toolQueued })
         XCTAssertEqual(model.selectedThread?.messages.last?.content, "continued")
+    }
+
+    func testStoppingPeriodSpendCapUsesSpecificAuditCopy() throws {
+        let root = try makeTempDirectory()
+        let request = ApprovalRequest(
+            id: "weekly-spend-review",
+            scope: .runSpendFuse,
+            toolCall: ToolCall(
+                name: RunSpendFusePolicy.toolName,
+                argumentsJSON: try JSONHelpers.encodePretty(RunSpendFuseApprovalPayload(
+                    totalUSD: 5,
+                    fuseUSD: 5,
+                    bucket: 1,
+                    pricedCallCount: 4,
+                    unpricedCallCount: 0,
+                    limitKind: .weekly
+                ))
+            ),
+            toolDefinition: nil,
+            reason: "Weekly Cap reached $5.00 against the $5.00 local limit.",
+            recommendedVerdict: .clarify
+        )
+        let thread = ChatThread(events: [
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: request.reason,
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )
+        ])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let didStop = model.runToolCardAction(ToolCardActionSurface(
+            title: "Stop",
+            kind: .deny,
+            requestID: "weekly-spend-review",
+            style: .secondary
+        ), workspaceRoot: root)
+
+        XCTAssertTrue(didStop)
+        let events = try XCTUnwrap(model.selectedThread?.events)
+        XCTAssertTrue(events.contains {
+            $0.kind == .approvalDecided
+                && $0.summary.contains("Stopped at the weekly spend cap")
+        })
+        XCTAssertTrue(events.contains {
+            $0.kind == .message
+                && $0.summary == "Stopped before crossing the weekly spend cap."
+        })
     }
 
     func testResumeIsSkippedWhenTheSelectedThreadIsNotTheApprovedOne() async throws {

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -75,7 +75,10 @@
   bucket. Optional local day/week/month spend caps now use the same Spend Review
   approval path: the runner combines the live active thread with the workspace
   thread snapshot, pauses when a configured period cap is reached, and tracks
-  thread-fuse/daily/weekly/monthly approvals as distinct buckets.
+  thread-fuse/daily/weekly/monthly approvals as distinct buckets. Period-cap
+  Spend Review cards and approval decisions now name the breached daily, weekly,
+  or monthly cap so the visible transcript and audit trail match the enforced
+  limit.
 - Project run hooks now execute local project scripts before and after each
   agent run through the normal `host.shell.run` tool-card path. Hooks are
   discovered from `.quillcode/hooks/before-agent-run/*.sh` and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -77,7 +77,9 @@
   after priced model receipts exist. Provider quota rows still come only from provider errors, not guesses. Period caps
   also enforce through the same Spend Review pause as the thread fuse: the app passes a start-of-run workspace thread
   snapshot into the runner, the runner replaces the active thread with live progress while evaluating caps, and approval
-  payloads include a limit kind so daily/weekly/monthly approvals cannot satisfy thread-fuse buckets.
+  payloads include a limit kind so daily/weekly/monthly approvals cannot satisfy thread-fuse buckets. The card title,
+  decision rationale, and stop notice all decode that same payload kind so the transcript says which cap is being
+  continued or stopped.
 - Model discovery should remain useful even when TrustedRouter's authenticated `/v1/models` endpoint is unavailable or
   the user has not signed in yet. `TrustedRouterModelCatalogClient` now falls back to the public TrustedRouter model
   catalog page, preserving the branded Recommended defaults while adding provider rows such as MiniMax to picker search.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,8 @@
   backward-compatible defaults. The displayed fuse crossing is backed by the
   same core `RunSpendLedger` that powers runtime enforcement, and runs now
   hard-pause on a Spend Review card until the user chooses Continue for the
-  current spend bucket. The top-bar budget meter also derives local Today/Week/
-  Month spend rows from persisted priced run receipts across threads; true
-  TrustedRouter account-history and provider quota rows remain future runtime
-  work.
+  current spend bucket. Period caps share that path and surface daily/weekly/
+  monthly-specific Spend Review copy and audit decisions. The top-bar budget
+  meter also derives local Today/Week/Month spend rows from persisted priced run
+  receipts across threads; true TrustedRouter account-history and provider
+  quota rows remain future runtime work.


### PR DESCRIPTION
## Summary
- title period-cap Spend Review cards as Daily/Weekly/Monthly Spend Review instead of the generic thread-fuse label
- decode the spend approval payload when recording Continue/Stop decisions so the audit trail names the breached cap
- document the UI/audit follow-through for local period spend caps

## Verification
- swift test --filter WorkspaceToolCardIntegrationTests
- swift test --filter WorkspaceApprovalActionPlannerTests
- git diff --check
- python3 scripts/grade-code-quality.py --root .