### PR TITLE
fix(plan): feed approved tool result into resumed runs

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModelReview.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelReview.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QuillCodeAgent
 import QuillCodeCore
 import QuillCodeTools
 
@@ -214,7 +215,10 @@ public extension QuillCodeWorkspaceModel {
             // approved tool does. The thread mode is intentionally LEFT as-is: a Plan-mode
             // approval stays in Plan, so the resumed agent's next mutation is gated again
             // (the user approves each change) rather than flipping to autonomous execution.
-            _ = runToolCall(plan.request.toolCall, workspaceRoot: workspaceRoot)
+            let result = runToolCall(plan.request.toolCall, workspaceRoot: workspaceRoot)
+            if selectedThread?.mode == .plan {
+                appendApprovedPlanToolFeedback(call: plan.request.toolCall, result: result)
+            }
         } else {
             if let assistantNotice = plan.assistantNotice {
                 appendAssistantNotice(assistantNotice)
@@ -236,6 +240,15 @@ public extension QuillCodeWorkspaceModel {
             )
         }
         return true
+    }
+
+    private func appendApprovedPlanToolFeedback(call: ToolCall, result: ToolResult) {
+        let feedback = AgentToolFeedback(toolCall: call, result: result, followUpResult: nil)
+        let content = (try? JSONHelpers.encodePretty(feedback)) ?? "{}"
+        mutateSelectedThread { thread in
+            thread.messages.append(.init(role: .tool, content: content))
+            thread.updatedAt = Date()
+        }
     }
 
     @discardableResult

--- a/Tests/QuillCodeAppTests/WorkspaceToolCardIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceToolCardIntegrationTests.swift
@@ -208,6 +208,49 @@ final class WorkspaceToolCardIntegrationTests: XCTestCase {
         XCTAssertTrue(events.contains { $0.kind == .toolCompleted })
     }
 
+    func testApprovingWhilePlanningRecordsToolFeedbackForTheResume() throws {
+        let root = try makeTempDirectory()
+        let call = ToolCall(
+            id: "plan-feedback-tool-run",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "printf plan-feedback"])
+        )
+        let request = ApprovalRequest(
+            id: "plan-feedback-run",
+            toolCall: call,
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "Planning — approve the proposed change to apply it and start executing.",
+            recommendedVerdict: .clarify
+        )
+        let thread = ChatThread(mode: .plan, messages: [
+            ChatMessage(role: .user, content: "run the first step")
+        ], events: [
+            ThreadEvent(
+                kind: .approvalRequested,
+                summary: "planning",
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )
+        ])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let didRun = model.runToolCardAction(ToolCardActionSurface(
+            title: "Approve",
+            kind: .approve,
+            requestID: "plan-feedback-run",
+            style: .primary
+        ), workspaceRoot: root)
+
+        XCTAssertTrue(didRun)
+        let toolMessage = try XCTUnwrap(model.selectedThread?.messages.last { $0.role == .tool })
+        let feedback = try JSONHelpers.decode(AgentToolFeedback.self, from: toolMessage.content)
+        XCTAssertEqual(feedback.toolCall.name, ToolDefinition.shellRun.name)
+        XCTAssertEqual(feedback.result.stdout, "plan-feedback")
+        XCTAssertTrue(feedback.result.ok)
+    }
+
     private func approvalRequestCount(_ model: QuillCodeWorkspaceModel) -> Int {
         model.selectedThread?.events.filter { $0.kind == .approvalRequested }.count ?? 0
     }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -3149,7 +3149,18 @@ The adversarial review reshaped the design. The first cut flipped `.plan`→`.au
 
 Residual risk:
 
-- The held tool's result is recorded as a thread *event* but not yet as a `.tool` *message*, so a resumed model could re-propose the just-run step — benign here because that re-proposal is itself gated (Plan mode), but appending tool feedback to `messages` is a clean follow-up. A user who wants "approve once, run the rest" uses `/mode auto` explicitly. Marking individual `AgentPlanItem` statuses from approvals remains a separate slice.
+- Marking individual `AgentPlanItem` statuses from approvals remains a separate slice. A user who wants "approve once, run the rest" uses `/mode auto` explicitly.
+
+## 2026-07-09 Plan Approval Tool Feedback Pass
+
+Overall grade after this slice: **A model-context parity, A minimal surface area**.
+
+Plan-mode approval already ran the held tool and resumed the agent in Plan mode, but the approved tool's result only existed as transcript events. The normal multi-step agent loop also appends hidden `.tool` feedback into `thread.messages`, which lets the next model call know the exact tool result and avoid proposing the same step again.
+
+| Before | After |
+| --- | --- |
+| Approving a held Plan-mode tool recorded queued/running/completed events, then resumed from the latest user intent. The resumed model could infer from visible events only indirectly and might re-propose the just-approved command. | Plan-mode approval now appends one hidden `AgentToolFeedback` message after the held tool runs, using the same schema as the normal agent loop. The resumed turn receives the exact tool call/result context without exposing model-facing feedback in visible transcript surfaces. |
+| The follow-up was documented but not enforced. | `testApprovingWhilePlanningRecordsToolFeedbackForTheResume` decodes the hidden feedback and asserts the approved shell result is present before resume logic can build on it. |
 
 ## 2026-06-30 Interactive Plan Mode Pass (PR1)
 


### PR DESCRIPTION
## Summary
- append hidden `AgentToolFeedback` after approved Plan-mode held tools run
- keep visible transcript/tool-card behavior unchanged while giving the resumed model exact result context
- document that the previous Plan approval feedback gap is now closed

## Validation
- `swift test --filter WorkspaceToolCardIntegrationTests`
- `git diff --check`
