### PR TITLE
Match compact model search aliases

### DIFF
--- a/Sources/QuillCodeApp/ModelCategorySearchFilter.swift
+++ b/Sources/QuillCodeApp/ModelCategorySearchFilter.swift
@@ -13,7 +13,11 @@ enum ModelCategorySearchFilter {
             }
             let models = category.models.filter { option in
                 let haystack = searchableText(for: option, in: category).lowercased()
-                return terms.allSatisfy { haystack.contains($0) }
+                let compactHaystack = compactSearchText(haystack)
+                return terms.allSatisfy { term in
+                    let compactTerm = compactSearchText(term)
+                    return haystack.contains(term) || (!compactTerm.isEmpty && compactHaystack.contains(compactTerm))
+                }
             }
             guard !models.isEmpty else {
                 return nil
@@ -71,5 +75,13 @@ enum ModelCategorySearchFilter {
                 row.label == "State" ? "state \(row.value)" : row.value
             }
             .joined(separator: " ")
+    }
+
+    private static func compactSearchText(_ text: String) -> String {
+        let scalars = text
+            .lowercased()
+            .unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+        return String(String.UnicodeScalarView(scalars))
     }
 }

--- a/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
@@ -232,6 +232,45 @@ final class QuillCodeTopBarSurfaceTests: XCTestCase {
         )
     }
 
+    func testModelCategorySearchFilterMatchesCompactProviderModelAliases() {
+        let categories = [
+            ModelCategorySurface(category: "Coding", models: [
+                modelOption(
+                    id: "deepseek/deepseek-v4-flash",
+                    provider: "deepseek",
+                    displayName: "DeepSeek V4 Flash",
+                    category: "Coding"
+                ),
+                modelOption(
+                    id: "moonshotai/kimi-k2.6",
+                    provider: "moonshotai",
+                    displayName: "Kimi K2.6",
+                    category: "Coding"
+                ),
+                modelOption(
+                    id: TrustedRouterDefaults.minimaxM3Model,
+                    provider: "minimax",
+                    displayName: "MiniMax M3",
+                    category: "minimax"
+                )
+            ])
+        ]
+
+        XCTAssertEqual(
+            ModelCategorySearchFilter.filter(categories, matching: "deepseekv4flash").flatMap(\.models).map(\.id),
+            ["deepseek/deepseek-v4-flash"]
+        )
+        XCTAssertEqual(
+            ModelCategorySearchFilter.filter(categories, matching: "kimi k26").flatMap(\.models).map(\.id),
+            ["moonshotai/kimi-k2.6"]
+        )
+        XCTAssertEqual(
+            ModelCategorySearchFilter.filter(categories, matching: "minimaxm3").flatMap(\.models).map(\.id),
+            [TrustedRouterDefaults.minimaxM3Model]
+        )
+        XCTAssertTrue(ModelCategorySearchFilter.filter(categories, matching: "! @").isEmpty)
+    }
+
     func testModelOptionBuildsTrustedRouterRecommendedMetadata() throws {
         let option = modelOption(
             id: TrustedRouterDefaults.defaultModel,


### PR DESCRIPTION
## Summary
- Let model-picker search match compact alphanumeric aliases such as deepseekv4flash, kimi k26, and minimaxm3.
- Keep normal provider/category/model/capability search behavior intact.
- Add focused top-bar/model-picker tests for compact TrustedRouter-style model names.

## Validation
- swift test --filter 'QuillCodeTopBarSurfaceTests|WorkspaceModelPickerSurfaceIntegrationTests|ParityTopBarSurfaceGateTests'
- git diff --check