### PR TITLE
Add Composer lockfile artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -73,6 +73,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             jestJSONContent(jestJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
+        } else if let composerLockfilePreview = artifact.composerLockfilePreview {
+            composerLockfileContent(composerLockfilePreview)
         } else if let pnpmLockfilePreview = artifact.pnpmLockfilePreview {
             pnpmLockfileContent(pnpmLockfilePreview)
         } else if let swiftPMPackageResolvedPreview = artifact.swiftPMPackageResolvedPreview {
@@ -309,6 +311,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(npmLockfilePreview.metadataLines)
             artifactContentList(title: "Packages", labels: npmLockfilePreview.packagePreviewLabels)
             artifactContentList(title: "Sources", labels: npmLockfilePreview.resolvedHostLabels)
+        }
+    }
+
+    private func composerLockfileContent(_ composerLockfilePreview: ToolArtifactComposerLockfilePreview) -> some View {
+        let hasLists = !composerLockfilePreview.packagePreviewLabels.isEmpty
+            || !composerLockfilePreview.resolvedHostLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(composerLockfilePreview.metadataLines)
+            artifactContentList(title: "Packages", labels: composerLockfilePreview.packagePreviewLabels)
+            artifactContentList(title: "Sources", labels: composerLockfilePreview.resolvedHostLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -522,6 +522,53 @@ public struct ToolArtifactNPMLockfilePreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactComposerLockfilePreview: Codable, Sendable, Hashable {
+    public var pluginAPIVersion: String?
+    public var contentHashPrefix: String?
+    public var packageCount: Int
+    public var devPackageCount: Int
+    public var resolvedHostLabels: [String]
+    public var packagePreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: Composer lockfile",
+            pluginAPIVersion.map { "Plugin API: \($0)" },
+            contentHashPrefix.map { "Content hash: \($0)..." },
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            devPackageCount > 0 ? "\(devPackageCount) dev package\(devPackageCount == 1 ? "" : "s")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount > 0
+            || devPackageCount > 0
+            || !metadataLines.isEmpty
+            || !resolvedHostLabels.isEmpty
+            || !packagePreviewLabels.isEmpty
+    }
+
+    public init(
+        pluginAPIVersion: String? = nil,
+        contentHashPrefix: String? = nil,
+        packageCount: Int,
+        devPackageCount: Int = 0,
+        resolvedHostLabels: [String] = [],
+        packagePreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.pluginAPIVersion = pluginAPIVersion
+        self.contentHashPrefix = contentHashPrefix
+        self.packageCount = packageCount
+        self.devPackageCount = devPackageCount
+        self.resolvedHostLabels = resolvedHostLabels
+        self.packagePreviewLabels = packagePreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactPNPMLockfilePreview: Codable, Sendable, Hashable {
     public var lockfileVersion: String?
     public var importerCount: Int
@@ -2685,6 +2732,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var npmLockfilePreview: ToolArtifactNPMLockfilePreview? {
         ToolArtifactNPMLockfilePreviewBuilder.npmLockfilePreview(for: value, kind: kind)
+    }
+    public var composerLockfilePreview: ToolArtifactComposerLockfilePreview? {
+        ToolArtifactComposerLockfilePreviewBuilder.composerLockfilePreview(for: value, kind: kind)
     }
     public var pnpmLockfilePreview: ToolArtifactPNPMLockfilePreview? {
         ToolArtifactPNPMLockfilePreviewBuilder.pnpmLockfilePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactComposerLockfilePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactComposerLockfilePreviewBuilder.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+enum ToolArtifactComposerLockfilePreviewBuilder {
+    static func composerLockfilePreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactComposerLockfilePreview? {
+        guard kind == .file,
+              let fileURL = localArtifactFileURL(for: value),
+              fileURL.lastPathComponent.lowercased() == "composer.lock"
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  isComposerLockfile(root)
+            else {
+                return nil
+            }
+            let preview = preview(
+                from: root,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func isComposerLockfile(_ root: [String: Any]) -> Bool {
+        root["packages"] is [[String: Any]]
+            || root["packages-dev"] is [[String: Any]]
+            || stringValue(root["plugin-api-version"]) != nil
+            || stringValue(root["content-hash"]) != nil
+    }
+
+    private static func preview(from root: [String: Any], byteSizeLabel: String?) -> ToolArtifactComposerLockfilePreview {
+        let packages = packageRecords(from: root["packages"])
+        let devPackages = packageRecords(from: root["packages-dev"])
+        let allPackages = (packages + devPackages).sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+
+        return ToolArtifactComposerLockfilePreview(
+            pluginAPIVersion: stringValue(root["plugin-api-version"]),
+            contentHashPrefix: stringValue(root["content-hash"]).map(contentHashPrefix),
+            packageCount: packages.count,
+            devPackageCount: devPackages.count,
+            resolvedHostLabels: resolvedHostLabels(from: allPackages),
+            packagePreviewLabels: Array(allPackages.prefix(previewLabelLimit)).map(\.label),
+            byteSizeLabel: byteSizeLabel
+        )
+    }
+
+    private static func packageRecords(from value: Any?) -> [PackageRecord] {
+        guard let objects = value as? [[String: Any]] else { return [] }
+        return objects.compactMap { object in
+            guard let name = stringValue(object["name"]) else { return nil }
+            return PackageRecord(
+                name: name,
+                version: stringValue(object["version"]),
+                sourceURL: stringValue((object["source"] as? [String: Any])?["url"]),
+                distURL: stringValue((object["dist"] as? [String: Any])?["url"])
+            )
+        }
+    }
+
+    private static func resolvedHostLabels(from packages: [PackageRecord]) -> [String] {
+        var labels: [String] = []
+        var seen = Set<String>()
+        for package in packages {
+            guard labels.count < previewLabelLimit,
+                  let host = package.resolvedHost,
+                  !seen.contains(host)
+            else {
+                continue
+            }
+            seen.insert(host)
+            labels.append(sanitizedLabel(host))
+        }
+        return labels
+    }
+
+    private static func contentHashPrefix(_ value: String) -> String {
+        String(value.prefix(12))
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let label = sanitizedLabel(string)
+        return label.isEmpty ? nil : label
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private struct PackageRecord {
+        var name: String
+        var version: String?
+        var sourceURL: String?
+        var distURL: String?
+
+        var label: String {
+            version.map { sanitizedLabel("\(name)@\($0)") } ?? name
+        }
+
+        var resolvedHost: String? {
+            [distURL, sourceURL].compactMap { $0 }.lazy.compactMap { value in
+                URL(string: value)?.host?.lowercased()
+            }.first
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -37,6 +37,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == "package.resolved" {
             return "spm"
         }
+        if filename == "composer.lock" {
+            return "composer-lock"
+        }
         if filename == "pnpm-lock.yaml" {
             return "pnpm-lock"
         }
@@ -77,6 +80,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "sarif": .data,
         "cfg": .data,
         "conf": .data,
+        "composer-lock": .data,
         "pnpm-lock": .data,
         "yarn-lock": .data,
         "cargo-lock": .data,

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -222,6 +222,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
+            let composerLockfilePreviewModel = artifact.composerLockfilePreview
+            let composerLockfilePreview = renderComposerLockfilePreview(composerLockfilePreviewModel)
             let pnpmLockfilePreviewModel = artifact.pnpmLockfilePreview
             let pnpmLockfilePreview = renderPNPMLockfilePreview(pnpmLockfilePreviewModel)
             let swiftPMPackageResolvedPreviewModel = artifact.swiftPMPackageResolvedPreview
@@ -278,6 +280,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
+                && composerLockfilePreviewModel == nil
                 && pnpmLockfilePreviewModel == nil
                 && swiftPMPackageResolvedPreviewModel == nil
                 && yarnLockfilePreviewModel == nil
@@ -310,6 +313,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(pytestJSONPreview)
               \(jestJSONPreview)
               \(npmLockfilePreview)
+              \(composerLockfilePreview)
               \(pnpmLockfilePreview)
               \(swiftPMPackageResolvedPreview)
               \(yarnLockfilePreview)
@@ -792,6 +796,41 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !packageList.isEmpty || !hostList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-npm-lockfile-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(hostList)
+        </div>
+        """
+    }
+
+    private static func renderComposerLockfilePreview(_ preview: ToolArtifactComposerLockfilePreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-composer-lockfile-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-composer-lockfile-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let hosts = preview.resolvedHostLabels.map {
+            #"<li data-testid="tool-card-composer-lockfile-preview-host-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-composer-lockfile-preview-packages">
+                <strong data-testid="tool-card-composer-lockfile-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let hostList = hosts.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-composer-lockfile-preview-hosts">
+                <strong data-testid="tool-card-composer-lockfile-preview-host-title">Sources</strong>
+                <ul>\(hosts)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !hostList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-composer-lockfile-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -810,6 +810,92 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteLock.pnpmLockfilePreview)
     }
 
+    func testArtifactStateDerivesComposerLockfilePreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("composer.lock")
+        let lockText = """
+        {
+          "_readme": ["This file locks the dependencies of your project."],
+          "content-hash": "abcdef1234567890abcdef1234567890",
+          "plugin-api-version": "2.6.0",
+          "packages": [
+            {
+              "name": "guzzlehttp/guzzle",
+              "version": "7.9.2",
+              "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "abc"
+              },
+              "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/abc",
+                "reference": "abc"
+              }
+            },
+            {
+              "name": "symfony/console",
+              "version": "v7.1.0",
+              "dist": {
+                "type": "zip",
+                "url": "https://codeload.github.com/symfony/console/legacy.zip/def",
+                "reference": "def"
+              }
+            }
+          ],
+          "packages-dev": [
+            {
+              "name": "phpunit/phpunit",
+              "version": "11.4.3",
+              "dist": {
+                "type": "zip",
+                "url": "https://repo.packagist.org/p2/phpunit/phpunit.json",
+                "reference": "ghi"
+              }
+            }
+          ]
+        }
+        """
+        try lockText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.composerLockfilePreview)
+        let byteSizeLabel = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(lockText.data(using: .utf8)).count))
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "COMPOSER-LOCK")
+        XCTAssertEqual(preview.pluginAPIVersion, "2.6.0")
+        XCTAssertEqual(preview.contentHashPrefix, "abcdef123456")
+        XCTAssertEqual(preview.packageCount, 2)
+        XCTAssertEqual(preview.devPackageCount, 1)
+        XCTAssertEqual(preview.resolvedHostLabels, [
+            "api.github.com",
+            "repo.packagist.org",
+            "codeload.github.com"
+        ])
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "guzzlehttp/guzzle@7.9.2",
+            "phpunit/phpunit@11.4.3",
+            "symfony/console@v7.1.0"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Composer lockfile",
+            "Plugin API: 2.6.0",
+            "Content hash: abcdef123456...",
+            "2 packages",
+            "1 dev package",
+            "Size: \(byteSizeLabel)"
+        ])
+
+        let packageJSON = directory.appendingPathComponent("composer.json")
+        try #"{"packages":[]}"#.write(to: packageJSON, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: packageJSON.path).composerLockfilePreview)
+
+        let remoteLock = ToolArtifactState(value: "https://example.com/composer.lock")
+        XCTAssertNil(remoteLock.composerLockfilePreview)
+    }
+
     func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bom.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -996,6 +996,74 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">pnpm-lock.yaml"#))
     }
 
+    func testHTMLRendererIncludesComposerLockfileArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("composer.lock")
+        try """
+        {
+          "content-hash": "abcdef1234567890",
+          "plugin-api-version": "2.6.0",
+          "packages": [
+            {
+              "name": "guzzlehttp/guzzle",
+              "version": "7.9.2",
+              "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/abc"
+              }
+            }
+          ],
+          "packages-dev": [
+            {
+              "name": "phpunit/phpunit",
+              "version": "11.4.3",
+              "dist": {
+                "type": "zip",
+                "url": "https://repo.packagist.org/p2/phpunit/phpunit.json"
+              }
+            }
+          ]
+        }
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"composer.lock"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote composer.lock\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Composer lock artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · COMPOSER-LOCK"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">composer.lock"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-meta">Format: Composer lockfile"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-meta">Plugin API: 2.6.0"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-meta">1 package"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-meta">1 dev package"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-package-item">guzzlehttp/guzzle@7.9.2"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-package-item">phpunit/phpunit@11.4.3"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-host-item">api.github.com"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-composer-lockfile-preview-host-item">repo.packagist.org"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">composer.lock"#))
+    }
+
     func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("bom.json")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,6 +96,10 @@
   lockfile version, root package, package/dependency/dev/optional counts, file size, capped package
   labels, and capped resolved registry hosts without expanding integrity hashes, package scripts, or
   fetching remote tarballs.
+- Artifact previews now include bounded local Composer lockfile metadata for `composer.lock` files:
+  plugin API version, content-hash prefix, package/dev-package counts, file size, capped package
+  labels, and capped source hosts without expanding install scripts, autoload metadata, full hashes,
+  or fetching Packagist/source archives.
 - Artifact previews now include bounded local pnpm lockfile metadata for `pnpm-lock.yaml` files:
   lockfile version, importer/package/dependency/integrity counts, file size, capped importer labels,
   capped package labels, and capped resolved registry hosts without expanding dependency graphs,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2561,3 +2561,24 @@
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPNPMLockfileArtifactPreview` covers
   static HTML selectors, rendered pnpm metadata, package/importer/host lists, YAML-preview suppression,
   and text-preview coexistence.
+
+## 2026-07-19: composer.lock artifacts render bounded package summaries
+
+- **Decision:** Local `composer.lock` artifacts render as structured Composer lockfile cards. The
+  preview shows plugin API version, content-hash prefix, package/dev-package counts, file size, capped
+  package labels, and capped source host labels. `composer.lock` is classified as a data artifact
+  through filename-specific detection.
+- **Why:** PHP dependency changes often produce large lockfile-only diffs. A bounded package/source
+  summary lets users inspect dependency impact without reading repetitive Composer lockfile JSON.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, filename-gated to
+  `composer.lock`, and capped at 512 KB. It reads shallow top-level `packages`, `packages-dev`,
+  `plugin-api-version`, and `content-hash`, plus package `name`, `version`, `source.url`, and
+  `dist.url`; it never expands autoload metadata, scripts, full hashes, package manifests, Packagist
+  metadata, source archives, or remote URLs. Generic JSON rendering is suppressed only after the
+  Composer lockfile shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesComposerLockfilePreviewMetadata`
+  covers filename-based document classification, plugin API, content-hash prefix, package/dev counts,
+  package labels, host labels, non-`composer.lock` exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesComposerLockfileArtifactPreview` covers
+  static HTML selectors, rendered Composer metadata, package/host lists, JSON-preview suppression, and
+  text-preview coexistence.


### PR DESCRIPTION
## Summary
- add bounded local composer.lock artifact metadata previews
- render Composer package/source summaries in native and HTML tool cards
- document the artifact-preview parity boundary

## Validation
- swift test --filter testArtifactStateDerivesComposerLockfilePreviewMetadata
- swift test --filter testHTMLRendererIncludesComposerLockfileArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check