### PR TITLE
Add LCOV artifact coverage previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -65,6 +65,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             tableContent(tablePreview)
         } else if let harPreview = artifact.harPreview {
             harContent(harPreview)
+        } else if let lcovPreview = artifact.lcovPreview {
+            lcovContent(lcovPreview)
         } else if let jsonLinesPreview = artifact.jsonLinesPreview {
             jsonLinesContent(jsonLinesPreview)
         } else if let tomlPreview = artifact.tomlPreview {
@@ -193,6 +195,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(harPreview.metadataLines)
             artifactContentList(title: "Hosts", labels: harPreview.hostPreviewLabels)
+        }
+    }
+
+    private func lcovContent(_ lcovPreview: ToolArtifactLCOVPreview) -> some View {
+        previewSurface(minHeight: lcovPreview.sourcePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chart.bar.doc.horizontal")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(lcovPreview.metadataLines)
+            artifactContentList(title: "Source files", labels: lcovPreview.sourcePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -509,6 +509,90 @@ public struct ToolArtifactHARPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactLCOVPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var sourceFileCount: Int
+    public var lineHitCount: Int?
+    public var lineFoundCount: Int?
+    public var branchHitCount: Int?
+    public var branchFoundCount: Int?
+    public var functionHitCount: Int?
+    public var functionFoundCount: Int?
+    public var byteSizeLabel: String?
+    public var isTruncated: Bool
+    public var sourcePreviewLabels: [String]
+
+    public var lineCoverageLabel: String? {
+        coverageLabel(hit: lineHitCount, found: lineFoundCount)
+    }
+
+    public var branchCoverageLabel: String? {
+        coverageLabel(hit: branchHitCount, found: branchFoundCount)
+    }
+
+    public var functionCoverageLabel: String? {
+        coverageLabel(hit: functionHitCount, found: functionFoundCount)
+    }
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(sourceFileCount) source file\(sourceFileCount == 1 ? "" : "s")",
+            lineCoverageLabel.map { "Lines: \($0)" },
+            branchCoverageLabel.map { "Branches: \($0)" },
+            functionCoverageLabel.map { "Functions: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" },
+            isTruncated ? "Preview: first 512 KB scanned" : nil
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        sourceFileCount > 0
+            || lineCoverageLabel != nil
+            || branchCoverageLabel != nil
+            || functionCoverageLabel != nil
+            || byteSizeLabel != nil
+            || isTruncated
+            || !sourcePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "LCOV",
+        sourceFileCount: Int,
+        lineHitCount: Int? = nil,
+        lineFoundCount: Int? = nil,
+        branchHitCount: Int? = nil,
+        branchFoundCount: Int? = nil,
+        functionHitCount: Int? = nil,
+        functionFoundCount: Int? = nil,
+        byteSizeLabel: String? = nil,
+        isTruncated: Bool = false,
+        sourcePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.sourceFileCount = sourceFileCount
+        self.lineHitCount = lineHitCount
+        self.lineFoundCount = lineFoundCount
+        self.branchHitCount = branchHitCount
+        self.branchFoundCount = branchFoundCount
+        self.functionHitCount = functionHitCount
+        self.functionFoundCount = functionFoundCount
+        self.byteSizeLabel = byteSizeLabel
+        self.isTruncated = isTruncated
+        self.sourcePreviewLabels = sourcePreviewLabels
+    }
+
+    private func coverageLabel(hit: Int?, found: Int?) -> String? {
+        guard let hit, let found, found > 0 else { return nil }
+        let percent = (Double(hit) / Double(found)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : String(format: "%.1f%%", rounded)
+        return "\(percentLabel) (\(hit)/\(found))"
+    }
+}
+
 public struct ToolArtifactNotebookPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var notebookVersionLabel: String?
@@ -1183,6 +1267,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var harPreview: ToolArtifactHARPreview? {
         ToolArtifactHARPreviewBuilder.harPreview(for: value, kind: kind)
+    }
+    public var lcovPreview: ToolArtifactLCOVPreview? {
+        ToolArtifactLCOVPreviewBuilder.lcovPreview(for: value, kind: kind)
     }
     public var notebookPreview: ToolArtifactNotebookPreview? {
         ToolArtifactNotebookPreviewBuilder.notebookPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -28,6 +28,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == ".env" || filename.hasPrefix(".env.") {
             return "env"
         }
+        if filename == "lcov.info" {
+            return "lcov"
+        }
         for compoundExtension in compoundPreviewExtensions {
             if filename.hasSuffix(".\(compoundExtension.suffix)") {
                 return compoundExtension.previewExtension
@@ -52,6 +55,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "mdx": .markdown,
         "json": .data,
         "jsonl": .data,
+        "lcov": .data,
         "ndjson": .data,
         "cfg": .data,
         "conf": .data,

--- a/Sources/QuillCodeApp/ToolArtifactLCOVPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactLCOVPreviewBuilder.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+enum ToolArtifactLCOVPreviewBuilder {
+    static func lcovPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactLCOVPreview? {
+        guard kind == .file,
+              ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind)?.extensionLabel.lowercased() == "lcov",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+
+            let handle = try FileHandle(forReadingFrom: fileURL)
+            defer { try? handle.close() }
+            guard let data = try handle.read(upToCount: byteLimit + 1),
+                  !data.isEmpty
+            else { return nil }
+
+            let isTruncated = data.count > byteLimit
+            let previewData = Data(data.prefix(byteLimit))
+            guard !previewData.contains(0),
+                  let text = String(data: previewData, encoding: .utf8)
+            else { return nil }
+
+            return preview(
+                from: text,
+                byteSizeLabel: resourceValues.fileSize.flatMap(ToolArtifactByteSizeFormatter.label),
+                isTruncated: isTruncated
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from text: String,
+        byteSizeLabel: String?,
+        isTruncated: Bool
+    ) -> ToolArtifactLCOVPreview? {
+        var sourceFiles: [SourceFileCoverage] = []
+        var current = SourceFileCoverage()
+        var sawLCOVRecord = false
+
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty else { continue }
+
+            if line == "end_of_record" {
+                appendCurrent(&current, to: &sourceFiles)
+                current = SourceFileCoverage()
+                continue
+            }
+
+            if line.hasPrefix("SF:") {
+                appendCurrent(&current, to: &sourceFiles)
+                current = SourceFileCoverage(path: String(line.dropFirst(3)))
+                sawLCOVRecord = true
+            } else if line.hasPrefix("LF:") {
+                current.lineFound = intValue(after: "LF:", in: line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("LH:") {
+                current.lineHit = intValue(after: "LH:", in: line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("BRF:") {
+                current.branchFound = intValue(after: "BRF:", in: line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("BRH:") {
+                current.branchHit = intValue(after: "BRH:", in: line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("FNF:") {
+                current.functionFound = intValue(after: "FNF:", in: line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("FNH:") {
+                current.functionHit = intValue(after: "FNH:", in: line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("DA:") {
+                current.observeLineHit(line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("FNDA:") {
+                current.observeFunctionHit(line)
+                sawLCOVRecord = true
+            } else if line.hasPrefix("BRDA:") {
+                current.observeBranchHit(line)
+                sawLCOVRecord = true
+            }
+        }
+        appendCurrent(&current, to: &sourceFiles)
+
+        guard sawLCOVRecord, !sourceFiles.isEmpty else { return nil }
+        let sourcePreviewLabels = sourceFiles
+            .prefix(sourcePreviewLimit)
+            .map(\.previewLabel)
+
+        return ToolArtifactLCOVPreview(
+            sourceFileCount: sourceFiles.count,
+            lineHitCount: summed(\.lineHit, in: sourceFiles),
+            lineFoundCount: summed(\.lineFound, in: sourceFiles),
+            branchHitCount: summed(\.branchHit, in: sourceFiles),
+            branchFoundCount: summed(\.branchFound, in: sourceFiles),
+            functionHitCount: summed(\.functionHit, in: sourceFiles),
+            functionFoundCount: summed(\.functionFound, in: sourceFiles),
+            byteSizeLabel: byteSizeLabel,
+            isTruncated: isTruncated,
+            sourcePreviewLabels: sourcePreviewLabels
+        )
+    }
+
+    private static func appendCurrent(_ current: inout SourceFileCoverage, to sourceFiles: inout [SourceFileCoverage]) {
+        guard current.hasCoverage else { return }
+        sourceFiles.append(current)
+        current = SourceFileCoverage()
+    }
+
+    private static func intValue(after prefix: String, in line: String) -> Int? {
+        let value = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
+        guard let int = Int(value), int >= 0 else { return nil }
+        return int
+    }
+
+    private static func summed(_ keyPath: KeyPath<SourceFileCoverage, Int?>, in sourceFiles: [SourceFileCoverage]) -> Int? {
+        var total = 0
+        var hasValue = false
+        for sourceFile in sourceFiles {
+            guard let value = sourceFile[keyPath: keyPath] else { continue }
+            total += value
+            hasValue = true
+        }
+        return hasValue ? total : nil
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else { return nil }
+        return url
+    }
+
+    private struct SourceFileCoverage {
+        var path: String?
+        var lineHit: Int?
+        var lineFound: Int?
+        var branchHit: Int?
+        var branchFound: Int?
+        var functionHit: Int?
+        var functionFound: Int?
+
+        var hasCoverage: Bool {
+            path != nil || lineHit != nil || lineFound != nil || branchHit != nil || branchFound != nil || functionHit != nil || functionFound != nil
+        }
+
+        var previewLabel: String {
+            let name = path.map(displayPath) ?? "Unknown source"
+            guard let lineHit, let lineFound, lineFound > 0 else { return name }
+            let percent = (Double(lineHit) / Double(lineFound)) * 100
+            let rounded = (percent * 10).rounded() / 10
+            let percentLabel = rounded == rounded.rounded()
+                ? "\(Int(rounded))%"
+                : String(format: "%.1f%%", rounded)
+            return "\(name) · \(percentLabel)"
+        }
+
+        mutating func observeLineHit(_ line: String) {
+            guard let count = line.split(separator: ",").dropFirst().first.flatMap({ Int($0) }) else {
+                return
+            }
+            lineFound = (lineFound ?? 0) + 1
+            if count > 0 {
+                lineHit = (lineHit ?? 0) + 1
+            } else if lineHit == nil {
+                lineHit = 0
+            }
+        }
+
+        mutating func observeFunctionHit(_ line: String) {
+            let parts = line.split(separator: ",", maxSplits: 1)
+            guard let countText = parts.first?.dropFirst(5),
+                  let count = Int(countText)
+            else { return }
+            functionFound = (functionFound ?? 0) + 1
+            if count > 0 {
+                functionHit = (functionHit ?? 0) + 1
+            } else if functionHit == nil {
+                functionHit = 0
+            }
+        }
+
+        mutating func observeBranchHit(_ line: String) {
+            guard let taken = line.split(separator: ",").last else { return }
+            branchFound = (branchFound ?? 0) + 1
+            if taken != "-", Int(taken).map({ $0 > 0 }) == true {
+                branchHit = (branchHit ?? 0) + 1
+            } else if branchHit == nil {
+                branchHit = 0
+            }
+        }
+
+        private func displayPath(_ path: String) -> String {
+            let components = path
+                .split(separator: "/")
+                .suffix(2)
+            return components.isEmpty ? path : components.joined(separator: "/")
+        }
+    }
+
+    private static let byteLimit = 512 * 1024
+    private static let sourcePreviewLimit = 6
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -213,6 +213,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let diffPreview = renderDiffPreview(artifact.diffPreview)
             let tablePreview = renderTablePreview(artifact.tablePreview)
             let harPreview = renderHARPreview(artifact.harPreview)
+            let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
             let iniPreview = renderINIPreview(artifact.iniPreview)
@@ -246,6 +247,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(diffPreview)
               \(tablePreview)
               \(harPreview)
+              \(lcovPreview)
               \(jsonLinesPreview)
               \(tomlPreview)
               \(iniPreview)
@@ -580,6 +582,33 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(hostList)
+        </div>
+        """
+    }
+
+    private static func renderLCOVPreview(_ preview: ToolArtifactLCOVPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-lcov-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let sourceFiles = preview.sourcePreviewLabels.map {
+            #"<li data-testid="tool-card-lcov-preview-source-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let sourceList = sourceFiles.isEmpty
+            ? ""
+            : """
+              <section class="artifact-office-contents" data-testid="tool-card-lcov-preview-sources">
+                <strong data-testid="tool-card-lcov-preview-source-title">Source files</strong>
+                <ul>\(sourceFiles)</ul>
+              </section>
+            """
+        guard !metadata.isEmpty || !sourceList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-lcov-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(sourceList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -512,6 +512,82 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteHAR.harPreview)
     }
 
+    func testArtifactStateDerivesLCOVPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let coverage = directory.appendingPathComponent("lcov.info")
+        let lcovText = """
+        TN:QuillCode
+        SF:/workspace/Sources/QuillCodeApp/Workspace.swift
+        FN:10,render
+        FNDA:3,render
+        DA:10,3
+        DA:11,0
+        DA:12,5
+        LF:3
+        LH:2
+        BRDA:12,0,0,1
+        BRDA:12,0,1,0
+        BRF:2
+        BRH:1
+        FNF:1
+        FNH:1
+        end_of_record
+        SF:/workspace/Tests/QuillCodeAppTests/WorkspaceTests.swift
+        DA:20,1
+        DA:21,1
+        DA:22,0
+        end_of_record
+        """
+        try lcovText.write(to: coverage, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: coverage.path)
+        let preview = try XCTUnwrap(artifact.lcovPreview)
+        let byteCount = try XCTUnwrap(lcovText.data(using: .utf8)?.count)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "LCOV")
+        XCTAssertEqual(preview.formatLabel, "LCOV")
+        XCTAssertEqual(preview.sourceFileCount, 2)
+        XCTAssertEqual(preview.lineHitCount, 4)
+        XCTAssertEqual(preview.lineFoundCount, 6)
+        XCTAssertEqual(preview.branchHitCount, 1)
+        XCTAssertEqual(preview.branchFoundCount, 2)
+        XCTAssertEqual(preview.functionHitCount, 1)
+        XCTAssertEqual(preview.functionFoundCount, 1)
+        XCTAssertEqual(preview.lineCoverageLabel, "66.7% (4/6)")
+        XCTAssertEqual(preview.branchCoverageLabel, "50% (1/2)")
+        XCTAssertEqual(preview.functionCoverageLabel, "100% (1/1)")
+        XCTAssertEqual(preview.sourcePreviewLabels, [
+            "QuillCodeApp/Workspace.swift · 66.7%",
+            "QuillCodeAppTests/WorkspaceTests.swift · 66.7%"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(byteCount) bytes")
+        XCTAssertFalse(preview.isTruncated)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: LCOV",
+            "2 source files",
+            "Lines: 66.7% (4/6)",
+            "Branches: 50% (1/2)",
+            "Functions: 100% (1/1)",
+            "Size: \(byteCount) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+        XCTAssertNil(artifact.jsonLinesPreview)
+
+        let extensionCoverage = directory.appendingPathComponent("coverage.lcov")
+        try lcovText.write(to: extensionCoverage, atomically: true, encoding: .utf8)
+        let extensionArtifact = ToolArtifactState(value: extensionCoverage.path)
+        XCTAssertEqual(extensionArtifact.documentPreview?.extensionLabel, "LCOV")
+        XCTAssertEqual(extensionArtifact.lcovPreview?.sourceFileCount, 2)
+
+        let remoteLCOV = ToolArtifactState(value: "https://example.com/lcov.info")
+        XCTAssertNil(remoteLCOV.lcovPreview)
+
+        let invalidLCOV = directory.appendingPathComponent("empty.info")
+        try "TN:empty\n".write(to: invalidLCOV, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: invalidLCOV.path).lcovPreview)
+    }
+
     func testArtifactStateDerivesNotebookPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let notebook = directory.appendingPathComponent("analysis.ipynb")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -767,6 +767,63 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesLCOVArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let coverageDirectory = root.appendingPathComponent("coverage", isDirectory: true)
+        try FileManager.default.createDirectory(at: coverageDirectory, withIntermediateDirectories: true)
+        let coverage = coverageDirectory.appendingPathComponent("lcov.info")
+        let lcovText = """
+        SF:/workspace/Sources/QuillCodeApp/Workspace.swift
+        DA:10,3
+        DA:11,0
+        DA:12,5
+        LF:3
+        LH:2
+        BRF:2
+        BRH:1
+        FNF:1
+        FNH:1
+        end_of_record
+        """
+        try lcovText.write(to: coverage, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"coverage/lcov.info"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote coverage/lcov.info\n", artifacts: [coverage.path])
+        let thread = ChatThread(
+            title: "Coverage artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · LCOV"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">lcov.info"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview-meta">Format: LCOV"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview-meta">1 source file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview-meta">Lines: 66.7% (2/3)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview-meta">Branches: 50% (1/2)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview-meta">Functions: 100% (1/1)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview-source-title">Source files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-lcov-preview-source-item">QuillCodeApp/Workspace.swift · 66.7%"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesJSONLinesArtifactPreview() throws {
         let root = try makeTempDirectory()
         let logs = root.appendingPathComponent("logs", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -73,6 +73,9 @@
 - Artifact previews now include bounded local HTTP Archive metadata for `.har` browser/network traces:
   HAR version, creator, entry count, observed methods, status groups, host previews, and file size
   without rendering request/response headers, cookies, bodies, or query values.
+- Artifact previews now include bounded local LCOV coverage-report metadata for `lcov.info` and
+  `.lcov` files: source-file counts, line/branch/function coverage, file size, truncation state, and
+  capped source-file previews without executing test tooling or following report paths.
 - Artifact previews now include bounded local font metadata for `.ttf`, `.otf`, `.ttc`, `.woff`,
   and `.woff2` files by validating fixed headers and rendering format, flavor, table count,
   declared size, and file size without parsing tables or decompressing webfont payloads.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2161,3 +2161,21 @@
 - **Evidence:** `MCPServerSessionTests` now assert path-keyed metadata for both `host.file.write` and
   `host.apply_patch` approval requests, including create/modify classification and non-execution after
   denial.
+
+## 2026-07-18: LCOV artifacts render bounded coverage summaries
+
+- **Decision:** Local `lcov.info` and `.lcov` artifacts render as structured coverage-report cards
+  instead of generic text/data files. The preview scans only the first 512 KB, parses standard LCOV
+  record lines, and shows source-file count, line/branch/function coverage, file size, truncation
+  state, and a capped source-file list.
+- **Why:** Coding agents commonly produce coverage reports while fixing tests. Codex-style artifact
+  handling should make the result immediately inspectable without asking the model to re-open the raw
+  report, and without executing test tooling or expanding arbitrary report contents.
+- **Boundary:** The parser is local-file-only, UTF-8-only, NUL-rejecting, and line-oriented. It never
+  shells out, never follows report paths, and never fetches remote coverage URLs. Explicit LCOV totals
+  (`LF`/`LH`, `BRF`/`BRH`, `FNF`/`FNH`) are preserved when present; per-line/function/branch records
+  provide fallback counts for partial reports.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesLCOVPreviewMetadata` covers
+  classification, totals, fallback counts, source labels, invalid reports, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesLCOVArtifactPreview` covers the static
+  HTML selectors and rendered coverage metadata.


### PR DESCRIPTION
## Summary
- classify local `lcov.info` and `.lcov` files as data artifacts
- add bounded LCOV coverage metadata previews in SwiftUI and static HTML
- document the local-only, non-executing preview boundary

## Validation
- `swift test --filter QuillCodeToolCardSurfaceTests`
- `swift test --filter WorkspaceHTMLToolCardRendererTests`
- `git diff --check`