### PR TITLE
feat(artifacts): preview plist metadata

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8208,6 +8208,7 @@
         jsonLinesPreview: artifactJSONLinesPreview(value, kind, documentPreview),
         tomlPreview: artifactTOMLPreview(value, kind, documentPreview),
         yamlPreview: artifactYAMLPreview(value, kind, documentPreview),
+        propertyListPreview: artifactPropertyListPreview(value, kind, documentPreview),
         jsonPreview: artifactJSONPreview(value, kind, documentPreview),
         archivePreview: artifactArchivePreview(value, kind, documentPreview),
         mediaPreview: artifactMediaPreview(value, kind, documentPreview),
@@ -8618,6 +8619,7 @@
       ['toml', { kind: 'data', typeLabel: 'Data', icon: 'TOML' }],
       ['yaml', { kind: 'data', typeLabel: 'Data', icon: 'YAML' }],
       ['yml', { kind: 'data', typeLabel: 'Data', icon: 'YML' }],
+      ['plist', { kind: 'data', typeLabel: 'Data', icon: 'PLIST' }],
       ['numbers', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
       ['csv', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
       ['ods', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
@@ -9197,6 +9199,69 @@
         `${preview.keyCount} key${preview.keyCount === 1 ? '' : 's'}`,
         preview.mappingCount > 0 ? `${preview.mappingCount} mapping${preview.mappingCount === 1 ? '' : 's'}` : null,
         preview.sequenceCount > 0 ? `${preview.sequenceCount} sequence${preview.sequenceCount === 1 ? '' : 's'}` : null,
+        preview.scalarCount > 0 ? `${preview.scalarCount} value${preview.scalarCount === 1 ? '' : 's'}` : null,
+        preview.keyPreviewLabel ? `Keys: ${preview.keyPreviewLabel}` : null,
+        preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
+      ].filter(Boolean);
+      return preview.metadataLines.length || preview.keyPreviewLabels.length ? preview : null;
+    }
+
+    function artifactPropertyListPreview(value, kind, documentPreview) {
+      if (kind !== 'file' || documentPreview?.kind !== 'data') return null;
+      const extension = artifactPreviewExtension(value);
+      if (extension !== 'plist') return null;
+      const path = artifactFilePath(value);
+      const content = path ? state.mockFiles[path] : null;
+      if (typeof content !== 'string' || !content.trim() || content.includes('\u0000')) return null;
+      const byteLimit = 64 * 1024;
+      if (content.length > byteLimit) return null;
+
+      const keyMatches = [...content.matchAll(/<key>([^<]+)<\/key>/g)].map(match => match[1].trim());
+      if (!keyMatches.length) return null;
+      const topKeys = [];
+      let rootDepth = 0;
+      for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (line === '<dict>') {
+          rootDepth += 1;
+          continue;
+        }
+        if (line === '</dict>') {
+          rootDepth = Math.max(0, rootDepth - 1);
+          continue;
+        }
+        const keyMatch = line.match(/^<key>([^<]+)<\/key>$/);
+        if (keyMatch && rootDepth === 1) topKeys.push(keyMatch[1].trim());
+      }
+      const dictionaryCount = (content.match(/<dict>/g) || []).length;
+      const arrayCount = (content.match(/<array>/g) || []).length;
+      const scalarCount = (content.match(/<(string|true|false|integer|real|date|data)(?:>|\/>)/g) || []).length;
+      const keys = topKeys.length ? [...new Set(topKeys)].sort() : [...new Set(keyMatches)].sort();
+      const visibleKeys = keys.slice(0, 6).map(jsonPreviewKeyLabel);
+      const remainder = keys.length - visibleKeys.length;
+      const keyPreviewLabel = visibleKeys.length
+        ? `${visibleKeys.join(', ')}${remainder > 0 ? `, +${remainder} more` : ''}`
+        : null;
+      const preview = {
+        rootLabel: 'Dictionary',
+        formatLabel: 'XML PLIST',
+        keyCount: keys.length,
+        itemCount: null,
+        dictionaryCount,
+        arrayCount,
+        scalarCount,
+        keyPreviewLabel,
+        keyPreviewLabels: visibleKeys,
+        byteSizeLabel: byteSizeLabel(content.length)
+      };
+      preview.metadataLines = [
+        `Format: ${preview.formatLabel}`,
+        `Root: ${preview.rootLabel}`,
+        `${preview.keyCount} key${preview.keyCount === 1 ? '' : 's'}`,
+        preview.dictionaryCount > 0
+          ? `${preview.dictionaryCount} dictionar${preview.dictionaryCount === 1 ? 'y' : 'ies'}`
+          : null,
+        preview.arrayCount > 0 ? `${preview.arrayCount} array${preview.arrayCount === 1 ? '' : 's'}` : null,
         preview.scalarCount > 0 ? `${preview.scalarCount} value${preview.scalarCount === 1 ? '' : 's'}` : null,
         preview.keyPreviewLabel ? `Keys: ${preview.keyPreviewLabel}` : null,
         preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
@@ -11516,6 +11581,25 @@
                   ${keyList}
                 </div>` : '';
         };
+        const renderPropertyListPreview = preview => {
+          if (!preview) return '';
+          const metadata = (preview.metadataLines || [])
+            .map(line => `<small data-testid="tool-card-plist-preview-meta">${escapeHTML(line)}</small>`)
+            .join('');
+          const keys = (preview.keyPreviewLabels || [])
+            .map(label => `<li data-testid="tool-card-plist-preview-key-item">${escapeHTML(label)}</li>`)
+            .join('');
+          const keyList = keys ? `
+                  <section class="artifact-office-contents" data-testid="tool-card-plist-preview-keys">
+                    <strong data-testid="tool-card-plist-preview-key-title">Top-level keys</strong>
+                    <ul>${keys}</ul>
+                  </section>` : '';
+          return metadata || keyList ? `
+                <div class="artifact-office-preview" data-testid="tool-card-plist-preview">
+                  <div>${metadata}</div>
+                  ${keyList}
+                </div>` : '';
+        };
         const renderMediaPreview = preview => {
           if (!preview) return '';
           const title = preview.title
@@ -11601,6 +11685,7 @@
                 ${renderJSONLinesPreview(artifact.jsonLinesPreview)}
                 ${renderTOMLPreview(artifact.tomlPreview)}
                 ${renderYAMLPreview(artifact.yamlPreview)}
+                ${renderPropertyListPreview(artifact.propertyListPreview)}
                 ${renderJSONPreview(artifact.jsonPreview)}
                 ${renderAppshotPreview(artifact.appshotPreview)}
                 ${renderArchivePreview(artifact.archivePreview)}
@@ -23326,6 +23411,43 @@
           outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
         });
         addMessage('assistant', 'Created `ci.yml`.');
+      } else if (text.toLowerCase().includes('plist artifact')) {
+        const path = '/mock/QuillCode/Info.plist';
+        state.mockFiles[path] = [
+          '<?xml version="1.0" encoding="UTF-8"?>',
+          '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+          '<plist version="1.0">',
+          '<dict>',
+          '  <key>CFBundleIdentifier</key>',
+          '  <string>co.lorehex.QuillCode</string>',
+          '  <key>CFBundleName</key>',
+          '  <string>QuillCode</string>',
+          '  <key>CFBundleURLTypes</key>',
+          '  <array>',
+          '    <dict>',
+          '      <key>CFBundleURLName</key>',
+          '      <string>TrustedRouter</string>',
+          '      <key>CFBundleURLSchemes</key>',
+          '      <array>',
+          '        <string>quillcode</string>',
+          '      </array>',
+          '    </dict>',
+          '  </array>',
+          '  <key>LSMinimumSystemVersion</key>',
+          '  <string>14.0</string>',
+          '  <key>NSPrincipalClass</key>',
+          '  <string>NSApplication</string>',
+          '</dict>',
+          '</plist>'
+        ].join('\n');
+        addToolCard({
+          title: 'host.file.write',
+          subtitle: 'Completed',
+          status: 'done',
+          inputJSON: JSON.stringify({ path, contentType: 'application/x-plist' }, null, 2),
+          outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
+        });
+        addMessage('assistant', 'Created `Info.plist`.');
       } else if (text.toLowerCase().includes('json artifact')) {
         const path = '/mock/QuillCode/reports/build-report.json';
         state.mockFiles[path] = JSON.stringify({

--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -382,6 +382,41 @@ test('mock harness renders YAML artifact metadata previews from tool cards', asy
   await expect(page.getByText('Created `ci.yml`.')).toBeVisible();
 });
 
+test('mock harness renders property list artifact metadata previews from tool cards', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('make a plist artifact');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.file.write');
+  await expect(page.getByTestId('tool-card-artifact-label')).toHaveText('Info.plist');
+  await expect(page.getByTestId('tool-card-artifact-detail')).toHaveText('/mock/QuillCode');
+  await expect(page.getByTestId('tool-card-document-previews')).toBeVisible();
+  await expect(page.getByTestId('tool-card-document-preview')).toHaveAttribute('data-kind', 'data');
+  await expect(page.getByTestId('tool-card-document-preview-type')).toHaveText('Data · PLIST');
+  await expect(page.getByTestId('tool-card-document-preview-label')).toHaveText('Info.plist');
+  await expect(page.getByTestId('tool-card-plist-preview')).toBeVisible();
+  await expect(page.getByTestId('tool-card-plist-preview-meta')).toHaveText([
+    'Format: XML PLIST',
+    'Root: Dictionary',
+    '5 keys',
+    '2 dictionaries',
+    '2 arrays',
+    '6 values',
+    'Keys: CFBundleIdentifier, CFBundleName, CFBundleURLTypes, LSMinimumSystemVersion, NSPrincipalClass',
+    /Size: \d+ bytes/
+  ]);
+  await expect(page.getByTestId('tool-card-plist-preview-key-title')).toHaveText('Top-level keys');
+  await expect(page.getByTestId('tool-card-plist-preview-key-item')).toHaveText([
+    'CFBundleIdentifier',
+    'CFBundleName',
+    'CFBundleURLTypes',
+    'LSMinimumSystemVersion',
+    'NSPrincipalClass'
+  ]);
+  await expect(page.getByText('Created `Info.plist`.')).toBeVisible();
+});
+
 test('mock harness renders office artifact metadata previews from tool cards', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -57,6 +57,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             tomlContent(tomlPreview)
         } else if let yamlPreview = artifact.yamlPreview {
             yamlContent(yamlPreview)
+        } else if let propertyListPreview = artifact.propertyListPreview {
+            propertyListContent(propertyListPreview)
         } else if let jsonPreview = artifact.jsonPreview {
             jsonContent(jsonPreview)
         } else if let archivePreview = artifact.archivePreview {
@@ -174,6 +176,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(yamlPreview.metadataLines)
             artifactContentList(title: "Top-level keys", labels: yamlPreview.keyPreviewLabels)
+        }
+    }
+
+    private func propertyListContent(_ propertyListPreview: ToolArtifactPropertyListPreview) -> some View {
+        previewSurface(minHeight: propertyListPreview.keyPreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "curlybraces")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(propertyListPreview.metadataLines)
+            artifactContentList(title: "Top-level keys", labels: propertyListPreview.keyPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -479,6 +479,61 @@ public struct ToolArtifactYAMLPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPropertyListPreview: Codable, Sendable, Hashable {
+    public var rootLabel: String
+    public var formatLabel: String?
+    public var keyCount: Int?
+    public var itemCount: Int?
+    public var dictionaryCount: Int
+    public var arrayCount: Int
+    public var scalarCount: Int
+    public var keyPreviewLabel: String?
+    public var keyPreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel ?? "PLIST")",
+            "Root: \(rootLabel)",
+            keyCount.map { "\($0) key\($0 == 1 ? "" : "s")" },
+            itemCount.map { "\($0) item\($0 == 1 ? "" : "s")" },
+            dictionaryCount > 0 ? "\(dictionaryCount) dictionar\(dictionaryCount == 1 ? "y" : "ies")" : nil,
+            arrayCount > 0 ? "\(arrayCount) array\(arrayCount == 1 ? "" : "s")" : nil,
+            scalarCount > 0 ? "\(scalarCount) value\(scalarCount == 1 ? "" : "s")" : nil,
+            keyPreviewLabel.map { "Keys: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        !metadataLines.isEmpty || !keyPreviewLabels.isEmpty
+    }
+
+    public init(
+        rootLabel: String,
+        formatLabel: String? = nil,
+        keyCount: Int? = nil,
+        itemCount: Int? = nil,
+        dictionaryCount: Int = 0,
+        arrayCount: Int = 0,
+        scalarCount: Int = 0,
+        keyPreviewLabel: String? = nil,
+        keyPreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.rootLabel = rootLabel
+        self.formatLabel = formatLabel
+        self.keyCount = keyCount
+        self.itemCount = itemCount
+        self.dictionaryCount = dictionaryCount
+        self.arrayCount = arrayCount
+        self.scalarCount = scalarCount
+        self.keyPreviewLabel = keyPreviewLabel
+        self.keyPreviewLabels = keyPreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactArchivePreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var entryCount: Int?
@@ -621,6 +676,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var yamlPreview: ToolArtifactYAMLPreview? {
         ToolArtifactYAMLPreviewBuilder.yamlPreview(for: value, kind: kind)
+    }
+    public var propertyListPreview: ToolArtifactPropertyListPreview? {
+        ToolArtifactPropertyListPreviewBuilder.propertyListPreview(for: value, kind: kind)
     }
     public var archivePreview: ToolArtifactArchivePreview? {
         ToolArtifactArchivePreviewBuilder.archivePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -52,6 +52,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "toml": .data,
         "yaml": .data,
         "yml": .data,
+        "plist": .data,
         "doc": .document,
         "docx": .document,
         "odt": .document,

--- a/Sources/QuillCodeApp/ToolArtifactPropertyListPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPropertyListPreviewBuilder.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+enum ToolArtifactPropertyListPreviewBuilder {
+    static func propertyListPreview(
+        for value: String,
+        kind: ToolArtifactKind
+    ) -> ToolArtifactPropertyListPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "plist",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            var format = PropertyListSerialization.PropertyListFormat.xml
+            let root = try PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: &format
+            )
+            let preview = preview(from: root, format: format, fileSize: fileSize)
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from root: Any,
+        format: PropertyListSerialization.PropertyListFormat,
+        fileSize: Int
+    ) -> ToolArtifactPropertyListPreview {
+        let counts = valueCounts(in: root)
+        if let dictionary = root as? [String: Any] {
+            let keys = dictionary.keys.sorted()
+            return ToolArtifactPropertyListPreview(
+                rootLabel: "Dictionary",
+                formatLabel: formatLabel(for: format),
+                keyCount: keys.count,
+                dictionaryCount: counts.dictionaries,
+                arrayCount: counts.arrays,
+                scalarCount: counts.scalars,
+                keyPreviewLabel: previewLabel(for: keys),
+                keyPreviewLabels: previewLabels(for: keys),
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        }
+        if let array = root as? [Any] {
+            return ToolArtifactPropertyListPreview(
+                rootLabel: "Array",
+                formatLabel: formatLabel(for: format),
+                itemCount: array.count,
+                dictionaryCount: counts.dictionaries,
+                arrayCount: counts.arrays,
+                scalarCount: counts.scalars,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        }
+        return ToolArtifactPropertyListPreview(
+            rootLabel: scalarRootLabel(for: root),
+            formatLabel: formatLabel(for: format),
+            dictionaryCount: counts.dictionaries,
+            arrayCount: counts.arrays,
+            scalarCount: counts.scalars,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+        )
+    }
+
+    private static func valueCounts(in value: Any) -> (dictionaries: Int, arrays: Int, scalars: Int) {
+        if let dictionary = value as? [String: Any] {
+            return dictionary.values.reduce((dictionaries: 1, arrays: 0, scalars: 0)) { result, value in
+                let nested = valueCounts(in: value)
+                return (
+                    dictionaries: result.dictionaries + nested.dictionaries,
+                    arrays: result.arrays + nested.arrays,
+                    scalars: result.scalars + nested.scalars
+                )
+            }
+        }
+        if let array = value as? [Any] {
+            return array.reduce((dictionaries: 0, arrays: 1, scalars: 0)) { result, value in
+                let nested = valueCounts(in: value)
+                return (
+                    dictionaries: result.dictionaries + nested.dictionaries,
+                    arrays: result.arrays + nested.arrays,
+                    scalars: result.scalars + nested.scalars
+                )
+            }
+        }
+        return (dictionaries: 0, arrays: 0, scalars: 1)
+    }
+
+    private static func formatLabel(for format: PropertyListSerialization.PropertyListFormat) -> String {
+        switch format {
+        case .binary:
+            return "Binary PLIST"
+        case .xml:
+            return "XML PLIST"
+        case .openStep:
+            return "OpenStep PLIST"
+        @unknown default:
+            return "PLIST"
+        }
+    }
+
+    private static func scalarRootLabel(for root: Any) -> String {
+        switch root {
+        case is String:
+            return "String"
+        case is NSNumber:
+            return "Scalar"
+        case is Date:
+            return "Date"
+        case is Data:
+            return "Data"
+        default:
+            return "Scalar"
+        }
+    }
+
+    private static func previewLabel(for keys: [String]) -> String? {
+        guard !keys.isEmpty else { return nil }
+        let visibleKeys = keys.prefix(keyPreviewLimit)
+        let labels = visibleKeys.map(sanitizedLabel)
+        let remainder = keys.count - visibleKeys.count
+        return ([labels.joined(separator: ", ")] + (remainder > 0 ? ["+\(remainder) more"] : []))
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+    }
+
+    private static func previewLabels(for keys: [String]) -> [String] {
+        Array(keys.prefix(keyPreviewLimit)).map(sanitizedLabel)
+    }
+
+    private static func sanitizedLabel(_ key: String) -> String {
+        let collapsedWhitespace = key
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "(empty key)" : collapsedWhitespace).prefix(keyCharacterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 64 * 1_024
+    private static let keyPreviewLimit = 6
+    private static let keyCharacterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -206,6 +206,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
             let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
+            let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
             let jsonPreview = renderJSONPreview(artifact.jsonPreview)
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
             let archivePreview = renderArchivePreview(artifact.archivePreview)
@@ -226,6 +227,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(jsonLinesPreview)
               \(tomlPreview)
               \(yamlPreview)
+              \(propertyListPreview)
               \(jsonPreview)
               \(appshotPreview)
               \(archivePreview)
@@ -529,6 +531,31 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !keyList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-yaml-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(keyList)
+        </div>
+        """
+    }
+
+    private static func renderPropertyListPreview(_ preview: ToolArtifactPropertyListPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-plist-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let keys = preview.keyPreviewLabels.map {
+            #"<li data-testid="tool-card-plist-preview-key-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let keyList = keys.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-plist-preview-keys">
+                <strong data-testid="tool-card-plist-preview-key-title">Top-level keys</strong>
+                <ul>\(keys)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !keyList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-plist-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -416,6 +416,67 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteYAML.yamlPreview)
     }
 
+    func testArtifactStateDerivesPropertyListPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let plist = directory.appendingPathComponent("Info.plist")
+        let payload: [String: Any] = [
+            "CFBundleIdentifier": "co.lorehex.QuillCode",
+            "CFBundleName": "QuillCode",
+            "CFBundleURLTypes": [
+                [
+                    "CFBundleURLName": "TrustedRouter",
+                    "CFBundleURLSchemes": ["quillcode"]
+                ]
+            ],
+            "LSMinimumSystemVersion": "14.0",
+            "NSPrincipalClass": "NSApplication"
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: payload, format: .xml, options: 0)
+        try data.write(to: plist)
+
+        let artifact = ToolArtifactState(value: plist.path)
+        let preview = try XCTUnwrap(artifact.propertyListPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "PLIST")
+        XCTAssertEqual(preview.formatLabel, "XML PLIST")
+        XCTAssertEqual(preview.rootLabel, "Dictionary")
+        XCTAssertEqual(preview.keyCount, 5)
+        XCTAssertNil(preview.itemCount)
+        XCTAssertEqual(preview.dictionaryCount, 2)
+        XCTAssertEqual(preview.arrayCount, 2)
+        XCTAssertEqual(preview.scalarCount, 6)
+        XCTAssertEqual(preview.keyPreviewLabels, [
+            "CFBundleIdentifier",
+            "CFBundleName",
+            "CFBundleURLTypes",
+            "LSMinimumSystemVersion",
+            "NSPrincipalClass"
+        ])
+        XCTAssertEqual(
+            preview.keyPreviewLabel,
+            "CFBundleIdentifier, CFBundleName, CFBundleURLTypes, LSMinimumSystemVersion, NSPrincipalClass"
+        )
+        XCTAssertEqual(preview.byteSizeLabel, "\(data.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: XML PLIST",
+            "Root: Dictionary",
+            "5 keys",
+            "2 dictionaries",
+            "2 arrays",
+            "6 values",
+            "Keys: CFBundleIdentifier, CFBundleName, CFBundleURLTypes, LSMinimumSystemVersion, NSPrincipalClass",
+            "Size: \(data.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+        XCTAssertNil(artifact.jsonLinesPreview)
+        XCTAssertNil(artifact.tomlPreview)
+        XCTAssertNil(artifact.yamlPreview)
+
+        let remotePlist = ToolArtifactState(value: "https://example.com/Info.plist")
+        XCTAssertNil(remotePlist.propertyListPreview)
+    }
+
     func testArtifactStateDerivesOfficePackagePreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let spreadsheet = directory.appendingPathComponent("budget.xlsx")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -792,6 +792,59 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-content">"#))
     }
 
+    func testHTMLRendererIncludesPropertyListArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let plist = root.appendingPathComponent("Info.plist")
+        let payload: [String: Any] = [
+            "CFBundleIdentifier": "co.lorehex.QuillCode",
+            "CFBundleName": "QuillCode",
+            "CFBundleURLTypes": [
+                [
+                    "CFBundleURLName": "TrustedRouter",
+                    "CFBundleURLSchemes": ["quillcode"]
+                ]
+            ],
+            "LSMinimumSystemVersion": "14.0",
+            "NSPrincipalClass": "NSApplication"
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: payload, format: .xml, options: 0)
+        try data.write(to: plist)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"Info.plist"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote Info.plist\n", artifacts: [plist.path])
+        let thread = ChatThread(
+            title: "Property list artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · PLIST"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">Info.plist"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview-meta">Format: XML PLIST"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview-meta">Root: Dictionary"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview-meta">5 keys"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview-key-title">Top-level keys"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview-key-item">CFBundleIdentifier"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview-key-item">NSPrincipalClass"#))
+    }
+
     func testHTMLRendererIncludesAppshotArtifactPreview() throws {
         let root = try makeTempDirectory()
         let appshots = root.appendingPathComponent("appshots", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -62,6 +62,8 @@
 
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
+- Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:
+  root kind, key/item counts, dictionary/array/value counts, file size, and capped key previews.
 - The app server exposes Codex-compatible response-first `thread/compact/start`.
 - The app server exposes Codex-compatible one-shot and live-session fuzzy file search with bounded
   shared indexing, exact wire fields, match scores/indices, cancellation, and disconnect cleanup.


### PR DESCRIPTION
## Summary
- classify .plist artifacts as Data previews
- add bounded local property-list metadata cards using Foundation plist parsing
- mirror plist preview rendering in SwiftUI, static HTML, and Playwright harness
- document the artifact parity note

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesPropertyListPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesPropertyListArtifactPreview
- swift test --filter ParityWorkspaceToolCardModelGateTests
- swift test --filter ParityHTMLToolCardRendererGateTests
- npm test -- artifacts.spec.ts
- git diff --check