### PR TITLE
Make workspace modals dismiss with Escape

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeWorkspaceSheets.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceSheets.swift
@@ -153,6 +153,7 @@ struct QuillCodeWorkspaceSheetsModifier: ViewModifier {
                 .accessibilityAddTraits(.isModal)
         }
         .transition(.opacity.combined(with: .scale(scale: 0.985)))
+        .onExitCommand(perform: onDismiss)
     }
 
     @ViewBuilder

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -61,6 +61,8 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         Self.assertSource(worktreeTasksText, contains: "final class QuillCodeWorktreeDialogTasks")
         Self.assertSource(worktreeTasksText, contains: "private enum Slot")
         Self.assertSource(worktreeTasksText, contains: "private var runningTasks: [Slot: Task<Void, Never>]")
+        Self.assertSource(sheetsText, contains: ".onTapGesture(perform: onDismiss)")
+        Self.assertSource(sheetsText, contains: ".onExitCommand(perform: onDismiss)")
         Self.assertSource(worktreeDialogsText, excludes: "struct QuillCodeWorktreeCreateDraft")
         Self.assertSource(worktreeDialogsText, excludes: "struct QuillCodeWorktreeChoiceSection")
         Self.assertSource(worktreeDialogsText, excludes: "struct QuillCodeWorktreeDialogFrame")


### PR DESCRIPTION
## Summary
- Add shared Escape/cancel handling to the workspace modal wrapper.
- Keep click-outside and Escape dismissal together in the same source-gated contract.
- Extend the settings/sheet parity gate so the modal escape path cannot regress.

## Validation
- swift test --filter 'ParityWorkspaceSettingsSheetGateTests|QuillCodeNativeHitTargetSurfaceAuditTests'
- git diff --check