### PR TITLE
Harden search dialog keyboard selection

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
+++ b/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
@@ -48,7 +48,7 @@ struct QuillCodeSearchView: View {
     var onClose: () -> Void
 
     @State private var localQuery: String
-    @State private var highlightedThreadID: UUID?
+    @State private var selection = WorkspaceSearchSelection()
     @FocusState private var isSearchFocused: Bool
 
     init(
@@ -98,8 +98,8 @@ struct QuillCodeSearchView: View {
                         ForEach(results) { item in
                             QuillCodeSearchResultRow(
                                 item: item,
-                                isHighlighted: highlightedThreadID == item.id,
-                                onSelect: onSelectThread
+                                isHighlighted: selection.highlightedThreadID == item.id,
+                                onSelect: selectResult
                             )
                         }
                     }
@@ -110,14 +110,14 @@ struct QuillCodeSearchView: View {
         .frame(width: 560, height: 520)
         .background(QuillCodePalette.background)
         .onAppear {
-            ensureHighlightedResult(preferredID: sidebar.selectedThreadID)
+            selection.reconcile(with: results, preferredID: sidebar.selectedThreadID)
             focusSearchField()
         }
         .onChange(of: localQuery) { _, newValue in
             if query != newValue {
                 query = newValue
             }
-            ensureHighlightedResult(preferredID: highlightedThreadID)
+            selection.reconcile(with: results)
         }
         .onChange(of: query) { _, newValue in
             if localQuery != newValue {
@@ -127,47 +127,32 @@ struct QuillCodeSearchView: View {
         .onMoveCommand { direction in
             switch direction {
             case .up:
-                moveHighlightedResult(by: -1)
+                selection.move(by: -1, in: results)
             case .down:
-                moveHighlightedResult(by: 1)
+                selection.move(by: 1, in: results)
             default:
                 break
             }
         }
+        .onKeyPress(.escape) {
+            onClose()
+            return .handled
+        }
         .onDisappear {
             isSearchFocused = false
-            highlightedThreadID = nil
+            selection = WorkspaceSearchSelection()
         }
-    }
-
-    private func ensureHighlightedResult(preferredID: UUID?) {
-        if let preferredID, results.contains(where: { $0.id == preferredID }) {
-            highlightedThreadID = preferredID
-            return
-        }
-        if let highlightedThreadID, results.contains(where: { $0.id == highlightedThreadID }) {
-            return
-        }
-        highlightedThreadID = results.first?.id
-    }
-
-    private func moveHighlightedResult(by delta: Int) {
-        guard !results.isEmpty else {
-            highlightedThreadID = nil
-            return
-        }
-        let currentIndex = highlightedThreadID.flatMap { id in
-            results.firstIndex { $0.id == id }
-        } ?? 0
-        let nextIndex = (currentIndex + delta + results.count) % results.count
-        highlightedThreadID = results[nextIndex].id
     }
 
     private func selectHighlightedResult() {
-        guard let highlighted = highlightedThreadID.flatMap({ id in
-            results.first { $0.id == id }
-        }) ?? results.first else { return }
+        guard let highlighted = selection.selectedItem(in: results) else { return }
         onSelectThread(highlighted.id)
+    }
+
+    private func selectResult(_ id: UUID) {
+        guard let item = results.first(where: { $0.id == id }) else { return }
+        selection.select(item)
+        onSelectThread(id)
     }
 
     private func focusSearchField() {

--- a/Sources/QuillCodeApp/WorkspaceSearchSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceSearchSelection.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct WorkspaceSearchSelection: Equatable {
+    private(set) var highlightedThreadID: UUID?
+
+    mutating func select(_ item: SidebarItemSurface) {
+        highlightedThreadID = item.id
+    }
+
+    mutating func reconcile(with items: [SidebarItemSurface], preferredID: UUID? = nil) {
+        guard !items.isEmpty else {
+            highlightedThreadID = nil
+            return
+        }
+
+        if let preferredID, items.contains(where: { $0.id == preferredID }) {
+            highlightedThreadID = preferredID
+            return
+        }
+
+        if let highlightedThreadID, items.contains(where: { $0.id == highlightedThreadID }) {
+            return
+        }
+
+        highlightedThreadID = items[0].id
+    }
+
+    mutating func move(by delta: Int, in items: [SidebarItemSurface]) {
+        guard !items.isEmpty else {
+            highlightedThreadID = nil
+            return
+        }
+
+        let currentIndex = highlightedThreadID.flatMap { id in
+            items.firstIndex { $0.id == id }
+        } ?? 0
+        let nextIndex = positiveModulo(currentIndex + delta, items.count)
+        highlightedThreadID = items[nextIndex].id
+    }
+
+    func selectedItem(in items: [SidebarItemSurface]) -> SidebarItemSurface? {
+        items.first { $0.id == highlightedThreadID } ?? items.first
+    }
+
+    private func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+        precondition(divisor > 0)
+        let remainder = value % divisor
+        return remainder >= 0 ? remainder : remainder + divisor
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceSearchSelectionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSearchSelectionTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceSearchSelectionTests: XCTestCase {
+    func testReconcileSelectsPreferredVisibleThread() {
+        var selection = WorkspaceSearchSelection()
+        let first = item(title: "First")
+        let second = item(title: "Second")
+
+        selection.reconcile(with: [first, second], preferredID: second.id)
+
+        XCTAssertEqual(selection.highlightedThreadID, second.id)
+    }
+
+    func testReconcileSelectsFirstResultWhenPreferredIsMissing() {
+        var selection = WorkspaceSearchSelection()
+        let first = item(title: "First")
+        let second = item(title: "Second")
+
+        selection.reconcile(with: [first, second], preferredID: UUID())
+
+        XCTAssertEqual(selection.highlightedThreadID, first.id)
+    }
+
+    func testReconcilePreservesVisibleHighlightAcrossQueryChanges() {
+        var selection = WorkspaceSearchSelection()
+        let first = item(title: "First")
+        let second = item(title: "Second")
+        selection.reconcile(with: [first, second])
+        selection.move(by: 1, in: [first, second])
+
+        selection.reconcile(with: [second, item(title: "Third")])
+
+        XCTAssertEqual(selection.highlightedThreadID, second.id)
+    }
+
+    func testReconcileFallsBackWhenHighlightDisappears() {
+        var selection = WorkspaceSearchSelection()
+        let first = item(title: "First")
+        let second = item(title: "Second")
+        let third = item(title: "Third")
+        selection.reconcile(with: [first, second])
+        selection.move(by: 1, in: [first, second])
+
+        selection.reconcile(with: [third])
+
+        XCTAssertEqual(selection.highlightedThreadID, third.id)
+    }
+
+    func testMoveWrapsInBothDirections() {
+        var selection = WorkspaceSearchSelection()
+        let first = item(title: "First")
+        let second = item(title: "Second")
+        let third = item(title: "Third")
+        let items = [first, second, third]
+        selection.reconcile(with: items)
+
+        selection.move(by: -1, in: items)
+        XCTAssertEqual(selection.highlightedThreadID, third.id)
+
+        selection.move(by: 1, in: items)
+        XCTAssertEqual(selection.highlightedThreadID, first.id)
+    }
+
+    func testSelectedItemFallsBackToFirstResultIfHighlightIsStale() {
+        var selection = WorkspaceSearchSelection()
+        let first = item(title: "First")
+        let second = item(title: "Second")
+        selection.reconcile(with: [first])
+
+        XCTAssertEqual(selection.selectedItem(in: [second])?.id, second.id)
+    }
+
+    func testSelectionClearsWhenNoResultsRemain() {
+        var selection = WorkspaceSearchSelection()
+        selection.reconcile(with: [item(title: "First")])
+
+        selection.reconcile(with: [])
+
+        XCTAssertNil(selection.highlightedThreadID)
+        XCTAssertNil(selection.selectedItem(in: []))
+    }
+
+    func testExplicitSelectionRecordsClickedResult() {
+        var selection = WorkspaceSearchSelection()
+        let clicked = item(title: "Clicked")
+
+        selection.select(clicked)
+
+        XCTAssertEqual(selection.highlightedThreadID, clicked.id)
+    }
+
+    private func item(title: String) -> SidebarItemSurface {
+        SidebarItemSurface(
+            item: SidebarItem(thread: ChatThread(title: title)),
+            selectedThreadID: nil
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParitySearchDialogGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySearchDialogGateTests.swift
@@ -3,19 +3,32 @@ import XCTest
 final class ParitySearchDialogGateTests: QuillCodeParityTestCase {
     func testNativeSearchDialogsKeepLocalTypingState() throws {
         let searchShortcutText = try Self.appSourceText(named: "QuillCodeSearchAndShortcutDialogs.swift")
+        let searchSelectionText = try Self.appSourceText(named: "WorkspaceSearchSelection.swift")
         let commandPaletteText = try Self.appSourceText(named: "QuillCodeCommandPaletteDialog.swift")
         let commandPaletteSelectionText = try Self.appSourceText(named: "WorkspaceCommandPaletteSelection.swift")
 
         for expected in [
             "@State private var localQuery",
+            "@State private var selection = WorkspaceSearchSelection()",
             "TextField(\"Search chats\", text: $localQuery)",
             ".accessibilityIdentifier(\"quillcode-search-input\")",
-            "@State private var highlightedThreadID",
             ".onMoveCommand",
+            ".onKeyPress(.escape)",
+            "selection.move(by: -1, in: results)",
+            "selection.move(by: 1, in: results)",
+            "selection.selectedItem(in: results)",
             "selectHighlightedResult()",
             "private func focusSearchField()"
         ] {
             Self.assertSource(searchShortcutText, contains: expected)
+        }
+        for expected in [
+            "struct WorkspaceSearchSelection",
+            "mutating func reconcile(with items: [SidebarItemSurface], preferredID: UUID? = nil)",
+            "mutating func move(by delta: Int, in items: [SidebarItemSurface])",
+            "func selectedItem(in items: [SidebarItemSurface]) -> SidebarItemSurface?"
+        ] {
+            Self.assertSource(searchSelectionText, contains: expected)
         }
         for expected in [
             "@State private var localQuery",


### PR DESCRIPTION
## Summary
- Extract Search dialog highlighted-result state into a tested `WorkspaceSearchSelection` model.
- Keep search typing local while preserving visible highlights across query changes, falling back cleanly when results disappear, and wrapping arrow navigation.
- Add Escape-to-close behavior to the Search dialog to match Command Palette/Codex-style modal behavior.

## Validation
- `swift test --filter WorkspaceSearchSelectionTests`
- `swift test --filter ParitySearchDialogGateTests`
- `swift test --filter QuillCodeNativeHitTargetSurfaceAuditTests`
- `swift test` (3387 tests, 2 skipped, 0 failures)
