### PR TITLE
fix(macOS): context banner honors unknown context window like the token chip

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceContextBannerBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceContextBannerBuilder.swift
@@ -5,12 +5,21 @@ struct WorkspaceContextBannerBuilder: Sendable, Hashable {
     static let defaultWarningThresholdPercent = 80
 
     var thread: ChatThread?
+    var selectedModelID: String = ""
+    var modelCatalog: [ModelInfo] = []
     var tokenBudget: Int = Self.defaultTokenBudget
     var warningThresholdPercent: Int = Self.defaultWarningThresholdPercent
 
     func banner() -> ContextBannerSurface? {
         guard let thread, !thread.messages.isEmpty else { return nil }
-        let usedPercent = contextUsedPercent(for: thread)
+        // Provider-reported usage against a model whose window the catalog does not know is not a
+        // percentage of anything — the top-bar token chip drops to a usage-only "window unknown"
+        // chip in exactly this case (see WorkspaceTokenBudgetSurfaceBuilder). The banner must agree:
+        // never fabricate "Context limit reached (100%)" from the 32k estimate fallback here. (The
+        // no-provider-usage estimate heuristic below keeps that conservative fallback, as before.)
+        let windowTokens = contextWindowTokens()
+        if Self.latestProviderUsage(for: thread) != nil, windowTokens == nil { return nil }
+        let usedPercent = contextUsedPercent(for: thread, windowTokens: windowTokens)
         guard usedPercent >= effectiveWarningThresholdPercent else { return nil }
         let hasProviderUsage = Self.latestProviderUsage(for: thread) != nil
         let progress = Self.contextSummaryProgress(for: thread)
@@ -35,8 +44,28 @@ struct WorkspaceContextBannerBuilder: Sendable, Hashable {
     }
 
     func contextUsedPercent(for thread: ChatThread) -> Int {
-        let tokens = max(1, Self.latestProviderUsage(for: thread)?.contextTokens ?? Self.estimatedContextTokens(for: thread))
-        return min(100, Int((Double(tokens) / Double(effectiveTokenBudget) * 100).rounded()))
+        contextUsedPercent(for: thread, windowTokens: contextWindowTokens())
+    }
+
+    private func contextUsedPercent(for thread: ChatThread, windowTokens: Int?) -> Int {
+        let usage = Self.latestProviderUsage(for: thread)
+        let tokens = max(1, usage?.contextTokens ?? Self.estimatedContextTokens(for: thread))
+        // Provider-reported usage is a percentage of the model's REAL window when the catalog knows
+        // it (so the banner and the top-bar chip agree); the local character estimate — and any
+        // unknown-window fallback — uses the injected conservative budget (32k by default).
+        let budget = usage == nil ? effectiveTokenBudget : (windowTokens ?? effectiveTokenBudget)
+        return min(100, Int((Double(tokens) / Double(budget) * 100).rounded()))
+    }
+
+    /// The catalog-reported context window for the thread's model (falling back to the top-bar
+    /// selection), or nil when the catalog does not know it — resolved through the SAME helper the
+    /// token-budget chip uses, so the chip and the banner can never disagree about the window.
+    private func contextWindowTokens() -> Int? {
+        WorkspaceTokenBudgetSurfaceBuilder.modelContextWindowTokens(
+            threadModel: thread?.model,
+            selectedModelID: selectedModelID,
+            modelCatalog: modelCatalog
+        )
     }
 
     static func estimatedContextTokens(for thread: ChatThread) -> Int {

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -178,7 +178,11 @@ public extension QuillCodeWorkspaceModel {
                     agentStatus: topBarState.agentStatus
                 ).surface()
             ),
-            contextBanner: WorkspaceContextBannerBuilder(thread: thread).banner(),
+            contextBanner: WorkspaceContextBannerBuilder(
+                thread: thread,
+                selectedModelID: topBarState.model,
+                modelCatalog: root.modelCatalog
+            ).banner(),
             sideConversation: sideConversationSurface(),
             codeReviewRequest: codeReviewRequest,
             review: review,

--- a/Tests/QuillCodeAppTests/WorkspaceContextBannerBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceContextBannerBuilderTests.swift
@@ -161,8 +161,12 @@ final class WorkspaceContextBannerBuilderTests: XCTestCase {
     }
 
     func testProviderUsageOverridesCharacterEstimate() throws {
+        // Provider-reported usage (25 tokens) is the numerator, not the tiny character estimate of
+        // "short". Measured against the model's KNOWN 25-token window ⇒ 100%. (Unknown window +
+        // provider usage is a separate case that suppresses the banner — see the test below.)
         let usage = ModelTokenUsage(promptTokens: 25, completionTokens: 0, totalTokens: 25)
         let thread = ChatThread(
+            model: "trustedrouter/fast",
             messages: [
                 .init(role: .user, content: "short")
             ],
@@ -172,7 +176,8 @@ final class WorkspaceContextBannerBuilderTests: XCTestCase {
         )
         let builder = WorkspaceContextBannerBuilder(
             thread: thread,
-            tokenBudget: 25,
+            selectedModelID: "trustedrouter/fast",
+            modelCatalog: [model(id: "trustedrouter/fast", contextWindowTokens: 25)],
             warningThresholdPercent: 100
         )
 
@@ -185,6 +190,70 @@ final class WorkspaceContextBannerBuilderTests: XCTestCase {
             banner.subtitle,
             "Provider-reported token usage is near the limit. Compact the thread, start fresh, or fork with latest, summarized, or full visible context."
         )
+    }
+
+    func testBannerSuppressedForUnknownWindowWithProviderUsage() {
+        // The asymmetry the top-bar usage-only chip exposed: provider-reported usage against a model
+        // whose window the catalog does not know must NOT fabricate "Context limit reached" from the
+        // 32k estimate fallback (58.4k / 32k ⇒ clamped 100%). Unknown window + provider usage ⇒ no
+        // banner, matching the usage-only chip. This FAILS against the pre-fix builder (it fires).
+        let thread = ChatThread(
+            title: "Fallback",
+            messages: [.init(role: .user, content: "short")],
+            events: [
+                ModelTokenUsageEvent.event(usage: ModelTokenUsage(promptTokens: 58_000, completionTokens: 400))
+            ]
+        )
+        let builder = WorkspaceContextBannerBuilder(
+            thread: thread,
+            selectedModelID: "missing/model",
+            modelCatalog: []
+        )
+
+        XCTAssertNil(builder.banner())
+    }
+
+    func testBannerUsesRealWindowForProviderUsageNotThe32kFallback() {
+        // Provider usage of 58.4k tokens against a KNOWN 200k window is 29% — nowhere near the limit.
+        // The pre-fix code measured it against the 32k fallback (183% ⇒ clamped 100% ⇒ false alarm);
+        // the banner must use the real window so it agrees with the top-bar chip and stays silent.
+        let thread = ChatThread(
+            model: "trustedrouter/fast",
+            messages: [.init(role: .user, content: "short")],
+            events: [
+                ModelTokenUsageEvent.event(usage: ModelTokenUsage(promptTokens: 58_000, completionTokens: 400))
+            ]
+        )
+        let builder = WorkspaceContextBannerBuilder(
+            thread: thread,
+            selectedModelID: "trustedrouter/fast",
+            modelCatalog: [model(id: "trustedrouter/fast", contextWindowTokens: 200_000)]
+        )
+
+        XCTAssertEqual(builder.contextUsedPercent(for: thread), 29)
+        XCTAssertNil(builder.banner())
+    }
+
+    func testBannerFiresForProviderUsageNearRealWindow() throws {
+        // The real window is respected in BOTH directions: usage genuinely near the known window
+        // still warns (guards against the fix simply muting provider-usage banners).
+        let thread = ChatThread(
+            model: "trustedrouter/fast",
+            messages: [.init(role: .user, content: "short")],
+            events: [
+                ModelTokenUsageEvent.event(usage: ModelTokenUsage(promptTokens: 190_000, completionTokens: 0, totalTokens: 190_000))
+            ]
+        )
+        let builder = WorkspaceContextBannerBuilder(
+            thread: thread,
+            selectedModelID: "trustedrouter/fast",
+            modelCatalog: [model(id: "trustedrouter/fast", contextWindowTokens: 200_000)]
+        )
+
+        let banner = try XCTUnwrap(builder.banner())
+
+        XCTAssertEqual(builder.contextUsedPercent(for: thread), 95)
+        XCTAssertEqual(banner.title, "Approaching context limit (95% used)")
     }
 
     func testCustomBudgetAndThresholdSupportSmallDeterministicTests() throws {
@@ -217,5 +286,15 @@ final class WorkspaceContextBannerBuilderTests: XCTestCase {
 
         XCTAssertEqual(builder.contextUsedPercent(for: thread), 100)
         XCTAssertEqual(banner.title, "Context limit reached (100% used)")
+    }
+
+    private func model(id: String, contextWindowTokens: Int) -> ModelInfo {
+        ModelInfo(
+            id: id,
+            provider: "TrustedRouter",
+            displayName: "Nike 1.0",
+            category: "Recommended",
+            capabilities: ModelCapabilities(contextWindowTokens: contextWindowTokens)
+        )
     }
 }


### PR DESCRIPTION
## What
The top-bar token chip already shows an honest usage-only **"window unknown"** chip when a model's context window isn't in the catalog but provider usage exists (it stopped inventing `58.4k / 32k · 183%`). The in-transcript **context banner** still measured that same case against the 32k fallback and fired **"Context limit reached (100%)"** — so the chip and the banner disagreed. codex-flagged P2 on the design-refresh PR #1239; a pre-existing asymmetry the top-bar improvement exposed.

## Fix
`WorkspaceContextBannerBuilder` now resolves the model's window through the **same** helper the chip uses (`WorkspaceTokenBudgetSurfaceBuilder.modelContextWindowTokens`), so the two can never disagree about the window:

- **provider usage + unknown window** → **no banner** (there's no real limit to be a percentage of — matches the usage-only chip).
- **provider usage + known window** → percent against the **real** window (a roomy 200k model no longer false-alarms at 29%; still warns near the true limit).
- **no provider usage** (estimate mode) → keeps the conservative 32k fallback, unchanged and still labeled *Estimated*.

The caller (`WorkspaceSurface`) now passes `selectedModelID` + `modelCatalog` (the exact inputs the token chip receives).

## Tests
- `testBannerSuppressedForUnknownWindowWithProviderUsage` — unknown window + usage ⇒ nil banner (fails against pre-fix).
- `testBannerUsesRealWindowForProviderUsageNotThe32kFallback` — 58.4k/200k = 29%, no false alarm (fails against pre-fix).
- `testBannerFiresForProviderUsageNearRealWindow` — 190k/200k = 95% still warns (guards against muting).
- `testProviderUsageOverridesCharacterEstimate` — numerator-override preserved via a known window.
- All estimate-mode + full-surface tests unchanged and green.

Full package suite: **4540 tests, 0 failures** (2 pre-existing skips).