### PR TITLE
Route project list in Playwright harness

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -4546,6 +4546,7 @@
         { id: 'project-move-up', title: 'Project: Move up', shortcut: '', category: 'Workspace', keywords: ['project', 'workspace', 'sidebar', 'reorder', 'up'], isEnabled: true },
         { id: 'project-move-down', title: 'Project: Move down', shortcut: '', category: 'Workspace', keywords: ['project', 'workspace', 'sidebar', 'reorder', 'down'], isEnabled: true },
         { id: 'project-move-to-bottom', title: 'Project: Move to bottom', shortcut: '', category: 'Workspace', keywords: ['project', 'workspace', 'sidebar', 'reorder', 'bottom', 'end'], isEnabled: true },
+        { id: 'project-list', title: 'List projects', shortcut: '', category: 'Workspace', keywords: ['project', 'workspace', 'list', 'show', 'registered'], isEnabled: true },
         { id: 'project-rename', title: 'Rename project', shortcut: '', category: 'Workspace', keywords: ['project', 'workspace', 'title', 'name'], isEnabled: true },
         { id: 'project-remove', title: 'Remove project from list', shortcut: '', category: 'Workspace', keywords: ['project', 'workspace', 'forget', 'remove'], isEnabled: true },
         { id: 'toggle-terminal', title: 'Terminal', shortcut: 'Ctrl+`', category: 'Workspace', keywords: ['shell', 'command', 'pty'], isEnabled: true },
@@ -4993,6 +4994,20 @@
     function projectListAccessibilitySummary() {
       if (!state.projects.items.length) return `${state.projects.title}, no projects`;
       return `${state.projects.title}, ${projectCountLabel()}. Drag project rows to reorder them.`;
+    }
+
+    function projectListTranscriptText() {
+      const projects = state.projects.items || [];
+      if (!projects.length) {
+        return 'No projects are registered. Use `/project open` to add a local project or `/ssh user@host:/path` for a remote project.';
+      }
+      const lines = projects.map(project => {
+        const labels = [];
+        if (project.id === state.projects.selectedProjectID) labels.push('selected');
+        labels.push(project.connectionKindLabel || (project.isRemote ? 'SSH Remote' : 'Local'));
+        return `- ${project.name} — ${labels.join(', ')} — ${project.path}`;
+      });
+      return ['Projects:', ...lines].join('\n');
     }
 
     function renderSidebarChrome(sidebarThreadHeader, sidebarContent, projectsContent) {
@@ -7152,6 +7167,7 @@
         command.id === 'project-new-chat' ? { ...command, isEnabled: hasProject } :
         command.id === 'project-refresh-context' ? { ...command, isEnabled: hasProject } :
         command.id === 'project-init' ? { ...command, isEnabled: hasProject } :
+        command.id === 'project-list' ? { ...command, isEnabled: true } :
         command.id === 'project-rename' ? { ...command, isEnabled: hasProject } :
         command.id === 'project-remove' ? { ...command, isEnabled: hasProject } :
         command.id === 'terminal-clear' ? { ...command, isEnabled: state.terminal.entries.length > 0 && !state.terminal.isRunning } :
@@ -13535,6 +13551,7 @@
       'project-move-up',
       'project-move-down',
       'project-move-to-bottom',
+      'project-list',
       'project-remove',
       'project-rename',
       'retry-last-turn',
@@ -13988,6 +14005,11 @@
       }
       if (commandID === 'project-move-to-bottom') {
         if (state.projects.selectedProjectID) runProjectAction('move-to-bottom', state.projects.selectedProjectID);
+        return;
+      }
+      if (commandID === 'project-list') {
+        addMessage('assistant', projectListTranscriptText());
+        render();
         return;
       }
       if (commandID === 'project-rename') {
@@ -16529,6 +16551,7 @@
       if (['up', 'move-up'].includes(subcommand)) return 'project-move-up';
       if (['down', 'move-down'].includes(subcommand)) return 'project-move-down';
       if (['bottom', 'move-bottom', 'move-to-bottom'].includes(subcommand)) return 'project-move-to-bottom';
+      if (['list', 'ls', 'show'].includes(subcommand)) return 'project-list';
       if (['remove', 'forget', 'delete'].includes(subcommand)) return 'project-remove';
       return null;
     }

--- a/E2E/playwright/tests/composer-slash.spec.ts
+++ b/E2E/playwright/tests/composer-slash.spec.ts
@@ -37,6 +37,12 @@ test('mock harness routes slash commands to workspace actions', async ({ page })
   await expect(page.getByTestId('project-item').first()).toContainText('Example Project');
   await expect(page.getByTestId('top-bar-subtitle')).toContainText('Example Project');
 
+  await page.getByLabel('Message').fill('/project list');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByTestId('message').last()).toContainText('Projects:\n- Example Project');
+  await expect(page.getByTestId('message').last()).toContainText('selected, Local');
+  await expect(page.getByTestId('message').last()).toContainText('/mock/example-');
+
   await page.getByLabel('Message').fill('/project remove');
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByTestId('project-item')).toHaveCount(1);


### PR DESCRIPTION
## Summary
- add a routable project-list command to the mock harness command registry
- route /project list, /project ls, and /project show through the instant slash dispatcher
- cover the transcript output in the composer slash Playwright flow

## Validation
- npm test -- composer-slash.spec.ts
- npm test -- interaction-audit-registry.spec.ts
- git diff --check