### PR TITLE
Harden managed worktree branch promotion

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceWorktreeListSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceWorktreeListSurface.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QuillCodeTools
 
 public struct WorkspaceWorktreeChoice: Sendable, Hashable, Identifiable {
     public var path: String
@@ -27,7 +28,7 @@ public struct WorkspaceWorktreeChoiceLoad: Sendable, Hashable {
 enum WorkspaceWorktreeListSurfaceBuilder {
     static func choices(fromPorcelain stdout: String, selectedProjectPath: String?) -> [WorkspaceWorktreeChoice] {
         let selectedPath = selectedProjectPath.map(normalizedPath)
-        return parse(stdout)
+        return GitWorktreePorcelainParser.parse(stdout)
             .filter { selectedPath == nil || normalizedPath($0.path) != selectedPath }
             .map { entry in
                 WorkspaceWorktreeChoice(
@@ -38,59 +39,12 @@ enum WorkspaceWorktreeListSurfaceBuilder {
             }
     }
 
-    private static func parse(_ stdout: String) -> [WorktreeEntry] {
-        var entries: [WorktreeEntry] = []
-        var current: WorktreeEntry?
-
-        func flush() {
-            if let current {
-                entries.append(current)
-            }
-            current = nil
-        }
-
-        for rawLine in stdout.components(separatedBy: .newlines) {
-            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-            if line.isEmpty {
-                flush()
-                continue
-            }
-            if line.hasPrefix("worktree ") {
-                flush()
-                let path = String(line.dropFirst("worktree ".count))
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                if !path.isEmpty {
-                    current = WorktreeEntry(path: path)
-                }
-                continue
-            }
-            guard current != nil else { continue }
-            if line.hasPrefix("branch ") {
-                current?.branch = displayBranch(String(line.dropFirst("branch ".count)))
-            } else if line == "detached" {
-                current?.isDetached = true
-            } else if line == "bare" {
-                current?.isBare = true
-            }
-        }
-        flush()
-        return entries
-    }
-
     private static func displayName(for path: String) -> String {
         let last = (path as NSString).lastPathComponent
         return last.isEmpty ? path : last
     }
 
-    private static func displayBranch(_ branch: String) -> String {
-        let trimmed = branch.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("refs/heads/") {
-            return String(trimmed.dropFirst("refs/heads/".count))
-        }
-        return trimmed
-    }
-
-    private static func detail(for entry: WorktreeEntry) -> String {
+    private static func detail(for entry: GitWorktreeRecord) -> String {
         if let branch = entry.branch, !branch.isEmpty {
             return branch
         }
@@ -106,11 +60,4 @@ enum WorkspaceWorktreeListSurfaceBuilder {
     private static func normalizedPath(_ path: String) -> String {
         URL(fileURLWithPath: path).standardizedFileURL.path
     }
-}
-
-private struct WorktreeEntry: Equatable {
-    var path: String
-    var branch: String?
-    var isDetached = false
-    var isBare = false
 }

--- a/Sources/QuillCodeTools/GitToolError.swift
+++ b/Sources/QuillCodeTools/GitToolError.swift
@@ -29,6 +29,8 @@ public enum GitToolError: Error, CustomStringConvertible {
     case mainWorkspaceWorktreePath
     case unregisteredWorktree(String)
     case worktreeAlreadyOwnsBranch(String)
+    case branchAlreadyExists(String)
+    case branchCheckedOutInWorktree(branch: String, path: String)
     case patchPathMismatch(String)
     case temporaryPatchFailed(String)
 
@@ -94,6 +96,10 @@ public enum GitToolError: Error, CustomStringConvertible {
             return "Git worktree is not registered: \(path)"
         case .worktreeAlreadyOwnsBranch(let branch):
             return "This worktree already owns branch \(branch). Create branch here is available only from detached HEAD."
+        case .branchAlreadyExists(let branch):
+            return "Git branch already exists: \(branch)"
+        case .branchCheckedOutInWorktree(let branch, let path):
+            return "Git branch '\(branch)' is already checked out in worktree: \(path)"
         case .patchPathMismatch(let path):
             return "Git patch touches a different path than requested: \(path)"
         case .temporaryPatchFailed(let message):

--- a/Sources/QuillCodeTools/GitWorktreeRecord.swift
+++ b/Sources/QuillCodeTools/GitWorktreeRecord.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public struct GitWorktreeRecord: Sendable, Hashable {
+    public var path: String
+    public var branch: String?
+    public var isDetached: Bool
+    public var isBare: Bool
+
+    public init(
+        path: String,
+        branch: String? = nil,
+        isDetached: Bool = false,
+        isBare: Bool = false
+    ) {
+        self.path = path
+        self.branch = branch
+        self.isDetached = isDetached
+        self.isBare = isBare
+    }
+}
+
+public enum GitWorktreePorcelainParser {
+    public static func parse(_ output: String) -> [GitWorktreeRecord] {
+        var records: [GitWorktreeRecord] = []
+        var current: GitWorktreeRecord?
+
+        func flush() {
+            if let current {
+                records.append(current)
+            }
+            current = nil
+        }
+
+        for rawLine in output.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty {
+                flush()
+            } else if line.hasPrefix("worktree ") {
+                flush()
+                let path = String(line.dropFirst("worktree ".count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !path.isEmpty {
+                    current = GitWorktreeRecord(path: path)
+                }
+            } else if line.hasPrefix("branch ") {
+                current?.branch = branchName(String(line.dropFirst("branch ".count)))
+            } else if line == "detached" {
+                current?.isDetached = true
+            } else if line == "bare" {
+                current?.isBare = true
+            }
+        }
+        flush()
+        return records
+    }
+
+    private static func branchName(_ value: String) -> String {
+        let branch = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = "refs/heads/"
+        return branch.hasPrefix(prefix) ? String(branch.dropFirst(prefix.count)) : branch
+    }
+}

--- a/Sources/QuillCodeTools/GitWorktreeToolExecutor.swift
+++ b/Sources/QuillCodeTools/GitWorktreeToolExecutor.swift
@@ -56,6 +56,54 @@ public struct GitWorktreeToolExecutor: Sendable {
         }
     }
 
+    public func createBranchHere(cwd: URL, branch: String) -> ToolResult {
+        do {
+            let branchName = try GitInputValidator.safeName(branch)
+            let currentPath = normalizedPath(cwd.path)
+            let registered = registeredWorktrees(cwd: cwd)
+            if let failure = registered.failure {
+                return failure
+            }
+            guard let currentIndex = registered.records.firstIndex(where: {
+                normalizedPath($0.path) == currentPath
+            }) else {
+                throw GitToolError.unregisteredWorktree(currentPath)
+            }
+            let current = registered.records[currentIndex]
+            guard current.isDetached else {
+                throw GitToolError.worktreeAlreadyOwnsBranch(current.branch ?? "an existing branch")
+            }
+            guard currentIndex > registered.records.startIndex else {
+                throw GitToolError.mainWorkspaceWorktreePath
+            }
+            if let owner = registered.records.first(where: { $0.branch == branchName }) {
+                throw GitToolError.branchCheckedOutInWorktree(branch: branchName, path: owner.path)
+            }
+
+            let existing = runGit(
+                ["show-ref", "--verify", "--quiet", "refs/heads/\(branchName)"],
+                cwd: cwd,
+                timeoutSeconds: 10
+            )
+            if existing.ok {
+                throw GitToolError.branchAlreadyExists(branchName)
+            }
+            guard existing.exitCode == 1 else { return existing }
+
+            let result = runGit(["switch", "-c", branchName], cwd: cwd, timeoutSeconds: 30)
+            guard result.ok else { return result }
+            return ToolResult(
+                ok: true,
+                stdout: result.stdout.isEmpty ? "Created branch \(branchName).\n" : result.stdout,
+                stderr: result.stderr,
+                exitCode: result.exitCode,
+                artifacts: [branchName]
+            )
+        } catch {
+            return ToolResult(ok: false, error: String(describing: error))
+        }
+    }
+
     public func open(cwd: URL, path: String) -> ToolResult {
         do {
             let worktreePath = try Self.safePath(path, cwd: cwd)
@@ -79,34 +127,6 @@ public struct GitWorktreeToolExecutor: Sendable {
 
     public func handoff(cwd: URL, destination: String) -> ToolResult {
         handoffExecutor.handoff(sourceRoot: cwd, destinationPath: destination)
-    }
-
-    public func createBranchHere(cwd: URL, branch: String) -> ToolResult {
-        do {
-            let branchName = try GitInputValidator.safeName(branch)
-            let symbolicRef = runGit(
-                ["symbolic-ref", "--quiet", "--short", "HEAD"],
-                cwd: cwd,
-                timeoutSeconds: 10
-            )
-            if symbolicRef.ok {
-                let current = symbolicRef.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-                throw GitToolError.worktreeAlreadyOwnsBranch(current.isEmpty ? "an existing branch" : current)
-            }
-            guard symbolicRef.exitCode == 1 else { return symbolicRef }
-
-            let result = runGit(["switch", "-c", branchName], cwd: cwd, timeoutSeconds: 30)
-            guard result.ok else { return result }
-            return ToolResult(
-                ok: true,
-                stdout: result.stdout.isEmpty ? "Created branch \(branchName).\n" : result.stdout,
-                stderr: result.stderr,
-                exitCode: result.exitCode,
-                artifacts: [branchName]
-            )
-        } catch {
-            return ToolResult(ok: false, error: String(describing: error))
-        }
     }
 
     public func remove(cwd: URL, path: String, force: Bool = false) -> ToolResult {
@@ -168,19 +188,27 @@ public struct GitWorktreeToolExecutor: Sendable {
     }
 
     private func registeredPaths(cwd: URL) -> (paths: Set<String>, failure: ToolResult?) {
+        let registered = registeredWorktrees(cwd: cwd)
+        if let failure = registered.failure {
+            return ([], failure)
+        }
+        let paths = registered.records.map { normalizedPath($0.path) }
+        return (Set(paths), nil)
+    }
+
+    private func registeredWorktrees(cwd: URL) -> (records: [GitWorktreeRecord], failure: ToolResult?) {
         let result = list(cwd: cwd)
         guard result.ok else {
             return ([], result)
         }
-        let paths = result.stdout
-            .components(separatedBy: .newlines)
-            .compactMap { line -> String? in
-                guard line.hasPrefix("worktree ") else { return nil }
-                return URL(fileURLWithPath: String(line.dropFirst("worktree ".count)))
-                    .standardizedFileURL
-                    .path
-            }
-        return (Set(paths), nil)
+        return (GitWorktreePorcelainParser.parse(result.stdout), nil)
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
     }
 
     private func runGit(_ arguments: [String], cwd: URL, timeoutSeconds: TimeInterval) -> ToolResult {

--- a/Tests/QuillCodeAppTests/WorkspaceWorktreeIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceWorktreeIntegrationTests.swift
@@ -217,6 +217,69 @@ final class WorkspaceWorktreeIntegrationTests: XCTestCase {
         XCTAssertEqual(model.currentToolCards.last?.status, .done)
     }
 
+    func testCreateBranchHerePromotesManagedThreadAndUpdatesCommandAvailability() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let model = QuillCodeWorkspaceModel()
+        let projectID = model.addProject(path: root, name: "Worktree Project")
+        model.selectProject(projectID)
+        let threadID = try XCTUnwrap(model.newWorktreeThread(name: "branch promotion"))
+        let worktreePath = try XCTUnwrap(model.selectedThread?.worktree?.path)
+        let branch = "feature/promoted-\(UUID().uuidString.prefix(8))"
+        defer {
+            _ = GitToolExecutor().removeWorktree(cwd: root, path: worktreePath, force: true)
+        }
+
+        XCTAssertEqual(model.selectedThread?.id, threadID)
+        XCTAssertTrue(model.surface().commands.first {
+            $0.id == WorkspaceCommandAction.threadCreateBranch.rawValue
+        }?.isEnabled == true)
+
+        let didCreate = model.createBranchHere(.init(branch: String(branch)))
+
+        XCTAssertTrue(didCreate)
+        XCTAssertEqual(model.selectedThread?.worktree?.branch, String(branch))
+        XCTAssertEqual(try currentBranchName(in: URL(fileURLWithPath: worktreePath)), String(branch))
+        XCTAssertFalse(model.surface().commands.first {
+            $0.id == WorkspaceCommandAction.threadCreateBranch.rawValue
+        }?.isEnabled == true)
+        let card = try XCTUnwrap(model.currentToolCards.last)
+        XCTAssertEqual(card.title, ToolDefinition.gitWorktreeCreateBranch.name)
+        XCTAssertEqual(card.status, .done)
+        let arguments = try ToolArguments(XCTUnwrap(card.inputJSON))
+        XCTAssertEqual(arguments.string("branch"), String(branch))
+    }
+
+    func testAgentBranchCreationReconcilesManagedThreadBinding() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let model = QuillCodeWorkspaceModel()
+        let projectID = model.addProject(path: root, name: "Worktree Project")
+        model.selectProject(projectID)
+        _ = try XCTUnwrap(model.newWorktreeThread(name: "agent branch promotion"))
+        let worktreePath = try XCTUnwrap(model.selectedThread?.worktree?.path)
+        let branch = "feature/agent-promoted-\(UUID().uuidString.prefix(8))"
+        defer {
+            _ = GitToolExecutor().removeWorktree(cwd: root, path: worktreePath, force: true)
+        }
+
+        let result = model.runToolCall(
+            ToolCall(
+                name: ToolDefinition.gitBranchSwitch.name,
+                argumentsJSON: ToolArguments.json([
+                    "branch": String(branch),
+                    "create": true
+                ])
+            ),
+            workspaceRoot: URL(fileURLWithPath: worktreePath)
+        )
+
+        XCTAssertTrue(result.ok, result.error ?? result.stderr)
+        XCTAssertEqual(model.selectedThread?.worktree?.branch, String(branch))
+        XCTAssertEqual(try currentBranchName(in: URL(fileURLWithPath: worktreePath)), String(branch))
+        XCTAssertFalse(model.surface().commands.first {
+            $0.id == WorkspaceCommandAction.threadCreateBranch.rawValue
+        }?.isEnabled == true)
+    }
+
     func testRemoteWorkspaceCreateWorktreeOpensSSHProjectAndKeepsToolAudit() throws {
         let fixture = try makeRemoteWorktreeFixture()
         let parent = fixture.remoteRoot.deletingLastPathComponent()

--- a/Tests/QuillCodeToolsTests/GitWorktreeToolExecutorTests.swift
+++ b/Tests/QuillCodeToolsTests/GitWorktreeToolExecutorTests.swift
@@ -338,6 +338,99 @@ final class GitWorktreeToolExecutorTests: XCTestCase {
         XCTAssertEqual(result.error, "Managed worktrees start detached and cannot create a branch.")
     }
 
+    func testCreateBranchHerePromotesDetachedManagedWorktree() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let worktreeName = "managed-branch-here-\(UUID().uuidString)"
+        let worktree = root.deletingLastPathComponent().appendingPathComponent(worktreeName)
+        let branch = "feature/managed-\(UUID().uuidString.prefix(8))"
+        let git = GitToolExecutor()
+        let create = git.createWorktree(cwd: root, path: worktreeName, managed: true)
+        XCTAssertTrue(create.ok, create.error ?? create.stderr)
+        defer { _ = git.removeWorktree(cwd: root, path: worktreeName, force: true) }
+
+        let promote = git.createWorktreeBranch(cwd: worktree, branch: String(branch))
+
+        XCTAssertTrue(promote.ok, promote.error ?? promote.stderr)
+        XCTAssertEqual(currentBranchName(in: worktree), String(branch))
+        XCTAssertEqual(promote.artifacts, [String(branch)])
+        XCTAssertTrue(promote.stdout.contains("Created branch"), promote.stdout)
+    }
+
+    func testCreateBranchHereRejectsExistingAndNonDetachedBranches() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let worktreeName = "managed-branch-collision-\(UUID().uuidString)"
+        let worktree = root.deletingLastPathComponent().appendingPathComponent(worktreeName)
+        let git = GitToolExecutor()
+        let create = git.createWorktree(cwd: root, path: worktreeName, managed: true)
+        XCTAssertTrue(create.ok, create.error ?? create.stderr)
+        defer { _ = git.removeWorktree(cwd: root, path: worktreeName, force: true) }
+
+        let existing = git.createWorktreeBranch(cwd: worktree, branch: "main")
+        XCTAssertFalse(existing.ok)
+        XCTAssertTrue(existing.error?.contains("already checked out") == true, existing.error ?? "")
+
+        let branch = "feature/owned-\(UUID().uuidString.prefix(8))"
+        XCTAssertTrue(git.createWorktreeBranch(cwd: worktree, branch: String(branch)).ok)
+        let secondPromotion = git.createWorktreeBranch(cwd: worktree, branch: "feature/second")
+        XCTAssertFalse(secondPromotion.ok)
+        XCTAssertTrue(
+            secondPromotion.error?.contains("already owns branch") == true,
+            secondPromotion.error ?? ""
+        )
+    }
+
+    func testCreateBranchHereRejectsExistingUnownedBranch() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let worktreeName = "managed-existing-branch-\(UUID().uuidString)"
+        let worktree = root.deletingLastPathComponent().appendingPathComponent(worktreeName)
+        let branch = "feature/existing-\(UUID().uuidString.prefix(8))"
+        let git = GitToolExecutor()
+        let createBranch = ShellToolExecutor().run(.init(command: "git branch \(branch)", cwd: root))
+        XCTAssertTrue(createBranch.ok, createBranch.error ?? createBranch.stderr)
+        let createWorktree = git.createWorktree(cwd: root, path: worktreeName, managed: true)
+        XCTAssertTrue(createWorktree.ok, createWorktree.error ?? createWorktree.stderr)
+        defer { _ = git.removeWorktree(cwd: root, path: worktreeName, force: true) }
+
+        let promote = git.createWorktreeBranch(cwd: worktree, branch: String(branch))
+
+        XCTAssertFalse(promote.ok)
+        XCTAssertTrue(promote.error?.contains("branch already exists") == true, promote.error ?? "")
+        XCTAssertEqual(currentBranchName(in: worktree), "")
+    }
+
+    func testCreateBranchHereRejectsDetachedMainCheckout() throws {
+        let root = try makeTempGitRepoWithInitialCommit()
+        let detach = ShellToolExecutor().run(.init(command: "git checkout --detach", cwd: root))
+        XCTAssertTrue(detach.ok, detach.error ?? detach.stderr)
+
+        let result = GitToolExecutor().createWorktreeBranch(cwd: root, branch: "feature/not-managed")
+
+        XCTAssertFalse(result.ok)
+        XCTAssertEqual(result.error, "Git worktree path cannot be the main workspace.")
+        XCTAssertEqual(currentBranchName(in: root), "")
+    }
+
+    func testWorktreePorcelainParserNormalizesLocalBranchNames() {
+        let records = GitWorktreePorcelainParser.parse(
+            """
+            worktree /repo/main
+            HEAD 1111111
+            branch refs/heads/main
+
+            worktree /repo/task
+            HEAD 2222222
+            detached
+
+            """
+        )
+
+        XCTAssertEqual(records.count, 2)
+        XCTAssertEqual(records[0].branch, "main")
+        XCTAssertFalse(records[0].isDetached)
+        XCTAssertNil(records[1].branch)
+        XCTAssertTrue(records[1].isDetached)
+    }
+
     func testCreateListOpenAndRemoveSibling() throws {
         let root = try makeTempGitRepoWithInitialCommit()
         let parent = root.deletingLastPathComponent()

--- a/docs/CODEX_RESEARCH.md
+++ b/docs/CODEX_RESEARCH.md
@@ -6,6 +6,7 @@ QuillCode tracks Codex workflow parity without copying private implementation or
 
 - Codex app: projects, worktrees, automations, Git review, in-app browser, Computer Use, artifact previews.
 - Official managed-worktree behavior: new Worktree tasks start at detached HEAD from the selected branch, can carry current uncommitted changes, copy normally ignored files only when selected by `.worktreeinclude`, automatically copy ignored `AGENTS.override.md`, and keep a stable task/worktree association. Handoff moves a task and its code between Local and that same worktree; managed cleanup saves restorable snapshots before deletion. Source: current Codex manual, Worktrees section (`environments/git-worktrees`).
+- Codex keeps two deliberate exit paths from a detached managed task. **Create branch here** stays in the worktree and creates a branch owned by that checkout; **Hand off** moves the task and code to Local. Git permits one checkout to own a branch, so QuillCode must reject an existing or already-checked-out branch before promotion and explain that Handoff is the right path when the user needs the branch locally.
 - Codex commands: command menu, keyboard shortcuts, thread search, slash commands.
 - Sandbox and Auto-review: enforce boundaries first, route eligible review requests through a reviewer model.
 - Remote connections: phone/host pairing, remote approvals, host-local files and tools.

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -15813,3 +15813,25 @@ Validation:
 - `npm test`
 - `python3 scripts/grade-code-quality.py`
 - `git diff --check`
+
+## 2026-07-12 Managed Worktree Branch Promotion Hardening
+
+Overall grade after this slice: **A+ Git ownership boundary, A+ regression coverage**.
+This follow-up hardens the merged Create branch here workflow without changing its public tool or UI contracts.
+
+Strict grades:
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Architecture | A+ | The existing typed tool contract remains stable while one focused executor owns all branch-promotion invariants. |
+| Git correctness | A+ | Promotion requires a registered detached linked worktree, rejects the main checkout, existing branches, and branches owned by another worktree, then leaves final race enforcement to `git switch -c`. |
+| State integrity | A+ | Real-workspace tests verify both direct promotion and reconciliation after a generic agent branch-switch tool. |
+| Maintainability | A+ | One typed porcelain parser now serves both worktree UI projection and Git ownership validation. |
+| Tests | A+ | Real Git fixtures cover success, main-checkout rejection, existing and worktree-owned branches, attached worktrees, parsing, and durable model reconciliation. |
+
+Validation:
+
+- `swift test --filter 'GitWorktreeToolExecutorTests|WorkspaceWorktreeIntegrationTests|WorkspaceWorktreeListSurfaceTests'`
+- `npm test`
+- `python3 scripts/grade-code-quality.py`
+- `git diff --check`


### PR DESCRIPTION
## Summary
- require Create branch here to run in a registered detached linked worktree
- reject the main checkout, existing unowned branches, and branches checked out in another worktree
- preserve the merged tool name, result artifacts, UI placement, and final-answer behavior
- share one typed Git worktree porcelain parser across ownership validation and worktree UI projection
- add real-Git regression coverage for promotion, collisions, main-checkout rejection, and agent branch reconciliation

## Verification
- swift test: 3,562 passed, 2 skipped, 0 failures
- npm test: 212 passed
- focused real-Git/worktree suite: 39 passed
- packaged macOS smoke passed, including Launch Services and live window
- native desktop executable smoke passed
- code-quality audit: every module A+
- git diff --check