### PR TITLE
fix(mcp): use canonical JSONL stdio framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ only the compatible account kind and auth mode; delegated keys never appear on t
 App-server clients can also use Codex-compatible `mcpServerStatus/list`,
 `config/mcpServer/reload`, `mcpServer/tool/call`, and `mcpServer/resource/read`. MCP configuration is
 read from global `mcp_servers` tables plus the selected thread workspace's `.codex/config.toml` and
-`.quillcode/config.toml`. Stdio and HTTP transports share the desktop's bounded MCP session runtime;
+`.quillcode/config.toml`. Stdio uses MCP's canonical newline-delimited JSON wire format while still
+accepting legacy `Content-Length` responses from early QuillCode servers. Stdio and HTTP transports
+share the desktop's bounded MCP session runtime;
 status preserves raw tool/resource metadata, while `toolsAndAuthOnly` skips the heavier resource and
 prompt inventory. Reload and disconnect terminate cached sessions. App-server MCP OAuth
 returns a real authorization URL, persists refreshable per-server credentials, emits asynchronous

--- a/Sources/QuillCodeCLI/AppServerProcessSession.swift
+++ b/Sources/QuillCodeCLI/AppServerProcessSession.swift
@@ -7,9 +7,16 @@ final class AppServerProcessSession: @unchecked Sendable {
     private static let readChunkBytes = 64 * 1_024
     private static let outputDrainMilliseconds = 500
     private static let terminationGraceMilliseconds = 1_000
+    private static let completionQueue = DispatchQueue(
+        label: "com.lorehex.quillcode.app-server-process-completion",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
 
     private let request: AppServerProcessSpawnRequest
     private let continuation: AsyncStream<AppServerProcessEvent>.Continuation
+    // An instant child exit must not finalize before its pipe readers are installed.
+    private let launchReady = DispatchSemaphore(value: 0)
     private let lock = NSLock()
     private let readers = DispatchGroup()
     private var process: Process?
@@ -55,19 +62,25 @@ final class AppServerProcessSession: @unchecked Sendable {
         lock.appServerWithLock {
             self.process = process
         }
+        process.terminationHandler = { [weak self] terminatedProcess in
+            Self.completionQueue.async { [weak self] in
+                guard let self else { return }
+                self.launchReady.wait()
+                self.finish(terminatedProcess)
+            }
+        }
         do {
             try process.run()
         } catch {
             cleanUpFailedStart()
+            launchReady.signal()
             throw AppServerRPCError.internalError("failed to spawn process: \(error.localizedDescription)")
         }
 
         closeParentOnlyDescriptorsAfterStart()
         startReaders()
         scheduleTimeoutIfNeeded()
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            self?.waitForExit()
-        }
+        launchReady.signal()
     }
 
     func writeStdin(_ data: Data, closeStdin: Bool) throws {
@@ -314,9 +327,7 @@ final class AppServerProcessSession: @unchecked Sendable {
         }
     }
 
-    private func waitForExit() {
-        guard let process = lock.appServerWithLock({ process }) else { return }
-        process.waitUntilExit()
+    private func finish(_ process: Process) {
         if readers.wait(timeout: .now() + .milliseconds(Self.outputDrainMilliseconds)) == .timedOut {
             let handles = lock.appServerWithLock { outputHandles }
             for handle in handles { try? handle.close() }

--- a/Sources/QuillCodeTools/MCPStdioMessageCodec.swift
+++ b/Sources/QuillCodeTools/MCPStdioMessageCodec.swift
@@ -3,25 +3,74 @@ import Foundation
 public enum MCPStdioMessageCodec {
     public static let maxMessageBytes = 5_000_000
 
+    private static let legacyHeaderPrefix = Data("Content-Length:".utf8)
+    private static let legacyHeaderSeparator = Data("\r\n\r\n".utf8)
+
     public static func encodeJSONObject(_ object: [String: Any]) throws -> Data {
-        let header = "Content-Length: \(try jsonBody(object).count)\r\n\r\n"
-        var data = Data(header.utf8)
-        data.append(try jsonBody(object))
+        var data = try jsonBody(object)
+        guard data.count <= maxMessageBytes else {
+            throw MCPProbeError.invalidMessage("MCP message exceeded \(maxMessageBytes) bytes.")
+        }
+        data.append(0x0A)
         return data
     }
 
-    /// Serialize a JSON-RPC message to bare JSON bytes, WITHOUT the stdio `Content-Length`
-    /// framing header. Used by the HTTP transport, whose framing is HTTP itself.
+    /// Serialize a JSON-RPC message to bare JSON bytes. The HTTP transport supplies its own framing;
+    /// the stdio transport appends one newline through `encodeJSONObject` as required by MCP.
     public static func jsonBody(_ object: [String: Any]) throws -> Data {
         try JSONSerialization.data(withJSONObject: object, options: [])
     }
 
     public static func nextMessageData(from buffer: inout Data) throws -> Data? {
-        let separator = Data("\r\n\r\n".utf8)
-        guard let headerRange = buffer.range(of: separator) else {
-            return nil
-        }
+        while !buffer.isEmpty {
+            if buffer.starts(with: legacyHeaderPrefix) {
+                return try nextLegacyMessageData(from: &buffer)
+            }
+            if legacyHeaderPrefix.starts(with: buffer) {
+                return nil
+            }
 
+            guard let newline = buffer.firstIndex(of: 0x0A) else {
+                guard buffer.count <= maxMessageBytes else {
+                    throw MCPProbeError.invalidMessage("MCP message exceeded \(maxMessageBytes) bytes.")
+                }
+                return nil
+            }
+
+            var message = buffer.subdata(in: buffer.startIndex..<newline)
+            buffer.removeSubrange(buffer.startIndex...newline)
+            if message.last == 0x0D { message.removeLast() }
+            if message.isEmpty { continue }
+            guard message.count <= maxMessageBytes else {
+                throw MCPProbeError.invalidMessage("MCP message exceeded \(maxMessageBytes) bytes.")
+            }
+            return message
+        }
+        return nil
+    }
+
+    /// Accept the framing used by early QuillCode builds so an upgraded client can still connect to
+    /// a legacy local server. New outbound messages always use MCP's newline-delimited JSON format.
+    static func encodeLegacyJSONObject(_ object: [String: Any]) throws -> Data {
+        let body = try jsonBody(object)
+        guard body.count <= maxMessageBytes else {
+            throw MCPProbeError.invalidMessage("MCP message exceeded \(maxMessageBytes) bytes.")
+        }
+        var data = Data("Content-Length: \(body.count)\r\n\r\n".utf8)
+        data.append(body)
+        return data
+    }
+
+    public static func decodeJSONObject(_ data: Data) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: data, options: [])
+        guard let dictionary = object as? [String: Any] else {
+            throw MCPProbeError.invalidMessage("MCP message body is not a JSON object.")
+        }
+        return dictionary
+    }
+
+    private static func nextLegacyMessageData(from buffer: inout Data) throws -> Data? {
+        guard let headerRange = buffer.range(of: legacyHeaderSeparator) else { return nil }
         let headerData = buffer.subdata(in: buffer.startIndex..<headerRange.lowerBound)
         guard let header = String(data: headerData, encoding: .utf8) else {
             throw MCPProbeError.invalidMessage("MCP message header is not UTF-8.")
@@ -40,14 +89,6 @@ public enum MCPStdioMessageCodec {
         let message = buffer.subdata(in: bodyStart..<bodyEnd)
         buffer.removeSubrange(buffer.startIndex..<bodyEnd)
         return message
-    }
-
-    public static func decodeJSONObject(_ data: Data) throws -> [String: Any] {
-        let object = try JSONSerialization.jsonObject(with: data, options: [])
-        guard let dictionary = object as? [String: Any] else {
-            throw MCPProbeError.invalidMessage("MCP message body is not a JSON object.")
-        }
-        return dictionary
     }
 
     private static func contentLength(from header: String) throws -> Int {

--- a/Sources/QuillCodeTools/MCPStdioProber.swift
+++ b/Sources/QuillCodeTools/MCPStdioProber.swift
@@ -1,18 +1,13 @@
 import Foundation
 import QuillCodeCore
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 
 public final class MCPStdioProber: @unchecked Sendable {
-    private let standardInput: FileHandle
-    private let standardOutput: FileHandle
-    private let ioLock = NSLock()
-    private var readBuffer = Data()
-    private var nextRequestID = 1
-    private var clientCapabilities = MCPClientCapabilities.none
+    let standardInput: FileHandle
+    let standardOutput: FileHandle
+    let ioLock = NSLock()
+    var readBuffer = Data()
+    var nextRequestID = 1
+    var clientCapabilities = MCPClientCapabilities.none
 
     public init(standardInput: FileHandle, standardOutput: FileHandle) {
         self.standardInput = standardInput
@@ -42,7 +37,8 @@ public final class MCPStdioProber: @unchecked Sendable {
             "protocolVersion": "2025-06-18",
             "capabilities": clientCapabilities.initializeObject,
             "clientInfo": [
-                "name": "QuillCode",
+                "name": "quillcode-mcp-client",
+                "title": "QuillCode",
                 "version": "0.1.0"
             ]
         ])
@@ -52,7 +48,10 @@ public final class MCPStdioProber: @unchecked Sendable {
 
         try writeNotification(method: "notifications/initialized", params: [:])
         let toolsListID = nextID()
-        try write(method: "tools/list", id: toolsListID, params: [:])
+        let toolsListContext = try MCPProgressRequestContext(metadata: nil)
+        try write(method: "tools/list", id: toolsListID, params: [
+            "_meta": MCPJSONValue.object(toolsListContext.metadata).foundationObject
+        ])
 
         let toolsList = try readResponse(id: toolsListID, deadline: deadline)
         let toolsResult = try resultDictionary(from: toolsList)
@@ -119,131 +118,6 @@ public final class MCPStdioProber: @unchecked Sendable {
         return MCPStdioResultMapper.toolResult(from: result)
     }
 
-    public func callToolResult(
-        toolName: String,
-        arguments: MCPJSONValue?,
-        metadata: MCPJSONValue?,
-        timeout: TimeInterval = 10.0
-    ) throws -> MCPToolCallResult {
-        ioLock.lock()
-        defer { ioLock.unlock() }
-
-        let toolName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !toolName.isEmpty else {
-            throw MCPProbeError.invalidMessage("MCP tool name is required.")
-        }
-        return try callToolResultLocked(
-            toolName: toolName,
-            arguments: arguments,
-            metadata: metadata,
-            timeout: timeout,
-            progressContext: nil,
-            onProgress: nil
-        )
-    }
-
-    public func callToolEvents(
-        toolName: String,
-        arguments: MCPJSONValue?,
-        metadata: MCPJSONValue?,
-        timeout: TimeInterval = 10.0
-    ) -> AsyncThrowingStream<MCPClientToolEvent, Error> {
-        callToolEvents(
-            toolName: toolName,
-            arguments: arguments,
-            metadata: metadata,
-            timeout: timeout,
-            elicitationHandler: nil
-        )
-    }
-
-    public func callToolEvents(
-        toolName: String,
-        arguments: MCPJSONValue?,
-        metadata: MCPJSONValue?,
-        timeout: TimeInterval = 10.0,
-        elicitationHandler: MCPClientElicitationHandler?
-    ) -> AsyncThrowingStream<MCPClientToolEvent, Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task.detached { [self] in
-                do {
-                    let progressContext = try MCPProgressRequestContext(metadata: metadata)
-                    let result = try performStreamingToolCall(
-                        toolName: toolName,
-                        arguments: arguments,
-                        metadata: metadata,
-                        timeout: timeout,
-                        progressContext: progressContext,
-                        onProgress: { continuation.yield(.progress($0)) },
-                        elicitationHandler: elicitationHandler
-                    )
-                    continuation.yield(.result(result))
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-            continuation.onTermination = { _ in task.cancel() }
-        }
-    }
-
-    private func performStreamingToolCall(
-        toolName: String,
-        arguments: MCPJSONValue?,
-        metadata: MCPJSONValue?,
-        timeout: TimeInterval,
-        progressContext: MCPProgressRequestContext,
-        onProgress: @escaping @Sendable (ToolExecutionProgress) -> Void,
-        elicitationHandler: MCPClientElicitationHandler?
-    ) throws -> MCPToolCallResult {
-        ioLock.lock()
-        defer { ioLock.unlock() }
-        return try callToolResultLocked(
-            toolName: toolName,
-            arguments: arguments,
-            metadata: metadata,
-            timeout: timeout,
-            progressContext: progressContext,
-            onProgress: onProgress,
-            elicitationHandler: elicitationHandler
-        )
-    }
-
-    private func callToolResultLocked(
-        toolName: String,
-        arguments: MCPJSONValue?,
-        metadata: MCPJSONValue?,
-        timeout: TimeInterval,
-        progressContext: MCPProgressRequestContext?,
-        onProgress: ((ToolExecutionProgress) -> Void)?,
-        elicitationHandler: MCPClientElicitationHandler? = nil
-    ) throws -> MCPToolCallResult {
-        let toolName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !toolName.isEmpty else {
-            throw MCPProbeError.invalidMessage("MCP tool name is required.")
-        }
-        var params: [String: Any] = [
-            "name": toolName,
-            "arguments": (arguments ?? .object([:])).foundationObject
-        ]
-        if let progressContext {
-            params["_meta"] = MCPJSONValue.object(progressContext.metadata).foundationObject
-        } else if let metadata {
-            params["_meta"] = metadata.foundationObject
-        }
-        let requestID = nextID()
-        try write(method: "tools/call", id: requestID, params: params)
-        var tracker = progressContext.map { MCPProgressTracker(token: $0.token) }
-        let response = try readResponse(
-            id: requestID,
-            deadline: Date().addingTimeInterval(timeout),
-            progressTracker: &tracker,
-            onProgress: onProgress,
-            elicitationHandler: elicitationHandler
-        )
-        return MCPStdioResultMapper.toolCallResult(from: try resultDictionary(from: response))
-    }
-
     public func readResource(
         uri: String,
         timeout: TimeInterval = 10.0
@@ -303,12 +177,12 @@ public final class MCPStdioProber: @unchecked Sendable {
         return MCPStdioResultMapper.promptResult(from: result, name: name)
     }
 
-    private func nextID() -> Int {
+    func nextID() -> Int {
         defer { nextRequestID += 1 }
         return nextRequestID
     }
 
-    private func write(method: String, id: Int, params: [String: Any]) throws {
+    func write(method: String, id: Int, params: [String: Any]) throws {
         let message: [String: Any] = [
             "jsonrpc": "2.0",
             "id": id,
@@ -318,7 +192,7 @@ public final class MCPStdioProber: @unchecked Sendable {
         standardInput.write(try MCPStdioMessageCodec.encodeJSONObject(message))
     }
 
-    private func writeNotification(method: String, params: [String: Any]) throws {
+    func writeNotification(method: String, params: [String: Any]) throws {
         let message: [String: Any] = [
             "jsonrpc": "2.0",
             "method": method,
@@ -327,110 +201,7 @@ public final class MCPStdioProber: @unchecked Sendable {
         standardInput.write(try MCPStdioMessageCodec.encodeJSONObject(message))
     }
 
-    private func readResponse(id: Int, deadline: Date) throws -> [String: Any] {
-        var tracker: MCPProgressTracker?
-        return try readResponse(
-            id: id,
-            deadline: deadline,
-            progressTracker: &tracker,
-            onProgress: nil
-        )
-    }
-
-    private func readResponse(
-        id: Int,
-        deadline: Date,
-        progressTracker: inout MCPProgressTracker?,
-        onProgress: ((ToolExecutionProgress) -> Void)?,
-        elicitationHandler: MCPClientElicitationHandler? = nil
-    ) throws -> [String: Any] {
-        while Date() < deadline {
-            if Task.isCancelled { throw CancellationError() }
-            if let message = try MCPStdioMessageCodec.nextMessageData(from: &readBuffer) {
-                let object = try MCPStdioMessageCodec.decodeJSONObject(message)
-                if object["method"] == nil, matchesResponseID(object["id"], id: id) {
-                    return object
-                }
-                if try handleElicitationRequest(
-                    object,
-                    deadline: deadline,
-                    handler: elicitationHandler
-                ) {
-                    continue
-                }
-                if var tracker = progressTracker {
-                    let progress = tracker.consume(object)
-                    progressTracker = tracker
-                    if let progress { onProgress?(progress) }
-                }
-                continue
-            }
-
-            let remaining = min(0.1, max(0.05, deadline.timeIntervalSinceNow))
-            if let data = try readAvailableData(timeout: remaining),
-               !data.isEmpty {
-                readBuffer.append(data)
-            }
-        }
-        throw MCPProbeError.timeout("MCP server did not respond before the request timed out.")
-    }
-
-    private func handleElicitationRequest(
-        _ object: [String: Any],
-        deadline: Date,
-        handler: MCPClientElicitationHandler?
-    ) throws -> Bool {
-        guard let requestID = MCPServerElicitationEnvelope.requestIDIfRecognized(in: object) else {
-            return false
-        }
-
-        let response: MCPClientElicitationResponse
-        do {
-            let envelope = try MCPServerElicitationEnvelope.decode(from: object)
-            guard clientCapabilities.supports(envelope.request) else {
-                try writeResponse(id: requestID, response: .cancel())
-                return true
-            }
-            response = try MCPAsyncElicitationBridge.resolve(
-                envelope.request,
-                using: handler,
-                deadline: deadline
-            )
-        } catch is CancellationError {
-            try writeResponse(id: requestID, response: .cancel())
-            throw CancellationError()
-        } catch {
-            response = .cancel()
-        }
-        try writeResponse(id: requestID, response: response)
-        return true
-    }
-
-    private func writeResponse(
-        id: MCPJSONRPCRequestID,
-        response: MCPClientElicitationResponse
-    ) throws {
-        standardInput.write(try MCPStdioMessageCodec.encodeJSONObject([
-            "jsonrpc": "2.0",
-            "id": id.foundationObject,
-            "result": response.foundationObject
-        ]))
-    }
-
-    private func matchesResponseID(_ value: Any?, id: Int) -> Bool {
-        if let int = value as? Int {
-            return int == id
-        }
-        if let number = value as? NSNumber {
-            return number.intValue == id
-        }
-        if let string = value as? String {
-            return string == "\(id)"
-        }
-        return false
-    }
-
-    private func resultDictionary(from response: [String: Any]) throws -> [String: Any] {
+    func resultDictionary(from response: [String: Any]) throws -> [String: Any] {
         if let error = response["error"] as? [String: Any] {
             let message = error["message"] as? String ?? "MCP server returned an error."
             throw MCPProbeError.responseError(message)
@@ -487,29 +258,6 @@ public final class MCPStdioProber: @unchecked Sendable {
         } catch {
             return []
         }
-    }
-
-    private func readAvailableData(timeout: TimeInterval) throws -> Data? {
-        let timeoutMilliseconds = Int32(max(1, min(timeout * 1000, Double(Int32.max))))
-        var descriptor = pollfd(
-            fd: Int32(standardOutput.fileDescriptor),
-            events: Int16(POLLIN),
-            revents: 0
-        )
-        let pollResult = poll(&descriptor, 1, timeoutMilliseconds)
-        if pollResult == 0 {
-            return nil
-        }
-        guard pollResult > 0 else {
-            throw MCPProbeError.invalidMessage("MCP stdout poll failed with errno \(errno).")
-        }
-
-        var bytes = [UInt8](repeating: 0, count: 64 * 1024)
-        let byteCount = read(descriptor.fd, &bytes, bytes.count)
-        guard byteCount >= 0 else {
-            throw MCPProbeError.invalidMessage("MCP stdout read failed with errno \(errno).")
-        }
-        return Data(bytes.prefix(byteCount))
     }
 
 }

--- a/Sources/QuillCodeTools/MCPStdioProberEvents.swift
+++ b/Sources/QuillCodeTools/MCPStdioProberEvents.swift
@@ -1,0 +1,251 @@
+import Foundation
+import QuillCodeCore
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+extension MCPStdioProber {
+    public func callToolResult(
+        toolName: String,
+        arguments: MCPJSONValue?,
+        metadata: MCPJSONValue?,
+        timeout: TimeInterval = 10.0
+    ) throws -> MCPToolCallResult {
+        ioLock.lock()
+        defer { ioLock.unlock() }
+
+        let toolName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !toolName.isEmpty else {
+            throw MCPProbeError.invalidMessage("MCP tool name is required.")
+        }
+        return try callToolResultLocked(
+            toolName: toolName,
+            arguments: arguments,
+            metadata: metadata,
+            timeout: timeout,
+            progressContext: nil,
+            onProgress: nil
+        )
+    }
+
+    public func callToolEvents(
+        toolName: String,
+        arguments: MCPJSONValue?,
+        metadata: MCPJSONValue?,
+        timeout: TimeInterval = 10.0
+    ) -> AsyncThrowingStream<MCPClientToolEvent, Error> {
+        callToolEvents(
+            toolName: toolName,
+            arguments: arguments,
+            metadata: metadata,
+            timeout: timeout,
+            elicitationHandler: nil
+        )
+    }
+
+    public func callToolEvents(
+        toolName: String,
+        arguments: MCPJSONValue?,
+        metadata: MCPJSONValue?,
+        timeout: TimeInterval = 10.0,
+        elicitationHandler: MCPClientElicitationHandler?
+    ) -> AsyncThrowingStream<MCPClientToolEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task.detached { [self] in
+                do {
+                    let progressContext = try MCPProgressRequestContext(metadata: metadata)
+                    let result = try performStreamingToolCall(
+                        toolName: toolName,
+                        arguments: arguments,
+                        metadata: metadata,
+                        timeout: timeout,
+                        progressContext: progressContext,
+                        onProgress: { continuation.yield(.progress($0)) },
+                        elicitationHandler: elicitationHandler
+                    )
+                    continuation.yield(.result(result))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func readResponse(id: Int, deadline: Date) throws -> [String: Any] {
+        var tracker: MCPProgressTracker?
+        return try readResponse(
+            id: id,
+            deadline: deadline,
+            progressTracker: &tracker,
+            onProgress: nil
+        )
+    }
+
+    private func performStreamingToolCall(
+        toolName: String,
+        arguments: MCPJSONValue?,
+        metadata: MCPJSONValue?,
+        timeout: TimeInterval,
+        progressContext: MCPProgressRequestContext,
+        onProgress: @escaping @Sendable (ToolExecutionProgress) -> Void,
+        elicitationHandler: MCPClientElicitationHandler?
+    ) throws -> MCPToolCallResult {
+        ioLock.lock()
+        defer { ioLock.unlock() }
+        return try callToolResultLocked(
+            toolName: toolName,
+            arguments: arguments,
+            metadata: metadata,
+            timeout: timeout,
+            progressContext: progressContext,
+            onProgress: onProgress,
+            elicitationHandler: elicitationHandler
+        )
+    }
+
+    private func callToolResultLocked(
+        toolName: String,
+        arguments: MCPJSONValue?,
+        metadata: MCPJSONValue?,
+        timeout: TimeInterval,
+        progressContext: MCPProgressRequestContext?,
+        onProgress: ((ToolExecutionProgress) -> Void)?,
+        elicitationHandler: MCPClientElicitationHandler? = nil
+    ) throws -> MCPToolCallResult {
+        let toolName = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !toolName.isEmpty else {
+            throw MCPProbeError.invalidMessage("MCP tool name is required.")
+        }
+        var params: [String: Any] = [
+            "name": toolName,
+            "arguments": (arguments ?? .object([:])).foundationObject
+        ]
+        if let progressContext {
+            params["_meta"] = MCPJSONValue.object(progressContext.metadata).foundationObject
+        } else if let metadata {
+            params["_meta"] = metadata.foundationObject
+        }
+        let requestID = nextID()
+        try write(method: "tools/call", id: requestID, params: params)
+        var tracker = progressContext.map { MCPProgressTracker(token: $0.token) }
+        let response = try readResponse(
+            id: requestID,
+            deadline: Date().addingTimeInterval(timeout),
+            progressTracker: &tracker,
+            onProgress: onProgress,
+            elicitationHandler: elicitationHandler
+        )
+        return MCPStdioResultMapper.toolCallResult(from: try resultDictionary(from: response))
+    }
+
+    private func readResponse(
+        id: Int,
+        deadline: Date,
+        progressTracker: inout MCPProgressTracker?,
+        onProgress: ((ToolExecutionProgress) -> Void)?,
+        elicitationHandler: MCPClientElicitationHandler? = nil
+    ) throws -> [String: Any] {
+        while Date() < deadline {
+            if Task.isCancelled { throw CancellationError() }
+            if let message = try MCPStdioMessageCodec.nextMessageData(from: &readBuffer) {
+                let object = try MCPStdioMessageCodec.decodeJSONObject(message)
+                if object["method"] == nil, matchesResponseID(object["id"], id: id) {
+                    return object
+                }
+                if try handleElicitationRequest(
+                    object,
+                    deadline: deadline,
+                    handler: elicitationHandler
+                ) {
+                    continue
+                }
+                if var tracker = progressTracker {
+                    let progress = tracker.consume(object)
+                    progressTracker = tracker
+                    if let progress { onProgress?(progress) }
+                }
+                continue
+            }
+
+            let remaining = min(0.1, max(0.05, deadline.timeIntervalSinceNow))
+            if let data = try readAvailableData(timeout: remaining), !data.isEmpty {
+                readBuffer.append(data)
+            }
+        }
+        throw MCPProbeError.timeout("MCP server did not respond before the request timed out.")
+    }
+
+    private func handleElicitationRequest(
+        _ object: [String: Any],
+        deadline: Date,
+        handler: MCPClientElicitationHandler?
+    ) throws -> Bool {
+        guard let requestID = MCPServerElicitationEnvelope.requestIDIfRecognized(in: object) else {
+            return false
+        }
+
+        let response: MCPClientElicitationResponse
+        do {
+            let envelope = try MCPServerElicitationEnvelope.decode(from: object)
+            guard clientCapabilities.supports(envelope.request) else {
+                try writeResponse(id: requestID, response: .cancel())
+                return true
+            }
+            response = try MCPAsyncElicitationBridge.resolve(
+                envelope.request,
+                using: handler,
+                deadline: deadline
+            )
+        } catch is CancellationError {
+            try writeResponse(id: requestID, response: .cancel())
+            throw CancellationError()
+        } catch {
+            response = .cancel()
+        }
+        try writeResponse(id: requestID, response: response)
+        return true
+    }
+
+    private func writeResponse(
+        id: MCPJSONRPCRequestID,
+        response: MCPClientElicitationResponse
+    ) throws {
+        standardInput.write(try MCPStdioMessageCodec.encodeJSONObject([
+            "jsonrpc": "2.0",
+            "id": id.foundationObject,
+            "result": response.foundationObject
+        ]))
+    }
+
+    private func matchesResponseID(_ value: Any?, id: Int) -> Bool {
+        if let int = value as? Int { return int == id }
+        if let number = value as? NSNumber { return number.intValue == id }
+        if let string = value as? String { return string == "\(id)" }
+        return false
+    }
+
+    private func readAvailableData(timeout: TimeInterval) throws -> Data? {
+        let timeoutMilliseconds = Int32(max(1, min(timeout * 1000, Double(Int32.max))))
+        var descriptor = pollfd(
+            fd: Int32(standardOutput.fileDescriptor),
+            events: Int16(POLLIN),
+            revents: 0
+        )
+        let pollResult = poll(&descriptor, 1, timeoutMilliseconds)
+        if pollResult == 0 { return nil }
+        guard pollResult > 0 else {
+            throw MCPProbeError.invalidMessage("MCP stdout poll failed with errno \(errno).")
+        }
+
+        var bytes = [UInt8](repeating: 0, count: 64 * 1024)
+        let byteCount = read(descriptor.fd, &bytes, bytes.count)
+        guard byteCount >= 0 else {
+            throw MCPProbeError.invalidMessage("MCP stdout read failed with errno \(errno).")
+        }
+        return Data(bytes.prefix(byteCount))
+    }
+}

--- a/Tests/QuillCodeCLITests/AppServerCommandExecTests.swift
+++ b/Tests/QuillCodeCLITests/AppServerCommandExecTests.swift
@@ -476,7 +476,7 @@ private extension AppServerCommandExecTests {
         match: ([[String: CLIJSONValue]]) -> Value?
     ) async throws -> Value {
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(10))
+        let deadline = clock.now.advanced(by: .seconds(30))
         while clock.now < deadline {
             if let value = match(try await output.records()) { return value }
             try await clock.sleep(for: .milliseconds(10))

--- a/Tests/QuillCodeCLITests/AppServerCommandExecTests.swift
+++ b/Tests/QuillCodeCLITests/AppServerCommandExecTests.swift
@@ -195,7 +195,7 @@ final class AppServerCommandExecTests: XCTestCase {
         )
         _ = try await waitForResponse(id: 2, output: fixture.output)
 
-        for generation in 0..<8 {
+        for generation in 0..<24 {
             let requestID = 5 + generation
             let expected = "reused-\(generation)"
             try await sendRequest(

--- a/Tests/QuillCodeParityTests/ParityAppServerMCPElicitationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAppServerMCPElicitationGateTests.swift
@@ -5,7 +5,10 @@ final class ParityAppServerMCPElicitationGateTests: QuillCodeParityTestCase {
         let root = Self.packageRoot()
         let contract = try text(root, "Sources/QuillCodeTools/MCPClientElicitation.swift")
         let schema = try text(root, "Sources/QuillCodeTools/MCPFormElicitationSchemaValidator.swift")
-        let stdio = try text(root, "Sources/QuillCodeTools/MCPStdioProber.swift")
+        let stdio = try [
+            text(root, "Sources/QuillCodeTools/MCPStdioProber.swift"),
+            text(root, "Sources/QuillCodeTools/MCPStdioProberEvents.swift")
+        ].joined(separator: "\n")
         let streamableHTTP = try text(root, "Sources/QuillCodeTools/MCPHTTPProberStreamableHTTP.swift")
         let legacyHTTP = try text(root, "Sources/QuillCodeTools/MCPHTTPProberHTTPSSE.swift")
         let appServer = try text(root, "Sources/QuillCodeCLI/AppServerMCPElicitation.swift")

--- a/Tests/QuillCodeParityTests/ParityMCPGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityMCPGateTests.swift
@@ -81,7 +81,7 @@ final class ParityMCPGateTests: QuillCodeParityTestCase {
         let definitionsText = try Self.toolsSourceText(named: "MCPToolDefinitions.swift")
 
         XCTAssertTrue(proberText.contains("public final class MCPStdioProber"), "MCP stdio session orchestration should remain in the prober.")
-        XCTAssertTrue(codecText.contains("public enum MCPStdioMessageCodec"), "MCP Content-Length framing should live in a focused codec.")
+        XCTAssertTrue(codecText.contains("public enum MCPStdioMessageCodec"), "MCP JSONL framing should live in a focused codec.")
         XCTAssertTrue(mapperText.contains("enum MCPStdioResultMapper"), "MCP result mapping should live in a focused mapper.")
         XCTAssertTrue(modelsText.contains("public struct MCPServerProbeResult"), "MCP probe result models should live outside the stdio prober.")
         XCTAssertTrue(modelsText.contains("public enum MCPProbeError"), "MCP probe errors should live with the public stdio models.")

--- a/Tests/QuillCodeToolsTests/MCPStdioProberTests.swift
+++ b/Tests/QuillCodeToolsTests/MCPStdioProberTests.swift
@@ -88,18 +88,26 @@ final class MCPStdioProberTests: XCTestCase {
         ))
         _ = try prober.probe(timeout: 1)
 
-        let initialize = try XCTUnwrap(
-            fixture.readRequests().first { $0["method"] as? String == "initialize" }
-        )
+        let requests = try fixture.readRequests()
+        let initialize = try XCTUnwrap(requests.first { $0["method"] as? String == "initialize" })
         let params = try XCTUnwrap(initialize["params"] as? [String: Any])
         let capabilities = try XCTUnwrap(params["capabilities"] as? [String: Any])
         let extensions = try XCTUnwrap(capabilities["extensions"] as? [String: Any])
+        let clientInfo = try XCTUnwrap(params["clientInfo"] as? [String: Any])
         XCTAssertEqual(params["protocolVersion"] as? String, "2025-06-18")
+        XCTAssertEqual(clientInfo["name"] as? String, "quillcode-mcp-client")
+        XCTAssertEqual(clientInfo["title"] as? String, "QuillCode")
+        XCTAssertEqual(clientInfo["version"] as? String, "0.1.0")
         XCTAssertNotNil(capabilities["elicitation"] as? [String: Any])
         XCTAssertNotNil(extensions["openai/form"] as? [String: Any])
+
+        let toolsList = try XCTUnwrap(requests.first { $0["method"] as? String == "tools/list" })
+        let toolsListParams = try XCTUnwrap(toolsList["params"] as? [String: Any])
+        let toolsListMetadata = try XCTUnwrap(toolsListParams["_meta"] as? [String: Any])
+        XCTAssertTrue((toolsListMetadata["progressToken"] as? String)?.hasPrefix("quillcode-") == true)
     }
 
-    func testCodecEncodesAndParsesContentLengthMessages() throws {
+    func testCodecEncodesAndParsesNewlineDelimitedMessages() throws {
         let first = try MCPStdioMessageCodec.encodeJSONObject([
             "jsonrpc": "2.0",
             "id": 1,
@@ -110,6 +118,9 @@ final class MCPStdioProberTests: XCTestCase {
             "id": 2,
             "result": ["tools": []]
         ])
+
+        XCTAssertEqual(first.last, 0x0A)
+        XCTAssertFalse(String(decoding: first, as: UTF8.self).contains("Content-Length"))
 
         var buffer = Data()
         buffer.append(first.prefix(8))
@@ -124,6 +135,35 @@ final class MCPStdioProberTests: XCTestCase {
         let secondMessage = try XCTUnwrap(MCPStdioMessageCodec.nextMessageData(from: &buffer))
         let secondObject = try MCPStdioMessageCodec.decodeJSONObject(secondMessage)
         XCTAssertEqual(secondObject["id"] as? Int, 2)
+        XCTAssertTrue(buffer.isEmpty)
+    }
+
+    func testCodecAcceptsLegacyContentLengthMessages() throws {
+        var buffer = try MCPStdioMessageCodec.encodeLegacyJSONObject([
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": ["ok": true]
+        ])
+
+        let message = try XCTUnwrap(MCPStdioMessageCodec.nextMessageData(from: &buffer))
+        let object = try MCPStdioMessageCodec.decodeJSONObject(message)
+
+        XCTAssertEqual(object["id"] as? Int, 7)
+        XCTAssertTrue(buffer.isEmpty)
+    }
+
+    func testCodecIgnoresBlankLinesBetweenMessages() throws {
+        var buffer = Data("\r\n\n".utf8)
+        buffer.append(try MCPStdioMessageCodec.encodeJSONObject([
+            "jsonrpc": "2.0",
+            "id": 9,
+            "result": ["ok": true]
+        ]))
+
+        let message = try XCTUnwrap(MCPStdioMessageCodec.nextMessageData(from: &buffer))
+        let object = try MCPStdioMessageCodec.decodeJSONObject(message)
+
+        XCTAssertEqual(object["id"] as? Int, 9)
         XCTAssertTrue(buffer.isEmpty)
     }
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1683,8 +1683,23 @@
   retain input ordering. EOF cancels and joins the outstanding request before dependency teardown.
 - **Evidence:** Schema, bridge, stdio, both HTTP transport, fake-session app-server, interruption,
   capability-gating, and malformed-response tests cover the typed boundaries. The real app-server
-  smoke drives a framed child MCP request through the JSONL client response and verifies capability
-  advertisement, metadata sanitization, resolved ordering, and the final accepted payload.
+  smoke drives a newline-delimited child MCP request through the JSONL client response and verifies
+  capability advertisement, metadata sanitization, resolved ordering, and the final accepted payload.
+
+## 2026-07-16: MCP stdio uses canonical newline-delimited JSON
+
+- **Outbound boundary:** Every stdio request, response, and notification is one bounded JSON object
+  followed by a newline, matching MCP 2025-06-18 and Codex. HTTP sessions continue to use the same
+  JSON body encoder without adding stdio framing.
+- **Compatibility boundary:** The incremental decoder accepts both canonical JSONL and the legacy
+  `Content-Length` frames emitted by early QuillCode builds. Compatibility is input-only; new clients
+  cannot silently perpetuate the obsolete framing.
+- **Identity and progress:** Initialization reports `quillcode-mcp-client`, the QuillCode product
+  title, and its client version. Tool discovery carries a unique progress token, as do individual
+  tool calls, so modern servers can associate progress without cross-request collisions.
+- **Evidence:** Focused codec/session tests cover fragmented JSONL, blank separators, legacy input,
+  client metadata, and discovery metadata. The real app-server smoke launches a strict JSONL-only MCP
+  child and completes startup, tool calls, progress metadata, elicitation, and resource reads.
 
 ## 2026-07-16: Direct user shell is a host escape hatch with hidden durable context
 

--- a/scripts/fixtures/mcp-stdio-server.py
+++ b/scripts/fixtures/mcp-stdio-server.py
@@ -5,25 +5,17 @@ import sys
 
 
 def read_message():
-    content_length = None
-    while True:
-        line = sys.stdin.buffer.readline()
-        if not line:
-            return None
-        if line in (b"\n", b"\r\n"):
-            break
-        name, value = line.decode("ascii").split(":", 1)
-        if name.lower() == "content-length":
-            content_length = int(value.strip())
-    if content_length is None:
-        raise RuntimeError("missing Content-Length")
-    return json.loads(sys.stdin.buffer.read(content_length))
+    line = sys.stdin.buffer.readline()
+    if not line:
+        return None
+    if line.lower().startswith(b"content-length:"):
+        raise RuntimeError("legacy Content-Length framing is not supported by this fixture")
+    return json.loads(line)
 
 
 def send(message):
     payload = json.dumps(message, separators=(",", ":")).encode("utf-8")
-    sys.stdout.buffer.write(f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii"))
-    sys.stdout.buffer.write(payload)
+    sys.stdout.buffer.write(payload + b"\n")
     sys.stdout.buffer.flush()
 
 


### PR DESCRIPTION
## Summary
- emit canonical newline-delimited JSON for MCP stdio while retaining input-only compatibility with early QuillCode Content-Length responses
- advertise stable QuillCode client identity and per-request progress metadata
- split stdio event handling into a focused extension and make the real fixture reject legacy outbound framing

## Verification
- `swift test`: 4,542 tests, 2 skipped, 0 failures
- `swift test --filter MCPStdioProberTests`: 15 tests, 0 failures
- `swift test --filter ParityMCPGateTests`: 4 tests, 0 failures
- `scripts/app-server-smoke.sh`
- `scripts/cli-exec-smoke.sh`
- `python3 scripts/grade-code-quality.py`: all modules A+
- `git diff --check`