### PR TITLE
Add Clover artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -83,6 +83,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             junitContent(junitPreview)
         } else if let coberturaPreview = artifact.coberturaPreview {
             coberturaContent(coberturaPreview)
+        } else if let cloverPreview = artifact.cloverPreview {
+            cloverContent(cloverPreview)
         } else if let xmlPreview = artifact.xmlPreview {
             xmlContent(xmlPreview)
         } else if let propertyListPreview = artifact.propertyListPreview {
@@ -358,6 +360,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(coberturaPreview.metadataLines)
             artifactContentList(title: "Packages", labels: coberturaPreview.packagePreviewLabels)
             artifactContentList(title: "Classes", labels: coberturaPreview.classPreviewLabels)
+        }
+    }
+
+    private func cloverContent(_ cloverPreview: ToolArtifactCloverPreview) -> some View {
+        previewSurface(minHeight: cloverPreview.filePreviewLabels.isEmpty ? 92 : 154) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chart.line.uptrend.xyaxis")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(cloverPreview.metadataLines)
+            artifactContentList(title: "Projects", labels: cloverPreview.projectPreviewLabels)
+            artifactContentList(title: "Files", labels: cloverPreview.filePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1104,6 +1104,108 @@ public struct ToolArtifactCoberturaPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactCloverPreview: Codable, Sendable, Hashable {
+    public var packageCount: Int?
+    public var fileCount: Int?
+    public var classCount: Int?
+    public var methodCoveredCount: Int?
+    public var methodCount: Int?
+    public var statementCoveredCount: Int?
+    public var statementCount: Int?
+    public var conditionalCoveredCount: Int?
+    public var conditionalCount: Int?
+    public var elementCoveredCount: Int?
+    public var elementCount: Int?
+    public var byteSizeLabel: String?
+    public var projectPreviewLabels: [String]
+    public var filePreviewLabels: [String]
+
+    public var elementCoverageLabel: String? {
+        coverageLabel(covered: elementCoveredCount, total: elementCount)
+    }
+
+    public var methodCoverageLabel: String? {
+        coverageLabel(covered: methodCoveredCount, total: methodCount)
+    }
+
+    public var statementCoverageLabel: String? {
+        coverageLabel(covered: statementCoveredCount, total: statementCount)
+    }
+
+    public var conditionalCoverageLabel: String? {
+        coverageLabel(covered: conditionalCoveredCount, total: conditionalCount)
+    }
+
+    public var metadataLines: [String] {
+        [
+            "Format: Clover XML",
+            packageCount.map { "\($0) package\($0 == 1 ? "" : "s")" },
+            fileCount.map { "\($0) file\($0 == 1 ? "" : "s")" },
+            classCount.map { "\($0) class\($0 == 1 ? "" : "es")" },
+            elementCoverageLabel.map { "Elements: \($0)" },
+            methodCoverageLabel.map { "Methods: \($0)" },
+            statementCoverageLabel.map { "Statements: \($0)" },
+            conditionalCoverageLabel.map { "Conditionals: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount != nil
+            || fileCount != nil
+            || classCount != nil
+            || elementCoverageLabel != nil
+            || methodCoverageLabel != nil
+            || statementCoverageLabel != nil
+            || conditionalCoverageLabel != nil
+            || byteSizeLabel != nil
+            || !projectPreviewLabels.isEmpty
+            || !filePreviewLabels.isEmpty
+    }
+
+    public init(
+        packageCount: Int? = nil,
+        fileCount: Int? = nil,
+        classCount: Int? = nil,
+        methodCoveredCount: Int? = nil,
+        methodCount: Int? = nil,
+        statementCoveredCount: Int? = nil,
+        statementCount: Int? = nil,
+        conditionalCoveredCount: Int? = nil,
+        conditionalCount: Int? = nil,
+        elementCoveredCount: Int? = nil,
+        elementCount: Int? = nil,
+        byteSizeLabel: String? = nil,
+        projectPreviewLabels: [String] = [],
+        filePreviewLabels: [String] = []
+    ) {
+        self.packageCount = packageCount
+        self.fileCount = fileCount
+        self.classCount = classCount
+        self.methodCoveredCount = methodCoveredCount
+        self.methodCount = methodCount
+        self.statementCoveredCount = statementCoveredCount
+        self.statementCount = statementCount
+        self.conditionalCoveredCount = conditionalCoveredCount
+        self.conditionalCount = conditionalCount
+        self.elementCoveredCount = elementCoveredCount
+        self.elementCount = elementCount
+        self.byteSizeLabel = byteSizeLabel
+        self.projectPreviewLabels = projectPreviewLabels
+        self.filePreviewLabels = filePreviewLabels
+    }
+
+    private func coverageLabel(covered: Int?, total: Int?) -> String? {
+        guard let covered, let total, total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : "\(rounded)%"
+        return "\(percentLabel) (\(covered)/\(total))"
+    }
+}
+
 public struct ToolArtifactPropertyListPreview: Codable, Sendable, Hashable {
     public var rootLabel: String
     public var formatLabel: String?
@@ -1494,6 +1596,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var coberturaPreview: ToolArtifactCoberturaPreview? {
         ToolArtifactCoberturaPreviewBuilder.coberturaPreview(for: value, kind: kind)
+    }
+    public var cloverPreview: ToolArtifactCloverPreview? {
+        ToolArtifactCloverPreviewBuilder.cloverPreview(for: value, kind: kind)
     }
     public var xmlPreview: ToolArtifactXMLPreview? {
         ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactCloverPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCloverPreviewBuilder.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-enum ToolArtifactCoberturaPreviewBuilder {
-    static func coberturaPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactCoberturaPreview? {
+enum ToolArtifactCloverPreviewBuilder {
+    static func cloverPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactCloverPreview? {
         guard kind == .file,
               let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
               documentPreview.kind == .data,
@@ -18,7 +18,7 @@ enum ToolArtifactCoberturaPreviewBuilder {
             guard fileSize > 0, fileSize <= byteLimit else { return nil }
             let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
             guard !data.contains(0) else { return nil }
-            let collector = CoberturaPreviewCollector()
+            let collector = CloverPreviewCollector()
             let parser = XMLParser(data: data)
             parser.delegate = collector
             parser.shouldProcessNamespaces = false
@@ -49,21 +49,23 @@ enum ToolArtifactCoberturaPreviewBuilder {
     private static let byteLimit = 512 * 1_024
 }
 
-private final class CoberturaPreviewCollector: NSObject, XMLParserDelegate {
+private final class CloverPreviewCollector: NSObject, XMLParserDelegate {
     private var depth = 0
     private var rootElementLabel: String?
-    private var versionLabel: String?
-    private var lineCoveredCount: Int?
-    private var lineValidCount: Int?
-    private var branchCoveredCount: Int?
-    private var branchValidCount: Int?
-    private var lineRateLabel: String?
-    private var branchRateLabel: String?
-    private var packageCount = 0
-    private var classCount = 0
-    private var packageLabels: [String] = []
-    private var classLabels: [String] = []
-    private var hasCoberturaMarker = false
+    private var hasCloverMarker = false
+    private var packageCount: Int?
+    private var fileCount: Int?
+    private var classCount: Int?
+    private var methodCoveredCount: Int?
+    private var methodCount: Int?
+    private var statementCoveredCount: Int?
+    private var statementCount: Int?
+    private var conditionalCoveredCount: Int?
+    private var conditionalCount: Int?
+    private var elementCoveredCount: Int?
+    private var elementCount: Int?
+    private var projectLabels: [String] = []
+    private var fileLabels: [String] = []
 
     func parser(
         _ parser: XMLParser,
@@ -75,14 +77,18 @@ private final class CoberturaPreviewCollector: NSObject, XMLParserDelegate {
         let label = qualifiedElementName(elementName: elementName, qName: qName)
         if depth == 0 {
             rootElementLabel = label
-            recordCoverage(attributeDict)
+            hasCloverMarker = attributeDict["clover"] != nil || attributeDict["generated"] != nil
         }
 
         switch label {
-        case "package":
-            recordPackage(attributeDict)
-        case "class":
-            recordClass(attributeDict)
+        case "project":
+            hasCloverMarker = true
+            appendUniqueLabel(sanitizedLabel(attributeDict["name"]), to: &projectLabels)
+        case "metrics":
+            hasCloverMarker = true
+            recordMetrics(attributeDict)
+        case "file":
+            appendUniqueLabel(fileLabel(attributeDict), to: &fileLabels)
         default:
             break
         }
@@ -98,61 +104,42 @@ private final class CoberturaPreviewCollector: NSObject, XMLParserDelegate {
         depth = max(0, depth - 1)
     }
 
-    func preview(fileSize: Int) -> ToolArtifactCoberturaPreview? {
-        guard rootElementLabel == "coverage", hasCoberturaMarker else { return nil }
-        return ToolArtifactCoberturaPreview(
-            versionLabel: versionLabel,
+    func preview(fileSize: Int) -> ToolArtifactCloverPreview? {
+        guard rootElementLabel == "coverage", hasCloverMarker else { return nil }
+        return ToolArtifactCloverPreview(
             packageCount: packageCount,
+            fileCount: fileCount,
             classCount: classCount,
-            lineCoveredCount: lineCoveredCount,
-            lineValidCount: lineValidCount,
-            branchCoveredCount: branchCoveredCount,
-            branchValidCount: branchValidCount,
-            lineRateLabel: lineRateLabel,
-            branchRateLabel: branchRateLabel,
+            methodCoveredCount: methodCoveredCount,
+            methodCount: methodCount,
+            statementCoveredCount: statementCoveredCount,
+            statementCount: statementCount,
+            conditionalCoveredCount: conditionalCoveredCount,
+            conditionalCount: conditionalCount,
+            elementCoveredCount: elementCoveredCount,
+            elementCount: elementCount,
             byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
-            packagePreviewLabels: Array(packageLabels.prefix(previewLabelLimit)),
-            classPreviewLabels: Array(classLabels.prefix(previewLabelLimit))
+            projectPreviewLabels: Array(projectLabels.prefix(previewLabelLimit)),
+            filePreviewLabels: Array(fileLabels.prefix(previewLabelLimit))
         )
     }
 
-    private func recordCoverage(_ attributes: [String: String]) {
-        versionLabel = sanitizedLabel(attributes["version"])
-        lineCoveredCount = intAttribute("lines-covered", in: attributes)
-        lineValidCount = intAttribute("lines-valid", in: attributes)
-        branchCoveredCount = intAttribute("branches-covered", in: attributes)
-        branchValidCount = intAttribute("branches-valid", in: attributes)
-        lineRateLabel = rateLabel(attributes["line-rate"])
-        branchRateLabel = rateLabel(attributes["branch-rate"])
-        hasCoberturaMarker = attributes["line-rate"] != nil
-            || attributes["branch-rate"] != nil
-            || attributes["lines-covered"] != nil
-            || attributes["lines-valid"] != nil
-            || attributes["branches-covered"] != nil
-            || attributes["branches-valid"] != nil
+    private func recordMetrics(_ attributes: [String: String]) {
+        packageCount = intAttribute("packages", in: attributes) ?? packageCount
+        fileCount = intAttribute("files", in: attributes) ?? fileCount
+        classCount = intAttribute("classes", in: attributes) ?? classCount
+        methodCoveredCount = intAttribute("coveredmethods", in: attributes) ?? methodCoveredCount
+        methodCount = intAttribute("methods", in: attributes) ?? methodCount
+        statementCoveredCount = intAttribute("coveredstatements", in: attributes) ?? statementCoveredCount
+        statementCount = intAttribute("statements", in: attributes) ?? statementCount
+        conditionalCoveredCount = intAttribute("coveredconditionals", in: attributes) ?? conditionalCoveredCount
+        conditionalCount = intAttribute("conditionals", in: attributes) ?? conditionalCount
+        elementCoveredCount = intAttribute("coveredelements", in: attributes) ?? elementCoveredCount
+        elementCount = intAttribute("elements", in: attributes) ?? elementCount
     }
 
-    private func recordPackage(_ attributes: [String: String]) {
-        packageCount += 1
-        appendUniqueLabel(sanitizedLabel(attributes["name"]), to: &packageLabels)
-    }
-
-    private func recordClass(_ attributes: [String: String]) {
-        classCount += 1
-        let name = sanitizedLabel(attributes["name"])
-        let filename = sanitizedLabel(attributes["filename"])
-        let label: String?
-        switch (name, filename) {
-        case let (name?, filename?) where name != filename:
-            label = "\(name) · \(filename)"
-        case let (name?, _):
-            label = name
-        case let (_, filename?):
-            label = filename
-        default:
-            label = nil
-        }
-        appendUniqueLabel(label, to: &classLabels)
+    private func fileLabel(_ attributes: [String: String]) -> String? {
+        sanitizedLabel(attributes["path"]) ?? sanitizedLabel(attributes["name"])
     }
 
     private func appendUniqueLabel(_ label: String?, to labels: inout [String]) {
@@ -168,20 +155,6 @@ private final class CoberturaPreviewCollector: NSObject, XMLParserDelegate {
             return nil
         }
         return intValue
-    }
-
-    private func rateLabel(_ label: String?) -> String? {
-        guard let label = sanitizedLabel(label),
-              let rate = Double(label),
-              rate >= 0
-        else {
-            return nil
-        }
-        let percent = min(rate, 1) * 100
-        let rounded = (percent * 10).rounded() / 10
-        return rounded == rounded.rounded()
-            ? "\(Int(rounded))%"
-            : "\(rounded)%"
     }
 
     private func sanitizedLabel(_ label: String?) -> String? {

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -224,7 +224,9 @@ enum WorkspaceHTMLToolCardRenderer {
             let junitPreview = renderJUnitPreview(junitPreviewModel)
             let coberturaPreviewModel = artifact.coberturaPreview
             let coberturaPreview = renderCoberturaPreview(coberturaPreviewModel)
-            let xmlPreview = junitPreviewModel == nil && coberturaPreviewModel == nil
+            let cloverPreviewModel = artifact.cloverPreview
+            let cloverPreview = renderCloverPreview(cloverPreviewModel)
+            let xmlPreview = junitPreviewModel == nil && coberturaPreviewModel == nil && cloverPreviewModel == nil
                 ? renderXMLPreview(artifact.xmlPreview)
                 : ""
             let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
@@ -263,6 +265,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(yamlPreview)
               \(junitPreview)
               \(coberturaPreview)
+              \(cloverPreview)
               \(xmlPreview)
               \(propertyListPreview)
               \(sqlitePreview)
@@ -878,6 +881,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(packageList)
           \(classList)
+        </div>
+        """
+    }
+
+    private static func renderCloverPreview(_ preview: ToolArtifactCloverPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-clover-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let projects = preview.projectPreviewLabels.map {
+            #"<li data-testid="tool-card-clover-preview-project-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-clover-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let projectList = projects.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-clover-preview-projects">
+                <strong data-testid="tool-card-clover-preview-project-title">Projects</strong>
+                <ul>\(projects)</ul>
+              </section>
+        """
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-clover-preview-files">
+                <strong data-testid="tool-card-clover-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !projectList.isEmpty || !fileList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-clover-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(projectList)
+          \(fileList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1210,12 +1210,72 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertEqual(ratePreview.lineCoverageLabel, "83.3%")
         XCTAssertEqual(ratePreview.branchCoverageLabel, "25%")
 
+        let clover = directory.appendingPathComponent("clover.xml")
+        try #"<coverage generated="1780000000"><project><metrics elements="10" coveredelements="8" /></project></coverage>"#
+            .write(to: clover, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: clover.path).coberturaPreview)
+
         let nonCobertura = directory.appendingPathComponent("manifest.xml")
         try "<project><target /></project>".write(to: nonCobertura, atomically: true, encoding: .utf8)
         XCTAssertNil(ToolArtifactState(value: nonCobertura.path).coberturaPreview)
 
         let remoteCobertura = ToolArtifactState(value: "https://example.com/coverage.xml")
         XCTAssertNil(remoteCobertura.coberturaPreview)
+    }
+
+    func testArtifactStateDerivesCloverPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("clover.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <coverage generated="1780000000" clover="4.5.0">
+          <project name="QuillCode">
+            <file name="Workspace.swift" path="Sources/QuillCodeApp/Workspace.swift" />
+            <file name="ShellToolExecutor.swift" path="Sources/QuillCodeTools/ShellToolExecutor.swift" />
+            <metrics packages="2" files="2" classes="3" methods="10" coveredmethods="8" statements="20" coveredstatements="15" conditionals="6" coveredconditionals="3" elements="36" coveredelements="26" />
+          </project>
+        </coverage>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.cloverPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.packageCount, 2)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.classCount, 3)
+        XCTAssertEqual(preview.elementCoverageLabel, "72.2% (26/36)")
+        XCTAssertEqual(preview.methodCoverageLabel, "80% (8/10)")
+        XCTAssertEqual(preview.statementCoverageLabel, "75% (15/20)")
+        XCTAssertEqual(preview.conditionalCoverageLabel, "50% (3/6)")
+        XCTAssertEqual(preview.projectPreviewLabels, ["QuillCode"])
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "Sources/QuillCodeApp/Workspace.swift",
+            "Sources/QuillCodeTools/ShellToolExecutor.swift"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Clover XML",
+            "2 packages",
+            "2 files",
+            "3 classes",
+            "Elements: 72.2% (26/36)",
+            "Methods: 80% (8/10)",
+            "Statements: 75% (15/20)",
+            "Conditionals: 50% (3/6)",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.coberturaPreview)
+        XCTAssertNil(artifact.junitPreview)
+
+        let nonClover = directory.appendingPathComponent("coverage-generic.xml")
+        try "<coverage><packages /></coverage>".write(to: nonClover, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: nonClover.path).cloverPreview)
+
+        let remoteClover = ToolArtifactState(value: "https://example.com/clover.xml")
+        XCTAssertNil(remoteClover.cloverPreview)
     }
 
     func testArtifactStateDerivesSQLitePreviewMetadata() throws {

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1393,6 +1393,64 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesCloverArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("clover.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <coverage generated="1780000000" clover="4.5.0">
+          <project name="QuillCode">
+            <file name="Workspace.swift" path="Sources/QuillCodeApp/Workspace.swift" />
+            <file name="ShellToolExecutor.swift" path="Sources/QuillCodeTools/ShellToolExecutor.swift" />
+            <metrics packages="2" files="2" classes="3" methods="10" coveredmethods="8" statements="20" coveredstatements="15" conditionals="6" coveredconditionals="3" elements="36" coveredelements="26" />
+          </project>
+        </coverage>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"clover.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote clover.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Clover artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">clover.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">Format: Clover XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">2 packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">3 classes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">Elements: 72.2% (26/36)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">Methods: 80% (8/10)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">Statements: 75% (15/20)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-meta">Conditionals: 50% (3/6)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-project-title">Projects"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-project-item">QuillCode"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-file-item">Sources/QuillCodeApp/Workspace.swift"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-clover-preview-file-item">Sources/QuillCodeTools/ShellToolExecutor.swift"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-cobertura-preview""#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesAppshotArtifactPreview() throws {
         let root = try makeTempDirectory()
         let appshots = root.appendingPathComponent("appshots", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,6 +96,10 @@
 - Artifact previews now include bounded local Cobertura XML coverage-report metadata for `.xml` files
   whose root is `coverage`: package/class counts, line/branch coverage, file size, package labels,
   and class labels without executing coverage tooling, expanding source files, or following paths.
+- Artifact previews now include bounded local Clover XML coverage-report metadata for `.xml` files
+  whose root is `coverage` plus Clover project/metrics markers: package/file/class counts,
+  element/method/statement/conditional coverage, file size, project labels, and file labels without
+  executing coverage tooling or following paths.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2232,3 +2232,23 @@
   and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCoberturaArtifactPreview` covers static
   HTML selectors, rendered coverage metadata, content lists, and generic XML suppression.
+
+## 2026-07-19: Clover XML artifacts render bounded coverage summaries
+
+- **Decision:** Local `.xml` artifacts whose root element is `coverage` and whose content has
+  Clover-style project/metrics markers render as structured Clover coverage cards instead of generic
+  XML. The preview shows package/file/class counts, element/method/statement/conditional coverage,
+  file size, capped project labels, and capped file labels.
+- **Why:** Clover and Cobertura both use a `coverage` root, but they encode coverage shape
+  differently. Codex-style artifact handling should recognize both common CI report formats without
+  treating one as the other or dumping a raw XML tree into the transcript.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It never executes coverage tools, never follows file paths from `<file>` elements, never
+  reads referenced source files, and never fetches remote coverage URLs. Cobertura detection now
+  requires Cobertura-specific coverage attributes so Clover reports are not misclassified.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesCloverPreviewMetadata` covers
+  metric-derived coverage labels, project/file labels, non-Clover XML exclusion, Cobertura
+  disambiguation, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCloverArtifactPreview` covers static
+  HTML selectors, rendered coverage metadata, content lists, Cobertura suppression, and generic XML
+  suppression.


### PR DESCRIPTION
## Summary
- add bounded Clover XML coverage-report artifact previews for local clover.xml-style files
- render element/method/statement/conditional coverage plus project/file labels in SwiftUI and static HTML
- tighten Cobertura detection so Clover reports are not misclassified as Cobertura
- suppress generic XML previews for validated Clover coverage reports

## Tests
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check