### PR TITLE
Add NUnit XML artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -97,6 +97,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             trxContent(trxPreview)
         } else if let xunitPreview = artifact.xunitPreview {
             xunitContent(xunitPreview)
+        } else if let nunitPreview = artifact.nunitPreview {
+            nunitContent(nunitPreview)
         } else if let coberturaPreview = artifact.coberturaPreview {
             coberturaContent(coberturaPreview)
         } else if let cloverPreview = artifact.cloverPreview {
@@ -476,6 +478,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(xunitPreview.metadataLines)
             artifactContentList(title: "Assemblies", labels: xunitPreview.assemblyPreviewLabels)
             artifactContentList(title: "Failing tests", labels: xunitPreview.failurePreviewLabels)
+        }
+    }
+
+    private func nunitContent(_ nunitPreview: ToolArtifactNUnitPreview) -> some View {
+        previewSurface(minHeight: nunitPreview.failurePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checkmark.seal")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(nunitPreview.metadataLines)
+            artifactContentList(title: "Failing tests", labels: nunitPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1575,6 +1575,60 @@ public struct ToolArtifactXUnitPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactNUnitPreview: Codable, Sendable, Hashable {
+    public var runName: String?
+    public var testCount: Int
+    public var passedCount: Int
+    public var failedCount: Int
+    public var inconclusiveCount: Int
+    public var skippedCount: Int
+    public var durationLabel: String?
+    public var byteSizeLabel: String?
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: NUnit XML",
+            runName.map { "Run: \($0)" },
+            "\(testCount) test\(testCount == 1 ? "" : "s")",
+            "Passed: \(passedCount)",
+            failedCount > 0 ? "Failed: \(failedCount)" : nil,
+            inconclusiveCount > 0 ? "Inconclusive: \(inconclusiveCount)" : nil,
+            skippedCount > 0 ? "Skipped: \(skippedCount)" : nil,
+            durationLabel.map { "Duration: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        testCount > 0
+            || !metadataLines.isEmpty
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        runName: String? = nil,
+        testCount: Int,
+        passedCount: Int = 0,
+        failedCount: Int = 0,
+        inconclusiveCount: Int = 0,
+        skippedCount: Int = 0,
+        durationLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        failurePreviewLabels: [String] = []
+    ) {
+        self.runName = runName
+        self.testCount = testCount
+        self.passedCount = passedCount
+        self.failedCount = failedCount
+        self.inconclusiveCount = inconclusiveCount
+        self.skippedCount = skippedCount
+        self.durationLabel = durationLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactCoberturaPreview: Codable, Sendable, Hashable {
     public var versionLabel: String?
     public var packageCount: Int
@@ -2279,6 +2333,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var xunitPreview: ToolArtifactXUnitPreview? {
         ToolArtifactXUnitPreviewBuilder.xunitPreview(for: value, kind: kind)
+    }
+    public var nunitPreview: ToolArtifactNUnitPreview? {
+        ToolArtifactNUnitPreviewBuilder.nunitPreview(for: value, kind: kind)
     }
     public var coberturaPreview: ToolArtifactCoberturaPreview? {
         ToolArtifactCoberturaPreviewBuilder.coberturaPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactNUnitPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactNUnitPreviewBuilder.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+enum ToolArtifactNUnitPreviewBuilder {
+    static func nunitPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactNUnitPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let collector = NUnitPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class NUnitPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var runName: String?
+    private var testCount = 0
+    private var passedCount = 0
+    private var failedCount = 0
+    private var inconclusiveCount = 0
+    private var skippedCount = 0
+    private var durationSeconds = 0.0
+    private var hasAggregateCounts = false
+    private var hasDuration = false
+    private var failureLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = localElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+            runName = sanitizedLabel(attributeDict["name"])
+            recordRun(attributeDict)
+        }
+
+        if label == "test-case" {
+            recordTestCase(attributeDict)
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactNUnitPreview? {
+        guard rootElementLabel == "test-run",
+              testCount > 0
+        else {
+            return nil
+        }
+        return ToolArtifactNUnitPreview(
+            runName: runName,
+            testCount: testCount,
+            passedCount: passedCount,
+            failedCount: failedCount,
+            inconclusiveCount: inconclusiveCount,
+            skippedCount: skippedCount,
+            durationLabel: hasDuration ? durationLabel(for: durationSeconds) : nil,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            failurePreviewLabels: previewLabels(for: failureLabels)
+        )
+    }
+
+    private func recordRun(_ attributes: [String: String]) {
+        guard let total = intAttribute("total", in: attributes) else { return }
+        hasAggregateCounts = true
+        testCount = total
+        passedCount = intAttribute("passed", in: attributes) ?? 0
+        failedCount = intAttribute("failed", in: attributes) ?? 0
+        inconclusiveCount = intAttribute("inconclusive", in: attributes) ?? 0
+        skippedCount = intAttribute("skipped", in: attributes) ?? 0
+        if let duration = doubleAttribute("duration", in: attributes) {
+            hasDuration = true
+            durationSeconds = duration
+        }
+    }
+
+    private func recordTestCase(_ attributes: [String: String]) {
+        let result = sanitizedLabel(attributes["result"])?.lowercased()
+        if !hasAggregateCounts {
+            testCount += 1
+            switch result {
+            case "passed":
+                passedCount += 1
+            case "failed", "error", "cancelled":
+                failedCount += 1
+            case "inconclusive":
+                inconclusiveCount += 1
+            case "skipped", "ignored":
+                skippedCount += 1
+            default:
+                break
+            }
+        }
+        if !hasAggregateCounts,
+           let duration = doubleAttribute("duration", in: attributes) {
+            hasDuration = true
+            durationSeconds += duration
+        }
+        if result == "failed" || result == "error" || result == "cancelled",
+           let label = testLabel(from: attributes),
+           !failureLabels.contains(label) {
+            failureLabels.append(label)
+        }
+    }
+
+    private func testLabel(from attributes: [String: String]) -> String? {
+        sanitizedLabel(attributes["fullname"])
+            ?? sanitizedLabel(attributes["name"])
+            ?? sanitizedLabel(attributes["id"])
+    }
+
+    private func intAttribute(_ key: String, in attributes: [String: String]) -> Int? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let intValue = Int(value),
+              intValue >= 0
+        else {
+            return nil
+        }
+        return intValue
+    }
+
+    private func doubleAttribute(_ key: String, in attributes: [String: String]) -> Double? {
+        guard let value = attributes[key].flatMap(sanitizedLabel),
+              let doubleValue = Double(value),
+              doubleValue >= 0
+        else {
+            return nil
+        }
+        return doubleValue
+    }
+
+    private func durationLabel(for seconds: Double) -> String {
+        if seconds < 1 {
+            return "\(Int((seconds * 1_000).rounded())) ms"
+        }
+        let rounded = (seconds * 100).rounded() / 100
+        if rounded == rounded.rounded() {
+            return "\(Int(rounded)) s"
+        }
+        return "\(rounded) s"
+    }
+
+    private func previewLabels(for labels: [String]) -> [String] {
+        Array(labels.prefix(previewLabelLimit))
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func localElementName(elementName: String, qName: String?) -> String {
+        let qualified = qName.flatMap { $0.isEmpty ? nil : $0 } ?? elementName
+        return qualified.split(separator: ":").last.map(String.init) ?? qualified
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -235,6 +235,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let trxPreview = renderTRXPreview(artifact.trxPreview)
             let xunitPreviewModel = artifact.xunitPreview
             let xunitPreview = renderXUnitPreview(xunitPreviewModel)
+            let nunitPreviewModel = artifact.nunitPreview
+            let nunitPreview = renderNUnitPreview(nunitPreviewModel)
             let coberturaPreviewModel = artifact.coberturaPreview
             let coberturaPreview = renderCoberturaPreview(coberturaPreviewModel)
             let cloverPreviewModel = artifact.cloverPreview
@@ -243,6 +245,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jaCoCoPreview = renderJaCoCoPreview(jaCoCoPreviewModel)
             let xmlPreview = junitPreviewModel == nil
                 && xunitPreviewModel == nil
+                && nunitPreviewModel == nil
                 && coberturaPreviewModel == nil
                 && cloverPreviewModel == nil
                 && jaCoCoPreviewModel == nil
@@ -296,6 +299,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(junitPreview)
               \(trxPreview)
               \(xunitPreview)
+              \(nunitPreview)
               \(coberturaPreview)
               \(cloverPreview)
               \(jaCoCoPreview)
@@ -1090,6 +1094,31 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(assemblyList)
+          \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderNUnitPreview(_ preview: ToolArtifactNUnitPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-nunit-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-nunit-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-nunit-preview-failures">
+                <strong data-testid="tool-card-nunit-preview-failure-title">Failing tests</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-nunit-preview">
+          <div>
+            \(metadata)
+          </div>
           \(failureList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1675,6 +1675,71 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteXUnit.xunitPreview)
     }
 
+    func testArtifactStateDerivesNUnitPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("TestResult.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <test-run id="2" name="QuillCode NUnit Tests" total="4" passed="2" failed="1" inconclusive="0" skipped="1" duration="4.25">
+          <test-suite type="Assembly" name="QuillCode.Tests.dll">
+            <test-case id="0-1001" fullname="QuillCode.Tests.AppTests.RendersPrompt" result="Passed" duration="1.25" />
+            <test-case id="0-1002" fullname="QuillCode.Tests.AppTests.WritesFile" result="Failed" duration="2.00" />
+            <test-case id="0-1003" fullname="QuillCode.Tests.CliTests.IsSkipped" result="Skipped" duration="0.25" />
+          </test-suite>
+        </test-run>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.nunitPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.runName, "QuillCode NUnit Tests")
+        XCTAssertEqual(preview.testCount, 4)
+        XCTAssertEqual(preview.passedCount, 2)
+        XCTAssertEqual(preview.failedCount, 1)
+        XCTAssertEqual(preview.inconclusiveCount, 0)
+        XCTAssertEqual(preview.skippedCount, 1)
+        XCTAssertEqual(preview.durationLabel, "4.25 s")
+        XCTAssertEqual(preview.failurePreviewLabels, ["QuillCode.Tests.AppTests.WritesFile"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: NUnit XML",
+            "Run: QuillCode NUnit Tests",
+            "4 tests",
+            "Passed: 2",
+            "Failed: 1",
+            "Skipped: 1",
+            "Duration: 4.25 s",
+            "Size: \(content.utf8.count) bytes"
+        ])
+
+        let fallbackReport = directory.appendingPathComponent("nunit-fallback.xml")
+        try """
+        <test-run name="Fallback NUnit">
+          <test-case fullname="FallbackTests.Pass" result="Passed" duration="0.25" />
+          <test-case fullname="FallbackTests.Fail" result="Failed" duration="0.75" />
+          <test-case fullname="FallbackTests.Inconclusive" result="Inconclusive" duration="0.50" />
+          <test-case fullname="FallbackTests.Skip" result="Skipped" duration="0.00" />
+        </test-run>
+        """.write(to: fallbackReport, atomically: true, encoding: .utf8)
+        let fallbackPreview = try XCTUnwrap(ToolArtifactState(value: fallbackReport.path).nunitPreview)
+        XCTAssertEqual(fallbackPreview.testCount, 4)
+        XCTAssertEqual(fallbackPreview.passedCount, 1)
+        XCTAssertEqual(fallbackPreview.failedCount, 1)
+        XCTAssertEqual(fallbackPreview.inconclusiveCount, 1)
+        XCTAssertEqual(fallbackPreview.skippedCount, 1)
+        XCTAssertEqual(fallbackPreview.durationLabel, "1.5 s")
+
+        let nonNUnit = directory.appendingPathComponent("manifest.xml")
+        try "<project><target /></project>".write(to: nonNUnit, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: nonNUnit.path).nunitPreview)
+
+        let remoteNUnit = ToolArtifactState(value: "https://example.com/TestResult.xml")
+        XCTAssertNil(remoteNUnit.nunitPreview)
+    }
+
     func testArtifactStateDerivesCoberturaPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("coverage.xml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1801,6 +1801,59 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesNUnitArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("TestResult.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <test-run id="2" name="QuillCode NUnit Tests" total="3" passed="1" failed="1" inconclusive="0" skipped="1" duration="3.50">
+          <test-suite type="Assembly" name="QuillCode.Tests.dll">
+            <test-case id="0-1001" fullname="QuillCode.Tests.AppTests.RendersPrompt" result="Passed" duration="1.25" />
+            <test-case id="0-1002" fullname="QuillCode.Tests.AppTests.WritesFile" result="Failed" duration="2.00" />
+            <test-case id="0-1003" fullname="QuillCode.Tests.CliTests.IsSkipped" result="Skipped" duration="0.25" />
+          </test-suite>
+        </test-run>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"TestResult.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote TestResult.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "NUnit artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">TestResult.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-meta">Format: NUnit XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-meta">Run: QuillCode NUnit Tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-meta">3 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-meta">Passed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-meta">Failed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-meta">Skipped: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-meta">Duration: 3.5 s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-failure-title">Failing tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-nunit-preview-failure-item">QuillCode.Tests.AppTests.WritesFile"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesCoberturaArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("coverage.xml")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -104,6 +104,9 @@
   whose root is `assemblies` or `assembly`: assembly/collection/test counts, pass/fail/skip counts,
   duration, file size, capped assembly names, and capped failing test names without expanding failure
   output or fetching remote reports.
+- Artifact previews now include bounded local NUnit XML test-report metadata for `.xml` files whose
+  root is `test-run`: run name, test outcome counts, duration, file size, and capped failing test
+  names without expanding failure output or fetching remote reports.
 - Artifact previews now include bounded local Cobertura XML coverage-report metadata for `.xml` files
   whose root is `coverage`: package/class counts, line/branch coverage, file size, package labels,
   and class labels without executing coverage tooling, expanding source files, or following paths.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2408,3 +2408,20 @@
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesXUnitArtifactPreview` covers static
   HTML selectors, rendered report metadata, assembly lists, failure lists, and generic XML
   suppression.
+
+## 2026-07-19: NUnit XML artifacts render bounded test summaries
+
+- **Decision:** Local `.xml` artifacts whose root validates as `test-run` render as structured NUnit
+  report cards. The preview shows run name, test, pass, fail, inconclusive, and skip counts plus
+  duration, file size, and capped failing test names.
+- **Why:** NUnit is a common .NET test runner and often emits `TestResult.xml` instead of TRX or
+  xUnit XML. A Codex-style artifact surface should make the useful result summary visible without
+  asking the model to inspect raw XML.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, root-gated, and
+  capped at 512 KB. It reads run and `test-case` attributes only, never expands failure output,
+  assertion messages, stack traces, source files, or referenced assemblies, and never fetches remote
+  XML reports. Generic XML rendering is suppressed only after the NUnit root validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesNUnitPreviewMetadata` covers
+  aggregate and per-test counts, duration, failing labels, non-NUnit exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesNUnitArtifactPreview` covers static
+  HTML selectors, rendered report metadata, failure lists, and generic XML suppression.


### PR DESCRIPTION
## Summary
- Add bounded local NUnit XML artifact previews
- Render NUnit test metadata in SwiftUI and static HTML tool cards
- Document parser boundaries and parity notes

## Validation
- git diff --check
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests