### PR TITLE
Add JUnit artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -79,6 +79,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             dotenvContent(dotenvPreview)
         } else if let yamlPreview = artifact.yamlPreview {
             yamlContent(yamlPreview)
+        } else if let junitPreview = artifact.junitPreview {
+            junitContent(junitPreview)
         } else if let xmlPreview = artifact.xmlPreview {
             xmlContent(xmlPreview)
         } else if let propertyListPreview = artifact.propertyListPreview {
@@ -324,6 +326,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(xmlPreview.metadataLines)
             artifactContentList(title: "Root children", labels: xmlPreview.childPreviewLabels)
+        }
+    }
+
+    private func junitContent(_ junitPreview: ToolArtifactJUnitPreview) -> some View {
+        previewSurface(minHeight: junitPreview.failurePreviewLabels.isEmpty ? 92 : 142) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checkmark.seal")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(junitPreview.metadataLines)
+            artifactContentList(title: "Suites", labels: junitPreview.suitePreviewLabels)
+            artifactContentList(title: "Failing tests", labels: junitPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -966,6 +966,61 @@ public struct ToolArtifactXMLPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactJUnitPreview: Codable, Sendable, Hashable {
+    public var suiteCount: Int
+    public var testCount: Int
+    public var failureCount: Int
+    public var errorCount: Int
+    public var skippedCount: Int
+    public var durationLabel: String?
+    public var byteSizeLabel: String?
+    public var suitePreviewLabels: [String]
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: JUnit XML",
+            "\(suiteCount) suite\(suiteCount == 1 ? "" : "s")",
+            "\(testCount) test\(testCount == 1 ? "" : "s")",
+            failureCount > 0 ? "Failures: \(failureCount)" : nil,
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            skippedCount > 0 ? "Skipped: \(skippedCount)" : nil,
+            durationLabel.map { "Duration: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        suiteCount > 0
+            || testCount > 0
+            || !metadataLines.isEmpty
+            || !suitePreviewLabels.isEmpty
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        suiteCount: Int,
+        testCount: Int,
+        failureCount: Int = 0,
+        errorCount: Int = 0,
+        skippedCount: Int = 0,
+        durationLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        suitePreviewLabels: [String] = [],
+        failurePreviewLabels: [String] = []
+    ) {
+        self.suiteCount = suiteCount
+        self.testCount = testCount
+        self.failureCount = failureCount
+        self.errorCount = errorCount
+        self.skippedCount = skippedCount
+        self.durationLabel = durationLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.suitePreviewLabels = suitePreviewLabels
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactPropertyListPreview: Codable, Sendable, Hashable {
     public var rootLabel: String
     public var formatLabel: String?
@@ -1350,6 +1405,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var yamlPreview: ToolArtifactYAMLPreview? {
         ToolArtifactYAMLPreviewBuilder.yamlPreview(for: value, kind: kind)
+    }
+    public var junitPreview: ToolArtifactJUnitPreview? {
+        ToolArtifactJUnitPreviewBuilder.junitPreview(for: value, kind: kind)
     }
     public var xmlPreview: ToolArtifactXMLPreview? {
         ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactJUnitPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactJUnitPreviewBuilder.swift
@@ -1,0 +1,257 @@
+import Foundation
+
+enum ToolArtifactJUnitPreviewBuilder {
+    static func junitPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactJUnitPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let collector = JUnitPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class JUnitPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var suiteLabels: [String] = []
+    private var suiteCount = 0
+    private var aggregateTestCount = 0
+    private var aggregateFailureCount = 0
+    private var aggregateErrorCount = 0
+    private var aggregateSkippedCount = 0
+    private var aggregateDurationSeconds = 0.0
+    private var hasAggregateTestCounts = false
+    private var hasAggregateFailureCounts = false
+    private var hasAggregateErrorCounts = false
+    private var hasAggregateSkippedCounts = false
+    private var hasAggregateDuration = false
+    private var testcaseCount = 0
+    private var observedFailureCount = 0
+    private var observedErrorCount = 0
+    private var observedSkippedCount = 0
+    private var activeTestcaseLabel: String?
+    private var activeTestcaseHasFailure = false
+    private var activeTestcaseHasError = false
+    private var activeTestcaseHasSkipped = false
+    private var failureLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = qualifiedElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+        }
+
+        switch label {
+        case "testsuite":
+            recordSuite(attributeDict)
+        case "testcase":
+            recordTestcase(attributeDict)
+        case "failure":
+            activeTestcaseHasFailure = true
+        case "error":
+            activeTestcaseHasError = true
+        case "skipped":
+            activeTestcaseHasSkipped = true
+        default:
+            break
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        let label = qualifiedElementName(elementName: elementName, qName: qName)
+        if label == "testcase" {
+            finishTestcase()
+        }
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactJUnitPreview? {
+        guard rootElementLabel == "testsuites" || rootElementLabel == "testsuite" else { return nil }
+        let tests = hasAggregateTestCounts ? aggregateTestCount : testcaseCount
+        let failures = hasAggregateFailureCounts ? aggregateFailureCount : observedFailureCount
+        let errors = hasAggregateErrorCounts ? aggregateErrorCount : observedErrorCount
+        let skipped = hasAggregateSkippedCounts ? aggregateSkippedCount : observedSkippedCount
+        return ToolArtifactJUnitPreview(
+            suiteCount: suiteCount,
+            testCount: tests,
+            failureCount: failures,
+            errorCount: errors,
+            skippedCount: skipped,
+            durationLabel: hasAggregateDuration ? durationLabel(for: aggregateDurationSeconds) : nil,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            suitePreviewLabels: previewLabels(for: suiteLabels),
+            failurePreviewLabels: previewLabels(for: failureLabels)
+        )
+    }
+
+    private func recordSuite(_ attributes: [String: String]) {
+        suiteCount += 1
+        if let name = sanitizedLabel(attributes["name"]) {
+            suiteLabels.append(name)
+        }
+        if let tests = intAttribute("tests", in: attributes) {
+            hasAggregateTestCounts = true
+            aggregateTestCount += tests
+        }
+        if let failures = intAttribute("failures", in: attributes) {
+            hasAggregateFailureCounts = true
+            aggregateFailureCount += failures
+        }
+        if let errors = intAttribute("errors", in: attributes) {
+            hasAggregateErrorCounts = true
+            aggregateErrorCount += errors
+        }
+        if let skipped = intAttribute("skipped", in: attributes) {
+            hasAggregateSkippedCounts = true
+            aggregateSkippedCount += skipped
+        }
+        if let time = doubleAttribute("time", in: attributes) {
+            hasAggregateDuration = true
+            aggregateDurationSeconds += time
+        }
+    }
+
+    private func recordTestcase(_ attributes: [String: String]) {
+        testcaseCount += 1
+        activeTestcaseLabel = testcaseLabel(className: attributes["classname"], name: attributes["name"])
+        activeTestcaseHasFailure = false
+        activeTestcaseHasError = false
+        activeTestcaseHasSkipped = false
+    }
+
+    private func finishTestcase() {
+        if activeTestcaseHasFailure {
+            observedFailureCount += 1
+            appendFailureLabel()
+        }
+        if activeTestcaseHasError {
+            observedErrorCount += 1
+            appendFailureLabel()
+        }
+        if activeTestcaseHasSkipped {
+            observedSkippedCount += 1
+        }
+        activeTestcaseLabel = nil
+        activeTestcaseHasFailure = false
+        activeTestcaseHasError = false
+        activeTestcaseHasSkipped = false
+    }
+
+    private func appendFailureLabel() {
+        guard let activeTestcaseLabel,
+              !failureLabels.contains(activeTestcaseLabel)
+        else {
+            return
+        }
+        failureLabels.append(activeTestcaseLabel)
+    }
+
+    private func testcaseLabel(className: String?, name: String?) -> String? {
+        let components = [sanitizedLabel(className), sanitizedLabel(name)].compactMap { $0 }
+        guard !components.isEmpty else { return nil }
+        return components.joined(separator: ".")
+    }
+
+    private func intAttribute(_ key: String, in attributes: [String: String]) -> Int? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let intValue = Int(value),
+              intValue >= 0
+        else {
+            return nil
+        }
+        return intValue
+    }
+
+    private func doubleAttribute(_ key: String, in attributes: [String: String]) -> Double? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let doubleValue = Double(value),
+              doubleValue >= 0
+        else {
+            return nil
+        }
+        return doubleValue
+    }
+
+    private func durationLabel(for seconds: Double) -> String {
+        if seconds < 1 {
+            return "\(Int((seconds * 1_000).rounded())) ms"
+        }
+        let rounded = (seconds * 100).rounded() / 100
+        if rounded == rounded.rounded() {
+            return "\(Int(rounded)) s"
+        }
+        return "\(rounded) s"
+    }
+
+    private func previewLabels(for labels: [String]) -> [String] {
+        Array(labels.prefix(previewLabelLimit))
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func qualifiedElementName(elementName: String, qName: String?) -> String {
+        guard let qName, !qName.isEmpty else { return elementName }
+        return qName
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -220,7 +220,9 @@ enum WorkspaceHTMLToolCardRenderer {
             let iniPreview = renderINIPreview(artifact.iniPreview)
             let dotenvPreview = renderDotenvPreview(artifact.dotenvPreview)
             let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
-            let xmlPreview = renderXMLPreview(artifact.xmlPreview)
+            let junitPreviewModel = artifact.junitPreview
+            let junitPreview = renderJUnitPreview(junitPreviewModel)
+            let xmlPreview = junitPreviewModel == nil ? renderXMLPreview(artifact.xmlPreview) : ""
             let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
             let sqlitePreview = renderSQLitePreview(artifact.sqlitePreview)
             let webAssemblyPreview = renderWebAssemblyPreview(artifact.webAssemblyPreview)
@@ -255,6 +257,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(iniPreview)
               \(dotenvPreview)
               \(yamlPreview)
+              \(junitPreview)
               \(xmlPreview)
               \(propertyListPreview)
               \(sqlitePreview)
@@ -800,6 +803,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(childList)
+        </div>
+        """
+    }
+
+    private static func renderJUnitPreview(_ preview: ToolArtifactJUnitPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-junit-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let suites = preview.suitePreviewLabels.map {
+            #"<li data-testid="tool-card-junit-preview-suite-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-junit-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let suiteList = suites.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-junit-preview-suites">
+                <strong data-testid="tool-card-junit-preview-suite-title">Suites</strong>
+                <ul>\(suites)</ul>
+              </section>
+        """
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-junit-preview-failures">
+                <strong data-testid="tool-card-junit-preview-failure-title">Failing tests</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !suiteList.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-junit-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(suiteList)
+          \(failureList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1076,6 +1076,82 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteXML.xmlPreview)
     }
 
+    func testArtifactStateDerivesJUnitPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("TEST-QuillCode.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+          <testsuite name="QuillCodeAppTests" tests="3" failures="1" errors="0" skipped="1" time="1.25">
+            <testcase classname="QuillCodeAppTests.WorkspaceTests" name="testRendersArtifacts" time="0.1" />
+            <testcase classname="QuillCodeAppTests.WorkspaceTests" name="testStreamsOutput" time="0.2">
+              <failure message="expected streamed output" />
+            </testcase>
+            <testcase classname="QuillCodeAppTests.WorkspaceTests" name="testSkipped">
+              <skipped />
+            </testcase>
+          </testsuite>
+          <testsuite name="QuillCodeToolsTests" tests="2" failures="0" errors="1" skipped="0" time="0.75">
+            <testcase classname="QuillCodeToolsTests.ShellTests" name="testWhoami" />
+            <testcase classname="QuillCodeToolsTests.ShellTests" name="testTimeout">
+              <error message="timed out" />
+            </testcase>
+          </testsuite>
+        </testsuites>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.junitPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.suiteCount, 2)
+        XCTAssertEqual(preview.testCount, 5)
+        XCTAssertEqual(preview.failureCount, 1)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.skippedCount, 1)
+        XCTAssertEqual(preview.durationLabel, "2 s")
+        XCTAssertEqual(preview.suitePreviewLabels, ["QuillCodeAppTests", "QuillCodeToolsTests"])
+        XCTAssertEqual(preview.failurePreviewLabels, [
+            "QuillCodeAppTests.WorkspaceTests.testStreamsOutput",
+            "QuillCodeToolsTests.ShellTests.testTimeout"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: JUnit XML",
+            "2 suites",
+            "5 tests",
+            "Failures: 1",
+            "Errors: 1",
+            "Skipped: 1",
+            "Duration: 2 s",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let fallbackReport = directory.appendingPathComponent("fallback.xml")
+        try """
+        <testsuite name="FallbackSuite">
+          <testcase classname="FallbackTests" name="testPass" />
+          <testcase classname="FallbackTests" name="testFailure"><failure /></testcase>
+          <testcase classname="FallbackTests" name="testError"><error /></testcase>
+          <testcase classname="FallbackTests" name="testSkipped"><skipped /></testcase>
+        </testsuite>
+        """.write(to: fallbackReport, atomically: true, encoding: .utf8)
+        let fallbackPreview = try XCTUnwrap(ToolArtifactState(value: fallbackReport.path).junitPreview)
+        XCTAssertEqual(fallbackPreview.testCount, 4)
+        XCTAssertEqual(fallbackPreview.failureCount, 1)
+        XCTAssertEqual(fallbackPreview.errorCount, 1)
+        XCTAssertEqual(fallbackPreview.skippedCount, 1)
+
+        let nonJUnit = directory.appendingPathComponent("manifest.xml")
+        try "<project><target /></project>".write(to: nonJUnit, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: nonJUnit.path).junitPreview)
+
+        let remoteJUnit = ToolArtifactState(value: "https://example.com/TEST-QuillCode.xml")
+        XCTAssertNil(remoteJUnit.junitPreview)
+    }
+
     func testArtifactStateDerivesSQLitePreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let database = directory.appendingPathComponent("cache.sqlite3")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1274,6 +1274,67 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-xml-preview-child-item">settings"#))
     }
 
+    func testHTMLRendererIncludesJUnitArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("TEST-QuillCode.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuite name="QuillCodeAppTests" tests="3" failures="1" errors="1" skipped="1" time="1.25">
+          <testcase classname="QuillCodeAppTests.WorkspaceTests" name="testRendersArtifacts" />
+          <testcase classname="QuillCodeAppTests.WorkspaceTests" name="testStreamsOutput">
+            <failure message="expected streamed output" />
+          </testcase>
+          <testcase classname="QuillCodeAppTests.WorkspaceTests" name="testTimeout">
+            <error message="timed out" />
+          </testcase>
+          <testcase classname="QuillCodeAppTests.WorkspaceTests" name="testSkipped">
+            <skipped />
+          </testcase>
+        </testsuite>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"TEST-QuillCode.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote TEST-QuillCode.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "JUnit artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">TEST-QuillCode.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-meta">Format: JUnit XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-meta">1 suite"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-meta">3 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-meta">Failures: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-meta">Skipped: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-meta">Duration: 1.25 s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-suite-title">Suites"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-suite-item">QuillCodeAppTests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-failure-title">Failing tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-failure-item">QuillCodeAppTests.WorkspaceTests.testStreamsOutput"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-junit-preview-failure-item">QuillCodeAppTests.WorkspaceTests.testTimeout"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesAppshotArtifactPreview() throws {
         let root = try makeTempDirectory()
         let appshots = root.appendingPathComponent("appshots", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -90,6 +90,9 @@
   or rendering notebook outputs.
 - Artifact previews now include bounded local XML metadata using native XML parsing:
   root element, element/attribute/namespace counts, file size, and capped root-child previews.
+- Artifact previews now include bounded local JUnit XML test-report metadata for `.xml` files whose
+  root is `testsuite` or `testsuites`: suite/test counts, failure/error/skipped counts, duration,
+  file size, suite labels, and failing-test labels without expanding testcase logs or following paths.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2197,3 +2197,20 @@
   exclusion, and generic JSON suppression.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesSARIFArtifactPreview` covers static HTML
   selectors and rendered SARIF metadata.
+
+## 2026-07-18: JUnit XML artifacts render bounded test-report summaries
+
+- **Decision:** Local `.xml` artifacts whose root element is `testsuite` or `testsuites` render as
+  structured JUnit report cards instead of generic XML. The preview shows suite/test counts,
+  failure/error/skipped counts, aggregate duration, file size, capped suite labels, and capped failing
+  testcase labels.
+- **Why:** Coding agents frequently create JUnit XML through test runners and CI jobs. A Codex-style
+  artifact surface should make pass/fail shape immediately visible without asking the model to parse a
+  raw XML tree or flood the transcript with testcase logs.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at 512 KB.
+  It never expands testcase stdout/stderr, never follows paths or classname references, and never
+  fetches remote reports. Generic XML rendering is suppressed only when the JUnit root validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesJUnitPreviewMetadata` covers
+  aggregate attributes, testcase-observed fallback counts, failing labels, non-JUnit XML exclusion,
+  and remote exclusion. `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesJUnitArtifactPreview`
+  covers static HTML selectors, rendered metadata, and generic XML suppression.


### PR DESCRIPTION
## Summary
- detect local XML artifacts whose root is testsuite/testsuites and render them as JUnit test-report previews
- show suite/test counts, failure/error/skipped counts, duration, suite labels, and failing-test labels in SwiftUI and static HTML
- suppress generic XML rendering only for validated JUnit reports

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check