### PR TITLE
feat(app-server): add fuzzy file search parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ watches instead of leaving work stranded.
 the same turn ID, and survives app-server restart. It is rejected while a turn or compaction is active
 and deliberately does not undo workspace files, commands, account state, or recorded token spend.
 
+`fuzzyFileSearch` provides bounded, case-insensitive multi-root file and directory matching with
+Codex-compatible scores, character indices, and deterministic ordering. Experimental clients can
+keep an indexed search alive with `fuzzyFileSearch/sessionStart`, `sessionUpdate`, and `sessionStop`;
+query edits cancel stale generations, and stop or disconnect suppresses late notifications.
+
 Account clients can start API-key or browser-based TrustedRouter sign-in through
 `account/login/start`, cancel an outstanding browser flow through `account/login/cancel`, and clear
 the managed credential through `account/logout`. Responses are emitted before the matching

--- a/Sources/QuillCodeCLI/AppServerFuzzyFileSearch.swift
+++ b/Sources/QuillCodeCLI/AppServerFuzzyFileSearch.swift
@@ -1,0 +1,361 @@
+import Foundation
+import QuillCodeTools
+
+struct AppServerFuzzyFileSearchResult: Sendable, Equatable {
+    enum MatchType: String, Sendable {
+        case file
+        case directory
+    }
+
+    var root: String
+    var path: String
+    var matchType: MatchType
+    var fileName: String
+    var score: Int
+    var indices: [Int]
+
+    var jsonValue: CLIJSONValue {
+        .object([
+            "root": .string(root),
+            "path": .string(path),
+            "match_type": .string(matchType.rawValue),
+            "file_name": .string(fileName),
+            "score": .number(Double(score)),
+            "indices": .array(indices.map { .number(Double($0)) })
+        ])
+    }
+}
+
+struct AppServerFuzzyFileSearchIndex: Sendable {
+    struct Entry: Sendable {
+        var root: String
+        var path: String
+        var fileName: String
+        var matchType: AppServerFuzzyFileSearchResult.MatchType
+    }
+
+    var entries: [Entry]
+}
+
+enum AppServerFuzzyFileSearchEngine {
+    static let matchLimit = 50
+    static let maximumRoots = 32
+    static let maximumRootBytes = 4_096
+    static let maximumQueryCharacters = 256
+    static let maximumIndexedEntries = 100_000
+    static let maximumEntriesPerRoot = 20_000
+
+    static func buildIndex(roots: [String], relativeTo currentDirectory: URL) -> AppServerFuzzyFileSearchIndex {
+        var entries: [AppServerFuzzyFileSearchIndex.Entry] = []
+        entries.reserveCapacity(min(maximumIndexedEntries, roots.count * 4_000))
+
+        for root in roots {
+            guard !Task.isCancelled, entries.count < maximumIndexedEntries else { break }
+            let rootURL = resolvedRoot(root, relativeTo: currentDirectory)
+            let remaining = maximumIndexedEntries - entries.count
+            let index = WorkspaceFileIndexer(workspaceRoot: rootURL).index(
+                maxFiles: min(maximumEntriesPerRoot, remaining)
+            )
+            entries.append(contentsOf: index.entries.prefix(remaining).map { entry in
+                AppServerFuzzyFileSearchIndex.Entry(
+                    root: root,
+                    path: entry.path,
+                    fileName: entry.name,
+                    matchType: entry.kind == .directory ? .directory : .file
+                )
+            })
+        }
+
+        return AppServerFuzzyFileSearchIndex(entries: entries)
+    }
+
+    static func search(
+        query: String,
+        index: AppServerFuzzyFileSearchIndex
+    ) -> [AppServerFuzzyFileSearchResult] {
+        guard !query.isEmpty else { return [] }
+
+        var matches: [AppServerFuzzyFileSearchResult] = []
+        matches.reserveCapacity(matchLimit)
+        for entry in index.entries {
+            guard !Task.isCancelled else { break }
+            guard let match = AppServerFuzzyPathMatcher.match(query: query, path: entry.path) else {
+                continue
+            }
+            matches.append(AppServerFuzzyFileSearchResult(
+                root: entry.root,
+                path: entry.path,
+                matchType: entry.matchType,
+                fileName: entry.fileName,
+                score: match.score,
+                indices: match.indices
+            ))
+        }
+
+        matches.sort {
+            if $0.score != $1.score { return $0.score > $1.score }
+            if $0.path != $1.path { return $0.path < $1.path }
+            return $0.root < $1.root
+        }
+        return Array(matches.prefix(matchLimit))
+    }
+
+    private static func resolvedRoot(_ root: String, relativeTo currentDirectory: URL) -> URL {
+        guard !root.hasPrefix("/") else {
+            return URL(fileURLWithPath: root, isDirectory: true).standardizedFileURL
+        }
+        return currentDirectory
+            .appendingPathComponent(root, isDirectory: true)
+            .standardizedFileURL
+    }
+}
+
+enum AppServerFuzzyPathMatcher {
+    struct Match: Sendable, Equatable {
+        var score: Int
+        var indices: [Int]
+    }
+
+    static func match(query: String, path: String) -> Match? {
+        let needle = Array(query.lowercased())
+        let haystack = Array(path.lowercased())
+        guard !needle.isEmpty, needle.count <= haystack.count else { return nil }
+
+        var best: Match?
+        for start in haystack.indices where haystack[start] == needle[0] {
+            guard let indices = greedyIndices(needle: needle, haystack: haystack, start: start) else {
+                continue
+            }
+            let candidate = Match(score: score(queryCount: needle.count, indices: indices), indices: indices)
+            if isBetter(candidate, than: best) { best = candidate }
+        }
+        return best
+    }
+
+    private static func greedyIndices(
+        needle: [Character],
+        haystack: [Character],
+        start: Int
+    ) -> [Int]? {
+        var indices = [start]
+        var cursor = start + 1
+        for character in needle.dropFirst() {
+            guard let index = haystack[cursor...].firstIndex(of: character) else { return nil }
+            indices.append(index)
+            cursor = index + 1
+        }
+        return indices
+    }
+
+    private static func score(queryCount: Int, indices: [Int]) -> Int {
+        let leadingPenalty = (indices[0] * 3 + 1) / 2
+        let gapPenalty = zip(indices, indices.dropFirst()).reduce(into: 0) { penalty, pair in
+            let skipped = pair.1 - pair.0 - 1
+            guard skipped > 0 else { return }
+            penalty += skipped * 6
+            if skipped > 1 { penalty += 1 }
+        }
+        return max(1, queryCount * 28 - leadingPenalty - gapPenalty)
+    }
+
+    private static func isBetter(_ candidate: Match, than current: Match?) -> Bool {
+        guard let current else { return true }
+        if candidate.score != current.score { return candidate.score > current.score }
+        return candidate.indices.lexicographicallyPrecedes(current.indices)
+    }
+}
+
+struct AppServerFuzzyFileSearchRequest: Sendable {
+    var query: String
+    var roots: [String]
+    var cancellationToken: String?
+
+    init(params: CLIJSONValue) throws {
+        let params = try AppServerParams(params)
+        self.query = try params.requiredString("query", allowingEmpty: true)
+        self.roots = try Self.roots(from: params)
+        self.cancellationToken = try params.optionalString("cancellationToken")
+        try Self.validateQuery(query)
+    }
+
+    static func roots(from params: AppServerParams) throws -> [String] {
+        guard let values = try params.optionalArray("roots") else {
+            throw AppServerRPCError.invalidParams("roots is required")
+        }
+        guard values.count <= AppServerFuzzyFileSearchEngine.maximumRoots else {
+            throw AppServerRPCError.invalidParams(
+                "roots may contain at most \(AppServerFuzzyFileSearchEngine.maximumRoots) entries"
+            )
+        }
+        return try values.enumerated().map { index, value in
+            guard let root = value.stringValue else {
+                throw AppServerRPCError.invalidParams("roots[\(index)] must be a string")
+            }
+            guard root.utf8.count <= AppServerFuzzyFileSearchEngine.maximumRootBytes else {
+                throw AppServerRPCError.invalidParams("roots[\(index)] is too long")
+            }
+            return root
+        }
+    }
+
+    static func validateQuery(_ query: String) throws {
+        guard query.count <= AppServerFuzzyFileSearchEngine.maximumQueryCharacters else {
+            throw AppServerRPCError.invalidParams(
+                "query may contain at most \(AppServerFuzzyFileSearchEngine.maximumQueryCharacters) characters"
+            )
+        }
+    }
+}
+
+struct AppServerActiveFuzzyFileSearch: Sendable {
+    var cancellationToken: String?
+    var task: Task<Void, Never>
+}
+
+struct AppServerFuzzyFileSearchSession: Sendable {
+    var indexTask: Task<AppServerFuzzyFileSearchIndex, Never>
+    var queryGeneration: UInt64 = 0
+    var queryTask: Task<Void, Never>?
+
+    func cancel() {
+        indexTask.cancel()
+        queryTask?.cancel()
+    }
+}
+
+extension AppServerSession {
+    func startFuzzyFileSearchRequest(id: AppServerRequestID, params: CLIJSONValue) throws {
+        let request = try AppServerFuzzyFileSearchRequest(params: params)
+        if let token = request.cancellationToken,
+           let activeID = fuzzyFileSearchTokens[token],
+           let active = activeFuzzyFileSearches[activeID] {
+            active.task.cancel()
+        }
+
+        let activeID = UUID()
+        let currentDirectory = self.currentDirectory
+        let task = Task.detached(priority: .userInitiated) { [weak self] in
+            let index = AppServerFuzzyFileSearchEngine.buildIndex(
+                roots: request.roots,
+                relativeTo: currentDirectory
+            )
+            let files = AppServerFuzzyFileSearchEngine.search(query: request.query, index: index)
+            await self?.completeFuzzyFileSearchRequest(
+                activeID: activeID,
+                id: id,
+                cancellationToken: request.cancellationToken,
+                files: files
+            )
+        }
+        activeFuzzyFileSearches[activeID] = AppServerActiveFuzzyFileSearch(
+            cancellationToken: request.cancellationToken,
+            task: task
+        )
+        if let token = request.cancellationToken { fuzzyFileSearchTokens[token] = activeID }
+    }
+
+    func startFuzzyFileSearchSession(_ params: CLIJSONValue) throws -> CLIJSONValue {
+        try requireExperimentalAPI(for: "fuzzyFileSearch/sessionStart")
+        let params = try AppServerParams(params)
+        let sessionID = try params.requiredString("sessionId")
+        let roots = try AppServerFuzzyFileSearchRequest.roots(from: params)
+        fuzzyFileSearchSessions.removeValue(forKey: sessionID)?.cancel()
+
+        let currentDirectory = self.currentDirectory
+        let indexTask = Task.detached(priority: .userInitiated) {
+            AppServerFuzzyFileSearchEngine.buildIndex(roots: roots, relativeTo: currentDirectory)
+        }
+        fuzzyFileSearchSessions[sessionID] = AppServerFuzzyFileSearchSession(indexTask: indexTask)
+        return .object([:])
+    }
+
+    func updateFuzzyFileSearchSession(_ params: CLIJSONValue) throws -> CLIJSONValue {
+        try requireExperimentalAPI(for: "fuzzyFileSearch/sessionUpdate")
+        let params = try AppServerParams(params)
+        let sessionID = try params.requiredString("sessionId")
+        let query = try params.requiredString("query", allowingEmpty: true)
+        try AppServerFuzzyFileSearchRequest.validateQuery(query)
+        guard var session = fuzzyFileSearchSessions[sessionID] else {
+            throw AppServerRPCError.invalidRequest("fuzzy file search session not found: \(sessionID)")
+        }
+
+        session.queryTask?.cancel()
+        session.queryGeneration &+= 1
+        let generation = session.queryGeneration
+        let indexTask = session.indexTask
+        session.queryTask = Task.detached(priority: .userInitiated) { [weak self] in
+            let index = await indexTask.value
+            guard !Task.isCancelled else { return }
+            let files = AppServerFuzzyFileSearchEngine.search(query: query, index: index)
+            guard !Task.isCancelled else { return }
+            await self?.publishFuzzyFileSearchSession(
+                sessionID: sessionID,
+                generation: generation,
+                query: query,
+                files: files
+            )
+        }
+        fuzzyFileSearchSessions[sessionID] = session
+        return .object([:])
+    }
+
+    func stopFuzzyFileSearchSession(_ params: CLIJSONValue) throws -> CLIJSONValue {
+        try requireExperimentalAPI(for: "fuzzyFileSearch/sessionStop")
+        let params = try AppServerParams(params)
+        let sessionID = try params.requiredString("sessionId")
+        fuzzyFileSearchSessions.removeValue(forKey: sessionID)?.cancel()
+        return .object([:])
+    }
+
+    func cancelAllFuzzyFileSearches() async {
+        let activeTasks = activeFuzzyFileSearches.values.map(\.task)
+        let sessions = Array(fuzzyFileSearchSessions.values)
+        for task in activeTasks { task.cancel() }
+        for session in sessions { session.cancel() }
+        for task in activeTasks { await task.value }
+        for session in sessions {
+            _ = await session.indexTask.value
+            await session.queryTask?.value
+        }
+        activeFuzzyFileSearches.removeAll()
+        fuzzyFileSearchTokens.removeAll()
+        fuzzyFileSearchSessions.removeAll()
+    }
+
+    private func completeFuzzyFileSearchRequest(
+        activeID: UUID,
+        id: AppServerRequestID,
+        cancellationToken: String?,
+        files: [AppServerFuzzyFileSearchResult]
+    ) async {
+        guard activeFuzzyFileSearches.removeValue(forKey: activeID) != nil else { return }
+        if let cancellationToken, fuzzyFileSearchTokens[cancellationToken] == activeID {
+            fuzzyFileSearchTokens.removeValue(forKey: cancellationToken)
+        }
+        guard !inputFinished else { return }
+        await send(.response(id: id, result: .object([
+            "files": .array(files.map(\.jsonValue))
+        ])))
+    }
+
+    private func publishFuzzyFileSearchSession(
+        sessionID: String,
+        generation: UInt64,
+        query: String,
+        files: [AppServerFuzzyFileSearchResult]
+    ) async {
+        guard !inputFinished,
+              fuzzyFileSearchSessions[sessionID]?.queryGeneration == generation else { return }
+        await sendNotification("fuzzyFileSearch/sessionUpdated", params: .object([
+            "sessionId": .string(sessionID),
+            "query": .string(query),
+            "files": .array(files.map(\.jsonValue))
+        ]))
+
+        guard !inputFinished,
+              fuzzyFileSearchSessions[sessionID]?.queryGeneration == generation else { return }
+        await sendNotification("fuzzyFileSearch/sessionCompleted", params: .object([
+            "sessionId": .string(sessionID)
+        ]))
+    }
+}

--- a/Sources/QuillCodeCLI/AppServerProcessManagement.swift
+++ b/Sources/QuillCodeCLI/AppServerProcessManagement.swift
@@ -116,7 +116,7 @@ extension AppServerSession {
         return session
     }
 
-    private func requireExperimentalAPI(for method: String) throws {
+    func requireExperimentalAPI(for method: String) throws {
         guard experimentalAPIEnabled else {
             throw AppServerRPCError.invalidRequest(
                 "\(method) requires capabilities.experimentalApi: true"

--- a/Sources/QuillCodeCLI/AppServerSession.swift
+++ b/Sources/QuillCodeCLI/AppServerSession.swift
@@ -68,6 +68,9 @@ actor AppServerSession {
     var activeRollbacks: Set<UUID> = []
     var processSessions: [String: AppServerProcessSession] = [:]
     var processEventTasks: [String: Task<Void, Never>] = [:]
+    var activeFuzzyFileSearches: [UUID: AppServerActiveFuzzyFileSearch] = [:]
+    var fuzzyFileSearchTokens: [String: UUID] = [:]
+    var fuzzyFileSearchSessions: [String: AppServerFuzzyFileSearchSession] = [:]
     var nextServerRequestSequence: Int64 = 1
     var pendingApprovals: [AppServerRequestID: AppServerPendingApproval] = [:]
     var pendingAccountLogins: [String: AppServerPendingAccountLogin] = [:]
@@ -142,6 +145,9 @@ actor AppServerSession {
         let tasks = activeTurns.values.compactMap(\.task)
             + activeCompactions.values.compactMap(\.task)
         for task in tasks { await task.value }
+        let fuzzyTasks = activeFuzzyFileSearches.values.map(\.task)
+            + fuzzyFileSearchSessions.values.compactMap(\.queryTask)
+        for task in fuzzyTasks { await task.value }
     }
 
     func hasActiveOperation(for threadID: UUID) -> Bool {
@@ -156,6 +162,7 @@ actor AppServerSession {
         cancelAllFileWatches()
         cancelAllAccountLogins()
         cancelAllMCPServerOAuthLogins()
+        await cancelAllFuzzyFileSearches()
         await terminateAllProcesses()
         await mcpRegistry.terminateAll()
         resolveAllPendingApprovals(
@@ -174,6 +181,17 @@ actor AppServerSession {
         }
         guard handshake == .ready else {
             await send(.error(id: id, error: .notInitialized))
+            return
+        }
+
+        if method == "fuzzyFileSearch" {
+            do {
+                try startFuzzyFileSearchRequest(id: id, params: params)
+            } catch let error as AppServerRPCError {
+                await send(.error(id: id, error: error))
+            } catch {
+                await send(.error(id: id, error: .internalError(error.localizedDescription)))
+            }
             return
         }
 
@@ -236,6 +254,9 @@ actor AppServerSession {
             case "process/writeStdin": result = try writeProcessStdin(params)
             case "process/resizePty": result = try resizeProcessPTY(params)
             case "process/kill": result = try killProcess(params)
+            case "fuzzyFileSearch/sessionStart": result = try startFuzzyFileSearchSession(params)
+            case "fuzzyFileSearch/sessionUpdate": result = try updateFuzzyFileSearchSession(params)
+            case "fuzzyFileSearch/sessionStop": result = try stopFuzzyFileSearchSession(params)
             case "thread/start": result = try await startThread(params)
             case "thread/resume": result = try await resumeThread(params)
             case "thread/fork": result = try await forkThread(params)

--- a/Tests/QuillCodeCLITests/AppServerFuzzyFileSearchTests.swift
+++ b/Tests/QuillCodeCLITests/AppServerFuzzyFileSearchTests.swift
@@ -1,0 +1,377 @@
+import Foundation
+import QuillCodeAgent
+@testable import QuillCodeCLI
+import QuillCodeCore
+import QuillCodeSafety
+import XCTest
+
+final class AppServerFuzzyFileSearchTests: XCTestCase {
+    func testPathMatcherMatchesCodexScoresIndicesAndCaseInsensitivity() throws {
+        XCTAssertEqual(
+            AppServerFuzzyPathMatcher.match(query: "abe", path: "abexy"),
+            .init(score: 84, indices: [0, 1, 2])
+        )
+        XCTAssertEqual(
+            AppServerFuzzyPathMatcher.match(query: "abe", path: "sub/abce"),
+            .init(score: 72, indices: [4, 5, 7])
+        )
+        XCTAssertEqual(
+            AppServerFuzzyPathMatcher.match(query: "ABE", path: "abcde"),
+            .init(score: 71, indices: [0, 1, 4])
+        )
+        XCTAssertNil(AppServerFuzzyPathMatcher.match(query: "missing", path: "abcde"))
+    }
+
+    func testOneShotSearchMatchesCodexWireShapeAndOrdering() async throws {
+        let fixture = try await makeFixture()
+        try writeSearchFixture(to: fixture.workspace)
+
+        try await sendRequest(
+            id: 2,
+            method: "fuzzyFileSearch",
+            params: ["query": "abe", "roots": [fixture.workspace.path]],
+            to: fixture.session
+        )
+
+        let response = try await waitForResponse(id: 2, output: fixture.output)
+        let files = try XCTUnwrap(response["result"]?.objectValue?["files"]?.arrayValue)
+        XCTAssertEqual(files.count, 3)
+        XCTAssertEqual(files.compactMap { $0.objectValue?["path"]?.stringValue }, [
+            "abexy", "sub/abce", "abcde"
+        ])
+        XCTAssertEqual(files.compactMap { $0.objectValue?["score"]?.numberValue }, [84, 72, 71])
+        XCTAssertEqual(
+            files[1].objectValue?["indices"]?.arrayValue?.compactMap(\.numberValue),
+            [4, 5, 7]
+        )
+        XCTAssertTrue(files.allSatisfy {
+            $0.objectValue?["root"]?.stringValue == fixture.workspace.path
+                && $0.objectValue?["match_type"]?.stringValue == "file"
+                && $0.objectValue?["file_name"]?.stringValue != nil
+        })
+    }
+
+    func testCancellationTokenSupersedesWorkWithoutStrandingEitherResponse() async throws {
+        let fixture = try await makeFixture()
+        for index in 0..<2_000 {
+            try "contents".write(
+                to: fixture.workspace.appendingPathComponent("alpha-\(index).txt"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let params: [String: Any] = [
+            "query": "alpha",
+            "roots": [fixture.workspace.path],
+            "cancellationToken": "composer-search"
+        ]
+        try await sendRequest(id: 2, method: "fuzzyFileSearch", params: params, to: fixture.session)
+        try await sendRequest(id: 3, method: "fuzzyFileSearch", params: params, to: fixture.session)
+
+        _ = try await waitForResponse(id: 2, output: fixture.output)
+        let second = try await waitForResponse(id: 3, output: fixture.output)
+        XCTAssertEqual(try XCTUnwrap(second["result"]?.objectValue?["files"]?.arrayValue).count, 50)
+    }
+
+    func testSessionStreamsUpdatesCompletesAndClearsQuery() async throws {
+        let fixture = try await makeFixture()
+        try "contents".write(
+            to: fixture.workspace.appendingPathComponent("alpha.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try await sendRequest(
+            id: 2,
+            method: "fuzzyFileSearch/sessionStart",
+            params: ["sessionId": "composer", "roots": [fixture.workspace.path]],
+            to: fixture.session
+        )
+        try await sendRequest(
+            id: 3,
+            method: "fuzzyFileSearch/sessionUpdate",
+            params: ["sessionId": "composer", "query": "ALP"],
+            to: fixture.session
+        )
+
+        let first = try await waitForNotification(
+            method: "fuzzyFileSearch/sessionUpdated",
+            count: 1,
+            output: fixture.output
+        ).last
+        let firstParams = try XCTUnwrap(first?["params"]?.objectValue)
+        XCTAssertEqual(firstParams["sessionId"]?.stringValue, "composer")
+        XCTAssertEqual(firstParams["query"]?.stringValue, "ALP")
+        XCTAssertEqual(firstParams["files"]?.arrayValue?.first?.objectValue?["path"]?.stringValue, "alpha.txt")
+        _ = try await waitForNotification(
+            method: "fuzzyFileSearch/sessionCompleted",
+            count: 1,
+            output: fixture.output
+        )
+
+        try await sendRequest(
+            id: 4,
+            method: "fuzzyFileSearch/sessionUpdate",
+            params: ["sessionId": "composer", "query": ""],
+            to: fixture.session
+        )
+        let records = try await waitForNotification(
+            method: "fuzzyFileSearch/sessionUpdated",
+            count: 2,
+            output: fixture.output
+        )
+        let cleared = try XCTUnwrap(records.last?["params"]?.objectValue)
+        XCTAssertEqual(cleared["query"]?.stringValue, "")
+        XCTAssertEqual(cleared["files"]?.arrayValue, [])
+    }
+
+    func testSessionStopPreventsFurtherUpdatesAndMissingSessionUsesCodexError() async throws {
+        let fixture = try await makeFixture()
+        try await sendRequest(
+            id: 2,
+            method: "fuzzyFileSearch/sessionStart",
+            params: ["sessionId": "stopped", "roots": [fixture.workspace.path]],
+            to: fixture.session
+        )
+        try await sendRequest(
+            id: 3,
+            method: "fuzzyFileSearch/sessionStop",
+            params: ["sessionId": "stopped"],
+            to: fixture.session
+        )
+        try await sendRequest(
+            id: 4,
+            method: "fuzzyFileSearch/sessionUpdate",
+            params: ["sessionId": "stopped", "query": "alp"],
+            to: fixture.session
+        )
+
+        let response = try await waitForResponse(id: 4, output: fixture.output)
+        XCTAssertEqual(response["error"]?.objectValue?["code"]?.numberValue, -32_600)
+        XCTAssertEqual(
+            response["error"]?.objectValue?["message"]?.stringValue,
+            "fuzzy file search session not found: stopped"
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let records = try await fixture.output.records()
+        XCTAssertFalse(records.contains { record in
+            record["method"]?.stringValue == "fuzzyFileSearch/sessionUpdated"
+                && record["params"]?.objectValue?["sessionId"]?.stringValue == "stopped"
+        })
+    }
+
+    func testTwoSessionsKeepRootsAndQueriesIndependent() async throws {
+        let fixture = try await makeFixture()
+        let secondRoot = try temporaryDirectory(prefix: "app-server-fuzzy-second-root")
+        try "a".write(
+            to: fixture.workspace.appendingPathComponent("alpha.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "b".write(
+            to: secondRoot.appendingPathComponent("beta.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try await sendRequest(
+            id: 2,
+            method: "fuzzyFileSearch/sessionStart",
+            params: ["sessionId": "a", "roots": [fixture.workspace.path]],
+            to: fixture.session
+        )
+        try await sendRequest(
+            id: 3,
+            method: "fuzzyFileSearch/sessionStart",
+            params: ["sessionId": "b", "roots": [secondRoot.path]],
+            to: fixture.session
+        )
+        try await sendRequest(
+            id: 4,
+            method: "fuzzyFileSearch/sessionUpdate",
+            params: ["sessionId": "a", "query": "alp"],
+            to: fixture.session
+        )
+        try await sendRequest(
+            id: 5,
+            method: "fuzzyFileSearch/sessionUpdate",
+            params: ["sessionId": "b", "query": "bet"],
+            to: fixture.session
+        )
+
+        let records = try await waitForNotification(
+            method: "fuzzyFileSearch/sessionUpdated",
+            count: 2,
+            output: fixture.output
+        )
+        let updates = Dictionary(uniqueKeysWithValues: try records.map { record in
+            let params = try XCTUnwrap(record["params"]?.objectValue)
+            let sessionID = try XCTUnwrap(params["sessionId"]?.stringValue)
+            let firstFile = try XCTUnwrap(params["files"]?.arrayValue?.first?.objectValue)
+            return (sessionID, firstFile)
+        })
+        XCTAssertEqual(updates["a"]?["root"]?.stringValue, fixture.workspace.path)
+        XCTAssertEqual(updates["a"]?["path"]?.stringValue, "alpha.txt")
+        XCTAssertEqual(updates["b"]?["root"]?.stringValue, secondRoot.path)
+        XCTAssertEqual(updates["b"]?["path"]?.stringValue, "beta.txt")
+    }
+
+    func testInputBoundsFailBeforeStartingSearchWork() async throws {
+        let fixture = try await makeFixture()
+        try await sendRequest(
+            id: 2,
+            method: "fuzzyFileSearch",
+            params: [
+                "query": String(repeating: "x", count: 257),
+                "roots": [fixture.workspace.path]
+            ],
+            to: fixture.session
+        )
+        try await sendRequest(
+            id: 3,
+            method: "fuzzyFileSearch",
+            params: [
+                "query": "x",
+                "roots": Array(repeating: fixture.workspace.path, count: 33)
+            ],
+            to: fixture.session
+        )
+
+        let queryError = try await waitForResponse(id: 2, output: fixture.output)
+        let rootsError = try await waitForResponse(id: 3, output: fixture.output)
+        XCTAssertEqual(queryError["error"]?.objectValue?["code"]?.numberValue, -32_602)
+        XCTAssertEqual(rootsError["error"]?.objectValue?["code"]?.numberValue, -32_602)
+    }
+
+    func testSessionMethodsRequireExperimentalCapability() async throws {
+        let fixture = try await makeFixture(experimentalAPI: false)
+        try await sendRequest(
+            id: 2,
+            method: "fuzzyFileSearch/sessionStart",
+            params: ["sessionId": "disabled", "roots": [fixture.workspace.path]],
+            to: fixture.session
+        )
+        let response = try await waitForResponse(id: 2, output: fixture.output)
+        XCTAssertEqual(
+            response["error"]?.objectValue?["message"]?.stringValue,
+            "fuzzyFileSearch/sessionStart requires capabilities.experimentalApi: true"
+        )
+    }
+
+    private func makeFixture(experimentalAPI: Bool = true) async throws -> FuzzySearchFixture {
+        let home = try temporaryDirectory(prefix: "app-server-fuzzy-home")
+        let workspace = try temporaryDirectory(prefix: "app-server-fuzzy-workspace")
+        let output = FuzzySearchOutputCollector()
+        let session = try AppServerSession(
+            request: CLIAppServerRequest(live: false, home: home),
+            environment: [:],
+            currentDirectory: workspace,
+            runnerFactory: { configuration in
+                AgentRunner(
+                    llm: MockLLMClient(),
+                    safety: StaticSafetyReviewer(),
+                    maxToolSteps: configuration.appConfig.maxToolSteps
+                )
+            },
+            sink: { line in await output.append(line) }
+        )
+        try await sendRequest(
+            id: 1,
+            method: "initialize",
+            params: [
+                "clientInfo": ["name": "FuzzySearchTests", "version": "1"],
+                "capabilities": ["experimentalApi": experimentalAPI]
+            ],
+            to: session
+        )
+        try await send(["method": "initialized", "params": [:]], to: session)
+        return FuzzySearchFixture(session: session, output: output, workspace: workspace)
+    }
+
+    private func writeSearchFixture(to root: URL) throws {
+        try "x".write(to: root.appendingPathComponent("abc"), atomically: true, encoding: .utf8)
+        try "x".write(to: root.appendingPathComponent("abcde"), atomically: true, encoding: .utf8)
+        try "x".write(to: root.appendingPathComponent("abexy"), atomically: true, encoding: .utf8)
+        try "x".write(to: root.appendingPathComponent("zzz.txt"), atomically: true, encoding: .utf8)
+        let subdirectory = root.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirectory, withIntermediateDirectories: true)
+        try "x".write(to: subdirectory.appendingPathComponent("abce"), atomically: true, encoding: .utf8)
+    }
+
+    private func sendRequest(
+        id: Int,
+        method: String,
+        params: [String: Any],
+        to session: AppServerSession
+    ) async throws {
+        try await send(["id": id, "method": method, "params": params], to: session)
+    }
+
+    private func send(_ object: [String: Any], to session: AppServerSession) async throws {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        await session.receive(data)
+    }
+
+    private func waitForResponse(
+        id: Int,
+        output: FuzzySearchOutputCollector
+    ) async throws -> [String: CLIJSONValue] {
+        for _ in 0..<400 {
+            if let record = try await output.records().first(where: { $0["id"]?.numberValue == Double(id) }) {
+                return record
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        throw FuzzySearchTestError.timedOut
+    }
+
+    private func waitForNotification(
+        method: String,
+        count: Int,
+        output: FuzzySearchOutputCollector
+    ) async throws -> [[String: CLIJSONValue]] {
+        for _ in 0..<400 {
+            let matches = try await output.records().filter { $0["method"]?.stringValue == method }
+            if matches.count >= count { return matches }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        throw FuzzySearchTestError.timedOut
+    }
+
+    private func temporaryDirectory(prefix: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+}
+
+private struct FuzzySearchFixture {
+    var session: AppServerSession
+    var output: FuzzySearchOutputCollector
+    var workspace: URL
+}
+
+private actor FuzzySearchOutputCollector {
+    private var lines: [String] = []
+
+    func append(_ line: String) {
+        lines.append(line)
+    }
+
+    func records() throws -> [[String: CLIJSONValue]] {
+        try lines.map { line in
+            guard let record = try CLIJSONCodec.decode(line).objectValue else {
+                throw FuzzySearchTestError.invalidRecord
+            }
+            return record
+        }
+    }
+}
+
+private enum FuzzySearchTestError: Error {
+    case invalidRecord
+    case timedOut
+}

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -45,6 +45,8 @@
 ## Current Parity Notes
 
 - The app server exposes Codex-compatible response-first `thread/compact/start`.
+- The app server exposes Codex-compatible one-shot and live-session fuzzy file search with bounded
+  shared indexing, exact wire fields, match scores/indices, cancellation, and disconnect cleanup.
   It emits a non-steerable `contextCompaction` turn, reuses the desktop's
   live/mock compaction policy and compact hooks, persists progress transactionally,
   rejects concurrent turns, and can be interrupted without mutating history after

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,21 @@
 # QuillCode Decisions
 
+## 2026-07-15: App-server fuzzy search is bounded, cancellable, and connection-scoped
+
+- **Wire contract:** Stable `fuzzyFileSearch` and experimental `fuzzyFileSearch/sessionStart`,
+  `sessionUpdate`, and `sessionStop` mirror Codex 0.142.5 field names, result ordering, match indices,
+  empty-query behavior, missing-session errors, and updated/completed notifications.
+- **Shared traversal:** Search reuses `WorkspaceFileIndexer` rather than adding another filesystem
+  crawler. It inherits hidden/build-directory exclusions and deterministic paths, then applies explicit
+  root, query, entry, and result caps before projecting the Codex response shape.
+- **Concurrency contract:** One-shot requests run outside the session actor so a repeated cancellation
+  token can supersede work without blocking input. Live sessions build one index, cancel stale query
+  generations, and re-check generation after every notification await. Stop and EOF cancel and drain
+  all work, preventing late notifications or detached connection-owned tasks.
+- **Evidence:** Focused tests pin Codex's reference scores and indices, case-insensitive matching,
+  response shape and ordering, cancellation response completion, query clearing, stop behavior,
+  capability gating, and exact errors. The real JSONL process smoke exercises one-shot and live search.
+
 ## 2026-07-15: Doctor diagnostics are bounded, read-only, and redacted at every boundary
 
 - **Compatibility contract:** `quill-code doctor` follows the observable Codex 0.142.5 command and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,6 +23,10 @@
   client-message identities keep steering grouped across relaunch, explicit names remain distinct
   from generated desktop titles, active turns/compactions exclude rollback, and atomic persistence
   never pretends to reverse workspace or account side effects.
+- App-server fuzzy file search now mirrors Codex's stable one-shot request and experimental live
+  session lifecycle. Multi-root traversal is bounded and shared with composer indexing; scores,
+  indices, deterministic ordering, cancellation tokens, query generations, updated/completed
+  notifications, stop, and EOF cleanup have focused and real-process coverage.
 - `quill-code doctor` now provides the Codex-compatible support surface across installation, runtime,
   config, auth, Git, terminal, MCP, sandbox, state/task inventory, TrustedRouter reachability, and
   app-server checks. Collection is bounded and read-only, JSON is stable and redacted, and focused plus

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -19,6 +19,9 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 - App-server wire and state reducers: string/integer IDs, invalid JSON versus invalid envelopes,
   strict initialize/initialized sequencing, notification opt-outs, thread cursors/settings/goals,
   turn input bounds, managed local-image copying, projection deduplication, and approval decisions.
+- App-server fuzzy search: Codex reference scores/indices, case-insensitive multi-root ordering, empty
+  queries, result and traversal caps, cancellation-token replacement, live-session query generations,
+  independent sessions, stop/missing-session behavior, experimental gating, and EOF cleanup.
 - App-server account lifecycle: API-key and browser start response shapes, response-before-notification
   ordering, profile persistence, credential non-disclosure, exchange and save failure, cancel/not-found
   status, exactly-once completion, logout with managed versus external credentials, notification

--- a/scripts/app-server-smoke.sh
+++ b/scripts/app-server-smoke.sh
@@ -34,6 +34,8 @@ description: Review the smoke-test workspace.
 
 # Smoke review
 """)
+with open(os.path.join(workspace, "alpha-search.txt"), "w", encoding="utf-8") as file:
+    file.write("fuzzy search smoke\n")
 extra_skill_root = os.path.join(home, "extra-skills")
 os.makedirs(os.path.join(extra_skill_root, "smoke-advisor"), exist_ok=True)
 with open(
@@ -161,6 +163,37 @@ models, _ = read_until(lambda record: record.get("id") == 2)
 assert len(models["result"]["data"]) == 2, models
 assert models["result"]["data"][0]["isDefault"] is True, models
 assert models["result"]["nextCursor"], models
+
+send({"id": 200, "method": "fuzzyFileSearch", "params": {
+    "query": "alps",
+    "roots": [workspace],
+}})
+search, _ = read_until(lambda record: record.get("id") == 200)
+assert search["result"]["files"][0]["path"] == "alpha-search.txt", search
+assert search["result"]["files"][0]["match_type"] == "file", search
+assert search["result"]["files"][0]["indices"] == [0, 1, 2, 6], search
+
+send({"id": 202, "method": "fuzzyFileSearch/sessionStart", "params": {
+    "sessionId": "smoke-search",
+    "roots": [workspace],
+}})
+search_start, _ = read_until(lambda record: record.get("id") == 202)
+assert search_start["result"] == {}, search_start
+send({"id": 203, "method": "fuzzyFileSearch/sessionUpdate", "params": {
+    "sessionId": "smoke-search",
+    "query": "ALPS",
+}})
+search_complete, search_records = read_until(
+    lambda record: record.get("method") == "fuzzyFileSearch/sessionCompleted"
+)
+search_update = next(
+    record for record in search_records
+    if record.get("method") == "fuzzyFileSearch/sessionUpdated"
+)
+assert search_update["params"]["sessionId"] == "smoke-search", search_update
+assert search_update["params"]["query"] == "ALPS", search_update
+assert search_update["params"]["files"][0]["path"] == "alpha-search.txt", search_update
+assert search_complete["params"] == {"sessionId": "smoke-search"}, search_complete
 
 send({"id": 201, "method": "process/spawn", "params": {
     "command": ["/bin/sh", "-c", "printf process-smoke"],


### PR DESCRIPTION
## Summary
- add Codex-compatible one-shot fuzzy file search with bounded multi-root indexing, deterministic scores/indices, and cancellation tokens
- add experimental live search sessions with generation-safe updates, completion notifications, stop handling, and EOF cleanup
- cover the wire contract with focused XCTest, real JSONL process smoke, parity docs, and release-gate validation

## Validation
- `swift test --quiet` (4,345 tests; 2 skipped; 0 failures)
- `npm test` in `E2E/playwright` (240 passed)
- `QUILLCODE_SKIP_BUILD=1 scripts/app-server-smoke.sh`
- `scripts/packaged-macos-smoke.sh`
- Swift 6.2 Noble Docker: CLI build + Linux Computer Use smoke
- `python3 scripts/grade-code-quality.py --root .` (affected source and module A+)
- no app-level Linux conditionals; `git diff --check` clean
