### PR TITLE
Add Go coverage artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -69,6 +69,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             harContent(harPreview)
         } else if let lcovPreview = artifact.lcovPreview {
             lcovContent(lcovPreview)
+        } else if let goCoveragePreview = artifact.goCoveragePreview {
+            goCoverageContent(goCoveragePreview)
         } else if let sarifPreview = artifact.sarifPreview {
             sarifContent(sarifPreview)
         } else if let jsonLinesPreview = artifact.jsonLinesPreview {
@@ -235,6 +237,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(lcovPreview.metadataLines)
             artifactContentList(title: "Source files", labels: lcovPreview.sourcePreviewLabels)
+        }
+    }
+
+    private func goCoverageContent(_ goCoveragePreview: ToolArtifactGoCoveragePreview) -> some View {
+        previewSurface(minHeight: goCoveragePreview.sourcePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chart.bar.doc.horizontal")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(goCoveragePreview.metadataLines)
+            artifactContentList(title: "Source files", labels: goCoveragePreview.sourcePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -684,6 +684,75 @@ public struct ToolArtifactLCOVPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactGoCoveragePreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var modeLabel: String?
+    public var sourceFileCount: Int
+    public var blockCount: Int
+    public var statementCoveredCount: Int
+    public var statementTotalCount: Int
+    public var byteSizeLabel: String?
+    public var isTruncated: Bool
+    public var sourcePreviewLabels: [String]
+
+    public var statementCoverageLabel: String? {
+        coverageLabel(covered: statementCoveredCount, total: statementTotalCount)
+    }
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            modeLabel.map { "Mode: \($0)" },
+            "\(sourceFileCount) source file\(sourceFileCount == 1 ? "" : "s")",
+            "\(blockCount) block\(blockCount == 1 ? "" : "s")",
+            statementCoverageLabel.map { "Statements: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" },
+            isTruncated ? "Preview: first 512 KB scanned" : nil
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        sourceFileCount > 0
+            || blockCount > 0
+            || statementCoverageLabel != nil
+            || byteSizeLabel != nil
+            || isTruncated
+            || !sourcePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Go coverage",
+        modeLabel: String? = nil,
+        sourceFileCount: Int,
+        blockCount: Int,
+        statementCoveredCount: Int,
+        statementTotalCount: Int,
+        byteSizeLabel: String? = nil,
+        isTruncated: Bool = false,
+        sourcePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.modeLabel = modeLabel
+        self.sourceFileCount = sourceFileCount
+        self.blockCount = blockCount
+        self.statementCoveredCount = statementCoveredCount
+        self.statementTotalCount = statementTotalCount
+        self.byteSizeLabel = byteSizeLabel
+        self.isTruncated = isTruncated
+        self.sourcePreviewLabels = sourcePreviewLabels
+    }
+
+    private func coverageLabel(covered: Int, total: Int) -> String? {
+        guard total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : String(format: "%.1f%%", rounded)
+        return "\(percentLabel) (\(covered)/\(total))"
+    }
+}
+
 public struct ToolArtifactSARIFPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var runCount: Int
@@ -1771,6 +1840,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var lcovPreview: ToolArtifactLCOVPreview? {
         ToolArtifactLCOVPreviewBuilder.lcovPreview(for: value, kind: kind)
+    }
+    public var goCoveragePreview: ToolArtifactGoCoveragePreview? {
+        ToolArtifactGoCoveragePreviewBuilder.goCoveragePreview(for: value, kind: kind)
     }
     public var sarifPreview: ToolArtifactSARIFPreview? {
         ToolArtifactSARIFPreviewBuilder.sarifPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -31,6 +31,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == "lcov.info" {
             return "lcov"
         }
+        if filename == "cover.out" || filename == "coverage.out" {
+            return "gocover"
+        }
         for compoundExtension in compoundPreviewExtensions {
             if filename.hasSuffix(".\(compoundExtension.suffix)") {
                 return compoundExtension.previewExtension
@@ -57,6 +60,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "json": .data,
         "jsonl": .data,
         "lcov": .data,
+        "gocover": .data,
         "ndjson": .data,
         "sarif": .data,
         "cfg": .data,

--- a/Sources/QuillCodeApp/ToolArtifactGoCoveragePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactGoCoveragePreviewBuilder.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+enum ToolArtifactGoCoveragePreviewBuilder {
+    static func goCoveragePreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactGoCoveragePreview? {
+        guard kind == .file,
+              ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind)?.extensionLabel.lowercased() == "gocover",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+
+            let handle = try FileHandle(forReadingFrom: fileURL)
+            defer { try? handle.close() }
+            guard let data = try handle.read(upToCount: byteLimit + 1),
+                  !data.isEmpty
+            else { return nil }
+
+            let isTruncated = data.count > byteLimit
+            let previewData = Data(data.prefix(byteLimit))
+            guard !previewData.contains(0),
+                  let text = String(data: previewData, encoding: .utf8)
+            else { return nil }
+
+            return preview(
+                from: text,
+                byteSizeLabel: resourceValues.fileSize.flatMap(ToolArtifactByteSizeFormatter.label),
+                isTruncated: isTruncated
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from text: String,
+        byteSizeLabel: String?,
+        isTruncated: Bool
+    ) -> ToolArtifactGoCoveragePreview? {
+        var modeLabel: String?
+        var filesByPath: [String: SourceFileCoverage] = [:]
+        var blockCount = 0
+
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty else { continue }
+
+            if line.hasPrefix("mode:") {
+                modeLabel = sanitizedMode(String(line.dropFirst(5)))
+                continue
+            }
+
+            guard let block = CoverageBlock(line) else { continue }
+            blockCount += 1
+            filesByPath[block.path, default: SourceFileCoverage(path: block.path)].record(block)
+        }
+
+        let sourceFiles = filesByPath.values
+            .filter(\.hasCoverage)
+            .sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+        guard modeLabel != nil, !sourceFiles.isEmpty else { return nil }
+
+        return ToolArtifactGoCoveragePreview(
+            modeLabel: modeLabel,
+            sourceFileCount: sourceFiles.count,
+            blockCount: blockCount,
+            statementCoveredCount: sourceFiles.reduce(0) { $0 + $1.statementCoveredCount },
+            statementTotalCount: sourceFiles.reduce(0) { $0 + $1.statementTotalCount },
+            byteSizeLabel: byteSizeLabel,
+            isTruncated: isTruncated,
+            sourcePreviewLabels: sourceFiles.prefix(sourcePreviewLimit).map(\.previewLabel)
+        )
+    }
+
+    private static func sanitizedMode(_ rawMode: String) -> String? {
+        let mode = rawMode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard ["set", "count", "atomic"].contains(mode) else { return nil }
+        return mode
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else { return nil }
+        return url
+    }
+
+    private struct CoverageBlock {
+        var path: String
+        var statementCount: Int
+        var executionCount: Int
+
+        init?(_ line: String) {
+            let parts = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard parts.count == 3,
+                  let statementCount = Int(parts[1]),
+                  let executionCount = Int(parts[2]),
+                  statementCount >= 0,
+                  executionCount >= 0,
+                  let path = Self.path(from: String(parts[0]))
+            else { return nil }
+            self.path = path
+            self.statementCount = statementCount
+            self.executionCount = executionCount
+        }
+
+        private static func path(from range: String) -> String? {
+            guard let colonIndex = range.lastIndex(of: ":") else { return nil }
+            let path = String(range[..<colonIndex])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return path.isEmpty ? nil : path
+        }
+    }
+
+    private struct SourceFileCoverage {
+        var path: String
+        var statementCoveredCount = 0
+        var statementTotalCount = 0
+
+        var hasCoverage: Bool { statementTotalCount > 0 }
+
+        var previewLabel: String {
+            guard let coverage = ToolArtifactGoCoveragePreviewBuilder.coverageLabel(
+                covered: statementCoveredCount,
+                total: statementTotalCount
+            ) else {
+                return displayPath(path)
+            }
+            return "\(displayPath(path)) · \(coverage)"
+        }
+
+        mutating func record(_ block: CoverageBlock) {
+            statementTotalCount += block.statementCount
+            if block.executionCount > 0 {
+                statementCoveredCount += block.statementCount
+            }
+        }
+
+        private func displayPath(_ path: String) -> String {
+            let collapsedWhitespace = path
+                .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let fallback = collapsedWhitespace.isEmpty ? "Unknown source" : collapsedWhitespace
+            let suffix = fallback
+                .split(separator: "/")
+                .suffix(2)
+            let label = suffix.isEmpty ? fallback : suffix.joined(separator: "/")
+            return String(label.prefix(characterLimit))
+        }
+    }
+
+    private static func coverageLabel(covered: Int, total: Int) -> String? {
+        guard total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : String(format: "%.1f%%", rounded)
+        return percentLabel
+    }
+
+    private static let byteLimit = 512 * 1024
+    private static let sourcePreviewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -216,6 +216,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let istanbulPreview = renderIstanbulPreview(istanbulPreviewModel)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
+            let goCoveragePreview = renderGoCoveragePreview(artifact.goCoveragePreview)
             let sarifPreview = renderSARIFPreview(artifact.sarifPreview)
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
@@ -265,6 +266,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(istanbulPreview)
               \(harPreview)
               \(lcovPreview)
+              \(goCoveragePreview)
               \(sarifPreview)
               \(jsonLinesPreview)
               \(tomlPreview)
@@ -652,6 +654,33 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !sourceList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-lcov-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(sourceList)
+        </div>
+        """
+    }
+
+    private static func renderGoCoveragePreview(_ preview: ToolArtifactGoCoveragePreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-go-coverage-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let sourceFiles = preview.sourcePreviewLabels.map {
+            #"<li data-testid="tool-card-go-coverage-preview-source-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let sourceList = sourceFiles.isEmpty
+            ? ""
+            : """
+              <section class="artifact-office-contents" data-testid="tool-card-go-coverage-preview-sources">
+                <strong data-testid="tool-card-go-coverage-preview-source-title">Source files</strong>
+                <ul>\(sourceFiles)</ul>
+              </section>
+            """
+        guard !metadata.isEmpty || !sourceList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-go-coverage-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -588,6 +588,65 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(ToolArtifactState(value: invalidLCOV.path).lcovPreview)
     }
 
+    func testArtifactStateDerivesGoCoveragePreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let coverage = directory.appendingPathComponent("cover.out")
+        let coverageText = """
+        mode: atomic
+        github.com/lore/QuillCode/internal/runtime/runner.go:10.1,12.2 3 1
+        github.com/lore/QuillCode/internal/runtime/runner.go:14.1,15.2 2 0
+        github.com/lore/QuillCode/pkg/tools/shell.go:20.1,24.2 5 2
+        """
+        try coverageText.write(to: coverage, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: coverage.path)
+        let preview = try XCTUnwrap(artifact.goCoveragePreview)
+        let byteCount = try XCTUnwrap(coverageText.data(using: .utf8)?.count)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "GOCOVER")
+        XCTAssertEqual(preview.formatLabel, "Go coverage")
+        XCTAssertEqual(preview.modeLabel, "atomic")
+        XCTAssertEqual(preview.sourceFileCount, 2)
+        XCTAssertEqual(preview.blockCount, 3)
+        XCTAssertEqual(preview.statementCoveredCount, 8)
+        XCTAssertEqual(preview.statementTotalCount, 10)
+        XCTAssertEqual(preview.statementCoverageLabel, "80% (8/10)")
+        XCTAssertEqual(preview.sourcePreviewLabels, [
+            "runtime/runner.go · 60%",
+            "tools/shell.go · 100%"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(byteCount) bytes")
+        XCTAssertFalse(preview.isTruncated)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Go coverage",
+            "Mode: atomic",
+            "2 source files",
+            "3 blocks",
+            "Statements: 80% (8/10)",
+            "Size: \(byteCount) bytes"
+        ])
+
+        let coverageOut = directory.appendingPathComponent("coverage.out")
+        try coverageText.write(to: coverageOut, atomically: true, encoding: .utf8)
+        XCTAssertEqual(ToolArtifactState(value: coverageOut.path).goCoveragePreview?.sourceFileCount, 2)
+
+        let genericOut = directory.appendingPathComponent("build.out")
+        try coverageText.write(to: genericOut, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: genericOut.path).documentPreview)
+        XCTAssertNil(ToolArtifactState(value: genericOut.path).goCoveragePreview)
+
+        let invalidDirectory = directory.appendingPathComponent("invalid", isDirectory: true)
+        try FileManager.default.createDirectory(at: invalidDirectory, withIntermediateDirectories: true)
+        let invalid = invalidDirectory.appendingPathComponent("coverage.out")
+        try "mode: weird\nmain.go:1.1,2.1 1 1\n".write(to: invalid, atomically: true, encoding: .utf8)
+        XCTAssertEqual(ToolArtifactState(value: invalid.path).documentPreview?.extensionLabel, "GOCOVER")
+        XCTAssertNil(ToolArtifactState(value: invalid.path).goCoveragePreview)
+
+        let remote = ToolArtifactState(value: "https://example.com/cover.out")
+        XCTAssertNil(remote.goCoveragePreview)
+    }
+
     func testArtifactStateDerivesSARIFPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("codeql.sarif.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -881,6 +881,54 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesGoCoverageArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let coverageDirectory = root.appendingPathComponent("coverage", isDirectory: true)
+        try FileManager.default.createDirectory(at: coverageDirectory, withIntermediateDirectories: true)
+        let coverage = coverageDirectory.appendingPathComponent("cover.out")
+        let coverageText = """
+        mode: set
+        github.com/lore/QuillCode/internal/runtime/runner.go:10.1,12.2 3 1
+        github.com/lore/QuillCode/internal/runtime/runner.go:14.1,15.2 2 0
+        """
+        try coverageText.write(to: coverage, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"coverage/cover.out"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote coverage/cover.out\n", artifacts: [coverage.path])
+        let thread = ChatThread(
+            title: "Go coverage artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · GOCOVER"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">cover.out"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview-meta">Format: Go coverage"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview-meta">Mode: set"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview-meta">1 source file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview-meta">2 blocks"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview-meta">Statements: 60% (3/5)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview-source-title">Source files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-coverage-preview-source-item">runtime/runner.go · 60%"#))
+    }
+
     func testHTMLRendererIncludesSARIFArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reportsDirectory = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -76,6 +76,10 @@
 - Artifact previews now include bounded local LCOV coverage-report metadata for `lcov.info` and
   `.lcov` files: source-file counts, line/branch/function coverage, file size, truncation state, and
   capped source-file previews without executing test tooling or following report paths.
+- Artifact previews now include bounded local Go coverage-profile metadata for `cover.out` and
+  `coverage.out` files: mode, source-file counts, block counts, statement coverage, file size,
+  truncation state, and capped source-file previews without running `go tool cover` or following
+  covered source paths.
 - Artifact previews now include bounded local SARIF static-analysis metadata for `.sarif` and
   `.sarif.json` files: SARIF version, run/result counts, level counts, file size, capped tool labels,
   and capped rule labels without fetching remote reports or following result paths.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2290,3 +2290,22 @@
   and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesIstanbulArtifactPreview` covers static
   HTML selectors, rendered coverage metadata, content lists, and generic JSON suppression.
+
+## 2026-07-19: Go coverage artifacts render bounded coverage summaries
+
+- **Decision:** Local `cover.out` and `coverage.out` artifacts with a valid Go coverage `mode:`
+  header render as structured Go coverage cards instead of generic `.out` files. The preview shows
+  coverage mode, source-file count, block count, statement coverage, file size, truncation state, and
+  capped source-file labels.
+- **Why:** Go projects commonly produce coverage profiles through `go test -coverprofile=cover.out`.
+  A Codex-style artifact surface should make those reports scannable in the transcript without
+  requiring the agent to run `go tool cover` or infer coverage from raw profile lines.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It accepts only `set`, `count`, and `atomic` modes, reads only the coverage profile,
+  never executes Go tooling, never follows covered source paths, never reads referenced source files,
+  and never fetches remote coverage URLs. Other `.out` files remain unclassified.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesGoCoveragePreviewMetadata`
+  covers mode parsing, aggregate statement coverage, source labels, `coverage.out`, generic `.out`
+  exclusion, invalid-mode rejection, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesGoCoverageArtifactPreview` covers
+  static HTML selectors, rendered coverage metadata, and source-file lists.


### PR DESCRIPTION
## Summary
- classify local cover.out and coverage.out artifacts as Go coverage data
- add bounded Go coverage-profile parsing for mode, block count, statement coverage, and capped source-file labels
- render Go coverage cards in SwiftUI/static HTML and document the parser boundary

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check