### PR TITLE
feat(agent): wire proactive compaction to the active model's real context window

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceAgentRunContextBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentRunContextBuilder.swift
@@ -64,7 +64,31 @@ struct WorkspaceAgentRunContextBuilder: Sendable {
         if let modelID {
             activeRunner.llm = overridingModelIfSupported(activeRunner.llm, modelID: modelID)
         }
+        // Proactive compaction: compact BEFORE the provider wall, sized to the ACTIVE model's real
+        // context window from the catalog (85%), recomputed per send so a /model switch takes effect
+        // immediately. The base runner is built reactive-only (limit 0) long before the catalog is
+        // fetched; this fill-in only runs when the limit is still 0 (an explicitly configured policy
+        // survives), never fabricates a compactor for runners built without one, and leaves
+        // reactive-only when the catalog does not know the model's window.
+        if var compaction = activeRunner.compaction,
+           compaction.proactiveTokenLimit == 0,
+           let limit = proactiveCompactionTokenLimit(modelID: modelID) {
+            compaction.proactiveTokenLimit = limit
+            activeRunner.compaction = compaction
+        }
         return activeRunner
+    }
+
+    /// 85% of the active model's catalog context window, or nil when the catalog has no entry (or no
+    /// window) for it — mirroring `WorkspaceTokenBudgetSurfaceBuilder`'s resolution so the compaction
+    /// threshold and the top-bar token chip agree on what "the window" is.
+    private func proactiveCompactionTokenLimit(modelID: String?) -> Int? {
+        let canonicalModelID = TrustedRouterDefaults.canonicalModelID(modelID ?? config.defaultModel)
+        let model = TrustedRouterDefaults.normalizedModelCatalog(modelCatalog).first {
+            TrustedRouterDefaults.canonicalModelID($0.id) == canonicalModelID
+        }
+        guard let tokens = model?.capabilities.contextWindowTokens, tokens > 0 else { return nil }
+        return tokens * 85 / 100
     }
 
     var baseToolDefinitions: [ToolDefinition] {

--- a/Tests/QuillCodeAppTests/WorkspaceAgentRunContextBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentRunContextBuilderTests.swift
@@ -65,6 +65,65 @@ final class WorkspaceAgentRunContextBuilderTests: XCTestCase {
         )
     }
 
+    func testConfiguredRunnerWiresProactiveCompactionToTheActiveModelsContextWindow() {
+        var builder = WorkspaceAgentRunContextBuilder(
+            selectedProject: nil,
+            browser: BrowserState(),
+            computerUseBackend: nil,
+            globalMemoryDirectory: nil,
+            mcpToolDefinitions: [],
+            mcpToolExecutionOverride: nil,
+            sshRemoteShellExecutor: SSHRemoteShellExecutor()
+        )
+        builder.config = AppConfig(defaultModel: "trustedrouter/fast")
+        builder.modelCatalog = [
+            catalogModel(id: "trustedrouter/fast", contextWindowTokens: 100_000),
+            catalogModel(id: "trustedrouter/deep", contextWindowTokens: 200_000)
+        ]
+        let baseRunner = AgentRunner(compaction: AgentCompactionPolicy(compactor: ThreadCompactor()))
+
+        // The default model's window sizes the proactive threshold (85%).
+        XCTAssertEqual(
+            builder.configuredRunner(from: baseRunner).compaction?.proactiveTokenLimit,
+            85_000
+        )
+        // A per-send model override resolves THAT model's window, so /model switches take effect.
+        XCTAssertEqual(
+            builder.configuredRunner(from: baseRunner, modelID: "trustedrouter/deep")
+                .compaction?.proactiveTokenLimit,
+            170_000
+        )
+
+        // Unknown model → catalog has no window → stays reactive-only (0), never a guess.
+        XCTAssertEqual(
+            builder.configuredRunner(from: baseRunner, modelID: "trustedrouter/unknown")
+                .compaction?.proactiveTokenLimit,
+            0
+        )
+
+        // A runner built WITHOUT compaction never gains a fabricated one.
+        XCTAssertNil(builder.configuredRunner(from: AgentRunner()).compaction)
+
+        // An explicitly configured proactive limit survives (the fill-in only lifts 0).
+        let explicit = AgentRunner(
+            compaction: AgentCompactionPolicy(compactor: ThreadCompactor(), proactiveTokenLimit: 12_345)
+        )
+        XCTAssertEqual(
+            builder.configuredRunner(from: explicit).compaction?.proactiveTokenLimit,
+            12_345
+        )
+    }
+
+    private func catalogModel(id: String, contextWindowTokens: Int) -> ModelInfo {
+        ModelInfo(
+            id: id,
+            provider: "TrustedRouter",
+            displayName: id,
+            category: "Recommended",
+            capabilities: ModelCapabilities(contextWindowTokens: contextWindowTokens)
+        )
+    }
+
     func testContextPreservesUnrelatedToolFeedbackAttachmentProvider() {
         let baseRunner = AgentRunner(
             baseToolDefinitions: [],


### PR DESCRIPTION
## The finding (gap #8 from the verified Codex gap analysis)
The proactive-compaction engine is fully built (`AgentCompaction.swift` — estimate tokens, compact BEFORE the model call, bounded rounds) but **production never turns it on**: `RuntimeFactory` constructs `AgentCompactionPolicy` with the default `proactiveTokenLimit = 0` ("reactive-only"). So every context overflow costs a **failed provider round-trip** and depends on `ContextOverflowDetector` recognizing that provider's error shape — fragile exactly where unattended runs need it not to be. (Codex auto-compacts as the window fills.)

## The fix
`configuredRunner` (the per-send choke point that already wires the spend fuse from config + catalog) now sizes the proactive threshold to the **active model's real context window**: 85% of `capabilities.contextWindowTokens`, resolved from the catalog with the same canonical-ID lookup the top-bar token chip uses — so the chip and the compactor agree on what "the window" is, and a per-send `/model` switch resizes the threshold immediately.

Guard rails:
- Fill-in only when the policy's limit is still 0 (an explicitly configured policy survives).
- Never fabricates a compactor for runners built without one.
- Unknown model / no catalog window → stays reactive-only (never a guessed limit).

## Tests (`WorkspaceAgentRunContextBuilderTests`)
- Default model with a 100k window → threshold 85,000; per-send override to a 200k model → 170,000.
- Unknown model → stays 0 (reactive-only); runner without compaction stays nil; an explicit 12,345 limit survives.
- Full Swift suite green.

Follow-up (same gap, PR2): align the context-pressure banner with the same model-aware budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
