### PR TITLE
Tighten command palette row density

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeCommandPaletteDialog.swift
+++ b/Sources/QuillCodeApp/QuillCodeCommandPaletteDialog.swift
@@ -205,14 +205,15 @@ private struct QuillCodeCommandRow: View {
                         .foregroundStyle(QuillCodePalette.muted)
                 }
             }
-            .padding(12)
-            .quillCodeFullRowButtonTarget(radius: 12)
+            .padding(.horizontal, QuillCodeMetrics.commandPaletteRowHorizontalPadding)
+            .padding(.vertical, QuillCodeMetrics.commandPaletteRowVerticalPadding)
+            .quillCodeFullRowButtonTarget(radius: QuillCodeMetrics.commandPaletteRowRadius)
             .background(isSelected ? QuillCodePalette.selection : QuillCodePalette.panel)
             .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                RoundedRectangle(cornerRadius: QuillCodeMetrics.commandPaletteRowRadius, style: .continuous)
                     .stroke(isSelected ? QuillCodePalette.blue.opacity(0.6) : Color.clear)
             )
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: QuillCodeMetrics.commandPaletteRowRadius, style: .continuous))
         }
         .buttonStyle(QuillCodePressableButtonStyle())
         .disabled(!command.isEnabled)

--- a/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
+++ b/Sources/QuillCodeApp/QuillCodeDesignSystem.swift
@@ -27,6 +27,9 @@ public enum QuillCodeMetrics {
     public static let sidebarVisibleRowHeight: CGFloat = 25
     public static let sidebarVisibleRowHorizontalPadding: CGFloat = 11
     public static let sidebarVisibleRowRadius: CGFloat = 6
+    public static let commandPaletteRowHorizontalPadding: CGFloat = 10
+    public static let commandPaletteRowVerticalPadding: CGFloat = 7
+    public static let commandPaletteRowRadius: CGFloat = 9
     public static let composerSurfaceRadius: CGFloat = 12
     public static let composerControlRadius: CGFloat = 10
     public static let toolCardMinimumHeight: CGFloat = 74

--- a/Tests/QuillCodeAppTests/QuillCodeCommandPaletteDensityTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeCommandPaletteDensityTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class QuillCodeCommandPaletteDensityTests: XCTestCase {
+    func testCommandPaletteRowChromeIsCompactButKeepsHitTargetProtection() {
+        XCTAssertLessThan(
+            QuillCodeMetrics.commandPaletteRowVerticalPadding,
+            12,
+            "Command palette rows should keep Codex-like visual density; hit-target size comes from quillCodeFullRowButtonTarget."
+        )
+        XCTAssertGreaterThanOrEqual(
+            QuillCodeMetrics.minimumHitTarget,
+            40,
+            "Tighter visible row padding must not weaken the shared native hit-target minimum."
+        )
+        XCTAssertLessThanOrEqual(
+            QuillCodeMetrics.commandPaletteRowRadius,
+            9,
+            "Command palette rows should avoid oversized card-like corners."
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityNativePrimaryChromeHitTargetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityNativePrimaryChromeHitTargetGateTests.swift
@@ -55,7 +55,7 @@ final class ParityNativePrimaryChromeHitTargetGateTests: QuillCodeParityTestCase
         }
         Self.assertSource(searchDialogText, contains: ".quillCodeFullRowButtonTarget(radius: 12)")
         Self.assertSource(searchDialogText, contains: ".quillCodeTextEntryTarget()")
-        Self.assertSource(commandPaletteText, contains: ".quillCodeFullRowButtonTarget(radius: 12)")
+        Self.assertSource(commandPaletteText, contains: ".quillCodeFullRowButtonTarget(radius: QuillCodeMetrics.commandPaletteRowRadius)")
         Self.assertSource(commandPaletteText, contains: ".quillCodeTextEntryTarget()")
         Self.assertSource(dialogChromeText, contains: ".quillCodeTextButtonTarget()")
         for expected in [

--- a/Tests/QuillCodeParityTests/ParityWorkspaceCommandPaletteContractGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceCommandPaletteContractGateTests.swift
@@ -47,4 +47,23 @@ final class ParityWorkspaceCommandPaletteContractGateTests: QuillCodeParityTestC
             "testWorkspaceCommandSurfaceDecodesOlderPayloadWithoutCategoryMetadata"
         ])
     }
+
+    func testCommandPaletteRowsUseNamedDenseChromeMetrics() throws {
+        let dialogText = try Self.appSourceText(named: "QuillCodeCommandPaletteDialog.swift")
+        let designText = try Self.appSourceText(named: "QuillCodeDesignSystem.swift")
+        let densityTests = try Self.appTestSourceText(named: "QuillCodeCommandPaletteDensityTests.swift")
+
+        Self.assertSource(designText, containsAll: [
+            "static let commandPaletteRowHorizontalPadding: CGFloat = 10",
+            "static let commandPaletteRowVerticalPadding: CGFloat = 7",
+            "static let commandPaletteRowRadius: CGFloat = 9"
+        ])
+        Self.assertSource(dialogText, containsAll: [
+            ".padding(.horizontal, QuillCodeMetrics.commandPaletteRowHorizontalPadding)",
+            ".padding(.vertical, QuillCodeMetrics.commandPaletteRowVerticalPadding)",
+            ".quillCodeFullRowButtonTarget(radius: QuillCodeMetrics.commandPaletteRowRadius)"
+        ])
+        Self.assertSource(dialogText, excludes: ".padding(12)")
+        Self.assertSource(densityTests, contains: "testCommandPaletteRowChromeIsCompactButKeepsHitTargetProtection")
+    }
 }


### PR DESCRIPTION
## Summary
- add named command-palette row chrome metrics
- tighten visible command palette row padding/radius toward Codex-like density
- keep the shared full-row hit-target contract and add focused density/parity coverage

## Validation
- swift test --filter QuillCodeCommandPaletteDensityTests
- swift test --filter ParityWorkspaceCommandPaletteContractGateTests
- swift test --filter ParityNativePrimaryChromeHitTargetGateTests
- swift test