### PR TITLE
Polish live work tool labels

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceToolDisplayNameBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolDisplayNameBuilder.swift
@@ -1,0 +1,127 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+import QuillComputerUseKit
+
+enum WorkspaceToolDisplayNameBuilder {
+    static func displayName(for toolName: String) -> String {
+        switch toolName {
+        case ToolDefinition.shellRun.name:
+            return "Shell command"
+        case ToolDefinition.fileRead.name:
+            return "Read file"
+        case ToolDefinition.fileWrite.name:
+            return "Write file"
+        case ToolDefinition.fileList.name:
+            return "List files"
+        case ToolDefinition.fileSearch.name:
+            return "Search files"
+        case ToolDefinition.applyPatch.name:
+            return "Apply patch"
+        case ToolDefinition.gitStatus.name:
+            return "Git status"
+        case ToolDefinition.gitDiff.name:
+            return "Git diff"
+        case ToolDefinition.gitFetch.name:
+            return "Git fetch"
+        case ToolDefinition.gitPull.name:
+            return "Git pull"
+        case ToolDefinition.gitBranchList.name:
+            return "Git branches"
+        case ToolDefinition.gitBranchSwitch.name:
+            return "Switch branch"
+        case ToolDefinition.gitStage.name, ToolDefinition.gitStageHunk.name:
+            return "Stage changes"
+        case ToolDefinition.gitRestore.name, ToolDefinition.gitRestoreHunk.name:
+            return "Restore changes"
+        case ToolDefinition.gitCommit.name:
+            return "Git commit"
+        case ToolDefinition.gitPush.name:
+            return "Git push"
+        case ToolDefinition.gitPullRequestList.name:
+            return "List pull requests"
+        case ToolDefinition.gitPullRequestCreate.name:
+            return "Create pull request"
+        case ToolDefinition.gitPullRequestView.name:
+            return "View pull request"
+        case ToolDefinition.gitPullRequestChecks.name:
+            return "Pull request checks"
+        case ToolDefinition.gitPullRequestDiff.name:
+            return "Pull request diff"
+        case ToolDefinition.gitPullRequestCheckout.name:
+            return "Checkout pull request"
+        case ToolDefinition.gitPullRequestComment.name:
+            return "Pull request comment"
+        case ToolDefinition.gitPullRequestReview.name:
+            return "Pull request review"
+        case ToolDefinition.gitPullRequestReviewComment.name:
+            return "Review comment"
+        case ToolDefinition.gitPullRequestReviewReply.name:
+            return "Review reply"
+        case ToolDefinition.gitPullRequestReviewThreads.name:
+            return "Review threads"
+        case ToolDefinition.gitPullRequestReviewThread.name:
+            return "Review thread"
+        case ToolDefinition.gitPullRequestReviewers.name:
+            return "Pull request reviewers"
+        case ToolDefinition.gitPullRequestLabels.name:
+            return "Pull request labels"
+        case ToolDefinition.gitPullRequestLifecycle.name:
+            return "Pull request lifecycle"
+        case ToolDefinition.gitPullRequestMerge.name:
+            return "Merge pull request"
+        case ToolDefinition.gitWorktreeList.name:
+            return "List worktrees"
+        case ToolDefinition.gitWorktreeCreate.name:
+            return "Create worktree"
+        case ToolDefinition.gitWorktreeOpen.name:
+            return "Open worktree"
+        case ToolDefinition.gitWorktreeRemove.name:
+            return "Remove worktree"
+        case ToolDefinition.gitWorktreePrune.name:
+            return "Prune worktrees"
+        case ToolDefinition.browserOpen.name:
+            return "Open browser"
+        case ToolDefinition.browserInspect.name:
+            return "Inspect browser"
+        case ToolDefinition.browserClick.name:
+            return "Browser click"
+        case ToolDefinition.browserType.name:
+            return "Browser type"
+        case ToolDefinition.browserScript.name:
+            return "Browser script"
+        case ToolDefinition.webSearch.name:
+            return "Web search"
+        case ToolDefinition.webFetch.name:
+            return "Web fetch"
+        case ToolDefinition.computerScreenshot.name:
+            return "Screenshot"
+        case ToolDefinition.computerClick.name:
+            return "Computer click"
+        case ToolDefinition.computerType.name:
+            return "Computer type"
+        case ToolDefinition.computerScroll.name:
+            return "Computer scroll"
+        case ToolDefinition.computerMove.name:
+            return "Move pointer"
+        case ToolDefinition.computerKey.name:
+            return "Keyboard shortcut"
+        case ToolDefinition.mcpCall.name:
+            return "MCP tool"
+        case ToolDefinition.mcpReadResource.name:
+            return "MCP resource"
+        case ToolDefinition.mcpGetPrompt.name:
+            return "MCP prompt"
+        case ToolDefinition.memoryRemember.name:
+            return "Save memory"
+        case ToolDefinition.planUpdate.name:
+            return "Update plan"
+        case ToolDefinition.handoffUpdate.name:
+            return "Update handoff"
+        case ToolDefinition.subagentsUpdate.name:
+            return "Update subagents"
+        default:
+            return toolName
+        }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceTopBarLiveWorkBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarLiveWorkBuilder.swift
@@ -36,7 +36,7 @@ struct WorkspaceTopBarLiveWorkBuilder: Sendable, Hashable {
 
     private static func label(for primary: ToolCardState, activeCount: Int) -> String {
         if activeCount == 1 {
-            return "\(primary.status.topBarVerb) \(primary.title)"
+            return "\(primary.status.topBarVerb) \(WorkspaceToolDisplayNameBuilder.displayName(for: primary.title))"
         }
         return "\(activeCount) active tasks"
     }
@@ -53,13 +53,33 @@ struct WorkspaceTopBarLiveWorkBuilder: Sendable, Hashable {
             countPhrase(queuedCount, noun: "queued"),
             countPhrase(reviewCount, noun: "awaiting review"),
         ].compactMap { $0 }
-        let titleList = activeCards.prefix(4).map(\.title).joined(separator: ", ")
+        let titleList = activeCards.prefix(4)
+            .map { WorkspaceToolDisplayNameBuilder.displayName(for: $0.title) }
+            .joined(separator: ", ")
         let overflow = activeCards.count > 4 ? " and \(activeCards.count - 4) more" : ""
-        return "Current work: \(counts.joined(separator: ", ")). Focus: \(primary.title). Active tools: \(titleList)\(overflow)."
+        return "Current work: \(counts.joined(separator: ", ")). Focus: \(focusName(for: primary)). Active tools: \(titleList)\(overflow)."
     }
 
     private static func countPhrase(_ count: Int, noun: String) -> String? {
         count > 0 ? "\(count) \(noun)" : nil
+    }
+
+    private static func focusName(for card: ToolCardState) -> String {
+        let displayName = WorkspaceToolDisplayNameBuilder.displayName(for: card.title)
+        guard let detail = subtitleDetail(card.subtitle) else {
+            return displayName
+        }
+        return "\(displayName): \(detail)"
+    }
+
+    private static func subtitleDetail(_ subtitle: String) -> String? {
+        let parts = subtitle
+            .split(separator: "·", maxSplits: 1)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard parts.count == 2, !parts[1].isEmpty else {
+            return nil
+        }
+        return parts[1]
     }
 }
 

--- a/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
@@ -111,8 +111,8 @@ final class QuillCodeTopBarSurfaceTests: XCTestCase {
             modeLabel: "Auto",
             agentStatus: "Running",
             liveWork: TopBarLiveWorkSurface(
-                label: "Running host.shell.run",
-                detail: "Current work: 1 running. Focus: host.shell.run. Active tools: host.shell.run.",
+                label: "Running Shell command",
+                detail: "Current work: 1 running. Focus: Shell command: swift test. Active tools: Shell command.",
                 tone: .running
             ),
             computerUseLabel: "Computer Use Ready",
@@ -123,7 +123,7 @@ final class QuillCodeTopBarSurfaceTests: XCTestCase {
 
         XCTAssertTrue(html.contains(#"data-testid="top-bar-live-work""#))
         XCTAssertTrue(html.contains(#"data-tone="running""#))
-        XCTAssertTrue(html.contains("Running host.shell.run"))
+        XCTAssertTrue(html.contains("Running Shell command"))
         XCTAssertTrue(html.contains("Current work: 1 running"))
     }
 

--- a/Tests/QuillCodeAppTests/WorkspaceToolDisplayNameBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceToolDisplayNameBuilderTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+import QuillComputerUseKit
+@testable import QuillCodeApp
+
+final class WorkspaceToolDisplayNameBuilderTests: XCTestCase {
+    func testDisplayNamesHideInternalToolIdentifiers() {
+        XCTAssertEqual(
+            WorkspaceToolDisplayNameBuilder.displayName(for: ToolDefinition.shellRun.name),
+            "Shell command"
+        )
+        XCTAssertEqual(
+            WorkspaceToolDisplayNameBuilder.displayName(for: ToolDefinition.browserInspect.name),
+            "Inspect browser"
+        )
+        XCTAssertEqual(
+            WorkspaceToolDisplayNameBuilder.displayName(for: ToolDefinition.computerScreenshot.name),
+            "Screenshot"
+        )
+    }
+
+    func testDisplayNameFallsBackForUnknownTools() {
+        XCTAssertEqual(
+            WorkspaceToolDisplayNameBuilder.displayName(for: "host.custom.tool"),
+            "host.custom.tool"
+        )
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
@@ -213,7 +213,9 @@ final class WorkspaceTopBarSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(liveWork.tone, .running)
         XCTAssertTrue(liveWork.detail.contains("1 running"))
         XCTAssertTrue(liveWork.detail.contains("1 queued"))
-        XCTAssertTrue(liveWork.detail.contains(ToolDefinition.shellRun.name))
+        XCTAssertTrue(liveWork.detail.contains("Focus: Shell command: swift test"))
+        XCTAssertTrue(liveWork.detail.contains("Active tools: Shell command, Inspect browser"))
+        XCTAssertFalse(liveWork.detail.contains(ToolDefinition.shellRun.name))
         XCTAssertTrue(topBar.topBarAccessibilityLabel.contains("current work: 2 active tasks"))
     }
 
@@ -251,9 +253,10 @@ final class WorkspaceTopBarSurfaceBuilderTests: XCTestCase {
         ).surface()
 
         let liveWork = try XCTUnwrap(topBar.liveWork)
-        XCTAssertEqual(liveWork.label, "Review \(ToolDefinition.shellRun.name)")
+        XCTAssertEqual(liveWork.label, "Review Shell command")
         XCTAssertEqual(liveWork.tone, .review)
         XCTAssertTrue(liveWork.detail.contains("1 awaiting review"))
+        XCTAssertTrue(liveWork.detail.contains("Focus: Shell command: git push"))
         XCTAssertTrue(topBar.topBarHelpText.contains("Current work:"))
     }
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,10 @@
 
 ## 2026-07-05
 
+- Top-bar live work should speak in user-facing action names instead of internal tool identifiers. Transcript tool cards
+  can still preserve exact `host.*` names in details, but persistent chrome is scan-first status copy such as `Running
+  Shell command`, `Review Shell command`, and focused details like `Shell command: swift test`. The display names live in
+  one shared app presentation helper so future Codex-style surfaces do not each reinvent their own raw-tool-name mapping.
 - Visible browser agent actions are routed through a desktop executor, not the desktop controller or the app model.
   `QuillCodeDesktopVisibleBrowserToolExecutor` owns the `host.browser.inspect`, `host.browser.click`,
   `host.browser.type`, and `host.browser.script` override path for the open WebKit session, while the controller only


### PR DESCRIPTION
## Summary
- add a shared app presentation helper for user-facing tool display names
- use friendly names in the top-bar live-work chip instead of raw host.* tool identifiers
- include focused subtitle detail in live-work copy and document the presentation decision

## Validation
- git diff --check
- swift test --filter WorkspaceTopBarSurfaceBuilderTests
- swift test --filter WorkspaceToolDisplayNameBuilderTests
- swift test --filter QuillCodeTopBarSurfaceTests
- swift test