### PR TITLE
fix(terminal): home scroll regions with origin mode

### DIFF
--- a/Sources/QuillCodeTools/TerminalScreenBufferScrollRegion.swift
+++ b/Sources/QuillCodeTools/TerminalScreenBufferScrollRegion.swift
@@ -16,7 +16,7 @@ extension TerminalScreenBuffer {
 
         setRow(bottom)
         scrollRegion = (top, bottom)
-        setCursor(row: 0, col: 0)
+        setCursor(row: originMode ? top : 0, col: 0)
     }
 
     mutating func resetScrollRegion() {

--- a/Tests/QuillCodeParityTests/ParityTerminalRendererGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTerminalRendererGateTests.swift
@@ -113,6 +113,7 @@ final class ParityTerminalRendererGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(testsText.contains("testOriginModeAddressesRowsRelativeToScrollRegion"))
         XCTAssertTrue(testsText.contains("testOriginModeResetRestoresAbsoluteAddressing"))
         XCTAssertTrue(testsText.contains("testOriginModeClampsAddressedRowsToScrollRegion"))
+        XCTAssertTrue(testsText.contains("testScrollRegionSetHomesToRegionTopWhenOriginModeIsAlreadyEnabled"))
         XCTAssertTrue(testsText.contains("testVerticalPositionAbsoluteHonorsOriginMode"))
         XCTAssertTrue(testsText.contains("testC1CSISequencesShareTheNormalCSIParser"))
         XCTAssertTrue(testsText.contains("testRelativePositionAliasesMoveCursorRightAndDown"))

--- a/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
+++ b/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
@@ -359,6 +359,19 @@ final class TerminalOutputRendererTests: XCTestCase {
         XCTAssertEqual(render(raw), "top\nmiddle\nXottom\nfooter")
     }
 
+    func testScrollRegionSetHomesToRegionTopWhenOriginModeIsAlreadyEnabled() {
+        let raw = [
+            "top",
+            "middle",
+            "bottom"
+        ].joined(separator: "\n")
+            + "\u{1B}[?6h"
+            + "\u{1B}[2;3r"
+            + "X"
+
+        XCTAssertEqual(render(raw), "top\nXiddle\nbottom")
+    }
+
     func testVerticalPositionAbsoluteHonorsOriginMode() {
         let raw = [
             "top",


### PR DESCRIPTION
## Summary
- homes DECSTBM scroll-region changes to the region top when DEC origin mode is already enabled
- adds a terminal renderer regression for origin-mode scroll-region rehome behavior
- extends the terminal parity gate for the new edge case

## Validation
- swift test --filter TerminalOutputRendererTests
- swift test --filter ParityTerminalRendererGateTests
- git diff --check