### PR TITLE
feat(artifacts): preview 7z and rar containers

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -9623,6 +9623,8 @@
       const extension = artifactPreviewExtension(value);
       if (![
         'zip',
+        '7z',
+        'rar',
         'tar',
         'gz',
         'tar.gz',
@@ -9640,6 +9642,9 @@
       ].includes(extension)) return null;
       const path = artifactFilePath(value);
       const packageInfo = path ? state.mockOfficePackages[path] : null;
+      if (['7z', 'rar'].includes(extension)) {
+        return artifactContainerOnlyPreview(path, packageInfo, extension);
+      }
       if (['gz', 'tar.gz', 'tgz'].includes(extension)) {
         return artifactGzipPreview(path, packageInfo, extension);
       }
@@ -9678,6 +9683,26 @@
           ? `${preview.topLevelCount} top-level item${preview.topLevelCount === 1 ? '' : 's'}`
           : null,
         preview.entryPreviewLabel ? `Entries: ${preview.entryPreviewLabel}` : null,
+        preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
+      ].filter(Boolean);
+      return preview.metadataLines.length ? preview : null;
+    }
+
+    function artifactContainerOnlyPreview(path, packageInfo, extension) {
+      if (!packageInfo || packageInfo.format !== extension) return null;
+      const byteSize = Number.isFinite(packageInfo.sizeBytes)
+        ? packageInfo.sizeBytes
+        : (state.mockFiles[path] || '').length;
+      const preview = {
+        formatLabel: extension === '7z' ? '7Z' : extension.toUpperCase(),
+        entryCount: null,
+        topLevelCount: null,
+        entryPreviewLabel: null,
+        entryPreviewLabels: [],
+        byteSizeLabel: byteSizeLabel(byteSize)
+      };
+      preview.metadataLines = [
+        `Format: ${preview.formatLabel}`,
         preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
       ].filter(Boolean);
       return preview.metadataLines.length ? preview : null;
@@ -24674,6 +24699,8 @@
         addMessage('assistant', 'Created media artifacts.');
       } else if (text.toLowerCase().includes('archive') && text.toLowerCase().includes('artifact')) {
         const zipPath = '/mock/QuillCode/packages/source.zip';
+        const sevenZipPath = '/mock/QuillCode/packages/sources.7z';
+        const rarPath = '/mock/QuillCode/packages/sources.rar';
         const tarPath = '/mock/QuillCode/packages/sources.tar';
         const gzipPath = '/mock/QuillCode/packages/report.txt.gz';
         const tarGzPath = '/mock/QuillCode/packages/logs.tar.gz';
@@ -24684,6 +24711,8 @@
         const zstdPath = '/mock/QuillCode/packages/report.txt.zst';
         const tarZstdPath = '/mock/QuillCode/packages/logs.tar.zst';
         state.mockFiles[zipPath] = 'PK\u0003\u0004';
+        state.mockFiles[sevenZipPath] = '7z\u00bc\u00af\u0027\u001c';
+        state.mockFiles[rarPath] = 'Rar!\u001a\u0007\u0001\u0000';
         state.mockFiles[tarPath] = 'ustar';
         state.mockFiles[gzipPath] = '\u001f\u008b\u0008\u0008';
         state.mockFiles[tarGzPath] = '\u001f\u008b\u0008\u0008';
@@ -24696,6 +24725,14 @@
         state.mockOfficePackages[zipPath] = {
           fileNames: ['Sources/App.swift', 'Sources/Model.swift', 'Tests/AppTests.swift', 'README.md'],
           sizeBytes: 4096
+        };
+        state.mockOfficePackages[sevenZipPath] = {
+          format: '7z',
+          sizeBytes: 72
+        };
+        state.mockOfficePackages[rarPath] = {
+          format: 'rar',
+          sizeBytes: 80
         };
         state.mockOfficePackages[tarPath] = {
           fileNames: ['Sources/App.swift', 'Sources/Model.swift', 'Tests/AppTests.swift'],
@@ -24751,11 +24788,13 @@
           outputJSON: JSON.stringify({
             ok: true,
             stdout: [
-              `Wrote ${zipPath}, ${tarPath}, ${gzipPath}, ${tarGzPath}, ${xzPath}, ${tarXzPath},`,
+              `Wrote ${zipPath}, ${sevenZipPath}, ${rarPath}, ${tarPath}, ${gzipPath}, ${tarGzPath}, ${xzPath}, ${tarXzPath},`,
               `${bzipPath}, ${tarBzipPath}, ${zstdPath}, and ${tarZstdPath}\n`
             ].join(' '),
             artifacts: [
               zipPath,
+              sevenZipPath,
+              rarPath,
               tarPath,
               gzipPath,
               tarGzPath,

--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -786,6 +786,8 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
   await expect(page.getByTestId('tool-card-title')).toHaveText('host.file.write');
   await expect(page.getByTestId('tool-card-artifact-label')).toHaveText([
     'source.zip',
+    'sources.7z',
+    'sources.rar',
     'sources.tar',
     'report.txt.gz',
     'logs.tar.gz',
@@ -797,12 +799,14 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     'logs.tar.zst'
   ]);
   await expect(page.getByTestId('tool-card-document-previews')).toBeVisible();
-  await expect(page.getByTestId('tool-card-document-preview')).toHaveCount(10);
-  for (let index = 0; index < 10; index += 1) {
+  await expect(page.getByTestId('tool-card-document-preview')).toHaveCount(12);
+  for (let index = 0; index < 12; index += 1) {
     await expect(page.getByTestId('tool-card-document-preview').nth(index)).toHaveAttribute('data-kind', 'archive');
   }
   await expect(page.getByTestId('tool-card-document-preview-type')).toHaveText([
     'Archive · ZIP',
+    'Archive · 7Z',
+    'Archive · RAR',
     'Archive · TAR',
     'Archive · GZ',
     'Archive · TAR.GZ',
@@ -815,6 +819,8 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
   ]);
   await expect(page.getByTestId('tool-card-document-preview-label')).toHaveText([
     'source.zip',
+    'sources.7z',
+    'sources.rar',
     'sources.tar',
     'report.txt.gz',
     'logs.tar.gz',
@@ -835,15 +841,21 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     '/mock/QuillCode/packages',
     '/mock/QuillCode/packages',
     '/mock/QuillCode/packages',
+    '/mock/QuillCode/packages',
+    '/mock/QuillCode/packages',
     '/mock/QuillCode/packages'
   ]);
-  await expect(page.getByTestId('tool-card-archive-preview')).toHaveCount(10);
+  await expect(page.getByTestId('tool-card-archive-preview')).toHaveCount(12);
   await expect(page.getByTestId('tool-card-archive-preview-meta')).toHaveText([
     'Format: ZIP',
     '4 entries',
     '3 top-level items',
     'Entries: Sources/App.swift, Sources/Model.swift, Tests/AppTests.swift, +1 more',
     'Size: 4 KB',
+    'Format: 7Z',
+    'Size: 72 bytes',
+    'Format: RAR',
+    'Size: 80 bytes',
     'Format: TAR',
     '3 entries',
     '2 top-level items',
@@ -918,37 +930,45 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(1)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/sources.tar'
+    'file:///mock/QuillCode/packages/sources.7z'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(2)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.gz'
+    'file:///mock/QuillCode/packages/sources.rar'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(3)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/logs.tar.gz'
+    'file:///mock/QuillCode/packages/sources.tar'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(4)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.xz'
+    'file:///mock/QuillCode/packages/report.txt.gz'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(5)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/logs.tar.xz'
+    'file:///mock/QuillCode/packages/logs.tar.gz'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(6)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.bz2'
+    'file:///mock/QuillCode/packages/report.txt.xz'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(7)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/logs.tar.bz2'
+    'file:///mock/QuillCode/packages/logs.tar.xz'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(8)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.zst'
+    'file:///mock/QuillCode/packages/report.txt.bz2'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(9)).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/packages/logs.tar.bz2'
+  );
+  await expect(page.getByTestId('tool-card-document-preview-open').nth(10)).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/packages/report.txt.zst'
+  );
+  await expect(page.getByTestId('tool-card-document-preview-open').nth(11)).toHaveAttribute(
     'href',
     'file:///mock/QuillCode/packages/logs.tar.zst'
   );

--- a/Sources/QuillCodeApp/ToolArtifactArchivePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactArchivePreviewBuilder.swift
@@ -20,6 +20,26 @@ enum ToolArtifactArchivePreviewBuilder {
             switch documentPreview.extensionLabel.lowercased() {
             case "zip":
                 preview = try zipPreview(from: fileURL, fileSize: fileSize)
+            case "7z":
+                preview = try magicOnlyPreview(
+                    from: fileURL,
+                    fileSize: fileSize,
+                    formatLabel: "7Z",
+                    memberName: nil,
+                    includesSingleMemberCounts: false,
+                    minimumSize: sevenZipMagic.count,
+                    magicValidator: hasSevenZipMagic
+                )
+            case "rar":
+                preview = try magicOnlyPreview(
+                    from: fileURL,
+                    fileSize: fileSize,
+                    formatLabel: "RAR",
+                    memberName: nil,
+                    includesSingleMemberCounts: false,
+                    minimumSize: rarMinimumSize,
+                    magicValidator: hasRarMagic
+                )
             case "tar":
                 preview = try tarPreview(from: fileURL, fileSize: fileSize)
             case "gz":
@@ -386,6 +406,18 @@ enum ToolArtifactArchivePreviewBuilder {
         data.count >= zstandardMagic.count && Array(data.prefix(zstandardMagic.count)) == zstandardMagic
     }
 
+    private static func hasSevenZipMagic(_ data: Data) -> Bool {
+        data.count >= sevenZipMagic.count && Array(data.prefix(sevenZipMagic.count)) == sevenZipMagic
+    }
+
+    private static func hasRarMagic(_ data: Data) -> Bool {
+        guard data.count >= rarV4Magic.count else { return false }
+        if Array(data.prefix(rarV4Magic.count)) == rarV4Magic {
+            return true
+        }
+        return data.count >= rarV5Magic.count && Array(data.prefix(rarV5Magic.count)) == rarV5Magic
+    }
+
     private static func gzipLittleEndianUInt32(_ data: Data) -> UInt32 {
         UInt32(data[0])
             | (UInt32(data[1]) << 8)
@@ -465,6 +497,10 @@ enum ToolArtifactArchivePreviewBuilder {
     private static let gzipOriginalNameFlag: UInt8 = 0x08
     private static let gzipReservedFlags: UInt8 = 0xe0
     private static let bzip2MinimumSize = 4
+    private static let sevenZipMagic: [UInt8] = [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]
+    private static let rarV4Magic: [UInt8] = [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x00]
+    private static let rarV5Magic: [UInt8] = [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x01, 0x00]
+    private static let rarMinimumSize = rarV5Magic.count
     private static let xzHeaderMagic: [UInt8] = [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00]
     private static let xzFooterMagic: [UInt8] = [0x59, 0x5a]
     private static let xzMinimumSize = 12

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -901,6 +901,40 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
             "Size: \(byteSize)"
         ])
 
+        let sevenZipArchive = directory.appendingPathComponent("sources.7z")
+        let sevenZipBytes = Data([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x04, 0x00, 0x00])
+        try sevenZipBytes.write(to: sevenZipArchive)
+        let sevenZipByteSize = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: sevenZipBytes.count))
+
+        let sevenZipPreview = try XCTUnwrap(ToolArtifactState(value: sevenZipArchive.path).archivePreview)
+        XCTAssertEqual(sevenZipPreview.formatLabel, "7Z")
+        XCTAssertNil(sevenZipPreview.entryCount)
+        XCTAssertNil(sevenZipPreview.topLevelCount)
+        XCTAssertNil(sevenZipPreview.entryPreviewLabel)
+        XCTAssertTrue(sevenZipPreview.entryPreviewLabels.isEmpty)
+        XCTAssertEqual(sevenZipPreview.byteSizeLabel, sevenZipByteSize)
+        XCTAssertEqual(sevenZipPreview.metadataLines, [
+            "Format: 7Z",
+            "Size: \(sevenZipByteSize)"
+        ])
+
+        let rarArchive = directory.appendingPathComponent("sources.rar")
+        let rarBytes = Data([0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x01, 0x00, 0x00, 0x00])
+        try rarBytes.write(to: rarArchive)
+        let rarByteSize = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: rarBytes.count))
+
+        let rarPreview = try XCTUnwrap(ToolArtifactState(value: rarArchive.path).archivePreview)
+        XCTAssertEqual(rarPreview.formatLabel, "RAR")
+        XCTAssertNil(rarPreview.entryCount)
+        XCTAssertNil(rarPreview.topLevelCount)
+        XCTAssertNil(rarPreview.entryPreviewLabel)
+        XCTAssertTrue(rarPreview.entryPreviewLabels.isEmpty)
+        XCTAssertEqual(rarPreview.byteSizeLabel, rarByteSize)
+        XCTAssertEqual(rarPreview.metadataLines, [
+            "Format: RAR",
+            "Size: \(rarByteSize)"
+        ])
+
         let tarArchive = directory.appendingPathComponent("sources.tar")
         let tarBytes = TarArchiveFixture.tarArchive(entries: [
             ("Sources/App.swift", Data("print(\"hi\")".utf8)),

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -83,6 +83,9 @@
   EditorConfig, Prettier config, CMake, Justfile, Taskfile, Bazel BUILD/WORKSPACE, Nix, Meson,
   Homebrew, Procfile, pnpm, and Yarn files with specific labels in SwiftUI and the Playwright
   harness.
+- Archive artifact previews now include bounded local 7z/RAR container cards by validating
+  signature bytes and rendering truthful format/size metadata without extraction or synthetic
+  entry listings.
 - The app server exposes Codex-compatible response-first `thread/compact/start`.
 - The app server exposes Codex-compatible one-shot and live-session fuzzy file search with bounded
   shared indexing, exact wire fields, match scores/indices, cancellation, and disconnect cleanup.


### PR DESCRIPTION
## Summary
- add bounded 7z and RAR archive metadata previews after validating signature bytes
- mirror archive preview support in the Playwright harness
- document the parity note for non-extracting archive container cards

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesArchivePreviewMetadata
- npm test -- artifacts.spec.ts --grep "archive artifact"
- npm test -- artifacts.spec.ts
- git diff --check