### PR TITLE
Add TAP artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -69,6 +69,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             coveragePyContent(coveragePyPreview)
         } else if let pytestJSONPreview = artifact.pytestJSONPreview {
             pytestJSONContent(pytestJSONPreview)
+        } else if let tapPreview = artifact.tapPreview {
+            tapContent(tapPreview)
         } else if let harPreview = artifact.harPreview {
             harContent(harPreview)
         } else if let lcovPreview = artifact.lcovPreview {
@@ -255,6 +257,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(pytestJSONPreview.metadataLines)
             artifactContentList(title: "Failures", labels: pytestJSONPreview.failurePreviewLabels)
+        }
+    }
+
+    private func tapContent(_ tapPreview: ToolArtifactTAPPreview) -> some View {
+        previewSurface(minHeight: tapPreview.failurePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(tapPreview.metadataLines)
+            artifactContentList(title: "Failures", labels: tapPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -700,6 +700,65 @@ public struct ToolArtifactPytestJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var planLabel: String?
+    public var assertionCount: Int
+    public var passedCount: Int
+    public var failedCount: Int
+    public var skippedCount: Int
+    public var todoCount: Int
+    public var bailoutLabel: String?
+    public var byteSizeLabel: String?
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            planLabel.map { "Plan: \($0)" },
+            "\(assertionCount) assertion\(assertionCount == 1 ? "" : "s")",
+            "Passed: \(passedCount)",
+            failedCount > 0 ? "Failed: \(failedCount)" : nil,
+            skippedCount > 0 ? "Skipped: \(skippedCount)" : nil,
+            todoCount > 0 ? "TODO: \(todoCount)" : nil,
+            bailoutLabel.map { "Bail out: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        assertionCount > 0
+            || planLabel != nil
+            || bailoutLabel != nil
+            || byteSizeLabel != nil
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "TAP",
+        planLabel: String? = nil,
+        assertionCount: Int,
+        passedCount: Int = 0,
+        failedCount: Int = 0,
+        skippedCount: Int = 0,
+        todoCount: Int = 0,
+        bailoutLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        failurePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.planLabel = planLabel
+        self.assertionCount = assertionCount
+        self.passedCount = passedCount
+        self.failedCount = failedCount
+        self.skippedCount = skippedCount
+        self.todoCount = todoCount
+        self.bailoutLabel = bailoutLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactHARPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var creatorLabel: String?
@@ -1984,6 +2043,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var pytestJSONPreview: ToolArtifactPytestJSONPreview? {
         ToolArtifactPytestJSONPreviewBuilder.pytestJSONPreview(for: value, kind: kind)
+    }
+    public var tapPreview: ToolArtifactTAPPreview? {
+        ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)
     }
     public var harPreview: ToolArtifactHARPreview? {
         ToolArtifactHARPreviewBuilder.harPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -80,6 +80,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "sqlite": .data,
         "sqlite3": .data,
         "so": .data,
+        "tap": .data,
         "ttc": .data,
         "ttf": .data,
         "toml": .data,

--- a/Sources/QuillCodeApp/ToolArtifactTAPPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactTAPPreviewBuilder.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+enum ToolArtifactTAPPreviewBuilder {
+    static func tapPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactTAPPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "tap",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  var text = String(data: data, encoding: .utf8)
+            else { return nil }
+            text = text
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+            return preview(
+                from: text,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from text: String, byteSizeLabel: String?) -> ToolArtifactTAPPreview? {
+        var planLabel: String?
+        var assertionCount = 0
+        var passedCount = 0
+        var failedCount = 0
+        var skippedCount = 0
+        var todoCount = 0
+        var bailoutLabel: String?
+        var failures: [String] = []
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false).prefix(lineLimit) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") {
+                continue
+            }
+            if let plan = parsePlan(line) {
+                planLabel = plan
+                continue
+            }
+            if line.lowercased().hasPrefix("bail out!") {
+                bailoutLabel = sanitizedLabel(String(line.dropFirst("Bail out!".count)))
+                continue
+            }
+            guard let assertion = parseAssertion(line) else {
+                continue
+            }
+            assertionCount += 1
+            if assertion.isTodo {
+                todoCount += 1
+            }
+            if assertion.isSkipped {
+                skippedCount += 1
+            }
+            if assertion.isPassing || assertion.isTodo {
+                passedCount += 1
+            } else {
+                failedCount += 1
+                if failures.count < failurePreviewLimit {
+                    failures.append(assertion.label)
+                }
+            }
+        }
+
+        guard assertionCount > 0 || planLabel != nil || bailoutLabel != nil else { return nil }
+        return ToolArtifactTAPPreview(
+            planLabel: planLabel,
+            assertionCount: assertionCount,
+            passedCount: passedCount,
+            failedCount: failedCount,
+            skippedCount: skippedCount,
+            todoCount: todoCount,
+            bailoutLabel: bailoutLabel,
+            byteSizeLabel: byteSizeLabel,
+            failurePreviewLabels: failures
+        )
+    }
+
+    private static func parsePlan(_ line: String) -> String? {
+        guard line.range(of: #"^\d+\.\.\d+"#, options: .regularExpression) != nil else {
+            return nil
+        }
+        return sanitizedLabel(line)
+    }
+
+    private static func parseAssertion(_ line: String) -> Assertion? {
+        let lowercased = line.lowercased()
+        let isPassing: Bool
+        let remainder: Substring
+        if lowercased.hasPrefix("ok") {
+            isPassing = true
+            remainder = line.dropFirst(2)
+        } else if lowercased.hasPrefix("not ok") {
+            isPassing = false
+            remainder = line.dropFirst(6)
+        } else {
+            return nil
+        }
+
+        let detail = String(remainder).trimmingCharacters(in: .whitespaces)
+        let directive = directive(in: detail)
+        let label = sanitizedLabel(detail.isEmpty ? line : detail)
+        return Assertion(
+            isPassing: isPassing,
+            isSkipped: directive == "skip",
+            isTodo: directive == "todo",
+            label: label
+        )
+    }
+
+    private static func directive(in detail: String) -> String? {
+        guard let hash = detail.firstIndex(of: "#") else { return nil }
+        let directive = detail[detail.index(after: hash)...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if directive.hasPrefix("skip") {
+            return "skip"
+        }
+        if directive.hasPrefix("todo") {
+            return "todo"
+        }
+        return nil
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unnamed assertion" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private struct Assertion {
+        var isPassing: Bool
+        var isSkipped: Bool
+        var isTodo: Bool
+        var label: String
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let lineLimit = 20_000
+    private static let failurePreviewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -218,6 +218,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let coveragePyPreview = renderCoveragePyPreview(coveragePyPreviewModel)
             let pytestJSONPreviewModel = artifact.pytestJSONPreview
             let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
+            let tapPreview = renderTAPPreview(artifact.tapPreview)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
             let goCoveragePreview = renderGoCoveragePreview(artifact.goCoveragePreview)
@@ -274,6 +275,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(istanbulPreview)
               \(coveragePyPreview)
               \(pytestJSONPreview)
+              \(tapPreview)
               \(harPreview)
               \(lcovPreview)
               \(goCoveragePreview)
@@ -687,6 +689,31 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-pytest-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderTAPPreview(_ preview: ToolArtifactTAPPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-tap-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-tap-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-tap-preview-failures">
+                <strong data-testid="tool-card-tap-preview-failure-title">Failures</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-tap-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1356,6 +1356,55 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePytest.pytestJSONPreview)
     }
 
+    func testArtifactStateDerivesTAPPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("test.tap")
+        let content = """
+        TAP version 13
+        1..4
+        ok 1 - loads app
+        not ok 2 - writes file
+        ok 3 - optional browser # SKIP no browser
+        not ok 4 - planned support # TODO implement later
+        Bail out! database unavailable
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.tapPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "TAP")
+        XCTAssertEqual(preview.formatLabel, "TAP")
+        XCTAssertEqual(preview.planLabel, "1..4")
+        XCTAssertEqual(preview.assertionCount, 4)
+        XCTAssertEqual(preview.passedCount, 3)
+        XCTAssertEqual(preview.failedCount, 1)
+        XCTAssertEqual(preview.skippedCount, 1)
+        XCTAssertEqual(preview.todoCount, 1)
+        XCTAssertEqual(preview.bailoutLabel, "database unavailable")
+        XCTAssertEqual(preview.failurePreviewLabels, ["2 - writes file"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: TAP",
+            "Plan: 1..4",
+            "4 assertions",
+            "Passed: 3",
+            "Failed: 1",
+            "Skipped: 1",
+            "TODO: 1",
+            "Bail out: database unavailable",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let generic = directory.appendingPathComponent("notes.tap")
+        try "this is not tap\n".write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).tapPreview)
+
+        let remoteTAP = ToolArtifactState(value: "https://example.com/test.tap")
+        XCTAssertNil(remoteTAP.tapPreview)
+    }
+
     func testArtifactStateDerivesJUnitPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("TEST-QuillCode.xml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -892,6 +892,58 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesTAPArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("test.tap")
+        let tapText = """
+        TAP version 13
+        1..4
+        ok 1 - loads app
+        not ok 2 - writes file
+        ok 3 - optional browser # SKIP no browser
+        not ok 4 - planned support # TODO implement later
+        Bail out! database unavailable
+        """
+        try tapText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/test.tap"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/test.tap\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "TAP artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · TAP"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">test.tap"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview-meta">Format: TAP"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview-meta">Plan: 1..4"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview-meta">4 assertions"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview-meta">Failed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview-meta">Bail out: database unavailable"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview-failure-title">Failures"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-tap-preview-failure-item">2 - writes file"#))
+    }
+
     func testHTMLRendererIncludesHARArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -119,6 +119,9 @@
 - Artifact previews now include bounded local pytest JSON report metadata for pytest-json-report
   artifacts: total/pass/fail/error/skip counts, exit code, duration, file size, and capped failing
   test node IDs without expanding captured logs or fetching remote JSON.
+- Artifact previews now include bounded local TAP report metadata for `.tap` files: plan, assertion
+  counts, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing assertion labels
+  without expanding diagnostics or fetching remote reports.
 - Artifact previews now include bounded local INI-style config metadata for `.ini`, `.cfg`, and `.conf`:
   section/key counts, file size, truncation state, and capped section previews.
 - Artifact previews now include bounded local dotenv metadata for `.env` and `.env.*` files:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2343,3 +2343,19 @@
   covers summary counts, failing labels, generic JSON exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPytestJSONArtifactPreview` covers
   static HTML selectors, rendered report metadata, failure lists, and generic JSON suppression.
+
+## 2026-07-19: TAP artifacts render bounded test summaries
+
+- **Decision:** Local `.tap` artifacts that match Test Anything Protocol plan/assertion/bailout
+  lines render as structured TAP report cards instead of generic data files. The preview shows plan,
+  assertion count, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing
+  assertion labels.
+- **Why:** TAP remains common in Node, Perl, and CI test output. A Codex-style artifact surface should
+  make failing assertions scannable without forcing the agent to inspect raw test protocol text.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB plus 20,000 lines. It reads only TAP protocol summary lines, never expands YAML-ish
+  diagnostics, never opens referenced source files, and never fetches remote TAP reports.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesTAPPreviewMetadata` covers
+  plan parsing, pass/fail/skip/TODO counts, bailout labels, generic `.tap` exclusion, and remote
+  exclusion. `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesTAPArtifactPreview` covers
+  static HTML selectors, rendered report metadata, and failure lists.


### PR DESCRIPTION
## Summary
- Add bounded local TAP artifact previews for .tap test reports
- Render TAP metadata in SwiftUI and static HTML tool cards
- Document parser boundaries and parity notes

## Validation
- swift test --filter testArtifactStateDerivesTAPPreviewMetadata
- swift test --filter testHTMLRendererIncludesTAPArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check