### PR TITLE
fix(terminal): preserve visible page for scrollback erase

### DIFF
--- a/Sources/QuillCodeTools/TerminalScreenBufferEraseControls.swift
+++ b/Sources/QuillCodeTools/TerminalScreenBufferEraseControls.swift
@@ -14,10 +14,12 @@ extension TerminalScreenBuffer {
 
     mutating func eraseDisplay(_ params: String) {
         switch params {
-        case "2", "3":  // whole screen (+ scrollback) -> reset
+        case "2":  // whole screen -> reset visible page
             lines = [[]]
             row = 0
             col = 0
+        case "3":  // scrollback only; the single-page renderer has no saved lines to clear
+            break
         case "", "0":  // cursor to end of screen
             eraseLineFromCursor()
             if row + 1 < lines.count { lines.removeSubrange((row + 1)..<lines.count) }

--- a/Tests/QuillCodeParityTests/ParityTerminalRendererGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTerminalRendererGateTests.swift
@@ -120,6 +120,7 @@ final class ParityTerminalRendererGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(testsText.contains("testRISResetClearsScreenCursorStyleAndModes"))
         XCTAssertTrue(testsText.contains("testRISResetDropsAlternateScreenSnapshot"))
         XCTAssertTrue(testsText.contains("testSoftResetPreservesScreenButResetsStyleModesAndTabs"))
+        XCTAssertTrue(testsText.contains("testEraseScrollbackPreservesVisiblePage"))
         XCTAssertTrue(testsText.contains("testScreenAlignmentPatternFillsFallbackViewport"))
         XCTAssertTrue(testsText.contains("testScreenAlignmentPatternPreservesCurrentStyleAndHomesCursor"))
         XCTAssertTrue(testsText.contains("testStripsTerminalStringControlPayloads"))

--- a/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
+++ b/Tests/QuillCodeToolsTests/TerminalOutputRendererTests.swift
@@ -173,6 +173,12 @@ final class TerminalOutputRendererTests: XCTestCase {
         XCTAssertEqual(render("old output\u{1B}[2Jfresh"), "fresh")
     }
 
+    func testEraseScrollbackPreservesVisiblePage() {
+        let raw = "top\nbottom\u{1B}[3J\rX"
+
+        XCTAssertEqual(render(raw), "top\nXottom")
+    }
+
     func testCursorHomeRedrawsExistingScreen() {
         let raw = "cpu: 10%\nmem: 20%\u{1B}[Hcpu: 90%"
 


### PR DESCRIPTION
## Summary
- Treat CSI 3J as scrollback-only erase in the terminal renderer
- Preserve the visible single-page frame because QuillCode does not model saved scrollback lines
- Add renderer regression coverage and parity-gate coverage

## Validation
- swift test --filter TerminalOutputRendererTests
- swift test --filter ParityTerminalRendererGateTests
- git diff --check