### PR TITLE
Add uv lock artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -83,6 +83,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             poetryLockContent(poetryLockPreview)
         } else if let pipfileLockPreview = artifact.pipfileLockPreview {
             pipfileLockContent(pipfileLockPreview)
+        } else if let uvLockPreview = artifact.uvLockPreview {
+            uvLockContent(uvLockPreview)
         } else if let pnpmLockfilePreview = artifact.pnpmLockfilePreview {
             pnpmLockfileContent(pnpmLockfilePreview)
         } else if let swiftPMPackageResolvedPreview = artifact.swiftPMPackageResolvedPreview {
@@ -405,6 +407,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(pipfileLockPreview.metadataLines)
             artifactContentList(title: "Packages", labels: pipfileLockPreview.packagePreviewLabels)
             artifactContentList(title: "Sources", labels: pipfileLockPreview.sourcePreviewLabels)
+        }
+    }
+
+    private func uvLockContent(_ uvLockPreview: ToolArtifactUVLockPreview) -> some View {
+        let hasLists = !uvLockPreview.packagePreviewLabels.isEmpty
+            || !uvLockPreview.sourcePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shippingbox")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(uvLockPreview.metadataLines)
+            artifactContentList(title: "Packages", labels: uvLockPreview.packagePreviewLabels)
+            artifactContentList(title: "Sources", labels: uvLockPreview.sourcePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -805,6 +805,65 @@ public struct ToolArtifactPipfileLockPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactUVLockPreview: Codable, Sendable, Hashable {
+    public var pythonRequirement: String?
+    public var packageCount: Int
+    public var versionedPackageCount: Int
+    public var dependencyCount: Int
+    public var sourceCount: Int
+    public var hashCount: Int
+    public var sourcePreviewLabels: [String]
+    public var packagePreviewLabels: [String]
+    public var byteSizeLabel: String?
+
+    public var metadataLines: [String] {
+        [
+            "Format: uv lockfile",
+            pythonRequirement.map { "Python: \($0)" },
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            versionedPackageCount > 0 ? "\(versionedPackageCount) versioned" : nil,
+            dependencyCount > 0 ? "\(dependencyCount) dependenc\(dependencyCount == 1 ? "y" : "ies")" : nil,
+            sourceCount > 0 ? "\(sourceCount) source\(sourceCount == 1 ? "" : "s")" : nil,
+            hashCount > 0 ? "\(hashCount) hash\(hashCount == 1 ? "" : "es")" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        pythonRequirement != nil
+            || packageCount > 0
+            || versionedPackageCount > 0
+            || dependencyCount > 0
+            || sourceCount > 0
+            || hashCount > 0
+            || !metadataLines.isEmpty
+            || !sourcePreviewLabels.isEmpty
+            || !packagePreviewLabels.isEmpty
+    }
+
+    public init(
+        pythonRequirement: String? = nil,
+        packageCount: Int,
+        versionedPackageCount: Int = 0,
+        dependencyCount: Int = 0,
+        sourceCount: Int = 0,
+        hashCount: Int = 0,
+        sourcePreviewLabels: [String] = [],
+        packagePreviewLabels: [String] = [],
+        byteSizeLabel: String? = nil
+    ) {
+        self.pythonRequirement = pythonRequirement
+        self.packageCount = packageCount
+        self.versionedPackageCount = versionedPackageCount
+        self.dependencyCount = dependencyCount
+        self.sourceCount = sourceCount
+        self.hashCount = hashCount
+        self.sourcePreviewLabels = sourcePreviewLabels
+        self.packagePreviewLabels = packagePreviewLabels
+        self.byteSizeLabel = byteSizeLabel
+    }
+}
+
 public struct ToolArtifactPNPMLockfilePreview: Codable, Sendable, Hashable {
     public var lockfileVersion: String?
     public var importerCount: Int
@@ -2983,6 +3042,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var pipfileLockPreview: ToolArtifactPipfileLockPreview? {
         ToolArtifactPipfileLockPreviewBuilder.pipfileLockPreview(for: value, kind: kind)
+    }
+    public var uvLockPreview: ToolArtifactUVLockPreview? {
+        ToolArtifactUVLockPreviewBuilder.uvLockPreview(for: value, kind: kind)
     }
     public var pnpmLockfilePreview: ToolArtifactPNPMLockfilePreview? {
         ToolArtifactPNPMLockfilePreviewBuilder.pnpmLockfilePreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDocumentPreviewBuilder.swift
@@ -46,6 +46,9 @@ enum ToolArtifactDocumentPreviewBuilder {
         if filename == "pipfile.lock" {
             return "pipfile-lock"
         }
+        if filename == "uv.lock" {
+            return "uv-lock"
+        }
         if filename == "package.resolved" {
             return "spm"
         }
@@ -92,6 +95,7 @@ enum ToolArtifactDocumentPreviewBuilder {
         "requirements": .data,
         "poetry-lock": .data,
         "pipfile-lock": .data,
+        "uv-lock": .data,
         "ndjson": .data,
         "sarif": .data,
         "cfg": .data,

--- a/Sources/QuillCodeApp/ToolArtifactTextPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactTextPreviewBuilder.swift
@@ -177,7 +177,8 @@ enum ToolArtifactTextPreviewBuilder {
         "workspace",
         "workspace.bazel",
         "yarn.lock",
-        "pnpm-lock.yaml"
+        "pnpm-lock.yaml",
+        "uv.lock"
     ]
     private static let filenameLabels: [String: String] = [
         ".gitignore": "Git ignore",
@@ -237,7 +238,8 @@ enum ToolArtifactTextPreviewBuilder {
         "workspace": "Bazel workspace",
         "workspace.bazel": "Bazel workspace",
         "yarn.lock": "Yarn lockfile",
-        "pnpm-lock.yaml": "pnpm lockfile"
+        "pnpm-lock.yaml": "pnpm lockfile",
+        "uv.lock": "uv lockfile"
     ]
     private static let extensions: Set<String> = [
         "astro",

--- a/Sources/QuillCodeApp/ToolArtifactUVLockPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactUVLockPreviewBuilder.swift
@@ -1,0 +1,281 @@
+import Foundation
+
+enum ToolArtifactUVLockPreviewBuilder {
+    static func uvLockPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactUVLockPreview? {
+        guard kind == .file,
+              let fileURL = localArtifactFileURL(for: value),
+              fileURL.lastPathComponent.lowercased() == "uv.lock"
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+            let packages = packageRecords(from: text)
+            guard !packages.isEmpty else { return nil }
+            let preview = preview(
+                from: packages,
+                rootPythonRequirement: rootPythonRequirement(from: text),
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from packages: [PackageRecord],
+        rootPythonRequirement: String?,
+        byteSizeLabel: String?
+    ) -> ToolArtifactUVLockPreview {
+        let sourceLabels = sourcePreviewLabels(from: packages)
+        return ToolArtifactUVLockPreview(
+            pythonRequirement: rootPythonRequirement,
+            packageCount: packages.count,
+            versionedPackageCount: packages.filter { $0.version != nil }.count,
+            dependencyCount: packages.reduce(0) { $0 + $1.dependencyCount },
+            sourceCount: sourceLabels.count,
+            hashCount: packages.reduce(0) { $0 + $1.hashCount },
+            sourcePreviewLabels: sourceLabels,
+            packagePreviewLabels: Array(packages.prefix(previewLabelLimit)).map(\.label),
+            byteSizeLabel: byteSizeLabel
+        )
+    }
+
+    private static func packageRecords(from text: String) -> [PackageRecord] {
+        var packages: [PackageRecord] = []
+        var current = PartialPackage()
+        var insidePackage = false
+        var insideDependencyList = false
+
+        func flushCurrentPackage() {
+            guard let package = current.packageRecord else {
+                current = PartialPackage()
+                return
+            }
+            packages.append(package)
+            current = PartialPackage()
+        }
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+            if line == "[[package]]" {
+                if insidePackage {
+                    flushCurrentPackage()
+                }
+                insidePackage = true
+                insideDependencyList = false
+                continue
+            }
+            if line.hasPrefix("[") {
+                insideDependencyList = false
+                continue
+            }
+            guard insidePackage else {
+                continue
+            }
+            current.addHashCount(from: line)
+            if insideDependencyList {
+                current.addDependencyNameReferences(from: line)
+                if line.contains("]") {
+                    insideDependencyList = false
+                }
+            } else if line.hasPrefix("dependencies") {
+                current.addDependencyCount(from: line)
+                insideDependencyList = line.contains("[") && !line.contains("]")
+            }
+            current.addSourceLabel(from: line)
+            guard let assignment = assignment(from: line) else { continue }
+            current.set(value: assignment.value, for: assignment.key)
+        }
+        flushCurrentPackage()
+
+        return packages.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private static func rootPythonRequirement(from text: String) -> String? {
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            guard let assignment = assignment(from: line),
+                  assignment.key == "requires-python"
+            else {
+                continue
+            }
+            return unquoted(assignment.value)
+        }
+        return nil
+    }
+
+    private static func assignment(from line: String) -> (key: String, value: String)? {
+        guard let separator = line.firstIndex(of: "=") else { return nil }
+        let key = line[..<separator].trimmingCharacters(in: .whitespaces)
+        let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+        guard trackedKeys.contains(String(key)), !value.isEmpty else { return nil }
+        return (String(key), String(value))
+    }
+
+    private static func sourcePreviewLabels(from packages: [PackageRecord]) -> [String] {
+        var labels: [String] = []
+        var seen = Set<String>()
+        for package in packages {
+            for label in package.sourceLabels where labels.count < previewLabelLimit && !seen.contains(label) {
+                seen.insert(label)
+                labels.append(label)
+            }
+        }
+        return labels
+    }
+
+    private static func hosts(in value: String) -> [String] {
+        value
+            .split { $0.isWhitespace || $0 == "," || $0 == "}" || $0 == "]" }
+            .compactMap { token in
+                var text = String(token).trimmingCharacters(in: CharacterSet(charactersIn: "\\\",'()[]{}<>"))
+                if text.lowercased().hasPrefix("git+") {
+                    text.removeFirst(4)
+                }
+                guard text.hasPrefix("http://") || text.hasPrefix("https://"),
+                      let host = URL(string: text)?.host?.lowercased()
+                else {
+                    return nil
+                }
+                return sanitizedLabel(host)
+            }
+    }
+
+    private static func unquoted(_ value: String) -> String {
+        var text = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.hasPrefix("\""), text.hasSuffix("\""), text.count >= 2 {
+            text.removeFirst()
+            text.removeLast()
+        }
+        return sanitizedLabel(text)
+    }
+
+    private static func dependencyCount(in value: String) -> Int {
+        let quotedNames = (try? NSRegularExpression(pattern: #"name\s*=\s*"[^"]+""#))
+            .map { regex in
+                regex.numberOfMatches(
+                    in: value,
+                    range: NSRange(value.startIndex..., in: value)
+                )
+            } ?? 0
+        if quotedNames > 0 {
+            return quotedNames
+        }
+        return value.components(separatedBy: "{").count - 1
+    }
+
+    private static func hashCount(in value: String) -> Int {
+        value.components(separatedBy: "hash =").count - 1
+            + value.components(separatedBy: "\"hash\"").count - 1
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private struct PartialPackage {
+        var name: String?
+        var version: String?
+        var sourceLabels: [String] = []
+        var dependencyCount = 0
+        var hashCount = 0
+
+        mutating func set(value: String, for key: String) {
+            switch key {
+            case "name":
+                name = ToolArtifactUVLockPreviewBuilder.unquoted(value)
+            case "version":
+                version = ToolArtifactUVLockPreviewBuilder.unquoted(value)
+            case "source", "sdist", "wheels":
+                addSourceLabel(from: value)
+            case "dependencies":
+                break
+            default:
+                break
+            }
+        }
+
+        mutating func addSourceLabel(from line: String) {
+            for label in ToolArtifactUVLockPreviewBuilder.hosts(in: line) where !sourceLabels.contains(label) {
+                sourceLabels.append(label)
+            }
+        }
+
+        mutating func addDependencyCount(from line: String) {
+            guard line.hasPrefix("dependencies") else { return }
+            dependencyCount += ToolArtifactUVLockPreviewBuilder.dependencyCount(in: line)
+        }
+
+        mutating func addDependencyNameReferences(from line: String) {
+            dependencyCount += ToolArtifactUVLockPreviewBuilder.dependencyCount(in: line)
+        }
+
+        mutating func addHashCount(from line: String) {
+            hashCount += ToolArtifactUVLockPreviewBuilder.hashCount(in: line)
+        }
+
+        var packageRecord: PackageRecord? {
+            guard let name, !name.isEmpty else { return nil }
+            return PackageRecord(
+                name: name,
+                version: version,
+                sourceLabels: sourceLabels,
+                dependencyCount: dependencyCount,
+                hashCount: hashCount
+            )
+        }
+    }
+
+    private struct PackageRecord {
+        var name: String
+        var version: String?
+        var sourceLabels: [String]
+        var dependencyCount: Int
+        var hashCount: Int
+
+        var label: String {
+            ToolArtifactUVLockPreviewBuilder.sanitizedLabel(version.map { "\(name)@\($0)" } ?? name)
+        }
+    }
+
+    private static let trackedKeys: Set<String> = [
+        "name",
+        "version",
+        "requires-python",
+        "source",
+        "dependencies",
+        "sdist",
+        "wheels"
+    ]
+    private static let byteLimit = 512 * 1_024
+    private static let previewLabelLimit = 6
+    private static let characterLimit = 120
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -229,6 +229,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let poetryLockPreview = renderPoetryLockPreview(artifact.poetryLockPreview)
             let pipfileLockPreviewModel = artifact.pipfileLockPreview
             let pipfileLockPreview = renderPipfileLockPreview(pipfileLockPreviewModel)
+            let uvLockPreviewModel = artifact.uvLockPreview
+            let uvLockPreview = renderUVLockPreview(uvLockPreviewModel)
             let pnpmLockfilePreviewModel = artifact.pnpmLockfilePreview
             let pnpmLockfilePreview = renderPNPMLockfilePreview(pnpmLockfilePreviewModel)
             let swiftPMPackageResolvedPreviewModel = artifact.swiftPMPackageResolvedPreview
@@ -247,7 +249,9 @@ enum WorkspaceHTMLToolCardRenderer {
             let goCoveragePreview = renderGoCoveragePreview(artifact.goCoveragePreview)
             let sarifPreview = renderSARIFPreview(artifact.sarifPreview)
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
-            let tomlPreview = renderTOMLPreview(artifact.tomlPreview)
+            let tomlPreview = uvLockPreviewModel == nil
+                ? renderTOMLPreview(artifact.tomlPreview)
+                : ""
             let iniPreview = renderINIPreview(artifact.iniPreview)
             let dotenvPreview = renderDotenvPreview(artifact.dotenvPreview)
             let yamlPreview = pnpmLockfilePreviewModel == nil
@@ -324,6 +328,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(pythonRequirementsPreview)
               \(poetryLockPreview)
               \(pipfileLockPreview)
+              \(uvLockPreview)
               \(pnpmLockfilePreview)
               \(swiftPMPackageResolvedPreview)
               \(yarnLockfilePreview)
@@ -981,6 +986,41 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !packageList.isEmpty || !sourceList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-pipfile-lock-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(sourceList)
+        </div>
+        """
+    }
+
+    private static func renderUVLockPreview(_ preview: ToolArtifactUVLockPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-uv-lock-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-uv-lock-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let sources = preview.sourcePreviewLabels.map {
+            #"<li data-testid="tool-card-uv-lock-preview-source-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-uv-lock-preview-packages">
+                <strong data-testid="tool-card-uv-lock-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let sourceList = sources.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-uv-lock-preview-sources">
+                <strong data-testid="tool-card-uv-lock-preview-source-title">Sources</strong>
+                <ul>\(sources)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !sourceList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-uv-lock-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -1161,6 +1161,83 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePipfileLock.pipfileLockPreview)
     }
 
+    func testArtifactStateDerivesUVLockPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("uv.lock")
+        let lockText = """
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "anyio"
+        version = "4.7.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/anyio.tar.gz", hash = "sha256:aaa" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/anyio.whl", hash = "sha256:bbb" },
+            { url = "https://files.pythonhosted.org/packages/anyio-py3-none-any.whl", hash = "sha256:ccc" },
+        ]
+
+        [[package]]
+        name = "idna"
+        version = "3.10"
+        source = { registry = "https://pypi.org/simple" }
+
+        [[package]]
+        name = "quillcode"
+        source = { git = "git+https://github.com/Lore-Hex/QuillCode.git" }
+        """
+        try lockText.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.uvLockPreview)
+        let byteSizeLabel = try XCTUnwrap(
+            ToolArtifactByteSizeFormatter.label(for: XCTUnwrap(lockText.data(using: .utf8)).count)
+        )
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "UV-LOCK")
+        XCTAssertEqual(preview.pythonRequirement, ">=3.12")
+        XCTAssertEqual(preview.packageCount, 3)
+        XCTAssertEqual(preview.versionedPackageCount, 2)
+        XCTAssertEqual(preview.dependencyCount, 2)
+        XCTAssertEqual(preview.sourceCount, 3)
+        XCTAssertEqual(preview.hashCount, 3)
+        XCTAssertEqual(preview.sourcePreviewLabels, [
+            "pypi.org",
+            "files.pythonhosted.org",
+            "github.com"
+        ])
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "anyio@4.7.0",
+            "idna@3.10",
+            "quillcode"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: uv lockfile",
+            "Python: >=3.12",
+            "3 packages",
+            "2 versioned",
+            "2 dependencies",
+            "3 sources",
+            "3 hashes",
+            "Size: \(byteSizeLabel)"
+        ])
+
+        let notUVLock = directory.appendingPathComponent("uv.toml")
+        try lockText.write(to: notUVLock, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: notUVLock.path).uvLockPreview)
+
+        let remoteUVLock = ToolArtifactState(value: "https://example.com/uv.lock")
+        XCTAssertNil(remoteUVLock.uvLockPreview)
+    }
+
     func testArtifactStateDerivesCycloneDXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bom.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -1280,6 +1280,69 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesUVLockArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("uv.lock")
+        try """
+        version = 1
+        requires-python = ">=3.12"
+
+        [[package]]
+        name = "anyio"
+        version = "4.7.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/anyio.tar.gz", hash = "sha256:aaa" }
+
+        [[package]]
+        name = "idna"
+        version = "3.10"
+        source = { registry = "https://pypi.org/simple" }
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"uv.lock"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote uv.lock\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "uv lock artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · UV-LOCK"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">uv.lock"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-meta">Format: uv lockfile"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-meta">Python: &gt;=3.12"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-meta">2 packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-meta">2 versioned"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-meta">1 dependency"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-meta">2 sources"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-meta">1 hash"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-package-item">anyio@4.7.0"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-package-item">idna@3.10"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-source-item">pypi.org"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-uv-lock-preview-source-item">files.pythonhosted.org"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-label">uv.lock"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-toml-preview""#))
+    }
+
     func testHTMLRendererIncludesCycloneDXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("bom.json")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -115,6 +115,10 @@
   default/develop/pinned/editable/source/hash counts, file size, capped package labels, and capped
   source labels without expanding dependency graphs, validating hashes, reading package metadata, or
   fetching package indexes/distributions.
+- Artifact previews now include bounded local uv lockfile metadata for `uv.lock` files:
+  Python requirement, package/version/dependency/source/hash counts, file size, capped package labels,
+  and capped source labels without expanding dependency graphs, validating hashes, reading package
+  metadata, or fetching package indexes/distributions.
 - Artifact previews now include bounded local pnpm lockfile metadata for `pnpm-lock.yaml` files:
   lockfile version, importer/package/dependency/integrity counts, file size, capped importer labels,
   capped package labels, and capped resolved registry hosts without expanding dependency graphs,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2662,3 +2662,25 @@
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPipfileLockArtifactPreview` covers
   static HTML selectors, rendered Pipfile metadata, package/source lists, generic JSON suppression,
   and text-preview coexistence.
+
+## 2026-07-19: uv.lock artifacts render bounded Python lockfile summaries
+
+- **Decision:** Local `uv.lock` artifacts render as structured uv lockfile cards. The preview shows
+  root Python requirement, package, versioned-package, dependency, source, and hash counts, file size,
+  capped package labels, and capped source labels. `uv.lock` is classified as a data artifact through
+  filename-specific detection.
+- **Why:** uv is increasingly common in Python projects, and coding-agent dependency changes often
+  produce `uv.lock` as the main review artifact. A bounded dependency/source/hash summary keeps the
+  impact visible without rendering raw TOML-like lockfile content first.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, filename-gated to
+  `uv.lock`, and capped at 512 KB. It reads only the root `requires-python`, shallow `[[package]]`
+  sections, package `name`/`version`, inline dependency entries, source URLs, and hash markers; it
+  never expands dependency graphs, validates hashes, reads package metadata, contacts package
+  indexes, or fetches distributions. Generic TOML rendering is suppressed only after the uv lockfile
+  shape validates.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesUVLockPreviewMetadata` covers
+  filename-based document classification, Python requirement, package/version/dependency/source/hash
+  counts, package labels, source labels, non-`uv.lock` exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesUVLockArtifactPreview` covers static
+  HTML selectors, rendered uv metadata, package/source lists, generic TOML suppression, and
+  text-preview coexistence.


### PR DESCRIPTION
## Summary
- add bounded local uv.lock metadata previews for native and HTML tool cards
- classify uv.lock artifacts as UV-LOCK data documents while keeping text previews
- document the preview boundary and parity matrix coverage

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check