### PR TITLE
Add Stylelint JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -73,6 +73,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             jestJSONContent(jestJSONPreview)
         } else if let eslintJSONPreview = artifact.eslintJSONPreview {
             eslintJSONContent(eslintJSONPreview)
+        } else if let stylelintJSONPreview = artifact.stylelintJSONPreview {
+            stylelintJSONContent(stylelintJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -331,6 +333,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(eslintJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: eslintJSONPreview.filePreviewLabels)
             artifactContentList(title: "Rules", labels: eslintJSONPreview.rulePreviewLabels)
+        }
+    }
+
+    private func stylelintJSONContent(_ stylelintJSONPreview: ToolArtifactStylelintJSONPreview) -> some View {
+        let hasLists = !stylelintJSONPreview.sourcePreviewLabels.isEmpty || !stylelintJSONPreview.rulePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(stylelintJSONPreview.metadataLines)
+            artifactContentList(title: "Sources", labels: stylelintJSONPreview.sourcePreviewLabels)
+            artifactContentList(title: "Rules", labels: stylelintJSONPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1805,6 +1805,68 @@ public struct ToolArtifactESLintJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactStylelintJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var fileCount: Int
+    public var warningCount: Int
+    public var errorCount: Int
+    public var parseErrorCount: Int
+    public var deprecationCount: Int
+    public var invalidOptionWarningCount: Int
+    public var byteSizeLabel: String?
+    public var sourcePreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            parseErrorCount > 0 ? "Parse errors: \(parseErrorCount)" : nil,
+            deprecationCount > 0 ? "Deprecations: \(deprecationCount)" : nil,
+            invalidOptionWarningCount > 0 ? "Invalid options: \(invalidOptionWarningCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        fileCount > 0
+            || warningCount > 0
+            || errorCount > 0
+            || parseErrorCount > 0
+            || deprecationCount > 0
+            || invalidOptionWarningCount > 0
+            || byteSizeLabel != nil
+            || !sourcePreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Stylelint JSON",
+        fileCount: Int,
+        warningCount: Int = 0,
+        errorCount: Int = 0,
+        parseErrorCount: Int = 0,
+        deprecationCount: Int = 0,
+        invalidOptionWarningCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        sourcePreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.fileCount = fileCount
+        self.warningCount = warningCount
+        self.errorCount = errorCount
+        self.parseErrorCount = parseErrorCount
+        self.deprecationCount = deprecationCount
+        self.invalidOptionWarningCount = invalidOptionWarningCount
+        self.byteSizeLabel = byteSizeLabel
+        self.sourcePreviewLabels = sourcePreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3310,7 +3372,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
         ToolArtifactTablePreviewBuilder.tablePreview(for: value, kind: kind)
     }
     public var jsonPreview: ToolArtifactJSONPreview? {
-        guard eslintJSONPreview == nil else { return nil }
+        guard eslintJSONPreview == nil,
+              stylelintJSONPreview == nil
+        else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
     public var npmLockfilePreview: ToolArtifactNPMLockfilePreview? {
@@ -3378,6 +3442,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var eslintJSONPreview: ToolArtifactESLintJSONPreview? {
         ToolArtifactESLintJSONPreviewBuilder.eslintJSONPreview(for: value, kind: kind)
+    }
+    public var stylelintJSONPreview: ToolArtifactStylelintJSONPreview? {
+        ToolArtifactStylelintJSONPreviewBuilder.stylelintJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactStylelintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactStylelintJSONPreviewBuilder.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+enum ToolArtifactStylelintJSONPreviewBuilder {
+    static func stylelintJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactStylelintJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let results = root as? [[String: Any]] else { return nil }
+            return preview(
+                from: results,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from results: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactStylelintJSONPreview? {
+        guard !results.isEmpty, results.allSatisfy(hasStylelintResultShape) else { return nil }
+
+        var warningCount = 0
+        var errorCount = 0
+        var parseErrorCount = 0
+        var deprecationCount = 0
+        var invalidOptionWarningCount = 0
+        var sourceLabels: [String] = []
+        var ruleLabels: [String] = []
+
+        for result in results {
+            if let source = stringValue(result["source"]) {
+                appendUnique(sanitizedPathLabel(source), to: &sourceLabels, limit: previewLimit)
+            }
+
+            let warnings = result["warnings"] as? [[String: Any]] ?? []
+            warningCount += warnings.count
+            errorCount += warnings.filter { stringValue($0["severity"])?.lowercased() == "error" }.count
+            parseErrorCount += (result["parseErrors"] as? [[String: Any]] ?? []).count
+            deprecationCount += (result["deprecations"] as? [[String: Any]] ?? []).count
+            invalidOptionWarningCount += (result["invalidOptionWarnings"] as? [[String: Any]] ?? []).count
+
+            for warning in warnings {
+                guard let rule = stringValue(warning["rule"]) else { continue }
+                appendUnique(sanitizedLabel(rule), to: &ruleLabels, limit: previewLimit)
+            }
+        }
+
+        return ToolArtifactStylelintJSONPreview(
+            fileCount: results.count,
+            warningCount: warningCount,
+            errorCount: errorCount,
+            parseErrorCount: parseErrorCount,
+            deprecationCount: deprecationCount,
+            invalidOptionWarningCount: invalidOptionWarningCount,
+            byteSizeLabel: byteSizeLabel,
+            sourcePreviewLabels: sourceLabels,
+            rulePreviewLabels: ruleLabels
+        )
+    }
+
+    private static func hasStylelintResultShape(_ result: [String: Any]) -> Bool {
+        guard stringValue(result["source"]) != nil else { return false }
+        return result["warnings"] is [[String: Any]]
+            || result["parseErrors"] is [[String: Any]]
+            || result["deprecations"] is [[String: Any]]
+            || result["invalidOptionWarnings"] is [[String: Any]]
+            || result.keys.contains("errored")
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -222,6 +222,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
             let eslintJSONPreviewModel = artifact.eslintJSONPreview
             let eslintJSONPreview = renderESLintJSONPreview(eslintJSONPreviewModel)
+            let stylelintJSONPreviewModel = artifact.stylelintJSONPreview
+            let stylelintJSONPreview = renderStylelintJSONPreview(stylelintJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -297,6 +299,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
                 && eslintJSONPreviewModel == nil
+                && stylelintJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -334,6 +337,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(pytestJSONPreview)
               \(jestJSONPreview)
               \(eslintJSONPreview)
+              \(stylelintJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -831,6 +835,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(fileList)
+          \(ruleList)
+        </div>
+        """
+    }
+
+    private static func renderStylelintJSONPreview(_ preview: ToolArtifactStylelintJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-stylelint-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let sources = preview.sourcePreviewLabels.map {
+            #"<li data-testid="tool-card-stylelint-json-preview-source-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let sourceList = sources.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-stylelint-json-preview-sources">
+                <strong data-testid="tool-card-stylelint-json-preview-source-title">Sources</strong>
+                <ul>\(sources)</ul>
+              </section>
+        """
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-stylelint-json-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let ruleList = rules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-stylelint-json-preview-rules">
+                <strong data-testid="tool-card-stylelint-json-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !sourceList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-stylelint-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(sourceList)
           \(ruleList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2832,6 +2832,90 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteESLint.eslintJSONPreview)
     }
 
+    func testArtifactStateDerivesStylelintJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("stylelint-results.json")
+        let content = """
+        [
+          {
+            "source": "/repo/Sources/App.css",
+            "deprecations": [
+              {"text": "Deprecated rule"}
+            ],
+            "invalidOptionWarnings": [
+              {"text": "Invalid option"}
+            ],
+            "parseErrors": [],
+            "errored": true,
+            "warnings": [
+              {
+                "line": 1,
+                "column": 1,
+                "rule": "color-no-invalid-hex",
+                "severity": "error",
+                "text": "Unexpected invalid hex color"
+              },
+              {
+                "line": 2,
+                "column": 4,
+                "rule": "selector-class-pattern",
+                "severity": "warning",
+                "text": "Expected class selector to be kebab-case"
+              }
+            ]
+          },
+          {
+            "source": "/repo/Tests/fixtures/theme.css",
+            "parseErrors": [
+              {"text": "Unexpected token"}
+            ],
+            "warnings": []
+          }
+        ]
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.stylelintJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Stylelint JSON")
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.warningCount, 2)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.parseErrorCount, 1)
+        XCTAssertEqual(preview.deprecationCount, 1)
+        XCTAssertEqual(preview.invalidOptionWarningCount, 1)
+        XCTAssertEqual(preview.sourcePreviewLabels, [
+            "repo/Sources/App.css",
+            "Tests/fixtures/theme.css"
+        ])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "color-no-invalid-hex",
+            "selector-class-pattern"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Stylelint JSON",
+            "2 files",
+            "Warnings: 2",
+            "Errors: 1",
+            "Parse errors: 1",
+            "Deprecations: 1",
+            "Invalid options: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"[{"source":"/repo/file.css","status":"ok"}]"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).stylelintJSONPreview)
+
+        let remoteStylelint = ToolArtifactState(value: "https://example.com/stylelint-results.json")
+        XCTAssertNil(remoteStylelint.stylelintJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2068,6 +2068,69 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesStylelintJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("stylelint-results.json")
+        let reportText = """
+        [
+          {
+            "source": "/repo/Sources/App.css",
+            "deprecations": [{"text": "Deprecated rule"}],
+            "invalidOptionWarnings": [{"text": "Invalid option"}],
+            "parseErrors": [],
+            "errored": true,
+            "warnings": [
+              {"rule": "color-no-invalid-hex", "severity": "error", "text": "Unexpected invalid hex color"},
+              {"rule": "selector-class-pattern", "severity": "warning", "text": "Expected kebab-case"}
+            ]
+          }
+        ]
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/stylelint-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/stylelint-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Stylelint artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">stylelint-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-meta">Format: Stylelint JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-meta">1 file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-meta">Warnings: 2"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-meta">Deprecations: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-meta">Invalid options: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-source-title">Sources"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-source-item">repo/Sources/App.css"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-rule-item">color-no-invalid-hex"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-stylelint-json-preview-rule-item">selector-class-pattern"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -205,6 +205,10 @@
   root validates as ESLint formatter output: file/message/error/warning/fixable counts, file size,
   capped file labels, and capped rule labels without reading source files, loading lint rules, or
   fetching remote JSON.
+- Artifact previews now include bounded local Stylelint JSON report metadata for `.json` files whose
+  root validates as Stylelint formatter output: file/warning/error/parse-error/deprecation/invalid
+  option counts, file size, capped source labels, and capped rule labels without reading stylesheet
+  sources, loading plugins, or fetching remote JSON.
 - Artifact previews now include bounded local TAP report metadata for `.tap` files: plan, assertion
   counts, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing assertion labels
   without expanding diagnostics or fetching remote reports.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Stylelint JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Stylelint formatter output as a
+  specialized lint report artifact rather than generic JSON.
+- **Rationale:** Stylelint reports are common in frontend coding sessions and need the same compact
+  Codex-style artifact treatment as ESLint: source counts, warning/error severity, parse errors,
+  deprecations, invalid option warnings, and capped rule/source labels.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read the
+  referenced stylesheets, load Stylelint plugins, or fetch remote reports.
+
 ## 2026-07-19: Render ESLint JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as ESLint formatter output as a


### PR DESCRIPTION
## Summary
- add bounded local Stylelint JSON report artifact previews
- render file/warning/error/parse-error/deprecation/invalid-option counts plus capped source and rule labels in SwiftUI and HTML
- document the artifact-preview parity decision

## Validation
- swift test --filter testArtifactStateDerivesStylelintJSONPreviewMetadata
- swift test --filter testHTMLRendererIncludesStylelintJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check