### PR TITLE
Harden project remove slash flow

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -16483,6 +16483,12 @@
     }
 
     function runInstantViewSlashCommand(text) {
+      const projectCommandID = instantProjectSlashCommandID(text);
+      if (projectCommandID) {
+        runInstantSlashCommand(text, projectCommandID);
+        return true;
+      }
+
       const commandID = /^\/(focus|composer|input)\b/i.test(text)
         ? 'focus-composer'
         : /^\/(retry|rerun|again)\b/i.test(text)
@@ -16509,6 +16515,22 @@
       if (!commandID) return false;
       runInstantSlashCommand(text, commandID);
       return true;
+    }
+
+    function instantProjectSlashCommandID(text) {
+      const match = String(text || '').trim().match(/^\/project\s+(\S+)/i);
+      if (!match) return null;
+      const subcommand = match[1].toLowerCase();
+      if (['open', 'add'].includes(subcommand)) return 'add-project';
+      if (['new', 'new-chat', 'chat'].includes(subcommand)) return 'project-new-chat';
+      if (['refresh', 'reload', 'context'].includes(subcommand)) return 'project-refresh-context';
+      if (['init', 'initialize', 'agents', 'agents.md'].includes(subcommand)) return 'project-init';
+      if (['top', 'move-top', 'move-to-top'].includes(subcommand)) return 'project-move-to-top';
+      if (['up', 'move-up'].includes(subcommand)) return 'project-move-up';
+      if (['down', 'move-down'].includes(subcommand)) return 'project-move-down';
+      if (['bottom', 'move-bottom', 'move-to-bottom'].includes(subcommand)) return 'project-move-to-bottom';
+      if (['remove', 'forget', 'delete'].includes(subcommand)) return 'project-remove';
+      return null;
     }
 
     function runInstantSlashCommand(text, commandID) {

--- a/E2E/playwright/tests/composer-slash.spec.ts
+++ b/E2E/playwright/tests/composer-slash.spec.ts
@@ -37,6 +37,17 @@ test('mock harness routes slash commands to workspace actions', async ({ page })
   await expect(page.getByTestId('project-item').first()).toContainText('Example Project');
   await expect(page.getByTestId('top-bar-subtitle')).toContainText('Example Project');
 
+  await page.getByLabel('Message').fill('/project remove');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('project-item')).toHaveCount(1);
+  await expect(page.getByTestId('project-item').first()).toContainText('QuillCode');
+  await expect(page.getByTestId('project-count')).toHaveText('1 project');
+
+  await page.getByLabel('Message').fill('/project open');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('project-item').first()).toContainText('Example Project');
+  await expect(page.getByTestId('top-bar-subtitle')).toContainText('Example Project');
+
   await page.getByLabel('Message').fill('/worktree create slash-worktree --branch slash/demo --base main');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('project-item').first()).toContainText('slash-worktree');

--- a/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
@@ -155,7 +155,11 @@ enum WorkspaceProjectEngine {
             changedThreadIDs.append(threads[threadIndex].id)
         }
 
-        let nextSelection = selectedProjectID == id ? nil : knownProjectID(selectedProjectID, projects: projects)
+        let nextSelection = if selectedProjectID == id {
+            projects.isEmpty ? nil : projects[min(index, projects.count - 1)].id
+        } else {
+            knownProjectID(selectedProjectID, projects: projects)
+        }
         return WorkspaceProjectRemovalResult(
             selectedProjectID: nextSelection,
             changedThreadIDs: changedThreadIDs

--- a/Tests/QuillCodeAppTests/WorkspaceProjectEngineTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProjectEngineTests.swift
@@ -391,7 +391,7 @@ final class WorkspaceProjectEngineTests: XCTestCase {
         XCTAssertEqual(projects[0].lastOpenedAt, renamedAt)
     }
 
-    func testRemoveProjectClearsThreadOwnershipAndSanitizesSelection() {
+    func testRemoveProjectClearsThreadOwnershipAndFallsBackToNextProjectSelection() {
         let removedProject = ProjectRef(name: "Remove", path: "/tmp/remove")
         let keptProject = ProjectRef(name: "Keep", path: "/tmp/keep")
         let affectedThread = ChatThread(title: "Affected", projectID: removedProject.id)
@@ -406,7 +406,7 @@ final class WorkspaceProjectEngineTests: XCTestCase {
             selectedProjectID: removedProject.id
         )
 
-        XCTAssertEqual(result?.selectedProjectID, nil)
+        XCTAssertEqual(result?.selectedProjectID, keptProject.id)
         XCTAssertEqual(result?.changedThreadIDs, [affectedThread.id])
         XCTAssertEqual(projects.map(\.id), [keptProject.id])
         XCTAssertNil(threads.first { $0.id == affectedThread.id }?.projectID)

--- a/Tests/QuillCodeAppTests/WorkspaceSlashCommandIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSlashCommandIntegrationTests.swift
@@ -130,6 +130,22 @@ final class WorkspaceSlashCommandIntegrationTests: XCTestCase {
         XCTAssertEqual(model.currentToolCards.last?.title, ToolDefinition.gitWorktreeRemove.name)
     }
 
+    func testSlashProjectRemoveForgetsSelectedProjectWithoutDeletingFiles() async throws {
+        let firstRoot = try makeQuillCodeTestDirectory()
+        let secondRoot = try makeQuillCodeTestDirectory()
+        let model = QuillCodeWorkspaceModel()
+        let firstProjectID = model.addProject(path: firstRoot, name: "First Project")
+        let secondProjectID = model.addProject(path: secondRoot, name: "Second Project")
+        model.selectProject(secondProjectID)
+
+        model.setDraft("/project remove")
+        await model.submitComposer(workspaceRoot: secondRoot)
+
+        XCTAssertEqual(model.root.projects.map(\.id), [firstProjectID])
+        XCTAssertEqual(model.selectedProject?.id, firstProjectID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: secondRoot.path))
+    }
+
     private func worktreeCard(
         in model: QuillCodeWorkspaceModel,
         title: String


### PR DESCRIPTION
Adds regression coverage for removing the selected project through /project remove and keeps selection on the next available project instead of dropping to no project. Aligns the Playwright harness project slash dispatcher with native project command routing.

Validation:
- swift test --filter WorkspaceSlashCommandIntegrationTests
- npm test -- composer-slash.spec.ts
- git diff --check