### PR TITLE
Fix globstar directory permission matching

### DIFF
--- a/Sources/QuillCodeSafety/PermissionWildcardPattern.swift
+++ b/Sources/QuillCodeSafety/PermissionWildcardPattern.swift
@@ -5,6 +5,7 @@ import Foundation
 /// Semantics:
 /// - `*` matches any run of characters except `/`.
 /// - `**` matches any run of characters including `/`.
+/// - `**/` matches zero or more complete path segments.
 /// - Everything else matches literally. There are no escapes, classes, or regexes.
 ///
 /// The matcher is a bit-parallel NFA simulation over pattern positions. That makes
@@ -22,6 +23,14 @@ public struct PermissionWildcardPattern: Sendable {
     private let globstarMask: [UInt64]
     /// States holding `*`, which self-loop on every scalar except `/`.
     private let starMask: [UInt64]
+    /// Boundary states for `**/`; only these states may skip the directory prefix.
+    private let directoryBoundaryMask: [UInt64]
+    /// In-segment states for `**/`; a separator returns these states to their boundary.
+    private let directorySegmentMask: [UInt64]
+    /// `**/` states that own a directory-fragment epsilon transition.
+    private let directoryEpsilonSourceMask: [UInt64]
+    /// Precomputed transitive directory-fragment epsilon destinations by token state.
+    private let directoryEpsilonClosureMasks: [[UInt64]]
     /// Per-scalar masks of literal states. Consuming that scalar advances those states by one.
     private let literalMasks: [Unicode.Scalar: [UInt64]]
 
@@ -35,6 +44,9 @@ public struct PermissionWildcardPattern: Sendable {
         let wordCount = (stateCount + 63) / 64
         var globstarMask = [UInt64](repeating: 0, count: wordCount)
         var starMask = [UInt64](repeating: 0, count: wordCount)
+        var directoryBoundaryMask = [UInt64](repeating: 0, count: wordCount)
+        var directorySegmentMask = [UInt64](repeating: 0, count: wordCount)
+        var directoryEpsilonAdvances = [UInt8](repeating: 0, count: tokens.count)
         var literalMasks: [Unicode.Scalar: [UInt64]] = [:]
 
         for (state, token) in tokens.enumerated() {
@@ -47,13 +59,26 @@ public struct PermissionWildcardPattern: Sendable {
                 starMask[state >> 6] |= 1 << UInt64(state & 63)
             case .globstar:
                 globstarMask[state >> 6] |= 1 << UInt64(state & 63)
+            case .directoryBoundary:
+                directoryBoundaryMask[state >> 6] |= 1 << UInt64(state & 63)
+                directoryEpsilonAdvances[state] = 2
+            case .directorySegment:
+                directorySegmentMask[state >> 6] |= 1 << UInt64(state & 63)
             }
         }
+        let epsilon = Self.epsilonClosures(
+            advances: directoryEpsilonAdvances,
+            wordCount: wordCount
+        )
 
         self.stateCount = stateCount
         self.wordCount = wordCount
         self.globstarMask = globstarMask
         self.starMask = starMask
+        self.directoryBoundaryMask = directoryBoundaryMask
+        self.directorySegmentMask = directorySegmentMask
+        self.directoryEpsilonSourceMask = epsilon.sourceMask
+        self.directoryEpsilonClosureMasks = epsilon.closures
         self.literalMasks = literalMasks
     }
 
@@ -88,7 +113,15 @@ public struct PermissionWildcardPattern: Sendable {
         while index < scalars.count {
             if scalars[index] == "*" {
                 let starCount = countStarRun(in: scalars, startingAt: &index)
-                tokens.append(starCount >= 2 ? .globstar : .star)
+                if starCount >= 2,
+                   index < scalars.count,
+                   scalars[index] == Self.pathSeparator {
+                    tokens.append(.directoryBoundary)
+                    tokens.append(.directorySegment)
+                    index += 1
+                } else {
+                    tokens.append(starCount >= 2 ? .globstar : .star)
+                }
             } else {
                 tokens.append(.literal(scalars[index]))
                 index += 1
@@ -110,6 +143,27 @@ public struct PermissionWildcardPattern: Sendable {
         return count
     }
 
+    private static func epsilonClosures(
+        advances: [UInt8],
+        wordCount: Int
+    ) -> (sourceMask: [UInt64], closures: [[UInt64]]) {
+        var sourceMask = [UInt64](repeating: 0, count: wordCount)
+        var closures = Array(
+            repeating: [UInt64](repeating: 0, count: wordCount),
+            count: advances.count
+        )
+
+        for source in advances.indices where advances[source] > 0 {
+            sourceMask[source >> 6] |= UInt64(1) << UInt64(source & 63)
+            var state = source
+            while state < advances.count, advances[state] > 0 {
+                state += Int(advances[state])
+                closures[source][state >> 6] |= UInt64(1) << UInt64(state & 63)
+            }
+        }
+        return (sourceMask, closures)
+    }
+
     private func applyWildcardTransitions(
         from active: [UInt64],
         scalar: Unicode.Scalar,
@@ -118,9 +172,41 @@ public struct PermissionWildcardPattern: Sendable {
         for word in 0..<wordCount {
             var value = active[word] & globstarMask[word]
             if scalar != Self.pathSeparator {
-                value |= active[word] & starMask[word]
+                value |= active[word] & (starMask[word] | directorySegmentMask[word])
+            } else {
+                value |= active[word] & directoryBoundaryMask[word]
             }
             next[word] = value
+        }
+
+        if scalar == Self.pathSeparator {
+            mergeDirectorySegmentToBoundary(from: active, into: &next)
+        } else {
+            mergeDirectoryBoundaryToSegment(from: active, into: &next)
+        }
+    }
+
+    private func mergeDirectoryBoundaryToSegment(
+        from active: [UInt64],
+        into next: inout [UInt64]
+    ) {
+        var carry: UInt64 = 0
+        for word in 0..<wordCount {
+            let boundaries = active[word] & directoryBoundaryMask[word]
+            next[word] |= (boundaries << 1) | carry
+            carry = boundaries >> 63
+        }
+    }
+
+    private func mergeDirectorySegmentToBoundary(
+        from active: [UInt64],
+        into next: inout [UInt64]
+    ) {
+        var carry: UInt64 = 0
+        for word in stride(from: wordCount - 1, through: 0, by: -1) {
+            let segments = active[word] & directorySegmentMask[word]
+            next[word] |= (segments >> 1) | carry
+            carry = segments << 63
         }
     }
 
@@ -139,14 +225,34 @@ public struct PermissionWildcardPattern: Sendable {
         }
     }
 
-    /// Epsilon closure: every active star state can also match empty, activating its successor.
-    /// One shifted-OR pass suffices because token parsing collapses adjacent star runs.
+    /// Applies one bit-parallel closure pass for ordinary stars, the transitive `**/` boundary
+    /// closure, then one final star pass for a star reached by skipping a directory fragment.
     private func applyEpsilonClosure(_ states: inout [UInt64]) {
+        applyStarEpsilonClosure(&states)
+        applyDirectoryEpsilonClosure(&states)
+        applyStarEpsilonClosure(&states)
+    }
+
+    private func applyStarEpsilonClosure(_ states: inout [UInt64]) {
         var carry: UInt64 = 0
         for word in 0..<wordCount {
             let stars = states[word] & (starMask[word] | globstarMask[word])
             states[word] |= (stars << 1) | carry
             carry = stars >> 63
+        }
+    }
+
+    private func applyDirectoryEpsilonClosure(_ states: inout [UInt64]) {
+        for sourceWord in 0..<wordCount {
+            var activeSources = states[sourceWord] & directoryEpsilonSourceMask[sourceWord]
+            while activeSources != 0 {
+                let bit = activeSources.trailingZeroBitCount
+                let source = sourceWord * 64 + bit
+                for destinationWord in 0..<wordCount {
+                    states[destinationWord] |= directoryEpsilonClosureMasks[source][destinationWord]
+                }
+                activeSources &= activeSources - 1
+            }
         }
     }
 }
@@ -155,4 +261,6 @@ private enum PermissionWildcardToken {
     case literal(Unicode.Scalar)
     case star
     case globstar
+    case directoryBoundary
+    case directorySegment
 }

--- a/Tests/QuillCodeParityTests/ParityPermissionWildcardGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPermissionWildcardGateTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+final class ParityPermissionWildcardGateTests: QuillCodeParityTestCase {
+    func testPermissionGlobstarDirectorySemanticsStaySegmentBoundedAndOracleBacked() throws {
+        let matcher = try Self.safetySourceText(named: "PermissionWildcardPattern.swift")
+        let tests = try Self.safetyTestSourceText(named: "PermissionWildcardPatternTests.swift")
+
+        Self.assertSource(matcher, contains: "case directoryBoundary")
+        Self.assertSource(matcher, contains: "case directorySegment")
+        Self.assertSource(matcher, contains: "mergeDirectoryBoundaryToSegment")
+        Self.assertSource(matcher, contains: "mergeDirectorySegmentToBoundary")
+        Self.assertSource(
+            tests,
+            contains: "testGlobstarDirectoryMatchesZeroOrMoreCompleteSegments"
+        )
+        Self.assertSource(
+            tests,
+            contains: "testGlobstarDirectoryDoesNotConsumePartialSegments"
+        )
+        Self.assertSource(
+            tests,
+            contains: "testMatcherAgreesWithRecursiveReferenceOracleAcrossGeneratedCorpus"
+        )
+        Self.assertSource(
+            tests,
+            contains: "testPermissionTableDenyCoversRootAndNestedSecretFiles"
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityTestSupport.swift
+++ b/Tests/QuillCodeParityTests/ParityTestSupport.swift
@@ -259,4 +259,11 @@ class QuillCodeParityTestCase: XCTestCase {
             .appendingPathComponent(fileName)
         return try String(contentsOf: file, encoding: .utf8)
     }
+
+    static func safetyTestSourceText(named fileName: String) throws -> String {
+        let file = packageRoot()
+            .appendingPathComponent("Tests/QuillCodeSafetyTests")
+            .appendingPathComponent(fileName)
+        return try String(contentsOf: file, encoding: .utf8)
+    }
 }

--- a/Tests/QuillCodeSafetyTests/PermissionWildcardPatternTests.swift
+++ b/Tests/QuillCodeSafetyTests/PermissionWildcardPatternTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import QuillCodeSafety
+
+final class PermissionWildcardPatternTests: XCTestCase {
+    func testGlobstarDirectoryMatchesZeroOrMoreCompleteSegments() throws {
+        try assertMatches("**/.env", [".env", "sub/.env", "a/b/.env"])
+        try assertMatches("a/**/b", ["a/b", "a/x/b"])
+        try assertMatches("**/x", ["x", "a/x"])
+    }
+
+    func testGlobstarDirectoryDoesNotConsumePartialSegments() throws {
+        try assertDoesNotMatch("**/.env", ["x.env"])
+        try assertDoesNotMatch("a/**/b", ["a/xb"])
+        try assertDoesNotMatch("**/x", ["ax"])
+    }
+
+    func testGlobstarDirectorySupportsEmptyAndUnicodeSegments() throws {
+        try assertMatches("**/", ["", "/", "a/", "a/b/"])
+        try assertMatches("**/.env", ["/π/.env", "π/.env"])
+        try assertDoesNotMatch("**/", ["a", "a/b"])
+    }
+
+    func testBareGlobstarStillCrossesSeparatorsWithoutDirectoryBoundaries() throws {
+        try assertMatches("a/**/b**", ["a/b", "a/x/b", "a/x/beta", "a/x/b/y"])
+        try assertMatches("**", ["", "x", "a/b", "/a/"])
+    }
+
+    func testPermissionTableDenyCoversRootAndNestedSecretFiles() {
+        let table = PermissionRuleTable(rules: [
+            PermissionRule(
+                action: "host.file.read",
+                resource: "**/.env",
+                decision: .deny
+            )
+        ])
+
+        XCTAssertEqual(
+            table.decision(action: "host.file.read", resource: ".env"),
+            .deny
+        )
+        XCTAssertEqual(
+            table.decision(action: "host.file.read", resource: "Sources/App/.env"),
+            .deny
+        )
+        XCTAssertNil(table.decision(action: "host.file.read", resource: "Sources/App.env"))
+    }
+
+    func testRepeatedGlobstarDirectoriesStayBoundedAtInputLimits() throws {
+        let pattern = String(repeating: "**/", count: 84) + "end"
+        let candidate = String(repeating: "segment/", count: 500) + "miss"
+        let matcher = try XCTUnwrap(PermissionWildcardPattern(pattern))
+
+        for _ in 0..<10 {
+            XCTAssertFalse(matcher.matches(candidate))
+        }
+    }
+
+    func testGlobstarDirectoryTransitionsCrossBitsetWordBoundaries() throws {
+        for prefixLength in [62, 63, 64, 126, 127, 128] {
+            let prefix = String(repeating: "a", count: prefixLength)
+            let matcher = try XCTUnwrap(PermissionWildcardPattern(prefix + "**/z"))
+
+            XCTAssertTrue(matcher.matches(prefix + "z"), "prefixLength=\(prefixLength)")
+            XCTAssertTrue(matcher.matches(prefix + "path/z"), "prefixLength=\(prefixLength)")
+            XCTAssertFalse(matcher.matches(prefix + "pathz"), "prefixLength=\(prefixLength)")
+        }
+    }
+
+    func testMatcherAgreesWithRecursiveReferenceOracleAcrossGeneratedCorpus() throws {
+        let patterns = generatedStrings(
+            atoms: ["a", "b", "/", "*", "**", "**/"],
+            maximumAtomCount: 3
+        )
+        let candidates = generatedStrings(atoms: ["a", "b", "/"], maximumAtomCount: 4)
+
+        for pattern in patterns {
+            let matcher = try XCTUnwrap(PermissionWildcardPattern(pattern))
+            for candidate in candidates {
+                XCTAssertEqual(
+                    matcher.matches(candidate),
+                    ReferencePermissionWildcardMatcher.matches(pattern: pattern, candidate: candidate),
+                    "pattern=\(pattern.debugDescription), candidate=\(candidate.debugDescription)"
+                )
+            }
+        }
+    }
+
+    private func assertMatches(_ pattern: String, _ candidates: [String]) throws {
+        let matcher = try XCTUnwrap(PermissionWildcardPattern(pattern))
+        for candidate in candidates {
+            XCTAssertTrue(
+                matcher.matches(candidate),
+                "expected \(pattern.debugDescription) to match \(candidate.debugDescription)"
+            )
+        }
+    }
+
+    private func assertDoesNotMatch(_ pattern: String, _ candidates: [String]) throws {
+        let matcher = try XCTUnwrap(PermissionWildcardPattern(pattern))
+        for candidate in candidates {
+            XCTAssertFalse(
+                matcher.matches(candidate),
+                "expected \(pattern.debugDescription) not to match \(candidate.debugDescription)"
+            )
+        }
+    }
+
+    private func generatedStrings(atoms: [String], maximumAtomCount: Int) -> [String] {
+        var all = Set([""])
+        var frontier = [""]
+        for _ in 0..<maximumAtomCount {
+            frontier = frontier.flatMap { prefix in atoms.map { prefix + $0 } }
+            all.formUnion(frontier)
+        }
+        return all.sorted()
+    }
+}
+
+private enum ReferencePermissionWildcardMatcher {
+    static func matches(pattern: String, candidate: String) -> Bool {
+        var matcher = Matcher(
+            pattern: Array(pattern.unicodeScalars),
+            candidate: Array(candidate.unicodeScalars)
+        )
+        return matcher.matches(patternIndex: 0, candidateIndex: 0)
+    }
+
+    private struct State: Hashable {
+        var patternIndex: Int
+        var candidateIndex: Int
+    }
+
+    private struct Matcher {
+        var pattern: [Unicode.Scalar]
+        var candidate: [Unicode.Scalar]
+        var memo: [State: Bool] = [:]
+
+        mutating func matches(patternIndex: Int, candidateIndex: Int) -> Bool {
+            let state = State(patternIndex: patternIndex, candidateIndex: candidateIndex)
+            if let cached = memo[state] { return cached }
+
+            let result = uncachedMatch(patternIndex: patternIndex, candidateIndex: candidateIndex)
+            memo[state] = result
+            return result
+        }
+
+        private mutating func uncachedMatch(patternIndex: Int, candidateIndex: Int) -> Bool {
+            guard patternIndex < pattern.count else { return candidateIndex == candidate.count }
+            guard pattern[patternIndex] == "*" else {
+                return candidateIndex < candidate.count
+                    && pattern[patternIndex] == candidate[candidateIndex]
+                    && matches(patternIndex: patternIndex + 1, candidateIndex: candidateIndex + 1)
+            }
+
+            var afterStars = patternIndex
+            while afterStars < pattern.count, pattern[afterStars] == "*" {
+                afterStars += 1
+            }
+            let isGlobstar = afterStars - patternIndex >= 2
+            if isGlobstar,
+               afterStars < pattern.count,
+               pattern[afterStars] == "/" {
+                return matchesGlobstarDirectory(
+                    patternIndex: patternIndex,
+                    afterSlash: afterStars + 1,
+                    candidateIndex: candidateIndex
+                )
+            }
+            return matchesStarRun(
+                afterStars: afterStars,
+                candidateIndex: candidateIndex,
+                crossesSeparators: isGlobstar
+            )
+        }
+
+        private mutating func matchesGlobstarDirectory(
+            patternIndex: Int,
+            afterSlash: Int,
+            candidateIndex: Int
+        ) -> Bool {
+            if matches(patternIndex: afterSlash, candidateIndex: candidateIndex) {
+                return true
+            }
+            for index in candidateIndex..<candidate.count where candidate[index] == "/" {
+                if matches(patternIndex: patternIndex, candidateIndex: index + 1) {
+                    return true
+                }
+                break
+            }
+            return false
+        }
+
+        private mutating func matchesStarRun(
+            afterStars: Int,
+            candidateIndex: Int,
+            crossesSeparators: Bool
+        ) -> Bool {
+            if matches(patternIndex: afterStars, candidateIndex: candidateIndex) {
+                return true
+            }
+            var index = candidateIndex
+            while index < candidate.count,
+                  crossesSeparators || candidate[index] != "/" {
+                index += 1
+                if matches(patternIndex: afterStars, candidateIndex: index) {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,19 @@
 # Code Quality Audit
 
+## 2026-07-12 Permission Globstar Directory Semantics
+
+Overall grade after this slice: **A+ safety correctness, A+ bounded matching**.
+
+`PermissionWildcardPattern` previously represented every `**` with one self-looping state. That
+kept matching bounded, but `**/` could not skip zero complete path segments: for example,
+`**/.env` missed `.env`, and `a/**/b` missed `a/b`. The matcher now compiles `**/` into separate
+boundary and in-segment states. Only a boundary can skip to the following token, so root matches
+work without allowing partial-segment counterexamples such as `x.env`, `a/xb`, or `ax`.
+
+The implementation remains backtracking-free and input-bounded. Dedicated tests cover positive
+and negative examples, permission-table integration, maximum-size repeated fragments, Unicode and
+empty segments, and a generated corpus checked against an independent memoized recursive oracle.
+
 ## 2026-07-12 Managed Worktree Environment Setup Slice
 
 Overall grade after this slice: **A+ execution reuse, A+ path safety, A worktree setup parity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-12
 
+- Permission wildcard `**/` is compiled as a two-state complete-segment NFA fragment, while bare `**` keeps its cross-separator self-loop. Only the directory-boundary state may epsilon-skip the fragment. A direct epsilon edge around the slash would also be reachable after consuming a partial segment and could broaden an allow rule, so the matcher is regression-checked against an independent recursive oracle over a generated corpus.
 - Managed Worktree tasks are transactional detached checkouts, not implicit feature branches. The materializer snapshots staged and unstaged patches plus frozen bounded local-file content before `git worktree add --detach`, then rolls the registered worktree back on any apply/copy failure. `.worktreeinclude` is evaluated as a gitignore-style selector but candidates must also be normally ignored; ignored `AGENTS.override.md` is included automatically. Untracked nonignored files transfer as current work, source symlinks are skipped, existing destinations are never overwritten, and explicit branch-creating worktrees remain a separate permanent workflow. This gives future Local/Worktree Handoff, cleanup snapshots, and restoration one deterministic materialization boundary.
 
 ## 2026-07-05


### PR DESCRIPTION
## Summary

- compile `**/` as a two-state complete-segment fragment while leaving bare `**` unchanged
- fix root-level secret denies without broadening allow rules to partial path segments
- add positive, negative, bit-boundary, maximum-input, permission-table, parity, and oracle-backed corpus tests

Fixes #1061

## Validation

- `swift test`: 3,633 passed, 2 skipped, 0 failed
- Playwright: 215 passed
- `scripts/smoke.sh`: packaged macOS, live-window, CLI/file/git/browser flows passed
- Linux Docker build and Computer Use helper smoke passed
- focused permission and security suites: 70 passed, 1 expected skip, 0 failed
- code-quality grader: all modules A+
- `git diff --check`
