### PR TITLE
Add JaCoCo artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -85,6 +85,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             coberturaContent(coberturaPreview)
         } else if let cloverPreview = artifact.cloverPreview {
             cloverContent(cloverPreview)
+        } else if let jaCoCoPreview = artifact.jaCoCoPreview {
+            jaCoCoContent(jaCoCoPreview)
         } else if let xmlPreview = artifact.xmlPreview {
             xmlContent(xmlPreview)
         } else if let propertyListPreview = artifact.propertyListPreview {
@@ -375,6 +377,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(cloverPreview.metadataLines)
             artifactContentList(title: "Projects", labels: cloverPreview.projectPreviewLabels)
             artifactContentList(title: "Files", labels: cloverPreview.filePreviewLabels)
+        }
+    }
+
+    private func jaCoCoContent(_ jaCoCoPreview: ToolArtifactJaCoCoPreview) -> some View {
+        previewSurface(minHeight: jaCoCoPreview.sourceFilePreviewLabels.isEmpty ? 92 : 154) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chart.bar.xaxis")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(jaCoCoPreview.metadataLines)
+            artifactContentList(title: "Packages", labels: jaCoCoPreview.packagePreviewLabels)
+            artifactContentList(title: "Source files", labels: jaCoCoPreview.sourceFilePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1206,6 +1206,114 @@ public struct ToolArtifactCloverPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactJaCoCoPreview: Codable, Sendable, Hashable {
+    public var reportNameLabel: String?
+    public var packageCount: Int
+    public var sourceFileCount: Int
+    public var classCount: Int
+    public var lineCoveredCount: Int?
+    public var lineMissedCount: Int?
+    public var branchCoveredCount: Int?
+    public var branchMissedCount: Int?
+    public var methodCoveredCount: Int?
+    public var methodMissedCount: Int?
+    public var classCoveredCount: Int?
+    public var classMissedCount: Int?
+    public var byteSizeLabel: String?
+    public var packagePreviewLabels: [String]
+    public var sourceFilePreviewLabels: [String]
+
+    public var lineCoverageLabel: String? {
+        coverageLabel(covered: lineCoveredCount, missed: lineMissedCount)
+    }
+
+    public var branchCoverageLabel: String? {
+        coverageLabel(covered: branchCoveredCount, missed: branchMissedCount)
+    }
+
+    public var methodCoverageLabel: String? {
+        coverageLabel(covered: methodCoveredCount, missed: methodMissedCount)
+    }
+
+    public var classCoverageLabel: String? {
+        coverageLabel(covered: classCoveredCount, missed: classMissedCount)
+    }
+
+    public var metadataLines: [String] {
+        [
+            "Format: JaCoCo XML",
+            reportNameLabel.map { "Report: \($0)" },
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            "\(sourceFileCount) source file\(sourceFileCount == 1 ? "" : "s")",
+            "\(classCount) class\(classCount == 1 ? "" : "es")",
+            lineCoverageLabel.map { "Lines: \($0)" },
+            branchCoverageLabel.map { "Branches: \($0)" },
+            methodCoverageLabel.map { "Methods: \($0)" },
+            classCoverageLabel.map { "Classes: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount > 0
+            || sourceFileCount > 0
+            || classCount > 0
+            || lineCoverageLabel != nil
+            || branchCoverageLabel != nil
+            || methodCoverageLabel != nil
+            || classCoverageLabel != nil
+            || byteSizeLabel != nil
+            || !packagePreviewLabels.isEmpty
+            || !sourceFilePreviewLabels.isEmpty
+    }
+
+    public init(
+        reportNameLabel: String? = nil,
+        packageCount: Int,
+        sourceFileCount: Int,
+        classCount: Int,
+        lineCoveredCount: Int? = nil,
+        lineMissedCount: Int? = nil,
+        branchCoveredCount: Int? = nil,
+        branchMissedCount: Int? = nil,
+        methodCoveredCount: Int? = nil,
+        methodMissedCount: Int? = nil,
+        classCoveredCount: Int? = nil,
+        classMissedCount: Int? = nil,
+        byteSizeLabel: String? = nil,
+        packagePreviewLabels: [String] = [],
+        sourceFilePreviewLabels: [String] = []
+    ) {
+        self.reportNameLabel = reportNameLabel
+        self.packageCount = packageCount
+        self.sourceFileCount = sourceFileCount
+        self.classCount = classCount
+        self.lineCoveredCount = lineCoveredCount
+        self.lineMissedCount = lineMissedCount
+        self.branchCoveredCount = branchCoveredCount
+        self.branchMissedCount = branchMissedCount
+        self.methodCoveredCount = methodCoveredCount
+        self.methodMissedCount = methodMissedCount
+        self.classCoveredCount = classCoveredCount
+        self.classMissedCount = classMissedCount
+        self.byteSizeLabel = byteSizeLabel
+        self.packagePreviewLabels = packagePreviewLabels
+        self.sourceFilePreviewLabels = sourceFilePreviewLabels
+    }
+
+    private func coverageLabel(covered: Int?, missed: Int?) -> String? {
+        guard let covered, let missed else { return nil }
+        let total = covered + missed
+        guard total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : "\(rounded)%"
+        return "\(percentLabel) (\(covered)/\(total))"
+    }
+}
+
 public struct ToolArtifactPropertyListPreview: Codable, Sendable, Hashable {
     public var rootLabel: String
     public var formatLabel: String?
@@ -1599,6 +1707,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var cloverPreview: ToolArtifactCloverPreview? {
         ToolArtifactCloverPreviewBuilder.cloverPreview(for: value, kind: kind)
+    }
+    public var jaCoCoPreview: ToolArtifactJaCoCoPreview? {
+        ToolArtifactJaCoCoPreviewBuilder.jaCoCoPreview(for: value, kind: kind)
     }
     public var xmlPreview: ToolArtifactXMLPreview? {
         ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactJaCoCoPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactJaCoCoPreviewBuilder.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+enum ToolArtifactJaCoCoPreviewBuilder {
+    static func jaCoCoPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactJaCoCoPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let collector = JaCoCoPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class JaCoCoPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var reportNameLabel: String?
+    private var packageCount = 0
+    private var sourceFileCount = 0
+    private var classCount = 0
+    private var lineCoveredCount: Int?
+    private var lineMissedCount: Int?
+    private var branchCoveredCount: Int?
+    private var branchMissedCount: Int?
+    private var methodCoveredCount: Int?
+    private var methodMissedCount: Int?
+    private var classCoveredCount: Int?
+    private var classMissedCount: Int?
+    private var hasJaCoCoMarker = false
+    private var packageLabels: [String] = []
+    private var sourceFileLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = qualifiedElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+            reportNameLabel = sanitizedLabel(attributeDict["name"])
+        }
+
+        switch label {
+        case "sessioninfo":
+            hasJaCoCoMarker = true
+        case "package":
+            recordPackage(attributeDict)
+        case "sourcefile":
+            recordSourceFile(attributeDict)
+        case "class":
+            classCount += 1
+        case "counter" where depth == 1:
+            recordRootCounter(attributeDict)
+        default:
+            break
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactJaCoCoPreview? {
+        guard rootElementLabel == "report", hasJaCoCoMarker else { return nil }
+        return ToolArtifactJaCoCoPreview(
+            reportNameLabel: reportNameLabel,
+            packageCount: packageCount,
+            sourceFileCount: sourceFileCount,
+            classCount: classCount,
+            lineCoveredCount: lineCoveredCount,
+            lineMissedCount: lineMissedCount,
+            branchCoveredCount: branchCoveredCount,
+            branchMissedCount: branchMissedCount,
+            methodCoveredCount: methodCoveredCount,
+            methodMissedCount: methodMissedCount,
+            classCoveredCount: classCoveredCount,
+            classMissedCount: classMissedCount,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            packagePreviewLabels: Array(packageLabels.prefix(previewLabelLimit)),
+            sourceFilePreviewLabels: Array(sourceFileLabels.prefix(previewLabelLimit))
+        )
+    }
+
+    private func recordPackage(_ attributes: [String: String]) {
+        hasJaCoCoMarker = true
+        packageCount += 1
+        appendUniqueLabel(sanitizedLabel(attributes["name"]), to: &packageLabels)
+    }
+
+    private func recordSourceFile(_ attributes: [String: String]) {
+        hasJaCoCoMarker = true
+        sourceFileCount += 1
+        appendUniqueLabel(sanitizedLabel(attributes["name"]), to: &sourceFileLabels)
+    }
+
+    private func recordRootCounter(_ attributes: [String: String]) {
+        guard let type = sanitizedLabel(attributes["type"])?.uppercased(),
+              let missed = intAttribute("missed", in: attributes),
+              let covered = intAttribute("covered", in: attributes)
+        else {
+            return
+        }
+        hasJaCoCoMarker = true
+        switch type {
+        case "LINE":
+            lineMissedCount = missed
+            lineCoveredCount = covered
+        case "BRANCH":
+            branchMissedCount = missed
+            branchCoveredCount = covered
+        case "METHOD":
+            methodMissedCount = missed
+            methodCoveredCount = covered
+        case "CLASS":
+            classMissedCount = missed
+            classCoveredCount = covered
+        default:
+            break
+        }
+    }
+
+    private func appendUniqueLabel(_ label: String?, to labels: inout [String]) {
+        guard let label, !labels.contains(label) else { return }
+        labels.append(label)
+    }
+
+    private func intAttribute(_ key: String, in attributes: [String: String]) -> Int? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let intValue = Int(value),
+              intValue >= 0
+        else {
+            return nil
+        }
+        return intValue
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func qualifiedElementName(elementName: String, qName: String?) -> String {
+        guard let qName, !qName.isEmpty else { return elementName }
+        return qName
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -226,7 +226,12 @@ enum WorkspaceHTMLToolCardRenderer {
             let coberturaPreview = renderCoberturaPreview(coberturaPreviewModel)
             let cloverPreviewModel = artifact.cloverPreview
             let cloverPreview = renderCloverPreview(cloverPreviewModel)
-            let xmlPreview = junitPreviewModel == nil && coberturaPreviewModel == nil && cloverPreviewModel == nil
+            let jaCoCoPreviewModel = artifact.jaCoCoPreview
+            let jaCoCoPreview = renderJaCoCoPreview(jaCoCoPreviewModel)
+            let xmlPreview = junitPreviewModel == nil
+                && coberturaPreviewModel == nil
+                && cloverPreviewModel == nil
+                && jaCoCoPreviewModel == nil
                 ? renderXMLPreview(artifact.xmlPreview)
                 : ""
             let propertyListPreview = renderPropertyListPreview(artifact.propertyListPreview)
@@ -266,6 +271,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(junitPreview)
               \(coberturaPreview)
               \(cloverPreview)
+              \(jaCoCoPreview)
               \(xmlPreview)
               \(propertyListPreview)
               \(sqlitePreview)
@@ -916,6 +922,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(projectList)
           \(fileList)
+        </div>
+        """
+    }
+
+    private static func renderJaCoCoPreview(_ preview: ToolArtifactJaCoCoPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-jacoco-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-jacoco-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let sourceFiles = preview.sourceFilePreviewLabels.map {
+            #"<li data-testid="tool-card-jacoco-preview-source-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-jacoco-preview-packages">
+                <strong data-testid="tool-card-jacoco-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let sourceFileList = sourceFiles.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-jacoco-preview-source-files">
+                <strong data-testid="tool-card-jacoco-preview-source-file-title">Source files</strong>
+                <ul>\(sourceFiles)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !sourceFileList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-jacoco-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(sourceFileList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1278,6 +1278,70 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteClover.cloverPreview)
     }
 
+    func testArtifactStateDerivesJaCoCoPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("jacoco.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <report name="QuillCode">
+          <sessioninfo id="test-host" start="1780000000" dump="1780000100" />
+          <package name="dev/quillcode/app">
+            <class name="dev/quillcode/app/Workspace" sourcefilename="Workspace.kt" />
+            <sourcefile name="Workspace.kt" />
+          </package>
+          <package name="dev/quillcode/tools">
+            <class name="dev/quillcode/tools/ShellToolExecutor" sourcefilename="ShellToolExecutor.kt" />
+            <sourcefile name="ShellToolExecutor.kt" />
+          </package>
+          <counter type="INSTRUCTION" missed="4" covered="96" />
+          <counter type="BRANCH" missed="2" covered="6" />
+          <counter type="LINE" missed="3" covered="17" />
+          <counter type="METHOD" missed="1" covered="9" />
+          <counter type="CLASS" missed="0" covered="2" />
+        </report>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.jaCoCoPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.reportNameLabel, "QuillCode")
+        XCTAssertEqual(preview.packageCount, 2)
+        XCTAssertEqual(preview.sourceFileCount, 2)
+        XCTAssertEqual(preview.classCount, 2)
+        XCTAssertEqual(preview.lineCoverageLabel, "85% (17/20)")
+        XCTAssertEqual(preview.branchCoverageLabel, "75% (6/8)")
+        XCTAssertEqual(preview.methodCoverageLabel, "90% (9/10)")
+        XCTAssertEqual(preview.classCoverageLabel, "100% (2/2)")
+        XCTAssertEqual(preview.packagePreviewLabels, ["dev/quillcode/app", "dev/quillcode/tools"])
+        XCTAssertEqual(preview.sourceFilePreviewLabels, ["Workspace.kt", "ShellToolExecutor.kt"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: JaCoCo XML",
+            "Report: QuillCode",
+            "2 packages",
+            "2 source files",
+            "2 classes",
+            "Lines: 85% (17/20)",
+            "Branches: 75% (6/8)",
+            "Methods: 90% (9/10)",
+            "Classes: 100% (2/2)",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.junitPreview)
+        XCTAssertNil(artifact.coberturaPreview)
+        XCTAssertNil(artifact.cloverPreview)
+
+        let nonJaCoCo = directory.appendingPathComponent("report.xml")
+        try "<report><summary /></report>".write(to: nonJaCoCo, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: nonJaCoCo.path).jaCoCoPreview)
+
+        let remoteJaCoCo = ToolArtifactState(value: "https://example.com/jacoco.xml")
+        XCTAssertNil(remoteJaCoCo.jaCoCoPreview)
+    }
+
     func testArtifactStateDerivesSQLitePreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let database = directory.appendingPathComponent("cache.sqlite3")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1451,6 +1451,67 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesJaCoCoArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("jacoco.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <report name="QuillCode">
+          <sessioninfo id="test-host" start="1780000000" dump="1780000100" />
+          <package name="dev/quillcode/app">
+            <class name="dev/quillcode/app/Workspace" sourcefilename="Workspace.kt" />
+            <sourcefile name="Workspace.kt" />
+          </package>
+          <counter type="BRANCH" missed="2" covered="6" />
+          <counter type="LINE" missed="3" covered="17" />
+          <counter type="METHOD" missed="1" covered="9" />
+          <counter type="CLASS" missed="0" covered="1" />
+        </report>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"jacoco.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote jacoco.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "JaCoCo artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">jacoco.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">Format: JaCoCo XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">Report: QuillCode"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">1 package"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">1 source file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">1 class"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">Lines: 85% (17/20)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">Branches: 75% (6/8)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">Methods: 90% (9/10)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-meta">Classes: 100% (1/1)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-package-title">Packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-package-item">dev/quillcode/app"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-source-file-title">Source files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jacoco-preview-source-file-item">Workspace.kt"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesAppshotArtifactPreview() throws {
         let root = try makeTempDirectory()
         let appshots = root.appendingPathComponent("appshots", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -100,6 +100,10 @@
   whose root is `coverage` plus Clover project/metrics markers: package/file/class counts,
   element/method/statement/conditional coverage, file size, project labels, and file labels without
   executing coverage tooling or following paths.
+- Artifact previews now include bounded local JaCoCo XML coverage-report metadata for `.xml` files
+  whose root is `report` plus JaCoCo package/session/counter markers: package/source/class counts,
+  line/branch/method/class coverage, file size, package labels, and source-file labels without
+  executing coverage tooling or following paths.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2252,3 +2252,22 @@
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCloverArtifactPreview` covers static
   HTML selectors, rendered coverage metadata, content lists, Cobertura suppression, and generic XML
   suppression.
+
+## 2026-07-19: JaCoCo XML artifacts render bounded coverage summaries
+
+- **Decision:** Local `.xml` artifacts whose root element is `report` and whose content has JaCoCo
+  package/session/counter markers render as structured JaCoCo coverage cards instead of generic XML.
+  The preview shows package/source/class counts, line/branch/method/class coverage, file size, capped
+  package labels, and capped source-file labels.
+- **Why:** Java and Kotlin projects often produce JaCoCo XML in CI. A Codex-style coding surface
+  should make those coverage reports immediately scannable without requiring the model to parse raw
+  XML or re-run coverage tooling.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It records only root-level aggregate counters, never executes coverage tools, never follows
+  package/source/class names as paths, never reads referenced source files, and never fetches remote
+  coverage URLs. Generic XML rendering is suppressed only after the JaCoCo root validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesJaCoCoPreviewMetadata` covers
+  aggregate counters, package/source labels, non-JaCoCo XML exclusion, non-overlap with other XML
+  report parsers, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesJaCoCoArtifactPreview` covers static
+  HTML selectors, rendered coverage metadata, content lists, and generic XML suppression.


### PR DESCRIPTION
## Summary
- add bounded JaCoCo XML coverage-report previews for local jacoco.xml-style artifacts
- render report/package/source/class counts and line/branch/method/class coverage in SwiftUI and static HTML
- suppress generic XML preview when JaCoCo root validation succeeds
- document local-only parser boundaries and parity notes

## Tests
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check