### PR TITLE
feat(artifacts): preview YAML metadata

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8207,6 +8207,7 @@
         tablePreview: artifactTablePreview(value, kind, documentPreview),
         jsonLinesPreview: artifactJSONLinesPreview(value, kind, documentPreview),
         tomlPreview: artifactTOMLPreview(value, kind, documentPreview),
+        yamlPreview: artifactYAMLPreview(value, kind, documentPreview),
         jsonPreview: artifactJSONPreview(value, kind, documentPreview),
         archivePreview: artifactArchivePreview(value, kind, documentPreview),
         mediaPreview: artifactMediaPreview(value, kind, documentPreview),
@@ -8615,6 +8616,8 @@
       ['jsonl', { kind: 'data', typeLabel: 'Data', icon: 'JSONL' }],
       ['ndjson', { kind: 'data', typeLabel: 'Data', icon: 'JSONL' }],
       ['toml', { kind: 'data', typeLabel: 'Data', icon: 'TOML' }],
+      ['yaml', { kind: 'data', typeLabel: 'Data', icon: 'YAML' }],
+      ['yml', { kind: 'data', typeLabel: 'Data', icon: 'YML' }],
       ['numbers', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
       ['csv', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
       ['ods', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
@@ -9100,6 +9103,105 @@
       const body = value.slice(1, -1).trim();
       if (!body) return 0;
       return body.split(',').map(item => item.trim()).filter(Boolean).length;
+    }
+
+    function artifactYAMLPreview(value, kind, documentPreview) {
+      if (kind !== 'file' || documentPreview?.kind !== 'data') return null;
+      const extension = artifactPreviewExtension(value);
+      if (extension !== 'yaml' && extension !== 'yml') return null;
+      const path = artifactFilePath(value);
+      const content = path ? state.mockFiles[path] : null;
+      if (typeof content !== 'string' || !content.trim() || content.includes('\u0000')) return null;
+      const byteLimit = 64 * 1024;
+      if (content.length > byteLimit) return null;
+
+      const lines = content
+        .split(/\r?\n/)
+        .map(rawLine => stripTOMLComment(rawLine))
+        .map(rawLine => ({ rawLine, line: rawLine.trim(), indent: rawLine.match(/^\s*/)[0].length }))
+        .filter(entry => entry.line);
+      if (!lines.length) return null;
+
+      const topKeys = new Set();
+      let mappingCount = 0;
+      let sequenceCount = 0;
+      let scalarCount = 0;
+      let hasRootMapping = false;
+      const mappingIndents = new Set();
+      const sequenceIndents = new Set();
+      for (let index = 0; index < lines.length; index += 1) {
+        const entry = lines[index];
+        const sequenceMatch = entry.line.match(/^-\s+([^:]+):(?:\s*(.*))?$/);
+        if (sequenceMatch) {
+          if (!mappingIndents.has(`item:${entry.indent}:${index}`)) {
+            mappingIndents.add(`item:${entry.indent}:${index}`);
+            mappingCount += 1;
+          }
+          if ((sequenceMatch[2] || '').trim()) scalarCount += 1;
+          continue;
+        }
+
+        const keyMatch = entry.line.match(/^([^:]+):(?:\s*(.*))?$/);
+        if (!keyMatch) return null;
+        const key = keyMatch[1].trim();
+        const rawValue = (keyMatch[2] || '').trim();
+        if (entry.indent === 0) {
+          topKeys.add(key);
+          hasRootMapping = true;
+        }
+        if (!rawValue) {
+          const next = lines.slice(index + 1).find(candidate => candidate.indent > entry.indent);
+          if (next?.line.startsWith('-')) {
+            if (!sequenceIndents.has(entry.indent)) {
+              sequenceIndents.add(entry.indent);
+              sequenceCount += 1;
+            }
+          } else if (!mappingIndents.has(entry.indent)) {
+            mappingIndents.add(entry.indent);
+            mappingCount += 1;
+          }
+          continue;
+        }
+        const arrayItems = tomlArrayItemCount(rawValue);
+        if (arrayItems !== null) {
+          sequenceCount += 1;
+          scalarCount += arrayItems;
+        } else {
+          scalarCount += 1;
+        }
+      }
+      if (hasRootMapping) mappingCount += 1;
+      if (!topKeys.size) return null;
+
+      const keys = [...topKeys].sort();
+      const visibleKeys = keys.slice(0, 6).map(jsonPreviewKeyLabel);
+      const remainder = keys.length - visibleKeys.length;
+      const keyPreviewLabel = visibleKeys.length
+        ? `${visibleKeys.join(', ')}${remainder > 0 ? `, +${remainder} more` : ''}`
+        : null;
+      const preview = {
+        formatLabel: extension.toUpperCase(),
+        rootLabel: 'Mapping',
+        keyCount: keys.length,
+        itemCount: null,
+        mappingCount,
+        sequenceCount,
+        scalarCount,
+        keyPreviewLabel,
+        keyPreviewLabels: visibleKeys,
+        byteSizeLabel: byteSizeLabel(content.length)
+      };
+      preview.metadataLines = [
+        `Format: ${preview.formatLabel}`,
+        `Root: ${preview.rootLabel}`,
+        `${preview.keyCount} key${preview.keyCount === 1 ? '' : 's'}`,
+        preview.mappingCount > 0 ? `${preview.mappingCount} mapping${preview.mappingCount === 1 ? '' : 's'}` : null,
+        preview.sequenceCount > 0 ? `${preview.sequenceCount} sequence${preview.sequenceCount === 1 ? '' : 's'}` : null,
+        preview.scalarCount > 0 ? `${preview.scalarCount} value${preview.scalarCount === 1 ? '' : 's'}` : null,
+        preview.keyPreviewLabel ? `Keys: ${preview.keyPreviewLabel}` : null,
+        preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
+      ].filter(Boolean);
+      return preview.metadataLines.length || preview.keyPreviewLabels.length ? preview : null;
     }
 
     function jsonPreviewFromRoot(root, byteSize) {
@@ -11395,6 +11497,25 @@
                   ${keyList}
                 </div>` : '';
         };
+        const renderYAMLPreview = preview => {
+          if (!preview) return '';
+          const metadata = (preview.metadataLines || [])
+            .map(line => `<small data-testid="tool-card-yaml-preview-meta">${escapeHTML(line)}</small>`)
+            .join('');
+          const keys = (preview.keyPreviewLabels || [])
+            .map(label => `<li data-testid="tool-card-yaml-preview-key-item">${escapeHTML(label)}</li>`)
+            .join('');
+          const keyList = keys ? `
+                  <section class="artifact-office-contents" data-testid="tool-card-yaml-preview-keys">
+                    <strong data-testid="tool-card-yaml-preview-key-title">Top-level keys</strong>
+                    <ul>${keys}</ul>
+                  </section>` : '';
+          return metadata || keyList ? `
+                <div class="artifact-office-preview" data-testid="tool-card-yaml-preview">
+                  <div>${metadata}</div>
+                  ${keyList}
+                </div>` : '';
+        };
         const renderMediaPreview = preview => {
           if (!preview) return '';
           const title = preview.title
@@ -11479,6 +11600,7 @@
                 ${renderTablePreview(artifact.tablePreview)}
                 ${renderJSONLinesPreview(artifact.jsonLinesPreview)}
                 ${renderTOMLPreview(artifact.tomlPreview)}
+                ${renderYAMLPreview(artifact.yamlPreview)}
                 ${renderJSONPreview(artifact.jsonPreview)}
                 ${renderAppshotPreview(artifact.appshotPreview)}
                 ${renderArchivePreview(artifact.archivePreview)}
@@ -23183,6 +23305,27 @@
           outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
         });
         addMessage('assistant', 'Created `config.toml`.');
+      } else if (text.toLowerCase().includes('yaml artifact')) {
+        const path = '/mock/QuillCode/.github/workflows/ci.yml';
+        state.mockFiles[path] = [
+          'name: CI',
+          'on: [push, pull_request]',
+          '',
+          'jobs:',
+          '  test:',
+          '    runs-on: ubuntu-latest',
+          '    steps:',
+          '      - uses: actions/checkout@v4',
+          '      - run: swift test'
+        ].join('\n');
+        addToolCard({
+          title: 'host.file.write',
+          subtitle: 'Completed',
+          status: 'done',
+          inputJSON: JSON.stringify({ path, contentType: 'application/yaml' }, null, 2),
+          outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
+        });
+        addMessage('assistant', 'Created `ci.yml`.');
       } else if (text.toLowerCase().includes('json artifact')) {
         const path = '/mock/QuillCode/reports/build-report.json';
         state.mockFiles[path] = JSON.stringify({

--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -351,6 +351,37 @@ test('mock harness renders TOML artifact metadata previews from tool cards', asy
   await expect(page.getByText('Created `config.toml`.')).toBeVisible();
 });
 
+test('mock harness renders YAML artifact metadata previews from tool cards', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('make a yaml artifact');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.file.write');
+  await expect(page.getByTestId('tool-card-artifact-label')).toHaveText('ci.yml');
+  await expect(page.getByTestId('tool-card-artifact-detail')).toHaveText('/mock/QuillCode/.github/workflows');
+  await expect(page.getByTestId('tool-card-document-previews')).toBeVisible();
+  await expect(page.getByTestId('tool-card-document-preview')).toHaveAttribute('data-kind', 'data');
+  await expect(page.getByTestId('tool-card-document-preview-type')).toHaveText('Data · YML');
+  await expect(page.getByTestId('tool-card-document-preview-label')).toHaveText('ci.yml');
+  await expect(page.getByTestId('tool-card-yaml-preview')).toBeVisible();
+  await expect(page.getByTestId('tool-card-yaml-preview-meta')).toHaveText([
+    'Format: YML',
+    'Root: Mapping',
+    '3 keys',
+    '5 mappings',
+    '2 sequences',
+    '6 values',
+    'Keys: jobs, name, on',
+    /Size: \d+ bytes/
+  ]);
+  await expect(page.getByTestId('tool-card-yaml-preview-key-title')).toHaveText('Top-level keys');
+  await expect(page.getByTestId('tool-card-yaml-preview-key-item')).toHaveText(['jobs', 'name', 'on']);
+  await expect(page.getByTestId('tool-card-text-preview-label')).toHaveText('ci.yml');
+  await expect(page.getByTestId('tool-card-text-preview-content')).toContainText('name: CI');
+  await expect(page.getByText('Created `ci.yml`.')).toBeVisible();
+});
+
 test('mock harness renders office artifact metadata previews from tool cards', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/Package.swift
+++ b/Package.swift
@@ -97,7 +97,8 @@ let package = Package(
                 "QuillCodeHooks",
                 "QuillCodeSafety",
                 "QuillComputerUseKit",
-                "QuillCodePlatformUI"
+                "QuillCodePlatformUI",
+                .product(name: "Yams", package: "Yams")
             ]
         ),
         .target(

--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -55,6 +55,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             jsonLinesContent(jsonLinesPreview)
         } else if let tomlPreview = artifact.tomlPreview {
             tomlContent(tomlPreview)
+        } else if let yamlPreview = artifact.yamlPreview {
+            yamlContent(yamlPreview)
         } else if let jsonPreview = artifact.jsonPreview {
             jsonContent(jsonPreview)
         } else if let archivePreview = artifact.archivePreview {
@@ -158,6 +160,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(tomlPreview.metadataLines)
             artifactContentList(title: "Top-level keys", labels: tomlPreview.keyPreviewLabels)
+        }
+    }
+
+    private func yamlContent(_ yamlPreview: ToolArtifactYAMLPreview) -> some View {
+        previewSurface(minHeight: yamlPreview.keyPreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "curlybraces")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(yamlPreview.metadataLines)
+            artifactContentList(title: "Top-level keys", labels: yamlPreview.keyPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -424,6 +424,61 @@ public struct ToolArtifactTOMLPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactYAMLPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var rootLabel: String
+    public var keyCount: Int?
+    public var itemCount: Int?
+    public var mappingCount: Int
+    public var sequenceCount: Int
+    public var scalarCount: Int
+    public var keyPreviewLabel: String?
+    public var keyPreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "Root: \(rootLabel)",
+            keyCount.map { "\($0) key\($0 == 1 ? "" : "s")" },
+            itemCount.map { "\($0) item\($0 == 1 ? "" : "s")" },
+            mappingCount > 0 ? "\(mappingCount) mapping\(mappingCount == 1 ? "" : "s")" : nil,
+            sequenceCount > 0 ? "\(sequenceCount) sequence\(sequenceCount == 1 ? "" : "s")" : nil,
+            scalarCount > 0 ? "\(scalarCount) value\(scalarCount == 1 ? "" : "s")" : nil,
+            keyPreviewLabel.map { "Keys: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        !metadataLines.isEmpty || !keyPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String,
+        rootLabel: String,
+        keyCount: Int? = nil,
+        itemCount: Int? = nil,
+        mappingCount: Int = 0,
+        sequenceCount: Int = 0,
+        scalarCount: Int = 0,
+        keyPreviewLabel: String? = nil,
+        keyPreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.formatLabel = formatLabel
+        self.rootLabel = rootLabel
+        self.keyCount = keyCount
+        self.itemCount = itemCount
+        self.mappingCount = mappingCount
+        self.sequenceCount = sequenceCount
+        self.scalarCount = scalarCount
+        self.keyPreviewLabel = keyPreviewLabel
+        self.keyPreviewLabels = keyPreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactArchivePreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var entryCount: Int?
@@ -563,6 +618,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var tomlPreview: ToolArtifactTOMLPreview? {
         ToolArtifactTOMLPreviewBuilder.tomlPreview(for: value, kind: kind)
+    }
+    public var yamlPreview: ToolArtifactYAMLPreview? {
+        ToolArtifactYAMLPreviewBuilder.yamlPreview(for: value, kind: kind)
     }
     public var archivePreview: ToolArtifactArchivePreview? {
         ToolArtifactArchivePreviewBuilder.archivePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -50,6 +50,8 @@ enum ToolArtifactDocumentPreviewBuilder {
         "jsonl": .data,
         "ndjson": .data,
         "toml": .data,
+        "yaml": .data,
+        "yml": .data,
         "doc": .document,
         "docx": .document,
         "odt": .document,

--- a/Sources/QuillCodeApp/ToolArtifactYAMLPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactYAMLPreviewBuilder.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Yams
+
+enum ToolArtifactYAMLPreviewBuilder {
+    static func yamlPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactYAMLPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              supportedExtensions.contains(documentPreview.extensionLabel.lowercased()),
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8),
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let root = try Yams.compose(yaml: text)
+            else {
+                return nil
+            }
+            let preview = preview(
+                from: root,
+                formatLabel: documentPreview.extensionLabel.uppercased(),
+                fileSize: fileSize
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from root: Node,
+        formatLabel: String,
+        fileSize: Int
+    ) -> ToolArtifactYAMLPreview {
+        let counts = valueCounts(in: root)
+        switch root {
+        case .mapping(let mapping):
+            let keys = mapping.compactMap { pair in scalarKeyLabel(pair.key) }.sorted()
+            return ToolArtifactYAMLPreview(
+                formatLabel: formatLabel,
+                rootLabel: "Mapping",
+                keyCount: keys.count,
+                mappingCount: counts.mappings,
+                sequenceCount: counts.sequences,
+                scalarCount: counts.scalars,
+                keyPreviewLabel: previewLabel(for: keys),
+                keyPreviewLabels: previewLabels(for: keys),
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        case .sequence(let sequence):
+            return ToolArtifactYAMLPreview(
+                formatLabel: formatLabel,
+                rootLabel: "Sequence",
+                itemCount: sequence.count,
+                mappingCount: counts.mappings,
+                sequenceCount: counts.sequences,
+                scalarCount: counts.scalars,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        case .scalar:
+            return ToolArtifactYAMLPreview(
+                formatLabel: formatLabel,
+                rootLabel: "Scalar",
+                mappingCount: counts.mappings,
+                sequenceCount: counts.sequences,
+                scalarCount: counts.scalars,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        case .alias:
+            return ToolArtifactYAMLPreview(
+                formatLabel: formatLabel,
+                rootLabel: "Alias",
+                mappingCount: counts.mappings,
+                sequenceCount: counts.sequences,
+                scalarCount: counts.scalars,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        }
+    }
+
+    private static func valueCounts(in node: Node) -> (mappings: Int, sequences: Int, scalars: Int) {
+        switch node {
+        case .mapping(let mapping):
+            return mapping.reduce((mappings: 1, sequences: 0, scalars: 0)) { result, pair in
+                let valueCounts = valueCounts(in: pair.value)
+                return (
+                    mappings: result.mappings + valueCounts.mappings,
+                    sequences: result.sequences + valueCounts.sequences,
+                    scalars: result.scalars + valueCounts.scalars
+                )
+            }
+        case .sequence(let sequence):
+            return sequence.reduce((mappings: 0, sequences: 1, scalars: 0)) { result, item in
+                let itemCounts = valueCounts(in: item)
+                return (
+                    mappings: result.mappings + itemCounts.mappings,
+                    sequences: result.sequences + itemCounts.sequences,
+                    scalars: result.scalars + itemCounts.scalars
+                )
+            }
+        case .scalar:
+            return (mappings: 0, sequences: 0, scalars: 1)
+        case .alias:
+            return (mappings: 0, sequences: 0, scalars: 0)
+        }
+    }
+
+    private static func scalarKeyLabel(_ node: Node) -> String? {
+        guard case .scalar(let scalar) = node else { return nil }
+        return sanitizedLabel(scalar.string)
+    }
+
+    private static func previewLabel(for keys: [String]) -> String? {
+        guard !keys.isEmpty else { return nil }
+        let visibleKeys = keys.prefix(keyPreviewLimit)
+        let remainder = keys.count - visibleKeys.count
+        return ([visibleKeys.joined(separator: ", ")] + (remainder > 0 ? ["+\(remainder) more"] : []))
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+    }
+
+    private static func previewLabels(for keys: [String]) -> [String] {
+        Array(keys.prefix(keyPreviewLimit))
+    }
+
+    private static func sanitizedLabel(_ key: String) -> String {
+        let collapsedWhitespace = key
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "(empty key)" : collapsedWhitespace).prefix(keyCharacterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let supportedExtensions: Set<String> = ["yaml", "yml"]
+    private static let byteLimit = 64 * 1_024
+    private static let keyPreviewLimit = 6
+    private static let keyCharacterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -205,6 +205,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let tablePreview = renderTablePreview(artifact.tablePreview)
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
+            let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
             let jsonPreview = renderJSONPreview(artifact.jsonPreview)
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
             let archivePreview = renderArchivePreview(artifact.archivePreview)
@@ -224,6 +225,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(tablePreview)
               \(jsonLinesPreview)
               \(tomlPreview)
+              \(yamlPreview)
               \(jsonPreview)
               \(appshotPreview)
               \(archivePreview)
@@ -502,6 +504,31 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !keyList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-toml-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(keyList)
+        </div>
+        """
+    }
+
+    private static func renderYAMLPreview(_ preview: ToolArtifactYAMLPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-yaml-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let keys = preview.keyPreviewLabels.map {
+            #"<li data-testid="tool-card-yaml-preview-key-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let keyList = keys.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-yaml-preview-keys">
+                <strong data-testid="tool-card-yaml-preview-key-title">Top-level keys</strong>
+                <ul>\(keys)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !keyList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-yaml-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -366,6 +366,56 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteTOML.tomlPreview)
     }
 
+    func testArtifactStateDerivesYAMLPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let workflow = directory.appendingPathComponent("ci.yml")
+        let yamlText = """
+        name: CI
+        on: [push, pull_request]
+
+        jobs:
+          test:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - run: swift test
+        """
+        try yamlText.write(to: workflow, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: workflow.path)
+        let preview = try XCTUnwrap(artifact.yamlPreview)
+        let byteCount = try XCTUnwrap(yamlText.data(using: .utf8)?.count)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "YML")
+        XCTAssertEqual(preview.formatLabel, "YML")
+        XCTAssertEqual(preview.rootLabel, "Mapping")
+        XCTAssertEqual(preview.keyCount, 3)
+        XCTAssertNil(preview.itemCount)
+        XCTAssertEqual(preview.mappingCount, 5)
+        XCTAssertEqual(preview.sequenceCount, 2)
+        XCTAssertEqual(preview.scalarCount, 6)
+        XCTAssertEqual(preview.keyPreviewLabels, ["jobs", "name", "on"])
+        XCTAssertEqual(preview.keyPreviewLabel, "jobs, name, on")
+        XCTAssertEqual(preview.byteSizeLabel, "\(byteCount) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: YML",
+            "Root: Mapping",
+            "3 keys",
+            "5 mappings",
+            "2 sequences",
+            "6 values",
+            "Keys: jobs, name, on",
+            "Size: \(byteCount) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+        XCTAssertNil(artifact.jsonLinesPreview)
+        XCTAssertNil(artifact.tomlPreview)
+
+        let remoteYAML = ToolArtifactState(value: "https://example.com/workflow.yml")
+        XCTAssertNil(remoteYAML.yamlPreview)
+    }
+
     func testArtifactStateDerivesOfficePackagePreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let spreadsheet = directory.appendingPathComponent("budget.xlsx")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -735,6 +735,63 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-content">"#))
     }
 
+    func testHTMLRendererIncludesYAMLArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let workflows = root
+            .appendingPathComponent(".github", isDirectory: true)
+            .appendingPathComponent("workflows", isDirectory: true)
+        try FileManager.default.createDirectory(at: workflows, withIntermediateDirectories: true)
+        let workflow = workflows.appendingPathComponent("ci.yml")
+        let yamlText = """
+        name: CI
+        on: [push, pull_request]
+
+        jobs:
+          test:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - run: swift test
+        """
+        try yamlText.write(to: workflow, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"ci.yml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote ci.yml\n", artifacts: [workflow.path])
+        let thread = ChatThread(
+            title: "YAML artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · YML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">ci.yml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-yaml-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-yaml-preview-meta">Format: YML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-yaml-preview-meta">Root: Mapping"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-yaml-preview-meta">3 keys"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-yaml-preview-key-title">Top-level keys"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-yaml-preview-key-item">jobs"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-yaml-preview-key-item">name"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">ci.yml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-content">"#))
+    }
+
     func testHTMLRendererIncludesAppshotArtifactPreview() throws {
         let root = try makeTempDirectory()
         let appshots = root.appendingPathComponent("appshots", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -60,6 +60,8 @@
 
 ## Current Parity Notes
 
+- Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
+  root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - The app server exposes Codex-compatible response-first `thread/compact/start`.
 - The app server exposes Codex-compatible one-shot and live-session fuzzy file search with bounded
   shared indexing, exact wire fields, match scores/indices, cancellation, and disconnect cleanup.


### PR DESCRIPTION
## Summary
- classify YAML/YML artifacts as Data previews
- add bounded local YAML metadata cards using the existing Yams parser
- mirror YAML preview rendering in SwiftUI, static HTML, and Playwright harness
- retain raw text previews and document the parity note

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesYAMLPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesYAMLArtifactPreview
- swift test --filter ParityWorkspaceToolCardModelGateTests
- swift test --filter ParityHTMLToolCardRendererGateTests
- npm test -- artifacts.spec.ts
- git diff --check