### PR TITLE
fix(macOS): persist background-run failures as a durable thread notice

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -372,6 +372,18 @@ extension QuillCodeWorkspaceModel {
     }
 
     private func finishFailedSend(_ error: any Error, runThreadID: UUID) {
+        // A terminal run failure must leave a DURABLE trace on its own thread. A background run that
+        // failed while the user was on another thread otherwise vanishes silently: finishAgentRun
+        // drops the failure for a non-selected thread, and lastError is session-only. Record it as a
+        // persisted `.notice` (mutateThread saves, guarded so ephemeral/incognito threads never
+        // persist) so the failure survives reload and shows in Activity. A no-op if the thread is
+        // already gone (a discarded incognito session whose run failed late).
+        mutateThread(runThreadID) { thread in
+            thread.events.append(ThreadEvent(
+                kind: .notice,
+                summary: WorkspaceRunFailureNoticePlanner.noticeSummary(for: error)
+            ))
+        }
         let terminal = WorkspaceAgentSendTerminalPlanner.failed(error, composer: composer)
         finishAgentRun(threadID: runThreadID, lifecycle: terminal.lifecycle)
     }

--- a/Sources/QuillCodeApp/WorkspaceRunFailureNoticePlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceRunFailureNoticePlanner.swift
@@ -1,0 +1,17 @@
+import Foundation
+import QuillCodeCore
+
+/// Builds the durable, secret-redacted one-line record of a terminal agent-run failure. The failure
+/// is appended to the run's OWN thread as a `.notice` so a background run that failed while the user
+/// was on another thread still leaves a visible trace on reload: the transient `lastError` is
+/// session-only (cleared on the next action, never persisted), and `finishAgentRun` drops the
+/// failure entirely for a non-selected thread. The notice surfaces in the Activity event stream.
+enum WorkspaceRunFailureNoticePlanner {
+    /// Reuses the summary sanitizer so a persisted failure can never carry an API key or private key
+    /// out of the raw error, and is collapsed to a single bounded line fit for the Activity row.
+    static func noticeSummary(for error: any Error) -> String {
+        let diagnostic = WorkspaceContextSummarySanitizer.diagnostic(from: String(describing: error))
+        guard !diagnostic.isEmpty else { return "Run stopped after an error." }
+        return "Run stopped after an error: \(diagnostic)"
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
@@ -503,6 +503,37 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
         XCTAssertTrue(secondThread.messages.isEmpty)
     }
 
+    func testBackgroundRunFailureLeavesADurableNoticeOnItsOwnThread() async throws {
+        let root = try makeTempDirectory()
+        let model = QuillCodeWorkspaceModel(runner: AgentRunner(llm: SlowThrowingLLMClient()))
+        let failingThreadID = model.newChat()
+
+        model.setDraft("do the risky thing")
+        let task = Task {
+            await model.submitComposer(workspaceRoot: root)
+        }
+        try await waitUntil(timeoutSeconds: 1) {
+            model.composer.isSending
+        }
+        // Navigate away BEFORE the run fails — this is exactly the case finishAgentRun drops (the
+        // failing thread is no longer selected, so lastError never even gets set). The durable notice
+        // is what lets the user see, on returning, that this background run failed.
+        let otherThreadID = model.newChat()
+        await task.value
+
+        XCTAssertEqual(model.root.selectedThreadID, otherThreadID)
+        let failed = try XCTUnwrap(model.root.threads.first { $0.id == failingThreadID })
+        XCTAssertTrue(
+            failed.events.contains { $0.kind == .notice && $0.summary.hasPrefix("Run stopped after an error") },
+            "a background run that failed must leave a durable notice on its own thread"
+        )
+        let other = try XCTUnwrap(model.root.threads.first { $0.id == otherThreadID })
+        XCTAssertFalse(
+            other.events.contains { $0.kind == .notice && $0.summary.hasPrefix("Run stopped after an error") },
+            "the failure notice belongs to the run's thread, not whichever thread is selected now"
+        )
+    }
+
     func testTwoThreadsRunConcurrentlyAndKeepIndependentPresentationState() async throws {
         let root = try makeTempDirectory()
         let gate = ConcurrentPromptGate()
@@ -689,6 +720,19 @@ private struct SlowLLMClient: LLMClient {
         try await Task.sleep(nanoseconds: 5_000_000_000)
         return .say("late response")
     }
+}
+
+/// Blocks briefly (long enough for a test to navigate away, making the run a background one) and then
+/// throws, driving the `.failed` outcome path for a non-selected thread.
+private struct SlowThrowingLLMClient: LLMClient {
+    func nextAction(thread _: ChatThread, userMessage _: String, tools _: [ToolDefinition]) async throws -> AgentAction {
+        try await Task.sleep(nanoseconds: 200_000_000)
+        throw BackgroundRunFailure.boom
+    }
+}
+
+private enum BackgroundRunFailure: Error {
+    case boom
 }
 
 private enum DelayedStreamingSayLLMError: Error {

--- a/Tests/QuillCodeAppTests/WorkspaceRunFailureNoticePlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRunFailureNoticePlannerTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class WorkspaceRunFailureNoticePlannerTests: XCTestCase {
+    private struct SecretBearingError: Error, CustomStringConvertible {
+        var description: String { "auth failed for key sk-tr-v1-abcdef123456ZZ hitting the gateway" }
+    }
+
+    private struct NoisyMultilineError: Error, CustomStringConvertible {
+        var description: String { "first line\nsecond line\n" + String(repeating: "x", count: 2_000) }
+    }
+
+    func testNoticeRedactsSecretsAndCarriesAReadablePrefix() {
+        let summary = WorkspaceRunFailureNoticePlanner.noticeSummary(for: SecretBearingError())
+
+        XCTAssertTrue(summary.hasPrefix("Run stopped after an error:"), summary)
+        XCTAssertFalse(
+            summary.contains("sk-tr-v1-abcdef123456ZZ"),
+            "an API key must never persist in a durable failure notice"
+        )
+        XCTAssertTrue(summary.contains("auth failed"), "the readable cause is kept")
+    }
+
+    func testNoticeCollapsesToASingleBoundedLine() {
+        let summary = WorkspaceRunFailureNoticePlanner.noticeSummary(for: NoisyMultilineError())
+
+        XCTAssertFalse(summary.contains("\n"), "the notice is a single Activity-row line")
+        XCTAssertLessThan(summary.count, 260, "the diagnostic is bounded, not the raw 2k-char error")
+    }
+}


### PR DESCRIPTION
## What

A terminal agent-run failure left **no durable trace** on its own thread. For a **background** run — one that failed while the user had navigated to another thread — `finishAgentRun` hits its `root.selectedThreadID == threadID` guard and returns, so the failure was dropped entirely (`lastError` is session-only and, for a non-selected thread, never even got set). The run silently vanished — which defeats the point of daily-driving on a loop where you aren't watching (task R2).

## Fix

`finishFailedSend` now appends a durable `.notice` event to the run's **own** thread (via `mutateThread`, which persists and is ephemeral-guarded so incognito/side threads never write to disk). The failure survives reload and surfaces in the Activity event stream — for both background and selected runs.

New `WorkspaceRunFailureNoticePlanner` builds the summary through the existing secret-sanitizer, so an API key or private key in a raw error can never persist in the notice; it's collapsed to a single bounded (≤180-char diagnostic) line.

## Tests (+3)

- `WorkspaceRunFailureNoticePlannerTests`: secret redaction + single-line bounding.
- `testBackgroundRunFailureLeavesADurableNoticeOnItsOwnThread`: a run that fails **while another thread is selected** leaves the notice on its own thread, and not on the now-selected one.

Full pyramid green: 4807 swift, native smoke, 252 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)