### PR TITLE
Harden Playwright composer prompt fills

### DIFF
--- a/E2E/playwright/tests/harness-helpers.ts
+++ b/E2E/playwright/tests/harness-helpers.ts
@@ -79,6 +79,32 @@ export async function fillCommandPalette(page: Page, query: string) {
   await expect(input).toHaveValue(query);
 }
 
+export async function fillComposer(page: Page, text: string) {
+  const message = page.getByLabel('Message');
+  await expect(message).toBeVisible();
+  await expect(message).toBeEnabled();
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await message.click();
+    await expect(message).toBeFocused();
+    await message.fill('');
+    await message.fill(text);
+    if ((await message.inputValue()) === text) {
+      await expect(message).toHaveValue(text);
+      return;
+    }
+  }
+
+  await expect(message).toHaveValue(text);
+}
+
+export async function sendComposerPrompt(page: Page, text: string) {
+  await fillComposer(page, text);
+  const sendButton = page.getByRole('button', { name: 'Send' });
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+}
+
 export async function clickCommandPaletteCommand(page: Page, query: string, commandID: string) {
   await fillCommandPalette(page, query);
   const result = commandPaletteResult(page, commandID);

--- a/E2E/playwright/tests/sidebar-test-helpers.ts
+++ b/E2E/playwright/tests/sidebar-test-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { sendComposerPrompt } from './harness-helpers';
 
 export async function clickProjectAction(row: Locator, name: string) {
   await row.getByLabel(/^Actions for project /).click();
@@ -17,8 +18,7 @@ export function sidebarSection(page: Page, title: string) {
 }
 
 export async function sendSidebarPrompt(page: Page, prompt: string) {
-  await page.getByLabel('Message').fill(prompt);
-  await page.getByRole('button', { name: 'Send' }).click();
+  await sendComposerPrompt(page, prompt);
 }
 
 export async function sendSidebarPromptThenNewChat(page: Page, prompt: string) {

--- a/E2E/playwright/tests/transcript-navigation.spec.ts
+++ b/E2E/playwright/tests/transcript-navigation.spec.ts
@@ -1,13 +1,8 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
-import { harnessURL } from './harness-helpers';
+import { harnessURL, sendComposerPrompt } from './harness-helpers';
 
 async function send(page: Page, text: string) {
-  const message = page.getByLabel('Message');
-  const sendButton = page.getByRole('button', { name: 'Send' });
-  await message.fill(text);
-  await expect(message).toHaveValue(text);
-  await expect(sendButton).toBeEnabled();
-  await sendButton.click();
+  await sendComposerPrompt(page, text);
 }
 
 function lastDiffJump(page: Page) {


### PR DESCRIPTION
## Summary
- add a reusable Playwright helper for stable composer fills
- reuse it in transcript navigation and sidebar prompt helpers
- reduce composer input flakes where a fill can appear to succeed but leave the textarea empty under CI load

## Validation
- npm test -- tests/transcript-navigation.spec.ts -g "read-only session keeps the last-diff affordance disabled"
- npm test -- tests/sidebar.spec.ts
- npm test