### PR TITLE
Add TRX artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -93,6 +93,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             yamlContent(yamlPreview)
         } else if let junitPreview = artifact.junitPreview {
             junitContent(junitPreview)
+        } else if let trxPreview = artifact.trxPreview {
+            trxContent(trxPreview)
         } else if let coberturaPreview = artifact.coberturaPreview {
             coberturaContent(coberturaPreview)
         } else if let cloverPreview = artifact.cloverPreview {
@@ -443,6 +445,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(junitPreview.metadataLines)
             artifactContentList(title: "Suites", labels: junitPreview.suitePreviewLabels)
             artifactContentList(title: "Failing tests", labels: junitPreview.failurePreviewLabels)
+        }
+    }
+
+    private func trxContent(_ trxPreview: ToolArtifactTRXPreview) -> some View {
+        previewSurface(minHeight: trxPreview.failurePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checkmark.seal")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(trxPreview.metadataLines)
+            artifactContentList(title: "Failing tests", labels: trxPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1457,6 +1457,65 @@ public struct ToolArtifactJUnitPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactTRXPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var testRunName: String?
+    public var totalCount: Int
+    public var passedCount: Int
+    public var failedCount: Int
+    public var inconclusiveCount: Int
+    public var notExecutedCount: Int
+    public var durationLabel: String?
+    public var byteSizeLabel: String?
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            testRunName.map { "Run: \($0)" },
+            "\(totalCount) test\(totalCount == 1 ? "" : "s")",
+            "Passed: \(passedCount)",
+            failedCount > 0 ? "Failed: \(failedCount)" : nil,
+            inconclusiveCount > 0 ? "Inconclusive: \(inconclusiveCount)" : nil,
+            notExecutedCount > 0 ? "Not executed: \(notExecutedCount)" : nil,
+            durationLabel.map { "Duration: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        totalCount > 0
+            || testRunName != nil
+            || durationLabel != nil
+            || byteSizeLabel != nil
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "TRX",
+        testRunName: String? = nil,
+        totalCount: Int,
+        passedCount: Int = 0,
+        failedCount: Int = 0,
+        inconclusiveCount: Int = 0,
+        notExecutedCount: Int = 0,
+        durationLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        failurePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.testRunName = testRunName
+        self.totalCount = totalCount
+        self.passedCount = passedCount
+        self.failedCount = failedCount
+        self.inconclusiveCount = inconclusiveCount
+        self.notExecutedCount = notExecutedCount
+        self.durationLabel = durationLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactCoberturaPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var packageCount: Int
@@ -2155,6 +2214,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var junitPreview: ToolArtifactJUnitPreview? {
         ToolArtifactJUnitPreviewBuilder.junitPreview(for: value, kind: kind)
+    }
+    public var trxPreview: ToolArtifactTRXPreview? {
+        ToolArtifactTRXPreviewBuilder.trxPreview(for: value, kind: kind)
     }
     public var coberturaPreview: ToolArtifactCoberturaPreview? {
         ToolArtifactCoberturaPreviewBuilder.coberturaPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -84,6 +84,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "ttc": .data,
         "ttf": .data,
         "toml": .data,
+        "trx": .data,
         "wasm": .data,
         "woff": .data,
         "woff2": .data,

--- a/Sources/QuillCodeApp/ToolArtifactTRXPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactTRXPreviewBuilder.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+enum ToolArtifactTRXPreviewBuilder {
+    static func trxPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactTRXPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "trx",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let collector = TRXPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class TRXPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var testRunName: String?
+    private var totalCount = 0
+    private var passedCount = 0
+    private var failedCount = 0
+    private var inconclusiveCount = 0
+    private var notExecutedCount = 0
+    private var durationSeconds = 0.0
+    private var hasDuration = false
+    private var failureLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = localElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+            testRunName = sanitizedLabel(attributeDict["name"])
+        }
+
+        if label == "UnitTestResult" {
+            recordResult(attributeDict)
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactTRXPreview? {
+        guard rootElementLabel == "TestRun",
+              totalCount > 0
+        else {
+            return nil
+        }
+        return ToolArtifactTRXPreview(
+            testRunName: testRunName,
+            totalCount: totalCount,
+            passedCount: passedCount,
+            failedCount: failedCount,
+            inconclusiveCount: inconclusiveCount,
+            notExecutedCount: notExecutedCount,
+            durationLabel: hasDuration ? durationLabel(for: durationSeconds) : nil,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            failurePreviewLabels: previewLabels(for: failureLabels)
+        )
+    }
+
+    private func recordResult(_ attributes: [String: String]) {
+        totalCount += 1
+        let outcome = sanitizedLabel(attributes["outcome"])?.lowercased()
+        switch outcome {
+        case "passed":
+            passedCount += 1
+        case "failed", "error", "timeout", "aborted":
+            failedCount += 1
+            if let label = resultLabel(from: attributes),
+               !failureLabels.contains(label) {
+                failureLabels.append(label)
+            }
+        case "inconclusive":
+            inconclusiveCount += 1
+        case "notexecuted", "not executed", "skipped":
+            notExecutedCount += 1
+        default:
+            break
+        }
+        if let duration = durationSeconds(attributes["duration"]) {
+            hasDuration = true
+            durationSeconds += duration
+        }
+    }
+
+    private func resultLabel(from attributes: [String: String]) -> String? {
+        sanitizedLabel(attributes["testName"])
+            ?? sanitizedLabel(attributes["testId"])
+            ?? sanitizedLabel(attributes["executionId"])
+    }
+
+    private func durationSeconds(_ value: String?) -> Double? {
+        guard let value = sanitizedLabel(value) else { return nil }
+        let components = value.split(separator: ":")
+        guard components.count == 3,
+              let hours = Double(components[0]),
+              let minutes = Double(components[1]),
+              let seconds = Double(components[2]),
+              hours >= 0,
+              minutes >= 0,
+              seconds >= 0
+        else {
+            return nil
+        }
+        return (hours * 3_600) + (minutes * 60) + seconds
+    }
+
+    private func durationLabel(for seconds: Double) -> String {
+        if seconds < 1 {
+            return "\(Int((seconds * 1_000).rounded())) ms"
+        }
+        let rounded = (seconds * 100).rounded() / 100
+        if rounded == rounded.rounded() {
+            return "\(Int(rounded)) s"
+        }
+        return "\(rounded) s"
+    }
+
+    private func previewLabels(for labels: [String]) -> [String] {
+        Array(labels.prefix(previewLabelLimit))
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func localElementName(elementName: String, qName: String?) -> String {
+        let qualified = qName.flatMap { $0.isEmpty ? nil : $0 } ?? elementName
+        return qualified.split(separator: ":").last.map(String.init) ?? qualified
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -232,6 +232,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
             let junitPreviewModel = artifact.junitPreview
             let junitPreview = renderJUnitPreview(junitPreviewModel)
+            let trxPreview = renderTRXPreview(artifact.trxPreview)
             let coberturaPreviewModel = artifact.coberturaPreview
             let coberturaPreview = renderCoberturaPreview(coberturaPreviewModel)
             let cloverPreviewModel = artifact.cloverPreview
@@ -290,6 +291,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(dotenvPreview)
               \(yamlPreview)
               \(junitPreview)
+              \(trxPreview)
               \(coberturaPreview)
               \(cloverPreview)
               \(jaCoCoPreview)
@@ -1024,6 +1026,31 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(suiteList)
+          \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderTRXPreview(_ preview: ToolArtifactTRXPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-trx-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-trx-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-trx-preview-failures">
+                <strong data-testid="tool-card-trx-preview-failure-title">Failing tests</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-trx-preview">
+          <div>
+            \(metadata)
+          </div>
           \(failureList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1555,6 +1555,57 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJUnit.junitPreview)
     }
 
+    func testArtifactStateDerivesTRXPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("results.trx")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <TestRun id="run-1" name="QuillCode .NET Tests" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+          <Results>
+            <UnitTestResult testName="QuillCode.Tests.AppTests.RendersPrompt" outcome="Passed" duration="00:00:01.1000000" />
+            <UnitTestResult testName="QuillCode.Tests.AppTests.WritesFile" outcome="Failed" duration="00:00:02.2500000" />
+            <UnitTestResult testName="QuillCode.Tests.CliTests.IsSkipped" outcome="NotExecuted" duration="00:00:00.0000000" />
+            <UnitTestResult testName="QuillCode.Tests.CliTests.IsInconclusive" outcome="Inconclusive" duration="00:00:00.5000000" />
+          </Results>
+        </TestRun>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.trxPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "TRX")
+        XCTAssertEqual(preview.formatLabel, "TRX")
+        XCTAssertEqual(preview.testRunName, "QuillCode .NET Tests")
+        XCTAssertEqual(preview.totalCount, 4)
+        XCTAssertEqual(preview.passedCount, 1)
+        XCTAssertEqual(preview.failedCount, 1)
+        XCTAssertEqual(preview.inconclusiveCount, 1)
+        XCTAssertEqual(preview.notExecutedCount, 1)
+        XCTAssertEqual(preview.durationLabel, "3.85 s")
+        XCTAssertEqual(preview.failurePreviewLabels, ["QuillCode.Tests.AppTests.WritesFile"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: TRX",
+            "Run: QuillCode .NET Tests",
+            "4 tests",
+            "Passed: 1",
+            "Failed: 1",
+            "Inconclusive: 1",
+            "Not executed: 1",
+            "Duration: 3.85 s",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let generic = directory.appendingPathComponent("report.trx")
+        try "<project><target /></project>".write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).trxPreview)
+
+        let remoteTRX = ToolArtifactState(value: "https://example.com/results.trx")
+        XCTAssertNil(remoteTRX.trxPreview)
+    }
+
     func testArtifactStateDerivesCoberturaPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("coverage.xml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1691,6 +1691,58 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesTRXArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("results.trx")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <TestRun id="run-1" name="QuillCode .NET Tests" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+          <Results>
+            <UnitTestResult testName="QuillCode.Tests.AppTests.RendersPrompt" outcome="Passed" duration="00:00:01.1000000" />
+            <UnitTestResult testName="QuillCode.Tests.AppTests.WritesFile" outcome="Failed" duration="00:00:02.2500000" />
+            <UnitTestResult testName="QuillCode.Tests.CliTests.IsSkipped" outcome="NotExecuted" duration="00:00:00.0000000" />
+          </Results>
+        </TestRun>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"results.trx"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote results.trx\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "TRX artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · TRX"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">results.trx"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-meta">Format: TRX"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-meta">Run: QuillCode .NET Tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-meta">3 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-meta">Passed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-meta">Failed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-meta">Not executed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-meta">Duration: 3.35 s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-failure-title">Failing tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-failure-item">QuillCode.Tests.AppTests.WritesFile"#))
+    }
+
     func testHTMLRendererIncludesCoberturaArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("coverage.xml")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -97,6 +97,9 @@
 - Artifact previews now include bounded local JUnit XML test-report metadata for `.xml` files whose
   root is `testsuite` or `testsuites`: suite/test counts, failure/error/skipped counts, duration,
   file size, suite labels, and failing-test labels without expanding testcase logs or following paths.
+- Artifact previews now include bounded local Visual Studio TRX test-report metadata for `.trx`
+  files: run name, test outcome counts, duration, file size, and capped failing test names without
+  expanding failure output or fetching remote reports.
 - Artifact previews now include bounded local Cobertura XML coverage-report metadata for `.xml` files
   whose root is `coverage`: package/class counts, line/branch coverage, file size, package labels,
   and class labels without executing coverage tooling, expanding source files, or following paths.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2376,3 +2376,18 @@
   exclusion. `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesJestJSONArtifactPreview`
   covers static HTML selectors, rendered report metadata, failure lists, and generic JSON
   suppression.
+
+## 2026-07-19: TRX artifacts render bounded test summaries
+
+- **Decision:** Local `.trx` artifacts whose XML root validates as `TestRun` and contains
+  `UnitTestResult` entries render as structured Visual Studio TRX report cards. The preview shows
+  run name, outcome counts, duration, file size, and capped failing test names.
+- **Why:** .NET and Visual Studio test loops commonly emit TRX reports. A Codex-style artifact surface
+  should make failed tests scannable without opening XML or asking the model to parse raw logs.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, root-gated, and
+  capped at 512 KB. It reads only `UnitTestResult` attributes, never expands failure output/stacks,
+  never opens referenced files, and never fetches remote TRX reports.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesTRXPreviewMetadata` covers
+  run metadata, outcome counts, duration, failing labels, non-TRX exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesTRXArtifactPreview` covers static HTML
+  selectors, rendered report metadata, and failure lists.


### PR DESCRIPTION
## Summary
- Add bounded local Visual Studio TRX artifact previews
- Render TRX test outcome metadata in SwiftUI and static HTML tool cards
- Document parser boundaries and parity notes

## Validation
- swift test --filter testArtifactStateDerivesTRXPreviewMetadata
- swift test --filter testHTMLRendererIncludesTRXArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check