### PR TITLE
Add Checkstyle XML artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -131,6 +131,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             yamlContent(yamlPreview)
         } else if let junitPreview = artifact.junitPreview {
             junitContent(junitPreview)
+        } else if let checkstylePreview = artifact.checkstylePreview {
+            checkstyleContent(checkstylePreview)
         } else if let trxPreview = artifact.trxPreview {
             trxContent(trxPreview)
         } else if let xunitPreview = artifact.xunitPreview {
@@ -804,6 +806,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(junitPreview.metadataLines)
             artifactContentList(title: "Suites", labels: junitPreview.suitePreviewLabels)
             artifactContentList(title: "Failing tests", labels: junitPreview.failurePreviewLabels)
+        }
+    }
+
+    private func checkstyleContent(_ checkstylePreview: ToolArtifactCheckstylePreview) -> some View {
+        previewSurface(minHeight: checkstylePreview.sourcePreviewLabels.isEmpty ? 92 : 142) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "exclamationmark.triangle")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(checkstylePreview.metadataLines)
+            artifactContentList(title: "Files", labels: checkstylePreview.filePreviewLabels)
+            artifactContentList(title: "Sources", labels: checkstylePreview.sourcePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2551,6 +2551,67 @@ public struct ToolArtifactJUnitPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactCheckstylePreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var fileCount: Int
+    public var issueCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var infoCount: Int
+    public var ignoreCount: Int
+    public var otherSeverityCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var sourcePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(issueCount) issue\(issueCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            infoCount > 0 ? "Info: \(infoCount)" : nil,
+            ignoreCount > 0 ? "Ignored: \(ignoreCount)" : nil,
+            otherSeverityCount > 0 ? "Other: \(otherSeverityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        fileCount > 0
+            || issueCount > 0
+            || !filePreviewLabels.isEmpty
+            || !sourcePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Checkstyle XML",
+        fileCount: Int,
+        issueCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        infoCount: Int = 0,
+        ignoreCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        sourcePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.fileCount = fileCount
+        self.issueCount = issueCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.infoCount = infoCount
+        self.ignoreCount = ignoreCount
+        self.otherSeverityCount = otherSeverityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.sourcePreviewLabels = sourcePreviewLabels
+    }
+}
+
 public struct ToolArtifactTRXPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var testRunName: String?
@@ -3482,6 +3543,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     public var junitPreview: ToolArtifactJUnitPreview? {
         ToolArtifactJUnitPreviewBuilder.junitPreview(for: value, kind: kind)
     }
+    public var checkstylePreview: ToolArtifactCheckstylePreview? {
+        ToolArtifactCheckstylePreviewBuilder.checkstylePreview(for: value, kind: kind)
+    }
     public var trxPreview: ToolArtifactTRXPreview? {
         ToolArtifactTRXPreviewBuilder.trxPreview(for: value, kind: kind)
     }
@@ -3501,7 +3565,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
         ToolArtifactJaCoCoPreviewBuilder.jaCoCoPreview(for: value, kind: kind)
     }
     public var xmlPreview: ToolArtifactXMLPreview? {
-        ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)
+        guard checkstylePreview == nil else { return nil }
+        return ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)
     }
     public var propertyListPreview: ToolArtifactPropertyListPreview? {
         ToolArtifactPropertyListPreviewBuilder.propertyListPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactCheckstylePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCheckstylePreviewBuilder.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+enum ToolArtifactCheckstylePreviewBuilder {
+    static func checkstylePreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactCheckstylePreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+
+            let collector = CheckstylePreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class CheckstylePreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var fileCount = 0
+    private var issueCount = 0
+    private var errorCount = 0
+    private var warningCount = 0
+    private var infoCount = 0
+    private var ignoreCount = 0
+    private var otherSeverityCount = 0
+    private var fileLabels: [String] = []
+    private var sourceLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = qualifiedElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+        }
+        if label == "file" {
+            recordFile(attributeDict)
+        } else if label == "error" {
+            recordIssue(attributeDict)
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactCheckstylePreview? {
+        guard rootElementLabel == "checkstyle",
+              fileCount > 0 || issueCount > 0
+        else {
+            return nil
+        }
+        return ToolArtifactCheckstylePreview(
+            fileCount: fileCount,
+            issueCount: issueCount,
+            errorCount: errorCount,
+            warningCount: warningCount,
+            infoCount: infoCount,
+            ignoreCount: ignoreCount,
+            otherSeverityCount: otherSeverityCount,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            filePreviewLabels: Array(fileLabels.prefix(previewLabelLimit)),
+            sourcePreviewLabels: Array(sourceLabels.prefix(previewLabelLimit))
+        )
+    }
+
+    private func recordFile(_ attributes: [String: String]) {
+        fileCount += 1
+        appendUnique(sanitizedPathLabel(attributes["name"]), to: &fileLabels)
+    }
+
+    private func recordIssue(_ attributes: [String: String]) {
+        issueCount += 1
+        switch sanitizedLabel(attributes["severity"])?.lowercased() {
+        case "error":
+            errorCount += 1
+        case "warning":
+            warningCount += 1
+        case "info":
+            infoCount += 1
+        case "ignore":
+            ignoreCount += 1
+        default:
+            otherSeverityCount += 1
+        }
+        appendUnique(sanitizedLabel(attributes["source"]), to: &sourceLabels)
+    }
+
+    private func appendUnique(_ label: String?, to labels: inout [String]) {
+        guard let label, !labels.contains(label) else { return }
+        labels.append(label)
+    }
+
+    private func sanitizedPathLabel(_ label: String?) -> String? {
+        guard let label = sanitizedLabel(label) else { return nil }
+        let components = label
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        guard components.count > 2 else { return label }
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func qualifiedElementName(elementName: String, qName: String?) -> String {
+        guard let qName, !qName.isEmpty else { return elementName }
+        return qName
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -269,6 +269,8 @@ enum WorkspaceHTMLToolCardRenderer {
                 : ""
             let junitPreviewModel = artifact.junitPreview
             let junitPreview = renderJUnitPreview(junitPreviewModel)
+            let checkstylePreviewModel = artifact.checkstylePreview
+            let checkstylePreview = renderCheckstylePreview(checkstylePreviewModel)
             let trxPreview = renderTRXPreview(artifact.trxPreview)
             let xunitPreviewModel = artifact.xunitPreview
             let xunitPreview = renderXUnitPreview(xunitPreviewModel)
@@ -281,6 +283,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jaCoCoPreviewModel = artifact.jaCoCoPreview
             let jaCoCoPreview = renderJaCoCoPreview(jaCoCoPreviewModel)
             let xmlPreview = junitPreviewModel == nil
+                && checkstylePreviewModel == nil
                 && xunitPreviewModel == nil
                 && nunitPreviewModel == nil
                 && coberturaPreviewModel == nil
@@ -366,6 +369,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(dotenvPreview)
               \(yamlPreview)
               \(junitPreview)
+              \(checkstylePreview)
               \(trxPreview)
               \(xunitPreview)
               \(nunitPreview)
@@ -1773,6 +1777,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(suiteList)
           \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderCheckstylePreview(_ preview: ToolArtifactCheckstylePreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-checkstyle-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-checkstyle-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let sources = preview.sourcePreviewLabels.map {
+            #"<li data-testid="tool-card-checkstyle-preview-source-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-checkstyle-preview-files">
+                <strong data-testid="tool-card-checkstyle-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let sourceList = sources.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-checkstyle-preview-sources">
+                <strong data-testid="tool-card-checkstyle-preview-source-title">Sources</strong>
+                <ul>\(sources)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !sourceList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-checkstyle-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(sourceList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3041,6 +3041,71 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJUnit.junitPreview)
     }
 
+    func testArtifactStateDerivesCheckstylePreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("checkstyle-result.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <checkstyle version="10.12.0">
+          <file name="/repo/Sources/App.swift">
+            <error line="12" column="5" severity="error" message="Use let" source="swiftlint:prefer_let" />
+            <error line="24" column="1" severity="warning" message="Line length" source="swiftlint:line_length" />
+          </file>
+          <file name="/repo/Tests/AppTests.swift">
+            <error line="4" severity="info" message="Todo" source="custom:todo" />
+            <error line="8" severity="ignore" message="Ignored" source="custom:ignore" />
+            <error line="9" severity="notice" message="Other" source="custom:notice" />
+          </file>
+        </checkstyle>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.checkstylePreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.formatLabel, "Checkstyle XML")
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.issueCount, 5)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 1)
+        XCTAssertEqual(preview.infoCount, 1)
+        XCTAssertEqual(preview.ignoreCount, 1)
+        XCTAssertEqual(preview.otherSeverityCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/Sources/App.swift",
+            "repo/Tests/AppTests.swift"
+        ])
+        XCTAssertEqual(preview.sourcePreviewLabels, [
+            "swiftlint:prefer_let",
+            "swiftlint:line_length",
+            "custom:todo",
+            "custom:ignore",
+            "custom:notice"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Checkstyle XML",
+            "2 files",
+            "5 issues",
+            "Errors: 1",
+            "Warnings: 1",
+            "Info: 1",
+            "Ignored: 1",
+            "Other: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.xmlPreview)
+
+        let generic = directory.appendingPathComponent("manifest.xml")
+        try "<project><target /></project>".write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).checkstylePreview)
+
+        let remoteCheckstyle = ToolArtifactState(value: "https://example.com/checkstyle-result.xml")
+        XCTAssertNil(remoteCheckstyle.checkstylePreview)
+    }
+
     func testArtifactStateDerivesTRXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("results.trx")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2865,6 +2865,59 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesCheckstyleArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("checkstyle-result.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <checkstyle version="10.12.0">
+          <file name="/repo/Sources/App.swift">
+            <error line="12" column="5" severity="error" message="Use let" source="swiftlint:prefer_let" />
+            <error line="24" column="1" severity="warning" message="Line length" source="swiftlint:line_length" />
+          </file>
+        </checkstyle>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"checkstyle-result.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote checkstyle-result.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Checkstyle artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">checkstyle-result.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-meta">Format: Checkstyle XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-meta">1 file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-meta">2 issues"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-file-item">repo/Sources/App.swift"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-source-title">Sources"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-source-item">swiftlint:prefer_let"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-checkstyle-preview-source-item">swiftlint:line_length"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesTRXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("results.trx")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -209,6 +209,10 @@
   root validates as Stylelint formatter output: file/warning/error/parse-error/deprecation/invalid
   option counts, file size, capped source labels, and capped rule labels without reading stylesheet
   sources, loading plugins, or fetching remote JSON.
+- Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
+  root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
+  and capped rule/source labels without reading source files, loading lint plugins, or fetching
+  remote reports.
 - Artifact previews now include bounded local TAP report metadata for `.tap` files: plan, assertion
   counts, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing assertion labels
   without expanding diagnostics or fetching remote reports.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Checkstyle XML As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.xml` files with a Checkstyle root as a specialized lint report
+  artifact rather than generic XML.
+- **Rationale:** Checkstyle XML is a common lint interchange format across Java, SwiftLint,
+  frontend tooling, and CI exports. A compact report card with file/issue/severity counts and
+  capped file/source labels is more useful than root-element metadata when reviewing tool output.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not open
+  referenced source files, load linter plugins, expand messages, or fetch remote reports.
+
 ## 2026-07-19: Render Stylelint JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as Stylelint formatter output as a


### PR DESCRIPTION
## Summary
- add bounded local Checkstyle XML artifact previews with file/issue/severity metadata
- render Checkstyle previews in native and HTML tool cards while suppressing generic XML fallback
- document the parity slice and decision rationale

## Validation
- swift test --filter testArtifactStateDerivesCheckstylePreviewMetadata
- swift test --filter testHTMLRendererIncludesCheckstyleArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check