### PR TITLE
Add pnpm lockfile artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -73,6 +73,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             jestJSONContent(jestJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
+        } else if let pnpmLockfilePreview = artifact.pnpmLockfilePreview {
+            pnpmLockfileContent(pnpmLockfilePreview)
         } else if let swiftPMPackageResolvedPreview = artifact.swiftPMPackageResolvedPreview {
             swiftPMPackageResolvedContent(swiftPMPackageResolvedPreview)
         } else if let yarnLockfilePreview = artifact.yarnLockfilePreview {
@@ -307,6 +309,25 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(npmLockfilePreview.metadataLines)
             artifactContentList(title: "Packages", labels: npmLockfilePreview.packagePreviewLabels)
             artifactContentList(title: "Sources", labels: npmLockfilePreview.resolvedHostLabels)
+        }
+    }
+
+    private func pnpmLockfileContent(_ pnpmLockfilePreview: ToolArtifactPNPMLockfilePreview) -> some View {
+        let hasLists = !pnpmLockfilePreview.packagePreviewLabels.isEmpty
+            || !pnpmLockfilePreview.importerPreviewLabels.isEmpty
+            || !pnpmLockfilePreview.resolvedHostLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 176 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(pnpmLockfilePreview.metadataLines)
+            artifactContentList(title: "Packages", labels: pnpmLockfilePreview.packagePreviewLabels)
+            artifactContentList(title: "Importers", labels: pnpmLockfilePreview.importerPreviewLabels)
+            artifactContentList(title: "Sources", labels: pnpmLockfilePreview.resolvedHostLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -522,6 +522,63 @@ public struct ToolArtifactNPMLockfilePreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPNPMLockfilePreview: Codable, Sendable, Hashable {
+    public var lockfileVersion: String?
+    public var importerCount: Int
+    public var packageCount: Int
+    public var dependencyCount: Int
+    public var integrityCount: Int
+    public var resolvedHostLabels: [String]
+    public var packagePreviewLabels: [String]
+    public var importerPreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: pnpm lockfile",
+            lockfileVersion.map { "Lockfile: \($0)" },
+            "\(importerCount) importer\(importerCount == 1 ? "" : "s")",
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            dependencyCount > 0 ? "\(dependencyCount) dependenc\(dependencyCount == 1 ? "y" : "ies")" : nil,
+            integrityCount > 0 ? "\(integrityCount) integrit\(integrityCount == 1 ? "y" : "ies")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        importerCount > 0
+            || packageCount > 0
+            || dependencyCount > 0
+            || integrityCount > 0
+            || !metadataLines.isEmpty
+            || !resolvedHostLabels.isEmpty
+            || !packagePreviewLabels.isEmpty
+            || !importerPreviewLabels.isEmpty
+    }
+
+    public init(
+        lockfileVersion: String? = nil,
+        importerCount: Int = 0,
+        packageCount: Int,
+        dependencyCount: Int = 0,
+        integrityCount: Int = 0,
+        resolvedHostLabels: [String] = [],
+        packagePreviewLabels: [String] = [],
+        importerPreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.lockfileVersion = lockfileVersion
+        self.importerCount = importerCount
+        self.packageCount = packageCount
+        self.dependencyCount = dependencyCount
+        self.integrityCount = integrityCount
+        self.resolvedHostLabels = resolvedHostLabels
+        self.packagePreviewLabels = packagePreviewLabels
+        self.importerPreviewLabels = importerPreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactSwiftPMPackageResolvedPreview: Codable, Sendable, Hashable {
     public var schemaVersion: String?
     public var pinCount: Int
@@ -2628,6 +2685,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var npmLockfilePreview: ToolArtifactNPMLockfilePreview? {
         ToolArtifactNPMLockfilePreviewBuilder.npmLockfilePreview(for: value, kind: kind)
+    }
+    public var pnpmLockfilePreview: ToolArtifactPNPMLockfilePreview? {
+        ToolArtifactPNPMLockfilePreviewBuilder.pnpmLockfilePreview(for: value, kind: kind)
     }
     public var swiftPMPackageResolvedPreview: ToolArtifactSwiftPMPackageResolvedPreview? {
         ToolArtifactSwiftPMPackageResolvedPreviewBuilder.packageResolvedPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -37,6 +37,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == "package.resolved" {
             return "spm"
         }
+        if filename == "pnpm-lock.yaml" {
+            return "pnpm-lock"
+        }
         if filename == "yarn.lock" {
             return "yarn-lock"
         }
@@ -74,6 +77,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "sarif": .data,
         "cfg": .data,
         "conf": .data,
+        "pnpm-lock": .data,
         "yarn-lock": .data,
         "cargo-lock": .data,
         "bin": .data,

--- a/Sources/QuillCodeApp/ToolArtifactPNPMLockfilePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPNPMLockfilePreviewBuilder.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Yams
+
+enum ToolArtifactPNPMLockfilePreviewBuilder {
+    static func pnpmLockfilePreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPNPMLockfilePreview? {
+        guard kind == .file,
+              let fileURL = localArtifactFileURL(for: value),
+              fileURL.lastPathComponent.lowercased() == "pnpm-lock.yaml"
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8),
+                  let root = try Yams.compose(yaml: text),
+                  case .mapping = root,
+                  scalarValue(forKey: "lockfileVersion", in: root) != nil
+            else {
+                return nil
+            }
+            let preview = preview(
+                from: root,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from root: Node, byteSizeLabel: String?) -> ToolArtifactPNPMLockfilePreview {
+        let importerRecords = mappingRecords(from: mappingValue(forKey: "importers", in: root))
+        let packageRecords = packageRecords(from: mappingValue(forKey: "packages", in: root))
+        let dependencyCount = importerRecords.reduce(0) { $0 + $1.dependencyCount }
+        return ToolArtifactPNPMLockfilePreview(
+            lockfileVersion: scalarValue(forKey: "lockfileVersion", in: root),
+            importerCount: importerRecords.count,
+            packageCount: packageRecords.count,
+            dependencyCount: dependencyCount,
+            integrityCount: packageRecords.filter { $0.integrity != nil }.count,
+            resolvedHostLabels: resolvedHostLabels(from: packageRecords),
+            packagePreviewLabels: Array(packageRecords.prefix(previewLabelLimit)).map(\.label),
+            importerPreviewLabels: Array(importerRecords.prefix(previewLabelLimit)).map(\.label),
+            byteSizeLabel: byteSizeLabel
+        )
+    }
+
+    private static func mappingRecords(from node: Node?) -> [ImporterRecord] {
+        guard case .mapping(let mapping) = node else { return [] }
+        return mapping.compactMap { pair in
+            guard let label = scalarLabel(pair.key) else { return nil }
+            let dependencyCount = dependencyCount(in: pair.value)
+            return ImporterRecord(label: label, dependencyCount: dependencyCount)
+        }
+        .sorted { $0.label.localizedStandardCompare($1.label) == .orderedAscending }
+    }
+
+    private static func dependencyCount(in importer: Node) -> Int {
+        dependencyKeys.reduce(0) { count, key in
+            guard case .mapping(let dependencies) = mappingValue(forKey: key, in: importer) else {
+                return count
+            }
+            return count + dependencies.count
+        }
+    }
+
+    private static func packageRecords(from node: Node?) -> [PackageRecord] {
+        guard case .mapping(let mapping) = node else { return [] }
+        return mapping.compactMap { pair in
+            guard let rawName = scalarLabel(pair.key) else { return nil }
+            let resolution = mappingValue(forKey: "resolution", in: pair.value)
+            let integrity = scalarValue(forKey: "integrity", in: resolution)
+            let tarball = scalarValue(forKey: "tarball", in: resolution)
+            return PackageRecord(
+                rawName: rawName,
+                integrity: integrity,
+                tarball: tarball
+            )
+        }
+        .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private static func resolvedHostLabels(from packages: [PackageRecord]) -> [String] {
+        var labels: [String] = []
+        var seen = Set<String>()
+        for package in packages {
+            guard labels.count < previewLabelLimit,
+                  let tarball = package.tarball,
+                  let host = URL(string: tarball)?.host?.lowercased(),
+                  !seen.contains(host)
+            else {
+                continue
+            }
+            seen.insert(host)
+            labels.append(sanitizedLabel(host))
+        }
+        return labels
+    }
+
+    private static func mappingValue(forKey key: String, in node: Node?) -> Node? {
+        guard case .mapping(let mapping) = node else { return nil }
+        return mapping.first { scalarLabel($0.key) == key }?.value
+    }
+
+    private static func scalarValue(forKey key: String, in node: Node?) -> String? {
+        guard let value = mappingValue(forKey: key, in: node) else { return nil }
+        return scalarLabel(value)
+    }
+
+    private static func scalarLabel(_ node: Node) -> String? {
+        guard case .scalar(let scalar) = node else { return nil }
+        let label = sanitizedLabel(scalar.string)
+        return label.isEmpty ? nil : label
+    }
+
+    private static func packageName(from rawName: String) -> String {
+        var text = rawName
+        if text.hasPrefix("/") {
+            text.removeFirst()
+        }
+        if let peerSuffix = text.firstIndex(of: "(") {
+            text = String(text[..<peerSuffix])
+        }
+        if let lastAt = text.lastIndex(of: "@"), lastAt != text.startIndex {
+            text = String(text[..<lastAt])
+        }
+        return sanitizedLabel(text)
+    }
+
+    private static func packageVersion(from rawName: String) -> String? {
+        var text = rawName
+        if let peerSuffix = text.firstIndex(of: "(") {
+            text = String(text[..<peerSuffix])
+        }
+        guard let lastAt = text.lastIndex(of: "@"), lastAt != text.startIndex else { return nil }
+        let version = text[text.index(after: lastAt)...]
+        let label = sanitizedLabel(String(version))
+        return label.isEmpty ? nil : label
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private struct ImporterRecord {
+        var label: String
+        var dependencyCount: Int
+    }
+
+    private struct PackageRecord {
+        var rawName: String
+        var integrity: String?
+        var tarball: String?
+
+        var name: String {
+            ToolArtifactPNPMLockfilePreviewBuilder.packageName(from: rawName)
+        }
+
+        var label: String {
+            let name = ToolArtifactPNPMLockfilePreviewBuilder.packageName(from: rawName)
+            guard let version = ToolArtifactPNPMLockfilePreviewBuilder.packageVersion(from: rawName) else {
+                return name
+            }
+            return ToolArtifactPNPMLockfilePreviewBuilder.sanitizedLabel("\(name)@\(version)")
+        }
+    }
+
+    private static let dependencyKeys = ["dependencies", "devDependencies", "optionalDependencies"]
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -222,6 +222,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
+            let pnpmLockfilePreviewModel = artifact.pnpmLockfilePreview
+            let pnpmLockfilePreview = renderPNPMLockfilePreview(pnpmLockfilePreviewModel)
             let swiftPMPackageResolvedPreviewModel = artifact.swiftPMPackageResolvedPreview
             let swiftPMPackageResolvedPreview = renderSwiftPMPackageResolvedPreview(swiftPMPackageResolvedPreviewModel)
             let yarnLockfilePreviewModel = artifact.yarnLockfilePreview
@@ -241,7 +243,9 @@ enum WorkspaceHTMLToolCardRenderer {
             let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
             let iniPreview = renderINIPreview(artifact.iniPreview)
             let dotenvPreview = renderDotenvPreview(artifact.dotenvPreview)
-            let yamlPreview = renderYAMLPreview(artifact.yamlPreview)
+            let yamlPreview = pnpmLockfilePreviewModel == nil
+                ? renderYAMLPreview(artifact.yamlPreview)
+                : ""
             let junitPreviewModel = artifact.junitPreview
             let junitPreview = renderJUnitPreview(junitPreviewModel)
             let trxPreview = renderTRXPreview(artifact.trxPreview)
@@ -274,6 +278,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
+                && pnpmLockfilePreviewModel == nil
                 && swiftPMPackageResolvedPreviewModel == nil
                 && yarnLockfilePreviewModel == nil
                 && cargoLockPreviewModel == nil
@@ -305,6 +310,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(pytestJSONPreview)
               \(jestJSONPreview)
               \(npmLockfilePreview)
+              \(pnpmLockfilePreview)
               \(swiftPMPackageResolvedPreview)
               \(yarnLockfilePreview)
               \(cargoLockPreview)
@@ -827,6 +833,53 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(pinList)
+          \(hostList)
+        </div>
+        """
+    }
+
+    private static func renderPNPMLockfilePreview(_ preview: ToolArtifactPNPMLockfilePreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-pnpm-lockfile-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-pnpm-lockfile-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let importers = preview.importerPreviewLabels.map {
+            #"<li data-testid="tool-card-pnpm-lockfile-preview-importer-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let hosts = preview.resolvedHostLabels.map {
+            #"<li data-testid="tool-card-pnpm-lockfile-preview-host-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pnpm-lockfile-preview-packages">
+                <strong data-testid="tool-card-pnpm-lockfile-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let importerList = importers.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pnpm-lockfile-preview-importers">
+                <strong data-testid="tool-card-pnpm-lockfile-preview-importer-title">Importers</strong>
+                <ul>\(importers)</ul>
+              </section>
+        """
+        let hostList = hosts.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pnpm-lockfile-preview-hosts">
+                <strong data-testid="tool-card-pnpm-lockfile-preview-host-title">Sources</strong>
+                <ul>\(hosts)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !importerList.isEmpty || !hostList.isEmpty else {
+            return ""
+        }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-pnpm-lockfile-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(importerList)
           \(hostList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -729,6 +729,87 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteLock.yarnLockfilePreview)
     }
 
+    func testArtifactStateDerivesPNPMLockfilePreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("pnpm-lock.yaml")
+        let lockText = """
+        lockfileVersion: '9.0'
+
+        importers:
+          .:
+            dependencies:
+              '@playwright/test':
+                specifier: ^1.55.0
+                version: 1.55.0
+              lucide-react:
+                specifier: ^0.468.0
+                version: 0.468.0
+            devDependencies:
+              typescript:
+                specifier: ^5.8.0
+                version: 5.8.3
+          apps/web:
+            optionalDependencies:
+              sharp:
+                specifier: ^0.33.5
+                version: 0.33.5
+
+        packages:
+          /@playwright/test@1.55.0:
+            resolution:
+              integrity: sha512-playwright
+              tarball: https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz
+          /lucide-react@0.468.0:
+            resolution:
+              integrity: sha512-lucide
+              tarball: https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz
+          /sharp@0.33.5:
+            resolution:
+              integrity: sha512-sharp
+              tarball: https://registry.yarnpkg.com/sharp/-/sharp-0.33.5.tgz
+        """
+        try lockText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.pnpmLockfilePreview)
+        let byteSizeLabel = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(lockText.data(using: .utf8)).count))
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "PNPM-LOCK")
+        XCTAssertEqual(preview.lockfileVersion, "9.0")
+        XCTAssertEqual(preview.importerCount, 2)
+        XCTAssertEqual(preview.packageCount, 3)
+        XCTAssertEqual(preview.dependencyCount, 4)
+        XCTAssertEqual(preview.integrityCount, 3)
+        XCTAssertEqual(preview.resolvedHostLabels, [
+            "registry.npmjs.org",
+            "registry.yarnpkg.com"
+        ])
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "@playwright/test@1.55.0",
+            "lucide-react@0.468.0",
+            "sharp@0.33.5"
+        ])
+        XCTAssertEqual(preview.importerPreviewLabels, [".", "apps/web"])
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: pnpm lockfile",
+            "Lockfile: 9.0",
+            "2 importers",
+            "3 packages",
+            "4 dependencies",
+            "3 integrities",
+            "Size: \(byteSizeLabel)"
+        ])
+
+        let packageYAML = directory.appendingPathComponent("package.yaml")
+        try "lockfileVersion: '9.0'\n".write(to: packageYAML, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: packageYAML.path).pnpmLockfilePreview)
+
+        let remoteLock = ToolArtifactState(value: "https://example.com/pnpm-lock.yaml")
+        XCTAssertNil(remoteLock.pnpmLockfilePreview)
+    }
+
     func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bom.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -934,6 +934,68 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">yarn.lock"#))
     }
 
+    func testHTMLRendererIncludesPNPMLockfileArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("pnpm-lock.yaml")
+        try """
+        lockfileVersion: '9.0'
+
+        importers:
+          .:
+            dependencies:
+              '@playwright/test':
+                specifier: ^1.55.0
+                version: 1.55.0
+
+        packages:
+          /@playwright/test@1.55.0:
+            resolution:
+              integrity: sha512-playwright
+              tarball: https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz
+          /lucide-react@0.468.0:
+            resolution:
+              integrity: sha512-lucide
+              tarball: https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.468.0.tgz
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"pnpm-lock.yaml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote pnpm-lock.yaml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "pnpm lock artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · PNPM-LOCK"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">pnpm-lock.yaml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-meta">Format: pnpm lockfile"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-meta">Lockfile: 9.0"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-meta">2 packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-package-item">@playwright/test@1.55.0"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-package-item">lucide-react@0.468.0"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-importer-item">."#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-host-item">registry.npmjs.org"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pnpm-lockfile-preview-host-item">registry.yarnpkg.com"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-yaml-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">pnpm-lock.yaml"#))
+    }
+
     func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("bom.json")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,6 +96,10 @@
   lockfile version, root package, package/dependency/dev/optional counts, file size, capped package
   labels, and capped resolved registry hosts without expanding integrity hashes, package scripts, or
   fetching remote tarballs.
+- Artifact previews now include bounded local pnpm lockfile metadata for `pnpm-lock.yaml` files:
+  lockfile version, importer/package/dependency/integrity counts, file size, capped importer labels,
+  capped package labels, and capped resolved registry hosts without expanding dependency graphs,
+  integrity values, package manifests, registry indexes, or fetching remote tarballs.
 - Artifact previews now include bounded local SwiftPM resolved-package metadata for `Package.resolved`
   files: schema version, pin/version/branch/revision-only counts, file size, capped pin labels, and
   capped source hosts without expanding full revisions, dependency source bodies, or fetching remote

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2540,3 +2540,24 @@
   labels, host labels, non-`yarn.lock` exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesYarnLockfileArtifactPreview` covers
   static HTML selectors, rendered Yarn metadata, package/host lists, and text-preview coexistence.
+
+## 2026-07-19: pnpm-lock.yaml artifacts render bounded package summaries
+
+- **Decision:** Local `pnpm-lock.yaml` artifacts render as structured pnpm lockfile cards. The preview
+  shows lockfile version, importer/package/dependency/integrity counts, file size, capped importer
+  labels, capped package labels, and capped resolved registry host labels. `pnpm-lock.yaml` is
+  classified as a data artifact through filename-specific detection.
+- **Why:** pnpm monorepos often produce lockfiles with multiple importers and large package sections.
+  A bounded importer/package/source summary makes dependency changes scannable without opening a
+  repetitive YAML lockfile.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, filename-gated to
+  `pnpm-lock.yaml`, and capped at 512 KB. It validates `lockfileVersion`, reads shallow top-level
+  `importers` and `packages` mappings plus package `resolution.integrity` and `resolution.tarball`,
+  and never expands dependency graphs, integrity values, package manifests, registry indexes, or remote
+  tarballs. Generic YAML rendering is suppressed only after the pnpm lockfile shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesPNPMLockfilePreviewMetadata`
+  covers filename-based document classification, lockfile version, importer/package/dependency/
+  integrity counts, package labels, host labels, non-`pnpm-lock.yaml` exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPNPMLockfileArtifactPreview` covers
+  static HTML selectors, rendered pnpm metadata, package/importer/host lists, YAML-preview suppression,
+  and text-preview coexistence.


### PR DESCRIPTION
## Summary
- add bounded local pnpm-lock.yaml artifact metadata previews
- render pnpm package/importer/source summaries in native and HTML tool cards
- document the artifact-preview parity decision

## Validation
- swift test --filter testArtifactStateDerivesPNPMLockfilePreviewMetadata
- swift test --filter testHTMLRendererIncludesPNPMLockfileArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check