### PR TITLE
Add xUnit XML artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -95,6 +95,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             junitContent(junitPreview)
         } else if let trxPreview = artifact.trxPreview {
             trxContent(trxPreview)
+        } else if let xunitPreview = artifact.xunitPreview {
+            xunitContent(xunitPreview)
         } else if let coberturaPreview = artifact.coberturaPreview {
             coberturaContent(coberturaPreview)
         } else if let cloverPreview = artifact.cloverPreview {
@@ -459,6 +461,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(trxPreview.metadataLines)
             artifactContentList(title: "Failing tests", labels: trxPreview.failurePreviewLabels)
+        }
+    }
+
+    private func xunitContent(_ xunitPreview: ToolArtifactXUnitPreview) -> some View {
+        previewSurface(minHeight: xunitPreview.failurePreviewLabels.isEmpty ? 92 : 154) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checkmark.seal")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(xunitPreview.metadataLines)
+            artifactContentList(title: "Assemblies", labels: xunitPreview.assemblyPreviewLabels)
+            artifactContentList(title: "Failing tests", labels: xunitPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1516,6 +1516,65 @@ public struct ToolArtifactTRXPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactXUnitPreview: Codable, Sendable, Hashable {
+    public var assemblyCount: Int
+    public var collectionCount: Int
+    public var testCount: Int
+    public var passedCount: Int
+    public var failedCount: Int
+    public var skippedCount: Int
+    public var durationLabel: String?
+    public var byteSizeLabel: String?
+    public var assemblyPreviewLabels: [String]
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: xUnit XML",
+            "\(assemblyCount) assembl\(assemblyCount == 1 ? "y" : "ies")",
+            collectionCount > 0 ? "\(collectionCount) collection\(collectionCount == 1 ? "" : "s")" : nil,
+            "\(testCount) test\(testCount == 1 ? "" : "s")",
+            "Passed: \(passedCount)",
+            failedCount > 0 ? "Failed: \(failedCount)" : nil,
+            skippedCount > 0 ? "Skipped: \(skippedCount)" : nil,
+            durationLabel.map { "Duration: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        assemblyCount > 0
+            || testCount > 0
+            || !metadataLines.isEmpty
+            || !assemblyPreviewLabels.isEmpty
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        assemblyCount: Int,
+        collectionCount: Int,
+        testCount: Int,
+        passedCount: Int = 0,
+        failedCount: Int = 0,
+        skippedCount: Int = 0,
+        durationLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        assemblyPreviewLabels: [String] = [],
+        failurePreviewLabels: [String] = []
+    ) {
+        self.assemblyCount = assemblyCount
+        self.collectionCount = collectionCount
+        self.testCount = testCount
+        self.passedCount = passedCount
+        self.failedCount = failedCount
+        self.skippedCount = skippedCount
+        self.durationLabel = durationLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.assemblyPreviewLabels = assemblyPreviewLabels
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactCoberturaPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var packageCount: Int
@@ -2217,6 +2276,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var trxPreview: ToolArtifactTRXPreview? {
         ToolArtifactTRXPreviewBuilder.trxPreview(for: value, kind: kind)
+    }
+    public var xunitPreview: ToolArtifactXUnitPreview? {
+        ToolArtifactXUnitPreviewBuilder.xunitPreview(for: value, kind: kind)
     }
     public var coberturaPreview: ToolArtifactCoberturaPreview? {
         ToolArtifactCoberturaPreviewBuilder.coberturaPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactXUnitPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactXUnitPreviewBuilder.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+enum ToolArtifactXUnitPreviewBuilder {
+    static func xunitPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactXUnitPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let collector = XUnitPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class XUnitPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var assemblyCount = 0
+    private var collectionCount = 0
+    private var testCount = 0
+    private var passedCount = 0
+    private var failedCount = 0
+    private var skippedCount = 0
+    private var durationSeconds = 0.0
+    private var hasAggregateCounts = false
+    private var hasDuration = false
+    private var assemblyLabels: [String] = []
+    private var failureLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = localElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+        }
+
+        switch label {
+        case "assembly":
+            recordAssembly(attributeDict)
+        case "collection":
+            collectionCount += 1
+        case "test":
+            recordTest(attributeDict)
+        default:
+            break
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactXUnitPreview? {
+        guard rootElementLabel == "assemblies" || rootElementLabel == "assembly",
+              assemblyCount > 0 || testCount > 0
+        else {
+            return nil
+        }
+        return ToolArtifactXUnitPreview(
+            assemblyCount: assemblyCount,
+            collectionCount: collectionCount,
+            testCount: testCount,
+            passedCount: passedCount,
+            failedCount: failedCount,
+            skippedCount: skippedCount,
+            durationLabel: hasDuration ? durationLabel(for: durationSeconds) : nil,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            assemblyPreviewLabels: previewLabels(for: assemblyLabels),
+            failurePreviewLabels: previewLabels(for: failureLabels)
+        )
+    }
+
+    private func recordAssembly(_ attributes: [String: String]) {
+        assemblyCount += 1
+        if let name = sanitizedLabel(attributes["name"]) {
+            assemblyLabels.append(lastPathComponent(name))
+        }
+        guard let total = intAttribute("total", in: attributes) else { return }
+        hasAggregateCounts = true
+        testCount += total
+        passedCount += intAttribute("passed", in: attributes) ?? 0
+        failedCount += intAttribute("failed", in: attributes) ?? 0
+        skippedCount += intAttribute("skipped", in: attributes) ?? 0
+        if let time = doubleAttribute("time", in: attributes) {
+            hasDuration = true
+            durationSeconds += time
+        }
+    }
+
+    private func recordTest(_ attributes: [String: String]) {
+        let result = sanitizedLabel(attributes["result"])?.lowercased()
+        if !hasAggregateCounts {
+            testCount += 1
+            switch result {
+            case "pass", "passed":
+                passedCount += 1
+            case "fail", "failed":
+                failedCount += 1
+            case "skip", "skipped":
+                skippedCount += 1
+            default:
+                break
+            }
+        }
+        if !hasAggregateCounts,
+           let time = doubleAttribute("time", in: attributes) {
+            hasDuration = true
+            durationSeconds += time
+        }
+        if result == "fail" || result == "failed",
+           let label = testLabel(from: attributes),
+           !failureLabels.contains(label) {
+            failureLabels.append(label)
+        }
+    }
+
+    private func testLabel(from attributes: [String: String]) -> String? {
+        sanitizedLabel(attributes["name"])
+            ?? sanitizedLabel(attributes["method"])
+            ?? sanitizedLabel(attributes["type"])
+    }
+
+    private func lastPathComponent(_ value: String) -> String {
+        value.split(whereSeparator: { $0 == "/" || $0 == "\\" }).last.map(String.init) ?? value
+    }
+
+    private func intAttribute(_ key: String, in attributes: [String: String]) -> Int? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let intValue = Int(value),
+              intValue >= 0
+        else {
+            return nil
+        }
+        return intValue
+    }
+
+    private func doubleAttribute(_ key: String, in attributes: [String: String]) -> Double? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let doubleValue = Double(value),
+              doubleValue >= 0
+        else {
+            return nil
+        }
+        return doubleValue
+    }
+
+    private func durationLabel(for seconds: Double) -> String {
+        if seconds < 1 {
+            return "\(Int((seconds * 1_000).rounded())) ms"
+        }
+        let rounded = (seconds * 100).rounded() / 100
+        if rounded == rounded.rounded() {
+            return "\(Int(rounded)) s"
+        }
+        return "\(rounded) s"
+    }
+
+    private func previewLabels(for labels: [String]) -> [String] {
+        Array(labels.prefix(previewLabelLimit))
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func localElementName(elementName: String, qName: String?) -> String {
+        let qualified = qName.flatMap { $0.isEmpty ? nil : $0 } ?? elementName
+        return qualified.split(separator: ":").last.map(String.init) ?? qualified
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -233,6 +233,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let junitPreviewModel = artifact.junitPreview
             let junitPreview = renderJUnitPreview(junitPreviewModel)
             let trxPreview = renderTRXPreview(artifact.trxPreview)
+            let xunitPreviewModel = artifact.xunitPreview
+            let xunitPreview = renderXUnitPreview(xunitPreviewModel)
             let coberturaPreviewModel = artifact.coberturaPreview
             let coberturaPreview = renderCoberturaPreview(coberturaPreviewModel)
             let cloverPreviewModel = artifact.cloverPreview
@@ -240,6 +242,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jaCoCoPreviewModel = artifact.jaCoCoPreview
             let jaCoCoPreview = renderJaCoCoPreview(jaCoCoPreviewModel)
             let xmlPreview = junitPreviewModel == nil
+                && xunitPreviewModel == nil
                 && coberturaPreviewModel == nil
                 && cloverPreviewModel == nil
                 && jaCoCoPreviewModel == nil
@@ -292,6 +295,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(yamlPreview)
               \(junitPreview)
               \(trxPreview)
+              \(xunitPreview)
               \(coberturaPreview)
               \(cloverPreview)
               \(jaCoCoPreview)
@@ -1051,6 +1055,41 @@ enum WorkspaceHTMLToolCardRenderer {
           <div>
             \(metadata)
           </div>
+          \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderXUnitPreview(_ preview: ToolArtifactXUnitPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-xunit-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let assemblies = preview.assemblyPreviewLabels.map {
+            #"<li data-testid="tool-card-xunit-preview-assembly-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-xunit-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let assemblyList = assemblies.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-xunit-preview-assemblies">
+                <strong data-testid="tool-card-xunit-preview-assembly-title">Assemblies</strong>
+                <ul>\(assemblies)</ul>
+              </section>
+        """
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-xunit-preview-failures">
+                <strong data-testid="tool-card-xunit-preview-failure-title">Failing tests</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !assemblyList.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-xunit-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(assemblyList)
           \(failureList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1606,6 +1606,75 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteTRX.trxPreview)
     }
 
+    func testArtifactStateDerivesXUnitPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("xunit-results.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <assemblies>
+          <assembly name="/workspace/bin/Debug/net8.0/QuillCode.Tests.dll" total="4" passed="2" failed="1" skipped="1" time="3.50">
+            <collection name="QuillCode app tests">
+              <test name="QuillCode.Tests.AppTests.RendersPrompt" result="Pass" time="1.25" />
+              <test name="QuillCode.Tests.AppTests.WritesFile" result="Fail" time="2.00" />
+              <test name="QuillCode.Tests.CliTests.IsSkipped" result="Skip" time="0.25" />
+            </collection>
+          </assembly>
+        </assemblies>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.xunitPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.assemblyCount, 1)
+        XCTAssertEqual(preview.collectionCount, 1)
+        XCTAssertEqual(preview.testCount, 4)
+        XCTAssertEqual(preview.passedCount, 2)
+        XCTAssertEqual(preview.failedCount, 1)
+        XCTAssertEqual(preview.skippedCount, 1)
+        XCTAssertEqual(preview.durationLabel, "3.5 s")
+        XCTAssertEqual(preview.assemblyPreviewLabels, ["QuillCode.Tests.dll"])
+        XCTAssertEqual(preview.failurePreviewLabels, ["QuillCode.Tests.AppTests.WritesFile"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: xUnit XML",
+            "1 assembly",
+            "1 collection",
+            "4 tests",
+            "Passed: 2",
+            "Failed: 1",
+            "Skipped: 1",
+            "Duration: 3.5 s",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let fallbackReport = directory.appendingPathComponent("xunit-fallback.xml")
+        try """
+        <assembly name="QuillCode.Fallback.dll">
+          <collection name="Fallback">
+            <test name="FallbackTests.Pass" result="Pass" time="0.25" />
+            <test name="FallbackTests.Fail" result="Fail" time="0.75" />
+            <test name="FallbackTests.Skip" result="Skip" time="0.00" />
+          </collection>
+        </assembly>
+        """.write(to: fallbackReport, atomically: true, encoding: .utf8)
+        let fallbackPreview = try XCTUnwrap(ToolArtifactState(value: fallbackReport.path).xunitPreview)
+        XCTAssertEqual(fallbackPreview.testCount, 3)
+        XCTAssertEqual(fallbackPreview.passedCount, 1)
+        XCTAssertEqual(fallbackPreview.failedCount, 1)
+        XCTAssertEqual(fallbackPreview.skippedCount, 1)
+        XCTAssertEqual(fallbackPreview.durationLabel, "1 s")
+
+        let nonXUnit = directory.appendingPathComponent("manifest.xml")
+        try "<project><target /></project>".write(to: nonXUnit, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: nonXUnit.path).xunitPreview)
+
+        let remoteXUnit = ToolArtifactState(value: "https://example.com/xunit-results.xml")
+        XCTAssertNil(remoteXUnit.xunitPreview)
+    }
+
     func testArtifactStateDerivesCoberturaPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("coverage.xml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1743,6 +1743,64 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-trx-preview-failure-item">QuillCode.Tests.AppTests.WritesFile"#))
     }
 
+    func testHTMLRendererIncludesXUnitArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("xunit-results.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <assemblies>
+          <assembly name="/workspace/bin/Debug/net8.0/QuillCode.Tests.dll" total="3" passed="1" failed="1" skipped="1" time="3.50">
+            <collection name="QuillCode app tests">
+              <test name="QuillCode.Tests.AppTests.RendersPrompt" result="Pass" time="1.25" />
+              <test name="QuillCode.Tests.AppTests.WritesFile" result="Fail" time="2.00" />
+              <test name="QuillCode.Tests.CliTests.IsSkipped" result="Skip" time="0.25" />
+            </collection>
+          </assembly>
+        </assemblies>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"xunit-results.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote xunit-results.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "xUnit artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">xunit-results.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">Format: xUnit XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">1 assembly"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">1 collection"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">3 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">Passed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">Failed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">Skipped: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-meta">Duration: 3.5 s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-assembly-title">Assemblies"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-assembly-item">QuillCode.Tests.dll"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-failure-title">Failing tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-xunit-preview-failure-item">QuillCode.Tests.AppTests.WritesFile"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesCoberturaArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("coverage.xml")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -100,6 +100,10 @@
 - Artifact previews now include bounded local Visual Studio TRX test-report metadata for `.trx`
   files: run name, test outcome counts, duration, file size, and capped failing test names without
   expanding failure output or fetching remote reports.
+- Artifact previews now include bounded local xUnit.net XML test-report metadata for `.xml` files
+  whose root is `assemblies` or `assembly`: assembly/collection/test counts, pass/fail/skip counts,
+  duration, file size, capped assembly names, and capped failing test names without expanding failure
+  output or fetching remote reports.
 - Artifact previews now include bounded local Cobertura XML coverage-report metadata for `.xml` files
   whose root is `coverage`: package/class counts, line/branch coverage, file size, package labels,
   and class labels without executing coverage tooling, expanding source files, or following paths.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2391,3 +2391,20 @@
   run metadata, outcome counts, duration, failing labels, non-TRX exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesTRXArtifactPreview` covers static HTML
   selectors, rendered report metadata, and failure lists.
+
+## 2026-07-19: xUnit XML artifacts render bounded test summaries
+
+- **Decision:** Local `.xml` artifacts whose root validates as `assemblies` or `assembly` render as
+  structured xUnit.net report cards. The preview shows assembly, collection, test, pass, fail, and
+  skip counts plus duration, file size, capped assembly names, and capped failing test names.
+- **Why:** .NET projects commonly emit xUnit XML when TRX is not enabled. Showing a compact report
+  keeps test artifacts useful in the transcript without asking the agent or user to inspect raw XML.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, root-gated, and
+  capped at 512 KB. It reads assembly/test attributes only, never expands failure output/stacks,
+  never opens referenced assemblies or source files, and never fetches remote XML reports. Generic
+  XML rendering is suppressed only after the xUnit report root validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesXUnitPreviewMetadata` covers
+  aggregate and per-test counts, duration, failing labels, non-xUnit exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesXUnitArtifactPreview` covers static
+  HTML selectors, rendered report metadata, assembly lists, failure lists, and generic XML
+  suppression.


### PR DESCRIPTION
## Summary
- Add bounded local xUnit.net XML artifact previews
- Render xUnit test metadata in SwiftUI and static HTML tool cards
- Document parser boundaries and parity notes

## Validation
- swift test --filter testArtifactStateDerivesXUnitPreviewMetadata
- swift test --filter testHTMLRendererIncludesXUnitArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check