### PR TITLE
Add project move up and down actions

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -11913,6 +11913,10 @@
     }
 
     function projectActionsFor(project = {}) {
+      const projects = state.projects.items || [];
+      const index = projects.findIndex(item => item.id === project.id);
+      const canMoveUp = index > 0;
+      const canMoveDown = index >= 0 && index < projects.length - 1;
       return [
         { id: 'new-chat', title: 'New chat' },
         {
@@ -11920,6 +11924,24 @@
           title: 'Refresh context',
           isEnabled: true,
           disabledReason: ''
+        },
+        {
+          id: 'move-to-top',
+          title: 'Move to top',
+          isEnabled: canMoveUp,
+          disabledReason: canMoveUp ? '' : 'Already at the top'
+        },
+        {
+          id: 'move-up',
+          title: 'Move up',
+          isEnabled: canMoveUp,
+          disabledReason: canMoveUp ? '' : 'Already at the top'
+        },
+        {
+          id: 'move-down',
+          title: 'Move down',
+          isEnabled: canMoveDown,
+          disabledReason: canMoveDown ? '' : 'Already at the bottom'
         },
         { id: 'rename', title: 'Rename' },
         { id: 'remove', title: 'Remove from list' }
@@ -12269,6 +12291,26 @@
       if (action === 'refresh-context') {
         selectProject(projectID);
         addMessage('assistant', `Refreshed project context for ${project.name}.`);
+        render();
+        return;
+      }
+      if (['move-to-top', 'move-up', 'move-down'].includes(action)) {
+        const previousLocation = currentWorkspaceLocation();
+        const currentIndex = state.projects.items.findIndex(item => item.id === projectID);
+        if (currentIndex < 0) return;
+        const nextItems = state.projects.items.slice();
+        if (action === 'move-to-top' && currentIndex > 0) {
+          nextItems.splice(currentIndex, 1);
+          nextItems.unshift(project);
+        } else if (action === 'move-up' && currentIndex > 0) {
+          [nextItems[currentIndex - 1], nextItems[currentIndex]] = [nextItems[currentIndex], nextItems[currentIndex - 1]];
+        } else if (action === 'move-down' && currentIndex < nextItems.length - 1) {
+          [nextItems[currentIndex + 1], nextItems[currentIndex]] = [nextItems[currentIndex], nextItems[currentIndex + 1]];
+        } else {
+          return;
+        }
+        state.projects.items = nextItems;
+        recordWorkspaceNavigation(previousLocation);
         render();
         return;
       }

--- a/E2E/playwright/tests/sidebar-projects.spec.ts
+++ b/E2E/playwright/tests/sidebar-projects.spec.ts
@@ -16,6 +16,11 @@ test('mock harness manages projects from the sidebar', async ({ page }) => {
   await clickSidebarTool(page, 'terminal-button');
   await expect(page.getByTestId('terminal-cwd')).toHaveText('/mock/example-2');
 
+  await clickProjectAction(page.getByTestId('project-row').first(), 'Move down');
+  await expect(page.getByTestId('project-item').first()).toContainText('QuillCode');
+  await clickProjectAction(page.getByTestId('project-row').nth(1), 'Move up');
+  await expect(page.getByTestId('project-item').first()).toContainText('Example Project 2');
+
   const activeProjectRow = page.getByTestId('project-row').first();
   page.once('dialog', async dialog => {
     expect(dialog.message()).toContain('Rename project');

--- a/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
@@ -65,8 +65,7 @@ struct WorkspaceNavigationSurfaceBuilder {
     }
 
     private func projectItems() -> [ProjectItemSurface] {
-        let sortedProjects = projects
-            .sorted { $0.lastOpenedAt > $1.lastOpenedAt }
+        let sortedProjects = WorkspaceProjectEngine.displayOrderedProjects(projects)
         return sortedProjects.enumerated().map { index, project in
             ProjectItemSurface(
                 project: project,

--- a/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
@@ -51,6 +51,10 @@ enum WorkspaceProjectError: Error, Equatable, Sendable {
 enum WorkspaceProjectEngine {
     static let invalidSSHAddressMessage = "Use SSH format user@host:/path or ssh://user@host/path."
 
+    static func displayOrderedProjects(_ projects: [ProjectRef]) -> [ProjectRef] {
+        projects.sorted(by: isEarlierInDisplayOrder)
+    }
+
     @discardableResult
     static func upsertLocalProject(
         path: URL,
@@ -206,7 +210,7 @@ enum WorkspaceProjectEngine {
         projects: inout [ProjectRef],
         now: Date = Date()
     ) -> Bool {
-        var ordered = projects.sorted { $0.lastOpenedAt > $1.lastOpenedAt }
+        var ordered = displayOrderedProjects(projects)
         guard let sourceIndex = ordered.firstIndex(where: { $0.id == id }) else {
             return false
         }
@@ -266,6 +270,13 @@ enum WorkspaceProjectEngine {
 
     private static func instructionDiagnosticIDs(for instructions: [ProjectInstruction]) -> Set<String> {
         Set(ProjectInstructionDiagnosticsBuilder.diagnostics(for: instructions).map(\.id))
+    }
+
+    private static func isEarlierInDisplayOrder(_ lhs: ProjectRef, _ rhs: ProjectRef) -> Bool {
+        if lhs.lastOpenedAt != rhs.lastOpenedAt {
+            return lhs.lastOpenedAt > rhs.lastOpenedAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
     }
 
     static func knownProjectID(_ id: UUID?, projects: [ProjectRef]) -> UUID? {

--- a/Tests/QuillCodeAppTests/QuillCodeProjectListSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeProjectListSurfaceTests.swift
@@ -28,6 +28,25 @@ final class QuillCodeProjectListSurfaceTests: XCTestCase {
         XCTAssertEqual(item.actions.first?.id, "\(projectID.uuidString)-newChat")
     }
 
+    func testProjectItemSurfaceDisablesUnavailableMoveActions() {
+        let project = ProjectRef(name: "QuillCode", path: "/repo")
+
+        let item = ProjectItemSurface(
+            project: project,
+            selectedProjectID: nil,
+            canMoveToTop: false,
+            canMoveUp: false,
+            canMoveDown: false
+        )
+
+        XCTAssertEqual(item.actions.first { $0.kind == .moveToTop }?.isEnabled, false)
+        XCTAssertEqual(item.actions.first { $0.kind == .moveToTop }?.disabledReason, "Already at the top")
+        XCTAssertEqual(item.actions.first { $0.kind == .moveUp }?.isEnabled, false)
+        XCTAssertEqual(item.actions.first { $0.kind == .moveUp }?.disabledReason, "Already at the top")
+        XCTAssertEqual(item.actions.first { $0.kind == .moveDown }?.isEnabled, false)
+        XCTAssertEqual(item.actions.first { $0.kind == .moveDown }?.disabledReason, "Already at the bottom")
+    }
+
     func testProjectItemSurfaceDecodesOlderPayloadWithoutRemoteMetadataOrActions() throws {
         let projectID = UUID()
         let json = """

--- a/Tests/QuillCodeAppTests/WorkspaceProjectEngineTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProjectEngineTests.swift
@@ -168,6 +168,72 @@ final class WorkspaceProjectEngineTests: XCTestCase {
         XCTAssertEqual(projects[0].lastOpenedAt, secondDate)
     }
 
+    func testDisplayOrderedProjectsUsesLastOpenedThenStableIDTieBreak() throws {
+        let lowerID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
+        let higherID = try XCTUnwrap(UUID(uuidString: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"))
+        let older = ProjectRef(
+            name: "Older",
+            path: "/older",
+            lastOpenedAt: Date(timeIntervalSince1970: 10)
+        )
+        let lower = ProjectRef(
+            id: lowerID,
+            name: "Lower",
+            path: "/lower",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+        let higher = ProjectRef(
+            id: higherID,
+            name: "Higher",
+            path: "/higher",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        XCTAssertEqual(
+            WorkspaceProjectEngine.displayOrderedProjects([older, higher, lower]).map(\.id),
+            [lowerID, higherID, older.id]
+        )
+    }
+
+    func testMoveProjectUpAndDownSwapsDisplayNeighbors() {
+        let oldest = ProjectRef(
+            name: "Oldest",
+            path: "/oldest",
+            lastOpenedAt: Date(timeIntervalSince1970: 10)
+        )
+        let middle = ProjectRef(
+            name: "Middle",
+            path: "/middle",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+        let newest = ProjectRef(
+            name: "Newest",
+            path: "/newest",
+            lastOpenedAt: Date(timeIntervalSince1970: 30)
+        )
+        var projects = [oldest, middle, newest]
+
+        XCTAssertFalse(WorkspaceProjectEngine.moveProject(newest.id, direction: .up, projects: &projects))
+        XCTAssertTrue(WorkspaceProjectEngine.moveProject(middle.id, direction: .up, projects: &projects))
+        XCTAssertEqual(
+            WorkspaceProjectEngine.displayOrderedProjects(projects).map(\.id),
+            [middle.id, newest.id, oldest.id]
+        )
+
+        XCTAssertTrue(WorkspaceProjectEngine.moveProject(middle.id, direction: .down, projects: &projects))
+        XCTAssertEqual(
+            WorkspaceProjectEngine.displayOrderedProjects(projects).map(\.id),
+            [newest.id, middle.id, oldest.id]
+        )
+
+        XCTAssertTrue(WorkspaceProjectEngine.moveProject(middle.id, direction: .down, projects: &projects))
+        XCTAssertEqual(
+            WorkspaceProjectEngine.displayOrderedProjects(projects).map(\.id),
+            [newest.id, oldest.id, middle.id]
+        )
+        XCTAssertFalse(WorkspaceProjectEngine.moveProject(middle.id, direction: .down, projects: &projects))
+    }
+
     func testSelectionAfterSelectingProjectUsesNewestUnarchivedThread() {
         let project = ProjectRef(name: "One", path: "/tmp/one")
         let otherProject = ProjectRef(name: "Two", path: "/tmp/two")

--- a/Tests/QuillCodeAppTests/WorkspaceSidebarRowActionPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSidebarRowActionPlannerTests.swift
@@ -117,6 +117,38 @@ final class WorkspaceSidebarRowActionPlannerTests: XCTestCase {
         XCTAssertNil(model.root.threads.first?.projectID)
     }
 
+    @MainActor
+    func testExecutorMovesProjectsUpAndDownThroughWorkspaceModel() {
+        let oldestProject = ProjectRef(
+            name: "Oldest",
+            path: "/oldest",
+            lastOpenedAt: Date(timeIntervalSince1970: 10)
+        )
+        let middleProject = ProjectRef(
+            name: "Middle",
+            path: "/middle",
+            lastOpenedAt: Date(timeIntervalSince1970: 20)
+        )
+        let newestProject = ProjectRef(
+            name: "Newest",
+            path: "/newest",
+            lastOpenedAt: Date(timeIntervalSince1970: 30)
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            projects: [oldestProject, middleProject, newestProject],
+            selectedProjectID: middleProject.id
+        ))
+
+        XCTAssertTrue(WorkspaceSidebarRowMutationExecutor.execute(.moveUp(middleProject.id), model: model))
+        XCTAssertEqual(model.surface().projects.items.map(\.id), [middleProject.id, newestProject.id, oldestProject.id])
+
+        XCTAssertTrue(WorkspaceSidebarRowMutationExecutor.execute(.moveDown(middleProject.id), model: model))
+        XCTAssertEqual(model.surface().projects.items.map(\.id), [newestProject.id, middleProject.id, oldestProject.id])
+
+        XCTAssertTrue(WorkspaceSidebarRowMutationExecutor.execute(.moveDown(middleProject.id), model: model))
+        XCTAssertEqual(model.surface().projects.items.map(\.id), [newestProject.id, oldestProject.id, middleProject.id])
+    }
+
     private func makePlanner(
         thread: ChatThread? = nil,
         project: ProjectRef? = nil

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -59,6 +59,8 @@ final class WorkspaceSurfaceTests: XCTestCase {
             surface.projects.items[0].actions.first { $0.kind == .moveToTop }?.disabledReason,
             "Already at the top"
         )
+        XCTAssertEqual(surface.projects.items[0].actions.first { $0.kind == .moveUp }?.isEnabled, false)
+        XCTAssertEqual(surface.projects.items[0].actions.first { $0.kind == .moveDown }?.isEnabled, false)
         XCTAssertEqual(surface.sidebar.items.count, 1)
         XCTAssertEqual(surface.sidebar.items[0].title, "Run whoami")
         XCTAssertTrue(surface.sidebar.items[0].isSelected)


### PR DESCRIPTION
## Summary
- add Move up and Move down actions to project rows alongside Move to top
- centralize deterministic project display ordering in WorkspaceProjectEngine
- wire Swift surfaces, row-action planner/executor, E2E harness behavior, and parity docs

## Validation
- swift test --filter 'QuillCodeProjectListSurfaceTests|WorkspaceNavigationSurfaceBuilderTests|WorkspaceSidebarRowActionPlannerTests|WorkspaceSurfaceTests|WorkspaceProjectEngineTests'
- python3 scripts/grade-code-quality.py
- git diff --check
- swift test
- cd E2E/playwright && npx playwright test tests/sidebar-projects.spec.ts
- cd E2E/playwright && npm test