### PR TITLE
Extract shared hook catalog

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "QuillCodeSafety", targets: ["QuillCodeSafety"]),
         .library(name: "QuillCodeTools", targets: ["QuillCodeTools"]),
         .library(name: "QuillCodePersistence", targets: ["QuillCodePersistence"]),
+        .library(name: "QuillCodeHooks", targets: ["QuillCodeHooks"]),
         .library(name: "QuillComputerUseKit", targets: ["QuillComputerUseKit"]),
         .library(name: "QuillCodePlatform", targets: ["QuillCodePlatform"]),
         .library(name: "QuillCodePlatformUI", targets: ["QuillCodePlatformUI"]),
@@ -54,6 +55,15 @@ let package = Package(
                 .product(name: "TOML", package: "swift-toml")
             ]
         ),
+        .target(
+            name: "QuillCodeHooks",
+            dependencies: [
+                "QuillCodeCore",
+                "QuillCodeTools",
+                "QuillCodePersistence",
+                .product(name: "TOMLDecoder", package: "TOMLDecoder")
+            ]
+        ),
         .target(name: "QuillComputerUseKit", dependencies: ["QuillCodeCore"]),
         .target(name: "QuillCodePlatformUI", dependencies: ["QuillCodeTools"]),
         .target(
@@ -84,10 +94,10 @@ let package = Package(
                 "QuillCodeReview",
                 "QuillCodeTools",
                 "QuillCodePersistence",
+                "QuillCodeHooks",
                 "QuillCodeSafety",
                 "QuillComputerUseKit",
-                "QuillCodePlatformUI",
-                .product(name: "TOMLDecoder", package: "TOMLDecoder")
+                "QuillCodePlatformUI"
             ]
         ),
         .target(
@@ -97,6 +107,7 @@ let package = Package(
                 "QuillCodeSafety",
                 "QuillCodeTools",
                 "QuillCodePersistence",
+                "QuillCodeHooks",
                 "QuillCodeAgent",
                 "QuillCodeReview",
                 "QuillCodePlatform",
@@ -127,6 +138,10 @@ let package = Package(
         .testTarget(name: "QuillCodeSafetyTests", dependencies: ["QuillCodeSafety"]),
         .testTarget(name: "QuillCodeToolsTests", dependencies: ["QuillCodeTools"]),
         .testTarget(name: "QuillCodePersistenceTests", dependencies: ["QuillCodePersistence", "QuillCodeSafety"]),
+        .testTarget(
+            name: "QuillCodeHooksTests",
+            dependencies: ["QuillCodeHooks", "QuillCodeCore", "QuillCodePersistence"]
+        ),
         .testTarget(name: "QuillComputerUseKitTests", dependencies: ["QuillComputerUseKit"]),
         .testTarget(
             name: "QuillCodePlatformTests",
@@ -151,7 +166,7 @@ let package = Package(
         ),
         .testTarget(
             name: "QuillCodeAppTests",
-            dependencies: ["QuillCodeApp", "QuillCodeAgent", "QuillCodeReview"]
+            dependencies: ["QuillCodeApp", "QuillCodeAgent", "QuillCodeReview", "QuillCodeHooks"]
         ),
         .testTarget(
             name: "QuillCodeDesktopTests",

--- a/Sources/QuillCodeApp/CodexPluginPackageLoader.swift
+++ b/Sources/QuillCodeApp/CodexPluginPackageLoader.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeCore
+import QuillCodeHooks
 import QuillCodeTools
 
 struct CodexPluginPackage: Sendable, Hashable {
@@ -150,14 +151,13 @@ enum CodexPluginPackageLoader {
     ) -> [ProjectPluginHook] {
         let reference = payload.hooks ?? defaultHooksRelativePath
         guard let configURL = resolveFile(reference, inside: packageRoot, maxBytes: maxManifestBytes),
-              let data = try? Data(contentsOf: configURL),
-              let configuration = CodexHookConfigurationDecoder.decodeJSON(data)
+              let data = try? Data(contentsOf: configURL)
         else { return [] }
 
         let configPath = relativePath(of: configURL, inside: projectRoot)
         let packageRootRelativePath = relativePath(of: packageRoot, inside: projectRoot)
-        return CodexHookDefinitionBuilder.definitions(
-            from: configuration,
+        return CodexHookDefinitionLoader.definitions(
+            fromJSON: data,
             source: CodexHookDefinitionSource(
                 idPrefix: "plugin_hook:\(pluginID)",
                 ownerID: "plugin:\(pluginID)",

--- a/Sources/QuillCodeApp/ProjectPluginCompactionHookExecutor.swift
+++ b/Sources/QuillCodeApp/ProjectPluginCompactionHookExecutor.swift
@@ -1,6 +1,7 @@
 import Foundation
 import QuillCodeAgent
 import QuillCodeCore
+import QuillCodeHooks
 import QuillCodeTools
 
 struct ProjectPluginCompactionHookExecutor: Sendable {

--- a/Sources/QuillCodeApp/ProjectPluginLifecycleHookExecutor.swift
+++ b/Sources/QuillCodeApp/ProjectPluginLifecycleHookExecutor.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeCore
+import QuillCodeHooks
 import QuillCodeTools
 
 struct ProjectPluginLifecycleHookExecutor: Sendable {

--- a/Sources/QuillCodeApp/ProjectPluginToolCallAdapter.swift
+++ b/Sources/QuillCodeApp/ProjectPluginToolCallAdapter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeCore
+import QuillCodeHooks
 import QuillCodeTools
 
 enum ProjectPluginToolKind: Sendable, Hashable {

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -1,6 +1,7 @@
 import Foundation
 import QuillCodeAgent
 import QuillCodeCore
+import QuillCodeHooks
 import QuillCodePersistence
 import QuillCodeTools
 

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import QuillCodeAgent
 import QuillCodeCore
+import QuillCodeHooks
 import QuillCodePersistence
 import QuillCodeReview
 import QuillCodeTools

--- a/Sources/QuillCodeApp/WorkspaceModelHooks.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelHooks.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeCore
+import QuillCodeHooks
 
 @MainActor
 extension QuillCodeWorkspaceModel {

--- a/Sources/QuillCodeApp/WorkspaceProjectMetadataLoader.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectMetadataLoader.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeCore
+import QuillCodeHooks
 import QuillCodePersistence
 import QuillCodeTools
 

--- a/Sources/QuillCodeHooks/CodexHookConfiguration.swift
+++ b/Sources/QuillCodeHooks/CodexHookConfiguration.swift
@@ -106,23 +106,31 @@ struct CodexHookHandler: Decodable {
 
 enum CodexHookConfigurationDecoder {
     static func decodeJSON(_ data: Data) -> CodexHookConfiguration? {
-        try? JSONDecoder().decode(CodexHookConfiguration.self, from: data)
+        try? decodeJSONThrowing(data)
     }
 
     static func decodeTOML(_ data: Data) -> CodexHookConfiguration? {
-        try? TOMLDecoder().decode(CodexHookConfiguration.self, from: data)
+        try? decodeTOMLThrowing(data)
+    }
+
+    static func decodeJSONThrowing(_ data: Data) throws -> CodexHookConfiguration {
+        try JSONDecoder().decode(CodexHookConfiguration.self, from: data)
+    }
+
+    static func decodeTOMLThrowing(_ data: Data) throws -> CodexHookConfiguration {
+        try TOMLDecoder().decode(CodexHookConfiguration.self, from: data)
     }
 }
 
-struct CodexHookDefinitionSource: Sendable, Hashable {
-    var idPrefix: String
-    var ownerID: String
-    var ownerName: String
-    var relativePath: String
-    var pluginRootRelativePath: String?
-    var trustScope: ProjectHookTrustScope?
+public struct CodexHookDefinitionSource: Sendable, Hashable {
+    public var idPrefix: String
+    public var ownerID: String
+    public var ownerName: String
+    public var relativePath: String
+    public var pluginRootRelativePath: String?
+    public var trustScope: ProjectHookTrustScope?
 
-    init(
+    public init(
         idPrefix: String,
         ownerID: String,
         ownerName: String,
@@ -136,6 +144,23 @@ struct CodexHookDefinitionSource: Sendable, Hashable {
         self.relativePath = relativePath
         self.pluginRootRelativePath = pluginRootRelativePath
         self.trustScope = trustScope
+    }
+}
+
+/// Public data-only entry point for plugin packages that keep hooks in JSON.
+/// Decoded configuration types remain private to this module so callers cannot couple to parser details.
+public enum CodexHookDefinitionLoader {
+    public static func definitions(
+        fromJSON data: Data,
+        source: CodexHookDefinitionSource,
+        limit: Int
+    ) -> [ProjectPluginHook] {
+        guard let configuration = CodexHookConfigurationDecoder.decodeJSON(data) else { return [] }
+        return CodexHookDefinitionBuilder.definitions(
+            from: configuration,
+            source: source,
+            limit: limit
+        )
     }
 }
 

--- a/Sources/QuillCodeHooks/GlobalHookConfigurationLoader.swift
+++ b/Sources/QuillCodeHooks/GlobalHookConfigurationLoader.swift
@@ -6,18 +6,21 @@ public struct WorkspaceGlobalHookConfiguration: Sendable, Hashable {
     public var hooks: [ProjectPluginHook]
     public var hooksEnabled: Bool
     public var managedOnly: Bool
+    public var warnings: [String]
 
     public init(
         hooks: [ProjectPluginHook] = [],
         hooksEnabled: Bool = true,
-        managedOnly: Bool = false
+        managedOnly: Bool = false,
+        warnings: [String] = []
     ) {
         self.hooks = hooks
         self.hooksEnabled = hooksEnabled
         self.managedOnly = managedOnly
+        self.warnings = warnings
     }
 
-    func resolvingTrust(_ trust: ProjectHookTrustLoadResult) -> WorkspaceGlobalHookConfiguration {
+    public func resolvingTrust(_ trust: ProjectHookTrustLoadResult) -> WorkspaceGlobalHookConfiguration {
         var resolved = self
         resolved.hooks = ProjectPluginHookResolver.resolve(hooks, trust: trust)
         return resolved
@@ -26,10 +29,10 @@ public struct WorkspaceGlobalHookConfiguration: Sendable, Hashable {
 
 /// Loads additive global hooks in deterministic low-to-high configuration order.
 /// System and requirements sources are managed; user sources retain exact-definition review.
-enum GlobalHookConfigurationLoader {
-    static let maxHooks = 192
+public enum GlobalHookConfigurationLoader {
+    public static let maxHooks = 192
 
-    static func load(from paths: HookConfigurationPaths) -> WorkspaceGlobalHookConfiguration {
+    public static func load(from paths: HookConfigurationPaths) -> WorkspaceGlobalHookConfiguration {
         let managed = CodexHookDocumentLoader.load(
             managedDocuments(from: paths),
             maxHooks: maxHooks
@@ -48,7 +51,8 @@ enum GlobalHookConfigurationLoader {
                 ? merged.filter { !managedOnly || $0.isManaged }
                 : [],
             hooksEnabled: hooksEnabled,
-            managedOnly: managedOnly
+            managedOnly: managedOnly,
+            warnings: ordinary.warnings + managed.warnings
         )
     }
 

--- a/Sources/QuillCodeHooks/ProjectHookConfigurationLoader.swift
+++ b/Sources/QuillCodeHooks/ProjectHookConfigurationLoader.swift
@@ -30,8 +30,19 @@ struct CodexHookDocument: Sendable, Hashable {
 
 struct CodexHookDocumentLoadResult: Sendable, Hashable {
     var hooks: [ProjectPluginHook] = []
+    var warnings: [String] = []
     var hooksFeatureOverride: Bool?
     var allowManagedHooksOnly: Bool?
+}
+
+public struct HookConfigurationDiscovery: Sendable, Hashable {
+    public var hooks: [ProjectPluginHook]
+    public var warnings: [String]
+
+    public init(hooks: [ProjectPluginHook] = [], warnings: [String] = []) {
+        self.hooks = hooks
+        self.warnings = warnings
+    }
 }
 
 /// Shared data-only loader for project, user, system, and managed hook documents.
@@ -45,9 +56,25 @@ enum CodexHookDocumentLoader {
     ) -> CodexHookDocumentLoadResult {
         var result = CodexHookDocumentLoadResult()
         for document in documents {
-            guard let data = loadDocument(document),
-                  let configuration = decode(data, format: document.format)
-            else { continue }
+            let data: Data
+            switch loadDocument(document) {
+            case .missing:
+                continue
+            case .failure(let warning):
+                result.warnings.append(warning)
+                continue
+            case .success(let loaded):
+                data = loaded
+            }
+            let configuration: CodexHookConfiguration
+            do {
+                configuration = try decode(data, format: document.format)
+            } catch {
+                result.warnings.append(
+                    "failed to parse hooks config \(documentURL(document).path): \(error.localizedDescription)"
+                )
+                continue
+            }
             let remaining = max(0, maxHooks - result.hooks.count)
             if remaining > 0 {
                 result.hooks.append(contentsOf: CodexHookDefinitionBuilder.definitions(
@@ -71,45 +98,89 @@ enum CodexHookDocumentLoader {
     private static func decode(
         _ data: Data,
         format: CodexHookDocumentFormat
-    ) -> CodexHookConfiguration? {
+    ) throws -> CodexHookConfiguration {
         switch format {
         case .json:
-            return CodexHookConfigurationDecoder.decodeJSON(data)
+            return try CodexHookConfigurationDecoder.decodeJSONThrowing(data)
         case .toml:
-            return CodexHookConfigurationDecoder.decodeTOML(data)
+            return try CodexHookConfigurationDecoder.decodeTOMLThrowing(data)
         }
     }
 
-    private static func loadDocument(_ document: CodexHookDocument) -> Data? {
+    private enum DocumentReadResult {
+        case missing
+        case success(Data)
+        case failure(String)
+    }
+
+    private static func loadDocument(_ document: CodexHookDocument) -> DocumentReadResult {
         let root = document.root.standardizedFileURL.resolvingSymlinksInPath()
-        let candidate = root
-            .appendingPathComponent(document.fileName)
-            .standardizedFileURL
-        guard WorkspaceBoundary.isWithin(candidate, root: root),
-              let values = try? candidate.resourceValues(
-                forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
-              ),
-              values.isRegularFile == true,
-              values.isSymbolicLink != true,
-              let fileSize = values.fileSize,
-              fileSize <= maxDocumentBytes
-        else { return nil }
+        let candidate = documentURL(document)
+        if (try? FileManager.default.destinationOfSymbolicLink(atPath: candidate.path)) != nil {
+            return .failure("refusing symlinked hooks config: \(candidate.path)")
+        }
+        guard WorkspaceBoundary.isWithin(candidate, root: root) else {
+            return .failure("refusing hooks config outside its source root: \(candidate.path)")
+        }
+        guard FileManager.default.fileExists(atPath: candidate.path) else { return .missing }
+
+        let values: URLResourceValues
+        do {
+            values = try candidate.resourceValues(
+                forKeys: [.isRegularFileKey, .fileSizeKey]
+            )
+        } catch {
+            return .failure("failed to inspect hooks config \(candidate.path): \(error.localizedDescription)")
+        }
+        guard values.isRegularFile == true else {
+            return .failure("hooks config is not a regular file: \(candidate.path)")
+        }
+        guard let fileSize = values.fileSize, fileSize <= maxDocumentBytes else {
+            return .failure(
+                "hooks config exceeds the \(maxDocumentBytes)-byte limit: \(candidate.path)"
+            )
+        }
 
         let resolved = candidate.resolvingSymlinksInPath()
-        guard WorkspaceBoundary.isWithin(resolved, root: root) else { return nil }
-        return try? Data(contentsOf: resolved, options: [.mappedIfSafe])
+        guard WorkspaceBoundary.isWithin(resolved, root: root) else {
+            return .failure("refusing hooks config outside its source root: \(candidate.path)")
+        }
+        do {
+            let data = try Data(contentsOf: resolved, options: [.mappedIfSafe])
+            guard data.count <= maxDocumentBytes else {
+                return .failure(
+                    "hooks config exceeds the \(maxDocumentBytes)-byte limit: \(candidate.path)"
+                )
+            }
+            return .success(data)
+        } catch {
+            return .failure("failed to read hooks config \(candidate.path): \(error.localizedDescription)")
+        }
+    }
+
+    private static func documentURL(_ document: CodexHookDocument) -> URL {
+        document.root
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(document.fileName)
+            .standardizedFileURL
     }
 }
 
-enum ProjectHookConfigurationLoader {
-    static let maxDocumentBytes = CodexHookDocumentLoader.maxDocumentBytes
-    static let maxHooks = 96
+public enum ProjectHookConfigurationLoader {
+    public static let maxDocumentBytes = CodexHookDocumentLoader.maxDocumentBytes
+    public static let maxHooks = 96
 
-    static func load(from projectRoot: URL) -> [ProjectPluginHook] {
-        CodexHookDocumentLoader.load(
+    public static func load(from projectRoot: URL) -> [ProjectPluginHook] {
+        discover(from: projectRoot).hooks
+    }
+
+    public static func discover(from projectRoot: URL) -> HookConfigurationDiscovery {
+        let result = CodexHookDocumentLoader.load(
             documents(for: projectRoot),
             maxHooks: maxHooks
-        ).hooks
+        )
+        return HookConfigurationDiscovery(hooks: result.hooks, warnings: result.warnings)
     }
 
     private static func documents(for projectRoot: URL) -> [CodexHookDocument] {

--- a/Sources/QuillCodeHooks/ProjectPluginHookMatcher.swift
+++ b/Sources/QuillCodeHooks/ProjectPluginHookMatcher.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-enum ProjectPluginHookMatcher {
-    static let maximumPatternCharacters = 512
-    static let maximumCandidateCharacters = 256
+public enum ProjectPluginHookMatcher {
+    public static let maximumPatternCharacters = 512
+    public static let maximumCandidateCharacters = 256
 
-    static func isValid(_ matcher: String?) -> Bool {
+    public static func isValid(_ matcher: String?) -> Bool {
         guard let matcher, !matcher.isEmpty, matcher != "*" else { return true }
         guard matcher.count <= maximumPatternCharacters else { return false }
         return (try? NSRegularExpression(pattern: matcher)) != nil
     }
 
-    static func matches(_ matcher: String?, candidates: [String]) -> Bool {
+    public static func matches(_ matcher: String?, candidates: [String]) -> Bool {
         guard let matcher, !matcher.isEmpty, matcher != "*" else { return true }
         guard matcher.count <= maximumPatternCharacters,
               let expression = try? NSRegularExpression(pattern: matcher)

--- a/Sources/QuillCodeHooks/ProjectPluginHookResolver.swift
+++ b/Sources/QuillCodeHooks/ProjectPluginHookResolver.swift
@@ -1,8 +1,8 @@
 import QuillCodeCore
 import QuillCodePersistence
 
-enum ProjectPluginHookResolver {
-    static func resolve(
+public enum ProjectPluginHookResolver {
+    public static func resolve(
         _ hooks: [ProjectPluginHook],
         trust: ProjectHookTrustLoadResult
     ) -> [ProjectPluginHook] {
@@ -13,7 +13,7 @@ enum ProjectPluginHookResolver {
         }
     }
 
-    static func executableRunHooks(from hooks: [ProjectPluginHook]) -> [ProjectRunHook] {
+    public static func executableRunHooks(from hooks: [ProjectPluginHook]) -> [ProjectRunHook] {
         hooks.compactMap { hook in
             guard hook.isExecutable,
                   let timing = timing(for: hook.event),

--- a/Tests/QuillCodeAppTests/GlobalHookConfigurationLoaderTests.swift
+++ b/Tests/QuillCodeAppTests/GlobalHookConfigurationLoaderTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import QuillCodeAgent
 import QuillCodeCore
+@testable import QuillCodeHooks
 import QuillCodePersistence
 import QuillCodeTools
 @testable import QuillCodeApp

--- a/Tests/QuillCodeAppTests/ProjectHookConfigurationLoaderTests.swift
+++ b/Tests/QuillCodeAppTests/ProjectHookConfigurationLoaderTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import QuillCodeAgent
 import QuillCodeCore
+@testable import QuillCodeHooks
 import QuillCodePersistence
 @testable import QuillCodeApp
 

--- a/Tests/QuillCodeHooksTests/HookConfigurationDiscoveryTests.swift
+++ b/Tests/QuillCodeHooksTests/HookConfigurationDiscoveryTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import XCTest
+@testable import QuillCodeHooks
+
+final class HookConfigurationDiscoveryTests: XCTestCase {
+    func testMissingHookDocumentsAreQuiet() throws {
+        let root = try temporaryDirectory()
+
+        let discovery = ProjectHookConfigurationLoader.discover(from: root)
+
+        XCTAssertTrue(discovery.hooks.isEmpty)
+        XCTAssertTrue(discovery.warnings.isEmpty)
+    }
+
+    func testValidDocumentsSurviveAParseFailureInAnotherLayer() throws {
+        let root = try temporaryDirectory()
+        try write(
+            #"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"printf valid"}]}]}}"#,
+            to: ".quillcode/hooks.json",
+            in: root
+        )
+        try write("not valid TOML", to: ".codex/config.toml", in: root)
+
+        let discovery = ProjectHookConfigurationLoader.discover(from: root)
+
+        XCTAssertEqual(discovery.hooks.map(\.command), ["printf valid"])
+        XCTAssertEqual(discovery.warnings.count, 1)
+        XCTAssertTrue(discovery.warnings[0].contains("failed to parse hooks config"))
+        XCTAssertTrue(discovery.warnings[0].contains(".codex/config.toml"))
+    }
+
+    func testUnsafeAndOversizedDocumentsReportBoundedWarnings() throws {
+        let root = try temporaryDirectory()
+        let outside = try temporaryDirectory()
+        let outsideHooks = outside.appendingPathComponent("hooks.json")
+        try #"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"printf escaped"}]}]}}"#
+            .write(to: outsideHooks, atomically: true, encoding: .utf8)
+
+        let link = root.appendingPathComponent(".codex/hooks.json")
+        try FileManager.default.createDirectory(
+            at: link.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outsideHooks)
+        try write(
+            String(repeating: "x", count: ProjectHookConfigurationLoader.maxDocumentBytes + 1),
+            to: ".quillcode/config.toml",
+            in: root
+        )
+
+        let discovery = ProjectHookConfigurationLoader.discover(from: root)
+
+        XCTAssertTrue(discovery.hooks.isEmpty)
+        XCTAssertEqual(discovery.warnings.count, 2)
+        XCTAssertTrue(discovery.warnings.contains { $0.contains("refusing symlinked hooks config") })
+        XCTAssertTrue(discovery.warnings.contains { $0.contains("byte limit") })
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("QuillCodeHooksTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func write(_ value: String, to relativePath: String, in root: URL) throws {
+        let destination = root.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try value.write(to: destination, atomically: true, encoding: .utf8)
+    }
+}

--- a/Tests/QuillCodeHooksTests/ProjectPluginHookMatcherTests.swift
+++ b/Tests/QuillCodeHooksTests/ProjectPluginHookMatcherTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import QuillCodeHooks
+
+final class ProjectPluginHookMatcherTests: XCTestCase {
+    func testMatchAllFormsAcceptEveryCandidate() {
+        XCTAssertTrue(ProjectPluginHookMatcher.matches(nil, candidates: ["shell.run"]))
+        XCTAssertTrue(ProjectPluginHookMatcher.matches("", candidates: ["shell.run"]))
+        XCTAssertTrue(ProjectPluginHookMatcher.matches("*", candidates: ["shell.run"]))
+    }
+
+    func testRegularExpressionMatchesAnyBoundedCandidate() {
+        XCTAssertTrue(ProjectPluginHookMatcher.matches(
+            "^(shell|file)\\.",
+            candidates: ["browser.open", "file.write"]
+        ))
+        XCTAssertFalse(ProjectPluginHookMatcher.matches(
+            "^(shell|file)\\.",
+            candidates: ["browser.open"]
+        ))
+    }
+
+    func testMalformedAndOversizedPatternsFailClosed() {
+        XCTAssertFalse(ProjectPluginHookMatcher.isValid("["))
+        XCTAssertFalse(ProjectPluginHookMatcher.matches("[", candidates: ["shell.run"]))
+        XCTAssertFalse(ProjectPluginHookMatcher.isValid(
+            String(repeating: "x", count: ProjectPluginHookMatcher.maximumPatternCharacters + 1)
+        ))
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityMCPGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityMCPGateTests.swift
@@ -119,10 +119,10 @@ final class ParityMCPGateTests: QuillCodeParityTestCase {
     }
 
     func testStandardHooksShareOneBoundedJSONAndTOMLDefinitionPipeline() throws {
-        let decoderText = try Self.appSourceText(named: "CodexHookConfiguration.swift")
+        let decoderText = try Self.hooksSourceText(named: "CodexHookConfiguration.swift")
         let pluginLoaderText = try Self.appSourceText(named: "CodexPluginPackageLoader.swift")
-        let configLoaderText = try Self.appSourceText(named: "ProjectHookConfigurationLoader.swift")
-        let globalLoaderText = try Self.appSourceText(named: "GlobalHookConfigurationLoader.swift")
+        let configLoaderText = try Self.hooksSourceText(named: "ProjectHookConfigurationLoader.swift")
+        let globalLoaderText = try Self.hooksSourceText(named: "GlobalHookConfigurationLoader.swift")
         let modelHooksText = try Self.appSourceText(named: "WorkspaceModelHooks.swift")
         let executionRoutingText = try Self.appSourceText(named: "ProjectHookExecutionRouting.swift")
         let metadataLoaderText = try Self.appSourceText(named: "WorkspaceProjectMetadataLoader.swift")
@@ -138,8 +138,9 @@ final class ParityMCPGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(decoderText.contains("decodeTOML"))
         XCTAssertTrue(decoderText.contains("command_windows"))
         XCTAssertTrue(decoderText.contains("status_message"))
-        XCTAssertTrue(pluginLoaderText.contains("CodexHookConfigurationDecoder.decodeJSON"))
-        XCTAssertTrue(pluginLoaderText.contains("CodexHookDefinitionBuilder.definitions"))
+        XCTAssertTrue(pluginLoaderText.contains("CodexHookDefinitionLoader.definitions"))
+        XCTAssertFalse(pluginLoaderText.contains("CodexHookConfigurationDecoder"))
+        XCTAssertFalse(pluginLoaderText.contains("CodexHookDefinitionBuilder"))
         XCTAssertTrue(configLoaderText.contains(".quillcode/hooks.json"))
         XCTAssertTrue(configLoaderText.contains(".quillcode/config.toml"))
         XCTAssertTrue(configLoaderText.contains(".codex/hooks.json"))
@@ -156,6 +157,7 @@ final class ParityMCPGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(testsText.contains("asynchronousHandler"))
         XCTAssertTrue(globalTestsText.contains("testManagedOnlyPolicySkipsUserAndProjectEligibleSources"))
         XCTAssertTrue(globalTestsText.contains("testUserRunHookStaysLocalWhenSelectedProjectIsRemote"))
+        XCTAssertTrue(packageText.contains("name: \"QuillCodeHooks\""))
         XCTAssertTrue(packageText.contains("TOMLDecoder"))
         XCTAssertFalse(configLoaderText.contains("Process()"), "Config discovery must never execute hooks.")
     }

--- a/Tests/QuillCodeParityTests/ParityTestSupport.swift
+++ b/Tests/QuillCodeParityTests/ParityTestSupport.swift
@@ -70,6 +70,13 @@ class QuillCodeParityTestCase: XCTestCase {
         return try String(contentsOf: file, encoding: .utf8)
     }
 
+    static func hooksSourceText(named fileName: String) throws -> String {
+        let file = packageRoot()
+            .appendingPathComponent("Sources/QuillCodeHooks")
+            .appendingPathComponent(fileName)
+        return try String(contentsOf: file, encoding: .utf8)
+    }
+
     static func appTestSourceText(named fileName: String) throws -> String {
         let file = packageRoot()
             .appendingPathComponent("Tests/QuillCodeAppTests")

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1755,3 +1755,20 @@
 - **Evidence:** Persistence tests cover nested, hidden, linked, missing, repeated, and unsafe roots;
   app-server tests cover omitted parameters and project isolation; the executable JSONL smoke verifies
   the public request against the built process.
+
+## 2026-07-16: Hook discovery has one shared data-only catalog boundary
+
+- **Ownership boundary:** Hook decoding, layered project/global discovery, matcher validation, and
+  trust resolution live in `QuillCodeHooks`. Desktop and CLI clients consume that module instead of
+  maintaining app-specific parsers or importing UI ownership into protocol code.
+- **Dependency boundary:** The catalog depends on Core models, Persistence path/trust models, the
+  shared Tools SHA-256 primitive, and the TOML decoder. It does not depend on App and cannot execute
+  hook commands during discovery.
+- **Filesystem boundary:** Missing documents are quiet. Symlinked, non-regular, oversized, escaped,
+  unreadable, or malformed documents fail closed with bounded diagnostics, while independent valid
+  layers continue to load in deterministic order.
+- **API boundary:** Plugin packages receive a narrow data-to-definition facade; internal decoder and
+  builder models remain module-private so callers cannot couple to parser internals.
+- **Evidence:** Dedicated catalog tests cover missing, malformed, symlinked, oversized, and regex
+  inputs. Existing project, global, plugin-integration, trust, and execution suites remain green, and
+  the parity gate enforces the module boundary and absence of discovery-time process execution.


### PR DESCRIPTION
## Summary
- move hook decoding, layered discovery, matching, and trust resolution into a shared QuillCodeHooks module
- expose a narrow data-only plugin hook facade while keeping parser internals private
- report bounded discovery diagnostics and fail closed on symlinked, escaped, malformed, non-regular, and oversized hook documents
- keep desktop and CLI consumers on one implementation and update the parity architecture gate

## Validation
- swift test (4,582 tests; 0 failures; 2 environment-dependent skips)
- swift build --target QuillCodeHooks
- swift build --target QuillCodeCLI
- python3 scripts/grade-code-quality.py (QuillCodeHooks and QuillCodeHooksTests: A+)
- git diff --check