### PR TITLE
feat(artifacts): preview webassembly modules

### DIFF
--- a/E2E/harness/index.html
+++ b/E2E/harness/index.html
@@ -8259,6 +8259,7 @@
         xmlPreview: artifactXMLPreview(value, kind, documentPreview),
         propertyListPreview: artifactPropertyListPreview(value, kind, documentPreview),
         sqlitePreview: artifactSQLitePreview(value, kind, documentPreview),
+        webAssemblyPreview: artifactWebAssemblyPreview(value, kind, documentPreview),
         jsonPreview: artifactJSONPreview(value, kind, documentPreview),
         archivePreview: artifactArchivePreview(value, kind, documentPreview),
         mediaPreview: artifactMediaPreview(value, kind, documentPreview),
@@ -8646,6 +8647,16 @@
       return binaryString(bytes);
     }
 
+    function mockWebAssemblyModule(version = 1) {
+      return binaryString([
+        0x00, 0x61, 0x73, 0x6D,
+        version & 0xFF,
+        (version >> 8) & 0xFF,
+        (version >> 16) & 0xFF,
+        (version >> 24) & 0xFF
+      ]);
+    }
+
     function mockTIFFHeader(width, height) {
       return binaryString([
         ...Array.from('II').map(character => character.charCodeAt(0)),
@@ -8694,6 +8705,7 @@
       ['sqlite', { kind: 'data', typeLabel: 'Data', icon: 'DB' }],
       ['sqlite3', { kind: 'data', typeLabel: 'Data', icon: 'DB' }],
       ['toml', { kind: 'data', typeLabel: 'Data', icon: 'TOML' }],
+      ['wasm', { kind: 'data', typeLabel: 'Data', icon: 'WASM' }],
       ['yaml', { kind: 'data', typeLabel: 'Data', icon: 'YAML' }],
       ['yml', { kind: 'data', typeLabel: 'Data', icon: 'YML' }],
       ['xml', { kind: 'data', typeLabel: 'Data', icon: 'XML' }],
@@ -9614,6 +9626,36 @@
         `Format: ${preview.formatLabel}`,
         preview.pageSize ? `Page size: ${preview.pageSize} bytes` : null,
         preview.pageCount ? `${preview.pageCount} page${preview.pageCount === 1 ? '' : 's'}` : null,
+        preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
+      ].filter(Boolean);
+      return preview.metadataLines.length ? preview : null;
+    }
+
+    function artifactWebAssemblyPreview(value, kind, documentPreview) {
+      if (kind !== 'file' || documentPreview?.kind !== 'data') return null;
+      if (artifactPreviewExtension(value) !== 'wasm') return null;
+      const path = artifactFilePath(value);
+      const content = path ? state.mockFiles[path] : null;
+      if (typeof content !== 'string' || content.length < 8) return null;
+      if (content.charCodeAt(0) !== 0x00
+          || content.charCodeAt(1) !== 0x61
+          || content.charCodeAt(2) !== 0x73
+          || content.charCodeAt(3) !== 0x6D) {
+        return null;
+      }
+
+      const version = content.charCodeAt(4)
+        | (content.charCodeAt(5) << 8)
+        | (content.charCodeAt(6) << 16)
+        | (content.charCodeAt(7) << 24);
+      const preview = {
+        formatLabel: 'WebAssembly',
+        version: version >>> 0,
+        byteSizeLabel: byteSizeLabel(content.length)
+      };
+      preview.metadataLines = [
+        `Format: ${preview.formatLabel}`,
+        `Version: ${preview.version}`,
         preview.byteSizeLabel ? `Size: ${preview.byteSizeLabel}` : null
       ].filter(Boolean);
       return preview.metadataLines.length ? preview : null;
@@ -12422,6 +12464,16 @@
                   <div>${metadata}</div>
                 </div>` : '';
         };
+        const renderWebAssemblyPreview = preview => {
+          if (!preview) return '';
+          const metadata = (preview.metadataLines || [])
+            .map(line => `<small data-testid="tool-card-wasm-preview-meta">${escapeHTML(line)}</small>`)
+            .join('');
+          return metadata ? `
+                <div class="artifact-office-preview" data-testid="tool-card-wasm-preview">
+                  <div>${metadata}</div>
+                </div>` : '';
+        };
         const renderMediaPreview = preview => {
           if (!preview) return '';
           const title = preview.title
@@ -12515,6 +12567,7 @@
                 ${renderXMLPreview(artifact.xmlPreview)}
                 ${renderPropertyListPreview(artifact.propertyListPreview)}
                 ${renderSQLitePreview(artifact.sqlitePreview)}
+                ${renderWebAssemblyPreview(artifact.webAssemblyPreview)}
                 ${renderJSONPreview(artifact.jsonPreview)}
                 ${renderAppshotPreview(artifact.appshotPreview)}
                 ${renderArchivePreview(artifact.archivePreview)}
@@ -24638,6 +24691,17 @@
           outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
         });
         addMessage('assistant', 'Created `cache.sqlite3`.');
+      } else if (text.toLowerCase().includes('wasm artifact') || text.toLowerCase().includes('webassembly artifact')) {
+        const path = '/mock/QuillCode/build/module.wasm';
+        state.mockFiles[path] = mockWebAssemblyModule(1);
+        addToolCard({
+          title: 'host.file.write',
+          subtitle: 'Completed',
+          status: 'done',
+          inputJSON: JSON.stringify({ path, contentType: 'application/wasm' }, null, 2),
+          outputJSON: JSON.stringify({ ok: true, stdout: `Wrote ${path}\n`, artifacts: [path] }, null, 2)
+        });
+        addMessage('assistant', 'Created `module.wasm`.');
       } else if (text.toLowerCase().includes('json artifact')) {
         const path = '/mock/QuillCode/reports/build-report.json';
         state.mockFiles[path] = JSON.stringify({

--- a/E2E/playwright/tests/artifacts.spec.ts
+++ b/E2E/playwright/tests/artifacts.spec.ts
@@ -694,6 +694,32 @@ test('mock harness renders SQLite artifact metadata previews from tool cards', a
   await expect(page.getByText('Created `cache.sqlite3`.')).toBeVisible();
 });
 
+test('mock harness renders WebAssembly artifact metadata previews from tool cards', async ({ page }) => {
+  await page.goto(harnessURL());
+
+  await page.getByLabel('Message').fill('make a wasm artifact');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByTestId('tool-card-title')).toHaveText('host.file.write');
+  await expect(page.getByTestId('tool-card-artifact-label')).toHaveText('module.wasm');
+  await expect(page.getByTestId('tool-card-artifact-detail')).toHaveText('/mock/QuillCode/build');
+  await expect(page.getByTestId('tool-card-document-previews')).toBeVisible();
+  await expect(page.getByTestId('tool-card-document-preview')).toHaveAttribute('data-kind', 'data');
+  await expect(page.getByTestId('tool-card-document-preview-type')).toHaveText('Data · WASM');
+  await expect(page.getByTestId('tool-card-document-preview-label')).toHaveText('module.wasm');
+  await expect(page.getByTestId('tool-card-document-preview-open')).toHaveAttribute(
+    'href',
+    'file:///mock/QuillCode/build/module.wasm'
+  );
+  await expect(page.getByTestId('tool-card-wasm-preview')).toBeVisible();
+  await expect(page.getByTestId('tool-card-wasm-preview-meta')).toHaveText([
+    'Format: WebAssembly',
+    'Version: 1',
+    'Size: 8 bytes'
+  ]);
+  await expect(page.getByText('Created `module.wasm`.')).toBeVisible();
+});
+
 test('mock harness renders XML artifact metadata previews from tool cards', async ({ page }) => {
   await page.goto(harnessURL());
 

--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -82,6 +82,11 @@ struct QuillCodeArtifactDocumentPreview: View {
                 title: artifact.label,
                 metadataLines: sqlitePreview.metadataLines
             )
+        } else if let webAssemblyPreview = artifact.webAssemblyPreview {
+            metadataContent(
+                title: artifact.label,
+                metadataLines: webAssemblyPreview.metadataLines
+            )
         } else if let jsonPreview = artifact.jsonPreview {
             jsonContent(jsonPreview)
         } else if let archivePreview = artifact.archivePreview {

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -817,6 +817,34 @@ public struct ToolArtifactSQLitePreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactWebAssemblyPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var version: UInt32?
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            version.map { "Version: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        !metadataLines.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "WebAssembly",
+        version: UInt32? = nil,
+        byteSizeLabel: String? = nil
+    ) {
+        self.formatLabel = formatLabel
+        self.version = version
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactArchivePreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var entryCount: Int?
@@ -1011,6 +1039,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var sqlitePreview: ToolArtifactSQLitePreview? {
         ToolArtifactSQLitePreviewBuilder.sqlitePreview(for: value, kind: kind)
+    }
+    public var webAssemblyPreview: ToolArtifactWebAssemblyPreview? {
+        ToolArtifactWebAssemblyPreviewBuilder.webAssemblyPreview(for: value, kind: kind)
     }
     public var archivePreview: ToolArtifactArchivePreview? {
         ToolArtifactArchivePreviewBuilder.archivePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -63,6 +63,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "sqlite": .data,
         "sqlite3": .data,
         "toml": .data,
+        "wasm": .data,
         "yaml": .data,
         "yml": .data,
         "xml": .data,

--- a/Sources/QuillCodeApp/ToolArtifactWebAssemblyPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactWebAssemblyPreviewBuilder.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum ToolArtifactWebAssemblyPreviewBuilder {
+    static func webAssemblyPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactWebAssemblyPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "wasm",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize >= headerSize else { return nil }
+
+            let handle = try FileHandle(forReadingFrom: fileURL)
+            defer { try? handle.close() }
+            let header = try handle.read(upToCount: headerSize) ?? Data()
+            guard header.count >= headerSize,
+                  header.prefix(wasmMagic.count) == wasmMagic
+            else {
+                return nil
+            }
+
+            return ToolArtifactWebAssemblyPreview(
+                version: wasmVersion(from: header),
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func wasmVersion(from header: Data) -> UInt32? {
+        guard header.count >= headerSize else { return nil }
+        return UInt32(header[4])
+            | UInt32(header[5]) << 8
+            | UInt32(header[6]) << 16
+            | UInt32(header[7]) << 24
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let headerSize = 8
+    private static let wasmMagic = Data([0x00, 0x61, 0x73, 0x6D])
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -220,6 +220,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let xmlPreview = renderXMLPreview(artifact.xmlPreview)
             let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
             let sqlitePreview = renderSQLitePreview(artifact.sqlitePreview)
+            let webAssemblyPreview = renderWebAssemblyPreview(artifact.webAssemblyPreview)
             let jsonPreview = renderJSONPreview(artifact.jsonPreview)
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
             let archivePreview = renderArchivePreview(artifact.archivePreview)
@@ -248,6 +249,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(xmlPreview)
               \(propertyListPreview)
               \(sqlitePreview)
+              \(webAssemblyPreview)
               \(jsonPreview)
               \(appshotPreview)
               \(archivePreview)
@@ -730,6 +732,21 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-sqlite-preview">
+          <div>
+            \(metadata)
+          </div>
+        </div>
+        """
+    }
+
+    private static func renderWebAssemblyPreview(_ preview: ToolArtifactWebAssemblyPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-wasm-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        guard !metadata.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-wasm-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -857,6 +857,50 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         return data
     }
 
+    func testArtifactStateDerivesWebAssemblyPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let module = directory.appendingPathComponent("module.wasm")
+        let bytes = wasmFixture(version: 1)
+        try bytes.write(to: module)
+
+        let artifact = ToolArtifactState(value: module.path)
+        let preview = try XCTUnwrap(artifact.webAssemblyPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "WASM")
+        XCTAssertEqual(preview.formatLabel, "WebAssembly")
+        XCTAssertEqual(preview.version, 1)
+        XCTAssertEqual(preview.byteSizeLabel, ToolArtifactByteSizeFormatter.label(for: bytes.count))
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: WebAssembly",
+            "Version: 1",
+            "Size: \(try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: bytes.count)))"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+        XCTAssertNil(artifact.jsonLinesPreview)
+        XCTAssertNil(artifact.tomlPreview)
+        XCTAssertNil(artifact.yamlPreview)
+        XCTAssertNil(artifact.propertyListPreview)
+        XCTAssertNil(artifact.sqlitePreview)
+
+        let corruptModule = directory.appendingPathComponent("corrupt.wasm")
+        try Data(repeating: 0, count: 8).write(to: corruptModule)
+        XCTAssertNil(ToolArtifactState(value: corruptModule.path).webAssemblyPreview)
+
+        let remoteModule = ToolArtifactState(value: "https://example.com/module.wasm")
+        XCTAssertNil(remoteModule.webAssemblyPreview)
+    }
+
+    private func wasmFixture(version: UInt32) -> Data {
+        Data([
+            0x00, 0x61, 0x73, 0x6D,
+            UInt8(version & 0xFF),
+            UInt8((version >> 8) & 0xFF),
+            UInt8((version >> 16) & 0xFF),
+            UInt8((version >> 24) & 0xFF)
+        ])
+    }
+
     func testArtifactStateDerivesOfficePackagePreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let spreadsheet = directory.appendingPathComponent("budget.xlsx")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -67,6 +67,9 @@
 - Artifact previews now include bounded local SQLite database metadata for `.db`, `.sqlite`, and
   `.sqlite3` files by validating the 100-byte SQLite header and rendering page size, page count,
   and file size without opening tables or shelling out.
+- Artifact previews now include bounded local WebAssembly metadata for `.wasm` files by validating
+  the 8-byte module header and rendering module version plus file size without disassembly or
+  shelling out.
 - Artifact previews now include bounded local XML metadata using native XML parsing:
   root element, element/attribute/namespace counts, file size, and capped root-child previews.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:


### PR DESCRIPTION
## Summary
- classify .wasm artifacts as data previews
- add bounded local WebAssembly header metadata previews for module version and file size
- render WebAssembly metadata in native and HTML tool cards without disassembly or shelling out

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesWebAssemblyPreviewMetadata
- swift test --filter QuillCodeToolCardSurfaceTests
- npm test -- artifacts.spec.ts --grep "WebAssembly artifact"
- npm test -- artifacts.spec.ts
- git diff --check