### PR TITLE
feat(agent): surface ceiling/flail stop reasons as honest notifications

### DIFF
--- a/Sources/QuillCodeApp/AgentRunNotification.swift
+++ b/Sources/QuillCodeApp/AgentRunNotification.swift
@@ -21,8 +21,21 @@ public struct AgentRunNotification: Sendable, Hashable, Identifiable {
         /// An edit-bearing run that was not verified (edits made, but no verification check ran) —
         /// an honest absence of a green claim.
         case unverified
+        /// The run exhausted its tool-step budget without the model returning a real conclusion — the
+        /// summary is synthesized from the last tool result, so this is "gave up", not "done".
+        case ceilingReached
+        /// The flail detector stopped a busy-but-stuck run to save the remaining budget.
+        case flailed
         /// The run produced a final answer with nothing pending.
         case finished
+    }
+
+    /// A non-finish run stop that must read as "gave up", not "done" — so an unattended run's OS ping is
+    /// honest. Kept App-local (rather than importing the agent's stop-reason enum here) so this pure
+    /// decision type stays decoupled; the builder maps `AgentRunStopReason` into it.
+    public enum BudgetStop: Sendable, Hashable {
+        case ceilingReached(limit: Int)
+        case flailed(reason: String)
     }
 
     public var kind: Kind
@@ -72,6 +85,7 @@ public enum AgentRunNotificationPlanner {
         didEditFiles: Bool = false,
         hasVerificationAction: Bool = false,
         verification: VerificationVerdict? = nil,
+        budgetStop: AgentRunNotification.BudgetStop? = nil,
         integrity: RunIntegrityVerdict? = nil
     ) -> AgentRunNotification? {
         let title = displayTitle(rawTitle)
@@ -92,6 +106,12 @@ public enum AgentRunNotificationPlanner {
                 body: "\(title) — the run hit an error and stopped.",
                 threadID: threadID
             )
+        }
+        // Ranked below a failure but ABOVE a plain finish/verification: a ceiling/flail run "gave up",
+        // so it must never masquerade as a checked-green finish. Stamped with the integrity badge like
+        // the finish paths so the honesty verdict still rides along.
+        if let budgetStop {
+            return stamped(budgetStopNotification(budgetStop, title: title, threadID: threadID), integrity: integrity)
         }
         // For an edit-bearing run, "finished" should be a CHECKED fact, not a claim: report the
         // verification verdict (green / failing), or an honest "unverified" when a verify action exists
@@ -143,6 +163,30 @@ public enum AgentRunNotificationPlanner {
             stamped.title = "[\(integrity.badgeLabel)] \(notification.title)"
         }
         return stamped
+    }
+
+    private static func budgetStopNotification(
+        _ budgetStop: AgentRunNotification.BudgetStop,
+        title: String,
+        threadID: UUID
+    ) -> AgentRunNotification {
+        switch budgetStop {
+        case .ceilingReached(let limit):
+            return AgentRunNotification(
+                kind: .ceilingReached,
+                title: "QuillCode hit its step limit",
+                body: "\(title) — stopped after \(limit) tool step\(limit == 1 ? "" : "s") without finishing.",
+                threadID: threadID
+            )
+        case .flailed(let reason):
+            let detail = trimmedNonEmpty(reason).map { firstLine($0, limit: 100) }
+            return AgentRunNotification(
+                kind: .flailed,
+                title: "QuillCode stopped — stuck",
+                body: detail.map { "\(title) — \($0)" } ?? "\(title) — the run was busy but not making progress.",
+                threadID: threadID
+            )
+        }
     }
 
     private static func verificationNotification(

--- a/Sources/QuillCodeApp/LinuxNotificationAdapter.swift
+++ b/Sources/QuillCodeApp/LinuxNotificationAdapter.swift
@@ -52,7 +52,9 @@ public enum LinuxNotificationAdapter {
             .init(urgency: .critical, expireTimeMilliseconds: 0)
         case .failed, .checksFailing:
             .init(urgency: .critical, expireTimeMilliseconds: 12_000)
-        case .unverified:
+        case .unverified, .ceilingReached, .flailed:
+            // The run "gave up" without finishing — worth noticing (normal urgency, lingers) but not a
+            // blocking critical like a failure or a pending approval.
             .init(urgency: .normal, expireTimeMilliseconds: 8_000)
         case .finished:
             .init(urgency: .normal, expireTimeMilliseconds: 6_000)

--- a/Sources/QuillCodeApp/WorkspaceAgentSendSession.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentSendSession.swift
@@ -7,17 +7,23 @@ struct WorkspaceAgentSendSessionResult: Sendable {
     var thread: ChatThread
     var savedMemory: Bool
     var pendingApproval: AgentPendingApproval?
+    /// How the underlying agent run ended (finished / ceiling / flail / approval / spend-fuse). Carried
+    /// so the composer + notification layer can tell a genuine finish from "gave up at the budget" —
+    /// without which an unattended ceiling/flail run pings the OS as `.finished`.
+    var stopReason: AgentRunStopReason
 
     var pendingApprovalToolCall: ToolCall? { pendingApproval?.heldToolCall }
 
     init(
         thread: ChatThread,
         savedMemory: Bool,
-        pendingApproval: AgentPendingApproval? = nil
+        pendingApproval: AgentPendingApproval? = nil,
+        stopReason: AgentRunStopReason = .finished
     ) {
         self.thread = thread
         self.savedMemory = savedMemory
         self.pendingApproval = pendingApproval
+        self.stopReason = stopReason
     }
 }
 
@@ -145,17 +151,35 @@ struct WorkspaceAgentSendSession: Sendable {
             return WorkspaceAgentSendSessionResult(
                 thread: activeThread,
                 savedMemory: false,
-                pendingApproval: pendingApproval
+                pendingApproval: pendingApproval,
+                stopReason: result.stopReason
             )
         }
 
-        return try await runAfterHooks(
-            thread: activeThread,
-            prompt: prompt,
-            stopHookActive: stopHookActive,
-            subagentStopHookActive: subagentStopHookActive,
-            onProgress: onProgress
+        return carrying(
+            result.stopReason,
+            into: try await runAfterHooks(
+                thread: activeThread,
+                prompt: prompt,
+                stopHookActive: stopHookActive,
+                subagentStopHookActive: subagentStopHookActive,
+                onProgress: onProgress
+            )
         )
+    }
+
+    /// After-hook and stop-hook processing returns a `.finished` session result (a hook ending a run is
+    /// a genuine finish). Overlay the model run's stop reason only when the pipeline itself did not set
+    /// a more specific one — a Stop-hook CONTINUATION re-runs the agent and already carries the fresh
+    /// run's reason, which must not be clobbered by the first run's `.finished`.
+    private func carrying(
+        _ stopReason: AgentRunStopReason,
+        into result: WorkspaceAgentSendSessionResult
+    ) -> WorkspaceAgentSendSessionResult {
+        guard result.stopReason == .finished else { return result }
+        var carried = result
+        carried.stopReason = stopReason
+        return carried
     }
 
     func resumeApproved(
@@ -184,15 +208,19 @@ struct WorkspaceAgentSendSession: Sendable {
             return WorkspaceAgentSendSessionResult(
                 thread: result.thread,
                 savedMemory: false,
-                pendingApproval: nextApproval
+                pendingApproval: nextApproval,
+                stopReason: result.stopReason
             )
         }
-        return try await runAfterHooks(
-            thread: result.thread,
-            prompt: activePrompt,
-            stopHookActive: stopContinuation != nil,
-            subagentStopHookActive: subagentContinuation != nil,
-            onProgress: onProgress
+        return carrying(
+            result.stopReason,
+            into: try await runAfterHooks(
+                thread: result.thread,
+                prompt: activePrompt,
+                stopHookActive: stopContinuation != nil,
+                subagentStopHookActive: subagentContinuation != nil,
+                onProgress: onProgress
+            )
         )
     }
 

--- a/Sources/QuillCodeApp/WorkspaceModelRunNotifications.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelRunNotifications.swift
@@ -27,8 +27,11 @@ extension QuillCodeWorkspaceModel {
     /// errored, or blocked on an approval gate. A user-cancelled run is skipped.
     func notifyRunFinishedIfNeeded(outcome: WorkspaceAgentSendTaskOutcome, threadID: UUID) {
         let didFail: Bool
+        var budgetStop: AgentRunNotification.BudgetStop?
         switch outcome {
-        case .completed: didFail = false
+        case .completed(let result):
+            didFail = false
+            budgetStop = WorkspaceRunNotificationBuilder.budgetStop(for: result.stopReason)
         case .failed: didFail = true
         case .cancelled: return
         }
@@ -39,6 +42,19 @@ extension QuillCodeWorkspaceModel {
             root.projects.first { $0.id == projectID }
         }
         let localActions = runProject?.localActions ?? []
+
+        // A ceiling/flail run "gave up" — surface that directly instead of running the verify command
+        // and reporting a checked-green finish. Approval/finish runs keep the verification path.
+        if let budgetStop {
+            postRunNotification(
+                thread: thread,
+                didFail: false,
+                localActions: localActions,
+                budgetStop: budgetStop,
+                handler: handler
+            )
+            return
+        }
 
         if let plan = verificationNotificationPlan(
             thread: thread,
@@ -85,12 +101,14 @@ extension QuillCodeWorkspaceModel {
         thread: ChatThread,
         didFail: Bool,
         localActions: [LocalEnvironmentAction],
+        budgetStop: AgentRunNotification.BudgetStop? = nil,
         handler: @MainActor @Sendable (AgentRunNotification) -> Void
     ) {
         guard let notification = WorkspaceRunNotificationBuilder.notification(
             thread: thread,
             didFail: didFail,
-            localActions: localActions
+            localActions: localActions,
+            budgetStop: budgetStop
         ) else {
             return
         }

--- a/Sources/QuillCodeApp/WorkspaceRunNotificationBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceRunNotificationBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QuillCodeAgent
 import QuillCodeCore
 
 /// Turns a just-finished agent run (its resulting thread + whether it errored) into an
@@ -14,7 +15,8 @@ enum WorkspaceRunNotificationBuilder {
         thread: ChatThread,
         didFail: Bool,
         localActions: [LocalEnvironmentAction] = [],
-        verification: VerificationVerdict? = nil
+        verification: VerificationVerdict? = nil,
+        budgetStop: AgentRunNotification.BudgetStop? = nil
     ) -> AgentRunNotification? {
         let pending = pendingApproval(in: thread)
         // The run-integrity badge is the honesty stamp on the transcript: prefer a verdict already
@@ -31,8 +33,20 @@ enum WorkspaceRunNotificationBuilder {
             didEditFiles: WorkspaceTurnRevertPlanner.threadMadeEdits(thread),
             hasVerificationAction: LocalEnvironmentActionMatcher.verificationAction(in: localActions) != nil,
             verification: verification,
+            budgetStop: budgetStop,
             integrity: integrity
         )
+    }
+
+    /// Maps the agent's run stop reason into the App-local `BudgetStop` the notification planner uses —
+    /// nil for a genuine finish, and for approval/spend-fuse pauses (those are surfaced by the
+    /// pending-approval path, not a "finished run" ping).
+    static func budgetStop(for stopReason: AgentRunStopReason) -> AgentRunNotification.BudgetStop? {
+        switch stopReason {
+        case .toolStepCeilingExhausted(let limit): return .ceilingReached(limit: limit)
+        case .flailDetected(let reason): return .flailed(reason: reason)
+        case .finished, .spendFuseApprovalRequired, .approvalRequired: return nil
+        }
     }
 
     /// An approval that was requested but never decided means the run stopped waiting on the user —

--- a/Tests/QuillCodeAppTests/AgentRunNotificationPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/AgentRunNotificationPlannerTests.swift
@@ -33,6 +33,60 @@ final class AgentRunNotificationPlannerTests: XCTestCase {
         XCTAssertTrue(note?.body.contains("Build the parser") == true, note?.body ?? "")
     }
 
+    func testCeilingRunReportsGaveUpNotFinished() {
+        // The whole point: a ceiling run carries a synthesized final answer, but the ping must say it
+        // stopped without finishing — NOT masquerade as a plain finish.
+        let note = AgentRunNotificationPlanner.notification(
+            threadTitle: "Migrate the schema",
+            threadID: threadID,
+            didFail: false,
+            pendingApprovalSummary: nil,
+            finalAnswer: "Ran the last tool; here is what I saw.",
+            budgetStop: .ceilingReached(limit: 64)
+        )
+        XCTAssertEqual(note?.kind, .ceilingReached)
+        XCTAssertTrue(note?.body.contains("64 tool steps") == true, note?.body ?? "")
+        XCTAssertTrue(note?.body.contains("without finishing") == true, note?.body ?? "")
+    }
+
+    func testFlailRunReportsStuckWithReason() {
+        let note = AgentRunNotificationPlanner.notification(
+            threadTitle: "Fix the flaky test",
+            threadID: threadID,
+            didFail: false,
+            pendingApprovalSummary: nil,
+            finalAnswer: nil,
+            budgetStop: .flailed(reason: "repeated the same failing command with no workspace change")
+        )
+        XCTAssertEqual(note?.kind, .flailed)
+        XCTAssertTrue(note?.body.contains("repeated the same failing command") == true, note?.body ?? "")
+    }
+
+    func testBudgetStopOutranksVerificationButNotApprovalOrFailure() {
+        // Approval/failure still win; a ceiling on an edit-bearing run does NOT become verifiedGreen.
+        let approval = AgentRunNotificationPlanner.notification(
+            threadTitle: "T", threadID: threadID, didFail: false,
+            pendingApprovalSummary: "host.shell.run", finalAnswer: nil,
+            budgetStop: .ceilingReached(limit: 8)
+        )
+        XCTAssertEqual(approval?.kind, .needsApproval)
+
+        let failed = AgentRunNotificationPlanner.notification(
+            threadTitle: "T", threadID: threadID, didFail: true,
+            pendingApprovalSummary: nil, finalAnswer: nil,
+            budgetStop: .ceilingReached(limit: 8)
+        )
+        XCTAssertEqual(failed?.kind, .failed)
+
+        let ceilingOverVerify = AgentRunNotificationPlanner.notification(
+            threadTitle: "T", threadID: threadID, didFail: false,
+            pendingApprovalSummary: nil, finalAnswer: "done",
+            didEditFiles: true, hasVerificationAction: true, verification: .passed,
+            budgetStop: .ceilingReached(limit: 8)
+        )
+        XCTAssertEqual(ceilingOverVerify?.kind, .ceilingReached)
+    }
+
     func testFinishedRunSummarizesTheAnswer() {
         let note = AgentRunNotificationPlanner.notification(
             threadTitle: "Add tests",

--- a/Tests/QuillCodeAppTests/WorkspaceRunNotificationBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRunNotificationBuilderTests.swift
@@ -138,4 +138,27 @@ final class WorkspaceRunNotificationBuilderTests: XCTestCase {
         let note = WorkspaceRunNotificationBuilder.notification(thread: t, didFail: false)
         XCTAssertEqual(note?.integrity, .red)
     }
+
+    func testBudgetStopMapsAgentStopReasonAndDrivesNotificationKind() {
+        // The agent's stop reason maps to the App-local BudgetStop; a genuine finish / approval /
+        // spend-fuse pause maps to nil (surfaced by other paths, not a "gave up" ping).
+        XCTAssertEqual(
+            WorkspaceRunNotificationBuilder.budgetStop(for: .toolStepCeilingExhausted(limit: 64)),
+            .ceilingReached(limit: 64)
+        )
+        XCTAssertEqual(
+            WorkspaceRunNotificationBuilder.budgetStop(for: .flailDetected(reason: "stuck")),
+            .flailed(reason: "stuck")
+        )
+        XCTAssertNil(WorkspaceRunNotificationBuilder.budgetStop(for: .finished))
+        XCTAssertNil(WorkspaceRunNotificationBuilder.budgetStop(for: .approvalRequired(requestID: "r")))
+        XCTAssertNil(WorkspaceRunNotificationBuilder.budgetStop(for: .spendFuseApprovalRequired(totalUSD: 2, fuseUSD: 1)))
+
+        // End-to-end through the builder: a ceiling stop yields the ceiling Kind, not a plain finish.
+        let t = thread(messages: [ChatMessage(role: .assistant, content: "last tool output")])
+        let note = WorkspaceRunNotificationBuilder.notification(
+            thread: t, didFail: false, budgetStop: .ceilingReached(limit: 64)
+        )
+        XCTAssertEqual(note?.kind, .ceilingReached)
+    }
 }


### PR DESCRIPTION
## The gap (rank 1 of the re-verified Codex roadmap)
When the agent stops at its tool-step ceiling or the flail detector halts a stuck run, the run carries a **synthesized** final answer (from the last tool result). Confirmed on current main: `WorkspaceAgentSendSession.run` dropped `AgentRunResult.stopReason`, so `WorkspaceRunNotificationBuilder` reported a ceiling/flail run as `.finished` / `.verifiedGreen`. The OS ping literally could not tell **"done"** from **"gave up at the budget"** — the single most important honesty signal for driving an agent unattended.

## The fix (pure plumbing + notification mapping, no visible-surface churn)
- `WorkspaceAgentSendSessionResult` now carries `stopReason: AgentRunStopReason`, populated from the runner result and carried through the after-hook pipeline (a hook-ended run stays `.finished`; a Stop-hook **continuation** re-runs the agent and keeps its own fresh reason — guarded so the first run's `.finished` can't clobber it).
- `AgentRunNotification.Kind` gains `.ceilingReached` / `.flailed`; a new App-local `BudgetStop` enum keeps `AgentRunNotification.swift` decoupled from the agent's stop-reason type. The planner ranks a budget stop **below** approval/failure but **above** a plain finish/verification, and still stamps the run-integrity badge.
- `WorkspaceModelRunNotifications` maps the completed outcome's stop reason via `WorkspaceRunNotificationBuilder.budgetStop(for:)` and, for a budget stop, posts the honest notification **instead of** running the verify command and reporting green.
- `LinuxNotificationAdapter` policy: ceiling/flail = normal urgency, lingering (not a blocking critical).

## Tests
- Planner: ceiling reports "N tool steps / without finishing"; flail carries the stuck reason; a budget stop is outranked by approval/failure but **outranks** an edit-bearing `verified` finish.
- Builder: `budgetStop(for:)` maps ceiling/flail and returns nil for finish/approval/spend-fuse; end-to-end a ceiling stop yields `.ceilingReached`.
- Full Swift suite green. No parity/Playwright surface in this PR (the transcript/activity surfacing is the ranked follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
