### PR TITLE
feat(artifacts): preview more zip containers

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8706,9 +8706,11 @@
       ['apk', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['bz2', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['ear', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
+      ['epub', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['gz', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['ipa', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['jar', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
+      ['nupkg', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['rar', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['tar', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['tar.bz2', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
@@ -8720,8 +8722,11 @@
       ['tgz', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['tzst', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['txz', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
+      ['vsix', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['war', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
+      ['whl', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['xz', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
+      ['xpi', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['zip', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }],
       ['zst', { kind: 'archive', typeLabel: 'Archive', icon: 'ARC' }]
     ]);
@@ -9633,6 +9638,11 @@
         'ear',
         'apk',
         'ipa',
+        'epub',
+        'whl',
+        'vsix',
+        'xpi',
+        'nupkg',
         '7z',
         'rar',
         'tar',
@@ -24718,6 +24728,11 @@
         const earPath = '/mock/QuillCode/packages/suite.ear';
         const apkPath = '/mock/QuillCode/packages/mobile.apk';
         const ipaPath = '/mock/QuillCode/packages/ios.ipa';
+        const epubPath = '/mock/QuillCode/packages/manual.epub';
+        const wheelPath = '/mock/QuillCode/packages/quillcode-1.0.0-py3-none-any.whl';
+        const vsixPath = '/mock/QuillCode/packages/quillcode.vsix';
+        const xpiPath = '/mock/QuillCode/packages/quillcode.xpi';
+        const nupkgPath = '/mock/QuillCode/packages/QuillCode.1.0.0.nupkg';
         const sevenZipPath = '/mock/QuillCode/packages/sources.7z';
         const rarPath = '/mock/QuillCode/packages/sources.rar';
         const tarPath = '/mock/QuillCode/packages/sources.tar';
@@ -24735,6 +24750,11 @@
         state.mockFiles[earPath] = 'PK\u0003\u0004';
         state.mockFiles[apkPath] = 'PK\u0003\u0004';
         state.mockFiles[ipaPath] = 'PK\u0003\u0004';
+        state.mockFiles[epubPath] = 'PK\u0003\u0004';
+        state.mockFiles[wheelPath] = 'PK\u0003\u0004';
+        state.mockFiles[vsixPath] = 'PK\u0003\u0004';
+        state.mockFiles[xpiPath] = 'PK\u0003\u0004';
+        state.mockFiles[nupkgPath] = 'PK\u0003\u0004';
         state.mockFiles[sevenZipPath] = '7z\u00bc\u00af\u0027\u001c';
         state.mockFiles[rarPath] = 'Rar!\u001a\u0007\u0001\u0000';
         state.mockFiles[tarPath] = 'ustar';
@@ -24770,6 +24790,26 @@
         state.mockOfficePackages[ipaPath] = {
           fileNames: packageArchiveEntries,
           sizeBytes: 7168
+        };
+        state.mockOfficePackages[epubPath] = {
+          fileNames: packageArchiveEntries,
+          sizeBytes: 8192
+        };
+        state.mockOfficePackages[wheelPath] = {
+          fileNames: packageArchiveEntries,
+          sizeBytes: 9216
+        };
+        state.mockOfficePackages[vsixPath] = {
+          fileNames: packageArchiveEntries,
+          sizeBytes: 10240
+        };
+        state.mockOfficePackages[xpiPath] = {
+          fileNames: packageArchiveEntries,
+          sizeBytes: 11264
+        };
+        state.mockOfficePackages[nupkgPath] = {
+          fileNames: packageArchiveEntries,
+          sizeBytes: 12288
         };
         state.mockOfficePackages[sevenZipPath] = {
           format: '7z',
@@ -24833,7 +24873,8 @@
           outputJSON: JSON.stringify({
             ok: true,
             stdout: [
-              `Wrote ${zipPath}, ${jarPath}, ${warPath}, ${earPath}, ${apkPath}, ${ipaPath}, ${sevenZipPath},`,
+              `Wrote ${zipPath}, ${jarPath}, ${warPath}, ${earPath}, ${apkPath}, ${ipaPath}, ${epubPath},`,
+              `${wheelPath}, ${vsixPath}, ${xpiPath}, ${nupkgPath}, ${sevenZipPath},`,
               `${rarPath}, ${tarPath}, ${gzipPath}, ${tarGzPath}, ${xzPath}, ${tarXzPath},`,
               `${bzipPath}, ${tarBzipPath}, ${zstdPath}, and ${tarZstdPath}\n`
             ].join(' '),
@@ -24844,6 +24885,11 @@
               earPath,
               apkPath,
               ipaPath,
+              epubPath,
+              wheelPath,
+              vsixPath,
+              xpiPath,
+              nupkgPath,
               sevenZipPath,
               rarPath,
               tarPath,

--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -791,6 +791,11 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     'suite.ear',
     'mobile.apk',
     'ios.ipa',
+    'manual.epub',
+    'quillcode-1.0.0-py3-none-any.whl',
+    'quillcode.vsix',
+    'quillcode.xpi',
+    'QuillCode.1.0.0.nupkg',
     'sources.7z',
     'sources.rar',
     'sources.tar',
@@ -804,8 +809,8 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     'logs.tar.zst'
   ]);
   await expect(page.getByTestId('tool-card-document-previews')).toBeVisible();
-  await expect(page.getByTestId('tool-card-document-preview')).toHaveCount(17);
-  for (let index = 0; index < 17; index += 1) {
+  await expect(page.getByTestId('tool-card-document-preview')).toHaveCount(22);
+  for (let index = 0; index < 22; index += 1) {
     await expect(page.getByTestId('tool-card-document-preview').nth(index)).toHaveAttribute('data-kind', 'archive');
   }
   await expect(page.getByTestId('tool-card-document-preview-type')).toHaveText([
@@ -815,6 +820,11 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     'Archive · EAR',
     'Archive · APK',
     'Archive · IPA',
+    'Archive · EPUB',
+    'Archive · WHL',
+    'Archive · VSIX',
+    'Archive · XPI',
+    'Archive · NUPKG',
     'Archive · 7Z',
     'Archive · RAR',
     'Archive · TAR',
@@ -834,6 +844,11 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     'suite.ear',
     'mobile.apk',
     'ios.ipa',
+    'manual.epub',
+    'quillcode-1.0.0-py3-none-any.whl',
+    'quillcode.vsix',
+    'quillcode.xpi',
+    'QuillCode.1.0.0.nupkg',
     'sources.7z',
     'sources.rar',
     'sources.tar',
@@ -863,9 +878,14 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     '/mock/QuillCode/packages',
     '/mock/QuillCode/packages',
     '/mock/QuillCode/packages',
+    '/mock/QuillCode/packages',
+    '/mock/QuillCode/packages',
+    '/mock/QuillCode/packages',
+    '/mock/QuillCode/packages',
+    '/mock/QuillCode/packages',
     '/mock/QuillCode/packages'
   ]);
-  await expect(page.getByTestId('tool-card-archive-preview')).toHaveCount(17);
+  await expect(page.getByTestId('tool-card-archive-preview')).toHaveCount(22);
   await expect(page.getByTestId('tool-card-archive-preview-meta')).toHaveText([
     'Format: ZIP',
     '4 entries',
@@ -897,6 +917,31 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     '3 top-level items',
     'Entries: META-INF/MANIFEST.MF, com/example/App.class, assets/config.json',
     'Size: 7 KB',
+    'Format: EPUB',
+    '3 entries',
+    '3 top-level items',
+    'Entries: META-INF/MANIFEST.MF, com/example/App.class, assets/config.json',
+    'Size: 8 KB',
+    'Format: WHL',
+    '3 entries',
+    '3 top-level items',
+    'Entries: META-INF/MANIFEST.MF, com/example/App.class, assets/config.json',
+    'Size: 9 KB',
+    'Format: VSIX',
+    '3 entries',
+    '3 top-level items',
+    'Entries: META-INF/MANIFEST.MF, com/example/App.class, assets/config.json',
+    'Size: 10 KB',
+    'Format: XPI',
+    '3 entries',
+    '3 top-level items',
+    'Entries: META-INF/MANIFEST.MF, com/example/App.class, assets/config.json',
+    'Size: 11 KB',
+    'Format: NUPKG',
+    '3 entries',
+    '3 top-level items',
+    'Entries: META-INF/MANIFEST.MF, com/example/App.class, assets/config.json',
+    'Size: 12 KB',
     'Format: 7Z',
     'Size: 72 bytes',
     'Format: RAR',
@@ -956,12 +1001,32 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
     'Contents',
     'Contents',
     'Contents',
+    'Contents',
+    'Contents',
+    'Contents',
+    'Contents',
+    'Contents',
     'Contents'
   ]);
   await expect(page.getByTestId('tool-card-archive-preview-entry-item')).toHaveText([
     'Sources/App.swift',
     'Sources/Model.swift',
     'Tests/AppTests.swift',
+    'META-INF/MANIFEST.MF',
+    'com/example/App.class',
+    'assets/config.json',
+    'META-INF/MANIFEST.MF',
+    'com/example/App.class',
+    'assets/config.json',
+    'META-INF/MANIFEST.MF',
+    'com/example/App.class',
+    'assets/config.json',
+    'META-INF/MANIFEST.MF',
+    'com/example/App.class',
+    'assets/config.json',
+    'META-INF/MANIFEST.MF',
+    'com/example/App.class',
+    'assets/config.json',
     'META-INF/MANIFEST.MF',
     'com/example/App.class',
     'assets/config.json',
@@ -1015,45 +1080,65 @@ test('mock harness renders archive artifact previews from tool cards', async ({ 
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(6)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/sources.7z'
+    'file:///mock/QuillCode/packages/manual.epub'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(7)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/sources.rar'
+    'file:///mock/QuillCode/packages/quillcode-1.0.0-py3-none-any.whl'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(8)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/sources.tar'
+    'file:///mock/QuillCode/packages/quillcode.vsix'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(9)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.gz'
+    'file:///mock/QuillCode/packages/quillcode.xpi'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(10)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/logs.tar.gz'
+    'file:///mock/QuillCode/packages/QuillCode.1.0.0.nupkg'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(11)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.xz'
+    'file:///mock/QuillCode/packages/sources.7z'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(12)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/logs.tar.xz'
+    'file:///mock/QuillCode/packages/sources.rar'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(13)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.bz2'
+    'file:///mock/QuillCode/packages/sources.tar'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(14)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/logs.tar.bz2'
+    'file:///mock/QuillCode/packages/report.txt.gz'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(15)).toHaveAttribute(
     'href',
-    'file:///mock/QuillCode/packages/report.txt.zst'
+    'file:///mock/QuillCode/packages/logs.tar.gz'
   );
   await expect(page.getByTestId('tool-card-document-preview-open').nth(16)).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/packages/report.txt.xz'
+  );
+  await expect(page.getByTestId('tool-card-document-preview-open').nth(17)).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/packages/logs.tar.xz'
+  );
+  await expect(page.getByTestId('tool-card-document-preview-open').nth(18)).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/packages/report.txt.bz2'
+  );
+  await expect(page.getByTestId('tool-card-document-preview-open').nth(19)).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/packages/logs.tar.bz2'
+  );
+  await expect(page.getByTestId('tool-card-document-preview-open').nth(20)).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/packages/report.txt.zst'
+  );
+  await expect(page.getByTestId('tool-card-document-preview-open').nth(21)).toHaveAttribute(
     'href',
     'file:///mock/QuillCode/packages/logs.tar.zst'
   );

--- a/Sources/QuillCodeApp/ToolArtifactArchivePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactArchivePreviewBuilder.swift
@@ -20,7 +20,7 @@ enum ToolArtifactArchivePreviewBuilder {
             switch documentPreview.extensionLabel.lowercased() {
             case "zip":
                 preview = try zipPreview(from: fileURL, fileSize: fileSize, formatLabel: "ZIP")
-            case "jar", "war", "ear", "apk", "ipa":
+            case "jar", "war", "ear", "apk", "ipa", "epub", "whl", "vsix", "xpi", "nupkg":
                 preview = try zipPreview(
                     from: fileURL,
                     fileSize: fileSize,

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -98,9 +98,11 @@ enum ToolArtifactDocumentPreviewBuilder {
         "apk": .archive,
         "bz2": .archive,
         "ear": .archive,
+        "epub": .archive,
         "gz": .archive,
         "ipa": .archive,
         "jar": .archive,
+        "nupkg": .archive,
         "rar": .archive,
         "tar": .archive,
         "tar.bz2": .archive,
@@ -112,8 +114,11 @@ enum ToolArtifactDocumentPreviewBuilder {
         "tgz": .archive,
         "tzst": .archive,
         "txz": .archive,
+        "vsix": .archive,
         "war": .archive,
+        "whl": .archive,
         "xz": .archive,
+        "xpi": .archive,
         "zip": .archive,
         "zst": .archive
     ]

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -911,7 +911,12 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
             ("war", "WAR"),
             ("ear", "EAR"),
             ("apk", "APK"),
-            ("ipa", "IPA")
+            ("ipa", "IPA"),
+            ("epub", "EPUB"),
+            ("whl", "WHL"),
+            ("vsix", "VSIX"),
+            ("xpi", "XPI"),
+            ("nupkg", "NUPKG")
         ] {
             let packageArchive = directory.appendingPathComponent("bundle.\(extensionLabel)")
             let packageBytes = OfficePackageFixture.zipPackage(fileNames: packageEntries)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -87,8 +87,9 @@
   signature bytes and rendering truthful format/size metadata without extraction or synthetic
   entry listings.
 - Archive artifact previews now classify common ZIP-container deliverables (`.jar`, `.war`,
-  `.ear`, `.apk`, and `.ipa`) and reuse the bounded central-directory reader to render exact
-  package-format labels, entry counts, capped contents, and file sizes without extraction.
+  `.ear`, `.apk`, `.ipa`, `.epub`, `.whl`, `.vsix`, `.xpi`, and `.nupkg`) and reuse the bounded
+  central-directory reader to render exact package-format labels, entry counts, capped contents,
+  and file sizes without extraction.
 - The app server exposes Codex-compatible response-first `thread/compact/start`.
 - The app server exposes Codex-compatible one-shot and live-session fuzzy file search with bounded
   shared indexing, exact wire fields, match scores/indices, cancellation, and disconnect cleanup.


### PR DESCRIPTION
## Summary
- classify EPUB, Python wheel, VSIX, XPI, and NuGet package artifacts as archive previews
- reuse the bounded ZIP central-directory preview path for exact package labels, entry counts, capped contents, and sizes
- update the parity matrix and Playwright harness coverage for the expanded archive set

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesArchivePreviewMetadata
- npm test -- artifacts.spec.ts --grep "archive artifact"
- npm test -- artifacts.spec.ts
- git diff --check