### PR TITLE
fix(terminal): clamp origin-mode cursor rows

### DIFF
--- a/Sources/QuillCodeTools/TerminalScreenBufferControls.swift
+++ b/Sources/QuillCodeTools/TerminalScreenBufferControls.swift
@@ -133,7 +133,8 @@ extension TerminalScreenBuffer {
 
     func addressedRow(_ target: Int) -> Int {
         guard originMode, let region = boundedScrollRegion() else { return target }
-        return region.top + max(0, target)
+        let relativeTarget = max(0, min(target, region.bottom - region.top))
+        return region.top + relativeTarget
     }
 
     mutating func saveCursor() {

--- a/Tests/QuillCodeParityTests/ParityTerminalRendererGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTerminalRendererGateTests.swift
@@ -112,6 +112,7 @@ final class ParityTerminalRendererGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(testsText.contains("testCSIExplicitScrollUpAndDownUseCurrentRegion"))
         XCTAssertTrue(testsText.contains("testOriginModeAddressesRowsRelativeToScrollRegion"))
         XCTAssertTrue(testsText.contains("testOriginModeResetRestoresAbsoluteAddressing"))
+        XCTAssertTrue(testsText.contains("testOriginModeClampsAddressedRowsToScrollRegion"))
         XCTAssertTrue(testsText.contains("testVerticalPositionAbsoluteHonorsOriginMode"))
         XCTAssertTrue(testsText.contains("testC1CSISequencesShareTheNormalCSIParser"))
         XCTAssertTrue(testsText.contains("testRelativePositionAliasesMoveCursorRightAndDown"))

--- a/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
+++ b/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
@@ -345,6 +345,20 @@ final class TerminalOutputRendererTests: XCTestCase {
         XCTAssertEqual(render(raw), "Xop\nmiddle\nbottom")
     }
 
+    func testOriginModeClampsAddressedRowsToScrollRegion() {
+        let raw = [
+            "top",
+            "middle",
+            "bottom",
+            "footer"
+        ].joined(separator: "\n")
+            + "\u{1B}[2;3r"
+            + "\u{1B}[?6h"
+            + "\u{1B}[99;1HX"
+
+        XCTAssertEqual(render(raw), "top\nmiddle\nXottom\nfooter")
+    }
+
     func testVerticalPositionAbsoluteHonorsOriginMode() {
         let raw = [
             "top",


### PR DESCRIPTION
## Summary
- clamps DEC origin-mode CUP/VPA row addressing inside the active scroll region
- adds a renderer regression test for oversized origin-mode row addresses
- extends the parity gate to keep this edge case covered

## Validation
- swift test --filter TerminalOutputRendererTests
- swift test --filter ParityTerminalRendererGateTests
- git diff --check