### PR TITLE
Add SARIF artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -67,6 +67,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             harContent(harPreview)
         } else if let lcovPreview = artifact.lcovPreview {
             lcovContent(lcovPreview)
+        } else if let sarifPreview = artifact.sarifPreview {
+            sarifContent(sarifPreview)
         } else if let jsonLinesPreview = artifact.jsonLinesPreview {
             jsonLinesContent(jsonLinesPreview)
         } else if let tomlPreview = artifact.tomlPreview {
@@ -209,6 +211,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(lcovPreview.metadataLines)
             artifactContentList(title: "Source files", labels: lcovPreview.sourcePreviewLabels)
+        }
+    }
+
+    private func sarifContent(_ sarifPreview: ToolArtifactSARIFPreview) -> some View {
+        previewSurface(minHeight: sarifPreview.rulePreviewLabels.isEmpty ? 92 : 142) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist.checked")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(sarifPreview.metadataLines)
+            artifactContentList(title: "Tools", labels: sarifPreview.toolPreviewLabels)
+            artifactContentList(title: "Rules", labels: sarifPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -593,6 +593,65 @@ public struct ToolArtifactLCOVPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactSARIFPreview: Codable, Sendable, Hashable {
+    public var versionLabel: String?
+    public var runCount: Int
+    public var resultCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var noteCount: Int
+    public var noneCount: Int
+    public var byteSizeLabel: String?
+    public var toolPreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: SARIF",
+            versionLabel.map { "Version: \($0)" },
+            "\(runCount) run\(runCount == 1 ? "" : "s")",
+            "\(resultCount) result\(resultCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            noteCount > 0 ? "Notes: \(noteCount)" : nil,
+            noneCount > 0 ? "None: \(noneCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        runCount > 0
+            || resultCount > 0
+            || !metadataLines.isEmpty
+            || !toolPreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        versionLabel: String? = nil,
+        runCount: Int,
+        resultCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        noteCount: Int = 0,
+        noneCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        toolPreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.versionLabel = versionLabel
+        self.runCount = runCount
+        self.resultCount = resultCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.noteCount = noteCount
+        self.noneCount = noneCount
+        self.byteSizeLabel = byteSizeLabel
+        self.toolPreviewLabels = toolPreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactNotebookPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var notebookVersionLabel: String?
@@ -1270,6 +1329,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var lcovPreview: ToolArtifactLCOVPreview? {
         ToolArtifactLCOVPreviewBuilder.lcovPreview(for: value, kind: kind)
+    }
+    public var sarifPreview: ToolArtifactSARIFPreview? {
+        ToolArtifactSARIFPreviewBuilder.sarifPreview(for: value, kind: kind)
     }
     public var notebookPreview: ToolArtifactNotebookPreview? {
         ToolArtifactNotebookPreviewBuilder.notebookPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -41,6 +41,7 @@ enum ToolArtifactDocumentPreviewBuilder {
 
     private static let compoundPreviewExtensions: [(suffix: String, previewExtension: String)] = [
         ("appshot.json", "appshot"),
+        ("sarif.json", "sarif"),
         ("tar.gz", "tar.gz"),
         ("tar.bz2", "tar.bz2"),
         ("tar.xz", "tar.xz"),
@@ -57,6 +58,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "jsonl": .data,
         "lcov": .data,
         "ndjson": .data,
+        "sarif": .data,
         "cfg": .data,
         "conf": .data,
         "bin": .data,

--- a/Sources/QuillCodeApp/ToolArtifactJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactJSONPreviewBuilder.swift
@@ -3,8 +3,9 @@ import Foundation
 enum ToolArtifactJSONPreviewBuilder {
     static func jsonPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactJSONPreview? {
         guard kind == .file,
-              ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind)?.kind == .data,
-              ToolArtifactValueClassifier.pathExtension(for: value) == "json",
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
               let fileURL = localArtifactFileURL(for: value)
         else {
             return nil

--- a/Sources/QuillCodeApp/ToolArtifactSARIFPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSARIFPreviewBuilder.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+enum ToolArtifactSARIFPreviewBuilder {
+    static func sarifPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactSARIFPreview? {
+        guard kind == .file,
+              ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind)?.extensionLabel.lowercased() == "sarif",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  let runs = root["runs"] as? [[String: Any]]
+            else {
+                return nil
+            }
+            let preview = preview(from: root, runs: runs, fileSize: fileSize)
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from root: [String: Any], runs: [[String: Any]], fileSize: Int) -> ToolArtifactSARIFPreview {
+        var resultCount = 0
+        var errorCount = 0
+        var warningCount = 0
+        var noteCount = 0
+        var noneCount = 0
+        var toolLabels: [String] = []
+        var seenTools = Set<String>()
+        var ruleLabels: [String] = []
+        var seenRules = Set<String>()
+
+        for run in runs {
+            appendToolLabels(from: run, into: &toolLabels, seen: &seenTools)
+            appendRuleLabels(from: run, into: &ruleLabels, seen: &seenRules)
+
+            let results = run["results"] as? [[String: Any]] ?? []
+            resultCount += results.count
+            for result in results {
+                switch (result["level"] as? String)?.lowercased() {
+                case "error":
+                    errorCount += 1
+                case "note":
+                    noteCount += 1
+                case "none":
+                    noneCount += 1
+                default:
+                    warningCount += 1
+                }
+                appendResultRuleLabel(from: result, into: &ruleLabels, seen: &seenRules)
+            }
+        }
+
+        return ToolArtifactSARIFPreview(
+            versionLabel: sanitizedLabel(root["version"] as? String),
+            runCount: runs.count,
+            resultCount: resultCount,
+            errorCount: errorCount,
+            warningCount: warningCount,
+            noteCount: noteCount,
+            noneCount: noneCount,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            toolPreviewLabels: Array(toolLabels.prefix(previewLabelLimit)),
+            rulePreviewLabels: Array(ruleLabels.prefix(previewLabelLimit))
+        )
+    }
+
+    private static func appendToolLabels(
+        from run: [String: Any],
+        into labels: inout [String],
+        seen: inout Set<String>
+    ) {
+        guard let tool = run["tool"] as? [String: Any],
+              let driver = tool["driver"] as? [String: Any],
+              let name = sanitizedLabel(driver["name"] as? String),
+              !seen.contains(name)
+        else {
+            return
+        }
+        seen.insert(name)
+        labels.append(name)
+    }
+
+    private static func appendRuleLabels(
+        from run: [String: Any],
+        into labels: inout [String],
+        seen: inout Set<String>
+    ) {
+        guard let tool = run["tool"] as? [String: Any],
+              let driver = tool["driver"] as? [String: Any],
+              let rules = driver["rules"] as? [[String: Any]]
+        else {
+            return
+        }
+        for rule in rules {
+            guard labels.count < previewLabelLimit,
+                  let ruleID = sanitizedLabel(rule["id"] as? String),
+                  !seen.contains(ruleID)
+            else {
+                continue
+            }
+            seen.insert(ruleID)
+            labels.append(ruleID)
+        }
+    }
+
+    private static func appendResultRuleLabel(
+        from result: [String: Any],
+        into labels: inout [String],
+        seen: inout Set<String>
+    ) {
+        guard labels.count < previewLabelLimit,
+              let ruleID = sanitizedLabel(result["ruleId"] as? String),
+              !seen.contains(ruleID)
+        else {
+            return
+        }
+        seen.insert(ruleID)
+        labels.append(ruleID)
+    }
+
+    private static func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(labelCharacterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let labelCharacterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -214,6 +214,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let tablePreview = renderTablePreview(artifact.tablePreview)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
+            let sarifPreview = renderSARIFPreview(artifact.sarifPreview)
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
             let iniPreview = renderINIPreview(artifact.iniPreview)
@@ -248,6 +249,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(tablePreview)
               \(harPreview)
               \(lcovPreview)
+              \(sarifPreview)
               \(jsonLinesPreview)
               \(tomlPreview)
               \(iniPreview)
@@ -609,6 +611,45 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(sourceList)
+        </div>
+        """
+    }
+
+    private static func renderSARIFPreview(_ preview: ToolArtifactSARIFPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-sarif-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let tools = preview.toolPreviewLabels.map {
+            #"<li data-testid="tool-card-sarif-preview-tool-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-sarif-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let toolList = tools.isEmpty
+            ? ""
+            : """
+              <section class="artifact-office-contents" data-testid="tool-card-sarif-preview-tools">
+                <strong data-testid="tool-card-sarif-preview-tool-title">Tools</strong>
+                <ul>\(tools)</ul>
+              </section>
+            """
+        let ruleList = rules.isEmpty
+            ? ""
+            : """
+              <section class="artifact-office-contents" data-testid="tool-card-sarif-preview-rules">
+                <strong data-testid="tool-card-sarif-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+            """
+        guard !metadata.isEmpty || !toolList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-sarif-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(toolList)
+          \(ruleList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -588,6 +588,89 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(ToolArtifactState(value: invalidLCOV.path).lcovPreview)
     }
 
+    func testArtifactStateDerivesSARIFPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("codeql.sarif.json")
+        let sarifText = """
+        {
+          "version": "2.1.0",
+          "runs": [
+            {
+              "tool": {
+                "driver": {
+                  "name": "CodeQL",
+                  "rules": [
+                    {"id": "swift/hardcoded-credential"},
+                    {"id": "swift/path-injection"}
+                  ]
+                }
+              },
+              "results": [
+                {"ruleId": "swift/hardcoded-credential", "level": "error"},
+                {"ruleId": "swift/path-injection", "level": "warning"},
+                {"ruleId": "swift/style", "level": "note"},
+                {"ruleId": "swift/suppressed", "level": "none"}
+              ]
+            },
+            {
+              "tool": {"driver": {"name": "Semgrep"}},
+              "results": [
+                {"ruleId": "swift/path-injection", "level": "warning"}
+              ]
+            }
+          ]
+        }
+        """
+        try sarifText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.sarifPreview)
+        let byteCount = try XCTUnwrap(sarifText.data(using: .utf8)?.count)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "SARIF")
+        XCTAssertEqual(preview.versionLabel, "2.1.0")
+        XCTAssertEqual(preview.runCount, 2)
+        XCTAssertEqual(preview.resultCount, 5)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 2)
+        XCTAssertEqual(preview.noteCount, 1)
+        XCTAssertEqual(preview.noneCount, 1)
+        XCTAssertEqual(preview.toolPreviewLabels, ["CodeQL", "Semgrep"])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "swift/hardcoded-credential",
+            "swift/path-injection",
+            "swift/style",
+            "swift/suppressed"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(byteCount) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: SARIF",
+            "Version: 2.1.0",
+            "2 runs",
+            "5 results",
+            "Errors: 1",
+            "Warnings: 2",
+            "Notes: 1",
+            "None: 1",
+            "Size: \(byteCount) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let extensionReport = directory.appendingPathComponent("security.sarif")
+        try sarifText.write(to: extensionReport, atomically: true, encoding: .utf8)
+        let extensionArtifact = ToolArtifactState(value: extensionReport.path)
+        XCTAssertEqual(extensionArtifact.documentPreview?.extensionLabel, "SARIF")
+        XCTAssertEqual(extensionArtifact.sarifPreview?.resultCount, 5)
+
+        let remoteSARIF = ToolArtifactState(value: "https://example.com/codeql.sarif.json")
+        XCTAssertNil(remoteSARIF.sarifPreview)
+
+        let invalidSARIF = directory.appendingPathComponent("invalid.sarif")
+        try #"{"version":"2.1.0"}"#.write(to: invalidSARIF, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: invalidSARIF.path).sarifPreview)
+    }
+
     func testArtifactStateDerivesNotebookPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let notebook = directory.appendingPathComponent("analysis.ipynb")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -824,6 +824,78 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesSARIFArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reportsDirectory = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reportsDirectory, withIntermediateDirectories: true)
+        let report = reportsDirectory.appendingPathComponent("scan.sarif.json")
+        let sarifText = """
+        {
+          "version": "2.1.0",
+          "runs": [
+            {
+              "tool": {
+                "driver": {
+                  "name": "CodeQL",
+                  "rules": [
+                    {"id": "swift/hardcoded-credential"},
+                    {"id": "swift/path-injection"}
+                  ]
+                }
+              },
+              "results": [
+                {"ruleId": "swift/hardcoded-credential", "level": "error"},
+                {"ruleId": "swift/path-injection", "level": "warning"},
+                {"ruleId": "swift/style", "level": "note"}
+              ]
+            }
+          ]
+        }
+        """
+        try sarifText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/scan.sarif.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/scan.sarif.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "SARIF artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · SARIF"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">scan.sarif.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-meta">Format: SARIF"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-meta">Version: 2.1.0"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-meta">1 run"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-meta">3 results"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-meta">Notes: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-tool-title">Tools"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-tool-item">CodeQL"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-rule-item">swift/hardcoded-credential"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-sarif-preview-rule-item">swift/path-injection"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesJSONLinesArtifactPreview() throws {
         let root = try makeTempDirectory()
         let logs = root.appendingPathComponent("logs", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -76,6 +76,9 @@
 - Artifact previews now include bounded local LCOV coverage-report metadata for `lcov.info` and
   `.lcov` files: source-file counts, line/branch/function coverage, file size, truncation state, and
   capped source-file previews without executing test tooling or following report paths.
+- Artifact previews now include bounded local SARIF static-analysis metadata for `.sarif` and
+  `.sarif.json` files: SARIF version, run/result counts, level counts, file size, capped tool labels,
+  and capped rule labels without fetching remote reports or following result paths.
 - Artifact previews now include bounded local font metadata for `.ttf`, `.otf`, `.ttc`, `.woff`,
   and `.woff2` files by validating fixed headers and rendering format, flavor, table count,
   declared size, and file size without parsing tables or decompressing webfont payloads.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2179,3 +2179,21 @@
   classification, totals, fallback counts, source labels, invalid reports, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesLCOVArtifactPreview` covers the static
   HTML selectors and rendered coverage metadata.
+
+## 2026-07-18: SARIF artifacts render bounded static-analysis summaries
+
+- **Decision:** Local `.sarif` and `.sarif.json` artifacts render as structured static-analysis
+  report cards instead of generic JSON. The preview parses bounded SARIF JSON and shows SARIF
+  version, run/result counts, level counts, file size, capped tool labels, and capped rule labels.
+- **Why:** Coding agents often produce CodeQL, Semgrep, and other scanner reports while reviewing or
+  hardening code. A Codex-style artifact surface should make those reports immediately scannable
+  without requiring the model to re-open a large JSON document or invent a summary.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at 512 KB.
+  It never shells out, never follows SARIF result paths, and never fetches remote report URLs. Compound
+  `.sarif.json` files are classified as SARIF before the generic JSON preview so only one truthful
+  preview is shown.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesSARIFPreviewMetadata` covers
+  compound and direct extensions, version/count metadata, tool/rule labels, invalid reports, remote
+  exclusion, and generic JSON suppression.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesSARIFArtifactPreview` covers static HTML
+  selectors and rendered SARIF metadata.


### PR DESCRIPTION
## Summary
- classify local .sarif and .sarif.json artifacts as SARIF data previews
- add bounded local SARIF parsing for run/result/level counts plus tool and rule labels
- render SARIF previews in native SwiftUI and static HTML, and avoid double-rendering compound SARIF JSON as generic JSON

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check