### PR TITLE
Add Poetry lock artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -79,6 +79,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             goSumContent(goSumPreview)
         } else if let pythonRequirementsPreview = artifact.pythonRequirementsPreview {
             pythonRequirementsContent(pythonRequirementsPreview)
+        } else if let poetryLockPreview = artifact.poetryLockPreview {
+            poetryLockContent(poetryLockPreview)
         } else if let pnpmLockfilePreview = artifact.pnpmLockfilePreview {
             pnpmLockfileContent(pnpmLockfilePreview)
         } else if let swiftPMPackageResolvedPreview = artifact.swiftPMPackageResolvedPreview {
@@ -367,6 +369,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(pythonRequirementsPreview.metadataLines)
             artifactContentList(title: "Packages", labels: pythonRequirementsPreview.packagePreviewLabels)
             artifactContentList(title: "Sources", labels: pythonRequirementsPreview.sourceHostLabels)
+        }
+    }
+
+    private func poetryLockContent(_ poetryLockPreview: ToolArtifactPoetryLockPreview) -> some View {
+        let hasLists = !poetryLockPreview.packagePreviewLabels.isEmpty
+            || !poetryLockPreview.sourcePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(poetryLockPreview.metadataLines)
+            artifactContentList(title: "Packages", labels: poetryLockPreview.packagePreviewLabels)
+            artifactContentList(title: "Sources", labels: poetryLockPreview.sourcePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -682,6 +682,65 @@ public struct ToolArtifactPythonRequirementsPreview: Codable, Sendable, Hashable
     }
 }
 
+public struct ToolArtifactPoetryLockPreview: Codable, Sendable, Hashable {
+    public var packageCount: Int
+    public var versionedPackageCount: Int
+    public var devPackageCount: Int
+    public var optionalPackageCount: Int
+    public var sourceCount: Int
+    public var hashCount: Int
+    public var sourcePreviewLabels: [String]
+    public var packagePreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: Poetry lockfile",
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            versionedPackageCount > 0 ? "\(versionedPackageCount) versioned" : nil,
+            devPackageCount > 0 ? "\(devPackageCount) dev package\(devPackageCount == 1 ? "" : "s")" : nil,
+            optionalPackageCount > 0 ? "\(optionalPackageCount) optional package\(optionalPackageCount == 1 ? "" : "s")" : nil,
+            sourceCount > 0 ? "\(sourceCount) source\(sourceCount == 1 ? "" : "s")" : nil,
+            hashCount > 0 ? "\(hashCount) hash\(hashCount == 1 ? "" : "es")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        packageCount > 0
+            || versionedPackageCount > 0
+            || devPackageCount > 0
+            || optionalPackageCount > 0
+            || sourceCount > 0
+            || hashCount > 0
+            || !metadataLines.isEmpty
+            || !sourcePreviewLabels.isEmpty
+            || !packagePreviewLabels.isEmpty
+    }
+
+    public init(
+        packageCount: Int,
+        versionedPackageCount: Int = 0,
+        devPackageCount: Int = 0,
+        optionalPackageCount: Int = 0,
+        sourceCount: Int = 0,
+        hashCount: Int = 0,
+        sourcePreviewLabels: [String] = [],
+        packagePreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.packageCount = packageCount
+        self.versionedPackageCount = versionedPackageCount
+        self.devPackageCount = devPackageCount
+        self.optionalPackageCount = optionalPackageCount
+        self.sourceCount = sourceCount
+        self.hashCount = hashCount
+        self.sourcePreviewLabels = sourcePreviewLabels
+        self.packagePreviewLabels = packagePreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactPNPMLockfilePreview: Codable, Sendable, Hashable {
     public var lockfileVersion: String?
     public var importerCount: Int
@@ -2854,6 +2913,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var pythonRequirementsPreview: ToolArtifactPythonRequirementsPreview? {
         ToolArtifactPythonRequirementsPreviewBuilder.requirementsPreview(for: value, kind: kind)
+    }
+    public var poetryLockPreview: ToolArtifactPoetryLockPreview? {
+        ToolArtifactPoetryLockPreviewBuilder.poetryLockPreview(for: value, kind: kind)
     }
     public var pnpmLockfilePreview: ToolArtifactPNPMLockfilePreview? {
         ToolArtifactPNPMLockfilePreviewBuilder.pnpmLockfilePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -40,6 +40,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == "requirements.txt" || (filename.hasPrefix("requirements-") && filename.hasSuffix(".txt")) {
             return "requirements"
         }
+        if filename == "poetry.lock" {
+            return "poetry-lock"
+        }
         if filename == "package.resolved" {
             return "spm"
         }
@@ -84,6 +87,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "gocover": .data,
         "gosum": .data,
         "requirements": .data,
+        "poetry-lock": .data,
         "ndjson": .data,
         "sarif": .data,
         "cfg": .data,

--- a/Sources/QuillCodeApp/ToolArtifactPoetryLockPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPoetryLockPreviewBuilder.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+enum ToolArtifactPoetryLockPreviewBuilder {
+    static func poetryLockPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPoetryLockPreview? {
+        guard kind == .file,
+              let fileURL = localArtifactFileURL(for: value),
+              fileURL.lastPathComponent.lowercased() == "poetry.lock"
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+            let packages = packageRecords(from: text)
+            guard !packages.isEmpty else { return nil }
+            let preview = preview(
+                from: packages,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from packages: [PackageRecord],
+        byteSizeLabel: String?
+    ) -> ToolArtifactPoetryLockPreview {
+        ToolArtifactPoetryLockPreview(
+            packageCount: packages.count,
+            versionedPackageCount: packages.filter { $0.version != nil }.count,
+            devPackageCount: packages.filter(\.isDevDependency).count,
+            optionalPackageCount: packages.filter(\.isOptional).count,
+            sourceCount: packages.filter { $0.sourceLabel != nil }.count,
+            hashCount: packages.reduce(0) { $0 + $1.hashCount },
+            sourcePreviewLabels: sourcePreviewLabels(from: packages),
+            packagePreviewLabels: Array(packages.prefix(previewLabelLimit)).map(\.label),
+            byteSizeLabel: byteSizeLabel
+        )
+    }
+
+    private static func packageRecords(from text: String) -> [PackageRecord] {
+        var packages: [PackageRecord] = []
+        var current = PartialPackage()
+        var insidePackage = false
+
+        func flushCurrentPackage() {
+            guard let package = current.packageRecord else {
+                current = PartialPackage()
+                return
+            }
+            packages.append(package)
+            current = PartialPackage()
+        }
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+            if line == "[[package]]" {
+                if insidePackage {
+                    flushCurrentPackage()
+                }
+                insidePackage = true
+                continue
+            }
+            if line.hasPrefix("[") {
+                continue
+            }
+            guard insidePackage else {
+                continue
+            }
+            current.addHashCount(from: line)
+            guard let assignment = assignment(from: line) else { continue }
+            current.set(value: assignment.value, for: assignment.key)
+        }
+        flushCurrentPackage()
+
+        return packages.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private static func assignment(from line: String) -> (key: String, value: String)? {
+        guard let separator = line.firstIndex(of: "=") else { return nil }
+        let key = line[..<separator].trimmingCharacters(in: .whitespaces)
+        let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+        guard trackedKeys.contains(String(key)), !value.isEmpty else { return nil }
+        return (String(key), String(value))
+    }
+
+    private static func sourcePreviewLabels(from packages: [PackageRecord]) -> [String] {
+        var labels: [String] = []
+        var seen = Set<String>()
+        for package in packages {
+            guard labels.count < previewLabelLimit,
+                  let label = package.sourceLabel,
+                  !seen.contains(label)
+            else {
+                continue
+            }
+            seen.insert(label)
+            labels.append(label)
+        }
+        return labels
+    }
+
+    private static func sourceLabel(from value: String) -> String? {
+        let hosts = hosts(in: value)
+        if let host = hosts.first {
+            return host
+        }
+        if let type = inlineTableValue(named: "type", in: value) {
+            return sanitizedLabel(type)
+        }
+        return nil
+    }
+
+    private static func hosts(in value: String) -> [String] {
+        value
+            .split { $0.isWhitespace || $0 == "," || $0 == "}" || $0 == "]" }
+            .compactMap { token in
+                var text = String(token).trimmingCharacters(in: CharacterSet(charactersIn: "\\\",'()[]{}<>"))
+                if text.lowercased().hasPrefix("git+") {
+                    text.removeFirst(4)
+                }
+                guard text.hasPrefix("http://") || text.hasPrefix("https://"),
+                      let host = URL(string: text)?.host?.lowercased()
+                else {
+                    return nil
+                }
+                return sanitizedLabel(host)
+            }
+    }
+
+    private static func inlineTableValue(named key: String, in value: String) -> String? {
+        guard let range = value.range(of: #"\b\#(NSRegularExpression.escapedPattern(for: key))\s*=\s*"([^"]+)""#, options: .regularExpression)
+        else {
+            return nil
+        }
+        let matched = String(value[range])
+        guard let quote = matched.firstIndex(of: "\"") else { return nil }
+        var content = String(matched[matched.index(after: quote)...])
+        if content.hasSuffix("\"") {
+            content.removeLast()
+        }
+        return sanitizedLabel(content)
+    }
+
+    private static func unquoted(_ value: String) -> String {
+        var text = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.hasPrefix("\""), text.hasSuffix("\""), text.count >= 2 {
+            text.removeFirst()
+            text.removeLast()
+        }
+        return sanitizedLabel(text)
+    }
+
+    private static func boolValue(_ value: String) -> Bool {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "true"
+    }
+
+    private static func containsDevGroup(_ value: String) -> Bool {
+        let lowercased = value.lowercased()
+        return lowercased.contains("\"dev\"") || lowercased.contains("'dev'")
+    }
+
+    private static func hashCount(in value: String) -> Int {
+        value.components(separatedBy: "hash =").count - 1
+            + value.components(separatedBy: "\"hash\"").count - 1
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private struct PartialPackage {
+        var name: String?
+        var version: String?
+        var category: String?
+        var groups: String?
+        var optional = false
+        var sourceLabel: String?
+        var hashCount = 0
+
+        mutating func set(value: String, for key: String) {
+            switch key {
+            case "name":
+                name = ToolArtifactPoetryLockPreviewBuilder.unquoted(value)
+            case "version":
+                version = ToolArtifactPoetryLockPreviewBuilder.unquoted(value)
+            case "category":
+                category = ToolArtifactPoetryLockPreviewBuilder.unquoted(value)
+            case "groups":
+                groups = value
+            case "optional":
+                optional = ToolArtifactPoetryLockPreviewBuilder.boolValue(value)
+            case "source":
+                sourceLabel = ToolArtifactPoetryLockPreviewBuilder.sourceLabel(from: value)
+            default:
+                break
+            }
+        }
+
+        mutating func addHashCount(from line: String) {
+            hashCount += ToolArtifactPoetryLockPreviewBuilder.hashCount(in: line)
+        }
+
+        var packageRecord: PackageRecord? {
+            guard let name, !name.isEmpty else { return nil }
+            return PackageRecord(
+                name: name,
+                version: version,
+                isDevDependency: category == "dev" || groups.map(ToolArtifactPoetryLockPreviewBuilder.containsDevGroup) == true,
+                isOptional: optional,
+                sourceLabel: sourceLabel,
+                hashCount: hashCount
+            )
+        }
+    }
+
+    private struct PackageRecord {
+        var name: String
+        var version: String?
+        var isDevDependency: Bool
+        var isOptional: Bool
+        var sourceLabel: String?
+        var hashCount: Int
+
+        var label: String {
+            ToolArtifactPoetryLockPreviewBuilder.sanitizedLabel(version.map { "\(name)@\($0)" } ?? name)
+        }
+    }
+
+    private static let trackedKeys: Set<String> = [
+        "name",
+        "version",
+        "category",
+        "groups",
+        "optional",
+        "source",
+        "files"
+    ]
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -226,6 +226,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let composerLockfilePreview = renderComposerLockfilePreview(composerLockfilePreviewModel)
             let goSumPreview = renderGoSumPreview(artifact.goSumPreview)
             let pythonRequirementsPreview = renderPythonRequirementsPreview(artifact.pythonRequirementsPreview)
+            let poetryLockPreview = renderPoetryLockPreview(artifact.poetryLockPreview)
             let pnpmLockfilePreviewModel = artifact.pnpmLockfilePreview
             let pnpmLockfilePreview = renderPNPMLockfilePreview(pnpmLockfilePreviewModel)
             let swiftPMPackageResolvedPreviewModel = artifact.swiftPMPackageResolvedPreview
@@ -318,6 +319,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(composerLockfilePreview)
               \(goSumPreview)
               \(pythonRequirementsPreview)
+              \(poetryLockPreview)
               \(pnpmLockfilePreview)
               \(swiftPMPackageResolvedPreview)
               \(yarnLockfilePreview)
@@ -910,6 +912,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(packageList)
           \(hostList)
+        </div>
+        """
+    }
+
+    private static func renderPoetryLockPreview(_ preview: ToolArtifactPoetryLockPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-poetry-lock-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-poetry-lock-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let sources = preview.sourcePreviewLabels.map {
+            #"<li data-testid="tool-card-poetry-lock-preview-source-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-poetry-lock-preview-packages">
+                <strong data-testid="tool-card-poetry-lock-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let sourceList = sources.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-poetry-lock-preview-sources">
+                <strong data-testid="tool-card-poetry-lock-preview-source-title">Sources</strong>
+                <ul>\(sources)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !sourceList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-poetry-lock-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(sourceList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1010,6 +1010,80 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteRequirements.pythonRequirementsPreview)
     }
 
+    func testArtifactStateDerivesPoetryLockPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("poetry.lock")
+        let lockText = """
+        [[package]]
+        name = "requests"
+        version = "2.32.3"
+        optional = false
+        groups = ["main"]
+        files = [{file = "requests-2.32.3.tar.gz", hash = "sha256:aaa"}]
+
+        [[package]]
+        name = "pytest"
+        version = "8.3.4"
+        optional = false
+        category = "dev"
+        source = { type = "legacy", url = "https://packages.example.com/simple" }
+        files = [
+            {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:bbb"},
+            {file = "pytest-8.3.4.tar.gz", hash = "sha256:ccc"},
+        ]
+
+        [[package]]
+        name = "uvicorn"
+        version = "0.35.0"
+        optional = true
+        groups = ["main", "dev"]
+        source = { type = "git", url = "git+https://github.com/encode/uvicorn.git" }
+        """
+        try lockText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.poetryLockPreview)
+        let byteSizeLabel = try XCTUnwrap(
+            ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(lockText.data(using: .utf8)).count)
+        )
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "POETRY-LOCK")
+        XCTAssertEqual(preview.packageCount, 3)
+        XCTAssertEqual(preview.versionedPackageCount, 3)
+        XCTAssertEqual(preview.devPackageCount, 2)
+        XCTAssertEqual(preview.optionalPackageCount, 1)
+        XCTAssertEqual(preview.sourceCount, 2)
+        XCTAssertEqual(preview.hashCount, 3)
+        XCTAssertEqual(preview.sourcePreviewLabels, [
+            "packages.example.com",
+            "github.com"
+        ])
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "pytest@8.3.4",
+            "requests@2.32.3",
+            "uvicorn@0.35.0"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Poetry lockfile",
+            "3 packages",
+            "3 versioned",
+            "2 dev packages",
+            "1 optional package",
+            "2 sources",
+            "3 hashes",
+            "Size: \(byteSizeLabel)"
+        ])
+
+        let notPoetryLock = directory.appendingPathComponent("poetry.toml")
+        try lockText.write(to: notPoetryLock, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: notPoetryLock.path).poetryLockPreview)
+
+        let remotePoetryLock = ToolArtifactState(value: "https://example.com/poetry.lock")
+        XCTAssertNil(remotePoetryLock.poetryLockPreview)
+    }
+
     func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bom.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1161,6 +1161,62 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">requirements.txt"#))
     }
 
+    func testHTMLRendererIncludesPoetryLockArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("poetry.lock")
+        try """
+        [[package]]
+        name = "requests"
+        version = "2.32.3"
+        optional = false
+        files = [{file = "requests-2.32.3.tar.gz", hash = "sha256:aaa"}]
+
+        [[package]]
+        name = "pytest"
+        version = "8.3.4"
+        category = "dev"
+        source = { type = "legacy", url = "https://packages.example.com/simple" }
+        files = [{file = "pytest-8.3.4.tar.gz", hash = "sha256:bbb"}]
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"poetry.lock"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote poetry.lock\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Poetry lock artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · POETRY-LOCK"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">poetry.lock"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-meta">Format: Poetry lockfile"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-meta">2 packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-meta">2 versioned"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-meta">1 dev package"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-meta">1 source"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-meta">2 hashes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-package-item">pytest@8.3.4"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-package-item">requests@2.32.3"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-poetry-lock-preview-source-item">packages.example.com"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">poetry.lock"#))
+    }
+
     func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("bom.json")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -107,6 +107,10 @@
   and `requirements-*.txt` files: package, pinned/ranged/editable/include/option/hash counts, file
   size, capped package labels, and capped source hosts without running pip, validating hashes,
   expanding requirement includes, or fetching package indexes.
+- Artifact previews now include bounded local Poetry lockfile metadata for `poetry.lock` files:
+  package/version/dev/optional/source/hash counts, file size, capped package labels, and capped
+  source labels without expanding dependency tables, validating hashes, reading package metadata, or
+  fetching package indexes/distributions.
 - Artifact previews now include bounded local pnpm lockfile metadata for `pnpm-lock.yaml` files:
   lockfile version, importer/package/dependency/integrity counts, file size, capped importer labels,
   capped package labels, and capped resolved registry hosts without expanding dependency graphs,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2621,3 +2621,23 @@
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPythonRequirementsArtifactPreview` covers
   static HTML selectors, rendered Python requirements metadata, package/host lists, and text-preview
   coexistence.
+
+## 2026-07-19: poetry.lock artifacts render bounded Python lockfile summaries
+
+- **Decision:** Local `poetry.lock` artifacts render as structured Poetry lockfile cards. The preview
+  shows package, versioned-package, dev-package, optional-package, source, and hash counts, file size,
+  capped package labels, and capped source labels. `poetry.lock` is classified as a data artifact
+  through filename-specific detection.
+- **Why:** Poetry lockfiles are common Python dependency artifacts. A bounded package/source/hash
+  summary gives the user useful dependency impact at a glance without asking the model to scan raw
+  lockfile text.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, filename-gated to
+  `poetry.lock`, and capped at 512 KB. It reads only shallow `[[package]]` sections and tracked scalar
+  or inline values for `name`, `version`, `category`, `groups`, `optional`, `source`, and `files`; it
+  never expands dependency tables, validates hashes, imports TOML package metadata, contacts package
+  indexes, or fetches distributions.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesPoetryLockPreviewMetadata`
+  covers filename-based document classification, package/version/dev/optional/source/hash counts,
+  package labels, source labels, non-`poetry.lock` exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPoetryLockArtifactPreview` covers static
+  HTML selectors, rendered Poetry metadata, package/source lists, and text-preview coexistence.


### PR DESCRIPTION
## Summary
- classify poetry.lock artifacts as data previews
- add a bounded local Poetry lock parser for package, versioned/dev/optional/source/hash counts
- render package/source summaries in native and HTML tool cards, with docs and parity matrix evidence

## Validation
- swift test --filter testArtifactStateDerivesPoetryLockPreviewMetadata
- swift test --filter testHTMLRendererIncludesPoetryLockArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check