### PR TITLE
Use friendly approval notification labels

### DIFF
--- a/Sources/QuillCodeApp/AgentRunNotification.swift
+++ b/Sources/QuillCodeApp/AgentRunNotification.swift
@@ -76,10 +76,11 @@ public enum AgentRunNotificationPlanner {
     ) -> AgentRunNotification? {
         let title = displayTitle(rawTitle)
         if let approval = trimmedNonEmpty(pendingApprovalSummary) {
+            let approvalLabel = WorkspaceToolDisplayNameBuilder.displayName(for: approval)
             return AgentRunNotification(
                 kind: .needsApproval,
                 title: "QuillCode needs your approval",
-                body: "\(title): approve \(approval) to continue.",
+                body: "\(title): approve \(approvalLabel) to continue.",
                 threadID: threadID,
                 approvalRequestID: trimmedNonEmpty(pendingApprovalRequestID)
             )

--- a/Tests/QuillCodeAppTests/AgentRunNotificationPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/AgentRunNotificationPlannerTests.swift
@@ -15,7 +15,8 @@ final class AgentRunNotificationPlannerTests: XCTestCase {
         )
         XCTAssertEqual(note?.kind, .needsApproval)
         XCTAssertEqual(note?.title, "QuillCode needs your approval")
-        XCTAssertTrue(note?.body.contains("host.shell.run") == true, note?.body ?? "")
+        XCTAssertTrue(note?.body.contains("Shell command") == true, note?.body ?? "")
+        XCTAssertFalse(note?.body.contains("host.shell.run") == true, note?.body ?? "")
         XCTAssertTrue(note?.body.contains("Refactor auth") == true, note?.body ?? "")
         XCTAssertEqual(note?.threadID, threadID)
     }

--- a/Tests/QuillCodeAppTests/WorkspaceRunNotificationBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRunNotificationBuilderTests.swift
@@ -55,7 +55,8 @@ final class WorkspaceRunNotificationBuilderTests: XCTestCase {
         )
         let note = WorkspaceRunNotificationBuilder.notification(thread: t, didFail: false)
         XCTAssertEqual(note?.kind, .needsApproval)
-        XCTAssertTrue(note?.body.contains("host.shell.run") == true, note?.body ?? "")
+        XCTAssertTrue(note?.body.contains("Shell command") == true, note?.body ?? "")
+        XCTAssertFalse(note?.body.contains("host.shell.run") == true, note?.body ?? "")
         // Carries the request id so the notification's Approve/Skip actions can decide this exact gate.
         XCTAssertEqual(note?.approvalRequestID, "a1")
     }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,7 +2,7 @@
 
 ## 2026-07-05
 
-- Live work, Activity, transcript export/search labels, and tool-card chrome should speak in user-facing action names instead of internal tool identifiers. Persisted
+- Live work, Activity, notification approval copy, transcript export/search labels, and tool-card chrome should speak in user-facing action names instead of internal tool identifiers. Persisted
   cards and HTML metadata still preserve exact `host.*` names, but visible status copy is scan-first text such as
   `Running Shell command`, `Review Shell command`, and focused details like `Shell command: swift test`. The display
   names live in one shared app presentation helper so future Codex-style surfaces do not each reinvent their own raw-tool


### PR DESCRIPTION
## Summary
- Render pending approval notification copy with the shared friendly tool display names.
- Keep approval request payloads and pending tool identity unchanged so notification actions still target the exact approval gate.
- Extend the display-name decision note to include notification approval copy.

## Validation
- git diff --check
- swift test --filter AgentRunNotificationPlannerTests
- swift test --filter WorkspaceRunNotificationBuilderTests
- swift test