### PR TITLE
fix(macOS): broaden run-error secret redaction in the summary sanitizer

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceContextSummarySanitizer.swift
+++ b/Sources/QuillCodeApp/WorkspaceContextSummarySanitizer.swift
@@ -33,16 +33,19 @@ private enum WorkspaceContextSummarySecrets {
     private static let redactionRules: [(pattern: String, replacement: String)] = [
         (#"-----BEGIN [A-Z ]*PRIVATE KEY-----"#, "[redacted]"),
         (#"sk-[A-Za-z0-9_-]{12,}"#, "[redacted]"),
-        // URL-embedded credentials — keep the scheme and host, drop user:pass.
-        (#"([A-Za-z][A-Za-z0-9+.-]*://)[^\s:/@]+:[^\s/@]+@"#, "$1[redacted]@"),
+        // URL-embedded credentials — keep the scheme and host, drop user:pass. The user is a simple
+        // token (no slash), but the PASSWORD may contain "/" unencoded (redis:// / postgres:// dumps),
+        // so it accepts anything up to the "@" that precedes the host.
+        (#"([A-Za-z][A-Za-z0-9+.-]*://)[^\s:/@]+:[^\s@]+@"#, "$1[redacted]@"),
         // Authorization: Bearer <token> / a bare "Bearer <token>".
         (#"(?i)(bearer)\s+[A-Za-z0-9._~+/=-]{8,}"#, "$1 [redacted]"),
         // Bare JWTs: three base64url segments, header begins "eyJ".
         (#"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#, "[redacted]"),
         // Provider tokens with recognizable prefixes.
-        (#"gh[pousr]_[A-Za-z0-9]{20,}"#, "[redacted]"),   // GitHub personal/OAuth/user/server/refresh
-        (#"AKIA[0-9A-Z]{16}"#, "[redacted]"),             // AWS access key id
-        (#"xox[baprs]-[A-Za-z0-9-]{10,}"#, "[redacted]"), // Slack bot/user/app/refresh/legacy
+        (#"gh[pousr]_[A-Za-z0-9]{20,}"#, "[redacted]"),      // GitHub personal/OAuth/user/server/refresh
+        (#"github_pat_[A-Za-z0-9_]{22,}"#, "[redacted]"),    // GitHub fine-grained PAT (current default)
+        (#"(?:AKIA|ASIA)[0-9A-Z]{16}"#, "[redacted]"),       // AWS access key id (long-term / temp STS)
+        (#"(?:xox[baprse]|xapp)-[A-Za-z0-9-]{10,}"#, "[redacted]"), // Slack bot/user/app/refresh/legacy/socket
         // Generic key=value secrets in query strings / opaque params — keep the key, drop the value.
         (#"(?i)(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?token)=[^\s&"']+"#, "$1=[redacted]")
     ]

--- a/Sources/QuillCodeApp/WorkspaceContextSummarySanitizer.swift
+++ b/Sources/QuillCodeApp/WorkspaceContextSummarySanitizer.swift
@@ -22,16 +22,36 @@ enum WorkspaceContextSummarySanitizer {
 }
 
 private enum WorkspaceContextSummarySecrets {
-    private static let secretPatterns = [
-        #"sk-[A-Za-z0-9_-]{12,}"#,
-        #"-----BEGIN [A-Z ]*PRIVATE KEY-----"#
+    /// (regex, replacement) pairs applied in order. A replacement may reference capture groups (`$1`)
+    /// to keep the NON-secret context — a URL's scheme+host, the "Bearer" word, a `token=` key — while
+    /// dropping only the value, which is far more useful in a diagnostic than blanking the whole line.
+    /// This runs on durable, persisted run-failure notices (WorkspaceRunFailureNoticePlanner) as well
+    /// as context summaries, so the shapes below are the ones a run/HTTP error commonly leaks.
+    /// Broadening only ever redacts MORE, which is always safe for a diagnostic.
+    /// Case-sensitivity is per-pattern (inline `(?i)`): the fixed-prefix keys (sk-, ghp_, AKIA, xox,
+    /// eyJ) are case-specific and must NOT be lowercased-matched, only "Bearer" and the key= names are.
+    private static let redactionRules: [(pattern: String, replacement: String)] = [
+        (#"-----BEGIN [A-Z ]*PRIVATE KEY-----"#, "[redacted]"),
+        (#"sk-[A-Za-z0-9_-]{12,}"#, "[redacted]"),
+        // URL-embedded credentials — keep the scheme and host, drop user:pass.
+        (#"([A-Za-z][A-Za-z0-9+.-]*://)[^\s:/@]+:[^\s/@]+@"#, "$1[redacted]@"),
+        // Authorization: Bearer <token> / a bare "Bearer <token>".
+        (#"(?i)(bearer)\s+[A-Za-z0-9._~+/=-]{8,}"#, "$1 [redacted]"),
+        // Bare JWTs: three base64url segments, header begins "eyJ".
+        (#"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#, "[redacted]"),
+        // Provider tokens with recognizable prefixes.
+        (#"gh[pousr]_[A-Za-z0-9]{20,}"#, "[redacted]"),   // GitHub personal/OAuth/user/server/refresh
+        (#"AKIA[0-9A-Z]{16}"#, "[redacted]"),             // AWS access key id
+        (#"xox[baprs]-[A-Za-z0-9-]{10,}"#, "[redacted]"), // Slack bot/user/app/refresh/legacy
+        // Generic key=value secrets in query strings / opaque params — keep the key, drop the value.
+        (#"(?i)(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?token)=[^\s&"']+"#, "$1=[redacted]")
     ]
 
     static func redacted(_ text: String) -> String {
-        secretPatterns.reduce(text) { result, pattern in
+        redactionRules.reduce(text) { result, rule in
             result.replacingOccurrences(
-                of: pattern,
-                with: "[redacted]",
+                of: rule.pattern,
+                with: rule.replacement,
                 options: .regularExpression
             )
         }

--- a/Tests/QuillCodeAppTests/WorkspaceContextSummarySecretRedactionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceContextSummarySecretRedactionTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import QuillCodeApp
+
+/// Covers the secret shapes a run/HTTP error commonly leaks, exercised through the public
+/// `diagnostic(from:)` path (WorkspaceContextSummarySecrets itself is private). These now feed
+/// DURABLE, persisted run-failure notices, so a miss writes a secret to disk + the Activity stream.
+final class WorkspaceContextSummarySecretRedactionTests: XCTestCase {
+    private func redact(_ text: String) -> String {
+        WorkspaceContextSummarySanitizer.diagnostic(from: text)
+    }
+
+    func testRedactsAuthorizationBearerTokenButKeepsTheWord() {
+        for header in ["Authorization: Bearer sk8sJ2ndU_secretTokenValue123", "bearer AbC123dEf456ghI789"] {
+            let out = redact("\(header) rejected")
+            XCTAssertFalse(out.contains("secretTokenValue123"), out)
+            XCTAssertFalse(out.contains("AbC123dEf456ghI789"), out)
+            XCTAssertTrue(out.lowercased().contains("bearer [redacted]"), out)
+        }
+    }
+
+    func testRedactsBareJWT() {
+        // Assembled from segments so the committed source never contains a full JWT literal (which
+        // trips GitHub push protection) — the runtime string is still a real three-segment JWT.
+        let jwt = ["eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiIxMjM0NTY3ODkwIn0", "dozjgNryP4J3jVmNHl0w5N"].joined(separator: ".")
+        let out = redact("decode failed for \(jwt) at gateway")
+        XCTAssertFalse(out.contains("eyJ"), out)
+        XCTAssertTrue(out.contains("[redacted]"), out)
+        XCTAssertTrue(out.contains("decode failed for"), "non-secret context is kept")
+    }
+
+    func testRedactsURLEmbeddedCredentialsKeepingSchemeAndHost() {
+        let out = redact("connect https://alice:hunter2secret@db.internal.example/v1 failed")
+        XCTAssertFalse(out.contains("alice"), out)
+        XCTAssertFalse(out.contains("hunter2secret"), out)
+        XCTAssertTrue(out.contains("https://[redacted]@db.internal.example/v1"), out)
+    }
+
+    func testRedactsProviderPrefixedTokens() {
+        // Each is assembled from a prefix + body so the committed source never holds a complete
+        // provider-token literal (GitHub push protection blocks those), while the runtime string that
+        // the redactor sees is byte-identical to a real token.
+        let body = "0123456789abcdefABCDEF0123456789xyzQ"
+        let cases = [
+            "ghp_" + body,                        // GitHub personal
+            "gho_" + body,                        // GitHub OAuth
+            "AKIA" + "ABCDEFGHIJ012345",          // AWS access key id
+            "xoxb" + "-1234567890-abcdefABCDEF0987" // Slack
+        ]
+        for secret in cases {
+            let out = redact("provider error with \(secret) here")
+            XCTAssertFalse(out.contains(secret), "\(secret) leaked: \(out)")
+            XCTAssertTrue(out.contains("[redacted]"), out)
+        }
+    }
+
+    func testRedactsGenericKeyValueSecretsKeepingTheKey() {
+        for pair in ["password=hunter2secret", "token=abc123DEFvalue", "api_key=SYNTHETIC_LEAK_VALUE", "access-token=zzz999"] {
+            let key = String(pair.prefix(upTo: pair.firstIndex(of: "=")!))
+            let value = String(pair.suffix(from: pair.index(after: pair.firstIndex(of: "=")!)))
+            let out = redact("request https://api.example/x?\(pair)&ok=1")
+            XCTAssertFalse(out.contains(value), "\(pair) value leaked: \(out)")
+            XCTAssertTrue(out.contains("\(key)=[redacted]"), out)
+            XCTAssertTrue(out.contains("ok=1"), "a non-secret param is untouched: \(out)")
+        }
+    }
+
+    func testKeepsRedactingTheOriginalSkKeysAndPrivateKeyBlocks() {
+        XCTAssertFalse(redact("boom sk-tr-v1-abcdef123456ZZ done").contains("sk-tr-v1-abcdef123456ZZ"))
+        let out = redact("-----BEGIN OPENSSH PRIVATE KEY----- blah")
+        XCTAssertFalse(out.contains("PRIVATE KEY"), out)
+        XCTAssertTrue(out.contains("[redacted]"), out)
+    }
+
+    func testDoesNotOverRedactOrdinaryDiagnostics() {
+        for benign in [
+            "Compacting context with TrustedRouter",
+            "HTTP 500 server error while streaming the response",
+            "the file token.swift could not be parsed at line 12"
+        ] {
+            XCTAssertEqual(redact(benign), benign, "no secret-shaped token here, so nothing should change")
+        }
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceContextSummarySecretRedactionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceContextSummarySecretRedactionTests.swift
@@ -35,16 +35,34 @@ final class WorkspaceContextSummarySecretRedactionTests: XCTestCase {
         XCTAssertTrue(out.contains("https://[redacted]@db.internal.example/v1"), out)
     }
 
+    func testRedactsURLPasswordContainingASlash() {
+        // Unencoded connection-string passwords routinely contain "/"; the redactor must still reach
+        // the "@" that ends the userinfo instead of leaking the password fragment.
+        let out = redact("redis://cacheuser:p/w+ratio/2@redis.internal:6379 refused")
+        XCTAssertFalse(out.contains("p/w+ratio/2"), out)
+        XCTAssertTrue(out.contains("redis://[redacted]@redis.internal:6379"), out)
+    }
+
+    func testDoesNotRedactAHostPortWithNoCredentials() {
+        // No user:pass@, so the URL rule must leave a plain host:port/path untouched.
+        let benign = "listening on https://service.internal:8080/health"
+        XCTAssertEqual(redact(benign), benign)
+    }
+
     func testRedactsProviderPrefixedTokens() {
         // Each is assembled from a prefix + body so the committed source never holds a complete
         // provider-token literal (GitHub push protection blocks those), while the runtime string that
         // the redactor sees is byte-identical to a real token.
         let body = "0123456789abcdefABCDEF0123456789xyzQ"
         let cases = [
-            "ghp_" + body,                        // GitHub personal
-            "gho_" + body,                        // GitHub OAuth
-            "AKIA" + "ABCDEFGHIJ012345",          // AWS access key id
-            "xoxb" + "-1234567890-abcdefABCDEF0987" // Slack
+            "ghp_" + body,                          // GitHub personal
+            "gho_" + body,                          // GitHub OAuth
+            "github" + "_pat_" + body + "1122334455", // GitHub fine-grained PAT (current default)
+            "AKIA" + "ABCDEFGHIJ012345",            // AWS access key id (long-term)
+            "ASIA" + "ABCDEFGHIJ012345",            // AWS temp STS key
+            "xoxb" + "-1234567890-abcdefABCDEF0987", // Slack bot
+            "xoxe" + "-1234567890-abcdefABCDEF0987", // Slack refresh
+            "xapp" + "-1-A0123456789-abcdefABCDEF"   // Slack app-level (socket mode)
         ]
         for secret in cases {
             let out = redact("provider error with \(secret) here")

--- a/Tests/QuillCodeAppTests/WorkspaceRunFailureNoticePlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRunFailureNoticePlannerTests.swift
@@ -10,6 +10,29 @@ final class WorkspaceRunFailureNoticePlannerTests: XCTestCase {
         var description: String { "first line\nsecond line\n" + String(repeating: "x", count: 2_000) }
     }
 
+    /// A plain error whose message we assemble at runtime, so a fake secret-shaped string never
+    /// appears as a complete literal in the committed source (GitHub push protection blocks those).
+    private struct MessageError: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    func testNoticeRedactsTransportSecretShapes() {
+        // The shapes a real HTTP/provider run error tends to carry — assembled from split literals.
+        let gh = "ghp_" + "0123456789abcdefABCDEF0123456789xyzQ"
+        let bearer = "AbC123dEf456ghI789"
+        let error = MessageError(
+            description: "POST https://svc:hunter2pass@api.example/v1 401 "
+                + "(Authorization: Bearer \(bearer), token=leaked-query-value, \(gh))"
+        )
+
+        let summary = WorkspaceRunFailureNoticePlanner.noticeSummary(for: error)
+
+        for leaked in ["hunter2pass", bearer, "leaked-query-value", gh] {
+            XCTAssertFalse(summary.contains(leaked), "a durable failure notice must not persist \(leaked): \(summary)")
+        }
+        XCTAssertTrue(summary.contains("[redacted]"), summary)
+    }
+
     func testNoticeRedactsSecretsAndCarriesAReadablePrefix() {
         let summary = WorkspaceRunFailureNoticePlanner.noticeSummary(for: SecretBearingError())
 


### PR DESCRIPTION
## What

`WorkspaceContextSummarySanitizer` now feeds **durable, persisted** run-failure notices (PR #1276) — a run error carrying a secret can be written to disk (non-ephemeral threads) and to the Activity stream — but it only redacted `sk-` keys and PRIVATE KEY headers.

## Fix

Broadened `WorkspaceContextSummarySecrets` to also catch the shapes a real HTTP/provider error commonly leaks:

- `Authorization: Bearer <token>` / bare Bearer tokens — keeps the word, drops the token
- bare JWTs (`eyJ….eyJ….…`)
- URL-embedded credentials `scheme://user:pass@host` — keeps scheme + host
- GitHub (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`), AWS (`AKIA…`), Slack (`xox[baprs]-…`)
- generic `password=`/`token=`/`api_key=`/`secret=`/`access_token=` params — keeps the key

Rules are `(regex, replacement)` pairs; replacements use capture groups to preserve the non-secret context rather than blanking the line. Case-sensitivity is per-pattern (fixed-prefix keys stay case-specific; only `Bearer` and the `key=` names are `(?i)`). Broadening only ever redacts **more**, so it's safe for the shared context-summary-diagnostic consumer too.

## Tests (+8)

A dedicated per-shape sanitizer suite (through the public `diagnostic` path, including a **no-over-redaction** check on ordinary diagnostics) plus an end-to-end assertion that a transport error's bearer/URL-cred/query/GitHub secrets never reach the durable notice.

> Fake secret fixtures are assembled from split literals at runtime, so the committed source contains no complete token (GitHub push protection blocks those) while the redactor still sees a real token string.

Full pyramid green: 4831 swift, native smoke, 252 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)