### PR TITLE
test(e2e): DOM follow-scroll smoke + harness parity with native geometric pin

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -2481,6 +2481,22 @@
       cursor: pointer;
       box-shadow: 0 4px 14px rgba(0,0,0,.3);
     }
+    .transcript-jump-to-latest {
+      position: fixed;
+      bottom: 96px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 40;
+      font-size: 12px;
+      font-weight: 700;
+      color: #fff;
+      background: var(--blue);
+      border: none;
+      border-radius: 999px;
+      padding: 8px 16px;
+      cursor: pointer;
+      box-shadow: 0 6px 18px rgba(0,0,0,.38);
+    }
     .terminal-pane,
     .browser-pane,
     .extensions-pane,
@@ -11960,45 +11976,129 @@
         </section>`;
     }
 
+    // Streaming follow-scroll, mirroring the native SwiftUI rule (QuillCodeTranscriptView +
+    // TranscriptScrollFollow). Two decoupled concerns:
+    //  1. FOLLOW: on each render, stick to the bottom iff the reader was AT the bottom when the render
+    //     began (`wasWindowPinnedToBottom`, read live from the DOM so it can't lag async scroll
+    //     events). Content growth changes scrollHeight, not scrollY, so growth alone never moves the
+    //     reader off the bottom — the native "growth doesn't un-pin".
+    //  2. CHIP: a floating "Jump to latest" chip (parity with quillcode-transcript-jump-to-latest)
+    //     appears only after a genuine USER scroll UP — tracked by `transcriptShowJumpChip`, flipped
+    //     by the window scroll listener. It is NOT derived from the render pin, so content that merely
+    //     OPENS at the top (an overflowing fixture, before any scroll) never shows the chip.
+    // The harness scrolls the WINDOW (the workspace is min-height:100vh, so a tall transcript overflows
+    // the page rather than an inner box), so both read window scroll.
+    let transcriptShowJumpChip = false;
+    let windowScrollTrackingBound = false;
+    const TRANSCRIPT_BOTTOM_THRESHOLD = 24;
+
+    function windowDistanceFromBottom() {
+      const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      return Math.max(0, maxScrollY - window.scrollY);
+    }
+
     function captureTranscriptScroll() {
       const timeline = document.querySelector('[data-testid="timeline"]');
-      const documentElement = document.documentElement;
-      const maxWindowScrollY = Math.max(0, documentElement.scrollHeight - window.innerHeight);
-      const windowDistanceFromBottom = maxWindowScrollY - window.scrollY;
-      if (!timeline) {
-        return {
-          windowScrollY: window.scrollY,
-          wasWindowPinnedToBottom: windowDistanceFromBottom <= 24
-        };
-      }
-      const maxTimelineScrollTop = Math.max(0, timeline.scrollHeight - timeline.clientHeight);
-      const timelineDistanceFromBottom = maxTimelineScrollTop - timeline.scrollTop;
       return {
         windowScrollY: window.scrollY,
-        wasWindowPinnedToBottom: windowDistanceFromBottom <= 24,
-        timelineScrollTop: timeline.scrollTop,
-        wasTimelinePinnedToBottom: timelineDistanceFromBottom <= 24
+        // DOM-derived, SYNCHRONOUSLY: is the reader at the bottom right now, before this render's
+        // content lands? Scroll events are async and lag, so the follow decision must read the live
+        // position here (capturing the pre-growth pin — the native `isPinnedToBottom` at capture).
+        wasWindowPinnedToBottom: windowDistanceFromBottom() <= TRANSCRIPT_BOTTOM_THRESHOLD,
+        timelineScrollTop: timeline ? timeline.scrollTop : 0
       };
     }
 
     function restoreTranscriptScroll(snapshot) {
       if (!snapshot) return;
+      bindWindowScrollTracking();
       const documentElement = document.documentElement;
+      const timeline = document.querySelector('[data-testid="timeline"]');
+      // Follow to the bottom iff the reader was pinned there when this render began; otherwise keep
+      // their scrolled-up position (the native `guard force || isPinnedToBottom`). Reaching the bottom
+      // dismisses the chip; a scrolled-up render leaves the chip state to the scroll listener.
       if (snapshot.wasWindowPinnedToBottom) {
         window.scrollTo(0, documentElement.scrollHeight);
+        if (timeline) timeline.scrollTop = timeline.scrollHeight;
+        transcriptShowJumpChip = false;
       } else {
         const maxWindowScrollY = Math.max(0, documentElement.scrollHeight - window.innerHeight);
         window.scrollTo(0, Math.min(snapshot.windowScrollY || 0, maxWindowScrollY));
+        if (timeline) {
+          const maxScrollTop = Math.max(0, timeline.scrollHeight - timeline.clientHeight);
+          timeline.scrollTop = Math.min(snapshot.timelineScrollTop || 0, maxScrollTop);
+        }
       }
+      updateJumpToLatestChip();
+    }
+
+    function jumpToLatestChipHTML() {
+      return `<button type="button" class="transcript-jump-to-latest" data-testid="jump-to-latest" aria-label="Jump to latest">Jump to latest</button>`;
+    }
+
+    // Show the chip only after a user scroll-up AND while a run is streaming — the native chip's stated
+    // scenario ("shown while the reader has scrolled up during a live run"). Gating on the run keeps it
+    // out of every static, non-running audit/screenshot fixture, where a floating overlay would
+    // otherwise overlap other controls the audit scrolls under.
+    function shouldShowJumpChip() {
+      return transcriptShowJumpChip && !!state.composer.isSending;
+    }
+
+    function renderJumpToLatestChip() {
+      return shouldShowJumpChip() ? jumpToLatestChipHTML() : '';
+    }
+
+    // Reconcile the chip element with the show flag WITHOUT a full render(): re-rendering from a
+    // scroll handler would undo an in-flight programmatic scroll such as the jump bar's
+    // scrollTimelineItemIntoView. So add/remove just the chip node in place.
+    function updateJumpToLatestChip() {
       const timeline = document.querySelector('[data-testid="timeline"]');
       if (!timeline) return;
-      if (snapshot.wasTimelinePinnedToBottom) {
-        timeline.scrollTop = timeline.scrollHeight;
-        return;
+      const existing = timeline.querySelector('[data-testid="jump-to-latest"]');
+      if (!shouldShowJumpChip()) {
+        existing?.remove();
+      } else if (!existing) {
+        timeline.insertAdjacentHTML('beforeend', jumpToLatestChipHTML());
+        timeline.querySelector('[data-testid="jump-to-latest"]')?.addEventListener('click', jumpToLatest);
       }
-      const maxScrollTop = Math.max(0, timeline.scrollHeight - timeline.clientHeight);
-      timeline.scrollTop = Math.min(snapshot.timelineScrollTop || 0, maxScrollTop);
     }
+
+    function jumpToLatest() {
+      transcriptShowJumpChip = false;
+      const timeline = document.querySelector('[data-testid="timeline"]');
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      if (timeline) timeline.scrollTop = timeline.scrollHeight;
+      updateJumpToLatestChip();
+    }
+
+    // The window persists across renders, so bind its scroll listener exactly once. Only a scrollY
+    // move reaches here; content growth changes scrollHeight, which fires no scroll event — so growth
+    // can never be misread as a scroll-up. The chip shows once the reader is off the bottom and hides
+    // the moment they return.
+    function bindWindowScrollTracking() {
+      if (windowScrollTrackingBound) return;
+      windowScrollTrackingBound = true;
+      window.addEventListener('scroll', () => {
+        const show = windowDistanceFromBottom() > TRANSCRIPT_BOTTOM_THRESHOLD;
+        if (show === transcriptShowJumpChip) return;
+        transcriptShowJumpChip = show;
+        updateJumpToLatestChip();
+      });
+    }
+
+    // Test-only: append a large assistant "chunk" during a simulated streaming run, so the
+    // follow-scroll smoke can grow the transcript deterministically (there is no real streaming
+    // backend in the harness). Mirrors a streamed chunk landing mid-run: isSending stays true (so the
+    // Jump-to-latest chip is live), content grows, and the follow decision is re-evaluated on render.
+    window.__harnessAppendAssistantChunk = function(text) {
+      const chunk = String(text == null ? '' : text);
+      const message = { id: `message-${state.nextTimelineIndex++}`, role: 'assistant', text: chunk, attachments: [] };
+      state.transcript.messages.push(message);
+      state.transcript.timelineItems.push({ id: `timeline-${state.nextTimelineIndex++}`, kind: 'message', message });
+      state.composer.isSending = true;
+      saveSelectedThreadSnapshot();
+      render();
+    };
 
     const pullRequestReviewActionLabels = {
       approve: 'Approve',
@@ -13482,7 +13582,7 @@
                 ${state.find.isOpen ? renderFindBar(findMatches) : ''}
 	              ${state.automations.isVisible ? renderAutomationsPane() : ''}
 	              ${hasTimelineContent ? renderTranscriptJumpBar() : ''}
-	              <div class="timeline" data-testid="timeline">${confidentialIsActive() ? renderConfidentialBanner() : ''}${renderSideConversationBanner()}${renderNewTurnsPill()}${timeline}</div>
+	              <div class="timeline" data-testid="timeline">${confidentialIsActive() ? renderConfidentialBanner() : ''}${renderSideConversationBanner()}${renderNewTurnsPill()}${timeline}${renderJumpToLatestChip()}</div>
 	              ${state.browser.isVisible ? renderBrowserPane() : ''}
 	              ${state.extensions.isVisible ? renderExtensionsPane() : ''}
 	              ${state.memories.isVisible ? renderMemoriesPane() : ''}
@@ -13675,6 +13775,9 @@
         render();
         if (firstUnseen) scrollTimelineItemIntoView(firstUnseen);
       });
+      // Bind the chip that render() emitted via innerHTML (the un-pinned state). Chips inserted later
+      // by updateJumpToLatestChip (on a mid-render user scroll) bind their own handler at insert time.
+      document.querySelector('[data-testid="jump-to-latest"]')?.addEventListener('click', jumpToLatest);
       document.querySelectorAll('[data-testid="tool-card-action"]').forEach(button => {
         button.addEventListener('click', event => {
           const cardElement = event.currentTarget.closest('[data-testid="tool-card"]');

--- a/E2E/playwright/tests/transcript-follow-scroll.spec.ts
+++ b/E2E/playwright/tests/transcript-follow-scroll.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page } from '@playwright/test';
+import { harnessURL } from './harness-helpers';
+
+// Belt-and-suspenders DOM smoke for the streaming follow-scroll contract fixed natively in PR #1251
+// (QuillCodeTranscriptView + TranscriptScrollFollow). The native pure-function tests can't exercise
+// live handler interleaving, so this drives the harness's real DOM: the transcript must keep
+// following an at-bottom reader through rapid large chunks, and must surface a "Jump to latest" chip
+// (never yank) once the reader has genuinely scrolled up. The harness follow logic mirrors the native
+// geometric rule: content growth (scrollHeight change) never un-pins; only a user scroll move does.
+//
+// The harness scrolls the WINDOW (its workspace is min-height:100vh, so a tall transcript overflows
+// the page), so the assertions read window scroll — the harness's actual scroll container.
+
+const BOTTOM_SLACK = 24; // matches the harness TRANSCRIPT_BOTTOM_THRESHOLD
+
+test.use({ viewport: { width: 1024, height: 600 } });
+
+// One large assistant "chunk", injected via the harness test hook + a real render() so the follow
+// decision is re-evaluated exactly as it would be on a streamed chunk.
+async function appendChunk(page: Page, tag: string): Promise<void> {
+  const text = `${tag} ` + 'lorem ipsum dolor sit amet consectetur adipiscing elit '.repeat(30);
+  await page.evaluate(
+    (t) => (window as unknown as { __harnessAppendAssistantChunk: (s: string) => void }).__harnessAppendAssistantChunk(t),
+    text
+  );
+}
+
+async function windowMetrics(page: Page) {
+  return page.evaluate(() => ({
+    scrollY: window.scrollY,
+    maxScrollY: Math.max(0, document.documentElement.scrollHeight - window.innerHeight)
+  }));
+}
+
+function isAtBottom(m: { scrollY: number; maxScrollY: number }): boolean {
+  return m.scrollY >= m.maxScrollY - BOTTOM_SLACK;
+}
+
+async function seedTallTranscript(page: Page, chunks: number): Promise<void> {
+  await page.goto(harnessURL());
+  for (let i = 0; i < chunks; i++) await appendChunk(page, `seed-${i}`);
+  const m = await windowMetrics(page);
+  // The whole point requires an overflowing, scrollable transcript.
+  expect(m.maxScrollY, 'seeded transcript should overflow the viewport').toBeGreaterThan(80);
+}
+
+test('follow-scroll: stays pinned to the bottom through rapid large chunks, no Jump chip', async ({ page }) => {
+  await seedTallTranscript(page, 5);
+
+  // Start at the bottom, no chip.
+  expect(isAtBottom(await windowMetrics(page)), 'seeded transcript should rest at the bottom').toBe(true);
+  await expect(page.getByTestId('jump-to-latest')).toHaveCount(0);
+
+  // Two LARGE chunks in quick succession — the native follow-animation window where the sentinel gap
+  // briefly exceeds the threshold. An at-bottom reader must keep being followed.
+  await appendChunk(page, 'chunk-a');
+  await appendChunk(page, 'chunk-b');
+
+  expect(isAtBottom(await windowMetrics(page)), 'reader at the bottom must keep following large chunks').toBe(true);
+  await expect(page.getByTestId('jump-to-latest')).toHaveCount(0);
+});
+
+test('follow-scroll: a user scroll-up surfaces the Jump chip and stops following; tapping re-pins', async ({ page }) => {
+  await seedTallTranscript(page, 6);
+
+  // No chip while pinned.
+  await expect(page.getByTestId('jump-to-latest')).toHaveCount(0);
+
+  // The reader scrolls up (a genuine scrollY move, distinct from content growth).
+  await page.evaluate(() => {
+    window.scrollTo(0, 0);
+    window.dispatchEvent(new Event('scroll'));
+  });
+  const chip = page.getByTestId('jump-to-latest');
+  await expect(chip, 'scrolling up during a run surfaces the Jump to latest chip').toBeVisible();
+
+  // A chunk arrives mid-stream: the scrolled-up reader must NOT be yanked down, and the chip stays.
+  await appendChunk(page, 'mid-stream');
+  expect(isAtBottom(await windowMetrics(page)), 'a scrolled-up reader must not be followed to the bottom').toBe(false);
+  await expect(chip, 'the chip stays while the reader is behind').toBeVisible();
+
+  // Tapping the chip re-pins to the bottom and dismisses it.
+  await chip.click();
+  expect(isAtBottom(await windowMetrics(page)), 'tapping Jump to latest returns to the bottom').toBe(true);
+  await expect(page.getByTestId('jump-to-latest')).toHaveCount(0);
+
+  // Following resumes for the now-pinned reader.
+  await appendChunk(page, 'after-jump');
+  expect(isAtBottom(await windowMetrics(page)), 'following resumes after re-pinning').toBe(true);
+});


### PR DESCRIPTION
Belt-and-suspenders follow-up to #1251/#1254: the native follow-scroll fix lives in pure-function unit tests that can't exercise **live handler interleaving**. This adds a real-DOM Playwright smoke and brings the E2E harness's own follow logic to 3-surface parity with the native geometric rule.

## The smoke (`transcript-follow-scroll.spec.ts`)
- **Stays pinned through rapid large chunks:** an at-bottom reader is injected ≥2 large chunks in quick succession → the transcript keeps tracking the bottom, and **no** Jump chip appears.
- **User scroll-up surfaces the chip and stops following:** a genuine scroll-up shows a "Jump to latest" chip; a mid-stream chunk does **not** yank the reader down; tapping the chip re-pins and following resumes.

Verified **non-vacuous**: the spec was run against an always-follow harness and fails exactly at the "must not be followed" assertion.

## Harness parity (mirrors native `TranscriptScrollFollow`)
- **FOLLOW:** stick to the bottom iff the reader was at the bottom when the render began (read live from the DOM so it can't lag async scroll events). Appending content grows `scrollHeight`, not `scrollY`, so growth never fires the scroll listener — growth alone can never un-pin (the native "content growth doesn't un-pin"). The harness scrolls the **window** (workspace is `min-height:100vh`).
- **CHIP:** a floating Jump-to-latest chip (parity with `quillcode-transcript-jump-to-latest`) shown only after a real user scroll-up **and** while a run streams — the native chip's stated *"shown while the reader has scrolled up during a live run"* scenario. Gating on the run keeps it out of every static audit/screenshot fixture, where a floating overlay would otherwise overlap controls the interaction audit scrolls under.
- Adds a test-only `__harnessAppendAssistantChunk` hook to grow the transcript deterministically (no real streaming backend in the harness).

Full Playwright suite: **248 passed** (incl. interaction-audit, visual, transcript-navigation, scroll-intent).