### PR TITLE
fix(automation): surface directory monitor palette search

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceCommandPaletteSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPaletteSurface.swift
@@ -126,6 +126,8 @@ public extension WorkspaceCommandSurface {
                 "watch",
                 "event",
                 "file",
+                "directory",
+                "folder",
                 "url",
                 "last-modified",
                 "feed",

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
@@ -18,6 +18,10 @@ final class WorkspaceCommandPaletteRankerTests: XCTestCase {
             WorkspaceCommandPaletteRanker.rankedCommands(commands, matching: "cmd option right").first?.id,
             "workspace-forward"
         )
+        XCTAssertEqual(
+            WorkspaceCommandPaletteRanker.rankedCommands(commands, matching: ">directory monitor").first?.id,
+            "automation-create-monitor"
+        )
         XCTAssertEqual(WorkspaceCommandPaletteRanker.rankedCommands(commands, matching: "shortcuts").first?.id, "keyboard-shortcuts")
     }
 


### PR DESCRIPTION
## Summary
- add `directory` and `folder` keywords to the Create monitor command-palette action
- cover action-scope search for `>directory monitor`

## Verification
- `swift test --filter WorkspaceCommandPaletteRankerTests`
- `git diff --check`
