### PR TITLE
Harden model picker keyboard selection

### DIFF
--- a/Sources/QuillCodeApp/ModelPickerSelection.swift
+++ b/Sources/QuillCodeApp/ModelPickerSelection.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct ModelPickerSelection: Equatable {
+    private(set) var highlightedModelID: String?
+
+    mutating func select(_ model: ModelOptionSurface) {
+        highlightedModelID = model.id
+    }
+
+    mutating func reconcile(with models: [ModelOptionSurface], preferredID: String? = nil) {
+        guard !models.isEmpty else {
+            highlightedModelID = nil
+            return
+        }
+
+        if let preferredID, models.contains(where: { $0.id == preferredID }) {
+            highlightedModelID = preferredID
+            return
+        }
+
+        if let highlightedModelID, models.contains(where: { $0.id == highlightedModelID }) {
+            return
+        }
+
+        highlightedModelID = models[0].id
+    }
+
+    mutating func move(by delta: Int, in models: [ModelOptionSurface]) {
+        guard !models.isEmpty else {
+            highlightedModelID = nil
+            return
+        }
+
+        let currentIndex = highlightedModelID.flatMap { id in
+            models.firstIndex { $0.id == id }
+        } ?? 0
+        let nextIndex = positiveModulo(currentIndex + delta, models.count)
+        highlightedModelID = models[nextIndex].id
+    }
+
+    func selectedModel(in models: [ModelOptionSurface]) -> ModelOptionSurface? {
+        models.first { $0.id == highlightedModelID } ?? models.first
+    }
+
+    private func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+        precondition(divisor > 0)
+        let remainder = value % divisor
+        return remainder >= 0 ? remainder : remainder + divisor
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
@@ -9,7 +9,7 @@ struct QuillCodeModelPickerView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var searchText = ""
     @State private var expandedModelID: String?
-    @State private var highlightedModelID: String?
+    @State private var selection = ModelPickerSelection()
     @FocusState private var isSearchFocused: Bool
 
     private var filteredCategories: [ModelCategorySurface] {
@@ -68,7 +68,7 @@ struct QuillCodeModelPickerView: View {
             } else {
                 searchText = ""
                 expandedModelID = nil
-                highlightedModelID = nil
+                selection.reconcile(with: [])
                 isSearchFocused = false
             }
         }
@@ -87,12 +87,15 @@ struct QuillCodeModelPickerView: View {
         .onMoveCommand { direction in
             switch direction {
             case .up:
-                moveHighlightedModel(by: -1)
+                selection.move(by: -1, in: filteredModels)
             case .down:
-                moveHighlightedModel(by: 1)
+                selection.move(by: 1, in: filteredModels)
             default:
                 break
             }
+        }
+        .onExitCommand {
+            isPresented = false
         }
         .onChange(of: searchText) { _, _ in
             ensureHighlightedModel(preferredID: highlightedModelID)
@@ -235,33 +238,16 @@ struct QuillCodeModelPickerView: View {
     }
 
     private func ensureHighlightedModel(preferredID: String?) {
-        if let preferredID, filteredModels.contains(where: { $0.id == preferredID }) {
-            highlightedModelID = preferredID
-            return
-        }
-        if let highlightedModelID, filteredModels.contains(where: { $0.id == highlightedModelID }) {
-            return
-        }
-        highlightedModelID = filteredModels.first?.id
-    }
-
-    private func moveHighlightedModel(by delta: Int) {
-        guard !filteredModels.isEmpty else {
-            highlightedModelID = nil
-            return
-        }
-        let currentIndex = highlightedModelID.flatMap { id in
-            filteredModels.firstIndex { $0.id == id }
-        } ?? 0
-        let nextIndex = (currentIndex + delta + filteredModels.count) % filteredModels.count
-        highlightedModelID = filteredModels[nextIndex].id
+        selection.reconcile(with: filteredModels, preferredID: preferredID)
     }
 
     private func selectHighlightedModel() {
-        guard let highlighted = highlightedModelID.flatMap({ id in
-            filteredModels.first { $0.id == id }
-        }) ?? filteredModels.first else { return }
+        guard let highlighted = selection.selectedModel(in: filteredModels) else { return }
         selectModel(highlighted)
+    }
+
+    private var highlightedModelID: String? {
+        selection.highlightedModelID
     }
 
     private func selectModel(_ option: ModelOptionSurface) {

--- a/Tests/QuillCodeAppTests/ModelPickerSelectionTests.swift
+++ b/Tests/QuillCodeAppTests/ModelPickerSelectionTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class ModelPickerSelectionTests: XCTestCase {
+    func testReconcilePrefersCurrentModelWhenVisible() {
+        var selection = ModelPickerSelection()
+
+        selection.reconcile(with: models(), preferredID: "moonshotai/kimi-k2.6")
+
+        XCTAssertEqual(selection.highlightedModelID, "moonshotai/kimi-k2.6")
+    }
+
+    func testReconcileKeepsExistingHighlightWhenStillVisible() {
+        var selection = ModelPickerSelection()
+        selection.select(models()[1])
+
+        selection.reconcile(with: models(), preferredID: "missing/model")
+
+        XCTAssertEqual(selection.highlightedModelID, "moonshotai/kimi-k2.6")
+    }
+
+    func testReconcileFallsBackToFirstModelWhenHighlightDisappears() {
+        var selection = ModelPickerSelection()
+        selection.select(models()[2])
+
+        selection.reconcile(with: Array(models().prefix(2)))
+
+        XCTAssertEqual(selection.highlightedModelID, "trustedrouter/fast")
+    }
+
+    func testReconcileClearsHighlightWhenNoModelsRemain() {
+        var selection = ModelPickerSelection()
+        selection.select(models()[0])
+
+        selection.reconcile(with: [])
+
+        XCTAssertNil(selection.highlightedModelID)
+    }
+
+    func testMoveWrapsThroughVisibleModels() {
+        var selection = ModelPickerSelection()
+        let visible = models()
+        selection.reconcile(with: visible)
+
+        selection.move(by: -1, in: visible)
+        XCTAssertEqual(selection.highlightedModelID, "minimax/minimax-m3")
+
+        selection.move(by: 1, in: visible)
+        XCTAssertEqual(selection.highlightedModelID, "trustedrouter/fast")
+
+        selection.move(by: 2, in: visible)
+        XCTAssertEqual(selection.highlightedModelID, "minimax/minimax-m3")
+    }
+
+    func testSelectedModelFallsBackToFirstVisibleModel() {
+        var selection = ModelPickerSelection()
+        let visible = models()
+
+        XCTAssertEqual(selection.selectedModel(in: visible)?.id, "trustedrouter/fast")
+
+        selection.select(visible[1])
+        XCTAssertEqual(selection.selectedModel(in: visible)?.id, "moonshotai/kimi-k2.6")
+    }
+
+    private func models() -> [ModelOptionSurface] {
+        [
+            model(id: "trustedrouter/fast", displayName: "Nike 1.0"),
+            model(id: "moonshotai/kimi-k2.6", displayName: "Kimi K2.6"),
+            model(id: "minimax/minimax-m3", displayName: "MiniMax M3")
+        ]
+    }
+
+    private func model(id: String, displayName: String) -> ModelOptionSurface {
+        ModelOptionSurface(
+            model: ModelInfo(
+                id: id,
+                provider: String(id.split(separator: "/").first ?? ""),
+                displayName: displayName,
+                category: "General"
+            ),
+            selectedModelID: "trustedrouter/fast"
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityModelPickerIntegrationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityModelPickerIntegrationGateTests.swift
@@ -27,4 +27,27 @@ final class ParityModelPickerIntegrationGateTests: QuillCodeParityTestCase {
             excludes: "func testModelOptionDecodesOlderPayloadWithoutBadges"
         )
     }
+
+    func testModelPickerKeyboardSelectionStaysFactoredAndCovered() throws {
+        let pickerText = try Self.appSourceText(named: "QuillCodeModelPickerView.swift")
+        let selectionText = try Self.appSourceText(named: "ModelPickerSelection.swift")
+        let testsText = try Self.appTestSourceText(named: "ModelPickerSelectionTests.swift")
+
+        [
+            "struct ModelPickerSelection",
+            "mutating func reconcile",
+            "mutating func move",
+            "func selectedModel"
+        ].forEach {
+            Self.assertSource(selectionText, contains: $0)
+        }
+
+        Self.assertSource(pickerText, contains: "selection.move(by:")
+        Self.assertSource(pickerText, contains: ".onExitCommand")
+        Self.assertSource(testsText, contains: "func testMoveWrapsThroughVisibleModels")
+        Self.assertSource(
+            testsText,
+            contains: "func testReconcileFallsBackToFirstModelWhenHighlightDisappears"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- factor model picker highlighted-row state into a pure ModelPickerSelection helper
- add Escape-to-dismiss handling for the model picker popover
- cover keyboard selection wrap/reconcile behavior with focused tests and a parity gate

## Validation
- swift test --filter ModelPickerSelectionTests
- swift test --filter ParityModelPickerIntegrationGateTests
- swift test