### PR TITLE
Add PMD XML artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -133,6 +133,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             junitContent(junitPreview)
         } else if let checkstylePreview = artifact.checkstylePreview {
             checkstyleContent(checkstylePreview)
+        } else if let pmdPreview = artifact.pmdPreview {
+            pmdContent(pmdPreview)
         } else if let trxPreview = artifact.trxPreview {
             trxContent(trxPreview)
         } else if let xunitPreview = artifact.xunitPreview {
@@ -821,6 +823,21 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(checkstylePreview.metadataLines)
             artifactContentList(title: "Files", labels: checkstylePreview.filePreviewLabels)
             artifactContentList(title: "Sources", labels: checkstylePreview.sourcePreviewLabels)
+        }
+    }
+
+    private func pmdContent(_ pmdPreview: ToolArtifactPMDPreview) -> some View {
+        previewSurface(minHeight: pmdPreview.rulePreviewLabels.isEmpty ? 92 : 142) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "exclamationmark.triangle")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(pmdPreview.metadataLines)
+            artifactContentList(title: "Files", labels: pmdPreview.filePreviewLabels)
+            artifactContentList(title: "Rules", labels: pmdPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2612,6 +2612,71 @@ public struct ToolArtifactCheckstylePreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPMDPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var fileCount: Int
+    public var violationCount: Int
+    public var priorityOneCount: Int
+    public var priorityTwoCount: Int
+    public var priorityThreeCount: Int
+    public var priorityFourCount: Int
+    public var priorityFiveCount: Int
+    public var otherPriorityCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(violationCount) violation\(violationCount == 1 ? "" : "s")",
+            priorityOneCount > 0 ? "Priority 1: \(priorityOneCount)" : nil,
+            priorityTwoCount > 0 ? "Priority 2: \(priorityTwoCount)" : nil,
+            priorityThreeCount > 0 ? "Priority 3: \(priorityThreeCount)" : nil,
+            priorityFourCount > 0 ? "Priority 4: \(priorityFourCount)" : nil,
+            priorityFiveCount > 0 ? "Priority 5: \(priorityFiveCount)" : nil,
+            otherPriorityCount > 0 ? "Other priority: \(otherPriorityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        fileCount > 0
+            || violationCount > 0
+            || !filePreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "PMD XML",
+        fileCount: Int,
+        violationCount: Int,
+        priorityOneCount: Int = 0,
+        priorityTwoCount: Int = 0,
+        priorityThreeCount: Int = 0,
+        priorityFourCount: Int = 0,
+        priorityFiveCount: Int = 0,
+        otherPriorityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.fileCount = fileCount
+        self.violationCount = violationCount
+        self.priorityOneCount = priorityOneCount
+        self.priorityTwoCount = priorityTwoCount
+        self.priorityThreeCount = priorityThreeCount
+        self.priorityFourCount = priorityFourCount
+        self.priorityFiveCount = priorityFiveCount
+        self.otherPriorityCount = otherPriorityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactTRXPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var testRunName: String?
@@ -3546,6 +3611,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     public var checkstylePreview: ToolArtifactCheckstylePreview? {
         ToolArtifactCheckstylePreviewBuilder.checkstylePreview(for: value, kind: kind)
     }
+    public var pmdPreview: ToolArtifactPMDPreview? {
+        ToolArtifactPMDPreviewBuilder.pmdPreview(for: value, kind: kind)
+    }
     public var trxPreview: ToolArtifactTRXPreview? {
         ToolArtifactTRXPreviewBuilder.trxPreview(for: value, kind: kind)
     }
@@ -3565,7 +3633,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
         ToolArtifactJaCoCoPreviewBuilder.jaCoCoPreview(for: value, kind: kind)
     }
     public var xmlPreview: ToolArtifactXMLPreview? {
-        guard checkstylePreview == nil else { return nil }
+        guard checkstylePreview == nil,
+              pmdPreview == nil
+        else { return nil }
         return ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)
     }
     public var propertyListPreview: ToolArtifactPropertyListPreview? {

--- a/Sources/QuillCodeApp/ToolArtifactPMDPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPMDPreviewBuilder.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+enum ToolArtifactPMDPreviewBuilder {
+    static func pmdPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPMDPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+
+            let collector = PMDPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class PMDPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var fileCount = 0
+    private var violationCount = 0
+    private var priorityOneCount = 0
+    private var priorityTwoCount = 0
+    private var priorityThreeCount = 0
+    private var priorityFourCount = 0
+    private var priorityFiveCount = 0
+    private var otherPriorityCount = 0
+    private var fileLabels: [String] = []
+    private var ruleLabels: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = qualifiedElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+        }
+        if label == "file" {
+            recordFile(attributeDict)
+        } else if label == "violation" {
+            recordViolation(attributeDict)
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactPMDPreview? {
+        guard rootElementLabel == "pmd",
+              fileCount > 0 || violationCount > 0
+        else {
+            return nil
+        }
+        return ToolArtifactPMDPreview(
+            fileCount: fileCount,
+            violationCount: violationCount,
+            priorityOneCount: priorityOneCount,
+            priorityTwoCount: priorityTwoCount,
+            priorityThreeCount: priorityThreeCount,
+            priorityFourCount: priorityFourCount,
+            priorityFiveCount: priorityFiveCount,
+            otherPriorityCount: otherPriorityCount,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            filePreviewLabels: Array(fileLabels.prefix(previewLabelLimit)),
+            rulePreviewLabels: Array(ruleLabels.prefix(previewLabelLimit))
+        )
+    }
+
+    private func recordFile(_ attributes: [String: String]) {
+        fileCount += 1
+        appendUnique(sanitizedPathLabel(attributes["name"]), to: &fileLabels)
+    }
+
+    private func recordViolation(_ attributes: [String: String]) {
+        violationCount += 1
+        switch sanitizedLabel(attributes["priority"]).flatMap(Int.init) {
+        case 1:
+            priorityOneCount += 1
+        case 2:
+            priorityTwoCount += 1
+        case 3:
+            priorityThreeCount += 1
+        case 4:
+            priorityFourCount += 1
+        case 5:
+            priorityFiveCount += 1
+        default:
+            otherPriorityCount += 1
+        }
+        appendUnique(sanitizedLabel(attributes["rule"]), to: &ruleLabels)
+    }
+
+    private func appendUnique(_ label: String?, to labels: inout [String]) {
+        guard let label, !labels.contains(label) else { return }
+        labels.append(label)
+    }
+
+    private func sanitizedPathLabel(_ label: String?) -> String? {
+        guard let label = sanitizedLabel(label) else { return nil }
+        let components = label
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        guard components.count > 2 else { return label }
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func qualifiedElementName(elementName: String, qName: String?) -> String {
+        guard let qName, !qName.isEmpty else { return elementName }
+        return qName
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -271,6 +271,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let junitPreview = renderJUnitPreview(junitPreviewModel)
             let checkstylePreviewModel = artifact.checkstylePreview
             let checkstylePreview = renderCheckstylePreview(checkstylePreviewModel)
+            let pmdPreviewModel = artifact.pmdPreview
+            let pmdPreview = renderPMDPreview(pmdPreviewModel)
             let trxPreview = renderTRXPreview(artifact.trxPreview)
             let xunitPreviewModel = artifact.xunitPreview
             let xunitPreview = renderXUnitPreview(xunitPreviewModel)
@@ -284,6 +286,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let jaCoCoPreview = renderJaCoCoPreview(jaCoCoPreviewModel)
             let xmlPreview = junitPreviewModel == nil
                 && checkstylePreviewModel == nil
+                && pmdPreviewModel == nil
                 && xunitPreviewModel == nil
                 && nunitPreviewModel == nil
                 && coberturaPreviewModel == nil
@@ -370,6 +373,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(yamlPreview)
               \(junitPreview)
               \(checkstylePreview)
+              \(pmdPreview)
               \(trxPreview)
               \(xunitPreview)
               \(nunitPreview)
@@ -1812,6 +1816,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(sourceList)
+        </div>
+        """
+    }
+
+    private static func renderPMDPreview(_ preview: ToolArtifactPMDPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-pmd-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-pmd-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-pmd-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pmd-preview-files">
+                <strong data-testid="tool-card-pmd-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let ruleList = rules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pmd-preview-rules">
+                <strong data-testid="tool-card-pmd-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-pmd-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(ruleList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3106,6 +3106,79 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteCheckstyle.checkstylePreview)
     }
 
+    func testArtifactStateDerivesPMDPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("pmd-result.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <pmd version="7.0.0" timestamp="2026-07-19T12:00:00.000">
+          <file name="/repo/src/main/java/App.java">
+            <violation beginline="12" endline="12" rule="UnusedPrivateField" ruleset="Best Practices" priority="3">
+              Avoid unused private fields.
+            </violation>
+            <violation beginline="22" endline="22" rule="SystemPrintln" ruleset="Best Practices" priority="2">
+              System.out.println is used.
+            </violation>
+          </file>
+          <file name="/repo/src/test/java/AppTest.java">
+            <violation beginline="4" endline="4" rule="JUnitAssertionsShouldIncludeMessage" priority="1" />
+            <violation beginline="8" endline="8" rule="LooseCoupling" priority="4" />
+            <violation beginline="9" endline="9" rule="ShortVariable" priority="5" />
+            <violation beginline="10" endline="10" rule="UnknownPriority" priority="critical" />
+          </file>
+        </pmd>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.pmdPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.formatLabel, "PMD XML")
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.violationCount, 6)
+        XCTAssertEqual(preview.priorityOneCount, 1)
+        XCTAssertEqual(preview.priorityTwoCount, 1)
+        XCTAssertEqual(preview.priorityThreeCount, 1)
+        XCTAssertEqual(preview.priorityFourCount, 1)
+        XCTAssertEqual(preview.priorityFiveCount, 1)
+        XCTAssertEqual(preview.otherPriorityCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "main/java/App.java",
+            "test/java/AppTest.java"
+        ])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "UnusedPrivateField",
+            "SystemPrintln",
+            "JUnitAssertionsShouldIncludeMessage",
+            "LooseCoupling",
+            "ShortVariable",
+            "UnknownPriority"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: PMD XML",
+            "2 files",
+            "6 violations",
+            "Priority 1: 1",
+            "Priority 2: 1",
+            "Priority 3: 1",
+            "Priority 4: 1",
+            "Priority 5: 1",
+            "Other priority: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.xmlPreview)
+
+        let generic = directory.appendingPathComponent("manifest.xml")
+        try "<project><target /></project>".write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).pmdPreview)
+
+        let remotePMD = ToolArtifactState(value: "https://example.com/pmd-result.xml")
+        XCTAssertNil(remotePMD.pmdPreview)
+    }
+
     func testArtifactStateDerivesTRXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("results.trx")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2918,6 +2918,59 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesPMDArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("pmd-result.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <pmd version="7.0.0">
+          <file name="/repo/src/main/java/App.java">
+            <violation beginline="12" endline="12" rule="UnusedPrivateField" priority="3" />
+            <violation beginline="22" endline="22" rule="SystemPrintln" priority="2" />
+          </file>
+        </pmd>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"pmd-result.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote pmd-result.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "PMD artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">pmd-result.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-meta">Format: PMD XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-meta">1 file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-meta">2 violations"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-meta">Priority 2: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-meta">Priority 3: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-file-item">main/java/App.java"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-rule-item">UnusedPrivateField"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pmd-preview-rule-item">SystemPrintln"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesTRXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("results.trx")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -213,6 +213,9 @@
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching
   remote reports.
+- Artifact previews now include bounded local PMD XML report metadata for `.xml` files whose root
+  validates as PMD output: file/violation/priority counts, file size, capped file labels, and capped
+  rule labels without reading source files, running PMD, or fetching remote reports.
 - Artifact previews now include bounded local TAP report metadata for `.tap` files: plan, assertion
   counts, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing assertion labels
   without expanding diagnostics or fetching remote reports.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render PMD XML As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.xml` files with a PMD root as a specialized lint report artifact
+  rather than generic XML.
+- **Rationale:** PMD XML is common in Java and CI coding workflows. Showing file/violation counts,
+  priority counts, and capped file/rule labels gives the user a useful Codex-style result card
+  without forcing them to open the raw XML.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not open
+  referenced source files, expand violation bodies, run PMD, or fetch remote reports.
+
 ## 2026-07-19: Render Checkstyle XML As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.xml` files with a Checkstyle root as a specialized lint report


### PR DESCRIPTION
## Summary
- add bounded local PMD XML artifact previews with file, violation, priority, and rule metadata
- render PMD previews in native and HTML tool cards while suppressing generic XML fallback
- document the parity slice and decision rationale

## Validation
- swift test --filter testArtifactStateDerivesPMDPreviewMetadata
- swift test --filter testHTMLRendererIncludesPMDArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check