### PR TITLE
fix(memory): expose edit slash command

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -5033,6 +5033,7 @@
       { usage: '/branch create name', title: 'Create branch', detail: 'Create and switch to a new branch.', insertText: '/branch create ', aliases: ['branch new', 'git switch -c'] },
       { usage: '/memories', title: 'Show memories', detail: 'Show loaded global and project memories.', insertText: '/memories', aliases: ['memory'] },
       { usage: '/remember text', title: 'Add memory', detail: 'Save an explicit global memory after redaction checks.', insertText: '/remember ', aliases: [] },
+      { usage: '/remember-edit memory-id', title: 'Edit memory', detail: 'Revise an existing memory by ID; put the updated memory text on the next line.', insertText: '/remember-edit ', aliases: ['memory edit', 'memory-edit'] },
       { usage: '/forget memory-id', title: 'Forget memory', detail: 'Remove a global or project memory by ID.', insertText: '/forget ', aliases: ['memory delete', 'remember delete'] },
       { usage: '/worktrees', title: 'List worktrees', detail: 'List git worktrees for the selected project.', insertText: '/worktrees', aliases: ['worktree', 'wt'] },
       { usage: '/worktree create path', title: 'Create worktree', detail: 'Create and switch to a sibling git worktree.', insertText: '/worktree create ', aliases: ['wt create', 'worktree add', 'worktree new'] },

--- a/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
+++ b/Sources/QuillCodeApp/SlashCommandCatalogDefinitions.swift
@@ -388,6 +388,13 @@ extension SlashCommandCatalog {
             insert: "/remember "
         ),
         slashDefinition(
+            "/remember-edit memory-id",
+            "Edit memory",
+            "Revise an existing memory by ID; put the updated memory text on the next line.",
+            insert: "/remember-edit ",
+            aliases: ["memory edit", "memory-edit"]
+        ),
+        slashDefinition(
             "/forget memory-id",
             "Forget memory",
             "Remove a global or project memory by ID.",

--- a/Tests/QuillCodeAppTests/WorkspaceSlashRegistryHarnessParityTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSlashRegistryHarnessParityTests.swift
@@ -143,6 +143,15 @@ final class WorkspaceSlashRegistryHarnessParityTests: XCTestCase {
                       "Harness must suppress the keyword fallback once the query has whitespace (matches native).")
     }
 
+    func testMemoryEditIsDiscoverableFromSlashSuggestions() {
+        let usages = SlashCommandCatalog.suggestions(for: "/remember-e").map(\.usage)
+
+        XCTAssertTrue(
+            usages.contains("/remember-edit memory-id"),
+            "`/remember-edit` is executable and should stay discoverable from slash suggestions."
+        )
+    }
+
     // MARK: - /model price-formatting parity
 
     /// The price label the two surfaces render must agree for present / one-sided / missing / zero /


### PR DESCRIPTION
## Summary
- add `/remember-edit memory-id` to the native slash-command catalog
- mirror the catalog entry in the Playwright harness slash definitions
- add a regression test proving `/remember-e` suggests `/remember-edit`

## Validation
- `swift test --filter WorkspaceSlashRegistryHarnessParityTests`
- `swift test --filter SlashMemoryCommandParserTests`
- `git diff --check`
