### PR TITLE
Add CycloneDX SBOM artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -71,6 +71,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pytestJSONContent(pytestJSONPreview)
         } else if let jestJSONPreview = artifact.jestJSONPreview {
             jestJSONContent(jestJSONPreview)
+        } else if let cycloneDXPreview = artifact.cycloneDXPreview {
+            cycloneDXContent(cycloneDXPreview)
         } else if let tapPreview = artifact.tapPreview {
             tapContent(tapPreview)
         } else if let harPreview = artifact.harPreview {
@@ -279,6 +281,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(jestJSONPreview.metadataLines)
             artifactContentList(title: "Failures", labels: jestJSONPreview.failurePreviewLabels)
+        }
+    }
+
+    private func cycloneDXContent(_ cycloneDXPreview: ToolArtifactCycloneDXPreview) -> some View {
+        previewSurface(minHeight: cycloneDXPreview.componentPreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(cycloneDXPreview.metadataLines)
+            artifactContentList(title: "Components", labels: cycloneDXPreview.componentPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -465,6 +465,79 @@ public struct ToolArtifactJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactCycloneDXPreview: Codable, Sendable, Hashable {
+    public var specVersion: String?
+    public var serialNumber: String?
+    public var rootComponentLabel: String?
+    public var componentCount: Int
+    public var serviceCount: Int
+    public var dependencyCount: Int
+    public var vulnerabilityCount: Int
+    public var criticalVulnerabilityCount: Int
+    public var highVulnerabilityCount: Int
+    public var mediumVulnerabilityCount: Int
+    public var lowVulnerabilityCount: Int
+    public var byteSizeLabel: String?
+    public var componentPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: CycloneDX",
+            specVersion.map { "Spec: \($0)" },
+            rootComponentLabel.map { "Root: \($0)" },
+            serialNumber.map { "Serial: \($0)" },
+            "\(componentCount) component\(componentCount == 1 ? "" : "s")",
+            serviceCount > 0 ? "\(serviceCount) service\(serviceCount == 1 ? "" : "s")" : nil,
+            dependencyCount > 0 ? "\(dependencyCount) dependenc\(dependencyCount == 1 ? "y" : "ies")" : nil,
+            vulnerabilityCount > 0 ? "Vulnerabilities: \(vulnerabilityCount)" : nil,
+            criticalVulnerabilityCount > 0 ? "Critical: \(criticalVulnerabilityCount)" : nil,
+            highVulnerabilityCount > 0 ? "High: \(highVulnerabilityCount)" : nil,
+            mediumVulnerabilityCount > 0 ? "Medium: \(mediumVulnerabilityCount)" : nil,
+            lowVulnerabilityCount > 0 ? "Low: \(lowVulnerabilityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        componentCount > 0
+            || serviceCount > 0
+            || dependencyCount > 0
+            || vulnerabilityCount > 0
+            || !metadataLines.isEmpty
+            || !componentPreviewLabels.isEmpty
+    }
+
+    public init(
+        specVersion: String? = nil,
+        serialNumber: String? = nil,
+        rootComponentLabel: String? = nil,
+        componentCount: Int,
+        serviceCount: Int = 0,
+        dependencyCount: Int = 0,
+        vulnerabilityCount: Int = 0,
+        criticalVulnerabilityCount: Int = 0,
+        highVulnerabilityCount: Int = 0,
+        mediumVulnerabilityCount: Int = 0,
+        lowVulnerabilityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        componentPreviewLabels: [String] = []
+    ) {
+        self.specVersion = specVersion
+        self.serialNumber = serialNumber
+        self.rootComponentLabel = rootComponentLabel
+        self.componentCount = componentCount
+        self.serviceCount = serviceCount
+        self.dependencyCount = dependencyCount
+        self.vulnerabilityCount = vulnerabilityCount
+        self.criticalVulnerabilityCount = criticalVulnerabilityCount
+        self.highVulnerabilityCount = highVulnerabilityCount
+        self.mediumVulnerabilityCount = mediumVulnerabilityCount
+        self.lowVulnerabilityCount = lowVulnerabilityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.componentPreviewLabels = componentPreviewLabels
+    }
+}
+
 public struct ToolArtifactIstanbulPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var sourceFileCount: Int
@@ -2279,6 +2352,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var jsonPreview: ToolArtifactJSONPreview? {
         ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
+    }
+    public var cycloneDXPreview: ToolArtifactCycloneDXPreview? {
+        ToolArtifactCycloneDXPreviewBuilder.cycloneDXPreview(for: value, kind: kind)
     }
     public var istanbulPreview: ToolArtifactIstanbulPreview? {
         ToolArtifactIstanbulPreviewBuilder.istanbulPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactCycloneDXPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCycloneDXPreviewBuilder.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+enum ToolArtifactCycloneDXPreviewBuilder {
+    static func cycloneDXPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactCycloneDXPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  stringValue(root["bomFormat"])?.lowercased() == "cyclonedx"
+            else {
+                return nil
+            }
+            let preview = preview(
+                from: root,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from root: [String: Any], byteSizeLabel: String?) -> ToolArtifactCycloneDXPreview {
+        let components = root["components"] as? [[String: Any]] ?? []
+        let services = root["services"] as? [[String: Any]] ?? []
+        let dependencies = root["dependencies"] as? [[String: Any]] ?? []
+        let vulnerabilities = root["vulnerabilities"] as? [[String: Any]] ?? []
+
+        return ToolArtifactCycloneDXPreview(
+            specVersion: stringValue(root["specVersion"]),
+            serialNumber: stringValue(root["serialNumber"]),
+            rootComponentLabel: rootComponentLabel(from: root["metadata"] as? [String: Any]),
+            componentCount: components.count,
+            serviceCount: services.count,
+            dependencyCount: dependencies.count,
+            vulnerabilityCount: vulnerabilities.count,
+            criticalVulnerabilityCount: vulnerabilityCount("critical", in: vulnerabilities),
+            highVulnerabilityCount: vulnerabilityCount("high", in: vulnerabilities),
+            mediumVulnerabilityCount: vulnerabilityCount("medium", in: vulnerabilities),
+            lowVulnerabilityCount: vulnerabilityCount("low", in: vulnerabilities),
+            byteSizeLabel: byteSizeLabel,
+            componentPreviewLabels: previewLabels(from: components)
+        )
+    }
+
+    private static func rootComponentLabel(from metadata: [String: Any]?) -> String? {
+        guard let component = metadata?["component"] as? [String: Any] else { return nil }
+        return componentLabel(from: component)
+    }
+
+    private static func previewLabels(from components: [[String: Any]]) -> [String] {
+        Array(components.compactMap(componentLabel(from:)).prefix(previewLabelLimit))
+    }
+
+    private static func componentLabel(from component: [String: Any]) -> String? {
+        guard let name = stringValue(component["name"]) else { return nil }
+        let version = stringValue(component["version"])
+        let type = stringValue(component["type"])
+        let packageURL = stringValue(component["purl"])
+        var label = version.map { "\(name)@\($0)" } ?? name
+        if let type {
+            label += " · \(type)"
+        }
+        if let packageURL {
+            label += " · \(packageURL)"
+        }
+        return sanitizedLabel(label)
+    }
+
+    private static func vulnerabilityCount(_ severity: String, in vulnerabilities: [[String: Any]]) -> Int {
+        vulnerabilities.filter { vulnerability in
+            vulnerabilitySeverity(from: vulnerability)?.lowercased() == severity
+        }.count
+    }
+
+    private static func vulnerabilitySeverity(from vulnerability: [String: Any]) -> String? {
+        if let ratings = vulnerability["ratings"] as? [[String: Any]] {
+            for rating in ratings {
+                if let severity = stringValue(rating["severity"]) {
+                    return severity
+                }
+            }
+        }
+        return stringValue(vulnerability["severity"])
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        return sanitizedLabel(string)
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String? {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -220,6 +220,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
             let jestJSONPreviewModel = artifact.jestJSONPreview
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
+            let cycloneDXPreviewModel = artifact.cycloneDXPreview
+            let cycloneDXPreview = renderCycloneDXPreview(cycloneDXPreviewModel)
             let tapPreview = renderTAPPreview(artifact.tapPreview)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
@@ -261,6 +263,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && coveragePyPreviewModel == nil
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
+                && cycloneDXPreviewModel == nil
                 ? renderJSONPreview(artifact.jsonPreview)
                 : ""
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
@@ -286,6 +289,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(coveragePyPreview)
               \(pytestJSONPreview)
               \(jestJSONPreview)
+              \(cycloneDXPreview)
               \(tapPreview)
               \(harPreview)
               \(lcovPreview)
@@ -732,6 +736,31 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderCycloneDXPreview(_ preview: ToolArtifactCycloneDXPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-cyclonedx-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let components = preview.componentPreviewLabels.map {
+            #"<li data-testid="tool-card-cyclonedx-preview-component-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let componentList = components.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-cyclonedx-preview-components">
+                <strong data-testid="tool-card-cyclonedx-preview-component-title">Components</strong>
+                <ul>\(components)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !componentList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-cyclonedx-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(componentList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -453,6 +453,94 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJSON.jsonPreview)
     }
 
+    func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("bom.json")
+        let jsonText = """
+        {
+          "bomFormat": "CycloneDX",
+          "specVersion": "1.6",
+          "serialNumber": "urn:uuid:7f9b2e15-40d4-4f37-9d97-6e5d5c76d601",
+          "metadata": {
+            "component": {
+              "type": "application",
+              "name": "QuillCode",
+              "version": "0.1.0",
+              "purl": "pkg:generic/quillcode@0.1.0"
+            }
+          },
+          "components": [
+            {
+              "type": "library",
+              "name": "trusted-router-swift",
+              "version": "1.2.3",
+              "purl": "pkg:swift/lore-hex/trusted-router-swift@1.2.3"
+            },
+            {
+              "type": "library",
+              "name": "Yams",
+              "version": "5.1.3"
+            }
+          ],
+          "services": [
+            { "name": "TrustedRouter" }
+          ],
+          "dependencies": [
+            { "ref": "pkg:generic/quillcode@0.1.0", "dependsOn": ["pkg:swift/lore-hex/trusted-router-swift@1.2.3"] }
+          ],
+          "vulnerabilities": [
+            { "id": "CVE-0000-0001", "ratings": [{ "severity": "high" }] },
+            { "id": "CVE-0000-0002", "ratings": [{ "severity": "critical" }] },
+            { "id": "CVE-0000-0003", "severity": "medium" }
+          ]
+        }
+        """
+        try jsonText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.cycloneDXPreview)
+        let byteSizeLabel = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(jsonText.data(using: .utf8)).count))
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.specVersion, "1.6")
+        XCTAssertEqual(preview.serialNumber, "urn:uuid:7f9b2e15-40d4-4f37-9d97-6e5d5c76d601")
+        XCTAssertEqual(preview.rootComponentLabel, "QuillCode@0.1.0 · application · pkg:generic/quillcode@0.1.0")
+        XCTAssertEqual(preview.componentCount, 2)
+        XCTAssertEqual(preview.serviceCount, 1)
+        XCTAssertEqual(preview.dependencyCount, 1)
+        XCTAssertEqual(preview.vulnerabilityCount, 3)
+        XCTAssertEqual(preview.criticalVulnerabilityCount, 1)
+        XCTAssertEqual(preview.highVulnerabilityCount, 1)
+        XCTAssertEqual(preview.mediumVulnerabilityCount, 1)
+        XCTAssertEqual(preview.lowVulnerabilityCount, 0)
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.componentPreviewLabels, [
+            "trusted-router-swift@1.2.3 · library · pkg:swift/lore-hex/trusted-router-swift@1.2.3",
+            "Yams@5.1.3 · library"
+        ])
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: CycloneDX",
+            "Spec: 1.6",
+            "Root: QuillCode@0.1.0 · application · pkg:generic/quillcode@0.1.0",
+            "Serial: urn:uuid:7f9b2e15-40d4-4f37-9d97-6e5d5c76d601",
+            "2 components",
+            "1 service",
+            "1 dependency",
+            "Vulnerabilities: 3",
+            "Critical: 1",
+            "High: 1",
+            "Medium: 1",
+            "Size: \(byteSizeLabel)"
+        ])
+        let packageJSON = directory.appendingPathComponent("package.json")
+        try #"{"name":"quillcode","version":"0.1.0"}"#.write(to: packageJSON, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: packageJSON.path).cycloneDXPreview)
+
+        let remoteSBOM = ToolArtifactState(value: "https://example.com/bom.json")
+        XCTAssertNil(remoteSBOM.cycloneDXPreview)
+    }
+
     func testArtifactStateDerivesHARPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let trace = directory.appendingPathComponent("network.har")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -701,6 +701,84 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-content">"#))
     }
 
+    func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("bom.json")
+        try """
+        {
+          "bomFormat": "CycloneDX",
+          "specVersion": "1.6",
+          "metadata": {
+            "component": {
+              "type": "application",
+              "name": "QuillCode",
+              "version": "0.1.0"
+            }
+          },
+          "components": [
+            {
+              "type": "library",
+              "name": "trusted-router-swift",
+              "version": "1.2.3"
+            },
+            {
+              "type": "library",
+              "name": "Yams",
+              "version": "5.1.3"
+            }
+          ],
+          "services": [
+            { "name": "TrustedRouter" }
+          ],
+          "dependencies": [
+            { "ref": "pkg:generic/quillcode@0.1.0", "dependsOn": ["pkg:swift/lore-hex/trusted-router-swift@1.2.3"] }
+          ],
+          "vulnerabilities": [
+            { "id": "CVE-0000-0001", "ratings": [{ "severity": "high" }] }
+          ]
+        }
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"bom.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote bom.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "CycloneDX artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">bom.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">Format: CycloneDX"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">Spec: 1.6"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">Root: QuillCode@0.1.0 · application"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">2 components"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">1 service"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">1 dependency"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">Vulnerabilities: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-meta">High: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-component-title">Components"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cyclonedx-preview-component-item">trusted-router-swift@1.2.3 · library"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesIstanbulArtifactPreview() throws {
         let root = try makeTempDirectory()
         let coverageDirectory = root.appendingPathComponent("coverage", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -83,6 +83,10 @@
 - Artifact previews now include bounded local SARIF static-analysis metadata for `.sarif` and
   `.sarif.json` files: SARIF version, run/result counts, level counts, file size, capped tool labels,
   and capped rule labels without fetching remote reports or following result paths.
+- Artifact previews now include bounded local CycloneDX SBOM metadata for `.json` files whose
+  `bomFormat` validates as `CycloneDX`: spec version, root component, component/service/dependency
+  counts, vulnerability severity counts, file size, and capped component labels without expanding
+  license text, hashes, evidence, or fetching remote SBOMs.
 - Artifact previews now include bounded local font metadata for `.ttf`, `.otf`, `.ttc`, `.woff`,
   and `.woff2` files by validating fixed headers and rendering format, flavor, table count,
   declared size, and file size without parsing tables or decompressing webfont payloads.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2425,3 +2425,23 @@
   aggregate and per-test counts, duration, failing labels, non-NUnit exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesNUnitArtifactPreview` covers static
   HTML selectors, rendered report metadata, failure lists, and generic XML suppression.
+
+## 2026-07-19: CycloneDX SBOM artifacts render bounded supply-chain summaries
+
+- **Decision:** Local `.json` artifacts whose top-level `bomFormat` validates as `CycloneDX` render
+  as structured SBOM cards. The preview shows spec version, serial number, root component,
+  component/service/dependency counts, vulnerability severity counts, file size, and capped component
+  labels.
+- **Why:** Coding agents increasingly produce SBOMs during build, release, dependency audit, and
+  security workflows. A Codex-style artifact surface should make the supply-chain shape immediately
+  scannable without asking the model to read or summarize raw SBOM JSON.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It validates `bomFormat: CycloneDX`, reads only shallow metadata, component labels,
+  dependency counts, service counts, and vulnerability severities, and never expands license text,
+  hashes, evidence, references, external references, advisories, or remote SBOM URLs. Generic JSON
+  rendering is suppressed only after the CycloneDX shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesCycloneDXPreviewMetadata`
+  covers metadata extraction, vulnerability severity counts, component labels, generic JSON
+  suppression, non-CycloneDX exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCycloneDXArtifactPreview` covers static
+  HTML selectors, rendered SBOM metadata, component lists, and generic JSON suppression.


### PR DESCRIPTION
## Summary
- Add bounded local CycloneDX SBOM artifact previews
- Render SBOM metadata in SwiftUI and static HTML tool cards
- Document parser boundaries and parity notes

## Validation
- git diff --check
- swift test --filter testArtifactStateDerivesCycloneDXPreviewMetadata
- swift test --filter testHTMLRendererIncludesCycloneDXArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests