### PR TITLE
feat(artifacts): preview xml metadata

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8208,6 +8208,7 @@
         jsonLinesPreview: artifactJSONLinesPreview(value, kind, documentPreview),
         tomlPreview: artifactTOMLPreview(value, kind, documentPreview),
         yamlPreview: artifactYAMLPreview(value, kind, documentPreview),
+        xmlPreview: artifactXMLPreview(value, kind, documentPreview),
         propertyListPreview: artifactPropertyListPreview(value, kind, documentPreview),
         jsonPreview: artifactJSONPreview(value, kind, documentPreview),
         archivePreview: artifactArchivePreview(value, kind, documentPreview),
@@ -8619,6 +8620,7 @@
       ['toml', { kind: 'data', typeLabel: 'Data', icon: 'TOML' }],
       ['yaml', { kind: 'data', typeLabel: 'Data', icon: 'YAML' }],
       ['yml', { kind: 'data', typeLabel: 'Data', icon: 'YML' }],
+      ['xml', { kind: 'data', typeLabel: 'Data', icon: 'XML' }],
       ['plist', { kind: 'data', typeLabel: 'Data', icon: 'PLIST' }],
       ['numbers', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
       ['csv', { kind: 'spreadsheet', typeLabel: 'Spreadsheet', icon: 'XLS' }],
@@ -9204,6 +9206,59 @@
         preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
       ].filter(Boolean);
       return preview.metadataLines.length || preview.keyPreviewLabels.length ? preview : null;
+    }
+
+    function artifactXMLPreview(value, kind, documentPreview) {
+      if (kind !== 'file' || documentPreview?.kind !== 'data') return null;
+      const extension = artifactPreviewExtension(value);
+      if (extension !== 'xml') return null;
+      const path = artifactFilePath(value);
+      const content = path ? state.mockFiles[path] : null;
+      if (typeof content !== 'string' || !content.trim() || content.includes('\u0000')) return null;
+      const byteLimit = 64 * 1024;
+      if (content.length > byteLimit) return null;
+
+      const parser = new DOMParser();
+      const document = parser.parseFromString(content, 'application/xml');
+      if (document.querySelector('parsererror') || !document.documentElement) return null;
+      const root = document.documentElement;
+      const elements = [...document.getElementsByTagName('*')];
+      const namespaceNames = new Set();
+      let attributeCount = 0;
+      for (const element of elements) {
+        for (const attribute of [...element.attributes]) {
+          if (attribute.name === 'xmlns' || attribute.name.startsWith('xmlns:')) {
+            namespaceNames.add(attribute.name);
+          } else {
+            attributeCount += 1;
+          }
+        }
+      }
+      const childLabels = [...new Set([...root.children].map(child => jsonPreviewKeyLabel(child.tagName)))].sort();
+      const visibleChildren = childLabels.slice(0, 6);
+      const remainder = childLabels.length - visibleChildren.length;
+      const childPreviewLabel = visibleChildren.length
+        ? `${visibleChildren.join(', ')}${remainder > 0 ? `, +${remainder} more` : ''}`
+        : null;
+      const preview = {
+        rootElementLabel: jsonPreviewKeyLabel(root.tagName),
+        elementCount: elements.length,
+        attributeCount,
+        namespaceCount: namespaceNames.size,
+        childPreviewLabel,
+        childPreviewLabels: visibleChildren,
+        byteSizeLabel: byteSizeLabel(content.length)
+      };
+      preview.metadataLines = [
+        'Format: XML',
+        `Root: ${preview.rootElementLabel}`,
+        `${preview.elementCount} element${preview.elementCount === 1 ? '' : 's'}`,
+        preview.attributeCount > 0 ? `${preview.attributeCount} attribute${preview.attributeCount === 1 ? '' : 's'}` : null,
+        preview.namespaceCount > 0 ? `${preview.namespaceCount} namespace${preview.namespaceCount === 1 ? '' : 's'}` : null,
+        preview.childPreviewLabel ? `Children: ${preview.childPreviewLabel}` : null,
+        preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
+      ].filter(Boolean);
+      return preview.metadataLines.length || preview.childPreviewLabels.length ? preview : null;
     }
 
     function artifactPropertyListPreview(value, kind, documentPreview) {
@@ -11581,6 +11636,25 @@
                   ${keyList}
                 </div>` : '';
         };
+        const renderXMLPreview = preview => {
+          if (!preview) return '';
+          const metadata = (preview.metadataLines || [])
+            .map(line => `<small data-testid="tool-card-xml-preview-meta">${escapeHTML(line)}</small>`)
+            .join('');
+          const children = (preview.childPreviewLabels || [])
+            .map(label => `<li data-testid="tool-card-xml-preview-child-item">${escapeHTML(label)}</li>`)
+            .join('');
+          const childList = children ? `
+                  <section class="artifact-office-contents" data-testid="tool-card-xml-preview-children">
+                    <strong data-testid="tool-card-xml-preview-child-title">Root children</strong>
+                    <ul>${children}</ul>
+                  </section>` : '';
+          return metadata || childList ? `
+                <div class="artifact-office-preview" data-testid="tool-card-xml-preview">
+                  <div>${metadata}</div>
+                  ${childList}
+                </div>` : '';
+        };
         const renderPropertyListPreview = preview => {
           if (!preview) return '';
           const metadata = (preview.metadataLines || [])
@@ -11685,6 +11759,7 @@
                 ${renderJSONLinesPreview(artifact.jsonLinesPreview)}
                 ${renderTOMLPreview(artifact.tomlPreview)}
                 ${renderYAMLPreview(artifact.yamlPreview)}
+                ${renderXMLPreview(artifact.xmlPreview)}
                 ${renderPropertyListPreview(artifact.propertyListPreview)}
                 ${renderJSONPreview(artifact.jsonPreview)}
                 ${renderAppshotPreview(artifact.appshotPreview)}
@@ -23411,6 +23486,31 @@
           outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
         });
         addMessage('assistant', 'Created `ci.yml`.');
+      } else if (text.toLowerCase().includes('xml artifact')) {
+        const path = '/mock/QuillCode/manifest.xml';
+        state.mockFiles[path] = [
+          '<?xml version="1.0" encoding="UTF-8"?>',
+          '<project xmlns="https://quillcode.dev/schema" name="QuillCode" version="1.0">',
+          '  <module name="QuillCodeApp">',
+          '    <target platform="macOS" />',
+          '    <target platform="Linux" />',
+          '  </module>',
+          '  <dependencies>',
+          '    <dependency id="TrustedRouterSwift" />',
+          '  </dependencies>',
+          '  <settings>',
+          '    <setting key="model" value="trustedrouter/fast" />',
+          '  </settings>',
+          '</project>'
+        ].join('\n');
+        addToolCard({
+          title: 'host.file.write',
+          subtitle: 'Completed',
+          status: 'done',
+          inputJSON: JSON.stringify({ path, contentType: 'application/xml' }, null, 2),
+          outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
+        });
+        addMessage('assistant', 'Created `manifest.xml`.');
       } else if (text.toLowerCase().includes('plist artifact')) {
         const path = '/mock/QuillCode/Info.plist';
         state.mockFiles[path] = [

--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -417,6 +417,38 @@ test('mock harness renders property list artifact metadata previews from tool ca
   await expect(page.getByText('Created `Info.plist`.')).toBeVisible();
 });
 
+test('mock harness renders XML artifact metadata previews from tool cards', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('make an xml artifact');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.file.write');
+  await expect(page.getByTestId('tool-card-artifact-label')).toHaveText('manifest.xml');
+  await expect(page.getByTestId('tool-card-artifact-detail')).toHaveText('/mock/QuillCode');
+  await expect(page.getByTestId('tool-card-document-previews')).toBeVisible();
+  await expect(page.getByTestId('tool-card-document-preview')).toHaveAttribute('data-kind', 'data');
+  await expect(page.getByTestId('tool-card-document-preview-type')).toHaveText('Data · XML');
+  await expect(page.getByTestId('tool-card-document-preview-label')).toHaveText('manifest.xml');
+  await expect(page.getByTestId('tool-card-xml-preview')).toBeVisible();
+  await expect(page.getByTestId('tool-card-xml-preview-meta')).toHaveText([
+    'Format: XML',
+    'Root: project',
+    '8 elements',
+    '8 attributes',
+    '1 namespace',
+    'Children: dependencies, module, settings',
+    /Size: \d+ bytes/
+  ]);
+  await expect(page.getByTestId('tool-card-xml-preview-child-title')).toHaveText('Root children');
+  await expect(page.getByTestId('tool-card-xml-preview-child-item')).toHaveText([
+    'dependencies',
+    'module',
+    'settings'
+  ]);
+  await expect(page.getByText('Created `manifest.xml`.')).toBeVisible();
+});
+
 test('mock harness renders office artifact metadata previews from tool cards', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -57,6 +57,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             tomlContent(tomlPreview)
         } else if let yamlPreview = artifact.yamlPreview {
             yamlContent(yamlPreview)
+        } else if let xmlPreview = artifact.xmlPreview {
+            xmlContent(xmlPreview)
         } else if let propertyListPreview = artifact.propertyListPreview {
             propertyListContent(propertyListPreview)
         } else if let jsonPreview = artifact.jsonPreview {
@@ -176,6 +178,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(yamlPreview.metadataLines)
             artifactContentList(title: "Top-level keys", labels: yamlPreview.keyPreviewLabels)
+        }
+    }
+
+    private func xmlContent(_ xmlPreview: ToolArtifactXMLPreview) -> some View {
+        previewSurface(minHeight: xmlPreview.childPreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chevron.left.forwardslash.chevron.right")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(xmlPreview.metadataLines)
+            artifactContentList(title: "Root children", labels: xmlPreview.childPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -479,6 +479,50 @@ public struct ToolArtifactYAMLPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactXMLPreview: Codable, Sendable, Hashable {
+    public var rootElementLabel: String
+    public var elementCount: Int
+    public var attributeCount: Int
+    public var namespaceCount: Int
+    public var childPreviewLabel: String?
+    public var childPreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: XML",
+            "Root: \(rootElementLabel)",
+            "\(elementCount) element\(elementCount == 1 ? "" : "s")",
+            attributeCount > 0 ? "\(attributeCount) attribute\(attributeCount == 1 ? "" : "s")" : nil,
+            namespaceCount > 0 ? "\(namespaceCount) namespace\(namespaceCount == 1 ? "" : "s")" : nil,
+            childPreviewLabel.map { "Children: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        !metadataLines.isEmpty || !childPreviewLabels.isEmpty
+    }
+
+    public init(
+        rootElementLabel: String,
+        elementCount: Int,
+        attributeCount: Int = 0,
+        namespaceCount: Int = 0,
+        childPreviewLabel: String? = nil,
+        childPreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.rootElementLabel = rootElementLabel
+        self.elementCount = elementCount
+        self.attributeCount = attributeCount
+        self.namespaceCount = namespaceCount
+        self.childPreviewLabel = childPreviewLabel
+        self.childPreviewLabels = childPreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactPropertyListPreview: Codable, Sendable, Hashable {
     public var rootLabel: String
     public var formatLabel: String?
@@ -676,6 +720,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var yamlPreview: ToolArtifactYAMLPreview? {
         ToolArtifactYAMLPreviewBuilder.yamlPreview(for: value, kind: kind)
+    }
+    public var xmlPreview: ToolArtifactXMLPreview? {
+        ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)
     }
     public var propertyListPreview: ToolArtifactPropertyListPreview? {
         ToolArtifactPropertyListPreviewBuilder.propertyListPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -52,6 +52,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "toml": .data,
         "yaml": .data,
         "yml": .data,
+        "xml": .data,
         "plist": .data,
         "doc": .document,
         "docx": .document,

--- a/Sources/QuillCodeApp/ToolArtifactXMLPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactXMLPreviewBuilder.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+enum ToolArtifactXMLPreviewBuilder {
+    static func xmlPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactXMLPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let collector = XMLPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 64 * 1_024
+}
+
+private final class XMLPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var childLabels: [String] = []
+    private var namespaceLabels: Set<String> = []
+    private(set) var elementCount = 0
+    private(set) var attributeCount = 0
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = sanitizedLabel(qualifiedElementName(elementName: elementName, qName: qName))
+        if depth == 0 {
+            rootElementLabel = label
+        } else if depth == 1 {
+            childLabels.append(label)
+        }
+        elementCount += 1
+        countAttributes(attributeDict)
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactXMLPreview? {
+        guard let rootElementLabel else { return nil }
+        let children = previewLabels(for: childLabels)
+        return ToolArtifactXMLPreview(
+            rootElementLabel: rootElementLabel,
+            elementCount: elementCount,
+            attributeCount: attributeCount,
+            namespaceCount: namespaceLabels.count,
+            childPreviewLabel: previewLabel(for: childLabels),
+            childPreviewLabels: children,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+        )
+    }
+
+    private func countAttributes(_ attributeDict: [String: String]) {
+        for key in attributeDict.keys {
+            if key == "xmlns" || key.hasPrefix("xmlns:") {
+                namespaceLabels.insert(key)
+            } else {
+                attributeCount += 1
+            }
+        }
+    }
+
+    private func previewLabel(for labels: [String]) -> String? {
+        let visibleLabels = previewLabels(for: labels)
+        guard !visibleLabels.isEmpty else { return nil }
+        let remainder = Set(labels).count - visibleLabels.count
+        return ([visibleLabels.joined(separator: ", ")] + (remainder > 0 ? ["+\(remainder) more"] : []))
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+    }
+
+    private func previewLabels(for labels: [String]) -> [String] {
+        Array(Set(labels).sorted().prefix(keyPreviewLimit))
+    }
+
+    private func sanitizedLabel(_ label: String) -> String {
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "(unnamed element)" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private func qualifiedElementName(elementName: String, qName: String?) -> String {
+        guard let qName, !qName.isEmpty else { return elementName }
+        return qName
+    }
+
+    private let keyPreviewLimit = 6
+    private let characterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -206,6 +206,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
             let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
+            let xmlPreview = renderXMLPreview(artifact.xmlPreview)
             let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
             let jsonPreview = renderJSONPreview(artifact.jsonPreview)
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
@@ -227,6 +228,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(jsonLinesPreview)
               \(tomlPreview)
               \(yamlPreview)
+              \(xmlPreview)
               \(propertyListPreview)
               \(jsonPreview)
               \(appshotPreview)
@@ -535,6 +537,31 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(keyList)
+        </div>
+        """
+    }
+
+    private static func renderXMLPreview(_ preview: ToolArtifactXMLPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-xml-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let children = preview.childPreviewLabels.map {
+            #"<li data-testid="tool-card-xml-preview-child-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let childList = children.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-xml-preview-children">
+                <strong data-testid="tool-card-xml-preview-child-title">Root children</strong>
+                <ul>\(children)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !childList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-xml-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(childList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -477,6 +477,57 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePlist.propertyListPreview)
     }
 
+    func testArtifactStateDerivesXMLPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let manifest = directory.appendingPathComponent("manifest.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <project xmlns="https://quillcode.dev/schema" name="QuillCode" version="1.0">
+          <module name="QuillCodeApp">
+            <target platform="macOS" />
+            <target platform="Linux" />
+          </module>
+          <dependencies>
+            <dependency id="TrustedRouterSwift" />
+          </dependencies>
+          <settings>
+            <setting key="model" value="trustedrouter/fast" />
+          </settings>
+        </project>
+        """
+        try content.write(to: manifest, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: manifest.path)
+        let preview = try XCTUnwrap(artifact.xmlPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.rootElementLabel, "project")
+        XCTAssertEqual(preview.elementCount, 8)
+        XCTAssertEqual(preview.attributeCount, 8)
+        XCTAssertEqual(preview.namespaceCount, 1)
+        XCTAssertEqual(preview.childPreviewLabels, ["dependencies", "module", "settings"])
+        XCTAssertEqual(preview.childPreviewLabel, "dependencies, module, settings")
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: XML",
+            "Root: project",
+            "8 elements",
+            "8 attributes",
+            "1 namespace",
+            "Children: dependencies, module, settings",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+        XCTAssertNil(artifact.jsonLinesPreview)
+        XCTAssertNil(artifact.tomlPreview)
+        XCTAssertNil(artifact.yamlPreview)
+        XCTAssertNil(artifact.propertyListPreview)
+
+        let remoteXML = ToolArtifactState(value: "https://example.com/manifest.xml")
+        XCTAssertNil(remoteXML.xmlPreview)
+    }
+
     func testArtifactStateDerivesOfficePackagePreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let spreadsheet = directory.appendingPathComponent("budget.xlsx")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -845,6 +845,63 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-plist-preview-key-item">NSPrincipalClass"#))
     }
 
+    func testHTMLRendererIncludesXMLArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let manifest = root.appendingPathComponent("manifest.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <project xmlns="https://quillcode.dev/schema" name="QuillCode" version="1.0">
+          <module name="QuillCodeApp">
+            <target platform="macOS" />
+            <target platform="Linux" />
+          </module>
+          <dependencies>
+            <dependency id="TrustedRouterSwift" />
+          </dependencies>
+          <settings>
+            <setting key="model" value="trustedrouter/fast" />
+          </settings>
+        </project>
+        """.write(to: manifest, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"manifest.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote manifest.xml\n", artifacts: [manifest.path])
+        let thread = ChatThread(
+            title: "XML artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">manifest.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-meta">Format: XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-meta">Root: project"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-meta">8 elements"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-meta">8 attributes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-meta">1 namespace"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-child-title">Root children"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-child-item">dependencies"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-child-item">module"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-child-item">settings"#))
+    }
+
     func testHTMLRendererIncludesAppshotArtifactPreview() throws {
         let root = try makeTempDirectory()
         let appshots = root.appendingPathComponent("appshots", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -64,6 +64,8 @@
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:
   root kind, key/item counts, dictionary/array/value counts, file size, and capped key previews.
+- Artifact previews now include bounded local XML metadata using native XML parsing:
+  root element, element/attribute/namespace counts, file size, and capped root-child previews.
 - The app server exposes Codex-compatible response-first `thread/compact/start`.
 - The app server exposes Codex-compatible one-shot and live-session fuzzy file search with bounded
   shared indexing, exact wire fields, match scores/indices, cancellation, and disconnect cleanup.


### PR DESCRIPTION
## Summary
- classify .xml artifacts as Data previews
- add bounded local XML metadata cards using native XML parsing
- render XML root/element/attribute/namespace metadata in SwiftUI, static HTML, and Playwright harness
- document the artifact parity note

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesXMLPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesXMLArtifactPreview
- swift test --filter ParityWorkspaceToolCardModelGateTests
- swift test --filter ParityHTMLToolCardRendererGateTests
- npm test -- artifacts.spec.ts
- git diff --check