### PR TITLE
Summarize model picker result scope

### DIFF
--- a/Sources/QuillCodeApp/ModelCategorySearchFilter.swift
+++ b/Sources/QuillCodeApp/ModelCategorySearchFilter.swift
@@ -26,6 +26,27 @@ enum ModelCategorySearchFilter {
         }
     }
 
+    static func scopeSummary(for categories: [ModelCategorySurface]) -> String? {
+        let categoryNames = orderedUnique(categories.map(\.category), limit: 3)
+        let providerNames = orderedUnique(categories.flatMap { $0.models.map(\.provider) }, limit: 3)
+        let categoryText = listSummary(categoryNames, overflow: overflowCount(in: categories.map(\.category), limit: 3))
+        let providerText = listSummary(
+            providerNames,
+            overflow: overflowCount(in: categories.flatMap { $0.models.map(\.provider) }, limit: 3)
+        )
+
+        switch (categoryText, providerText) {
+        case let (category?, provider?):
+            return "Categories: \(category) · Providers: \(provider)"
+        case let (category?, nil):
+            return "Categories: \(category)"
+        case let (nil, provider?):
+            return "Providers: \(provider)"
+        case (nil, nil):
+            return nil
+        }
+    }
+
     private static func normalizedTerms(from query: String) -> [String] {
         query
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -83,5 +104,38 @@ enum ModelCategorySearchFilter {
             .unicodeScalars
             .filter { CharacterSet.alphanumerics.contains($0) }
         return String(String.UnicodeScalarView(scalars))
+    }
+
+    private static func orderedUnique(_ values: [String], limit: Int) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let key = trimmed.lowercased()
+            guard seen.insert(key).inserted else { continue }
+            result.append(trimmed)
+            if result.count == limit { break }
+        }
+        return result
+    }
+
+    private static func overflowCount(in values: [String], limit: Int) -> Int {
+        var seen = Set<String>()
+        var count = 0
+        for value in values {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            if seen.insert(trimmed.lowercased()).inserted {
+                count += 1
+            }
+        }
+        return max(0, count - limit)
+    }
+
+    private static func listSummary(_ values: [String], overflow: Int) -> String? {
+        guard !values.isEmpty else { return nil }
+        let suffix = overflow > 0 ? " +\(overflow) more" : ""
+        return values.joined(separator: ", ") + suffix
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
@@ -161,23 +161,32 @@ struct QuillCodeModelPickerView: View {
     }
 
     private var resultSummary: some View {
-        HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
-            Text(resultSummaryText)
-                .font(.caption.weight(.medium))
-                .foregroundStyle(QuillCodePalette.muted)
-                .lineLimit(1)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: QuillCodeMetrics.controlClusterSpacing) {
+                Text(resultSummaryText)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .lineLimit(1)
 
-            Spacer(minLength: 8)
+                Spacer(minLength: 8)
 
-            if !searchText.isEmpty {
-                Button("Clear") {
-                    clearSearch()
+                if !searchText.isEmpty {
+                    Button("Clear") {
+                        clearSearch()
+                    }
+                    .font(.caption.weight(.semibold))
+                    .buttonStyle(QuillCodePressableButtonStyle())
+                    .foregroundStyle(QuillCodePalette.blue)
+                    .quillCodeTextButtonTarget(minWidth: 56)
+                    .help("Clear model search")
                 }
-                .font(.caption.weight(.semibold))
-                .buttonStyle(QuillCodePressableButtonStyle())
-                .foregroundStyle(QuillCodePalette.blue)
-                .quillCodeTextButtonTarget(minWidth: 56)
-                .help("Clear model search")
+            }
+            if let scopeSummary = topBar.filteredModelScopeSummary(matching: searchText), !filteredCategories.isEmpty {
+                Text(scopeSummary)
+                    .font(.caption2)
+                    .foregroundStyle(QuillCodePalette.muted.opacity(0.86))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarSurface.swift
@@ -120,6 +120,10 @@ public struct TopBarSurface: Codable, Sendable, Hashable {
     public func filteredModelCategories(matching query: String) -> [ModelCategorySurface] {
         ModelCategorySearchFilter.filter(modelCategories, matching: query)
     }
+
+    public func filteredModelScopeSummary(matching query: String) -> String? {
+        ModelCategorySearchFilter.scopeSummary(for: filteredModelCategories(matching: query))
+    }
 }
 
 public enum TopBarLiveWorkTone: String, Codable, Sendable, Hashable {

--- a/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeTopBarSurfaceTests.swift
@@ -96,6 +96,49 @@ final class QuillCodeTopBarSurfaceTests: XCTestCase {
         XCTAssertTrue(topBar.filteredModelCategories(matching: "does-not-exist").isEmpty)
     }
 
+    func testTopBarSummarizesFilteredModelScope() {
+        let topBar = TopBarSurface(
+            appName: "QuillCode",
+            primaryTitle: "Project",
+            subtitle: "Ready",
+            instructionLabel: "Instructions",
+            instructionSources: [],
+            memoryLabel: "Memory",
+            memorySources: [],
+            modelLabel: TrustedRouterDefaults.fastModelDisplayName,
+            selectedModelID: TrustedRouterDefaults.defaultModel,
+            modelCategories: [
+                ModelCategorySurface(category: "Coding", models: [
+                    modelOption(id: "acme/code-pro", provider: "acme", displayName: "Code Pro", category: "Coding"),
+                    modelOption(id: "deepseek/deepseek-v4-flash", provider: "deepseek", displayName: "DeepSeek V4 Flash", category: "Coding")
+                ]),
+                ModelCategorySurface(category: "Research", models: [
+                    modelOption(id: "moonshotai/kimi-k2.6", provider: "moonshotai", displayName: "Kimi K2.6", category: "Research")
+                ]),
+                ModelCategorySurface(category: "Vision", models: [
+                    modelOption(id: "minimax/vision", provider: "minimax", displayName: "MiniMax Vision", category: "Vision")
+                ]),
+                ModelCategorySurface(category: "Audio", models: [
+                    modelOption(id: "z-ai/audio", provider: "z-ai", displayName: "Z Audio", category: "Audio")
+                ])
+            ],
+            modeLabel: "Auto",
+            agentStatus: "Idle",
+            computerUseLabel: "Computer Use Ready",
+            showsComputerUseSetup: false
+        )
+
+        XCTAssertEqual(
+            topBar.filteredModelScopeSummary(matching: ""),
+            "Categories: Coding, Research, Vision +1 more · Providers: acme, deepseek, moonshotai +2 more"
+        )
+        XCTAssertEqual(
+            topBar.filteredModelScopeSummary(matching: "deepseekv4flash"),
+            "Categories: Coding · Providers: deepseek"
+        )
+        XCTAssertNil(topBar.filteredModelScopeSummary(matching: "does-not-exist"))
+    }
+
     func testHTMLTopBarRendersLiveWorkChip() {
         let topBar = TopBarSurface(
             appName: "QuillCode",

--- a/Tests/QuillCodeParityTests/ParityTopBarSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTopBarSurfaceGateTests.swift
@@ -68,6 +68,7 @@ final class ParityTopBarSurfaceGateTests: QuillCodeParityTestCase {
             "public struct ModelMetadataRowSurface",
             "public struct ModelOptionSurface",
             "filteredModelCategories",
+            "filteredModelScopeSummary",
             "ModelCategorySearchFilter.filter"
         ].forEach { Self.assertSource(source, contains: $0) }
     }
@@ -76,6 +77,7 @@ final class ParityTopBarSurfaceGateTests: QuillCodeParityTestCase {
         [
             "enum ModelCategorySearchFilter",
             "static func filter(",
+            "static func scopeSummary(",
             "normalizedTerms"
         ].forEach { Self.assertSource(source, contains: $0) }
     }


### PR DESCRIPTION
## Summary
- Add a tested model-search scope summary for matching categories and providers.
- Render that summary under the model-picker result count so broad searches explain what catalog area is visible.
- Keep provider/category summary logic in the surface/search-filter layer instead of the SwiftUI view.

## Validation
- swift test --filter 'QuillCodeTopBarSurfaceTests|WorkspaceModelPickerSurfaceIntegrationTests|ParityTopBarSurfaceGateTests'
- git diff --check