### PR TITLE
Add Jest JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -69,6 +69,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             coveragePyContent(coveragePyPreview)
         } else if let pytestJSONPreview = artifact.pytestJSONPreview {
             pytestJSONContent(pytestJSONPreview)
+        } else if let jestJSONPreview = artifact.jestJSONPreview {
+            jestJSONContent(jestJSONPreview)
         } else if let tapPreview = artifact.tapPreview {
             tapContent(tapPreview)
         } else if let harPreview = artifact.harPreview {
@@ -257,6 +259,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(pytestJSONPreview.metadataLines)
             artifactContentList(title: "Failures", labels: pytestJSONPreview.failurePreviewLabels)
+        }
+    }
+
+    private func jestJSONContent(_ jestJSONPreview: ToolArtifactJestJSONPreview) -> some View {
+        previewSurface(minHeight: jestJSONPreview.failurePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(jestJSONPreview.metadataLines)
+            artifactContentList(title: "Failures", labels: jestJSONPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -700,6 +700,79 @@ public struct ToolArtifactPytestJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactJestJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var success: Bool?
+    public var totalTestCount: Int?
+    public var passedTestCount: Int?
+    public var failedTestCount: Int?
+    public var pendingTestCount: Int?
+    public var todoTestCount: Int?
+    public var totalSuiteCount: Int?
+    public var failedSuiteCount: Int?
+    public var runtimeLabel: String?
+    public var byteSizeLabel: String?
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            success.map { "Result: \($0 ? "passed" : "failed")" },
+            runtimeLabel.map { "Runtime: \($0)" },
+            totalTestCount.map { "\($0) test\($0 == 1 ? "" : "s")" },
+            passedTestCount.map { "Passed: \($0)" },
+            failedTestCount.map { "Failed: \($0)" },
+            pendingTestCount.map { "Pending: \($0)" },
+            todoTestCount.map { "TODO: \($0)" },
+            totalSuiteCount.map { "\($0) suite\($0 == 1 ? "" : "s")" },
+            failedSuiteCount.map { "Failed suites: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        success != nil
+            || totalTestCount != nil
+            || passedTestCount != nil
+            || failedTestCount != nil
+            || pendingTestCount != nil
+            || todoTestCount != nil
+            || totalSuiteCount != nil
+            || failedSuiteCount != nil
+            || runtimeLabel != nil
+            || byteSizeLabel != nil
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Jest JSON",
+        success: Bool? = nil,
+        totalTestCount: Int? = nil,
+        passedTestCount: Int? = nil,
+        failedTestCount: Int? = nil,
+        pendingTestCount: Int? = nil,
+        todoTestCount: Int? = nil,
+        totalSuiteCount: Int? = nil,
+        failedSuiteCount: Int? = nil,
+        runtimeLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        failurePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.success = success
+        self.totalTestCount = totalTestCount
+        self.passedTestCount = passedTestCount
+        self.failedTestCount = failedTestCount
+        self.pendingTestCount = pendingTestCount
+        self.todoTestCount = todoTestCount
+        self.totalSuiteCount = totalSuiteCount
+        self.failedSuiteCount = failedSuiteCount
+        self.runtimeLabel = runtimeLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -2043,6 +2116,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var pytestJSONPreview: ToolArtifactPytestJSONPreview? {
         ToolArtifactPytestJSONPreviewBuilder.pytestJSONPreview(for: value, kind: kind)
+    }
+    public var jestJSONPreview: ToolArtifactJestJSONPreview? {
+        ToolArtifactJestJSONPreviewBuilder.jestJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactJestJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactJestJSONPreviewBuilder.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+enum ToolArtifactJestJSONPreviewBuilder {
+    static func jestJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactJestJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let object = root as? [String: Any] else { return nil }
+            return preview(
+                from: object,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from object: [String: Any], byteSizeLabel: String?) -> ToolArtifactJestJSONPreview? {
+        let suites = object["testResults"] as? [[String: Any]] ?? []
+        let counts = Counts(object: object, suiteCount: suites.count)
+        guard counts.hasJestShape || suites.contains(where: hasAssertionResults) else { return nil }
+
+        let failures = suites
+            .flatMap(failureLabels(from:))
+            .prefix(failurePreviewLimit)
+        return ToolArtifactJestJSONPreview(
+            success: boolValue(object["success"]),
+            totalTestCount: counts.totalTests,
+            passedTestCount: counts.passedTests,
+            failedTestCount: counts.failedTests,
+            pendingTestCount: counts.pendingTests,
+            todoTestCount: counts.todoTests,
+            totalSuiteCount: counts.totalSuites,
+            failedSuiteCount: counts.failedSuites,
+            runtimeLabel: runtimeLabel(from: suites),
+            byteSizeLabel: byteSizeLabel,
+            failurePreviewLabels: Array(failures)
+        )
+    }
+
+    private static func hasAssertionResults(_ suite: [String: Any]) -> Bool {
+        guard let assertions = suite["assertionResults"] as? [[String: Any]] else { return false }
+        return !assertions.isEmpty
+    }
+
+    private static func failureLabels(from suite: [String: Any]) -> [String] {
+        guard let assertions = suite["assertionResults"] as? [[String: Any]] else { return [] }
+        let suiteName = stringValue(suite["name"]) ?? stringValue(suite["testFilePath"])
+        return assertions.compactMap { assertion in
+            let status = stringValue(assertion["status"])?.lowercased()
+            guard status == "failed" || status == "fail" else { return nil }
+            return sanitizedLabel(assertionLabel(from: assertion, suiteName: suiteName))
+        }
+    }
+
+    private static func assertionLabel(from assertion: [String: Any], suiteName: String?) -> String {
+        if let fullName = stringValue(assertion["fullName"]) {
+            return fullName
+        }
+        var pieces = (assertion["ancestorTitles"] as? [String] ?? [])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        if let title = stringValue(assertion["title"]) {
+            pieces.append(title)
+        }
+        if !pieces.isEmpty {
+            return pieces.joined(separator: " > ")
+        }
+        if let suiteName {
+            return suiteName
+        }
+        return "Unknown test"
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        switch value {
+        case let bool as Bool:
+            return bool
+        case let number as NSNumber:
+            return number.boolValue
+        case let string as String:
+            let normalized = string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if normalized == "true" { return true }
+            if normalized == "false" { return false }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func runtimeLabel(from suites: [[String: Any]]) -> String? {
+        let runtimes = suites.compactMap { suite -> Int? in
+            guard let perfStats = suite["perfStats"] as? [String: Any] else { return nil }
+            return intValue(perfStats["runtime"])
+        }
+        let milliseconds = runtimes.reduce(0, +)
+        guard milliseconds > 0 else { return nil }
+        return durationLabel(milliseconds: milliseconds)
+    }
+
+    private static func durationLabel(milliseconds: Int) -> String {
+        let seconds = Double(milliseconds) / 1_000
+        if seconds < 10 {
+            return String(format: "%.2fs", seconds)
+        }
+        if seconds < 60 {
+            return String(format: "%.1fs", seconds)
+        }
+        let minutes = Int(seconds / 60)
+        let remainder = Int(seconds.rounded()) % 60
+        return "\(minutes)m \(remainder)s"
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown test" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private struct Counts {
+        var totalTests: Int?
+        var passedTests: Int?
+        var failedTests: Int?
+        var pendingTests: Int?
+        var todoTests: Int?
+        var totalSuites: Int?
+        var failedSuites: Int?
+
+        var hasJestShape: Bool {
+            totalTests != nil
+                || passedTests != nil
+                || failedTests != nil
+                || pendingTests != nil
+                || todoTests != nil
+                || totalSuites != nil
+                || failedSuites != nil
+        }
+
+        init(object: [String: Any], suiteCount: Int) {
+            totalTests = ToolArtifactJestJSONPreviewBuilder.intValue(object["numTotalTests"])
+            passedTests = ToolArtifactJestJSONPreviewBuilder.intValue(object["numPassedTests"])
+            failedTests = ToolArtifactJestJSONPreviewBuilder.intValue(object["numFailedTests"])
+            pendingTests = ToolArtifactJestJSONPreviewBuilder.intValue(object["numPendingTests"])
+            todoTests = ToolArtifactJestJSONPreviewBuilder.intValue(object["numTodoTests"])
+            totalSuites = ToolArtifactJestJSONPreviewBuilder.intValue(object["numTotalTestSuites"])
+                ?? (suiteCount > 0 ? suiteCount : nil)
+            failedSuites = ToolArtifactJestJSONPreviewBuilder.intValue(object["numFailedTestSuites"])
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let failurePreviewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -218,6 +218,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let coveragePyPreview = renderCoveragePyPreview(coveragePyPreviewModel)
             let pytestJSONPreviewModel = artifact.pytestJSONPreview
             let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
+            let jestJSONPreviewModel = artifact.jestJSONPreview
+            let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
             let tapPreview = renderTAPPreview(artifact.tapPreview)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
@@ -251,6 +253,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jsonPreview = istanbulPreviewModel == nil
                 && coveragePyPreviewModel == nil
                 && pytestJSONPreviewModel == nil
+                && jestJSONPreviewModel == nil
                 ? renderJSONPreview(artifact.jsonPreview)
                 : ""
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
@@ -275,6 +278,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(istanbulPreview)
               \(coveragePyPreview)
               \(pytestJSONPreview)
+              \(jestJSONPreview)
               \(tapPreview)
               \(harPreview)
               \(lcovPreview)
@@ -689,6 +693,31 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-pytest-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderJestJSONPreview(_ preview: ToolArtifactJestJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-jest-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-jest-json-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-jest-json-preview-failures">
+                <strong data-testid="tool-card-jest-json-preview-failure-title">Failures</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-jest-json-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1356,6 +1356,80 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePytest.pytestJSONPreview)
     }
 
+    func testArtifactStateDerivesJestJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("jest-results.json")
+        let content = """
+        {
+          "success": false,
+          "numTotalTests": 4,
+          "numPassedTests": 2,
+          "numFailedTests": 1,
+          "numPendingTests": 1,
+          "numTodoTests": 0,
+          "numTotalTestSuites": 2,
+          "numFailedTestSuites": 1,
+          "testResults": [
+            {
+              "name": "/repo/tests/app.test.ts",
+              "perfStats": {"runtime": 1234},
+              "assertionResults": [
+                {"ancestorTitles": ["App"], "title": "renders prompt", "status": "passed"},
+                {"ancestorTitles": ["App"], "title": "writes a file", "status": "failed"}
+              ]
+            },
+            {
+              "name": "/repo/tests/cli.test.ts",
+              "perfStats": {"runtime": 2000},
+              "assertionResults": [
+                {"fullName": "CLI starts quickly", "status": "passed"},
+                {"fullName": "CLI waits for fixture", "status": "pending"}
+              ]
+            }
+          ]
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.jestJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Jest JSON")
+        XCTAssertEqual(preview.success, false)
+        XCTAssertEqual(preview.totalTestCount, 4)
+        XCTAssertEqual(preview.passedTestCount, 2)
+        XCTAssertEqual(preview.failedTestCount, 1)
+        XCTAssertEqual(preview.pendingTestCount, 1)
+        XCTAssertEqual(preview.todoTestCount, 0)
+        XCTAssertEqual(preview.totalSuiteCount, 2)
+        XCTAssertEqual(preview.failedSuiteCount, 1)
+        XCTAssertEqual(preview.runtimeLabel, "3.23s")
+        XCTAssertEqual(preview.failurePreviewLabels, ["App > writes a file"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Jest JSON",
+            "Result: failed",
+            "Runtime: 3.23s",
+            "4 tests",
+            "Passed: 2",
+            "Failed: 1",
+            "Pending: 1",
+            "TODO: 0",
+            "2 suites",
+            "Failed suites: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"success":false,"durationMs":42}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).jestJSONPreview)
+
+        let remoteJest = ToolArtifactState(value: "https://example.com/jest-results.json")
+        XCTAssertNil(remoteJest.jestJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -892,6 +892,71 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesJestJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("jest-results.json")
+        let reportText = """
+        {
+          "success": false,
+          "numTotalTests": 4,
+          "numPassedTests": 2,
+          "numFailedTests": 1,
+          "numPendingTests": 1,
+          "numTotalTestSuites": 2,
+          "numFailedTestSuites": 1,
+          "testResults": [
+            {
+              "name": "/repo/tests/app.test.ts",
+              "perfStats": {"runtime": 1234},
+              "assertionResults": [
+                {"ancestorTitles": ["App"], "title": "renders prompt", "status": "passed"},
+                {"ancestorTitles": ["App"], "title": "writes a file", "status": "failed"}
+              ]
+            }
+          ]
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/jest-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/jest-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Jest artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">jest-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview-meta">Format: Jest JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview-meta">Result: failed"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview-meta">Runtime: 1.23s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview-meta">4 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview-meta">Failed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview-failure-title">Failures"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-jest-json-preview-failure-item">App &gt; writes a file"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -119,6 +119,10 @@
 - Artifact previews now include bounded local pytest JSON report metadata for pytest-json-report
   artifacts: total/pass/fail/error/skip counts, exit code, duration, file size, and capped failing
   test node IDs without expanding captured logs or fetching remote JSON.
+- Artifact previews now include bounded local Jest/Vitest-style JSON report metadata for `.json`
+  files with Jest-compatible `numTotalTests`/`testResults` shape: result, runtime, test/suite
+  counts, file size, and capped failing assertion labels without expanding failure messages or
+  fetching remote JSON.
 - Artifact previews now include bounded local TAP report metadata for `.tap` files: plan, assertion
   counts, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing assertion labels
   without expanding diagnostics or fetching remote reports.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2359,3 +2359,20 @@
   plan parsing, pass/fail/skip/TODO counts, bailout labels, generic `.tap` exclusion, and remote
   exclusion. `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesTAPArtifactPreview` covers
   static HTML selectors, rendered report metadata, and failure lists.
+
+## 2026-07-19: Jest JSON artifacts render bounded test summaries
+
+- **Decision:** Local `.json` artifacts with Jest-compatible `numTotalTests`/`testResults` report
+  shape render as structured Jest JSON report cards instead of generic JSON. The preview shows run
+  result, runtime, test/suite counts, file size, and capped failing assertion labels.
+- **Why:** TypeScript and JavaScript coding-agent loops commonly emit Jest or Vitest JSON reports.
+  Showing the failing assertions inline keeps generated test artifacts useful without requiring a
+  separate file open.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, shape-gated, and
+  capped at 512 KB. It reads only summary counts, suite runtime, and assertion titles, never expands
+  failure messages/stacks, never opens referenced source files, and never fetches remote JSON.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesJestJSONPreviewMetadata`
+  covers result/count/runtime parsing, failing assertion labels, generic JSON exclusion, and remote
+  exclusion. `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesJestJSONArtifactPreview`
+  covers static HTML selectors, rendered report metadata, failure lists, and generic JSON
+  suppression.


### PR DESCRIPTION
## Summary
- Add bounded local Jest/Vitest-style JSON artifact previews
- Render Jest-compatible test report metadata in SwiftUI and static HTML tool cards
- Suppress generic JSON cards only after the Jest report shape validates
- Document parser boundaries and parity notes

## Validation
- swift test --filter testArtifactStateDerivesJestJSONPreviewMetadata
- swift test --filter testHTMLRendererIncludesJestJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check