### PR TITLE
Add Istanbul coverage artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -63,6 +63,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             diffContent(diffPreview)
         } else if let tablePreview = artifact.tablePreview {
             tableContent(tablePreview)
+        } else if let istanbulPreview = artifact.istanbulPreview {
+            istanbulContent(istanbulPreview)
         } else if let harPreview = artifact.harPreview {
             harContent(harPreview)
         } else if let lcovPreview = artifact.lcovPreview {
@@ -205,6 +207,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(harPreview.metadataLines)
             artifactContentList(title: "Hosts", labels: harPreview.hostPreviewLabels)
+        }
+    }
+
+    private func istanbulContent(_ istanbulPreview: ToolArtifactIstanbulPreview) -> some View {
+        previewSurface(minHeight: istanbulPreview.filePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chart.bar.xaxis")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(istanbulPreview.metadataLines)
+            artifactContentList(title: "Source files", labels: istanbulPreview.filePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -465,6 +465,97 @@ public struct ToolArtifactJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactIstanbulPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var sourceFileCount: Int
+    public var statementCoveredCount: Int?
+    public var statementTotalCount: Int?
+    public var branchCoveredCount: Int?
+    public var branchTotalCount: Int?
+    public var functionCoveredCount: Int?
+    public var functionTotalCount: Int?
+    public var lineCoveredCount: Int?
+    public var lineTotalCount: Int?
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+
+    public var statementCoverageLabel: String? {
+        coverageLabel(covered: statementCoveredCount, total: statementTotalCount)
+    }
+
+    public var branchCoverageLabel: String? {
+        coverageLabel(covered: branchCoveredCount, total: branchTotalCount)
+    }
+
+    public var functionCoverageLabel: String? {
+        coverageLabel(covered: functionCoveredCount, total: functionTotalCount)
+    }
+
+    public var lineCoverageLabel: String? {
+        coverageLabel(covered: lineCoveredCount, total: lineTotalCount)
+    }
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(sourceFileCount) source file\(sourceFileCount == 1 ? "" : "s")",
+            lineCoverageLabel.map { "Lines: \($0)" },
+            statementCoverageLabel.map { "Statements: \($0)" },
+            branchCoverageLabel.map { "Branches: \($0)" },
+            functionCoverageLabel.map { "Functions: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        sourceFileCount > 0
+            || lineCoverageLabel != nil
+            || statementCoverageLabel != nil
+            || branchCoverageLabel != nil
+            || functionCoverageLabel != nil
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Istanbul JSON",
+        sourceFileCount: Int,
+        statementCoveredCount: Int? = nil,
+        statementTotalCount: Int? = nil,
+        branchCoveredCount: Int? = nil,
+        branchTotalCount: Int? = nil,
+        functionCoveredCount: Int? = nil,
+        functionTotalCount: Int? = nil,
+        lineCoveredCount: Int? = nil,
+        lineTotalCount: Int? = nil,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.sourceFileCount = sourceFileCount
+        self.statementCoveredCount = statementCoveredCount
+        self.statementTotalCount = statementTotalCount
+        self.branchCoveredCount = branchCoveredCount
+        self.branchTotalCount = branchTotalCount
+        self.functionCoveredCount = functionCoveredCount
+        self.functionTotalCount = functionTotalCount
+        self.lineCoveredCount = lineCoveredCount
+        self.lineTotalCount = lineTotalCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+    }
+
+    private func coverageLabel(covered: Int?, total: Int?) -> String? {
+        guard let covered, let total, total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : String(format: "%.1f%%", rounded)
+        return "\(percentLabel) (\(covered)/\(total))"
+    }
+}
+
 public struct ToolArtifactHARPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var creatorLabel: String?
@@ -1671,6 +1762,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var jsonPreview: ToolArtifactJSONPreview? {
         ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
+    }
+    public var istanbulPreview: ToolArtifactIstanbulPreview? {
+        ToolArtifactIstanbulPreviewBuilder.istanbulPreview(for: value, kind: kind)
     }
     public var harPreview: ToolArtifactHARPreview? {
         ToolArtifactHARPreviewBuilder.harPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactIstanbulPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactIstanbulPreviewBuilder.swift
@@ -1,0 +1,282 @@
+import Foundation
+
+enum ToolArtifactIstanbulPreviewBuilder {
+    static func istanbulPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactIstanbulPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let object = root as? [String: Any] else { return nil }
+            return preview(
+                from: object,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from object: [String: Any], byteSizeLabel: String?) -> ToolArtifactIstanbulPreview? {
+        if let summaryPreview = summaryPreview(from: object, byteSizeLabel: byteSizeLabel) {
+            return summaryPreview
+        }
+
+        let files = object
+            .compactMap { path, value -> FileCoverage? in
+                guard let coverage = value as? [String: Any] else { return nil }
+                return FileCoverage(path: path, object: coverage)
+            }
+            .sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+        guard !files.isEmpty else { return nil }
+
+        let filePreviewLabels = files
+            .prefix(filePreviewLimit)
+            .map(\.previewLabel)
+        return ToolArtifactIstanbulPreview(
+            sourceFileCount: files.count,
+            statementCoveredCount: summed(\.statementCoveredCount, in: files),
+            statementTotalCount: summed(\.statementTotalCount, in: files),
+            branchCoveredCount: summed(\.branchCoveredCount, in: files),
+            branchTotalCount: summed(\.branchTotalCount, in: files),
+            functionCoveredCount: summed(\.functionCoveredCount, in: files),
+            functionTotalCount: summed(\.functionTotalCount, in: files),
+            lineCoveredCount: summed(\.lineCoveredCount, in: files),
+            lineTotalCount: summed(\.lineTotalCount, in: files),
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: filePreviewLabels
+        )
+    }
+
+    private static func summaryPreview(from object: [String: Any], byteSizeLabel: String?) -> ToolArtifactIstanbulPreview? {
+        guard let total = object["total"] as? [String: Any],
+              let lines = counter(named: "lines", in: total)
+                ?? counter(named: "statements", in: total)
+        else { return nil }
+
+        let statements = counter(named: "statements", in: total)
+        let branches = counter(named: "branches", in: total)
+        let functions = counter(named: "functions", in: total)
+        let files = object
+            .filter { key, value in key != "total" && (value as? [String: Any]).map(isSummaryFileCoverage) == true }
+            .sorted { $0.key.localizedStandardCompare($1.key) == .orderedAscending }
+            .map { path, value -> String in
+                guard let coverage = value as? [String: Any],
+                      let fileLines = counter(named: "lines", in: coverage)
+                else { return displayPath(path) }
+                return "\(displayPath(path)) · \(coverageLabel(covered: fileLines.covered, total: fileLines.total) ?? "lines unknown")"
+            }
+            .prefix(filePreviewLimit)
+
+        return ToolArtifactIstanbulPreview(
+            sourceFileCount: object.filter { key, value in
+                key != "total" && (value as? [String: Any]).map(isSummaryFileCoverage) == true
+            }.count,
+            statementCoveredCount: statements?.covered,
+            statementTotalCount: statements?.total,
+            branchCoveredCount: branches?.covered,
+            branchTotalCount: branches?.total,
+            functionCoveredCount: functions?.covered,
+            functionTotalCount: functions?.total,
+            lineCoveredCount: lines.covered,
+            lineTotalCount: lines.total,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: Array(files)
+        )
+    }
+
+    private static func isSummaryFileCoverage(_ object: [String: Any]) -> Bool {
+        counter(named: "lines", in: object) != nil
+            || counter(named: "statements", in: object) != nil
+            || counter(named: "branches", in: object) != nil
+            || counter(named: "functions", in: object) != nil
+    }
+
+    private static func counter(named key: String, in object: [String: Any]) -> CoverageCounter? {
+        guard let counterObject = object[key] as? [String: Any],
+              let total = intValue(counterObject["total"]),
+              let covered = intValue(counterObject["covered"]),
+              total >= 0,
+              covered >= 0
+        else { return nil }
+        return CoverageCounter(covered: min(covered, total), total: total)
+    }
+
+    private static func summed(_ keyPath: KeyPath<FileCoverage, Int>, in files: [FileCoverage]) -> Int {
+        files.reduce(0) { $0 + $1[keyPath: keyPath] }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func displayPath(_ path: String) -> String {
+        let collapsedWhitespace = path
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallback = collapsedWhitespace.isEmpty ? "Unknown source" : collapsedWhitespace
+        let suffix = fallback
+            .split(separator: "/")
+            .suffix(2)
+        let label = suffix.isEmpty ? fallback : suffix.joined(separator: "/")
+        return String(label.prefix(characterLimit))
+    }
+
+    private static func coverageLabel(covered: Int, total: Int) -> String? {
+        guard total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : String(format: "%.1f%%", rounded)
+        return "\(percentLabel)"
+    }
+
+    private struct CoverageCounter {
+        var covered: Int
+        var total: Int
+    }
+
+    private struct FileCoverage {
+        var path: String
+        var statementCoveredCount: Int
+        var statementTotalCount: Int
+        var branchCoveredCount: Int
+        var branchTotalCount: Int
+        var functionCoveredCount: Int
+        var functionTotalCount: Int
+        var lineCoveredCount: Int
+        var lineTotalCount: Int
+
+        init?(path: String, object: [String: Any]) {
+            let statementCounts = Self.flatCounter(object["s"])
+            let functionCounts = Self.flatCounter(object["f"])
+            let branchCounts = Self.branchCounter(object["b"])
+            let lineCounts = Self.lineCounter(statementMap: object["statementMap"], statementHits: object["s"])
+
+            guard statementCounts.total > 0
+                || functionCounts.total > 0
+                || branchCounts.total > 0
+                || lineCounts.total > 0
+            else {
+                return nil
+            }
+
+            self.path = path
+            statementCoveredCount = statementCounts.covered
+            statementTotalCount = statementCounts.total
+            branchCoveredCount = branchCounts.covered
+            branchTotalCount = branchCounts.total
+            functionCoveredCount = functionCounts.covered
+            functionTotalCount = functionCounts.total
+            lineCoveredCount = lineCounts.covered
+            lineTotalCount = lineCounts.total
+        }
+
+        var previewLabel: String {
+            guard let coverage = ToolArtifactIstanbulPreviewBuilder.coverageLabel(
+                covered: lineCoveredCount,
+                total: lineTotalCount
+            ) else {
+                return ToolArtifactIstanbulPreviewBuilder.displayPath(path)
+            }
+            return "\(ToolArtifactIstanbulPreviewBuilder.displayPath(path)) · \(coverage)"
+        }
+
+        private static func flatCounter(_ value: Any?) -> CoverageCounter {
+            guard let object = value as? [String: Any] else {
+                return CoverageCounter(covered: 0, total: 0)
+            }
+            let hits = object.values.compactMap(ToolArtifactIstanbulPreviewBuilder.intValue)
+            return CoverageCounter(
+                covered: hits.filter { $0 > 0 }.count,
+                total: hits.count
+            )
+        }
+
+        private static func branchCounter(_ value: Any?) -> CoverageCounter {
+            guard let object = value as? [String: Any] else {
+                return CoverageCounter(covered: 0, total: 0)
+            }
+            var covered = 0
+            var total = 0
+            for value in object.values {
+                if let hits = value as? [Any] {
+                    for hit in hits.compactMap(ToolArtifactIstanbulPreviewBuilder.intValue) {
+                        total += 1
+                        if hit > 0 { covered += 1 }
+                    }
+                } else if let hit = ToolArtifactIstanbulPreviewBuilder.intValue(value) {
+                    total += 1
+                    if hit > 0 { covered += 1 }
+                }
+            }
+            return CoverageCounter(covered: covered, total: total)
+        }
+
+        private static func lineCounter(statementMap: Any?, statementHits: Any?) -> CoverageCounter {
+            guard let statementMap = statementMap as? [String: Any],
+                  let statementHits = statementHits as? [String: Any]
+            else {
+                return CoverageCounter(covered: 0, total: 0)
+            }
+
+            var coveredLines = Set<Int>()
+            var allLines = Set<Int>()
+            for (id, value) in statementMap {
+                guard let line = lineNumber(in: value) else { continue }
+                allLines.insert(line)
+                if ToolArtifactIstanbulPreviewBuilder.intValue(statementHits[id]).map({ $0 > 0 }) == true {
+                    coveredLines.insert(line)
+                }
+            }
+            return CoverageCounter(covered: coveredLines.count, total: allLines.count)
+        }
+
+        private static func lineNumber(in value: Any) -> Int? {
+            guard let object = value as? [String: Any] else { return nil }
+            if let line = ToolArtifactIstanbulPreviewBuilder.intValue(object["line"]) {
+                return line
+            }
+            guard let start = object["start"] as? [String: Any] else { return nil }
+            return ToolArtifactIstanbulPreviewBuilder.intValue(start["line"])
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let filePreviewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -212,6 +212,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let htmlPreview = renderHTMLPreview(artifact.htmlPreview)
             let diffPreview = renderDiffPreview(artifact.diffPreview)
             let tablePreview = renderTablePreview(artifact.tablePreview)
+            let istanbulPreviewModel = artifact.istanbulPreview
+            let istanbulPreview = renderIstanbulPreview(istanbulPreviewModel)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
             let sarifPreview = renderSARIFPreview(artifact.sarifPreview)
@@ -240,7 +242,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let fontPreview = renderFontPreview(artifact.fontPreview)
             let executablePreview = renderExecutablePreview(artifact.executablePreview)
             let notebookPreview = renderNotebookPreview(artifact.notebookPreview)
-            let jsonPreview = renderJSONPreview(artifact.jsonPreview)
+            let jsonPreview = istanbulPreviewModel == nil ? renderJSONPreview(artifact.jsonPreview) : ""
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
             let archivePreview = renderArchivePreview(artifact.archivePreview)
             let mediaPreview = renderMediaPreview(artifact.mediaPreview)
@@ -260,6 +262,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(htmlPreview)
               \(diffPreview)
               \(tablePreview)
+              \(istanbulPreview)
               \(harPreview)
               \(lcovPreview)
               \(sarifPreview)
@@ -601,6 +604,31 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(hostList)
+        </div>
+        """
+    }
+
+    private static func renderIstanbulPreview(_ preview: ToolArtifactIstanbulPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-istanbul-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-istanbul-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-istanbul-preview-files">
+                <strong data-testid="tool-card-istanbul-preview-file-title">Source files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-istanbul-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1076,6 +1076,91 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteXML.xmlPreview)
     }
 
+    func testArtifactStateDerivesIstanbulPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("coverage-final.json")
+        let content = """
+        {
+          "/workspace/Sources/QuillCodeApp/Workspace.swift": {
+            "statementMap": {
+              "0": {"start": {"line": 10}, "end": {"line": 10}},
+              "1": {"start": {"line": 11}, "end": {"line": 11}},
+              "2": {"start": {"line": 11}, "end": {"line": 11}}
+            },
+            "s": {"0": 1, "1": 0, "2": 2},
+            "fnMap": {"0": {"name": "render"}, "1": {"name": "send"}},
+            "f": {"0": 1, "1": 0},
+            "branchMap": {"0": {"type": "if"}, "1": {"type": "binary-expr"}},
+            "b": {"0": [1, 0], "1": [2, 1]}
+          },
+          "/workspace/Sources/QuillCodeTools/ShellToolExecutor.swift": {
+            "statementMap": {
+              "0": {"start": {"line": 20}, "end": {"line": 20}},
+              "1": {"start": {"line": 21}, "end": {"line": 21}}
+            },
+            "s": {"0": 0, "1": 0},
+            "fnMap": {"0": {"name": "run"}},
+            "f": {"0": 0},
+            "branchMap": {"0": {"type": "if"}},
+            "b": {"0": [0, 0]}
+          }
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.istanbulPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.sourceFileCount, 2)
+        XCTAssertEqual(preview.lineCoverageLabel, "50% (2/4)")
+        XCTAssertEqual(preview.statementCoverageLabel, "40% (2/5)")
+        XCTAssertEqual(preview.branchCoverageLabel, "50% (3/6)")
+        XCTAssertEqual(preview.functionCoverageLabel, "33.3% (1/3)")
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "QuillCodeApp/Workspace.swift · 100%",
+            "QuillCodeTools/ShellToolExecutor.swift · 0%"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Istanbul JSON",
+            "2 source files",
+            "Lines: 50% (2/4)",
+            "Statements: 40% (2/5)",
+            "Branches: 50% (3/6)",
+            "Functions: 33.3% (1/3)",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"status":"passed","durationMs":42}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).istanbulPreview)
+
+        let summary = directory.appendingPathComponent("coverage-summary.json")
+        try """
+        {
+          "total": {
+            "lines": {"total": 20, "covered": 18, "skipped": 0, "pct": 90},
+            "statements": {"total": 25, "covered": 20, "skipped": 0, "pct": 80},
+            "branches": {"total": 10, "covered": 7, "skipped": 0, "pct": 70},
+            "functions": {"total": 5, "covered": 4, "skipped": 0, "pct": 80}
+          },
+          "/workspace/Sources/QuillCodeApp/Workspace.swift": {
+            "lines": {"total": 10, "covered": 9, "skipped": 0, "pct": 90}
+          }
+        }
+        """.write(to: summary, atomically: true, encoding: .utf8)
+        let summaryPreview = try XCTUnwrap(ToolArtifactState(value: summary.path).istanbulPreview)
+        XCTAssertEqual(summaryPreview.lineCoverageLabel, "90% (18/20)")
+        XCTAssertEqual(summaryPreview.statementCoverageLabel, "80% (20/25)")
+        XCTAssertEqual(summaryPreview.branchCoverageLabel, "70% (7/10)")
+        XCTAssertEqual(summaryPreview.functionCoverageLabel, "80% (4/5)")
+
+        let remoteIstanbul = ToolArtifactState(value: "https://example.com/coverage-final.json")
+        XCTAssertNil(remoteIstanbul.istanbulPreview)
+    }
+
     func testArtifactStateDerivesJUnitPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("TEST-QuillCode.xml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -701,6 +701,63 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-content">"#))
     }
 
+    func testHTMLRendererIncludesIstanbulArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let coverageDirectory = root.appendingPathComponent("coverage", isDirectory: true)
+        try FileManager.default.createDirectory(at: coverageDirectory, withIntermediateDirectories: true)
+        let coverage = coverageDirectory.appendingPathComponent("coverage-final.json")
+        let coverageText = """
+        {
+          "/workspace/Sources/QuillCodeApp/Workspace.swift": {
+            "statementMap": {
+              "0": {"start": {"line": 10}, "end": {"line": 10}},
+              "1": {"start": {"line": 11}, "end": {"line": 11}}
+            },
+            "s": {"0": 1, "1": 0},
+            "fnMap": {"0": {"name": "render"}},
+            "f": {"0": 1},
+            "branchMap": {"0": {"type": "if"}},
+            "b": {"0": [1, 0]}
+          }
+        }
+        """
+        try coverageText.write(to: coverage, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"coverage/coverage-final.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote coverage/coverage-final.json\n", artifacts: [coverage.path])
+        let thread = ChatThread(
+            title: "Istanbul artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">coverage-final.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-istanbul-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-istanbul-preview-meta">Format: Istanbul JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-istanbul-preview-meta">1 source file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-istanbul-preview-meta">Lines: 50% (1/2)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-istanbul-preview-file-title">Source files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-istanbul-preview-file-item">QuillCodeApp/Workspace.swift · 50%"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesHARArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -104,6 +104,10 @@
   whose root is `report` plus JaCoCo package/session/counter markers: package/source/class counts,
   line/branch/method/class coverage, file size, package labels, and source-file labels without
   executing coverage tooling or following paths.
+- Artifact previews now include bounded local Istanbul/nyc JSON coverage-report metadata for
+  `coverage-final.json` and `coverage-summary.json` style artifacts: source-file counts,
+  line/statement/branch/function coverage, file size, and capped source-file previews without
+  executing coverage tooling, following report paths, or fetching remote JSON.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2271,3 +2271,22 @@
   report parsers, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesJaCoCoArtifactPreview` covers static
   HTML selectors, rendered coverage metadata, content lists, and generic XML suppression.
+
+## 2026-07-19: Istanbul JSON artifacts render bounded coverage summaries
+
+- **Decision:** Local JSON artifacts that match Istanbul/nyc `coverage-final.json` or
+  `coverage-summary.json` shapes render as structured Istanbul coverage cards instead of generic JSON.
+  The preview shows source-file count, line/statement/branch/function coverage, file size, and capped
+  source-file labels.
+- **Why:** JavaScript and TypeScript projects commonly emit Istanbul/nyc JSON while coding agents fix
+  test coverage. A Codex-style artifact surface should make the coverage shape visible without asking
+  the model to inspect raw JSON or re-run project tooling.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It reads only the artifact JSON, never executes coverage tools, never follows covered source
+  paths, never reads referenced source files, and never fetches remote coverage URLs. Generic JSON
+  rendering is suppressed only after an Istanbul coverage shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesIstanbulPreviewMetadata`
+  covers final-report counters, summary-report counters, source-file labels, generic JSON exclusion,
+  and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesIstanbulArtifactPreview` covers static
+  HTML selectors, rendered coverage metadata, content lists, and generic JSON suppression.


### PR DESCRIPTION
## Summary
- add bounded local Istanbul/nyc JSON coverage artifact previews for coverage-final.json and coverage-summary.json shapes
- render line/statement/branch/function coverage plus capped source-file labels in SwiftUI/static HTML surfaces
- document the artifact boundary in the parity matrix and decisions log

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check