### PR TITLE
Keep shortcut search action scoped

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
+++ b/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
@@ -13,7 +13,7 @@ struct QuillCodeKeyboardShortcutsView: View {
     }
 
     private var groups: [WorkspaceCommandGroupSurface] {
-        WorkspaceCommandPalette.groupedCommands(shortcutCommands, matching: query)
+        WorkspaceCommandPalette.groupedActionCommands(shortcutCommands, matching: query)
     }
 
     var body: some View {

--- a/Sources/QuillCodeApp/WorkspaceCommandPaletteRanker.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPaletteRanker.swift
@@ -5,7 +5,20 @@ enum WorkspaceCommandPaletteRanker {
         _ commands: [WorkspaceCommandSurface],
         matching query: String
     ) -> [WorkspaceCommandSurface] {
-        let request = QueryRequest(query)
+        rankedCommands(commands, request: QueryRequest(query))
+    }
+
+    static func rankedActionCommands(
+        _ commands: [WorkspaceCommandSurface],
+        matching query: String
+    ) -> [WorkspaceCommandSurface] {
+        rankedCommands(commands, request: QueryRequest(scope: .actions, rawQuery: query))
+    }
+
+    private static func rankedCommands(
+        _ commands: [WorkspaceCommandSurface],
+        request: QueryRequest
+    ) -> [WorkspaceCommandSurface] {
         let searchableCommands = request.searchableCommands(from: commands)
         let scoredCommands = searchableCommands.enumerated().compactMap { index, command in
             score(command, query: request.normalizedQuery).map { score in
@@ -30,8 +43,21 @@ enum WorkspaceCommandPaletteRanker {
         _ commands: [WorkspaceCommandSurface],
         matching query: String
     ) -> [WorkspaceCommandGroupSurface] {
+        groupedCommands(rankedCommands(commands, matching: query))
+    }
+
+    static func groupedActionCommands(
+        _ commands: [WorkspaceCommandSurface],
+        matching query: String
+    ) -> [WorkspaceCommandGroupSurface] {
+        groupedCommands(rankedActionCommands(commands, matching: query))
+    }
+
+    private static func groupedCommands(
+        _ rankedCommands: [WorkspaceCommandSurface]
+    ) -> [WorkspaceCommandGroupSurface] {
         var groupsByCategory: [String: [WorkspaceCommandSurface]] = [:]
-        for command in rankedCommands(commands, matching: query) {
+        for command in rankedCommands {
             groupsByCategory[command.category, default: []].append(command)
         }
         return groupsByCategory.keys.sorted { lhs, rhs in
@@ -139,6 +165,11 @@ enum WorkspaceCommandPaletteRanker {
                 self.scope = .mixed
                 self.normalizedQuery = WorkspaceCommandPaletteRanker.normalize(trimmed)
             }
+        }
+
+        init(scope: Scope, rawQuery: String) {
+            self.scope = scope
+            self.normalizedQuery = WorkspaceCommandPaletteRanker.normalize(rawQuery)
         }
 
         func searchableCommands(from commands: [WorkspaceCommandSurface]) -> [WorkspaceCommandSurface] {

--- a/Sources/QuillCodeApp/WorkspaceCommandPaletteSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPaletteSurface.swift
@@ -288,4 +288,11 @@ public enum WorkspaceCommandPalette {
     ) -> [WorkspaceCommandGroupSurface] {
         WorkspaceCommandPaletteRanker.groupedCommands(commands, matching: query)
     }
+
+    public static func groupedActionCommands(
+        _ commands: [WorkspaceCommandSurface],
+        matching query: String
+    ) -> [WorkspaceCommandGroupSurface] {
+        WorkspaceCommandPaletteRanker.groupedActionCommands(commands, matching: query)
+    }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPaletteRankerTests.swift
@@ -62,6 +62,17 @@ final class WorkspaceCommandPaletteRankerTests: XCTestCase {
         XCTAssertFalse(actionResults.contains { $0.id.hasPrefix(SlashCommandCatalog.commandPaletteIDPrefix) })
     }
 
+    func testActionOnlyGroupingDoesNotTreatSlashPrefixAsSlashScope() {
+        let commands = QuillCodeWorkspaceModel().surface().commands
+        let shortcutCommands = commands.filter { $0.shortcut?.isEmpty == false }
+
+        let groups = WorkspaceCommandPalette.groupedActionCommands(shortcutCommands, matching: "/")
+
+        XCTAssertFalse(groups.isEmpty)
+        XCTAssertFalse(groups.flatMap(\.commands).contains { $0.id.hasPrefix(SlashCommandCatalog.commandPaletteIDPrefix) })
+        XCTAssertTrue(groups.flatMap(\.commands).contains { $0.id == "keyboard-shortcuts" })
+    }
+
     func testMixedScopeAddsSlashCommandsOnlyForNonEmptyQueries() {
         let commands = QuillCodeWorkspaceModel().surface().commands
 

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -51,7 +51,7 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         Self.assertSource(searchShortcutText, contains: "struct QuillCodeKeyboardShortcutsView")
         Self.assertSource(searchShortcutText, contains: "TextField(\"Search shortcuts\"")
         Self.assertSource(searchShortcutText, contains: "accessibilityIdentifier(\"quillcode-shortcuts-search-input\")")
-        Self.assertSource(searchShortcutText, contains: "WorkspaceCommandPalette.groupedCommands(shortcutCommands, matching: query)")
+        Self.assertSource(searchShortcutText, contains: "WorkspaceCommandPalette.groupedActionCommands(shortcutCommands, matching: query)")
         Self.assertSource(worktreeDialogsText, contains: "struct QuillCodeWorktreeCreateView")
         Self.assertSource(worktreeDialogsText, contains: "struct QuillCodeWorktreeRemoveView")
         Self.assertSource(worktreeCoordinatorText, contains: "final class QuillCodeWorktreeDialogCoordinator")


### PR DESCRIPTION
## Summary\n- add explicit action-only command grouping for surfaces that should never search slash commands\n- switch the native Keyboard Shortcuts sheet to the action-only grouping path\n- cover the / query edge case so shortcut search cannot leak slash command rows\n\n## Validation\n- swift test --filter 'WorkspaceCommandPaletteRankerTests|ParityWorkspaceSettingsSheetGateTests'\n- npm test -- tests/shortcuts.spec.ts (from E2E/playwright)\n- git diff --check