### PR TITLE
fix(macOS): native refresh no longer drops plan rail, follow-ups, personality

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
@@ -41,10 +41,14 @@ struct QuillCodeDesktopModelStateCoordinator {
             draft = nextState.draft
         }
         // Rebuild from the LOCAL draft so slash/@-mention suggestions reflect live typing, but
-        // carry the model-derived fields the bare rebuild used to silently drop: the focusToken
-        // (focus-composer's signal — without it Cmd+L is dead on native because the view's
-        // .onChange never fires), the file-mention index + changed paths (so @-mentions aren't
-        // computed against an empty index), and the sent-message history (Up/Down recall).
+        // carry EVERY model-derived field the bare rebuild would otherwise silently drop: the
+        // focusToken (focus-composer's signal — without it Cmd+L is dead on native because the
+        // view's .onChange never fires), the file-mention index + changed paths (so @-mentions
+        // aren't computed against an empty index), the sent-message history (Up/Down recall), the
+        // live plan-progress strip + queued follow-up chips (the unattended-driving check-in surface
+        // — otherwise both vanish on every controller-triggered refresh), and supportsPersonality
+        // (drives whether personality slash suggestions appear; defaulting it true after a refresh
+        // would surface `/personality` on models that don't support it).
         surface.composer = ComposerSurface(
             composer: ComposerState(
                 draft: draft,
@@ -55,7 +59,10 @@ struct QuillCodeDesktopModelStateCoordinator {
             ),
             fileMentionIndex: model.fileMentionIndex,
             changedFilePaths: nextState.surface.changedFilePaths,
-            sentMessageHistory: nextState.surface.composer.sentMessageHistory
+            sentMessageHistory: nextState.surface.composer.sentMessageHistory,
+            planProgress: nextState.surface.composer.planProgress,
+            followUpQueue: model.selectedThread?.followUpQueue ?? [],
+            supportsPersonality: nextState.surface.composer.supportsPersonality
         )
         if terminalDraft != nextState.terminalDraft, !model.terminal.isRunning {
             terminalDraft = nextState.terminalDraft

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -907,6 +907,53 @@ final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
         XCTAssertEqual(surface.composer.placeholder, modelComposer.placeholder)
     }
 
+    /// The live plan-progress rail and queued follow-up chips are the unattended-driving check-in
+    /// surface — both are model-derived composer fields. `refreshState` rebuilds the composer from
+    /// the LOCAL draft, so it must carry them across; the bare rebuild dropped both, making the rail
+    /// and follow-ups vanish on every controller-triggered refresh. (`supportsPersonality` was in the
+    /// same dropped set; the structural `==` guard above catches it once a fixture exercises it.)
+    func testDesktopRefreshPreservesPlanProgressAndFollowUpQueue() throws {
+        let update = AgentPlanUpdate(plan: [
+            AgentPlanItem(step: "Inspect", status: .completed),
+            AgentPlanItem(step: "Change", status: .inProgress),
+            AgentPlanItem(step: "Verify", status: .pending)
+        ])
+        let planResult = ToolResult(ok: true, stdout: try JSONHelpers.encodePretty(update))
+        var thread = ChatThread(
+            title: "Plan work",
+            messages: [.init(role: .user, content: "plan the work")],
+            events: [.init(
+                kind: .toolCompleted,
+                summary: "\(ToolDefinition.planUpdate.name) completed",
+                payloadJSON: try JSONHelpers.encodePretty(planResult)
+            )]
+        )
+        thread.followUpQueue = [FollowUpItem(text: "queued follow-up")]
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        let expected = model.surface().composer
+        XCTAssertNotNil(expected.planProgress, "fixture must actually populate a plan")
+        XCTAssertFalse(expected.followUpQueue.isEmpty, "fixture must actually queue a follow-up")
+
+        var surface = model.surface()
+        var draft = model.composer.draft
+        var terminalDraft = model.terminal.draft
+        var browserAddressDraft = model.browser.addressDraft
+        QuillCodeDesktopModelStateCoordinator().refreshState(
+            from: model,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft
+        )
+
+        XCTAssertEqual(surface.composer.planProgress, expected.planProgress, "the plan rail must survive refresh")
+        XCTAssertEqual(surface.composer.followUpQueue, expected.followUpQueue, "queued follow-ups must survive refresh")
+        XCTAssertEqual(surface.composer, expected, "no model-derived composer field may be dropped by the rebuild")
+    }
+
     private func richlyPopulatedModel() -> QuillCodeWorkspaceModel {
         let thread = ChatThread(messages: [
             ChatMessage(role: .user, content: "first request"),


### PR DESCRIPTION
## What

`QuillCodeDesktopModelStateCoordinator.refreshState` rebuilds `surface.composer` from the **local draft** (so slash/@-mention suggestions reflect live typing), carrying over the model-derived fields the bare rebuild would otherwise reset to defaults. That carry list was missing three fields, so on **every** controller-triggered `refresh()`:

- `planProgress` → nil — the always-visible plan/progress rail vanished
- `followUpQueue` → [] — queued follow-up chips vanished
- `supportsPersonality` → true — `/personality` wrongly surfaced on models that don't support it

The plan rail + follow-up queue are the **unattended-driving check-in surface**, so this was a real daily-driving regression (task R4).

## Fix

Carry all three from the freshly-built `nextState.surface.composer` into the rebuilt composer — the same pattern as the earlier focusToken/history/index carry fix documented in the function.

## Tests

`+1` regression test `testDesktopRefreshPreservesPlanProgressAndFollowUpQueue`: fixture with an authored plan + a queued follow-up, asserts both survive `refreshState` and a full structural `composer ==` equality (catches any future dropped field). Fail-on-revert verified.

Full pyramid green: 4804 swift, native smoke, 252 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)