### PR TITLE
Add coverage.py artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -65,6 +65,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             tableContent(tablePreview)
         } else if let istanbulPreview = artifact.istanbulPreview {
             istanbulContent(istanbulPreview)
+        } else if let coveragePyPreview = artifact.coveragePyPreview {
+            coveragePyContent(coveragePyPreview)
         } else if let harPreview = artifact.harPreview {
             harContent(harPreview)
         } else if let lcovPreview = artifact.lcovPreview {
@@ -223,6 +225,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(istanbulPreview.metadataLines)
             artifactContentList(title: "Source files", labels: istanbulPreview.filePreviewLabels)
+        }
+    }
+
+    private func coveragePyContent(_ coveragePyPreview: ToolArtifactCoveragePyPreview) -> some View {
+        previewSurface(minHeight: coveragePyPreview.filePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "chart.bar.xaxis")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(coveragePyPreview.metadataLines)
+            artifactContentList(title: "Source files", labels: coveragePyPreview.filePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -556,6 +556,77 @@ public struct ToolArtifactIstanbulPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactCoveragePyPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var versionLabel: String?
+    public var sourceFileCount: Int
+    public var lineCoveredCount: Int?
+    public var lineTotalCount: Int?
+    public var branchCoveredCount: Int?
+    public var branchTotalCount: Int?
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+
+    public var lineCoverageLabel: String? {
+        coverageLabel(covered: lineCoveredCount, total: lineTotalCount)
+    }
+
+    public var branchCoverageLabel: String? {
+        coverageLabel(covered: branchCoveredCount, total: branchTotalCount)
+    }
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            versionLabel.map { "Version: \($0)" },
+            "\(sourceFileCount) source file\(sourceFileCount == 1 ? "" : "s")",
+            lineCoverageLabel.map { "Lines: \($0)" },
+            branchCoverageLabel.map { "Branches: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        sourceFileCount > 0
+            || lineCoverageLabel != nil
+            || branchCoverageLabel != nil
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "coverage.py JSON",
+        versionLabel: String? = nil,
+        sourceFileCount: Int,
+        lineCoveredCount: Int? = nil,
+        lineTotalCount: Int? = nil,
+        branchCoveredCount: Int? = nil,
+        branchTotalCount: Int? = nil,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.versionLabel = versionLabel
+        self.sourceFileCount = sourceFileCount
+        self.lineCoveredCount = lineCoveredCount
+        self.lineTotalCount = lineTotalCount
+        self.branchCoveredCount = branchCoveredCount
+        self.branchTotalCount = branchTotalCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+    }
+
+    private func coverageLabel(covered: Int?, total: Int?) -> String? {
+        guard let covered, let total, total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : String(format: "%.1f%%", rounded)
+        return "\(percentLabel) (\(covered)/\(total))"
+    }
+}
+
 public struct ToolArtifactHARPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var creatorLabel: String?
@@ -1834,6 +1905,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var istanbulPreview: ToolArtifactIstanbulPreview? {
         ToolArtifactIstanbulPreviewBuilder.istanbulPreview(for: value, kind: kind)
+    }
+    public var coveragePyPreview: ToolArtifactCoveragePyPreview? {
+        ToolArtifactCoveragePyPreviewBuilder.coveragePyPreview(for: value, kind: kind)
     }
     public var harPreview: ToolArtifactHARPreview? {
         ToolArtifactHARPreviewBuilder.harPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactCoveragePyPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCoveragePyPreviewBuilder.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+enum ToolArtifactCoveragePyPreviewBuilder {
+    static func coveragePyPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactCoveragePyPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let object = root as? [String: Any] else { return nil }
+            return preview(
+                from: object,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from object: [String: Any], byteSizeLabel: String?) -> ToolArtifactCoveragePyPreview? {
+        guard let meta = object["meta"] as? [String: Any],
+              object["files"] is [String: Any],
+              object["totals"] is [String: Any]
+        else { return nil }
+
+        let totals = object["totals"] as? [String: Any]
+        let files = (object["files"] as? [String: Any] ?? [:])
+            .compactMap { path, value -> SourceFileCoverage? in
+                guard let fileObject = value as? [String: Any],
+                      let summary = fileObject["summary"] as? [String: Any]
+                else { return nil }
+                return SourceFileCoverage(path: path, summary: summary)
+            }
+            .sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+        guard !files.isEmpty else { return nil }
+
+        let totalLines = lineCounter(from: totals) ?? aggregateLines(in: files)
+        let totalBranches = branchCounter(from: totals) ?? aggregateBranches(in: files)
+        let filePreviewLabels = files
+            .prefix(filePreviewLimit)
+            .map(\.previewLabel)
+
+        return ToolArtifactCoveragePyPreview(
+            versionLabel: stringValue(meta["version"]),
+            sourceFileCount: files.count,
+            lineCoveredCount: totalLines?.covered,
+            lineTotalCount: totalLines?.total,
+            branchCoveredCount: totalBranches?.covered,
+            branchTotalCount: totalBranches?.total,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: filePreviewLabels
+        )
+    }
+
+    private static func lineCounter(from object: [String: Any]?) -> CoverageCounter? {
+        guard let object,
+              let covered = intValue(object["covered_lines"]),
+              let total = intValue(object["num_statements"]),
+              covered >= 0,
+              total >= 0
+        else { return nil }
+        return CoverageCounter(covered: min(covered, total), total: total)
+    }
+
+    private static func branchCounter(from object: [String: Any]?) -> CoverageCounter? {
+        guard let object,
+              let covered = intValue(object["covered_branches"]),
+              let total = intValue(object["num_branches"]),
+              covered >= 0,
+              total >= 0
+        else { return nil }
+        return CoverageCounter(covered: min(covered, total), total: total)
+    }
+
+    private static func aggregateLines(in files: [SourceFileCoverage]) -> CoverageCounter? {
+        aggregate(\.lineCoveredCount, \.lineTotalCount, in: files)
+    }
+
+    private static func aggregateBranches(in files: [SourceFileCoverage]) -> CoverageCounter? {
+        aggregate(\.branchCoveredCount, \.branchTotalCount, in: files)
+    }
+
+    private static func aggregate(
+        _ coveredPath: KeyPath<SourceFileCoverage, Int?>,
+        _ totalPath: KeyPath<SourceFileCoverage, Int?>,
+        in files: [SourceFileCoverage]
+    ) -> CoverageCounter? {
+        var covered = 0
+        var total = 0
+        var hasCounter = false
+        for file in files {
+            guard let fileCovered = file[keyPath: coveredPath],
+                  let fileTotal = file[keyPath: totalPath]
+            else { continue }
+            covered += fileCovered
+            total += fileTotal
+            hasCounter = true
+        }
+        return hasCounter ? CoverageCounter(covered: covered, total: total) : nil
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : String(trimmed.prefix(characterLimit))
+    }
+
+    private static func displayPath(_ path: String) -> String {
+        let collapsedWhitespace = path
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallback = collapsedWhitespace.isEmpty ? "Unknown source" : collapsedWhitespace
+        let suffix = fallback
+            .split(separator: "/")
+            .suffix(2)
+        let label = suffix.isEmpty ? fallback : suffix.joined(separator: "/")
+        return String(label.prefix(characterLimit))
+    }
+
+    private static func coverageLabel(covered: Int?, total: Int?) -> String? {
+        guard let covered, let total, total > 0 else { return nil }
+        let percent = (Double(covered) / Double(total)) * 100
+        let rounded = (percent * 10).rounded() / 10
+        let percentLabel = rounded == rounded.rounded()
+            ? "\(Int(rounded))%"
+            : String(format: "%.1f%%", rounded)
+        return percentLabel
+    }
+
+    private struct CoverageCounter {
+        var covered: Int
+        var total: Int
+    }
+
+    private struct SourceFileCoverage {
+        var path: String
+        var lineCoveredCount: Int?
+        var lineTotalCount: Int?
+        var branchCoveredCount: Int?
+        var branchTotalCount: Int?
+
+        init?(path: String, summary: [String: Any]) {
+            guard lineCounter(from: summary) != nil || branchCounter(from: summary) != nil else {
+                return nil
+            }
+            self.path = path
+            let lines = lineCounter(from: summary)
+            lineCoveredCount = lines?.covered
+            lineTotalCount = lines?.total
+            let branches = branchCounter(from: summary)
+            branchCoveredCount = branches?.covered
+            branchTotalCount = branches?.total
+        }
+
+        var previewLabel: String {
+            guard let coverage = ToolArtifactCoveragePyPreviewBuilder.coverageLabel(
+                covered: lineCoveredCount,
+                total: lineTotalCount
+            ) else {
+                return ToolArtifactCoveragePyPreviewBuilder.displayPath(path)
+            }
+            return "\(ToolArtifactCoveragePyPreviewBuilder.displayPath(path)) · \(coverage)"
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let filePreviewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -214,6 +214,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let tablePreview = renderTablePreview(artifact.tablePreview)
             let istanbulPreviewModel = artifact.istanbulPreview
             let istanbulPreview = renderIstanbulPreview(istanbulPreviewModel)
+            let coveragePyPreviewModel = artifact.coveragePyPreview
+            let coveragePyPreview = renderCoveragePyPreview(coveragePyPreviewModel)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
             let goCoveragePreview = renderGoCoveragePreview(artifact.goCoveragePreview)
@@ -243,7 +245,9 @@ enum WorkspaceHTMLToolCardRenderer {
             let fontPreview = renderFontPreview(artifact.fontPreview)
             let executablePreview = renderExecutablePreview(artifact.executablePreview)
             let notebookPreview = renderNotebookPreview(artifact.notebookPreview)
-            let jsonPreview = istanbulPreviewModel == nil ? renderJSONPreview(artifact.jsonPreview) : ""
+            let jsonPreview = istanbulPreviewModel == nil && coveragePyPreviewModel == nil
+                ? renderJSONPreview(artifact.jsonPreview)
+                : ""
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
             let archivePreview = renderArchivePreview(artifact.archivePreview)
             let mediaPreview = renderMediaPreview(artifact.mediaPreview)
@@ -264,6 +268,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(diffPreview)
               \(tablePreview)
               \(istanbulPreview)
+              \(coveragePyPreview)
               \(harPreview)
               \(lcovPreview)
               \(goCoveragePreview)
@@ -627,6 +632,31 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !fileList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-istanbul-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+        </div>
+        """
+    }
+
+    private static func renderCoveragePyPreview(_ preview: ToolArtifactCoveragePyPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-coverage-py-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-coverage-py-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-coverage-py-preview-files">
+                <strong data-testid="tool-card-coverage-py-preview-file-title">Source files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-coverage-py-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1220,6 +1220,74 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteIstanbul.istanbulPreview)
     }
 
+    func testArtifactStateDerivesCoveragePyPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("coverage.json")
+        let content = """
+        {
+          "meta": {"format": 2, "version": "7.6.1", "branch_coverage": true},
+          "files": {
+            "src/quillcode/app.py": {
+              "executed_lines": [1, 2, 4],
+              "summary": {
+                "covered_lines": 3,
+                "num_statements": 4,
+                "covered_branches": 1,
+                "num_branches": 2
+              }
+            },
+            "tests/test_app.py": {
+              "executed_lines": [1, 2],
+              "summary": {
+                "covered_lines": 2,
+                "num_statements": 2,
+                "covered_branches": 0,
+                "num_branches": 0
+              }
+            }
+          },
+          "totals": {
+            "covered_lines": 5,
+            "num_statements": 6,
+            "covered_branches": 1,
+            "num_branches": 2
+          }
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.coveragePyPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "coverage.py JSON")
+        XCTAssertEqual(preview.versionLabel, "7.6.1")
+        XCTAssertEqual(preview.sourceFileCount, 2)
+        XCTAssertEqual(preview.lineCoverageLabel, "83.3% (5/6)")
+        XCTAssertEqual(preview.branchCoverageLabel, "50% (1/2)")
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "quillcode/app.py · 75%",
+            "tests/test_app.py · 100%"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: coverage.py JSON",
+            "Version: 7.6.1",
+            "2 source files",
+            "Lines: 83.3% (5/6)",
+            "Branches: 50% (1/2)",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"status":"passed","durationMs":42}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).coveragePyPreview)
+
+        let remoteCoveragePy = ToolArtifactState(value: "https://example.com/coverage.json")
+        XCTAssertNil(remoteCoveragePy.coveragePyPreview)
+    }
+
     func testArtifactStateDerivesJUnitPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("TEST-QuillCode.xml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -758,6 +758,78 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesCoveragePyArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let coverageDirectory = root.appendingPathComponent("coverage", isDirectory: true)
+        try FileManager.default.createDirectory(at: coverageDirectory, withIntermediateDirectories: true)
+        let coverage = coverageDirectory.appendingPathComponent("coverage.json")
+        let coverageText = """
+        {
+          "meta": {"format": 2, "version": "7.6.1", "branch_coverage": true},
+          "files": {
+            "src/quillcode/app.py": {
+              "summary": {
+                "covered_lines": 3,
+                "num_statements": 4,
+                "covered_branches": 1,
+                "num_branches": 2
+              }
+            },
+            "tests/test_app.py": {
+              "summary": {
+                "covered_lines": 2,
+                "num_statements": 2,
+                "covered_branches": 0,
+                "num_branches": 0
+              }
+            }
+          },
+          "totals": {
+            "covered_lines": 5,
+            "num_statements": 6,
+            "covered_branches": 1,
+            "num_branches": 2
+          }
+        }
+        """
+        try coverageText.write(to: coverage, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"coverage/coverage.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote coverage/coverage.json\n", artifacts: [coverage.path])
+        let thread = ChatThread(
+            title: "coverage.py artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">coverage.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-coverage-py-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-coverage-py-preview-meta">Format: coverage.py JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-coverage-py-preview-meta">Version: 7.6.1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-coverage-py-preview-meta">2 source files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-coverage-py-preview-meta">Lines: 83.3% (5/6)"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-coverage-py-preview-file-title">Source files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-coverage-py-preview-file-item">quillcode/app.py · 75%"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesHARArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -112,6 +112,10 @@
   `coverage-final.json` and `coverage-summary.json` style artifacts: source-file counts,
   line/statement/branch/function coverage, file size, and capped source-file previews without
   executing coverage tooling, following report paths, or fetching remote JSON.
+- Artifact previews now include bounded local coverage.py JSON metadata for `coverage json`
+  artifacts with `meta`, `files`, and `totals`: source-file counts, line/branch coverage, file size,
+  and capped source-file previews without running coverage.py, following report paths, or fetching
+  remote JSON.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2309,3 +2309,20 @@
   exclusion, invalid-mode rejection, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesGoCoverageArtifactPreview` covers
   static HTML selectors, rendered coverage metadata, and source-file lists.
+
+## 2026-07-19: coverage.py JSON artifacts render bounded coverage summaries
+
+- **Decision:** Local JSON artifacts with the coverage.py `meta`/`files`/`totals` shape render as
+  structured Python coverage cards instead of generic JSON. The preview shows coverage.py version,
+  source-file count, line/branch coverage, file size, and capped source-file labels.
+- **Why:** Python projects commonly emit `coverage json` reports while agents debug failing tests and
+  coverage regressions. A Codex-style artifact surface should make those reports immediately
+  scannable without asking the model to inspect raw JSON or rerun coverage.py.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It reads only the artifact JSON, never executes coverage.py, never follows covered source
+  paths, never reads referenced source files, and never fetches remote coverage URLs. Generic JSON
+  rendering is suppressed only after the coverage.py report shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesCoveragePyPreviewMetadata`
+  covers totals, source labels, generic JSON exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCoveragePyArtifactPreview` covers
+  static HTML selectors, rendered coverage metadata, source-file lists, and generic JSON suppression.


### PR DESCRIPTION
## Summary
- Add bounded local coverage.py JSON artifact previews for reports with meta/files/totals
- Render coverage.py metadata in SwiftUI and static HTML while suppressing generic JSON for validated reports
- Document the parser boundary and parity note

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check