### PR TITLE
Add pytest JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -67,6 +67,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             istanbulContent(istanbulPreview)
         } else if let coveragePyPreview = artifact.coveragePyPreview {
             coveragePyContent(coveragePyPreview)
+        } else if let pytestJSONPreview = artifact.pytestJSONPreview {
+            pytestJSONContent(pytestJSONPreview)
         } else if let harPreview = artifact.harPreview {
             harContent(harPreview)
         } else if let lcovPreview = artifact.lcovPreview {
@@ -239,6 +241,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(coveragePyPreview.metadataLines)
             artifactContentList(title: "Source files", labels: coveragePyPreview.filePreviewLabels)
+        }
+    }
+
+    private func pytestJSONContent(_ pytestJSONPreview: ToolArtifactPytestJSONPreview) -> some View {
+        previewSurface(minHeight: pytestJSONPreview.failurePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(pytestJSONPreview.metadataLines)
+            artifactContentList(title: "Failures", labels: pytestJSONPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -627,6 +627,79 @@ public struct ToolArtifactCoveragePyPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPytestJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var exitCode: Int?
+    public var durationLabel: String?
+    public var totalCount: Int?
+    public var passedCount: Int?
+    public var failedCount: Int?
+    public var errorCount: Int?
+    public var skippedCount: Int?
+    public var xfailedCount: Int?
+    public var xpassedCount: Int?
+    public var byteSizeLabel: String?
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            exitCode.map { "Exit code: \($0)" },
+            durationLabel.map { "Duration: \($0)" },
+            totalCount.map { "\($0) test\($0 == 1 ? "" : "s")" },
+            passedCount.map { "Passed: \($0)" },
+            failedCount.map { "Failed: \($0)" },
+            errorCount.map { "Errors: \($0)" },
+            skippedCount.map { "Skipped: \($0)" },
+            xfailedCount.map { "XFailed: \($0)" },
+            xpassedCount.map { "XPassed: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        totalCount != nil
+            || passedCount != nil
+            || failedCount != nil
+            || errorCount != nil
+            || skippedCount != nil
+            || xfailedCount != nil
+            || xpassedCount != nil
+            || exitCode != nil
+            || durationLabel != nil
+            || byteSizeLabel != nil
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "pytest JSON",
+        exitCode: Int? = nil,
+        durationLabel: String? = nil,
+        totalCount: Int? = nil,
+        passedCount: Int? = nil,
+        failedCount: Int? = nil,
+        errorCount: Int? = nil,
+        skippedCount: Int? = nil,
+        xfailedCount: Int? = nil,
+        xpassedCount: Int? = nil,
+        byteSizeLabel: String? = nil,
+        failurePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.exitCode = exitCode
+        self.durationLabel = durationLabel
+        self.totalCount = totalCount
+        self.passedCount = passedCount
+        self.failedCount = failedCount
+        self.errorCount = errorCount
+        self.skippedCount = skippedCount
+        self.xfailedCount = xfailedCount
+        self.xpassedCount = xpassedCount
+        self.byteSizeLabel = byteSizeLabel
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactHARPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var creatorLabel: String?
@@ -1908,6 +1981,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var coveragePyPreview: ToolArtifactCoveragePyPreview? {
         ToolArtifactCoveragePyPreviewBuilder.coveragePyPreview(for: value, kind: kind)
+    }
+    public var pytestJSONPreview: ToolArtifactPytestJSONPreview? {
+        ToolArtifactPytestJSONPreviewBuilder.pytestJSONPreview(for: value, kind: kind)
     }
     public var harPreview: ToolArtifactHARPreview? {
         ToolArtifactHARPreviewBuilder.harPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactPytestJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPytestJSONPreviewBuilder.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+enum ToolArtifactPytestJSONPreviewBuilder {
+    static func pytestJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPytestJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let object = root as? [String: Any] else { return nil }
+            return preview(
+                from: object,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from object: [String: Any], byteSizeLabel: String?) -> ToolArtifactPytestJSONPreview? {
+        guard let summary = object["summary"] as? [String: Any] else { return nil }
+        let tests = object["tests"] as? [[String: Any]] ?? []
+        let counts = Counts(summary: summary, testCount: tests.count)
+        guard counts.hasPytestShape || !tests.isEmpty else { return nil }
+
+        let failures = tests.compactMap(failureLabel(from:))
+            .prefix(failurePreviewLimit)
+        return ToolArtifactPytestJSONPreview(
+            exitCode: intValue(object["exitcode"]),
+            durationLabel: durationLabel(from: object["duration"]),
+            totalCount: counts.total,
+            passedCount: counts.passed,
+            failedCount: counts.failed,
+            errorCount: counts.error,
+            skippedCount: counts.skipped,
+            xfailedCount: counts.xfailed,
+            xpassedCount: counts.xpassed,
+            byteSizeLabel: byteSizeLabel,
+            failurePreviewLabels: Array(failures)
+        )
+    }
+
+    private static func failureLabel(from test: [String: Any]) -> String? {
+        let outcome = stringValue(test["outcome"])?.lowercased()
+        guard outcome == "failed" || outcome == "error" else { return nil }
+        let nodeID = stringValue(test["nodeid"]) ?? stringValue(test["name"])
+        return nodeID.map(sanitizedLabel)
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double? {
+        switch value {
+        case let double as Double:
+            return double
+        case let number as NSNumber:
+            return number.doubleValue
+        case let string as String:
+            return Double(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func durationLabel(from value: Any?) -> String? {
+        guard let duration = doubleValue(value), duration >= 0 else { return nil }
+        if duration < 10 {
+            return String(format: "%.2fs", duration)
+        }
+        if duration < 60 {
+            return String(format: "%.1fs", duration)
+        }
+        let minutes = Int(duration / 60)
+        let seconds = Int(duration.rounded()) % 60
+        return "\(minutes)m \(seconds)s"
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown test" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private struct Counts {
+        var total: Int?
+        var passed: Int?
+        var failed: Int?
+        var error: Int?
+        var skipped: Int?
+        var xfailed: Int?
+        var xpassed: Int?
+
+        var hasPytestShape: Bool {
+            total != nil
+                || passed != nil
+                || failed != nil
+                || error != nil
+                || skipped != nil
+                || xfailed != nil
+                || xpassed != nil
+        }
+
+        init(summary: [String: Any], testCount: Int) {
+            passed = ToolArtifactPytestJSONPreviewBuilder.intValue(summary["passed"])
+            failed = ToolArtifactPytestJSONPreviewBuilder.intValue(summary["failed"])
+            error = ToolArtifactPytestJSONPreviewBuilder.intValue(summary["error"])
+                ?? ToolArtifactPytestJSONPreviewBuilder.intValue(summary["errors"])
+            skipped = ToolArtifactPytestJSONPreviewBuilder.intValue(summary["skipped"])
+            xfailed = ToolArtifactPytestJSONPreviewBuilder.intValue(summary["xfailed"])
+            xpassed = ToolArtifactPytestJSONPreviewBuilder.intValue(summary["xpassed"])
+            total = ToolArtifactPytestJSONPreviewBuilder.intValue(summary["total"])
+                ?? ToolArtifactPytestJSONPreviewBuilder.intValue(summary["collected"])
+                ?? (testCount > 0 ? testCount : nil)
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let failurePreviewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -216,6 +216,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let istanbulPreview = renderIstanbulPreview(istanbulPreviewModel)
             let coveragePyPreviewModel = artifact.coveragePyPreview
             let coveragePyPreview = renderCoveragePyPreview(coveragePyPreviewModel)
+            let pytestJSONPreviewModel = artifact.pytestJSONPreview
+            let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
             let goCoveragePreview = renderGoCoveragePreview(artifact.goCoveragePreview)
@@ -245,7 +247,9 @@ enum WorkspaceHTMLToolCardRenderer {
             let fontPreview = renderFontPreview(artifact.fontPreview)
             let executablePreview = renderExecutablePreview(artifact.executablePreview)
             let notebookPreview = renderNotebookPreview(artifact.notebookPreview)
-            let jsonPreview = istanbulPreviewModel == nil && coveragePyPreviewModel == nil
+            let jsonPreview = istanbulPreviewModel == nil
+                && coveragePyPreviewModel == nil
+                && pytestJSONPreviewModel == nil
                 ? renderJSONPreview(artifact.jsonPreview)
                 : ""
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
@@ -269,6 +273,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(tablePreview)
               \(istanbulPreview)
               \(coveragePyPreview)
+              \(pytestJSONPreview)
               \(harPreview)
               \(lcovPreview)
               \(goCoveragePreview)
@@ -661,6 +666,31 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(fileList)
+        </div>
+        """
+    }
+
+    private static func renderPytestJSONPreview(_ preview: ToolArtifactPytestJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-pytest-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-pytest-json-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pytest-json-preview-failures">
+                <strong data-testid="tool-card-pytest-json-preview-failure-title">Failures</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-pytest-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(failureList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1288,6 +1288,74 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteCoveragePy.coveragePyPreview)
     }
 
+    func testArtifactStateDerivesPytestJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("report.json")
+        let content = """
+        {
+          "created": 1780000000.0,
+          "duration": 12.345,
+          "exitcode": 1,
+          "root": "/workspace",
+          "summary": {
+            "total": 5,
+            "passed": 2,
+            "failed": 1,
+            "error": 1,
+            "skipped": 1,
+            "xfailed": 0,
+            "xpassed": 0
+          },
+          "tests": [
+            {"nodeid": "tests/test_app.py::test_renders_prompt", "outcome": "passed"},
+            {"nodeid": "tests/test_app.py::test_writes_file", "outcome": "failed"},
+            {"nodeid": "tests/test_cli.py::test_bootstrap", "outcome": "error"},
+            {"nodeid": "tests/test_cli.py::test_skip", "outcome": "skipped"}
+          ]
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.pytestJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "pytest JSON")
+        XCTAssertEqual(preview.exitCode, 1)
+        XCTAssertEqual(preview.durationLabel, "12.3s")
+        XCTAssertEqual(preview.totalCount, 5)
+        XCTAssertEqual(preview.passedCount, 2)
+        XCTAssertEqual(preview.failedCount, 1)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.skippedCount, 1)
+        XCTAssertEqual(preview.failurePreviewLabels, [
+            "tests/test_app.py::test_writes_file",
+            "tests/test_cli.py::test_bootstrap"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: pytest JSON",
+            "Exit code: 1",
+            "Duration: 12.3s",
+            "5 tests",
+            "Passed: 2",
+            "Failed: 1",
+            "Errors: 1",
+            "Skipped: 1",
+            "XFailed: 0",
+            "XPassed: 0",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"status":"passed","durationMs":42}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).pytestJSONPreview)
+
+        let remotePytest = ToolArtifactState(value: "https://example.com/report.json")
+        XCTAssertNil(remotePytest.pytestJSONPreview)
+    }
+
     func testArtifactStateDerivesJUnitPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("TEST-QuillCode.xml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -830,6 +830,68 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesPytestJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("report.json")
+        let reportText = """
+        {
+          "duration": 12.345,
+          "exitcode": 1,
+          "summary": {
+            "total": 5,
+            "passed": 2,
+            "failed": 1,
+            "error": 1,
+            "skipped": 1
+          },
+          "tests": [
+            {"nodeid": "tests/test_app.py::test_renders_prompt", "outcome": "passed"},
+            {"nodeid": "tests/test_app.py::test_writes_file", "outcome": "failed"},
+            {"nodeid": "tests/test_cli.py::test_bootstrap", "outcome": "error"}
+          ]
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/report.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/report.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "pytest artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">report.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview-meta">Format: pytest JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview-meta">Exit code: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview-meta">Duration: 12.3s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview-meta">5 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview-meta">Failed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview-failure-title">Failures"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pytest-json-preview-failure-item">tests/test_app.py::test_writes_file"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesHARArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -116,6 +116,9 @@
   artifacts with `meta`, `files`, and `totals`: source-file counts, line/branch coverage, file size,
   and capped source-file previews without running coverage.py, following report paths, or fetching
   remote JSON.
+- Artifact previews now include bounded local pytest JSON report metadata for pytest-json-report
+  artifacts: total/pass/fail/error/skip counts, exit code, duration, file size, and capped failing
+  test node IDs without expanding captured logs or fetching remote JSON.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2326,3 +2326,20 @@
   covers totals, source labels, generic JSON exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCoveragePyArtifactPreview` covers
   static HTML selectors, rendered coverage metadata, source-file lists, and generic JSON suppression.
+
+## 2026-07-19: pytest JSON artifacts render bounded test summaries
+
+- **Decision:** Local JSON artifacts with the pytest-json-report `summary`/`tests` shape render as
+  structured pytest report cards instead of generic JSON. The preview shows exit code, duration,
+  total/pass/fail/error/skip counts, file size, and capped failed/error test node IDs.
+- **Why:** Python coding-agent loops often emit pytest JSON when narrowing failures. A Codex-style
+  artifact surface should make failing tests visible immediately without requiring the model to read
+  raw JSON or expand captured logs.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It reads only the artifact JSON, never opens referenced source files, never expands
+  captured stdout/stderr/tracebacks from test phases, and never fetches remote report URLs. Generic
+  JSON rendering is suppressed only after the pytest report shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesPytestJSONPreviewMetadata`
+  covers summary counts, failing labels, generic JSON exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPytestJSONArtifactPreview` covers
+  static HTML selectors, rendered report metadata, failure lists, and generic JSON suppression.


### PR DESCRIPTION
## Summary
- Add bounded local pytest-json-report artifact previews for JSON reports with summary/tests
- Render pytest report metadata in SwiftUI and static HTML while suppressing generic JSON for validated reports
- Document the parser boundary and parity note

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check