### PR TITLE
feat(worktree): show the bound branch as a chip on the sidebar thread row

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -280,6 +280,26 @@
       color: var(--yellow);
       background: rgba(255, 190, 92, 0.12);
     }
+    .sidebar-worktree-chip {
+      display: inline-block;
+      margin-top: 3px;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 10px;
+      font-weight: 600;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: var(--blue);
+      background: rgba(84, 179, 255, 0.10);
+      border-radius: 6px;
+      padding: 1px 6px;
+    }
+    .sidebar-worktree-chip[data-tone="warning"] {
+      color: var(--yellow);
+      background: rgba(255, 190, 92, 0.12);
+      font-family: inherit;
+    }
     .topbar-token-budget {
       flex: 0 1 min(420px, 40vw);
       min-width: 360px;
@@ -8108,6 +8128,13 @@
           }).join('')}
         </section>`;
       };
+      const renderSidebarWorktreeChip = (worktree) => {
+        if (!worktree) return '';
+        if (worktree.isResolvable) {
+          return `<span class="sidebar-worktree-chip" data-testid="sidebar-worktree-branch" title="${escapeHTML(worktree.branch)}">⑂ ${escapeHTML(worktree.branchLeaf)}</span>`;
+        }
+        return `<span class="sidebar-worktree-chip" data-tone="warning" data-testid="sidebar-worktree-warning" title="Worktree missing — running in the project root">⚠ Worktree missing</span>`;
+      };
       const renderSidebarSection = (title, items) => items.length ? `
         <section data-testid="sidebar-section">
           <h3 data-testid="sidebar-section-title">${escapeHTML(title)}</h3>
@@ -8117,6 +8144,7 @@
             <button class="sidebar-item hit-target-row ${item.isSelected ? 'selected' : ''}" data-testid="sidebar-item" data-thread-id="${escapeHTML(item.id)}" aria-current="${item.isSelected ? 'true' : 'false'}">
               <span>${escapeHTML(item.title)}</span>
               <small>${escapeHTML(item.subtitle)}</small>
+              ${renderSidebarWorktreeChip(item.worktree)}
             </button>
             <details class="sidebar-thread-menu" data-testid="sidebar-item-actions">
               <summary class="hit-target-icon" aria-label="Actions for ${escapeHTML(item.title)}">•••</summary>
@@ -13463,9 +13491,27 @@
         return;
       }
       if (commandID === 'thread-new-worktree') {
-        // Mock stand-in: the native model creates a fresh git worktree off the current branch and
-        // starts a thread bound to it. The harness has no git, so it just opens a new thread.
+        // Mock stand-in: the native newWorktreeThread creates a fresh git worktree off the current
+        // branch and materializes a thread bound to it. The harness has no git, so it opens a fresh
+        // chat and materializes a worktree-bound sidebar row directly (newChat alone only enters
+        // fresh-chat mode without a row), so the row shows the branch chip.
         newChat();
+        const threadID = `thread-${state.nextThreadIndex++}`;
+        state.sidebar.selectedThreadID = threadID;
+        state.sidebar.items = [{
+          id: threadID,
+          title: 'Worktree: experiment',
+          subtitle: state.topBar.modelLabel,
+          searchText: '',
+          updatedAt: new Date().toISOString(),
+          isSelected: true,
+          isPinned: false,
+          isArchived: false,
+          worktree: { branch: 'quill/experiment', branchLeaf: 'experiment', isResolvable: true }
+        }, ...state.sidebar.items.map(item => ({ ...item, isSelected: false }))];
+        state.topBar.primaryTitle = 'Worktree: experiment';
+        addMessage('assistant', 'Started a new chat in a fresh worktree off the current branch.');
+        render();
         return;
       }
       if (commandID === 'thread-pin') {
@@ -16345,11 +16391,10 @@
         addMessage('assistant', workspaceStatusText());
       } else if (/^\/(new-worktree|worktree-chat|worktree-thread)\b/i.test(text)) {
         // Must precede the /new branch: /new-worktree also matches /^\/(new)\b/. Mock stand-in for
-        // the native new-worktree thread type — the harness has no git, so it opens a new thread via
-        // the same command the palette runs, then notes the worktree intent.
+        // the native new-worktree thread type — routes through the same command the palette runs,
+        // which materializes a worktree-bound thread row and posts the confirmation message.
         state.composer.isSending = false;
         runCommand('thread-new-worktree');
-        addMessage('assistant', 'Started a new chat in a fresh worktree off the current branch.');
         return;
       } else if (/^\/(new|new-chat|newchat)\b/i.test(text)) {
         newChat();

--- a/E2E/playwright/tests/sidebar-worktree-badge.spec.ts
+++ b/E2E/playwright/tests/sidebar-worktree-badge.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+test('mock harness shows a worktree branch chip on the bound thread row', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  // A plain thread has no worktree chip.
+  await page.getByLabel('Message').fill('run whoami');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('sidebar-item').first()).toBeVisible();
+  await expect(page.getByTestId('sidebar-worktree-branch')).toHaveCount(0);
+
+  // Starting a worktree thread binds it to a branch → the row shows a monospace branch chip.
+  await page.getByLabel('Message').fill('/new-worktree');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  const chip = page.getByTestId('sidebar-worktree-branch');
+  await expect(chip).toBeVisible();
+  await expect(chip).toContainText('experiment');
+  await expect(chip).toHaveAttribute('title', 'quill/experiment');
+  // No dangling warning for a resolvable binding.
+  await expect(page.getByTestId('sidebar-worktree-warning')).toHaveCount(0);
+});

--- a/Sources/QuillCodeApp/AppState.swift
+++ b/Sources/QuillCodeApp/AppState.swift
@@ -12,6 +12,7 @@ public struct SidebarItem: Sendable, Hashable, Identifiable {
     public var updatedAt: Date
     public var isPinned: Bool
     public var isArchived: Bool
+    public var worktree: SidebarItemWorktreeSummary?
 
     public init(thread: ChatThread) {
         self.id = thread.id
@@ -25,6 +26,13 @@ public struct SidebarItem: Sendable, Hashable, Identifiable {
         self.searchText = String(combinedSearchText.prefix(8_000))
         self.isPinned = thread.isPinned
         self.isArchived = thread.isArchived
+        self.worktree = thread.worktree.map { binding in
+            SidebarItemWorktreeSummary(
+                branch: binding.branch,
+                branchLeaf: binding.branch.split(separator: "/").last.map(String.init) ?? binding.branch,
+                isResolvable: binding.isResolvable
+            )
+        }
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeSidebarItemSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarItemSurface.swift
@@ -13,6 +13,20 @@ public struct SidebarThreadSectionSurface: Codable, Sendable, Hashable, Identifi
     }
 }
 
+/// A thread's worktree binding, summarized for the sidebar row: the branch it runs on and whether the
+/// worktree directory still exists (a dangling binding falls back to the project root, so the row warns).
+public struct SidebarItemWorktreeSummary: Codable, Sendable, Hashable {
+    public var branch: String
+    public var branchLeaf: String
+    public var isResolvable: Bool
+
+    public init(branch: String, branchLeaf: String, isResolvable: Bool) {
+        self.branch = branch
+        self.branchLeaf = branchLeaf
+        self.isResolvable = isResolvable
+    }
+}
+
 public struct SidebarItemSurface: Codable, Sendable, Hashable, Identifiable {
     public var id: UUID
     public var title: String
@@ -24,6 +38,7 @@ public struct SidebarItemSurface: Codable, Sendable, Hashable, Identifiable {
     public var isBulkSelected: Bool
     public var isPinned: Bool
     public var isArchived: Bool
+    public var worktree: SidebarItemWorktreeSummary?
 
     public init(item: SidebarItem, selectedThreadID: UUID?, selectedThreadIDs: Set<UUID> = []) {
         self.id = item.id
@@ -36,6 +51,7 @@ public struct SidebarItemSurface: Codable, Sendable, Hashable, Identifiable {
         self.isBulkSelected = selectedThreadIDs.contains(item.id)
         self.isPinned = item.isPinned
         self.isArchived = item.isArchived
+        self.worktree = item.worktree
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -49,6 +65,7 @@ public struct SidebarItemSurface: Codable, Sendable, Hashable, Identifiable {
         case isBulkSelected
         case isPinned
         case isArchived
+        case worktree
     }
 
     public init(from decoder: Decoder) throws {
@@ -63,6 +80,7 @@ public struct SidebarItemSurface: Codable, Sendable, Hashable, Identifiable {
         self.isBulkSelected = try container.decodeIfPresent(Bool.self, forKey: .isBulkSelected) ?? false
         self.isPinned = try container.decode(Bool.self, forKey: .isPinned)
         self.isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+        self.worktree = try container.decodeIfPresent(SidebarItemWorktreeSummary.self, forKey: .worktree)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -77,6 +95,7 @@ public struct SidebarItemSurface: Codable, Sendable, Hashable, Identifiable {
         try container.encode(isBulkSelected, forKey: .isBulkSelected)
         try container.encode(isPinned, forKey: .isPinned)
         try container.encode(isArchived, forKey: .isArchived)
+        try container.encodeIfPresent(worktree, forKey: .worktree)
     }
 
     private static func actions(for item: SidebarItem) -> [SidebarItemActionSurface] {

--- a/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
@@ -49,6 +49,19 @@ struct QuillCodeSidebarThreadRowView: View {
                     .font(.system(size: 11, weight: .regular))
                     .foregroundStyle(QuillCodePalette.muted)
                     .lineLimit(1)
+                if let worktree = item.worktree {
+                    if worktree.isResolvable {
+                        Text("⑂ \(worktree.branchLeaf)")
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(QuillCodePalette.blue)
+                            .lineLimit(1)
+                    } else {
+                        Text("⚠ Worktree missing")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(QuillCodePalette.red)
+                            .lineLimit(1)
+                    }
+                }
             }
             .quillCodeSidebarRowChrome(background: item.isSelected ? QuillCodePalette.selection : Color.clear)
         }

--- a/Sources/QuillCodeApp/WorkspaceHTMLSidebarThreadRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLSidebarThreadRenderer.swift
@@ -163,11 +163,24 @@ enum WorkspaceHTMLSidebarThreadRenderer {
           ))>
             <span>\(escape(item.title))</span>
             <small>\(escape(item.subtitle))</small>
+            \(renderWorktreeChip(item.worktree))
           </button>
           <span data-testid="sidebar-item-actions">
             \(item.actions.map(renderAction).joined(separator: "\n"))
           </span>
         </div>
+        """
+    }
+
+    private static func renderWorktreeChip(_ worktree: SidebarItemWorktreeSummary?) -> String {
+        guard let worktree else { return "" }
+        if worktree.isResolvable {
+            return """
+            <span class="sidebar-worktree-chip" data-testid="sidebar-worktree-branch" title="\(escape(worktree.branch))">⑂ \(escape(worktree.branchLeaf))</span>
+            """
+        }
+        return """
+        <span class="sidebar-worktree-warning" data-testid="sidebar-worktree-warning" title="Worktree missing — running in the project root">⚠ Worktree missing</span>
         """
     }
 

--- a/Tests/QuillCodeAppTests/QuillCodeSidebarWorktreeBadgeTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeSidebarWorktreeBadgeTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Foundation
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class QuillCodeSidebarWorktreeBadgeTests: XCTestCase {
+    func testSidebarItemMapsResolvableWorktreeBinding() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wtbadge-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var thread = ChatThread(title: "Feature work")
+        thread.worktree = WorktreeBinding(path: dir.path, branch: "quill/add-login", base: "main")
+
+        let summary = try XCTUnwrap(SidebarItem(thread: thread).worktree)
+        XCTAssertEqual(summary.branch, "quill/add-login")
+        XCTAssertEqual(summary.branchLeaf, "add-login", "the chip shows the branch's last segment")
+        XCTAssertTrue(summary.isResolvable)
+    }
+
+    func testSidebarItemFlagsDanglingWorktreeBinding() {
+        var thread = ChatThread(title: "Stale")
+        thread.worktree = WorktreeBinding(path: "/does-not-exist-\(UUID().uuidString)", branch: "quill/gone")
+
+        let summary = SidebarItem(thread: thread).worktree
+        XCTAssertEqual(summary?.branchLeaf, "gone")
+        XCTAssertEqual(summary?.isResolvable, false, "a removed worktree dir must surface as dangling")
+    }
+
+    func testSidebarItemHasNoWorktreeSummaryForAnUnboundThread() {
+        XCTAssertNil(SidebarItem(thread: ChatThread(title: "Local")).worktree)
+    }
+
+    func testSidebarItemSurfaceCarriesAndRoundTripsWorktreeThroughCodable() throws {
+        let summary = SidebarItemWorktreeSummary(branch: "quill/x", branchLeaf: "x", isResolvable: true)
+        var item = SidebarItem(thread: ChatThread(title: "T"))
+        item.worktree = summary
+        let surface = SidebarItemSurface(item: item, selectedThreadID: nil)
+        XCTAssertEqual(surface.worktree, summary)
+
+        let decoded = try JSONDecoder().decode(
+            SidebarItemSurface.self,
+            from: JSONEncoder().encode(surface)
+        )
+        XCTAssertEqual(decoded.worktree, summary)
+    }
+
+    func testLegacySidebarItemSurfaceJSONWithoutWorktreeDecodesToNil() throws {
+        // A surface persisted before the worktree field existed must still decode (worktree = nil).
+        let json = """
+        {
+          "id": "\(UUID().uuidString)",
+          "title": "Legacy",
+          "subtitle": "trustedrouter/fast",
+          "searchText": "",
+          "actions": [],
+          "isSelected": false,
+          "isPinned": false,
+          "isArchived": false
+        }
+        """
+        let decoded = try JSONDecoder().decode(SidebarItemSurface.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.worktree)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityHTMLSidebarRendererGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityHTMLSidebarRendererGateTests.swift
@@ -46,8 +46,29 @@ final class ParityHTMLSidebarRendererGateTests: QuillCodeParityTestCase {
             "private static func renderBulkToolbar",
             "private static func renderSelectionHeaderAction",
             "sidebar-empty",
-            "WorkspaceHTMLPrimitives.escape"
+            "WorkspaceHTMLPrimitives.escape",
+            "renderWorktreeChip",
+            "sidebar-worktree-branch",
+            "sidebar-worktree-warning"
         ].forEach { Self.assertSource(source, contains: $0) }
+    }
+
+    func testWorktreeChipTestidsMatchBetweenHTMLRendererAndHarness() throws {
+        // The native thread renderer and the mock harness must render the same worktree-chip testids,
+        // so a change to one surface that isn't mirrored in the other fails here.
+        let threadText = try Self.appSourceText(named: "WorkspaceHTMLSidebarThreadRenderer.swift")
+        let harness = try harnessText()
+        for token in ["sidebar-worktree-branch", "sidebar-worktree-warning"] {
+            Self.assertSource(threadText, contains: token)
+            Self.assertSource(harness, contains: token)
+        }
+    }
+
+    private func harnessText() throws -> String {
+        try String(
+            contentsOf: Self.packageRoot().appendingPathComponent("E2E/harness/index.html"),
+            encoding: .utf8
+        )
     }
 
     private func assertSavedSearchSidebarContracts(_ source: String) {


### PR DESCRIPTION
Completes the worktree thread type (shipped in #1052/#1053/#1055): a thread bound to a worktree now shows **which branch it runs on** right in the sidebar row, so you can tell worktree-isolated threads apart at a glance — and a dangling binding (worktree dir deleted) warns instead of silently running in the project root.

## What it adds
- **Model:** `SidebarItem` / `SidebarItemSurface` carry a `SidebarItemWorktreeSummary { branch, branchLeaf, isResolvable }`, mapped from `thread.worktree` (nil for plain threads). `isResolvable` reuses the same existence check `activeWorkspaceRoot` uses — no new git calls.
- **Native** (`QuillCodeSidebarThreadRowView`): a monospace cyan `⑂ <branch-leaf>` chip when resolvable; a red `⚠ Worktree missing` chip when the binding is dangling.
- **Harness** (`WorkspaceHTMLSidebarThreadRenderer` + `index.html`): the same chips (cyan branch / yellow warning) with matching `data-testid`s, reusing the Codex-theme chip styling.

## Tests (full pyramid)
- **Unit:** `SidebarItem(thread:)` maps a resolvable binding → `branchLeaf` + `isResolvable=true`; a removed dir → `isResolvable=false`; an unbound thread → nil. `SidebarItemSurface` round-trips the summary through `Codable`, and legacy JSON without the field decodes to nil.
- **Parity gate:** the native thread renderer and the harness must render the same `sidebar-worktree-branch` / `sidebar-worktree-warning` testids (fails if one surface drifts).
- **Playwright** (`sidebar-worktree-badge.spec.ts`): a plain thread has no chip; `/new-worktree` binds a thread → its row shows the `⑂ experiment` branch chip (title `quill/experiment`), no warning.
- Full Swift + Playwright suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
