### PR TITLE
Add SPDX SBOM artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -73,6 +73,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             jestJSONContent(jestJSONPreview)
         } else if let cycloneDXPreview = artifact.cycloneDXPreview {
             cycloneDXContent(cycloneDXPreview)
+        } else if let spdxPreview = artifact.spdxPreview {
+            spdxContent(spdxPreview)
         } else if let tapPreview = artifact.tapPreview {
             tapContent(tapPreview)
         } else if let harPreview = artifact.harPreview {
@@ -295,6 +297,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(cycloneDXPreview.metadataLines)
             artifactContentList(title: "Components", labels: cycloneDXPreview.componentPreviewLabels)
+        }
+    }
+
+    private func spdxContent(_ spdxPreview: ToolArtifactSPDXPreview) -> some View {
+        let hasLists = !spdxPreview.packagePreviewLabels.isEmpty || !spdxPreview.licensePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "doc.badge.gearshape")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(spdxPreview.metadataLines)
+            artifactContentList(title: "Packages", labels: spdxPreview.packagePreviewLabels)
+            artifactContentList(title: "Licenses", labels: spdxPreview.licensePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -538,6 +538,71 @@ public struct ToolArtifactCycloneDXPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactSPDXPreview: Codable, Sendable, Hashable {
+    public var specVersion: String?
+    public var documentName: String?
+    public var documentNamespace: String?
+    public var packageCount: Int
+    public var fileCount: Int
+    public var relationshipCount: Int
+    public var extractedLicenseCount: Int
+    public var creatorCount: Int
+    public var byteSizeLabel: String?
+    public var packagePreviewLabels: [String]
+    public var licensePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: SPDX",
+            specVersion.map { "Spec: \($0)" },
+            documentName.map { "Document: \($0)" },
+            documentNamespace.map { "Namespace: \($0)" },
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            fileCount > 0 ? "\(fileCount) file\(fileCount == 1 ? "" : "s")" : nil,
+            relationshipCount > 0 ? "\(relationshipCount) relationship\(relationshipCount == 1 ? "" : "s")" : nil,
+            extractedLicenseCount > 0 ? "\(extractedLicenseCount) extracted license\(extractedLicenseCount == 1 ? "" : "s")" : nil,
+            creatorCount > 0 ? "\(creatorCount) creator\(creatorCount == 1 ? "" : "s")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount > 0
+            || fileCount > 0
+            || relationshipCount > 0
+            || extractedLicenseCount > 0
+            || !metadataLines.isEmpty
+            || !packagePreviewLabels.isEmpty
+            || !licensePreviewLabels.isEmpty
+    }
+
+    public init(
+        specVersion: String? = nil,
+        documentName: String? = nil,
+        documentNamespace: String? = nil,
+        packageCount: Int,
+        fileCount: Int = 0,
+        relationshipCount: Int = 0,
+        extractedLicenseCount: Int = 0,
+        creatorCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        packagePreviewLabels: [String] = [],
+        licensePreviewLabels: [String] = []
+    ) {
+        self.specVersion = specVersion
+        self.documentName = documentName
+        self.documentNamespace = documentNamespace
+        self.packageCount = packageCount
+        self.fileCount = fileCount
+        self.relationshipCount = relationshipCount
+        self.extractedLicenseCount = extractedLicenseCount
+        self.creatorCount = creatorCount
+        self.byteSizeLabel = byteSizeLabel
+        self.packagePreviewLabels = packagePreviewLabels
+        self.licensePreviewLabels = licensePreviewLabels
+    }
+}
+
 public struct ToolArtifactIstanbulPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var sourceFileCount: Int
@@ -2355,6 +2420,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var cycloneDXPreview: ToolArtifactCycloneDXPreview? {
         ToolArtifactCycloneDXPreviewBuilder.cycloneDXPreview(for: value, kind: kind)
+    }
+    public var spdxPreview: ToolArtifactSPDXPreview? {
+        ToolArtifactSPDXPreviewBuilder.spdxPreview(for: value, kind: kind)
     }
     public var istanbulPreview: ToolArtifactIstanbulPreview? {
         ToolArtifactIstanbulPreviewBuilder.istanbulPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactSPDXPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSPDXPreviewBuilder.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+enum ToolArtifactSPDXPreviewBuilder {
+    static func spdxPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactSPDXPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  isSPDXDocument(root)
+            else {
+                return nil
+            }
+            let preview = preview(
+                from: root,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func isSPDXDocument(_ root: [String: Any]) -> Bool {
+        guard let version = stringValue(root["spdxVersion"])?.uppercased(),
+              version.hasPrefix("SPDX-")
+        else {
+            return false
+        }
+        return stringValue(root["SPDXID"]) != nil
+            || stringValue(root["documentNamespace"]) != nil
+            || root["packages"] is [[String: Any]]
+            || root["files"] is [[String: Any]]
+    }
+
+    private static func preview(from root: [String: Any], byteSizeLabel: String?) -> ToolArtifactSPDXPreview {
+        let packages = root["packages"] as? [[String: Any]] ?? []
+        let files = root["files"] as? [[String: Any]] ?? []
+        let relationships = root["relationships"] as? [[String: Any]] ?? []
+        let extractedLicenses = root["hasExtractedLicensingInfos"] as? [[String: Any]] ?? []
+        let creators = (root["creationInfo"] as? [String: Any])?["creators"] as? [String] ?? []
+        let licenseLabels = licensePreviewLabels(from: packages, extractedLicenses: extractedLicenses)
+
+        return ToolArtifactSPDXPreview(
+            specVersion: stringValue(root["spdxVersion"]),
+            documentName: stringValue(root["name"]),
+            documentNamespace: stringValue(root["documentNamespace"]),
+            packageCount: packages.count,
+            fileCount: files.count,
+            relationshipCount: relationships.count,
+            extractedLicenseCount: extractedLicenses.count,
+            creatorCount: creators.count,
+            byteSizeLabel: byteSizeLabel,
+            packagePreviewLabels: previewLabels(from: packages),
+            licensePreviewLabels: licenseLabels
+        )
+    }
+
+    private static func previewLabels(from packages: [[String: Any]]) -> [String] {
+        Array(packages.compactMap(packageLabel(from:)).prefix(previewLabelLimit))
+    }
+
+    private static func packageLabel(from package: [String: Any]) -> String? {
+        guard let name = stringValue(package["name"]) else { return nil }
+        let version = stringValue(package["versionInfo"])
+        let identifier = stringValue(package["SPDXID"])
+        var label = version.map { "\(name)@\($0)" } ?? name
+        if let identifier {
+            label += " · \(identifier)"
+        }
+        return sanitizedLabel(label)
+    }
+
+    private static func licensePreviewLabels(
+        from packages: [[String: Any]],
+        extractedLicenses: [[String: Any]]
+    ) -> [String] {
+        var labels: [String] = []
+        var seen = Set<String>()
+        for package in packages {
+            appendLicenseLabel(stringValue(package["licenseConcluded"]), labels: &labels, seen: &seen)
+            appendLicenseLabel(stringValue(package["licenseDeclared"]), labels: &labels, seen: &seen)
+            guard labels.count < previewLabelLimit else { return labels }
+        }
+        for license in extractedLicenses {
+            appendLicenseLabel(stringValue(license["licenseId"]), labels: &labels, seen: &seen)
+            guard labels.count < previewLabelLimit else { return labels }
+        }
+        return labels
+    }
+
+    private static func appendLicenseLabel(_ label: String?, labels: inout [String], seen: inout Set<String>) {
+        guard labels.count < previewLabelLimit,
+              let label,
+              label != "NOASSERTION",
+              label != "NONE",
+              !seen.contains(label)
+        else {
+            return
+        }
+        seen.insert(label)
+        labels.append(label)
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        return sanitizedLabel(string)
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String? {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -222,6 +222,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
             let cycloneDXPreviewModel = artifact.cycloneDXPreview
             let cycloneDXPreview = renderCycloneDXPreview(cycloneDXPreviewModel)
+            let spdxPreviewModel = artifact.spdxPreview
+            let spdxPreview = renderSPDXPreview(spdxPreviewModel)
             let tapPreview = renderTAPPreview(artifact.tapPreview)
             let harPreview = renderHARPreview(artifact.harPreview)
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
@@ -264,6 +266,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
                 && cycloneDXPreviewModel == nil
+                && spdxPreviewModel == nil
                 ? renderJSONPreview(artifact.jsonPreview)
                 : ""
             let appshotPreview = renderAppshotPreview(artifact.appshotPreview)
@@ -290,6 +293,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(pytestJSONPreview)
               \(jestJSONPreview)
               \(cycloneDXPreview)
+              \(spdxPreview)
               \(tapPreview)
               \(harPreview)
               \(lcovPreview)
@@ -761,6 +765,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(componentList)
+        </div>
+        """
+    }
+
+    private static func renderSPDXPreview(_ preview: ToolArtifactSPDXPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-spdx-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-spdx-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let licenses = preview.licensePreviewLabels.map {
+            #"<li data-testid="tool-card-spdx-preview-license-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-spdx-preview-packages">
+                <strong data-testid="tool-card-spdx-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let licenseList = licenses.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-spdx-preview-licenses">
+                <strong data-testid="tool-card-spdx-preview-license-title">Licenses</strong>
+                <ul>\(licenses)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !licenseList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-spdx-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(licenseList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -541,6 +541,97 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteSBOM.cycloneDXPreview)
     }
 
+    func testArtifactStateDerivesSPDXPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("sbom.spdx.json")
+        let jsonText = """
+        {
+          "spdxVersion": "SPDX-2.3",
+          "SPDXID": "SPDXRef-DOCUMENT",
+          "name": "QuillCode SBOM",
+          "documentNamespace": "https://lorehex.example/spdx/quillcode-2026",
+          "creationInfo": {
+            "creators": [
+              "Tool: quill-code",
+              "Organization: Lore Hex"
+            ]
+          },
+          "packages": [
+            {
+              "name": "QuillCode",
+              "SPDXID": "SPDXRef-Package-QuillCode",
+              "versionInfo": "0.1.0",
+              "licenseConcluded": "Apache-2.0"
+            },
+            {
+              "name": "trusted-router-swift",
+              "SPDXID": "SPDXRef-Package-TrustedRouterSwift",
+              "versionInfo": "1.2.3",
+              "licenseDeclared": "MIT"
+            }
+          ],
+          "files": [
+            { "fileName": "Sources/QuillCodeApp/App.swift", "SPDXID": "SPDXRef-File-App" }
+          ],
+          "relationships": [
+            {
+              "spdxElementId": "SPDXRef-DOCUMENT",
+              "relationshipType": "DESCRIBES",
+              "relatedSpdxElement": "SPDXRef-Package-QuillCode"
+            }
+          ],
+          "hasExtractedLicensingInfos": [
+            { "licenseId": "LicenseRef-Lore-Hex-Notice", "extractedText": "Do not render this text" }
+          ]
+        }
+        """
+        try jsonText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.spdxPreview)
+        let byteSizeLabel = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(jsonText.data(using: .utf8)).count))
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.specVersion, "SPDX-2.3")
+        XCTAssertEqual(preview.documentName, "QuillCode SBOM")
+        XCTAssertEqual(preview.documentNamespace, "https://lorehex.example/spdx/quillcode-2026")
+        XCTAssertEqual(preview.packageCount, 2)
+        XCTAssertEqual(preview.fileCount, 1)
+        XCTAssertEqual(preview.relationshipCount, 1)
+        XCTAssertEqual(preview.extractedLicenseCount, 1)
+        XCTAssertEqual(preview.creatorCount, 2)
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "QuillCode@0.1.0 · SPDXRef-Package-QuillCode",
+            "trusted-router-swift@1.2.3 · SPDXRef-Package-TrustedRouterSwift"
+        ])
+        XCTAssertEqual(preview.licensePreviewLabels, [
+            "Apache-2.0",
+            "MIT",
+            "LicenseRef-Lore-Hex-Notice"
+        ])
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: SPDX",
+            "Spec: SPDX-2.3",
+            "Document: QuillCode SBOM",
+            "Namespace: https://lorehex.example/spdx/quillcode-2026",
+            "2 packages",
+            "1 file",
+            "1 relationship",
+            "1 extracted license",
+            "2 creators",
+            "Size: \(byteSizeLabel)"
+        ])
+
+        let packageJSON = directory.appendingPathComponent("package.json")
+        try #"{"name":"quillcode","version":"0.1.0"}"#.write(to: packageJSON, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: packageJSON.path).spdxPreview)
+
+        let remoteSBOM = ToolArtifactState(value: "https://example.com/sbom.spdx.json")
+        XCTAssertNil(remoteSBOM.spdxPreview)
+    }
+
     func testArtifactStateDerivesHARPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let trace = directory.appendingPathComponent("network.har")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -779,6 +779,91 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesSPDXArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("sbom.spdx.json")
+        try """
+        {
+          "spdxVersion": "SPDX-2.3",
+          "SPDXID": "SPDXRef-DOCUMENT",
+          "name": "QuillCode SBOM",
+          "documentNamespace": "https://lorehex.example/spdx/quillcode-2026",
+          "creationInfo": {
+            "creators": [
+              "Tool: quill-code"
+            ]
+          },
+          "packages": [
+            {
+              "name": "QuillCode",
+              "SPDXID": "SPDXRef-Package-QuillCode",
+              "versionInfo": "0.1.0",
+              "licenseConcluded": "Apache-2.0"
+            },
+            {
+              "name": "trusted-router-swift",
+              "SPDXID": "SPDXRef-Package-TrustedRouterSwift",
+              "versionInfo": "1.2.3",
+              "licenseDeclared": "MIT"
+            }
+          ],
+          "files": [
+            { "fileName": "Sources/QuillCodeApp/App.swift", "SPDXID": "SPDXRef-File-App" }
+          ],
+          "relationships": [
+            {
+              "spdxElementId": "SPDXRef-DOCUMENT",
+              "relationshipType": "DESCRIBES",
+              "relatedSpdxElement": "SPDXRef-Package-QuillCode"
+            }
+          ],
+          "hasExtractedLicensingInfos": [
+            { "licenseId": "LicenseRef-Lore-Hex-Notice", "extractedText": "Do not render this text" }
+          ]
+        }
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"sbom.spdx.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote sbom.spdx.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "SPDX artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">sbom.spdx.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-meta">Format: SPDX"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-meta">Spec: SPDX-2.3"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-meta">Document: QuillCode SBOM"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-meta">2 packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-meta">1 file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-meta">1 relationship"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-meta">1 extracted license"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-package-title">Packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-package-item">QuillCode@0.1.0 · SPDXRef-Package-QuillCode"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-license-title">Licenses"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spdx-preview-license-item">Apache-2.0"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesIstanbulArtifactPreview() throws {
         let root = try makeTempDirectory()
         let coverageDirectory = root.appendingPathComponent("coverage", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -87,6 +87,11 @@
   `bomFormat` validates as `CycloneDX`: spec version, root component, component/service/dependency
   counts, vulnerability severity counts, file size, and capped component labels without expanding
   license text, hashes, evidence, or fetching remote SBOMs.
+- Artifact previews now include bounded local SPDX JSON SBOM metadata for `.json` files whose
+  `spdxVersion` validates as SPDX: document name/namespace, package/file/relationship counts,
+  extracted-license and creator counts, file size, capped package labels, and capped license labels
+  without expanding extracted license text, checksums, snippets, relationships, or fetching remote
+  SBOMs.
 - Artifact previews now include bounded local font metadata for `.ttf`, `.otf`, `.ttc`, `.woff`,
   and `.woff2` files by validating fixed headers and rendering format, flavor, table count,
   declared size, and file size without parsing tables or decompressing webfont payloads.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2445,3 +2445,23 @@
   suppression, non-CycloneDX exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCycloneDXArtifactPreview` covers static
   HTML selectors, rendered SBOM metadata, component lists, and generic JSON suppression.
+
+## 2026-07-19: SPDX JSON artifacts render bounded SBOM summaries
+
+- **Decision:** Local `.json` artifacts whose top-level `spdxVersion` validates as an SPDX document
+  render as structured SPDX SBOM cards. The preview shows spec version, document name, namespace,
+  package/file/relationship counts, extracted-license count, creator count, file size, capped
+  package labels, and capped license identifiers.
+- **Why:** SPDX JSON is another common SBOM format for release, compliance, and dependency audit
+  workflows. QuillCode should make SPDX outputs scannable as first-class coding artifacts rather than
+  dropping users into raw JSON.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, and capped at
+  512 KB. It validates `spdxVersion` plus document/package/file shape, reads only shallow document,
+  package, creator, relationship, and license identifier metadata, and never expands extracted
+  license text, checksums, snippets, annotations, relationship bodies, external document references,
+  or remote SBOM URLs. Generic JSON rendering is suppressed only after SPDX shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesSPDXPreviewMetadata` covers
+  metadata extraction, package labels, license labels, non-SPDX exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesSPDXArtifactPreview` covers static HTML
+  selectors, rendered SBOM metadata, package and license lists, extracted-text exclusion, and generic
+  JSON suppression.


### PR DESCRIPTION
## Summary
- Add bounded local SPDX JSON SBOM artifact previews
- Render SPDX metadata in SwiftUI and static HTML tool cards
- Document parser boundaries and parity notes

## Validation
- git diff --check
- swift test --filter testArtifactStateDerivesSPDXPreviewMetadata
- swift test --filter testHTMLRendererIncludesSPDXArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests