### PR TITLE
Add Cobertura artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -81,6 +81,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             yamlContent(yamlPreview)
         } else if let junitPreview = artifact.junitPreview {
             junitContent(junitPreview)
+        } else if let coberturaPreview = artifact.coberturaPreview {
+            coberturaContent(coberturaPreview)
         } else if let xmlPreview = artifact.xmlPreview {
             xmlContent(xmlPreview)
         } else if let propertyListPreview = artifact.propertyListPreview {
@@ -341,6 +343,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(junitPreview.metadataLines)
             artifactContentList(title: "Suites", labels: junitPreview.suitePreviewLabels)
             artifactContentList(title: "Failing tests", labels: junitPreview.failurePreviewLabels)
+        }
+    }
+
+    private func coberturaContent(_ coberturaPreview: ToolArtifactCoberturaPreview) -> some View {
+        previewSurface(minHeight: coberturaPreview.classPreviewLabels.isEmpty ? 92 : 154) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chart.bar.doc.horizontal")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(coberturaPreview.metadataLines)
+            artifactContentList(title: "Packages", labels: coberturaPreview.packagePreviewLabels)
+            artifactContentList(title: "Classes", labels: coberturaPreview.classPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1021,6 +1021,89 @@ public struct ToolArtifactJUnitPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactCoberturaPreview: Codable, Sendable, Hashable {
+    public var versionLabel: String?
+    public var packageCount: Int
+    public var classCount: Int
+    public var lineCoveredCount: Int?
+    public var lineValidCount: Int?
+    public var branchCoveredCount: Int?
+    public var branchValidCount: Int?
+    public var lineRateLabel: String?
+    public var branchRateLabel: String?
+    public var byteSizeLabel: String?
+    public var packagePreviewLabels: [String]
+    public var classPreviewLabels: [String]
+
+    public var lineCoverageLabel: String? {
+        coverageLabel(covered: lineCoveredCount, valid: lineValidCount) ?? lineRateLabel
+    }
+
+    public var branchCoverageLabel: String? {
+        coverageLabel(covered: branchCoveredCount, valid: branchValidCount) ?? branchRateLabel
+    }
+
+    public var metadataLines: [String] {
+        [
+            "Format: Cobertura XML",
+            versionLabel.map { "Version: \($0)" },
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            "\(classCount) class\(classCount == 1 ? "" : "es")",
+            lineCoverageLabel.map { "Lines: \($0)" },
+            branchCoverageLabel.map { "Branches: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount > 0
+            || classCount > 0
+            || lineCoverageLabel != nil
+            || branchCoverageLabel != nil
+            || byteSizeLabel != nil
+            || !packagePreviewLabels.isEmpty
+            || !classPreviewLabels.isEmpty
+    }
+
+    public init(
+        versionLabel: String? = nil,
+        packageCount: Int,
+        classCount: Int,
+        lineCoveredCount: Int? = nil,
+        lineValidCount: Int? = nil,
+        branchCoveredCount: Int? = nil,
+        branchValidCount: Int? = nil,
+        lineRateLabel: String? = nil,
+        branchRateLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        packagePreviewLabels: [String] = [],
+        classPreviewLabels: [String] = []
+    ) {
+        self.versionLabel = versionLabel
+        self.packageCount = packageCount
+        self.classCount = classCount
+        self.lineCoveredCount = lineCoveredCount
+        self.lineValidCount = lineValidCount
+        self.branchCoveredCount = branchCoveredCount
+        self.branchValidCount = branchValidCount
+        self.lineRateLabel = lineRateLabel
+        self.branchRateLabel = branchRateLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.packagePreviewLabels = packagePreviewLabels
+        self.classPreviewLabels = classPreviewLabels
+    }
+
+    private func coverageLabel(covered: Int?, valid: Int?) -> String? {
+        guard let covered, let valid, valid > 0 else { return nil }
+        let percent = (Double(covered) / Double(valid)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : "\(rounded)%"
+        return "\(percentLabel) (\(covered)/\(valid))"
+    }
+}
+
 public struct ToolArtifactPropertyListPreview: Codable, Sendable, Hashable {
     public var rootLabel: String
     public var formatLabel: String?
@@ -1408,6 +1491,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var junitPreview: ToolArtifactJUnitPreview? {
         ToolArtifactJUnitPreviewBuilder.junitPreview(for: value, kind: kind)
+    }
+    public var coberturaPreview: ToolArtifactCoberturaPreview? {
+        ToolArtifactCoberturaPreviewBuilder.coberturaPreview(for: value, kind: kind)
     }
     public var xmlPreview: ToolArtifactXMLPreview? {
         ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactCoberturaPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCoberturaPreviewBuilder.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+enum ToolArtifactCoberturaPreviewBuilder {
+    static func coberturaPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactCoberturaPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let collector = CoberturaPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class CoberturaPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var versionLabel: String?
+    private var lineCoveredCount: Int?
+    private var lineValidCount: Int?
+    private var branchCoveredCount: Int?
+    private var branchValidCount: Int?
+    private var lineRateLabel: String?
+    private var branchRateLabel: String?
+    private var packageCount = 0
+    private var classCount = 0
+    private var packageLabels: [String] = []
+    private var classLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = qualifiedElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+            recordCoverage(attributeDict)
+        }
+
+        switch label {
+        case "package":
+            recordPackage(attributeDict)
+        case "class":
+            recordClass(attributeDict)
+        default:
+            break
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactCoberturaPreview? {
+        guard rootElementLabel == "coverage" else { return nil }
+        return ToolArtifactCoberturaPreview(
+            versionLabel: versionLabel,
+            packageCount: packageCount,
+            classCount: classCount,
+            lineCoveredCount: lineCoveredCount,
+            lineValidCount: lineValidCount,
+            branchCoveredCount: branchCoveredCount,
+            branchValidCount: branchValidCount,
+            lineRateLabel: lineRateLabel,
+            branchRateLabel: branchRateLabel,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            packagePreviewLabels: Array(packageLabels.prefix(previewLabelLimit)),
+            classPreviewLabels: Array(classLabels.prefix(previewLabelLimit))
+        )
+    }
+
+    private func recordCoverage(_ attributes: [String: String]) {
+        versionLabel = sanitizedLabel(attributes["version"])
+        lineCoveredCount = intAttribute("lines-covered", in: attributes)
+        lineValidCount = intAttribute("lines-valid", in: attributes)
+        branchCoveredCount = intAttribute("branches-covered", in: attributes)
+        branchValidCount = intAttribute("branches-valid", in: attributes)
+        lineRateLabel = rateLabel(attributes["line-rate"])
+        branchRateLabel = rateLabel(attributes["branch-rate"])
+    }
+
+    private func recordPackage(_ attributes: [String: String]) {
+        packageCount += 1
+        appendUniqueLabel(sanitizedLabel(attributes["name"]), to: &packageLabels)
+    }
+
+    private func recordClass(_ attributes: [String: String]) {
+        classCount += 1
+        let name = sanitizedLabel(attributes["name"])
+        let filename = sanitizedLabel(attributes["filename"])
+        let label: String?
+        switch (name, filename) {
+        case let (name?, filename?) where name != filename:
+            label = "\(name) · \(filename)"
+        case let (name?, _):
+            label = name
+        case let (_, filename?):
+            label = filename
+        default:
+            label = nil
+        }
+        appendUniqueLabel(label, to: &classLabels)
+    }
+
+    private func appendUniqueLabel(_ label: String?, to labels: inout [String]) {
+        guard let label, !labels.contains(label) else { return }
+        labels.append(label)
+    }
+
+    private func intAttribute(_ key: String, in attributes: [String: String]) -> Int? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let intValue = Int(value),
+              intValue >= 0
+        else {
+            return nil
+        }
+        return intValue
+    }
+
+    private func rateLabel(_ label: String?) -> String? {
+        guard let label = sanitizedLabel(label),
+              let rate = Double(label),
+              rate >= 0
+        else {
+            return nil
+        }
+        let percent = min(rate, 1) * 100
+        let rounded = (percent * 10).rounded() / 10
+        return rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : "\(rounded)%"
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func qualifiedElementName(elementName: String, qName: String?) -> String {
+        guard let qName, !qName.isEmpty else { return elementName }
+        return qName
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -222,7 +222,11 @@ enum WorkspaceHTMLToolCardRenderer {
             let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
             let junitPreviewModel = artifact.junitPreview
             let junitPreview = renderJUnitPreview(junitPreviewModel)
-            let xmlPreview = junitPreviewModel == nil ? renderXMLPreview(artifact.xmlPreview) : ""
+            let coberturaPreviewModel = artifact.coberturaPreview
+            let coberturaPreview = renderCoberturaPreview(coberturaPreviewModel)
+            let xmlPreview = junitPreviewModel == nil && coberturaPreviewModel == nil
+                ? renderXMLPreview(artifact.xmlPreview)
+                : ""
             let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
             let sqlitePreview = renderSQLitePreview(artifact.sqlitePreview)
             let webAssemblyPreview = renderWebAssemblyPreview(artifact.webAssemblyPreview)
@@ -258,6 +262,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(dotenvPreview)
               \(yamlPreview)
               \(junitPreview)
+              \(coberturaPreview)
               \(xmlPreview)
               \(propertyListPreview)
               \(sqlitePreview)
@@ -838,6 +843,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(suiteList)
           \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderCoberturaPreview(_ preview: ToolArtifactCoberturaPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-cobertura-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-cobertura-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let classes = preview.classPreviewLabels.map {
+            #"<li data-testid="tool-card-cobertura-preview-class-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-cobertura-preview-packages">
+                <strong data-testid="tool-card-cobertura-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let classList = classes.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-cobertura-preview-classes">
+                <strong data-testid="tool-card-cobertura-preview-class-title">Classes</strong>
+                <ul>\(classes)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !classList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-cobertura-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(classList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1152,6 +1152,72 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJUnit.junitPreview)
     }
 
+    func testArtifactStateDerivesCoberturaPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("coverage.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <coverage line-rate="0.75" branch-rate="0.5" lines-covered="3" lines-valid="4" branches-covered="1" branches-valid="2" version="1.9">
+          <packages>
+            <package name="QuillCodeApp">
+              <classes>
+                <class name="Workspace" filename="Sources/QuillCodeApp/Workspace.swift" />
+                <class name="ToolCard" filename="Sources/QuillCodeApp/ToolCard.swift" />
+              </classes>
+            </package>
+            <package name="QuillCodeTools">
+              <classes>
+                <class name="ShellToolExecutor" filename="Sources/QuillCodeTools/ShellToolExecutor.swift" />
+              </classes>
+            </package>
+          </packages>
+        </coverage>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.coberturaPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.versionLabel, "1.9")
+        XCTAssertEqual(preview.packageCount, 2)
+        XCTAssertEqual(preview.classCount, 3)
+        XCTAssertEqual(preview.lineCoverageLabel, "75% (3/4)")
+        XCTAssertEqual(preview.branchCoverageLabel, "50% (1/2)")
+        XCTAssertEqual(preview.packagePreviewLabels, ["QuillCodeApp", "QuillCodeTools"])
+        XCTAssertEqual(preview.classPreviewLabels, [
+            "Workspace · Sources/QuillCodeApp/Workspace.swift",
+            "ToolCard · Sources/QuillCodeApp/ToolCard.swift",
+            "ShellToolExecutor · Sources/QuillCodeTools/ShellToolExecutor.swift"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Cobertura XML",
+            "Version: 1.9",
+            "2 packages",
+            "3 classes",
+            "Lines: 75% (3/4)",
+            "Branches: 50% (1/2)",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.junitPreview)
+
+        let rateOnly = directory.appendingPathComponent("rate-only.xml")
+        try #"<coverage line-rate="0.8333" branch-rate="0.25"><packages /></coverage>"#
+            .write(to: rateOnly, atomically: true, encoding: .utf8)
+        let ratePreview = try XCTUnwrap(ToolArtifactState(value: rateOnly.path).coberturaPreview)
+        XCTAssertEqual(ratePreview.lineCoverageLabel, "83.3%")
+        XCTAssertEqual(ratePreview.branchCoverageLabel, "25%")
+
+        let nonCobertura = directory.appendingPathComponent("manifest.xml")
+        try "<project><target /></project>".write(to: nonCobertura, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: nonCobertura.path).coberturaPreview)
+
+        let remoteCobertura = ToolArtifactState(value: "https://example.com/coverage.xml")
+        XCTAssertNil(remoteCobertura.coberturaPreview)
+    }
+
     func testArtifactStateDerivesSQLitePreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let database = directory.appendingPathComponent("cache.sqlite3")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1335,6 +1335,64 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesCoberturaArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("coverage.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <coverage line-rate="0.75" branch-rate="0.5" lines-covered="3" lines-valid="4" branches-covered="1" branches-valid="2" version="1.9">
+          <packages>
+            <package name="QuillCodeApp">
+              <classes>
+                <class name="Workspace" filename="Sources/QuillCodeApp/Workspace.swift" />
+                <class name="ToolCard" filename="Sources/QuillCodeApp/ToolCard.swift" />
+              </classes>
+            </package>
+          </packages>
+        </coverage>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"coverage.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote coverage.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Cobertura artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">coverage.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-meta">Format: Cobertura XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-meta">Version: 1.9"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-meta">1 package"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-meta">2 classes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-meta">Lines: 75% (3/4)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-meta">Branches: 50% (1/2)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-package-title">Packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-package-item">QuillCodeApp"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-class-title">Classes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-class-item">Workspace · Sources/QuillCodeApp/Workspace.swift"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cobertura-preview-class-item">ToolCard · Sources/QuillCodeApp/ToolCard.swift"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesAppshotArtifactPreview() throws {
         let root = try makeTempDirectory()
         let appshots = root.appendingPathComponent("appshots", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -93,6 +93,9 @@
 - Artifact previews now include bounded local JUnit XML test-report metadata for `.xml` files whose
   root is `testsuite` or `testsuites`: suite/test counts, failure/error/skipped counts, duration,
   file size, suite labels, and failing-test labels without expanding testcase logs or following paths.
+- Artifact previews now include bounded local Cobertura XML coverage-report metadata for `.xml` files
+  whose root is `coverage`: package/class counts, line/branch coverage, file size, package labels,
+  and class labels without executing coverage tooling, expanding source files, or following paths.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2214,3 +2214,21 @@
   aggregate attributes, testcase-observed fallback counts, failing labels, non-JUnit XML exclusion,
   and remote exclusion. `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesJUnitArtifactPreview`
   covers static HTML selectors, rendered metadata, and generic XML suppression.
+
+## 2026-07-19: Cobertura XML artifacts render bounded coverage summaries
+
+- **Decision:** Local `.xml` artifacts whose root element is `coverage` render as structured
+  Cobertura coverage cards instead of generic XML. The preview shows package/class counts,
+  line/branch coverage, file size, capped package labels, and capped class labels.
+- **Why:** Coverage jobs commonly emit Cobertura XML even when LCOV is unavailable. Codex-style
+  artifact handling should make coverage shape visible in one glance without requiring the agent to
+  re-open raw XML or summarize a broad report tree in chat.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It never executes coverage tools, never follows class filenames or source paths, never reads
+  referenced files, and never fetches remote coverage URLs. Generic XML rendering is suppressed only
+  after the Cobertura root validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesCoberturaPreviewMetadata`
+  covers count-based coverage, rate-only fallback, package/class labels, non-Cobertura XML exclusion,
+  and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCoberturaArtifactPreview` covers static
+  HTML selectors, rendered coverage metadata, content lists, and generic XML suppression.


### PR DESCRIPTION
## Summary
- add bounded Cobertura XML coverage-report artifact previews for local coverage.xml-style files
- render package/class and line/branch coverage metadata in SwiftUI and static HTML
- suppress generic XML preview when Cobertura root validation succeeds
- document the parser boundary and parity note

## Tests
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check