### PR TITLE
Add Python requirements artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -77,6 +77,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             composerLockfileContent(composerLockfilePreview)
         } else if let goSumPreview = artifact.goSumPreview {
             goSumContent(goSumPreview)
+        } else if let pythonRequirementsPreview = artifact.pythonRequirementsPreview {
+            pythonRequirementsContent(pythonRequirementsPreview)
         } else if let pnpmLockfilePreview = artifact.pnpmLockfilePreview {
             pnpmLockfileContent(pnpmLockfilePreview)
         } else if let swiftPMPackageResolvedPreview = artifact.swiftPMPackageResolvedPreview {
@@ -346,6 +348,25 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(goSumPreview.metadataLines)
             artifactContentList(title: "Modules", labels: goSumPreview.modulePreviewLabels)
             artifactContentList(title: "Sources", labels: goSumPreview.sourceHostLabels)
+        }
+    }
+
+    private func pythonRequirementsContent(
+        _ pythonRequirementsPreview: ToolArtifactPythonRequirementsPreview
+    ) -> some View {
+        let hasLists = !pythonRequirementsPreview.packagePreviewLabels.isEmpty
+            || !pythonRequirementsPreview.sourceHostLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(pythonRequirementsPreview.metadataLines)
+            artifactContentList(title: "Packages", labels: pythonRequirementsPreview.packagePreviewLabels)
+            artifactContentList(title: "Sources", labels: pythonRequirementsPreview.sourceHostLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -618,6 +618,70 @@ public struct ToolArtifactGoSumPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPythonRequirementsPreview: Codable, Sendable, Hashable {
+    public var packageCount: Int
+    public var pinnedCount: Int
+    public var rangedCount: Int
+    public var editableCount: Int
+    public var includeCount: Int
+    public var optionCount: Int
+    public var hashCount: Int
+    public var sourceHostLabels: [String]
+    public var packagePreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: Python requirements",
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            pinnedCount > 0 ? "\(pinnedCount) pinned" : nil,
+            rangedCount > 0 ? "\(rangedCount) ranged" : nil,
+            editableCount > 0 ? "\(editableCount) editable" : nil,
+            includeCount > 0 ? "\(includeCount) include\(includeCount == 1 ? "" : "s")" : nil,
+            optionCount > 0 ? "\(optionCount) option\(optionCount == 1 ? "" : "s")" : nil,
+            hashCount > 0 ? "\(hashCount) hash\(hashCount == 1 ? "" : "es")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount > 0
+            || pinnedCount > 0
+            || rangedCount > 0
+            || editableCount > 0
+            || includeCount > 0
+            || optionCount > 0
+            || hashCount > 0
+            || !metadataLines.isEmpty
+            || !sourceHostLabels.isEmpty
+            || !packagePreviewLabels.isEmpty
+    }
+
+    public init(
+        packageCount: Int,
+        pinnedCount: Int = 0,
+        rangedCount: Int = 0,
+        editableCount: Int = 0,
+        includeCount: Int = 0,
+        optionCount: Int = 0,
+        hashCount: Int = 0,
+        sourceHostLabels: [String] = [],
+        packagePreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.packageCount = packageCount
+        self.pinnedCount = pinnedCount
+        self.rangedCount = rangedCount
+        self.editableCount = editableCount
+        self.includeCount = includeCount
+        self.optionCount = optionCount
+        self.hashCount = hashCount
+        self.sourceHostLabels = sourceHostLabels
+        self.packagePreviewLabels = packagePreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactPNPMLockfilePreview: Codable, Sendable, Hashable {
     public var lockfileVersion: String?
     public var importerCount: Int
@@ -2787,6 +2851,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var goSumPreview: ToolArtifactGoSumPreview? {
         ToolArtifactGoSumPreviewBuilder.goSumPreview(for: value, kind: kind)
+    }
+    public var pythonRequirementsPreview: ToolArtifactPythonRequirementsPreview? {
+        ToolArtifactPythonRequirementsPreviewBuilder.requirementsPreview(for: value, kind: kind)
     }
     public var pnpmLockfilePreview: ToolArtifactPNPMLockfilePreview? {
         ToolArtifactPNPMLockfilePreviewBuilder.pnpmLockfilePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -37,6 +37,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == "go.sum" {
             return "gosum"
         }
+        if filename == "requirements.txt" || (filename.hasPrefix("requirements-") && filename.hasSuffix(".txt")) {
+            return "requirements"
+        }
         if filename == "package.resolved" {
             return "spm"
         }
@@ -80,6 +83,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "lcov": .data,
         "gocover": .data,
         "gosum": .data,
+        "requirements": .data,
         "ndjson": .data,
         "sarif": .data,
         "cfg": .data,

--- a/Sources/QuillCodeApp/ToolArtifactPythonRequirementsPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPythonRequirementsPreviewBuilder.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+enum ToolArtifactPythonRequirementsPreviewBuilder {
+    static func requirementsPreview(
+        for value: String,
+        kind: ToolArtifactKind
+    ) -> ToolArtifactPythonRequirementsPreview? {
+        guard kind == .file,
+              let fileURL = localArtifactFileURL(for: value),
+              isRequirementsFilename(fileURL.lastPathComponent)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+            let records = requirementRecords(from: text)
+            guard records.hasDisplayContent else { return nil }
+            return ToolArtifactPythonRequirementsPreview(
+                packageCount: records.packageCount,
+                pinnedCount: records.pinnedCount,
+                rangedCount: records.rangedCount,
+                editableCount: records.editableCount,
+                includeCount: records.includeCount,
+                optionCount: records.optionCount,
+                hashCount: records.hashCount,
+                sourceHostLabels: Array(records.sourceHosts.prefix(previewLabelLimit)),
+                packagePreviewLabels: Array(records.packageLabels.prefix(previewLabelLimit)),
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func requirementRecords(from text: String) -> RequirementRecords {
+        var records = RequirementRecords()
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = strippedRequirementLine(String(rawLine))
+            guard !line.isEmpty else { continue }
+
+            let lowercased = line.lowercased()
+            records.hashCount += line.components(separatedBy: "--hash=").count - 1
+            records.addHosts(from: line)
+
+            if isIncludeLine(lowercased) {
+                records.includeCount += 1
+                continue
+            }
+            if isIndexOrFindLinksLine(lowercased) {
+                records.optionCount += 1
+                continue
+            }
+            if lowercased.hasPrefix("--hash=") {
+                continue
+            }
+            if isEditableLine(lowercased) {
+                records.editableCount += 1
+                if let label = editablePackageLabel(from: line) {
+                    records.addPackageLabel(label)
+                }
+                continue
+            }
+            guard let requirement = packageRequirement(from: line) else { continue }
+            records.packageCount += 1
+            if requirement.isPinned {
+                records.pinnedCount += 1
+            } else if requirement.isRanged {
+                records.rangedCount += 1
+            }
+            records.addPackageLabel(requirement.label)
+        }
+        return records
+    }
+
+    private static func packageRequirement(from line: String) -> PackageRequirement? {
+        let withoutEnvironmentMarker = line.split(separator: ";", maxSplits: 1).first.map(String.init) ?? line
+        let trimmed = withoutEnvironmentMarker.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              !trimmed.hasPrefix("-"),
+              !trimmed.lowercased().hasPrefix("git+"),
+              !trimmed.lowercased().hasPrefix("http://"),
+              !trimmed.lowercased().hasPrefix("https://")
+        else {
+            return nil
+        }
+
+        if let atRange = trimmed.range(of: " @ ") {
+            let name = sanitizedLabel(String(trimmed[..<atRange.lowerBound]))
+            guard isPackageNameLike(name) else { return nil }
+            return PackageRequirement(label: name, isPinned: false, isRanged: false)
+        }
+
+        let operatorRanges = requirementOperators.compactMap { op -> (String, Range<String.Index>)? in
+            trimmed.range(of: op).map { (op, $0) }
+        }
+        let firstOperator = operatorRanges.min { lhs, rhs in
+            lhs.1.lowerBound < rhs.1.lowerBound
+        }
+        let rawName = firstOperator.map { String(trimmed[..<$0.1.lowerBound]) } ?? trimmed
+        let name = sanitizedLabel(rawName.split(separator: "[").first.map(String.init) ?? rawName)
+        guard isPackageNameLike(name) else { return nil }
+        let label = firstOperator.map { op, range in
+            let versionSegment = trimmed[range.upperBound...]
+                .split(separator: ",", maxSplits: 1)
+                .first?
+                .split(whereSeparator: \.isWhitespace)
+                .first
+                .map(String.init) ?? ""
+            return sanitizedLabel("\(name)\(op)\(versionSegment)")
+        } ?? name
+        let operators = Set(operatorRanges.map(\.0))
+        return PackageRequirement(
+            label: label,
+            isPinned: operators.contains("==") || operators.contains("==="),
+            isRanged: !operators.isDisjoint(with: rangedOperators)
+        )
+    }
+
+    private static func strippedRequirementLine(_ value: String) -> String {
+        let withoutContinuation = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !withoutContinuation.hasPrefix("#") else { return "" }
+        if let commentRange = withoutContinuation.range(of: " #") {
+            return String(withoutContinuation[..<commentRange.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return withoutContinuation
+    }
+
+    private static func isIncludeLine(_ lowercased: String) -> Bool {
+        lowercased.hasPrefix("-r ")
+            || lowercased.hasPrefix("--requirement ")
+            || lowercased.hasPrefix("-c ")
+            || lowercased.hasPrefix("--constraint ")
+    }
+
+    private static func isIndexOrFindLinksLine(_ lowercased: String) -> Bool {
+        lowercased.hasPrefix("-i ")
+            || lowercased.hasPrefix("--index-url ")
+            || lowercased.hasPrefix("--extra-index-url ")
+            || lowercased.hasPrefix("-f ")
+            || lowercased.hasPrefix("--find-links ")
+            || lowercased.hasPrefix("--trusted-host ")
+    }
+
+    private static func isEditableLine(_ lowercased: String) -> Bool {
+        lowercased.hasPrefix("-e ") || lowercased.hasPrefix("--editable ")
+    }
+
+    private static func editablePackageLabel(from line: String) -> String? {
+        if let eggRange = line.range(of: "#egg=") {
+            let eggName = line[eggRange.upperBound...]
+                .split(separator: "&", maxSplits: 1)
+                .first
+                .map(String.init)
+            return eggName.map(sanitizedLabel).flatMap { $0.isEmpty ? nil : $0 }
+        }
+        let path = line.split(separator: " ").last.map(String.init) ?? line
+        let label = sanitizedLabel(URL(string: path)?.lastPathComponent ?? path)
+        return label.isEmpty ? nil : label
+    }
+
+    private static func isPackageNameLike(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return value.range(of: #"^[A-Za-z0-9][A-Za-z0-9_.-]*$"#, options: .regularExpression) != nil
+    }
+
+    private static func hosts(in line: String) -> [String] {
+        line.split(whereSeparator: \.isWhitespace).compactMap { token in
+            var value = String(token).trimmingCharacters(in: CharacterSet(charactersIn: "\\\",'()[]<>"))
+            if value.hasSuffix("\\") {
+                value.removeLast()
+            }
+            if value.lowercased().hasPrefix("git+") {
+                value.removeFirst(4)
+            }
+            guard value.hasPrefix("http://") || value.hasPrefix("https://"),
+                  let host = URL(string: value)?.host?.lowercased()
+            else {
+                return nil
+            }
+            return sanitizedLabel(host)
+        }
+    }
+
+    private static func isRequirementsFilename(_ filename: String) -> Bool {
+        let lowercased = filename.lowercased()
+        return lowercased == "requirements.txt"
+            || (lowercased.hasPrefix("requirements-") && lowercased.hasSuffix(".txt"))
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private struct PackageRequirement {
+        var label: String
+        var isPinned: Bool
+        var isRanged: Bool
+    }
+
+    private struct RequirementRecords {
+        var packageCount = 0
+        var pinnedCount = 0
+        var rangedCount = 0
+        var editableCount = 0
+        var includeCount = 0
+        var optionCount = 0
+        var hashCount = 0
+        private(set) var packageLabels: [String] = []
+        private(set) var sourceHosts: [String] = []
+        private var seenPackageLabels = Set<String>()
+        private var seenSourceHosts = Set<String>()
+
+        var hasDisplayContent: Bool {
+            packageCount > 0
+                || editableCount > 0
+                || includeCount > 0
+                || optionCount > 0
+                || hashCount > 0
+                || !packageLabels.isEmpty
+                || !sourceHosts.isEmpty
+        }
+
+        mutating func addPackageLabel(_ label: String) {
+            guard !label.isEmpty, !seenPackageLabels.contains(label) else { return }
+            seenPackageLabels.insert(label)
+            packageLabels.append(label)
+        }
+
+        mutating func addHosts(from line: String) {
+            for host in ToolArtifactPythonRequirementsPreviewBuilder.hosts(in: line) {
+                guard !seenSourceHosts.contains(host) else { continue }
+                seenSourceHosts.insert(host)
+                sourceHosts.append(host)
+            }
+        }
+    }
+
+    private static let requirementOperators = ["===", "==", "~=", ">=", "<=", "!=", ">", "<"]
+    private static let rangedOperators = Set(["~=", ">=", "<=", "!=", ">", "<"])
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -225,6 +225,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let composerLockfilePreviewModel = artifact.composerLockfilePreview
             let composerLockfilePreview = renderComposerLockfilePreview(composerLockfilePreviewModel)
             let goSumPreview = renderGoSumPreview(artifact.goSumPreview)
+            let pythonRequirementsPreview = renderPythonRequirementsPreview(artifact.pythonRequirementsPreview)
             let pnpmLockfilePreviewModel = artifact.pnpmLockfilePreview
             let pnpmLockfilePreview = renderPNPMLockfilePreview(pnpmLockfilePreviewModel)
             let swiftPMPackageResolvedPreviewModel = artifact.swiftPMPackageResolvedPreview
@@ -316,6 +317,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(npmLockfilePreview)
               \(composerLockfilePreview)
               \(goSumPreview)
+              \(pythonRequirementsPreview)
               \(pnpmLockfilePreview)
               \(swiftPMPackageResolvedPreview)
               \(yarnLockfilePreview)
@@ -872,6 +874,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(moduleList)
+          \(hostList)
+        </div>
+        """
+    }
+
+    private static func renderPythonRequirementsPreview(_ preview: ToolArtifactPythonRequirementsPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-python-requirements-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-python-requirements-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let hosts = preview.sourceHostLabels.map {
+            #"<li data-testid="tool-card-python-requirements-preview-host-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-python-requirements-preview-packages">
+                <strong data-testid="tool-card-python-requirements-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let hostList = hosts.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-python-requirements-preview-hosts">
+                <strong data-testid="tool-card-python-requirements-preview-host-title">Sources</strong>
+                <ul>\(hosts)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !hostList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-python-requirements-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
           \(hostList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -946,6 +946,70 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteSum.goSumPreview)
     }
 
+    func testArtifactStateDerivesPythonRequirementsPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("requirements-dev.txt")
+        let requirementsText = """
+        --index-url https://pypi.org/simple
+        --extra-index-url https://packages.example.com/simple
+        -r base.txt
+        requests==2.32.3 --hash=sha256:abc
+        rich>=13.7,<14
+        fastapi[standard]~=0.115.0 ; python_version >= "3.11"
+        -e git+https://github.com/Lore-Hex/QuillCode.git#egg=quillcode
+        uvicorn @ https://files.pythonhosted.org/packages/uvicorn.whl
+        """
+        try requirementsText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.pythonRequirementsPreview)
+        let byteSizeLabel = try XCTUnwrap(
+            ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(requirementsText.data(using: .utf8)).count)
+        )
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "REQUIREMENTS")
+        XCTAssertEqual(preview.packageCount, 4)
+        XCTAssertEqual(preview.pinnedCount, 1)
+        XCTAssertEqual(preview.rangedCount, 2)
+        XCTAssertEqual(preview.editableCount, 1)
+        XCTAssertEqual(preview.includeCount, 1)
+        XCTAssertEqual(preview.optionCount, 2)
+        XCTAssertEqual(preview.hashCount, 1)
+        XCTAssertEqual(preview.sourceHostLabels, [
+            "pypi.org",
+            "packages.example.com",
+            "github.com",
+            "files.pythonhosted.org"
+        ])
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "requests==2.32.3",
+            "rich>=13.7",
+            "fastapi~=0.115.0",
+            "quillcode",
+            "uvicorn"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Python requirements",
+            "4 packages",
+            "1 pinned",
+            "2 ranged",
+            "1 editable",
+            "1 include",
+            "2 options",
+            "1 hash",
+            "Size: \(byteSizeLabel)"
+        ])
+
+        let notRequirements = directory.appendingPathComponent("deps.txt")
+        try requirementsText.write(to: notRequirements, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: notRequirements.path).pythonRequirementsPreview)
+
+        let remoteRequirements = ToolArtifactState(value: "https://example.com/requirements.txt")
+        XCTAssertNil(remoteRequirements.pythonRequirementsPreview)
+    }
+
     func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bom.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1111,6 +1111,56 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">go.sum"#))
     }
 
+    func testHTMLRendererIncludesPythonRequirementsArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("requirements.txt")
+        try """
+        --index-url https://pypi.org/simple
+        requests==2.32.3 --hash=sha256:abc
+        rich>=13.7,<14
+        uvicorn @ https://files.pythonhosted.org/packages/uvicorn.whl
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"requirements.txt"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote requirements.txt\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Python requirements artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · REQUIREMENTS"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">requirements.txt"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-meta">Format: Python requirements"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-meta">3 packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-meta">1 pinned"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-meta">1 ranged"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-meta">1 option"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-meta">1 hash"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-package-item">requests==2.32.3"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-package-item">rich&gt;=13.7"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-package-item">uvicorn"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-host-item">pypi.org"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-python-requirements-preview-host-item">files.pythonhosted.org"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">requirements.txt"#))
+    }
+
     func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("bom.json")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -103,6 +103,10 @@
 - Artifact previews now include bounded local Go checksum metadata for `go.sum` files: module,
   version, checksum, and go.mod-checksum counts, file size, capped module labels, and capped source
   hosts without validating hashes through the Go checksum database or fetching module sources.
+- Artifact previews now include bounded local Python requirements metadata for `requirements.txt`
+  and `requirements-*.txt` files: package, pinned/ranged/editable/include/option/hash counts, file
+  size, capped package labels, and capped source hosts without running pip, validating hashes,
+  expanding requirement includes, or fetching package indexes.
 - Artifact previews now include bounded local pnpm lockfile metadata for `pnpm-lock.yaml` files:
   lockfile version, importer/package/dependency/integrity counts, file size, capped importer labels,
   capped package labels, and capped resolved registry hosts without expanding dependency graphs,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2600,3 +2600,24 @@
   labels, non-`go.sum` exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesGoSumArtifactPreview` covers static HTML
   selectors, rendered Go checksum metadata, module/host lists, and text-preview coexistence.
+
+## 2026-07-19: requirements.txt artifacts render bounded Python dependency summaries
+
+- **Decision:** Local `requirements.txt` and `requirements-*.txt` artifacts render as structured
+  Python requirements cards. The preview shows package, pinned/ranged/editable/include/option/hash
+  counts, file size, capped package labels, and capped source host labels. Matching requirements
+  filenames are classified as data artifacts through filename-specific detection.
+- **Why:** Python projects often expose dependency changes through requirements files rather than
+  lockfiles. A bounded package/source summary makes those artifacts scannable without asking the model
+  to read raw requirement lines.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, filename-gated to
+  `requirements.txt` and `requirements-*.txt`, and capped at 512 KB. It recognizes shallow pip
+  requirement forms, editable installs, include/constraint lines, index/find-links options, hashes,
+  environment markers, and direct URL host labels; it never runs pip, expands includes, validates
+  hashes, reads package metadata, contacts package indexes, or fetches distributions.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesPythonRequirementsPreviewMetadata`
+  covers filename-based document classification, package/pinned/ranged/editable/include/option/hash
+  counts, package labels, host labels, non-requirements exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPythonRequirementsArtifactPreview` covers
+  static HTML selectors, rendered Python requirements metadata, package/host lists, and text-preview
+  coexistence.


### PR DESCRIPTION
## Summary
- classify requirements.txt and requirements-*.txt artifacts as data previews
- add a bounded local Python requirements parser for package, pinned/ranged/editable/include/option/hash counts
- render package/source summaries in native and HTML tool cards, with docs and parity matrix evidence

## Validation
- swift test --filter testArtifactStateDerivesPythonRequirementsPreviewMetadata
- swift test --filter testHTMLRendererIncludesPythonRequirementsArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check