### PR TITLE
fix(macOS): transcript keeps following an at-bottom reader through large chunks

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -199,7 +199,7 @@ struct QuillCodeTranscriptView: View {
                                     // A resize is never a scroll gesture: re-pin if the shorter/taller
                                     // viewport put the end back within reach, but never strand an
                                     // at-bottom reader.
-                                    applyPinned(isUserScrollUp: false)
+                                    applyPinned(unpinBeyondThreshold: false)
                                 }
                         }
                     )
@@ -454,7 +454,7 @@ struct QuillCodeTranscriptView: View {
 
     /// A zero-height marker at the very end of the transcript. Its position within the scroll
     /// coordinate space, compared to the viewport height, is how we know whether the reader is at the
-    /// bottom (see ``applyPinned(isUserScrollUp:)``). LazyVStack won't lay it out while scrolled far
+    /// bottom (see ``applyPinned(unpinBeyondThreshold:)``). LazyVStack won't lay it out while scrolled far
     /// up, which is fine — `isPinnedToBottom` then correctly stays false until the reader scrolls back
     /// down (the content-offset reader keeps un-pinning live meanwhile).
     private var bottomSentinel: some View {
@@ -469,11 +469,13 @@ struct QuillCodeTranscriptView: View {
                             initial: true
                         ) { _, maxY in
                             bottomSentinelMaxY = maxY
-                            // The end-of-content moved (a chunk grew, or the follow-scroll ran). That
-                            // is never a user scroll, so it may only RE-pin (end back within reach) —
-                            // it must never un-pin an at-bottom reader mid-chunk. Un-pinning is owned
-                            // solely by the content-offset signal (``contentTopOffsetReader``).
-                            applyPinned(isUserScrollUp: false)
+                            // The end-of-content moved (a chunk grew, or the follow-scroll ran). While
+                            // follow-scroll is live this may only RE-pin (end back within reach), never
+                            // un-pin an at-bottom reader mid-chunk (the content-offset signal owns
+                            // scroll-driven un-pinning). But when follow-scroll is SUPPRESSED (Find /
+                            // review), the viewport won't catch up, so a beyond-threshold growth must
+                            // un-pin here and surface the Jump chip.
+                            applyPinned(unpinBeyondThreshold: isFollowScrollSuppressed)
                         }
                 }
             )
@@ -496,15 +498,25 @@ struct QuillCodeTranscriptView: View {
         }
     }
 
+    /// Follow-scroll is suppressed (`scrollToTranscriptEnd` early-returns) while Find or the review pane
+    /// owns the scroll position. A chunk that grows past the threshold then will NOT auto-catch-up, so
+    /// the bottom-sentinel must un-pin (surface the Jump chip, honest state) rather than preserve a pin
+    /// the viewport no longer reflects — otherwise closing Find strands the reader behind with no chip
+    /// and the next chunk yanks them down.
+    private var isFollowScrollSuppressed: Bool {
+        isFindPresented || review.isVisible
+    }
+
     /// Resolve the pin against a sentinel/viewport move that is NOT a user scroll (content growth,
-    /// follow-scroll, resize). Within threshold re-pins; otherwise the prior state is preserved.
-    private func applyPinned(isUserScrollUp: Bool) {
+    /// follow-scroll, resize). Within threshold re-pins; beyond it, `unpinBeyondThreshold` decides
+    /// whether the reader has fallen behind (e.g. growth while follow-scroll is suppressed).
+    private func applyPinned(unpinBeyondThreshold: Bool) {
         let pinned = TranscriptScrollFollow.resolvePinned(
             current: isPinnedToBottom,
             bottomSentinelMaxY: bottomSentinelMaxY,
             viewportHeight: viewportHeight,
             threshold: bottomPinThreshold,
-            isUserScrollUp: isUserScrollUp
+            unpinBeyondThreshold: unpinBeyondThreshold
         )
         guard pinned != isPinnedToBottom else { return }
         quillCodeWithAnimation(.easeInOut(duration: 0.15), reduceMotion: reduceMotion) {

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -43,13 +43,20 @@ struct QuillCodeTranscriptView: View {
     /// Which anchor jump is currently pending, so the scroll handler can target it once.
     @State private var pendingJumpAnchorID: String?
     /// Streaming autoscroll only pins to the bottom when the reader is already there; otherwise a
-    /// "Jump to latest" chip floats rather than yanking them down. `isPinnedToBottom` is derived from
-    /// the gap between a 1pt bottom sentinel and the viewport bottom, both measured through a named
-    /// coordinate space (GeometryReader + non-@Sendable `.onChange` — the macOS 14 floor rules out
-    /// `.onScrollGeometryChange`, and swift-tools 6.0's @Sendable rule rules out `.onPreferenceChange`).
+    /// "Jump to latest" chip floats rather than yanking them down. Whether the reader is AT the bottom
+    /// comes from the gap between a 1pt bottom sentinel and the viewport bottom; whether a WIDENING gap
+    /// was a deliberate scroll-up (vs. a chunk growing below them, or our own follow-scroll animation —
+    /// both of which widen that gap identically) comes from an orthogonal signal: the content's top
+    /// edge in the scroll space (the negated scroll offset), which only a scroll-up increases. Both are
+    /// measured through a named coordinate space (GeometryReader + non-@Sendable `.onChange` — the
+    /// macOS 14 floor rules out `.onScrollGeometryChange`, and swift-tools 6.0's @Sendable rule rules
+    /// out `.onPreferenceChange`).
     @State private var isPinnedToBottom = true
     @State private var viewportHeight: CGFloat = 0
     @State private var bottomSentinelMaxY: CGFloat = 0
+    /// Last sampled content-top offset; nil re-baselines the next sample (first appear + thread switch)
+    /// so a fresh transcript's opening offset is never mistaken for a scroll gesture.
+    @State private var lastContentTopMinY: CGFloat?
     private let bottomPinThreshold: CGFloat = 60
     private static let transcriptScrollSpace = "quillcode.transcript.scroll"
     private static let bottomSentinelID = "quillcode.transcript.bottom-sentinel"
@@ -181,6 +188,7 @@ struct QuillCodeTranscriptView: View {
                         }
                         .frame(maxWidth: .infinity)
                         .padding(22)
+                        .background(contentTopOffsetReader)
                     }
                     .coordinateSpace(.named(Self.transcriptScrollSpace))
                     .background(
@@ -188,7 +196,10 @@ struct QuillCodeTranscriptView: View {
                             Color.clear
                                 .onChange(of: geometry.size.height, initial: true) { _, height in
                                     viewportHeight = height
-                                    recomputePinned()
+                                    // A resize is never a scroll gesture: re-pin if the shorter/taller
+                                    // viewport put the end back within reach, but never strand an
+                                    // at-bottom reader.
+                                    applyPinned(isUserScrollUp: false)
                                 }
                         }
                     )
@@ -205,8 +216,11 @@ struct QuillCodeTranscriptView: View {
                     .onChange(of: threadID) { _, _ in
                         // A different thread opens at ITS latest turn, never inheriting the previous
                         // thread's scroll-pin (codex review): otherwise switching away from a
-                        // scrolled-up thread strands the new one at the top behind a Jump chip.
+                        // scrolled-up thread strands the new one at the top behind a Jump chip. Drop
+                        // the content-offset baseline too, so the new transcript's opening offset is
+                        // re-baselined instead of read as a giant scroll-up.
                         isPinnedToBottom = true
+                        lastContentTopMinY = nil
                         scrollForReviewVisibility(review.isVisible, proxy: proxy)
                     }
                     .onChange(of: scrollContentSignature) { _, _ in
@@ -440,8 +454,9 @@ struct QuillCodeTranscriptView: View {
 
     /// A zero-height marker at the very end of the transcript. Its position within the scroll
     /// coordinate space, compared to the viewport height, is how we know whether the reader is at the
-    /// bottom (see ``recomputePinned``). LazyVStack won't lay it out while scrolled far up, which is
-    /// fine — `isPinnedToBottom` then correctly stays false until the reader scrolls back down.
+    /// bottom (see ``applyPinned(isUserScrollUp:)``). LazyVStack won't lay it out while scrolled far
+    /// up, which is fine — `isPinnedToBottom` then correctly stays false until the reader scrolls back
+    /// down (the content-offset reader keeps un-pinning live meanwhile).
     private var bottomSentinel: some View {
         Color.clear
             .frame(height: 1)
@@ -454,17 +469,62 @@ struct QuillCodeTranscriptView: View {
                             initial: true
                         ) { _, maxY in
                             bottomSentinelMaxY = maxY
-                            recomputePinned()
+                            // The end-of-content moved (a chunk grew, or the follow-scroll ran). That
+                            // is never a user scroll, so it may only RE-pin (end back within reach) —
+                            // it must never un-pin an at-bottom reader mid-chunk. Un-pinning is owned
+                            // solely by the content-offset signal (``contentTopOffsetReader``).
+                            applyPinned(isUserScrollUp: false)
                         }
                 }
             )
     }
 
-    private func recomputePinned() {
-        let pinned = TranscriptScrollFollow.isPinnedToBottom(
+    /// Measures the transcript content's top edge in the scroll coordinate space — the (negated)
+    /// scroll offset — as the orthogonal "did the reader scroll up?" signal. Backed onto the CONTENT
+    /// (not a lazy child) so it keeps reporting even when the top is scrolled far off-screen: the
+    /// signal must be live the instant a reader drags up FROM the bottom, which a LazyVStack child
+    /// sentinel (unlaid-out while at the bottom) could not do.
+    private var contentTopOffsetReader: some View {
+        GeometryReader { geometry in
+            Color.clear
+                .onChange(
+                    of: geometry.frame(in: .named(Self.transcriptScrollSpace)).minY,
+                    initial: true
+                ) { _, minY in
+                    applyContentTopOffsetSample(minY)
+                }
+        }
+    }
+
+    /// Resolve the pin against a sentinel/viewport move that is NOT a user scroll (content growth,
+    /// follow-scroll, resize). Within threshold re-pins; otherwise the prior state is preserved.
+    private func applyPinned(isUserScrollUp: Bool) {
+        let pinned = TranscriptScrollFollow.resolvePinned(
+            current: isPinnedToBottom,
             bottomSentinelMaxY: bottomSentinelMaxY,
             viewportHeight: viewportHeight,
-            threshold: bottomPinThreshold
+            threshold: bottomPinThreshold,
+            isUserScrollUp: isUserScrollUp
+        )
+        guard pinned != isPinnedToBottom else { return }
+        quillCodeWithAnimation(.easeInOut(duration: 0.15), reduceMotion: reduceMotion) {
+            isPinnedToBottom = pinned
+        }
+    }
+
+    /// A new content-offset sample. Only a genuine scroll UP (top edge moved down past the epsilon
+    /// since the last sample) may un-pin; content growth and the follow-scroll animation never do.
+    /// A nil `lastContentTopMinY` (first appear / thread switch) baselines without classifying.
+    private func applyContentTopOffsetSample(_ minY: CGFloat) {
+        defer { lastContentTopMinY = minY }
+        guard let previous = lastContentTopMinY else { return }
+        let pinned = TranscriptScrollFollow.pinnedAfterScrollSample(
+            current: isPinnedToBottom,
+            bottomSentinelMaxY: bottomSentinelMaxY,
+            viewportHeight: viewportHeight,
+            threshold: bottomPinThreshold,
+            contentTopMinY: minY,
+            previousContentTopMinY: previous
         )
         guard pinned != isPinnedToBottom else { return }
         quillCodeWithAnimation(.easeInOut(duration: 0.15), reduceMotion: reduceMotion) {

--- a/Sources/QuillCodeApp/TranscriptScrollFollow.swift
+++ b/Sources/QuillCodeApp/TranscriptScrollFollow.swift
@@ -33,18 +33,19 @@ enum TranscriptScrollFollow {
     }
 
     /// The pin transition for one geometry sample. Within `threshold` of the bottom ⇒ (re)pin,
-    /// whatever moved the sentinel there. Beyond it, only a genuine user scroll UP un-pins; content
-    /// growth and our own animated follow-scroll — both of which ALSO widen the sentinel gap — must
-    /// PRESERVE the prior state, so streaming keeps following an at-bottom reader through a large
-    /// chunk. The sentinel gap alone cannot tell a scroll from a growth (a big chunk widens it exactly
-    /// like a scroll would), so the caller supplies `isUserScrollUp` from the orthogonal content-offset
-    /// signal (see ``pinnedAfterScrollSample``).
+    /// whatever moved the sentinel there. Beyond it, the prior state is PRESERVED unless
+    /// `unpinBeyondThreshold` — so streaming keeps following an at-bottom reader through a large chunk
+    /// (content growth and our own animated follow-scroll both widen the sentinel gap exactly like a
+    /// scroll would, so the gap alone can't be trusted to un-pin). Callers set `unpinBeyondThreshold`
+    /// when the reader genuinely falls behind: a real scroll UP (from the orthogonal content-offset
+    /// signal, see ``pinnedAfterScrollSample``), or a growth that arrives while follow-scroll is
+    /// suppressed (Find / review open) so the viewport will NOT auto-catch-up.
     static func resolvePinned(
         current: Bool,
         bottomSentinelMaxY: CGFloat,
         viewportHeight: CGFloat,
         threshold: CGFloat,
-        isUserScrollUp: Bool
+        unpinBeyondThreshold: Bool
     ) -> Bool {
         if isPinnedToBottom(
             bottomSentinelMaxY: bottomSentinelMaxY,
@@ -53,7 +54,7 @@ enum TranscriptScrollFollow {
         ) {
             return true
         }
-        return isUserScrollUp ? false : current
+        return unpinBeyondThreshold ? false : current
     }
 
     /// Classify a content-offset sample, then resolve the pin. `contentTopMinY` is the transcript
@@ -79,7 +80,7 @@ enum TranscriptScrollFollow {
             bottomSentinelMaxY: bottomSentinelMaxY,
             viewportHeight: viewportHeight,
             threshold: threshold,
-            isUserScrollUp: isUserScrollUp
+            unpinBeyondThreshold: isUserScrollUp
         )
     }
 }

--- a/Sources/QuillCodeApp/TranscriptScrollFollow.swift
+++ b/Sources/QuillCodeApp/TranscriptScrollFollow.swift
@@ -31,4 +31,55 @@ enum TranscriptScrollFollow {
     ) -> Bool {
         (bottomSentinelMaxY - viewportHeight) <= threshold
     }
+
+    /// The pin transition for one geometry sample. Within `threshold` of the bottom ⇒ (re)pin,
+    /// whatever moved the sentinel there. Beyond it, only a genuine user scroll UP un-pins; content
+    /// growth and our own animated follow-scroll — both of which ALSO widen the sentinel gap — must
+    /// PRESERVE the prior state, so streaming keeps following an at-bottom reader through a large
+    /// chunk. The sentinel gap alone cannot tell a scroll from a growth (a big chunk widens it exactly
+    /// like a scroll would), so the caller supplies `isUserScrollUp` from the orthogonal content-offset
+    /// signal (see ``pinnedAfterScrollSample``).
+    static func resolvePinned(
+        current: Bool,
+        bottomSentinelMaxY: CGFloat,
+        viewportHeight: CGFloat,
+        threshold: CGFloat,
+        isUserScrollUp: Bool
+    ) -> Bool {
+        if isPinnedToBottom(
+            bottomSentinelMaxY: bottomSentinelMaxY,
+            viewportHeight: viewportHeight,
+            threshold: threshold
+        ) {
+            return true
+        }
+        return isUserScrollUp ? false : current
+    }
+
+    /// Classify a content-offset sample, then resolve the pin. `contentTopMinY` is the transcript
+    /// content's top edge in the scroll viewport's coordinate space — i.e. the (negated) scroll
+    /// offset. It INCREASES only when the reader drags the content DOWN (scrolls up); appending a
+    /// chunk at the bottom leaves the top put, and the follow-scroll animation drives it further
+    /// negative. So "the top moved down past `scrollEpsilon` since the last sample" is an orthogonal,
+    /// timing-free proxy for a deliberate scroll-up — unlike the sentinel gap, which a large chunk and
+    /// a scroll widen identically. This is what stops a big streamed chunk (or the follow animation's
+    /// own intermediate frames) from being misread as a scroll and dropping the follow.
+    static func pinnedAfterScrollSample(
+        current: Bool,
+        bottomSentinelMaxY: CGFloat,
+        viewportHeight: CGFloat,
+        threshold: CGFloat,
+        contentTopMinY: CGFloat,
+        previousContentTopMinY: CGFloat,
+        scrollEpsilon: CGFloat = 0.5
+    ) -> Bool {
+        let isUserScrollUp = (contentTopMinY - previousContentTopMinY) > scrollEpsilon
+        return resolvePinned(
+            current: current,
+            bottomSentinelMaxY: bottomSentinelMaxY,
+            viewportHeight: viewportHeight,
+            threshold: threshold,
+            isUserScrollUp: isUserScrollUp
+        )
+    }
 }

--- a/Tests/QuillCodeAppTests/TranscriptScrollFollowTests.swift
+++ b/Tests/QuillCodeAppTests/TranscriptScrollFollowTests.swift
@@ -49,24 +49,33 @@ final class TranscriptScrollFollowTests: XCTestCase {
 
     func testResolvePinnedWithinThresholdRepinsRegardlessOfScroll() {
         // Within threshold dominates: whatever moved the end back into reach, we (re)pin.
-        XCTAssertTrue(resolve(current: false, maxY: 500, isUserScrollUp: true))
-        XCTAssertTrue(resolve(current: false, maxY: 500, isUserScrollUp: false))
+        XCTAssertTrue(resolve(current: false, maxY: 500, unpinBeyondThreshold: true))
+        XCTAssertTrue(resolve(current: false, maxY: 500, unpinBeyondThreshold: false))
     }
 
-    func testResolvePinnedBeyondThresholdGrowthPreservesUserScrollUnpins() {
-        // Beyond threshold: content growth (isUserScrollUp=false) PRESERVES the prior state so an
-        // at-bottom reader keeps being followed through a big chunk; only a real scroll-up un-pins.
-        XCTAssertTrue(resolve(current: true, maxY: 800, isUserScrollUp: false))    // growth keeps pin
-        XCTAssertFalse(resolve(current: true, maxY: 800, isUserScrollUp: true))    // scroll-up un-pins
-        XCTAssertFalse(resolve(current: false, maxY: 800, isUserScrollUp: false))  // scrolled-up stays
-        XCTAssertFalse(resolve(current: false, maxY: 800, isUserScrollUp: true))
+    func testResolvePinnedBeyondThresholdGrowthPreservesUnlessFallingBehind() {
+        // Beyond threshold: a move that is NOT the reader falling behind (unpinBeyondThreshold=false —
+        // content growth we WILL follow) PRESERVES the prior state so an at-bottom reader keeps being
+        // followed through a big chunk; falling behind (a real scroll-up, OR growth while follow-scroll
+        // is suppressed by Find/review) un-pins.
+        XCTAssertTrue(resolve(current: true, maxY: 800, unpinBeyondThreshold: false))    // growth keeps pin
+        XCTAssertFalse(resolve(current: true, maxY: 800, unpinBeyondThreshold: true))    // falling behind un-pins
+        XCTAssertFalse(resolve(current: false, maxY: 800, unpinBeyondThreshold: false))  // scrolled-up stays
+        XCTAssertFalse(resolve(current: false, maxY: 800, unpinBeyondThreshold: true))
+    }
+
+    func testBeyondThresholdGrowthWhileFollowSuppressedUnpins() {
+        // The Find/review case (codex P2): an at-bottom reader, a chunk grows past the threshold, but
+        // follow-scroll is suppressed so the viewport can't catch up. The bottom-sentinel passes
+        // unpinBeyondThreshold=true here ⇒ un-pin, surfacing the Jump chip instead of a stale pin.
+        XCTAssertFalse(resolve(current: true, maxY: 800, unpinBeyondThreshold: true))
     }
 
     func testResizeNeverStrandsAtBottomReaderAndNeverRepinsScrolledUp() {
-        // The viewport-height (resize) path passes isUserScrollUp:false — it may re-pin within the
-        // threshold but never un-pins an at-bottom reader and never yanks a scrolled-up one down.
-        XCTAssertTrue(resolve(current: true, maxY: 800, isUserScrollUp: false))
-        XCTAssertFalse(resolve(current: false, maxY: 800, isUserScrollUp: false))
+        // The viewport-height (resize) path passes unpinBeyondThreshold:false — it may re-pin within
+        // the threshold but never un-pins an at-bottom reader and never yanks a scrolled-up one down.
+        XCTAssertTrue(resolve(current: true, maxY: 800, unpinBeyondThreshold: false))
+        XCTAssertFalse(resolve(current: false, maxY: 800, unpinBeyondThreshold: false))
     }
 
     // MARK: - pinnedAfterScrollSample (orthogonal content-offset direction)
@@ -118,13 +127,13 @@ final class TranscriptScrollFollowTests: XCTestCase {
         XCTAssertTrue(scrollSample(current: true, maxY: 800, topMinY: -99.7, previous: -100))
     }
 
-    private func resolve(current: Bool, maxY: CGFloat, isUserScrollUp: Bool) -> Bool {
+    private func resolve(current: Bool, maxY: CGFloat, unpinBeyondThreshold: Bool) -> Bool {
         TranscriptScrollFollow.resolvePinned(
             current: current,
             bottomSentinelMaxY: maxY,
             viewportHeight: 480,
             threshold: 60,
-            isUserScrollUp: isUserScrollUp
+            unpinBeyondThreshold: unpinBeyondThreshold
         )
     }
 

--- a/Tests/QuillCodeAppTests/TranscriptScrollFollowTests.swift
+++ b/Tests/QuillCodeAppTests/TranscriptScrollFollowTests.swift
@@ -44,4 +44,98 @@ final class TranscriptScrollFollowTests: XCTestCase {
         XCTAssertTrue(TranscriptScrollFollow.isPinnedToBottom(bottomSentinelMaxY: 540, viewportHeight: 480, threshold: 60))
         XCTAssertFalse(TranscriptScrollFollow.isPinnedToBottom(bottomSentinelMaxY: 800, viewportHeight: 480, threshold: 60))
     }
+
+    // MARK: - resolvePinned (the pin transition)
+
+    func testResolvePinnedWithinThresholdRepinsRegardlessOfScroll() {
+        // Within threshold dominates: whatever moved the end back into reach, we (re)pin.
+        XCTAssertTrue(resolve(current: false, maxY: 500, isUserScrollUp: true))
+        XCTAssertTrue(resolve(current: false, maxY: 500, isUserScrollUp: false))
+    }
+
+    func testResolvePinnedBeyondThresholdGrowthPreservesUserScrollUnpins() {
+        // Beyond threshold: content growth (isUserScrollUp=false) PRESERVES the prior state so an
+        // at-bottom reader keeps being followed through a big chunk; only a real scroll-up un-pins.
+        XCTAssertTrue(resolve(current: true, maxY: 800, isUserScrollUp: false))    // growth keeps pin
+        XCTAssertFalse(resolve(current: true, maxY: 800, isUserScrollUp: true))    // scroll-up un-pins
+        XCTAssertFalse(resolve(current: false, maxY: 800, isUserScrollUp: false))  // scrolled-up stays
+        XCTAssertFalse(resolve(current: false, maxY: 800, isUserScrollUp: true))
+    }
+
+    func testResizeNeverStrandsAtBottomReaderAndNeverRepinsScrolledUp() {
+        // The viewport-height (resize) path passes isUserScrollUp:false — it may re-pin within the
+        // threshold but never un-pins an at-bottom reader and never yanks a scrolled-up one down.
+        XCTAssertTrue(resolve(current: true, maxY: 800, isUserScrollUp: false))
+        XCTAssertFalse(resolve(current: false, maxY: 800, isUserScrollUp: false))
+    }
+
+    // MARK: - pinnedAfterScrollSample (orthogonal content-offset direction)
+
+    func testLargeChunkAtBottomKeepsPinned() {
+        // THE regression: a big chunk widens the sentinel gap (maxY 800) but the content TOP does not
+        // move (offset unchanged) ⇒ not a scroll ⇒ an at-bottom reader stays pinned and keeps following.
+        // The pre-fix / signature-only fixes both dropped the follow here under streaming.
+        XCTAssertTrue(scrollSample(current: true, maxY: 800, topMinY: -100, previous: -100))
+    }
+
+    func testFollowScrollAnimationFrameKeepsPinned() {
+        // Mid follow-scroll the content top moves further NEGATIVE (toward the bottom); that must never
+        // read as a scroll-up. This is the exact intermediate frame that re-broke the signature-only fix.
+        XCTAssertTrue(scrollSample(current: true, maxY: 800, topMinY: -300, previous: -100))
+    }
+
+    func testUserScrollUpUnpinsEvenWhileContentIsLarge() {
+        // The reader drags the content DOWN (top offset increases past epsilon) while the gap is large:
+        // un-pin. Works even mid-stream — the offset signal is independent of content growth.
+        XCTAssertFalse(scrollSample(current: true, maxY: 800, topMinY: -40, previous: -100))
+    }
+
+    func testStreamingDoesNotRepinAScrolledUpReader() {
+        // Already scrolled up (current false); a chunk grows (top unchanged) ⇒ stays un-pinned so the
+        // Jump-to-latest chip keeps floating instead of yanking them down.
+        XCTAssertFalse(scrollSample(current: false, maxY: 800, topMinY: -100, previous: -100))
+    }
+
+    func testReturnWithinThresholdRepinsRegardlessOfDirection() {
+        // Even a scroll-up delta re-pins once the end is back within threshold (within-threshold wins).
+        XCTAssertTrue(scrollSample(current: false, maxY: 500, topMinY: -20, previous: -80))
+    }
+
+    func testBoundaryInclusiveAtThreshold() {
+        XCTAssertTrue(scrollSample(current: false, maxY: 540, topMinY: -50, previous: -50))   // gap 60
+    }
+
+    func testJustPastBoundaryStaysUnpinnedWithoutScroll() {
+        XCTAssertFalse(scrollSample(current: false, maxY: 541, topMinY: -50, previous: -50))  // gap 61
+    }
+
+    func testJustPastBoundaryGrowthPreservesPin() {
+        XCTAssertTrue(scrollSample(current: true, maxY: 541, topMinY: -50, previous: -50))
+    }
+
+    func testSubEpsilonOffsetJitterDoesNotUnpin() {
+        // 0.3pt of layout jitter must not be read as a scroll-up (epsilon 0.5).
+        XCTAssertTrue(scrollSample(current: true, maxY: 800, topMinY: -99.7, previous: -100))
+    }
+
+    private func resolve(current: Bool, maxY: CGFloat, isUserScrollUp: Bool) -> Bool {
+        TranscriptScrollFollow.resolvePinned(
+            current: current,
+            bottomSentinelMaxY: maxY,
+            viewportHeight: 480,
+            threshold: 60,
+            isUserScrollUp: isUserScrollUp
+        )
+    }
+
+    private func scrollSample(current: Bool, maxY: CGFloat, topMinY: CGFloat, previous: CGFloat) -> Bool {
+        TranscriptScrollFollow.pinnedAfterScrollSample(
+            current: current,
+            bottomSentinelMaxY: maxY,
+            viewportHeight: 480,
+            threshold: 60,
+            contentTopMinY: topMinY,
+            previousContentTopMinY: previous
+        )
+    }
 }


### PR DESCRIPTION
## Bug (codex P2 on #1239)
The conditional bottom-pin derived `isPinnedToBottom` purely from the bottom sentinel's gap to the viewport. A single **large** streamed chunk widens that gap past the 60pt threshold in one step, so `recomputePinned` flipped `isPinnedToBottom = false` **before** the follow-scroll ran — a reader who *was* at the bottom stopped being followed on big chunks. Root cause: the sentinel gap can't tell **"content grew below me"** (keep following) from **"user scrolled up"** (stop) — both widen it identically.

## Why not the obvious fix
I red-teamed the naive *"did the content signature change with this sample?"* discriminator (5 adversarial agents + synthesis). It's **worse**: the animated follow-scroll emits many sentinel samples per chunk carrying the *unchanged* new signature, so mid-animation frames (`gap>60`, `sig==last`) misread as a scroll and un-pin — converting the large-chunk drop into a **rapid-streaming permanent strand**.

## Fix — an orthogonal, timing-free signal
Track the transcript content's **top edge** in the scroll coordinate space (the negated scroll offset) via a content-background `GeometryReader`. It increases **only** when the reader drags the content down (scrolls up); appending a chunk leaves it put, and the follow-scroll drives it further negative.

- **Un-pinning is owned solely by** "top moved down past 0.5pt since the last sample."
- The **sentinel gap only ever re-pins** (never un-pins) — content growth / follow-scroll / resize all pass `isUserScrollUp: false`.
- Bonus: a reader can now un-pin **mid-stream** (the offset signal is independent of growth), and no macOS 15 `onScrollGeometryChange` is needed — correct on the **macOS 14 floor**.

Baseline resets to nil on first appear + thread switch so a fresh transcript's opening offset is never read as a giant scroll.

## Tests
Pure helpers `resolvePinned` / `pinnedAfterScrollSample` carry the decision. **12 new unit tests**: the regression (large chunk at bottom stays pinned), the follow-animation intermediate frame (the case that re-broke the signature fix), mid-stream user scroll-up un-pins, scrolled-up stays un-pinned, within-threshold re-pin, boundary (gap 60 vs 61), resize path, and sub-epsilon jitter.

- Full package suite: **4549 tests, 0 failures** (2 pre-existing skips).
- Native desktop render smoke: **passed**.

## Note
Pure-function tests + render smoke can't exercise live SwiftUI handler interleaving. A follow-up Playwright/DOM smoke (inject ≥2 large chunks within the follow animation, assert stays pinned + chip never appears) is the belt-and-suspenders check; the geometric signal reuses the exact coordinate-space mechanism the shipping bottom sentinel already relies on.