### PR TITLE
Add Go checksum artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -75,6 +75,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             npmLockfileContent(npmLockfilePreview)
         } else if let composerLockfilePreview = artifact.composerLockfilePreview {
             composerLockfileContent(composerLockfilePreview)
+        } else if let goSumPreview = artifact.goSumPreview {
+            goSumContent(goSumPreview)
         } else if let pnpmLockfilePreview = artifact.pnpmLockfilePreview {
             pnpmLockfileContent(pnpmLockfilePreview)
         } else if let swiftPMPackageResolvedPreview = artifact.swiftPMPackageResolvedPreview {
@@ -328,6 +330,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(composerLockfilePreview.metadataLines)
             artifactContentList(title: "Packages", labels: composerLockfilePreview.packagePreviewLabels)
             artifactContentList(title: "Sources", labels: composerLockfilePreview.resolvedHostLabels)
+        }
+    }
+
+    private func goSumContent(_ goSumPreview: ToolArtifactGoSumPreview) -> some View {
+        let hasLists = !goSumPreview.modulePreviewLabels.isEmpty || !goSumPreview.sourceHostLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(goSumPreview.metadataLines)
+            artifactContentList(title: "Modules", labels: goSumPreview.modulePreviewLabels)
+            artifactContentList(title: "Sources", labels: goSumPreview.sourceHostLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -569,6 +569,55 @@ public struct ToolArtifactComposerLockfilePreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactGoSumPreview: Codable, Sendable, Hashable {
+    public var moduleCount: Int
+    public var versionCount: Int
+    public var checksumCount: Int
+    public var goModChecksumCount: Int
+    public var sourceHostLabels: [String]
+    public var modulePreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: Go checksum database",
+            "\(moduleCount) module\(moduleCount == 1 ? "" : "s")",
+            versionCount > 0 ? "\(versionCount) version\(versionCount == 1 ? "" : "s")" : nil,
+            "\(checksumCount) checksum\(checksumCount == 1 ? "" : "s")",
+            goModChecksumCount > 0 ? "\(goModChecksumCount) go.mod checksum\(goModChecksumCount == 1 ? "" : "s")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        moduleCount > 0
+            || versionCount > 0
+            || checksumCount > 0
+            || goModChecksumCount > 0
+            || !metadataLines.isEmpty
+            || !sourceHostLabels.isEmpty
+            || !modulePreviewLabels.isEmpty
+    }
+
+    public init(
+        moduleCount: Int,
+        versionCount: Int = 0,
+        checksumCount: Int = 0,
+        goModChecksumCount: Int = 0,
+        sourceHostLabels: [String] = [],
+        modulePreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.moduleCount = moduleCount
+        self.versionCount = versionCount
+        self.checksumCount = checksumCount
+        self.goModChecksumCount = goModChecksumCount
+        self.sourceHostLabels = sourceHostLabels
+        self.modulePreviewLabels = modulePreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactPNPMLockfilePreview: Codable, Sendable, Hashable {
     public var lockfileVersion: String?
     public var importerCount: Int
@@ -2735,6 +2784,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var composerLockfilePreview: ToolArtifactComposerLockfilePreview? {
         ToolArtifactComposerLockfilePreviewBuilder.composerLockfilePreview(for: value, kind: kind)
+    }
+    public var goSumPreview: ToolArtifactGoSumPreview? {
+        ToolArtifactGoSumPreviewBuilder.goSumPreview(for: value, kind: kind)
     }
     public var pnpmLockfilePreview: ToolArtifactPNPMLockfilePreview? {
         ToolArtifactPNPMLockfilePreviewBuilder.pnpmLockfilePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -34,6 +34,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == "cover.out" || filename == "coverage.out" {
             return "gocover"
         }
+        if filename == "go.sum" {
+            return "gosum"
+        }
         if filename == "package.resolved" {
             return "spm"
         }
@@ -76,6 +79,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "jsonl": .data,
         "lcov": .data,
         "gocover": .data,
+        "gosum": .data,
         "ndjson": .data,
         "sarif": .data,
         "cfg": .data,

--- a/Sources/QuillCodeApp/ToolArtifactGoSumPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactGoSumPreviewBuilder.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+enum ToolArtifactGoSumPreviewBuilder {
+    static func goSumPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactGoSumPreview? {
+        guard kind == .file,
+              let fileURL = localArtifactFileURL(for: value),
+              fileURL.lastPathComponent.lowercased() == "go.sum"
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+            let entries = sumEntries(from: text)
+            guard !entries.isEmpty else { return nil }
+            let preview = preview(
+                from: entries,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from entries: [SumEntry], byteSizeLabel: String?) -> ToolArtifactGoSumPreview {
+        let modules = Dictionary(grouping: entries, by: \.modulePath)
+        let hostLabels = sourceHostLabels(from: entries)
+        let moduleLabels = modules.keys
+            .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+            .prefix(previewLabelLimit)
+            .map(sanitizedLabel)
+        return ToolArtifactGoSumPreview(
+            moduleCount: modules.count,
+            versionCount: Set(entries.map(\.version)).count,
+            checksumCount: entries.count,
+            goModChecksumCount: entries.filter(\.isGoModChecksum).count,
+            sourceHostLabels: hostLabels,
+            modulePreviewLabels: Array(moduleLabels),
+            byteSizeLabel: byteSizeLabel
+        )
+    }
+
+    private static func sumEntries(from text: String) -> [SumEntry] {
+        text.split(whereSeparator: \.isNewline).compactMap { line in
+            let fields = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard fields.count == 3,
+                  fields[2].hasPrefix("h1:"),
+                  !fields[0].contains("\\"),
+                  !fields[1].contains("\\")
+            else {
+                return nil
+            }
+            let modulePath = sanitizedLabel(String(fields[0]))
+            let version = sanitizedLabel(String(fields[1]))
+            guard !modulePath.isEmpty,
+                  !version.isEmpty,
+                  version.hasPrefix("v")
+            else {
+                return nil
+            }
+            return SumEntry(modulePath: modulePath, version: version)
+        }
+    }
+
+    private static func sourceHostLabels(from entries: [SumEntry]) -> [String] {
+        var labels: [String] = []
+        var seen = Set<String>()
+        for entry in entries {
+            guard labels.count < previewLabelLimit,
+                  let host = sourceHost(from: entry.modulePath),
+                  !seen.contains(host)
+            else {
+                continue
+            }
+            seen.insert(host)
+            labels.append(sanitizedLabel(host))
+        }
+        return labels
+    }
+
+    private static func sourceHost(from modulePath: String) -> String? {
+        guard let firstComponent = modulePath.split(separator: "/").first,
+              firstComponent.contains(".")
+        else {
+            return nil
+        }
+        return String(firstComponent).lowercased()
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private struct SumEntry {
+        var modulePath: String
+        var version: String
+
+        var isGoModChecksum: Bool {
+            version.hasSuffix("/go.mod")
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -224,6 +224,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let composerLockfilePreviewModel = artifact.composerLockfilePreview
             let composerLockfilePreview = renderComposerLockfilePreview(composerLockfilePreviewModel)
+            let goSumPreview = renderGoSumPreview(artifact.goSumPreview)
             let pnpmLockfilePreviewModel = artifact.pnpmLockfilePreview
             let pnpmLockfilePreview = renderPNPMLockfilePreview(pnpmLockfilePreviewModel)
             let swiftPMPackageResolvedPreviewModel = artifact.swiftPMPackageResolvedPreview
@@ -314,6 +315,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(jestJSONPreview)
               \(npmLockfilePreview)
               \(composerLockfilePreview)
+              \(goSumPreview)
               \(pnpmLockfilePreview)
               \(swiftPMPackageResolvedPreview)
               \(yarnLockfilePreview)
@@ -835,6 +837,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(packageList)
+          \(hostList)
+        </div>
+        """
+    }
+
+    private static func renderGoSumPreview(_ preview: ToolArtifactGoSumPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-go-sum-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let modules = preview.modulePreviewLabels.map {
+            #"<li data-testid="tool-card-go-sum-preview-module-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let hosts = preview.sourceHostLabels.map {
+            #"<li data-testid="tool-card-go-sum-preview-host-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let moduleList = modules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-go-sum-preview-modules">
+                <strong data-testid="tool-card-go-sum-preview-module-title">Modules</strong>
+                <ul>\(modules)</ul>
+              </section>
+        """
+        let hostList = hosts.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-go-sum-preview-hosts">
+                <strong data-testid="tool-card-go-sum-preview-host-title">Sources</strong>
+                <ul>\(hosts)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !moduleList.isEmpty || !hostList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-go-sum-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(moduleList)
           \(hostList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -896,6 +896,56 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteLock.composerLockfilePreview)
     }
 
+    func testArtifactStateDerivesGoSumPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("go.sum")
+        let sumText = """
+        github.com/charmbracelet/lipgloss v1.1.0 h1:lipgloss
+        github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:lipglossmod
+        golang.org/x/sys v0.34.0 h1:sys
+        golang.org/x/sys v0.34.0/go.mod h1:sysmod
+        gopkg.in/yaml.v3 v3.0.1 h1:yaml
+        """
+        try sumText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.goSumPreview)
+        let byteSizeLabel = try XCTUnwrap(ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(sumText.data(using: .utf8)).count))
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "GOSUM")
+        XCTAssertEqual(preview.moduleCount, 3)
+        XCTAssertEqual(preview.versionCount, 5)
+        XCTAssertEqual(preview.checksumCount, 5)
+        XCTAssertEqual(preview.goModChecksumCount, 2)
+        XCTAssertEqual(preview.sourceHostLabels, [
+            "github.com",
+            "golang.org",
+            "gopkg.in"
+        ])
+        XCTAssertEqual(preview.modulePreviewLabels, [
+            "github.com/charmbracelet/lipgloss",
+            "golang.org/x/sys",
+            "gopkg.in/yaml.v3"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Go checksum database",
+            "3 modules",
+            "5 versions",
+            "5 checksums",
+            "2 go.mod checksums",
+            "Size: \(byteSizeLabel)"
+        ])
+
+        let notGoSum = directory.appendingPathComponent("checksums.sum")
+        try sumText.write(to: notGoSum, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: notGoSum.path).goSumPreview)
+
+        let remoteSum = ToolArtifactState(value: "https://example.com/go.sum")
+        XCTAssertNil(remoteSum.goSumPreview)
+    }
+
     func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bom.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1064,6 +1064,53 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">composer.lock"#))
     }
 
+    func testHTMLRendererIncludesGoSumArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("go.sum")
+        try """
+        github.com/charmbracelet/lipgloss v1.1.0 h1:lipgloss
+        github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:lipglossmod
+        golang.org/x/sys v0.34.0 h1:sys
+        golang.org/x/sys v0.34.0/go.mod h1:sysmod
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"go.sum"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote go.sum\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Go checksum artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · GOSUM"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">go.sum"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-meta">Format: Go checksum database"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-meta">2 modules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-meta">4 checksums"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-meta">2 go.mod checksums"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-module-item">github.com/charmbracelet/lipgloss"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-module-item">golang.org/x/sys"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-host-item">github.com"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-sum-preview-host-item">golang.org"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">go.sum"#))
+    }
+
     func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("bom.json")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -100,6 +100,9 @@
   plugin API version, content-hash prefix, package/dev-package counts, file size, capped package
   labels, and capped source hosts without expanding install scripts, autoload metadata, full hashes,
   or fetching Packagist/source archives.
+- Artifact previews now include bounded local Go checksum metadata for `go.sum` files: module,
+  version, checksum, and go.mod-checksum counts, file size, capped module labels, and capped source
+  hosts without validating hashes through the Go checksum database or fetching module sources.
 - Artifact previews now include bounded local pnpm lockfile metadata for `pnpm-lock.yaml` files:
   lockfile version, importer/package/dependency/integrity counts, file size, capped importer labels,
   capped package labels, and capped resolved registry hosts without expanding dependency graphs,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2582,3 +2582,21 @@
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesComposerLockfileArtifactPreview` covers
   static HTML selectors, rendered Composer metadata, package/host lists, JSON-preview suppression, and
   text-preview coexistence.
+
+## 2026-07-19: go.sum artifacts render bounded checksum summaries
+
+- **Decision:** Local `go.sum` artifacts render as structured Go checksum cards. The preview shows
+  module, version, checksum, and go.mod-checksum counts, file size, capped module labels, and capped
+  source host labels. `go.sum` is classified as a data artifact through filename-specific detection.
+- **Why:** Go dependency updates frequently produce checksum-only artifacts. Users need to see the
+  module and source shape without reading a repetitive checksum file or asking the model to summarize
+  it.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, filename-gated to
+  `go.sum`, and capped at 512 KB. It validates only the standard three-field `module version h1:...`
+  line shape, records bounded module/version/host labels, and never expands hashes, runs Go tooling,
+  contacts the Go checksum database, or fetches module sources.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesGoSumPreviewMetadata` covers
+  filename-based document classification, module/version/checksum/go.mod counts, module labels, host
+  labels, non-`go.sum` exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesGoSumArtifactPreview` covers static HTML
+  selectors, rendered Go checksum metadata, module/host lists, and text-preview coexistence.


### PR DESCRIPTION
## Summary
- add bounded local go.sum artifact metadata previews
- render Go module/source summaries in native and HTML tool cards
- document the artifact-preview parity boundary

## Validation
- swift test --filter testArtifactStateDerivesGoSumPreviewMetadata
- swift test --filter testHTMLRendererIncludesGoSumArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check