### PR TITLE
Add command palette keyboard selection model

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeCommandPaletteDialog.swift
+++ b/Sources/QuillCodeApp/QuillCodeCommandPaletteDialog.swift
@@ -8,7 +8,7 @@ struct QuillCodeCommandPaletteView: View {
     var onClose: () -> Void
 
     @State private var localQuery: String
-    @State private var selectedCommandID: String?
+    @State private var selection = WorkspaceCommandPaletteSelection()
     @FocusState private var isSearchFocused: Bool
 
     init(
@@ -30,10 +30,6 @@ struct QuillCodeCommandPaletteView: View {
 
     private var groups: [WorkspaceCommandGroupSurface] {
         WorkspaceCommandPalette.groupedCommands(commands, matching: localQuery)
-    }
-
-    private var enabledResults: [WorkspaceCommandSurface] {
-        results.filter(\.isEnabled)
     }
 
     var body: some View {
@@ -75,7 +71,7 @@ struct QuillCodeCommandPaletteView: View {
                         ForEach(groups) { group in
                             QuillCodeCommandGroupView(
                                 group: group,
-                                selectedCommandID: selectedCommandID,
+                                selectedCommandID: selection.selectedCommandID,
                                 onSelectCommand: selectCommand
                             )
                         }
@@ -107,12 +103,16 @@ struct QuillCodeCommandPaletteView: View {
         .onMoveCommand { direction in
             switch direction {
             case .up:
-                moveSelection(by: -1)
+                selection.move(by: -1, in: results)
             case .down:
-                moveSelection(by: 1)
+                selection.move(by: 1, in: results)
             default:
                 break
             }
+        }
+        .onKeyPress(.escape) {
+            onClose()
+            return .handled
         }
     }
 
@@ -137,33 +137,18 @@ struct QuillCodeCommandPaletteView: View {
     }
 
     private func ensureSelection() {
-        if let selectedCommandID, enabledResults.contains(where: { $0.id == selectedCommandID }) {
-            return
-        }
-        selectedCommandID = enabledResults.first?.id
-    }
-
-    private func moveSelection(by delta: Int) {
-        guard !enabledResults.isEmpty else {
-            selectedCommandID = nil
-            return
-        }
-        let currentIndex = selectedCommandID.flatMap { id in
-            enabledResults.firstIndex(where: { $0.id == id })
-        } ?? 0
-        let nextIndex = (currentIndex + delta + enabledResults.count) % enabledResults.count
-        selectedCommandID = enabledResults[nextIndex].id
+        selection.reconcile(with: results)
     }
 
     private func selectHighlightedCommand() {
-        guard let command = enabledResults.first(where: { $0.id == selectedCommandID }) ?? enabledResults.first else {
+        guard let command = selection.selectedCommand(in: results) else {
             return
         }
         onSelectCommand(command)
     }
 
     private func selectCommand(_ command: WorkspaceCommandSurface) {
-        selectedCommandID = command.id
+        selection.select(command)
         onSelectCommand(command)
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceCommandPaletteSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPaletteSelection.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct WorkspaceCommandPaletteSelection: Equatable {
+    private(set) var selectedCommandID: String?
+
+    mutating func select(_ command: WorkspaceCommandSurface) {
+        selectedCommandID = command.isEnabled ? command.id : nil
+    }
+
+    mutating func reconcile(with commands: [WorkspaceCommandSurface]) {
+        let enabled = enabledCommands(from: commands)
+        guard !enabled.isEmpty else {
+            selectedCommandID = nil
+            return
+        }
+        if let selectedCommandID,
+           enabled.contains(where: { $0.id == selectedCommandID }) {
+            return
+        }
+        selectedCommandID = enabled[0].id
+    }
+
+    mutating func move(by delta: Int, in commands: [WorkspaceCommandSurface]) {
+        let enabled = enabledCommands(from: commands)
+        guard !enabled.isEmpty else {
+            selectedCommandID = nil
+            return
+        }
+        let currentIndex = selectedCommandID.flatMap { id in
+            enabled.firstIndex(where: { $0.id == id })
+        } ?? 0
+        let nextIndex = positiveModulo(currentIndex + delta, enabled.count)
+        selectedCommandID = enabled[nextIndex].id
+    }
+
+    func selectedCommand(in commands: [WorkspaceCommandSurface]) -> WorkspaceCommandSurface? {
+        let enabled = enabledCommands(from: commands)
+        return enabled.first(where: { $0.id == selectedCommandID }) ?? enabled.first
+    }
+
+    private func enabledCommands(from commands: [WorkspaceCommandSurface]) -> [WorkspaceCommandSurface] {
+        commands.filter(\.isEnabled)
+    }
+
+    private func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+        precondition(divisor > 0)
+        let remainder = value % divisor
+        return remainder >= 0 ? remainder : remainder + divisor
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPaletteSelectionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPaletteSelectionTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class WorkspaceCommandPaletteSelectionTests: XCTestCase {
+    func testReconcileSelectsFirstEnabledCommand() {
+        var selection = WorkspaceCommandPaletteSelection()
+
+        selection.reconcile(with: [
+            command("disabled", enabled: false),
+            command("enabled")
+        ])
+
+        XCTAssertEqual(selection.selectedCommandID, "enabled")
+    }
+
+    func testReconcilePreservesStillVisibleSelectionAcrossQueryChanges() {
+        var selection = WorkspaceCommandPaletteSelection()
+        selection.reconcile(with: [command("one"), command("two")])
+        selection.move(by: 1, in: [command("one"), command("two")])
+
+        selection.reconcile(with: [command("two"), command("three")])
+
+        XCTAssertEqual(selection.selectedCommandID, "two")
+    }
+
+    func testReconcileFallsBackWhenSelectionDisappearsOrBecomesDisabled() {
+        var selection = WorkspaceCommandPaletteSelection()
+        selection.reconcile(with: [command("one"), command("two")])
+        selection.move(by: 1, in: [command("one"), command("two")])
+
+        selection.reconcile(with: [command("two", enabled: false), command("three")])
+
+        XCTAssertEqual(selection.selectedCommandID, "three")
+    }
+
+    func testMoveWrapsAndSkipsDisabledCommands() {
+        var selection = WorkspaceCommandPaletteSelection()
+        let commands = [
+            command("one"),
+            command("two", enabled: false),
+            command("three")
+        ]
+        selection.reconcile(with: commands)
+
+        selection.move(by: 1, in: commands)
+        XCTAssertEqual(selection.selectedCommandID, "three")
+
+        selection.move(by: 1, in: commands)
+        XCTAssertEqual(selection.selectedCommandID, "one")
+
+        selection.move(by: -1, in: commands)
+        XCTAssertEqual(selection.selectedCommandID, "three")
+    }
+
+    func testSelectedCommandFallsBackToFirstEnabledIfSelectionIsStale() {
+        var selection = WorkspaceCommandPaletteSelection()
+        selection.reconcile(with: [command("one"), command("two")])
+        selection.move(by: 1, in: [command("one"), command("two")])
+
+        XCTAssertEqual(selection.selectedCommand(in: [command("fallback")])?.id, "fallback")
+    }
+
+    func testExplicitSelectionRecordsClickedEnabledCommand() {
+        var selection = WorkspaceCommandPaletteSelection()
+
+        selection.select(command("clicked"))
+
+        XCTAssertEqual(selection.selectedCommandID, "clicked")
+    }
+
+    func testExplicitSelectionClearsDisabledCommand() {
+        var selection = WorkspaceCommandPaletteSelection()
+        selection.reconcile(with: [command("one")])
+
+        selection.select(command("disabled", enabled: false))
+
+        XCTAssertNil(selection.selectedCommandID)
+    }
+
+    func testSelectionClearsWhenNoCommandsAreEnabled() {
+        var selection = WorkspaceCommandPaletteSelection()
+        selection.reconcile(with: [command("one")])
+
+        selection.reconcile(with: [command("disabled", enabled: false)])
+
+        XCTAssertNil(selection.selectedCommandID)
+        XCTAssertNil(selection.selectedCommand(in: [command("disabled", enabled: false)]))
+    }
+
+    private func command(_ id: String, enabled: Bool = true) -> WorkspaceCommandSurface {
+        WorkspaceCommandSurface(
+            id: id,
+            title: id,
+            shortcut: nil,
+            category: WorkspaceCommandPalette.workspaceCategory,
+            keywords: [],
+            isEnabled: enabled
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParitySearchDialogGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySearchDialogGateTests.swift
@@ -4,6 +4,7 @@ final class ParitySearchDialogGateTests: QuillCodeParityTestCase {
     func testNativeSearchDialogsKeepLocalTypingState() throws {
         let searchShortcutText = try Self.appSourceText(named: "QuillCodeSearchAndShortcutDialogs.swift")
         let commandPaletteText = try Self.appSourceText(named: "QuillCodeCommandPaletteDialog.swift")
+        let commandPaletteSelectionText = try Self.appSourceText(named: "WorkspaceCommandPaletteSelection.swift")
 
         for expected in [
             "@State private var localQuery",
@@ -18,11 +19,25 @@ final class ParitySearchDialogGateTests: QuillCodeParityTestCase {
         }
         for expected in [
             "@State private var localQuery",
+            "@State private var selection = WorkspaceCommandPaletteSelection()",
             "TextField(\"Search commands, > actions, / slash\", text: $localQuery)",
             ".accessibilityIdentifier(\"quillcode-command-palette-input\")",
+            ".onMoveCommand",
+            ".onKeyPress(.escape)",
+            "selection.move(by: -1, in: results)",
+            "selection.move(by: 1, in: results)",
+            "selection.selectedCommand(in: results)",
             "private func focusSearchField()"
         ] {
             Self.assertSource(commandPaletteText, contains: expected)
+        }
+        for expected in [
+            "struct WorkspaceCommandPaletteSelection",
+            "mutating func reconcile(with commands: [WorkspaceCommandSurface])",
+            "mutating func move(by delta: Int, in commands: [WorkspaceCommandSurface])",
+            "func selectedCommand(in commands: [WorkspaceCommandSurface]) -> WorkspaceCommandSurface?"
+        ] {
+            Self.assertSource(commandPaletteSelectionText, contains: expected)
         }
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -15485,3 +15485,31 @@ Validation:
 
 - `swift test --filter WorkspaceHTMLChromeRendererTests` (14 tests, 0 failures)
 - `git diff --check`
+
+## 2026-07-09 Command Palette Keyboard Selection Slice
+
+Overall grade after this slice: **A+ command-palette selection boundary, A native keyboard parity**.
+This closes the native command-palette keyboard-regression gap called out in the
+search/input stability audit: ranking remains separate from focus and selection,
+and arrow/submit behavior is now deterministic outside SwiftUI rendering.
+
+Code quality changes:
+
+- Extracted command-palette highlighted-row state into
+  `WorkspaceCommandPaletteSelection`, a tiny pure selection model that preserves
+  still-visible selections, skips disabled commands, wraps up/down movement, and
+  falls back safely when the highlighted command disappears after query changes.
+- Wired the SwiftUI command palette through that shared selection model instead
+  of keeping private row-navigation rules in the view.
+- Added explicit Escape handling on the native command palette so the keyboard
+  close path is as direct as the visible close button.
+- Added focused unit coverage for first-enabled selection, query-change
+  preservation, disabled rows, wraparound movement, click selection, stale
+  fallback, and empty enabled result sets.
+- Extended the native search/dialog parity gate so future changes must preserve
+  the command-palette selection seam and Escape/key movement hooks.
+
+Validation:
+
+- `swift test --filter 'WorkspaceCommandPaletteSelectionTests|WorkspaceCommandPaletteRankerTests|ParitySearchDialogGateTests'` (16 tests, 0 failures)
+- `git diff --check`


### PR DESCRIPTION
## Summary
- Extract native command-palette highlighted-row behavior into a pure WorkspaceCommandPaletteSelection model.
- Wire SwiftUI palette movement/submit through the shared selection model and add Escape-to-close handling.
- Add focused selection tests and extend the native search/dialog parity gate.

## Validation
- swift test --filter 'WorkspaceCommandPaletteSelectionTests|WorkspaceCommandPaletteRankerTests|ParitySearchDialogGateTests'
- git diff --check