### PR TITLE
Stabilize app-server process exit delivery

### DIFF
--- a/Sources/QuillCodeCLI/AppServerProcessSession.swift
+++ b/Sources/QuillCodeCLI/AppServerProcessSession.swift
@@ -15,6 +15,7 @@ final class AppServerProcessSession: @unchecked Sendable {
     private var process: Process?
     private var inputHandle: FileHandle?
     private var outputHandles: [FileHandle] = []
+    private var parentOnlyHandles: [FileHandle] = []
     private var masterFileDescriptor: Int32 = -1
     private var stdinClosed = false
     private var finished = false
@@ -184,7 +185,8 @@ final class AppServerProcessSession: @unchecked Sendable {
         process.standardError = slaveHandle
         lock.appServerWithLock {
             inputHandle = masterHandle
-            outputHandles = [masterHandle, slaveHandle]
+            outputHandles = [masterHandle]
+            parentOnlyHandles = [slaveHandle]
             masterFileDescriptor = master
         }
     }
@@ -202,16 +204,22 @@ final class AppServerProcessSession: @unchecked Sendable {
                 standardOutput.fileHandleForReading,
                 standardError.fileHandleForReading
             ]
+            parentOnlyHandles = [
+                standardInput.fileHandleForReading,
+                standardOutput.fileHandleForWriting,
+                standardError.fileHandleForWriting
+            ]
         }
     }
 
     private func closeParentOnlyDescriptorsAfterStart() {
-        if request.usesPTY {
-            let slave = lock.appServerWithLock {
-                outputHandles.count > 1 ? outputHandles.removeLast() : nil
-            }
-            try? slave?.close()
-        } else if !request.streamsStdin {
+        let handles = lock.appServerWithLock { () -> [FileHandle] in
+            defer { parentOnlyHandles.removeAll(keepingCapacity: false) }
+            return parentOnlyHandles
+        }
+        for handle in handles { try? handle.close() }
+
+        if !request.usesPTY, !request.streamsStdin {
             let input = lock.appServerWithLock { () -> FileHandle? in
                 stdinClosed = true
                 defer { inputHandle = nil }
@@ -340,6 +348,7 @@ final class AppServerProcessSession: @unchecked Sendable {
             self.process = nil
             inputHandle = nil
             outputHandles = []
+            parentOnlyHandles = []
             masterFileDescriptor = -1
             return result
         }
@@ -354,10 +363,11 @@ final class AppServerProcessSession: @unchecked Sendable {
                 process = nil
                 inputHandle = nil
                 outputHandles = []
+                parentOnlyHandles = []
                 masterFileDescriptor = -1
                 finished = true
             }
-            return Array(Set(outputHandles + [inputHandle].compactMap { $0 }))
+            return Array(Set(outputHandles + parentOnlyHandles + [inputHandle].compactMap { $0 }))
         }
         for handle in handles { try? handle.close() }
         continuation.finish()

--- a/Tests/QuillCodeCLITests/AppServerProcessTests.swift
+++ b/Tests/QuillCodeCLITests/AppServerProcessTests.swift
@@ -248,6 +248,8 @@ final class AppServerProcessTests: XCTestCase {
             params: ["processHandle": "kill"],
             to: fixture.session
         )
+        let killResponse = try await waitForResponse(id: 3, output: fixture.output)
+        XCTAssertNil(killResponse["error"], "process/kill should accept the running process")
 
         let records = try await waitForNotification("process/exited", output: fixture.output)
         XCTAssertNotNil(response(id: 3, in: records)["result"])
@@ -357,13 +359,12 @@ final class AppServerProcessTests: XCTestCase {
         id: Int,
         output: ProcessOutputCollector
     ) async throws -> [String: CLIJSONValue] {
-        for _ in 0..<400 {
-            if let record = try await output.records().first(where: { $0["id"]?.numberValue == Double(id) }) {
-                return record
-            }
-            try await Task.sleep(nanoseconds: 5_000_000)
+        try await waitForRecords(
+            output: output,
+            description: "response id \(id)"
+        ) { records in
+            records.first(where: { $0["id"]?.numberValue == Double(id) })
         }
-        throw ProcessTestError.timedOut
     }
 
     private func waitForNotification(
@@ -371,12 +372,28 @@ final class AppServerProcessTests: XCTestCase {
         count: Int = 1,
         output: ProcessOutputCollector
     ) async throws -> [[String: CLIJSONValue]] {
-        for _ in 0..<800 {
-            let records = try await output.records()
-            if records.filter({ $0["method"]?.stringValue == method }).count >= count { return records }
-            try await Task.sleep(nanoseconds: 5_000_000)
+        try await waitForRecords(
+            output: output,
+            description: "\(count) \(method) notification(s)"
+        ) { records in
+            records.filter { $0["method"]?.stringValue == method }.count >= count
+                ? records
+                : nil
         }
-        throw ProcessTestError.timedOut
+    }
+
+    private func waitForRecords<Value>(
+        output: ProcessOutputCollector,
+        description: String,
+        match: ([[String: CLIJSONValue]]) -> Value?
+    ) async throws -> Value {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(30))
+        while clock.now < deadline {
+            if let value = match(try await output.records()) { return value }
+            try await clock.sleep(for: .milliseconds(10))
+        }
+        throw ProcessTestError.timedOut(description)
     }
 
     private func sendRequest(
@@ -453,5 +470,5 @@ private struct ProcessEchoLLM: LLMClient {
 
 private enum ProcessTestError: Error {
     case invalidRecord
-    case timedOut
+    case timedOut(String)
 }


### PR DESCRIPTION
## Root cause
QuillCode retained the parent copies of the child stdout/stderr write descriptors after spawn. Under full-suite scheduler load, stream readers could therefore miss EOF and block the process-exit path indefinitely.

## Changes
- close all parent-only pipe and PTY descriptors immediately after a successful spawn
- include those descriptors in failed-start cleanup
- validate `process/kill` before awaiting exit
- replace scheduler-sensitive polling counts with a monotonic 30-second test deadline and actionable diagnostics

## Validation
- `git diff --check`
- `swift test --filter AppServerProcessTests` (11 passed)
- streamed-output exit path: 40/40 stress runs passed
- complete process suite: 20/20 stress runs, 220 test executions passed