### PR TITLE
Add ESLint JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -71,6 +71,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pytestJSONContent(pytestJSONPreview)
         } else if let jestJSONPreview = artifact.jestJSONPreview {
             jestJSONContent(jestJSONPreview)
+        } else if let eslintJSONPreview = artifact.eslintJSONPreview {
+            eslintJSONContent(eslintJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -313,6 +315,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(jestJSONPreview.metadataLines)
             artifactContentList(title: "Failures", labels: jestJSONPreview.failurePreviewLabels)
+        }
+    }
+
+    private func eslintJSONContent(_ eslintJSONPreview: ToolArtifactESLintJSONPreview) -> some View {
+        let hasLists = !eslintJSONPreview.filePreviewLabels.isEmpty || !eslintJSONPreview.rulePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(eslintJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: eslintJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Rules", labels: eslintJSONPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1748,6 +1748,63 @@ public struct ToolArtifactJestJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactESLintJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var fileCount: Int
+    public var messageCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var fixableCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(messageCount) message\(messageCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            fixableCount > 0 ? "Fixable: \(fixableCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        fileCount > 0
+            || messageCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || fixableCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "ESLint JSON",
+        fileCount: Int,
+        messageCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        fixableCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.fileCount = fileCount
+        self.messageCount = messageCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.fixableCount = fixableCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3253,7 +3310,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
         ToolArtifactTablePreviewBuilder.tablePreview(for: value, kind: kind)
     }
     public var jsonPreview: ToolArtifactJSONPreview? {
-        ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
+        guard eslintJSONPreview == nil else { return nil }
+        return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
     public var npmLockfilePreview: ToolArtifactNPMLockfilePreview? {
         ToolArtifactNPMLockfilePreviewBuilder.npmLockfilePreview(for: value, kind: kind)
@@ -3317,6 +3375,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var jestJSONPreview: ToolArtifactJestJSONPreview? {
         ToolArtifactJestJSONPreviewBuilder.jestJSONPreview(for: value, kind: kind)
+    }
+    public var eslintJSONPreview: ToolArtifactESLintJSONPreview? {
+        ToolArtifactESLintJSONPreviewBuilder.eslintJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactESLintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactESLintJSONPreviewBuilder.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+enum ToolArtifactESLintJSONPreviewBuilder {
+    static func eslintJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactESLintJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let results = root as? [[String: Any]] else { return nil }
+            return preview(
+                from: results,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from results: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactESLintJSONPreview? {
+        guard !results.isEmpty, results.allSatisfy(hasESLintResultShape) else { return nil }
+
+        var messageCount = 0
+        var errorCount = 0
+        var warningCount = 0
+        var fixableCount = 0
+        var fileLabels: [String] = []
+        var ruleLabels: [String] = []
+
+        for result in results {
+            if let filePath = stringValue(result["filePath"]) {
+                appendUnique(sanitizedPathLabel(filePath), to: &fileLabels, limit: previewLimit)
+            }
+            let messages = result["messages"] as? [[String: Any]] ?? []
+            messageCount += messages.count
+            errorCount += intValue(result["errorCount"]) ?? messages.filter { severityValue($0["severity"]) == 2 }.count
+            warningCount += intValue(result["warningCount"]) ?? messages.filter { severityValue($0["severity"]) == 1 }.count
+            let explicitFixableCount = (intValue(result["fixableErrorCount"]) ?? 0)
+                + (intValue(result["fixableWarningCount"]) ?? 0)
+            fixableCount += explicitFixableCount > 0
+                ? explicitFixableCount
+                : messages.filter { $0["fix"] != nil }.count
+            for message in messages {
+                guard let ruleID = stringValue(message["ruleId"]) else { continue }
+                appendUnique(sanitizedLabel(ruleID), to: &ruleLabels, limit: previewLimit)
+            }
+        }
+
+        guard messageCount > 0
+                || errorCount > 0
+                || warningCount > 0
+                || !fileLabels.isEmpty
+        else { return nil }
+
+        return ToolArtifactESLintJSONPreview(
+            fileCount: results.count,
+            messageCount: messageCount,
+            errorCount: errorCount,
+            warningCount: warningCount,
+            fixableCount: fixableCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            rulePreviewLabels: ruleLabels
+        )
+    }
+
+    private static func hasESLintResultShape(_ result: [String: Any]) -> Bool {
+        guard stringValue(result["filePath"]) != nil,
+              result["messages"] is [[String: Any]]
+        else {
+            return false
+        }
+        return result.keys.contains("errorCount")
+            || result.keys.contains("warningCount")
+            || result.keys.contains("fixableErrorCount")
+            || result.keys.contains("fixableWarningCount")
+            || !(result["messages"] as? [[String: Any]] ?? []).isEmpty
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func severityValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -220,6 +220,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
             let jestJSONPreviewModel = artifact.jestJSONPreview
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
+            let eslintJSONPreviewModel = artifact.eslintJSONPreview
+            let eslintJSONPreview = renderESLintJSONPreview(eslintJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -294,6 +296,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && coveragePyPreviewModel == nil
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
+                && eslintJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -330,6 +333,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(coveragePyPreview)
               \(pytestJSONPreview)
               \(jestJSONPreview)
+              \(eslintJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -793,6 +797,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderESLintJSONPreview(_ preview: ToolArtifactESLintJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-eslint-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-eslint-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-eslint-json-preview-files">
+                <strong data-testid="tool-card-eslint-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-eslint-json-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let ruleList = rules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-eslint-json-preview-rules">
+                <strong data-testid="tool-card-eslint-json-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-eslint-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(ruleList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2749,6 +2749,89 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJest.jestJSONPreview)
     }
 
+    func testArtifactStateDerivesESLintJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("eslint-results.json")
+        let content = """
+        [
+          {
+            "filePath": "/repo/Sources/App.ts",
+            "messages": [
+              {
+                "ruleId": "no-console",
+                "severity": 1,
+                "message": "Unexpected console statement.",
+                "fix": {"range": [10, 20], "text": ""}
+              },
+              {
+                "ruleId": "@typescript-eslint/no-floating-promises",
+                "severity": 2,
+                "message": "Promise must be handled."
+              }
+            ],
+            "errorCount": 1,
+            "warningCount": 1,
+            "fixableErrorCount": 0,
+            "fixableWarningCount": 1
+          },
+          {
+            "filePath": "/repo/Tests/App.test.ts",
+            "messages": [
+              {
+                "ruleId": "testing-library/no-debugging-utils",
+                "severity": 1,
+                "message": "Unexpected debug utility."
+              }
+            ],
+            "errorCount": 0,
+            "warningCount": 1,
+            "fixableErrorCount": 0,
+            "fixableWarningCount": 0
+          }
+        ]
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.eslintJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "ESLint JSON")
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.messageCount, 3)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 2)
+        XCTAssertEqual(preview.fixableCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/Sources/App.ts",
+            "repo/Tests/App.test.ts"
+        ])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "no-console",
+            "@typescript-eslint/no-floating-promises",
+            "testing-library/no-debugging-utils"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: ESLint JSON",
+            "2 files",
+            "3 messages",
+            "Errors: 1",
+            "Warnings: 2",
+            "Fixable: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"[{"filePath":"/repo/file.ts","status":"ok"}]"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).eslintJSONPreview)
+
+        let remoteESLint = ToolArtifactState(value: "https://example.com/eslint-results.json")
+        XCTAssertNil(remoteESLint.eslintJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2006,6 +2006,68 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesESLintJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("eslint-results.json")
+        let reportText = """
+        [
+          {
+            "filePath": "/repo/Sources/App.ts",
+            "messages": [
+              {"ruleId": "no-console", "severity": 1, "message": "Unexpected console statement."},
+              {"ruleId": "@typescript-eslint/no-floating-promises", "severity": 2, "message": "Promise must be handled."}
+            ],
+            "errorCount": 1,
+            "warningCount": 1,
+            "fixableErrorCount": 0,
+            "fixableWarningCount": 0
+          }
+        ]
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/eslint-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/eslint-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "ESLint artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">eslint-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-meta">Format: ESLint JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-meta">1 file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-meta">2 messages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-file-item">repo/Sources/App.ts"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-rule-item">no-console"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-eslint-json-preview-rule-item">@typescript-eslint/no-floating-promises"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -201,6 +201,10 @@
   files with Jest-compatible `numTotalTests`/`testResults` shape: result, runtime, test/suite
   counts, file size, and capped failing assertion labels without expanding failure messages or
   fetching remote JSON.
+- Artifact previews now include bounded local ESLint JSON report metadata for `.json` files whose
+  root validates as ESLint formatter output: file/message/error/warning/fixable counts, file size,
+  capped file labels, and capped rule labels without reading source files, loading lint rules, or
+  fetching remote JSON.
 - Artifact previews now include bounded local TAP report metadata for `.tap` files: plan, assertion
   counts, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing assertion labels
   without expanding diagnostics or fetching remote reports.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render ESLint JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as ESLint formatter output as a
+  specialized lint report artifact instead of falling back to generic JSON metadata.
+- **Rationale:** Codex-style coding sessions often generate lint reports. A bounded report card with
+  file/message/error/warning/fixable counts and capped file/rule labels is more useful than raw
+  top-level JSON keys while avoiding source-file reads, plugin/rule loading, or network lookups.
+- **Constraints:** Only local regular files under 512 KB are parsed; remote URLs, generic JSON
+  arrays, binary data, and non-ESLint shapes fall back to existing artifact handling.
+
 ## 2026-07-17: MCP run input aliases are compatible but fail closed
 
 - **Compatibility boundary:** The public `codex` MCP tool accepts and advertises Codex-style


### PR DESCRIPTION
## Summary
- add a bounded local ESLint JSON artifact preview for .json files matching ESLint formatter output
- render file/message/error/warning/fixable counts plus capped file and rule labels in SwiftUI and the HTML harness
- document the artifact-preview decision and parity matrix progress

## Validation
- swift test --filter testArtifactStateDerivesESLintJSONPreviewMetadata
- swift test --filter testHTMLRendererIncludesESLintJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check