### PR TITLE
Use friendly transcript tool labels

### DIFF
--- a/Sources/QuillCodeApp/TranscriptItemTextFormatter.swift
+++ b/Sources/QuillCodeApp/TranscriptItemTextFormatter.swift
@@ -13,7 +13,7 @@ public enum TranscriptItemTextFormatter {
            !inputJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return inputJSON
         }
-        return [card.title, card.subtitle]
+        return [WorkspaceToolDisplayNameBuilder.displayName(for: card.title), card.subtitle]
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
             .joined(separator: "\n")

--- a/Sources/QuillCodeApp/TranscriptMarkdownExporter.swift
+++ b/Sources/QuillCodeApp/TranscriptMarkdownExporter.swift
@@ -17,9 +17,10 @@ public enum TranscriptMarkdownExporter {
                 blocks.append("## \(heading)\n\n\(body)")
             case .toolCard:
                 guard let card = item.toolCard else { continue }
+                let title = WorkspaceToolDisplayNameBuilder.displayName(for: card.title)
                 let text = TranscriptItemTextFormatter.text(for: card)
                 let fence = codeFence(for: text)
-                blocks.append("### \(card.title)\n\n\(fence)\n\(text)\n\(fence)")
+                blocks.append("### \(title)\n\n\(fence)\n\(text)\n\(fence)")
             }
         }
         return blocks.joined(separator: "\n\n")

--- a/Sources/QuillCodeApp/TranscriptSearchIndex.swift
+++ b/Sources/QuillCodeApp/TranscriptSearchIndex.swift
@@ -132,7 +132,9 @@ struct TranscriptSearchIndex: Sendable, Equatable {
             ].compactMap { $0 }.joined(separator: "\n")
         case .toolCard:
             guard let card = item.toolCard else { return "" }
+            let displayTitle = WorkspaceToolDisplayNameBuilder.displayName(for: card.title)
             return [
+                displayTitle,
                 card.title,
                 card.subtitle,
                 card.inputJSON,
@@ -147,7 +149,8 @@ struct TranscriptSearchIndex: Sendable, Equatable {
         case .message:
             return item.message?.role.rawValue.capitalized ?? "Message"
         case .toolCard:
-            return item.toolCard?.title ?? "Tool"
+            guard let title = item.toolCard?.title else { return "Tool" }
+            return WorkspaceToolDisplayNameBuilder.displayName(for: title)
         }
     }
 }

--- a/Tests/QuillCodeAppTests/TranscriptMarkdownExporterTests.swift
+++ b/Tests/QuillCodeAppTests/TranscriptMarkdownExporterTests.swift
@@ -28,7 +28,7 @@ final class TranscriptMarkdownExporterTests: XCTestCase {
 
         Run the tests
 
-        ### host.shell.run
+        ### Shell command
 
         ```
         All tests passed
@@ -53,7 +53,7 @@ final class TranscriptMarkdownExporterTests: XCTestCase {
             TranscriptMarkdownExporter.markdown(
                 for: transcript([.toolCard(card(id: "c", title: "host.git.diff", subtitle: "no changes"))])
             ),
-            "### host.git.diff\n\n```\nhost.git.diff\nno changes\n```"
+            "### Git diff\n\n```\nGit diff\nno changes\n```"
         )
     }
 
@@ -76,7 +76,7 @@ final class TranscriptMarkdownExporterTests: XCTestCase {
         let tool = card(id: "t1", title: "host.shell.run", subtitle: "  done  ", input: nil, output: "   ")
         XCTAssertEqual(
             TranscriptMarkdownExporter.markdown(for: transcript([.toolCard(tool)])),
-            "### host.shell.run\n\n```\nhost.shell.run\ndone\n```"
+            "### Shell command\n\n```\nShell command\ndone\n```"
         )
     }
 
@@ -84,7 +84,7 @@ final class TranscriptMarkdownExporterTests: XCTestCase {
         let tool = card(id: "t1", title: "host.shell.run", output: "```\ncode\n```")
         XCTAssertEqual(
             TranscriptMarkdownExporter.markdown(for: transcript([.toolCard(tool)])),
-            "### host.shell.run\n\n````\n```\ncode\n```\n````"
+            "### Shell command\n\n````\n```\ncode\n```\n````"
         )
     }
 
@@ -130,7 +130,7 @@ final class TranscriptMarkdownExporterTests: XCTestCase {
 
         XCTAssertEqual(markdown,
             "## User\n\nRun the tests\n\n"
-            + "### host.shell.run\n\n```\n"
+            + "### Shell command\n\n```\n"
             + "{\n  \"ok\": true,\n  \"stdout\": \"ran: the tests\\n\",\n  \"stderr\": \"\",\n  \"exitCode\": 0\n}\n"
             + "```\n\n## Assistant\n\nOutput:\nran: the tests"
         )

--- a/Tests/QuillCodeAppTests/TranscriptSearchIndexTests.swift
+++ b/Tests/QuillCodeAppTests/TranscriptSearchIndexTests.swift
@@ -40,6 +40,25 @@ final class TranscriptSearchIndexTests: XCTestCase {
         XCTAssertEqual(TranscriptSearchIndex.build(transcript: surface, query: "report").matches.map(\.label), ["Run Shell"])
     }
 
+    func testToolSearchLabelsUseFriendlyNamesWhileRawIdentifiersRemainSearchable() {
+        let card = ToolCardState(
+            id: "tool-1",
+            title: "host.shell.run",
+            subtitle: "swift test",
+            status: .done
+        )
+        let surface = transcript(toolCards: [card])
+
+        XCTAssertEqual(
+            TranscriptSearchIndex.build(transcript: surface, query: "Shell command").matches.map(\.label),
+            ["Shell command"]
+        )
+        XCTAssertEqual(
+            TranscriptSearchIndex.build(transcript: surface, query: "host.shell.run").matches.map(\.label),
+            ["Shell command"]
+        )
+    }
+
     func testMatchRangesAreCharacterOffsetsAndNonOverlapping() {
         // "aaaa" contains "aa" twice (non-overlapping), at offsets 0 and 2.
         let ranges = TranscriptSearchIndex.literalRanges(of: Array("aa"), in: "aaaa")

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,7 +2,7 @@
 
 ## 2026-07-05
 
-- Live work, Activity, and tool-card chrome should speak in user-facing action names instead of internal tool identifiers. Persisted
+- Live work, Activity, transcript export/search labels, and tool-card chrome should speak in user-facing action names instead of internal tool identifiers. Persisted
   cards and HTML metadata still preserve exact `host.*` names, but visible status copy is scan-first text such as
   `Running Shell command`, `Review Shell command`, and focused details like `Shell command: swift test`. The display
   names live in one shared app presentation helper so future Codex-style surfaces do not each reinvent their own raw-tool


### PR DESCRIPTION
## Summary
- Render transcript export headings and fallback per-item copy with shared friendly tool names.
- Show friendly tool labels in transcript search results while keeping exact raw tool identifiers searchable.
- Extend the display-name decision note to cover transcript export/search labels.

## Validation
- git diff --check
- swift test --filter TranscriptMarkdownExporterTests
- swift test --filter TranscriptSearchIndexTests
- swift test