### PR TITLE
feat(artifacts): preview dotenv metadata

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8208,6 +8208,7 @@
         jsonLinesPreview: artifactJSONLinesPreview(value, kind, documentPreview),
         tomlPreview: artifactTOMLPreview(value, kind, documentPreview),
         iniPreview: artifactINIPreview(value, kind, documentPreview),
+        dotenvPreview: artifactDotenvPreview(value, kind, documentPreview),
         yamlPreview: artifactYAMLPreview(value, kind, documentPreview),
         xmlPreview: artifactXMLPreview(value, kind, documentPreview),
         propertyListPreview: artifactPropertyListPreview(value, kind, documentPreview),
@@ -8620,6 +8621,7 @@
       ['ndjson', { kind: 'data', typeLabel: 'Data', icon: 'JSONL' }],
       ['cfg', { kind: 'data', typeLabel: 'Data', icon: 'CFG' }],
       ['conf', { kind: 'data', typeLabel: 'Data', icon: 'CONF' }],
+      ['env', { kind: 'data', typeLabel: 'Data', icon: 'ENV' }],
       ['ini', { kind: 'data', typeLabel: 'Data', icon: 'INI' }],
       ['toml', { kind: 'data', typeLabel: 'Data', icon: 'TOML' }],
       ['yaml', { kind: 'data', typeLabel: 'Data', icon: 'YAML' }],
@@ -8685,6 +8687,7 @@
       } catch {
         filename = (value.split('/').filter(Boolean).at(-1) || '').toLowerCase();
       }
+      if (filename === '.env' || filename.startsWith('.env.')) return 'env';
       const compoundExtensions = new Map([
         ['appshot.json', 'appshot'],
         ['tar.gz', 'tar.gz'],
@@ -9173,6 +9176,76 @@
         preview.isTruncated ? 'Preview truncated' : null
       ].filter(Boolean);
       return preview.metadataLines.length || preview.sectionPreviewLabels.length ? preview : null;
+    }
+
+    function artifactDotenvPreview(value, kind, documentPreview) {
+      if (kind !== 'file' || documentPreview?.kind !== 'data') return null;
+      if (artifactPreviewExtension(value) !== 'env') return null;
+      const path = artifactFilePath(value);
+      const content = path ? state.mockFiles[path] : null;
+      if (typeof content !== 'string' || !content.trim() || content.includes('\u0000')) return null;
+      const byteLimit = 64 * 1024;
+      if (content.length > byteLimit) return null;
+
+      const keys = [];
+      const seenKeys = new Set();
+      let variableCount = 0;
+      let exportedVariableCount = 0;
+      let processedLines = 0;
+      let isTruncated = false;
+      for (const rawLine of content.split(/\r?\n/)) {
+        processedLines += 1;
+        if (processedLines > 2000) {
+          isTruncated = true;
+          break;
+        }
+        const assignment = dotenvAssignment(rawLine);
+        if (!assignment) continue;
+        variableCount += 1;
+        if (assignment.isExported) exportedVariableCount += 1;
+        if (!seenKeys.has(assignment.key)) {
+          seenKeys.add(assignment.key);
+          keys.push(assignment.key);
+        }
+      }
+      if (variableCount === 0) return null;
+      const visibleKeys = keys.slice(0, 8);
+      const remainder = keys.length - visibleKeys.length;
+      const keyPreviewLabel = visibleKeys.length
+        ? `${visibleKeys.join(', ')}${remainder > 0 ? `, +${remainder} more` : ''}`
+        : null;
+      const preview = {
+        variableCount,
+        exportedVariableCount,
+        keyPreviewLabel,
+        keyPreviewLabels: visibleKeys,
+        byteSizeLabel: byteSizeLabel(content.length),
+        isTruncated
+      };
+      preview.metadataLines = [
+        'Format: DOTENV',
+        `${preview.variableCount} variable${preview.variableCount === 1 ? '' : 's'}`,
+        preview.exportedVariableCount > 0 ? `${preview.exportedVariableCount} exported` : null,
+        preview.keyPreviewLabel ? `Keys: ${preview.keyPreviewLabel}` : null,
+        preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null,
+        preview.isTruncated ? 'Preview truncated' : null
+      ].filter(Boolean);
+      return preview.metadataLines.length || preview.keyPreviewLabels.length ? preview : null;
+    }
+
+    function dotenvAssignment(rawLine) {
+      let line = rawLine.trim();
+      if (!line || line.startsWith('#')) return null;
+      let isExported = false;
+      if (line.startsWith('export ')) {
+        isExported = true;
+        line = line.slice('export '.length).trim();
+      }
+      const delimiterIndex = line.indexOf('=');
+      if (delimiterIndex <= 0) return null;
+      const key = line.slice(0, delimiterIndex).trim();
+      if (!/^[_A-Za-z][_A-Za-z0-9]*$/.test(key)) return null;
+      return { key: key.slice(0, 80), isExported };
     }
 
     function artifactYAMLPreview(value, kind, documentPreview) {
@@ -9824,7 +9897,7 @@
       'xml', 'yaml', 'yml'
     ]);
     const textPreviewFilenames = new Set([
-      '.env.example', '.gitignore', 'dockerfile', 'gemfile', 'license', 'makefile', 'podfile', 'readme'
+      '.gitignore', 'dockerfile', 'gemfile', 'license', 'makefile', 'podfile', 'readme'
     ]);
 
     function artifactFilePath(value) {
@@ -9843,6 +9916,7 @@
       if (!path) return null;
       const name = path.split('/').filter(Boolean).at(-1)?.toLowerCase() || '';
       if (name.endsWith('.appshot') || name.endsWith('.appshot.json')) return null;
+      if (artifactPreviewExtension(value) === 'env') return null;
       const extension = name.includes('.') ? name.split('.').pop() : '';
       if (extension === 'csv' || extension === 'tsv') return null;
       if (!textPreviewFilenames.has(name) && !textPreviewExtensions.has(extension)) return null;
@@ -11702,6 +11776,25 @@
                   ${sectionList}
                 </div>` : '';
         };
+        const renderDotenvPreview = preview => {
+          if (!preview) return '';
+          const metadata = (preview.metadataLines || [])
+            .map(line => `<small data-testid="tool-card-dotenv-preview-meta">${escapeHTML(line)}</small>`)
+            .join('');
+          const keys = (preview.keyPreviewLabels || [])
+            .map(label => `<li data-testid="tool-card-dotenv-preview-key-item">${escapeHTML(label)}</li>`)
+            .join('');
+          const keyList = keys ? `
+                  <section class="artifact-office-contents" data-testid="tool-card-dotenv-preview-keys">
+                    <strong data-testid="tool-card-dotenv-preview-key-title">Variable names</strong>
+                    <ul>${keys}</ul>
+                  </section>` : '';
+          return metadata || keyList ? `
+                <div class="artifact-office-preview" data-testid="tool-card-dotenv-preview">
+                  <div>${metadata}</div>
+                  ${keyList}
+                </div>` : '';
+        };
         const renderYAMLPreview = preview => {
           if (!preview) return '';
           const metadata = (preview.metadataLines || [])
@@ -11844,6 +11937,7 @@
                 ${renderJSONLinesPreview(artifact.jsonLinesPreview)}
                 ${renderTOMLPreview(artifact.tomlPreview)}
                 ${renderINIPreview(artifact.iniPreview)}
+                ${renderDotenvPreview(artifact.dotenvPreview)}
                 ${renderYAMLPreview(artifact.yamlPreview)}
                 ${renderXMLPreview(artifact.xmlPreview)}
                 ${renderPropertyListPreview(artifact.propertyListPreview)}
@@ -23625,6 +23719,24 @@
           outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
         });
         addMessage('assistant', 'Created `quillcode.ini`.');
+      } else if (text.toLowerCase().includes('dotenv artifact') || text.toLowerCase().includes('env artifact')) {
+        const path = '/mock/QuillCode/.env.local';
+        state.mockFiles[path] = [
+          '# QuillCode local environment',
+          'TRUSTEDROUTER_API_KEY=sk-secret-value',
+          'QUILLCODE_MODEL=trustedrouter/fast',
+          'export QUILLCODE_DEBUG=true',
+          'EMPTY_VALUE=',
+          'INVALID-NAME=ignored'
+        ].join('\n');
+        addToolCard({
+          title: 'host.file.write',
+          subtitle: 'Completed',
+          status: 'done',
+          inputJSON: JSON.stringify({ path, contentType: 'application/dotenv' }, null, 2),
+          outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
+        });
+        addMessage('assistant', 'Created `.env.local`.');
       } else if (text.toLowerCase().includes('plist artifact')) {
         const path = '/mock/QuillCode/Info.plist';
         state.mockFiles[path] = [

--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -381,6 +381,38 @@ test('mock harness renders INI artifact metadata previews from tool cards', asyn
   await expect(page.getByText('Created `quillcode.ini`.')).toBeVisible();
 });
 
+test('mock harness renders dotenv artifact metadata previews without values', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('make a dotenv artifact');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.file.write');
+  await expect(page.getByTestId('tool-card-artifact-label')).toHaveText('.env.local');
+  await expect(page.getByTestId('tool-card-artifact-detail')).toHaveText('/mock/QuillCode');
+  await expect(page.getByTestId('tool-card-document-previews')).toBeVisible();
+  await expect(page.getByTestId('tool-card-document-preview')).toHaveAttribute('data-kind', 'data');
+  await expect(page.getByTestId('tool-card-document-preview-type')).toHaveText('Data · ENV');
+  await expect(page.getByTestId('tool-card-document-preview-label')).toHaveText('.env.local');
+  await expect(page.getByTestId('tool-card-dotenv-preview')).toBeVisible();
+  await expect(page.getByTestId('tool-card-dotenv-preview-meta')).toHaveText([
+    'Format: DOTENV',
+    '4 variables',
+    '1 exported',
+    'Keys: TRUSTEDROUTER_API_KEY, QUILLCODE_MODEL, QUILLCODE_DEBUG, EMPTY_VALUE',
+    /Size: \d+ bytes/
+  ]);
+  await expect(page.getByTestId('tool-card-dotenv-preview-key-title')).toHaveText('Variable names');
+  await expect(page.getByTestId('tool-card-dotenv-preview-key-item')).toHaveText([
+    'TRUSTEDROUTER_API_KEY',
+    'QUILLCODE_MODEL',
+    'QUILLCODE_DEBUG',
+    'EMPTY_VALUE'
+  ]);
+  await expect(page.getByText('sk-secret-value')).toHaveCount(0);
+  await expect(page.getByText('Created `.env.local`.')).toBeVisible();
+});
+
 test('mock harness renders YAML artifact metadata previews from tool cards', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -57,6 +57,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             tomlContent(tomlPreview)
         } else if let iniPreview = artifact.iniPreview {
             iniContent(iniPreview)
+        } else if let dotenvPreview = artifact.dotenvPreview {
+            dotenvContent(dotenvPreview)
         } else if let yamlPreview = artifact.yamlPreview {
             yamlContent(yamlPreview)
         } else if let xmlPreview = artifact.xmlPreview {
@@ -180,6 +182,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(iniPreview.metadataLines)
             artifactContentList(title: "Sections", labels: iniPreview.sectionPreviewLabels)
+        }
+    }
+
+    private func dotenvContent(_ dotenvPreview: ToolArtifactDotenvPreview) -> some View {
+        previewSurface(minHeight: dotenvPreview.keyPreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "key")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(dotenvPreview.metadataLines)
+            artifactContentList(title: "Variable names", labels: dotenvPreview.keyPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -467,6 +467,46 @@ public struct ToolArtifactINIPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactDotenvPreview: Codable, Sendable, Hashable {
+    public var variableCount: Int
+    public var exportedVariableCount: Int
+    public var keyPreviewLabel: String?
+    public var keyPreviewLabels: [String]
+    public var byteSizeLabel: String?
+    public var isTruncated: Bool
+
+    public var metadataLines: [String] {
+        [
+            "Format: DOTENV",
+            "\(variableCount) variable\(variableCount == 1 ? "" : "s")",
+            exportedVariableCount > 0 ? "\(exportedVariableCount) exported" : nil,
+            keyPreviewLabel.map { "Keys: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" },
+            isTruncated ? "Preview truncated" : nil
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        !metadataLines.isEmpty || !keyPreviewLabels.isEmpty
+    }
+
+    public init(
+        variableCount: Int,
+        exportedVariableCount: Int = 0,
+        keyPreviewLabel: String? = nil,
+        keyPreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil,
+        isTruncated: Bool = false
+    ) {
+        self.variableCount = variableCount
+        self.exportedVariableCount = exportedVariableCount
+        self.keyPreviewLabel = keyPreviewLabel
+        self.keyPreviewLabels = keyPreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+        self.isTruncated = isTruncated
+    }
+}
+
 public struct ToolArtifactYAMLPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var rootLabel: String
@@ -763,6 +803,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var iniPreview: ToolArtifactINIPreview? {
         ToolArtifactINIPreviewBuilder.iniPreview(for: value, kind: kind)
+    }
+    public var dotenvPreview: ToolArtifactDotenvPreview? {
+        ToolArtifactDotenvPreviewBuilder.dotenvPreview(for: value, kind: kind)
     }
     public var yamlPreview: ToolArtifactYAMLPreview? {
         ToolArtifactYAMLPreviewBuilder.yamlPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -25,6 +25,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         } else {
             filename = URL(fileURLWithPath: value).lastPathComponent.lowercased()
         }
+        if filename == ".env" || filename.hasPrefix(".env.") {
+            return "env"
+        }
         for compoundExtension in compoundPreviewExtensions {
             if filename.hasSuffix(".\(compoundExtension.suffix)") {
                 return compoundExtension.previewExtension
@@ -51,6 +54,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "ndjson": .data,
         "cfg": .data,
         "conf": .data,
+        "env": .data,
         "ini": .data,
         "toml": .data,
         "yaml": .data,

--- a/Sources/QuillCodeApp/ToolArtifactDotenvPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDotenvPreviewBuilder.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+enum ToolArtifactDotenvPreviewBuilder {
+    static func dotenvPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactDotenvPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "env",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8),
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                return nil
+            }
+            let preview = preview(from: text, fileSize: fileSize)
+            return preview.variableCount > 0 && preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from text: String, fileSize: Int) -> ToolArtifactDotenvPreview {
+        var keys: [String] = []
+        var seenKeys = Set<String>()
+        var variableCount = 0
+        var exportedVariableCount = 0
+        var processedLines = 0
+        var isTruncated = false
+
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            processedLines += 1
+            if processedLines > lineLimit {
+                isTruncated = true
+                break
+            }
+            guard let assignment = assignment(from: String(rawLine)) else { continue }
+            variableCount += 1
+            if assignment.isExported {
+                exportedVariableCount += 1
+            }
+            if seenKeys.insert(assignment.key).inserted {
+                keys.append(assignment.key)
+            }
+        }
+
+        let previewLabels = previewLabels(for: keys)
+        return ToolArtifactDotenvPreview(
+            variableCount: variableCount,
+            exportedVariableCount: exportedVariableCount,
+            keyPreviewLabel: previewLabel(for: keys),
+            keyPreviewLabels: previewLabels,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            isTruncated: isTruncated
+        )
+    }
+
+    private static func assignment(from rawLine: String) -> (key: String, isExported: Bool)? {
+        var line = rawLine.trimmingCharacters(in: .whitespaces)
+        guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
+
+        var isExported = false
+        if line.hasPrefix("export ") {
+            isExported = true
+            line = line.dropFirst("export ".count).trimmingCharacters(in: .whitespaces)
+        }
+
+        guard let delimiterIndex = line.firstIndex(of: "=") else { return nil }
+        let rawKey = line[..<delimiterIndex].trimmingCharacters(in: .whitespaces)
+        guard isValidKey(rawKey) else { return nil }
+        return (String(rawKey.prefix(keyCharacterLimit)), isExported)
+    }
+
+    private static func isValidKey(_ key: String) -> Bool {
+        guard let first = key.first,
+              first == "_" || first.isLetter
+        else {
+            return false
+        }
+        return key.allSatisfy { character in
+            character == "_" || character.isLetter || character.isNumber
+        }
+    }
+
+    private static func previewLabel(for keys: [String]) -> String? {
+        let visibleKeys = previewLabels(for: keys)
+        guard !visibleKeys.isEmpty else { return nil }
+        let remainder = keys.count - visibleKeys.count
+        return ([visibleKeys.joined(separator: ", ")] + (remainder > 0 ? ["+\(remainder) more"] : []))
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+    }
+
+    private static func previewLabels(for keys: [String]) -> [String] {
+        Array(keys.prefix(keyPreviewLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 64 * 1_024
+    private static let lineLimit = 2_000
+    private static let keyPreviewLimit = 8
+    private static let keyCharacterLimit = 80
+}

--- a/Sources/QuillCodeApp/ToolArtifactTextPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactTextPreviewBuilder.swift
@@ -6,6 +6,7 @@ enum ToolArtifactTextPreviewBuilder {
         guard artifact.kind == .file,
               !artifact.isImagePreview,
               artifact.documentPreview?.kind != .appshot,
+              artifact.documentPreview?.extensionLabel.lowercased() != "env",
               artifact.tablePreview == nil
         else { return nil }
         guard let fileURL = localArtifactFileURL(for: value) else { return nil }
@@ -69,7 +70,6 @@ enum ToolArtifactTextPreviewBuilder {
     private static let byteLimit = 6 * 1024
     private static let lineLimit = 80
     private static let filenames: Set<String> = [
-        ".env.example",
         ".gitignore",
         "dockerfile",
         "gemfile",

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -206,6 +206,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
             let iniPreview = renderINIPreview(artifact.iniPreview)
+            let dotenvPreview = renderDotenvPreview(artifact.dotenvPreview)
             let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
             let xmlPreview = renderXMLPreview(artifact.xmlPreview)
             let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
@@ -229,6 +230,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(jsonLinesPreview)
               \(tomlPreview)
               \(iniPreview)
+              \(dotenvPreview)
               \(yamlPreview)
               \(xmlPreview)
               \(propertyListPreview)
@@ -539,6 +541,31 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(sectionList)
+        </div>
+        """
+    }
+
+    private static func renderDotenvPreview(_ preview: ToolArtifactDotenvPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-dotenv-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let keys = preview.keyPreviewLabels.map {
+            #"<li data-testid="tool-card-dotenv-preview-key-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let keyList = keys.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-dotenv-preview-keys">
+                <strong data-testid="tool-card-dotenv-preview-key-title">Variable names</strong>
+                <ul>\(keys)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !keyList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-dotenv-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(keyList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -417,6 +417,50 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteINI.iniPreview)
     }
 
+    func testArtifactStateDerivesDotenvPreviewMetadataWithoutValues() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let dotenv = directory.appendingPathComponent(".env.local")
+        let dotenvText = """
+        # Local development settings
+        TRUSTEDROUTER_API_KEY=sk-secret-value
+        QUILLCODE_MODEL=trustedrouter/fast
+        export QUILLCODE_DEBUG=true
+        EMPTY_VALUE=
+        INVALID-NAME=ignored
+        """
+        try dotenvText.write(to: dotenv, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: dotenv.path)
+        let preview = try XCTUnwrap(artifact.dotenvPreview)
+        let byteCount = try XCTUnwrap(dotenvText.data(using: .utf8)?.count)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "ENV")
+        XCTAssertEqual(preview.variableCount, 4)
+        XCTAssertEqual(preview.exportedVariableCount, 1)
+        XCTAssertEqual(preview.keyPreviewLabels, [
+            "TRUSTEDROUTER_API_KEY",
+            "QUILLCODE_MODEL",
+            "QUILLCODE_DEBUG",
+            "EMPTY_VALUE"
+        ])
+        XCTAssertEqual(preview.keyPreviewLabel, "TRUSTEDROUTER_API_KEY, QUILLCODE_MODEL, QUILLCODE_DEBUG, EMPTY_VALUE")
+        XCTAssertEqual(preview.byteSizeLabel, "\(byteCount) bytes")
+        XCTAssertFalse(preview.isTruncated)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: DOTENV",
+            "4 variables",
+            "1 exported",
+            "Keys: TRUSTEDROUTER_API_KEY, QUILLCODE_MODEL, QUILLCODE_DEBUG, EMPTY_VALUE",
+            "Size: \(byteCount) bytes"
+        ])
+        XCTAssertNil(preview.metadataLines.first { $0.contains("sk-secret-value") })
+        XCTAssertNil(artifact.iniPreview)
+
+        let remoteDotenv = ToolArtifactState(value: "https://example.com/.env")
+        XCTAssertNil(remoteDotenv.dotenvPreview)
+    }
+
     func testArtifactStateDerivesYAMLPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let workflow = directory.appendingPathComponent("ci.yml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -795,6 +795,52 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-ini-preview-section-item">tools"#))
     }
 
+    func testHTMLRendererIncludesDotenvArtifactPreviewWithoutValues() throws {
+        let root = try makeTempDirectory()
+        let dotenv = root.appendingPathComponent(".env")
+        try """
+        TRUSTEDROUTER_API_KEY=sk-secret-value
+        QUILLCODE_MODEL=trustedrouter/fast
+        export QUILLCODE_DEBUG=true
+        EMPTY_VALUE=
+        """.write(to: dotenv, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":".env"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote .env\n", artifacts: [dotenv.path])
+        let thread = ChatThread(
+            title: "Dotenv artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · ENV"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">.env"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-dotenv-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-dotenv-preview-meta">Format: DOTENV"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-dotenv-preview-meta">4 variables"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-dotenv-preview-meta">1 exported"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-dotenv-preview-key-title">Variable names"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-dotenv-preview-key-item">TRUSTEDROUTER_API_KEY"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-dotenv-preview-key-item">QUILLCODE_MODEL"#))
+        XCTAssertFalse(html.contains("sk-secret-value"))
+    }
+
     func testHTMLRendererIncludesYAMLArtifactPreview() throws {
         let root = try makeTempDirectory()
         let workflows = root

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -68,6 +68,9 @@
   root element, element/attribute/namespace counts, file size, and capped root-child previews.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
+- Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:
+  variable/export counts, file size, truncation state, and capped variable-name previews without
+  rendering raw dotenv values in artifact cards.
 - The app server exposes Codex-compatible response-first `thread/compact/start`.
 - The app server exposes Codex-compatible one-shot and live-session fuzzy file search with bounded
   shared indexing, exact wire fields, match scores/indices, cancellation, and disconnect cleanup.


### PR DESCRIPTION
## Summary
- classify .env and .env.* artifacts as Data/ENV documents
- add bounded dotenv metadata previews with variable/export counts and key-name previews only
- suppress raw text previews for dotenv-classified files so secret values are not rendered in tool cards
- mirror the behavior in the Playwright harness and parity docs

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesDotenvPreviewMetadataWithoutValues
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesDotenvArtifactPreviewWithoutValues
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactTextPreviewBuilderReadsLocalTextFilesOnly
- swift test --filter ParityWorkspaceToolCardModelGateTests
- swift test --filter ParityHTMLToolCardRendererGateTests
- npm test -- artifacts.spec.ts
- git diff --check