### PR TITLE
fix(release): serialize download publishing

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: download-builds-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   macos:

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -89,6 +89,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         let workflow = try Self.workflowText(named: "download-builds.yml")
 
         Self.assertSource(workflow, containsAll: [
+            "group: download-builds-${{ github.ref }}",
+            "cancel-in-progress: false",
             "scripts/build-download-manifest.py",
             "--output \"$RUNNER_TEMP/release-assets/latest-tester-build.json\"",
             "RELEASE_CHANNEL=\"tester\"",
@@ -96,6 +98,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "\\`latest-tester-build.json\\`: machine-readable build metadata",
             "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/* --clobber"
         ])
+        XCTAssertFalse(
+            workflow.contains("cancel-in-progress: true"),
+            "a scheduled build must not cancel another run while it is publishing release assets"
+        )
     }
 
     func testDownloadDocsExposeStableManifestLink() throws {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -71,6 +71,10 @@
   workflows afterward. The train therefore dispatches both `ci.yml` and `download-builds.yml` explicitly after a
   successful merge. This keeps `main` validated and refreshes `tester-latest` without requiring a maintainer to
   remember a manual tester-build run after agent PRs land.
+- Download-build runs serialize instead of canceling an in-progress run. A delayed scheduled run can otherwise arrive
+  after both platform packages finish and cancel the publisher while it is fetching the repository, leaving valid
+  artifacts without an updated `tester-latest` release. Serial execution favors a complete release over a newer run
+  preempting the final publication step.
 - Tool-card image previews read only bounded local file headers for dimensions. `ToolArtifactImageMetadataReader`
   handles PNG, GIF, and JPEG width/height from the first 64 KiB and refuses URLs/non-file artifacts. The preview
   builders surface a plain `dimensionsLabel`, keeping SwiftUI/HTML renderers filesystem-free and avoiding a general


### PR DESCRIPTION
## Summary

- serialize Download Builds workflow runs instead of canceling an active publisher
- prevent delayed scheduled runs from discarding completed macOS/Linux packages before `tester-latest` publication
- add a parity regression gate and document the release reliability decision

## Root cause

A delayed scheduled run started after both platform jobs had completed in the post-merge run. Because workflow concurrency used `cancel-in-progress: true`, GitHub canceled the active publish job during checkout, leaving uploaded artifacts but no refreshed tester release.

## Verification

- `swift test --filter ParityDownloadBuildsGateTests`: 4 passed
- `git diff --check`: clean
