### PR TITLE
Add npm lockfile artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -71,6 +71,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pytestJSONContent(pytestJSONPreview)
         } else if let jestJSONPreview = artifact.jestJSONPreview {
             jestJSONContent(jestJSONPreview)
+        } else if let npmLockfilePreview = artifact.npmLockfilePreview {
+            npmLockfileContent(npmLockfilePreview)
         } else if let cycloneDXPreview = artifact.cycloneDXPreview {
             cycloneDXContent(cycloneDXPreview)
         } else if let spdxPreview = artifact.spdxPreview {
@@ -283,6 +285,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(jestJSONPreview.metadataLines)
             artifactContentList(title: "Failures", labels: jestJSONPreview.failurePreviewLabels)
+        }
+    }
+
+    private func npmLockfileContent(_ npmLockfilePreview: ToolArtifactNPMLockfilePreview) -> some View {
+        let hasLists = !npmLockfilePreview.packagePreviewLabels.isEmpty || !npmLockfilePreview.resolvedHostLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(npmLockfilePreview.metadataLines)
+            artifactContentList(title: "Packages", labels: npmLockfilePreview.packagePreviewLabels)
+            artifactContentList(title: "Sources", labels: npmLockfilePreview.resolvedHostLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -465,6 +465,63 @@ public struct ToolArtifactJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactNPMLockfilePreview: Codable, Sendable, Hashable {
+    public var lockfileVersion: String?
+    public var rootPackageLabel: String?
+    public var packageCount: Int
+    public var dependencyCount: Int
+    public var devPackageCount: Int
+    public var optionalPackageCount: Int
+    public var resolvedHostLabels: [String]
+    public var packagePreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: npm lockfile",
+            lockfileVersion.map { "Lockfile: \($0)" },
+            rootPackageLabel.map { "Root: \($0)" },
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            dependencyCount > 0 ? "\(dependencyCount) dependenc\(dependencyCount == 1 ? "y" : "ies")" : nil,
+            devPackageCount > 0 ? "\(devPackageCount) dev package\(devPackageCount == 1 ? "" : "s")" : nil,
+            optionalPackageCount > 0 ? "\(optionalPackageCount) optional package\(optionalPackageCount == 1 ? "" : "s")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount > 0
+            || dependencyCount > 0
+            || devPackageCount > 0
+            || optionalPackageCount > 0
+            || !metadataLines.isEmpty
+            || !resolvedHostLabels.isEmpty
+            || !packagePreviewLabels.isEmpty
+    }
+
+    public init(
+        lockfileVersion: String? = nil,
+        rootPackageLabel: String? = nil,
+        packageCount: Int,
+        dependencyCount: Int = 0,
+        devPackageCount: Int = 0,
+        optionalPackageCount: Int = 0,
+        resolvedHostLabels: [String] = [],
+        packagePreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.lockfileVersion = lockfileVersion
+        self.rootPackageLabel = rootPackageLabel
+        self.packageCount = packageCount
+        self.dependencyCount = dependencyCount
+        self.devPackageCount = devPackageCount
+        self.optionalPackageCount = optionalPackageCount
+        self.resolvedHostLabels = resolvedHostLabels
+        self.packagePreviewLabels = packagePreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactCycloneDXPreview: Codable, Sendable, Hashable {
     public var specVersion: String?
     public var serialNumber: String?
@@ -2417,6 +2474,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var jsonPreview: ToolArtifactJSONPreview? {
         ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
+    }
+    public var npmLockfilePreview: ToolArtifactNPMLockfilePreview? {
+        ToolArtifactNPMLockfilePreviewBuilder.npmLockfilePreview(for: value, kind: kind)
     }
     public var cycloneDXPreview: ToolArtifactCycloneDXPreview? {
         ToolArtifactCycloneDXPreviewBuilder.cycloneDXPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactNPMLockfilePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactNPMLockfilePreviewBuilder.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+enum ToolArtifactNPMLockfilePreviewBuilder {
+    static func npmLockfilePreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactNPMLockfilePreview? {
+        guard kind == .file,
+              let fileURL = localArtifactFileURL(for: value),
+              fileURL.lastPathComponent.lowercased() == "package-lock.json"
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  isNPMLockfile(root)
+            else {
+                return nil
+            }
+            let preview = preview(
+                from: root,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func isNPMLockfile(_ root: [String: Any]) -> Bool {
+        guard root["lockfileVersion"] != nil else { return false }
+        return root["packages"] is [String: Any] || root["dependencies"] is [String: Any]
+    }
+
+    private static func preview(from root: [String: Any], byteSizeLabel: String?) -> ToolArtifactNPMLockfilePreview {
+        let packages = root["packages"] as? [String: Any] ?? [:]
+        let packageEntries = packageRecords(from: packages)
+        let dependencyEntries = root["dependencies"] as? [String: Any] ?? [:]
+        let dependencyCount = max(dependencyEntries.count, packageEntries.count)
+
+        return ToolArtifactNPMLockfilePreview(
+            lockfileVersion: lockfileVersionLabel(root["lockfileVersion"]),
+            rootPackageLabel: rootPackageLabel(from: root, packages: packages),
+            packageCount: packageEntries.count,
+            dependencyCount: dependencyCount,
+            devPackageCount: packageEntries.filter(\.isDev).count,
+            optionalPackageCount: packageEntries.filter(\.isOptional).count,
+            resolvedHostLabels: resolvedHostLabels(from: packageEntries),
+            packagePreviewLabels: packagePreviewLabels(from: packageEntries, dependencyEntries: dependencyEntries),
+            byteSizeLabel: byteSizeLabel
+        )
+    }
+
+    private static func packageRecords(from packages: [String: Any]) -> [PackageRecord] {
+        packages.compactMap { path, value in
+            guard !path.isEmpty,
+                  let object = value as? [String: Any]
+            else {
+                return nil
+            }
+            return PackageRecord(
+                path: path,
+                version: stringValue(object["version"]),
+                resolved: stringValue(object["resolved"]),
+                isDev: boolValue(object["dev"]),
+                isOptional: boolValue(object["optional"])
+            )
+        }
+        .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private static func rootPackageLabel(from root: [String: Any], packages: [String: Any]) -> String? {
+        let rootPackage = packages[""] as? [String: Any]
+        let name = stringValue(rootPackage?["name"]) ?? stringValue(root["name"])
+        let version = stringValue(rootPackage?["version"]) ?? stringValue(root["version"])
+        guard let name else { return nil }
+        return version.map { sanitizedLabel("\(name)@\($0)") } ?? sanitizedLabel(name)
+    }
+
+    private static func packagePreviewLabels(
+        from packageEntries: [PackageRecord],
+        dependencyEntries: [String: Any]
+    ) -> [String] {
+        if !packageEntries.isEmpty {
+            return Array(packageEntries.prefix(previewLabelLimit)).map(\.label)
+        }
+        let labels = dependencyEntries.keys
+            .sorted()
+            .prefix(previewLabelLimit)
+            .map(sanitizedLabel)
+        return Array(labels)
+    }
+
+    private static func resolvedHostLabels(from packageEntries: [PackageRecord]) -> [String] {
+        var hosts: [String] = []
+        var seen = Set<String>()
+        for package in packageEntries {
+            guard hosts.count < previewLabelLimit,
+                  let resolved = package.resolved,
+                  let host = URL(string: resolved)?.host?.lowercased(),
+                  !seen.contains(host)
+            else {
+                continue
+            }
+            seen.insert(host)
+            hosts.append(sanitizedLabel(host))
+        }
+        return hosts
+    }
+
+    private static func lockfileVersionLabel(_ value: Any?) -> String? {
+        if let string = stringValue(value) {
+            return string
+        }
+        if let number = value as? NSNumber {
+            return number.stringValue
+        }
+        return nil
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let label = sanitizedLabel(string)
+        return label.isEmpty ? nil : label
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool {
+        guard let bool = value as? Bool else { return false }
+        return bool
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private struct PackageRecord {
+        var path: String
+        var version: String?
+        var resolved: String?
+        var isDev: Bool
+        var isOptional: Bool
+
+        var name: String {
+            path
+                .split(separator: "/")
+                .suffix(2)
+                .joined(separator: "/")
+                .replacingOccurrences(of: "node_modules/", with: "")
+        }
+
+        var label: String {
+            var label = version.map { "\(name)@\($0)" } ?? name
+            var tags: [String] = []
+            if isDev { tags.append("dev") }
+            if isOptional { tags.append("optional") }
+            if !tags.isEmpty {
+                label += " · \(tags.joined(separator: ", "))"
+            }
+            return sanitizedLabel(label)
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -220,6 +220,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
             let jestJSONPreviewModel = artifact.jestJSONPreview
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
+            let npmLockfilePreviewModel = artifact.npmLockfilePreview
+            let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let cycloneDXPreviewModel = artifact.cycloneDXPreview
             let cycloneDXPreview = renderCycloneDXPreview(cycloneDXPreviewModel)
             let spdxPreviewModel = artifact.spdxPreview
@@ -265,6 +267,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && coveragePyPreviewModel == nil
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
+                && npmLockfilePreviewModel == nil
                 && cycloneDXPreviewModel == nil
                 && spdxPreviewModel == nil
                 ? renderJSONPreview(artifact.jsonPreview)
@@ -292,6 +295,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(coveragePyPreview)
               \(pytestJSONPreview)
               \(jestJSONPreview)
+              \(npmLockfilePreview)
               \(cycloneDXPreview)
               \(spdxPreview)
               \(tapPreview)
@@ -740,6 +744,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderNPMLockfilePreview(_ preview: ToolArtifactNPMLockfilePreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-npm-lockfile-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-npm-lockfile-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let hosts = preview.resolvedHostLabels.map {
+            #"<li data-testid="tool-card-npm-lockfile-preview-host-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-npm-lockfile-preview-packages">
+                <strong data-testid="tool-card-npm-lockfile-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let hostList = hosts.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-npm-lockfile-preview-hosts">
+                <strong data-testid="tool-card-npm-lockfile-preview-host-title">Sources</strong>
+                <ul>\(hosts)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !hostList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-npm-lockfile-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(hostList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -453,6 +453,82 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJSON.jsonPreview)
     }
 
+    func testArtifactStateDerivesNPMLockfilePreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("package-lock.json")
+        let jsonText = """
+        {
+          "name": "quillcode-web",
+          "version": "0.1.0",
+          "lockfileVersion": 3,
+          "packages": {
+            "": {
+              "name": "quillcode-web",
+              "version": "0.1.0"
+            },
+            "node_modules/@playwright/test": {
+              "version": "1.55.0",
+              "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+              "dev": true
+            },
+            "node_modules/lucide-react": {
+              "version": "0.468.0",
+              "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz"
+            },
+            "node_modules/fsevents": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+              "optional": true
+            }
+          },
+          "dependencies": {
+            "@playwright/test": {"version": "1.55.0"},
+            "fsevents": {"version": "2.3.3"},
+            "lucide-react": {"version": "0.468.0"}
+          }
+        }
+        """
+        try jsonText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.npmLockfilePreview)
+        let byteSizeLabel = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(jsonText.data(using: .utf8)).count))
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.lockfileVersion, "3")
+        XCTAssertEqual(preview.rootPackageLabel, "quillcode-web@0.1.0")
+        XCTAssertEqual(preview.packageCount, 3)
+        XCTAssertEqual(preview.dependencyCount, 3)
+        XCTAssertEqual(preview.devPackageCount, 1)
+        XCTAssertEqual(preview.optionalPackageCount, 1)
+        XCTAssertEqual(preview.resolvedHostLabels, ["registry.npmjs.org"])
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "@playwright/test@1.55.0 · dev",
+            "fsevents@2.3.3 · optional",
+            "lucide-react@0.468.0"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: npm lockfile",
+            "Lockfile: 3",
+            "Root: quillcode-web@0.1.0",
+            "3 packages",
+            "3 dependencies",
+            "1 dev package",
+            "1 optional package",
+            "Size: \(byteSizeLabel)"
+        ])
+        XCTAssertNotNil(artifact.jsonPreview)
+
+        let packageJSON = directory.appendingPathComponent("package.json")
+        try #"{"name":"quillcode-web","lockfileVersion":3}"#.write(to: packageJSON, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: packageJSON.path).npmLockfilePreview)
+
+        let remoteLockfile = ToolArtifactState(value: "https://example.com/package-lock.json")
+        XCTAssertNil(remoteLockfile.npmLockfilePreview)
+    }
+
     func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bom.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -701,6 +701,68 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-content">"#))
     }
 
+    func testHTMLRendererIncludesNPMLockfileArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("package-lock.json")
+        try """
+        {
+          "name": "quillcode-web",
+          "version": "0.1.0",
+          "lockfileVersion": 3,
+          "packages": {
+            "": {"name": "quillcode-web", "version": "0.1.0"},
+            "node_modules/@playwright/test": {
+              "version": "1.55.0",
+              "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+              "dev": true
+            },
+            "node_modules/lucide-react": {
+              "version": "0.468.0",
+              "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz"
+            }
+          },
+          "dependencies": {
+            "@playwright/test": {"version": "1.55.0"},
+            "lucide-react": {"version": "0.468.0"}
+          }
+        }
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"package-lock.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote package-lock.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "npm lockfile artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">package-lock.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-npm-lockfile-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-npm-lockfile-preview-meta">Format: npm lockfile"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-npm-lockfile-preview-meta">2 packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-npm-lockfile-preview-meta">2 dependencies"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-npm-lockfile-preview-package-item">@playwright/test@1.55.0 · dev"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-npm-lockfile-preview-package-item">lucide-react@0.468.0"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-npm-lockfile-preview-host-item">registry.npmjs.org"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("bom.json")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -92,6 +92,10 @@
   extracted-license and creator counts, file size, capped package labels, and capped license labels
   without expanding extracted license text, checksums, snippets, relationships, or fetching remote
   SBOMs.
+- Artifact previews now include bounded local npm lockfile metadata for `package-lock.json` files:
+  lockfile version, root package, package/dependency/dev/optional counts, file size, capped package
+  labels, and capped resolved registry hosts without expanding integrity hashes, package scripts, or
+  fetching remote tarballs.
 - Artifact previews now include bounded local font metadata for `.ttf`, `.otf`, `.ttc`, `.woff`,
   and `.woff2` files by validating fixed headers and rendering format, flavor, table count,
   declared size, and file size without parsing tables or decompressing webfont payloads.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2465,3 +2465,22 @@
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesSPDXArtifactPreview` covers static HTML
   selectors, rendered SBOM metadata, package and license lists, extracted-text exclusion, and generic
   JSON suppression.
+
+## 2026-07-19: npm lockfile artifacts render bounded dependency summaries
+
+- **Decision:** Local `package-lock.json` artifacts render as structured npm lockfile cards. The
+  preview shows lockfile version, root package, package/dependency/dev/optional counts, file size,
+  capped package labels, and capped resolved registry hosts.
+- **Why:** Coding agents frequently touch JavaScript dependency graphs, and npm lockfiles are too
+  large and repetitive for raw text or generic JSON previews. A Codex-style artifact surface should
+  make dependency changes scannable without asking the model to inspect the entire lockfile.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, filename-gated to
+  `package-lock.json`, and capped at 512 KB. It validates `lockfileVersion` plus `packages` or
+  `dependencies`, reads only shallow package labels, counts, and resolved URL hosts, and never
+  expands integrity hashes, package scripts, dependency bodies, funding metadata, or remote tarballs.
+  Generic JSON rendering is suppressed only after the npm lockfile shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesNPMLockfilePreviewMetadata`
+  covers metadata extraction, package labels, registry host labels, non-lockfile exclusion, and remote
+  exclusion. `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesNPMLockfileArtifactPreview`
+  covers static HTML selectors, rendered npm metadata, package and source lists, and generic JSON
+  suppression.


### PR DESCRIPTION
## Summary
- add bounded local package-lock.json artifact previews with lockfile/root/package/dependency metadata
- render npm lockfile previews in SwiftUI and static HTML while suppressing generic JSON fallback
- document the artifact boundary and parity matrix entry

## Validation
- swift test --filter testArtifactStateDerivesNPMLockfilePreviewMetadata
- swift test --filter testHTMLRendererIncludesNPMLockfileArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check