### PR TITLE
Add RuboCop JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -75,6 +75,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             eslintJSONContent(eslintJSONPreview)
         } else if let stylelintJSONPreview = artifact.stylelintJSONPreview {
             stylelintJSONContent(stylelintJSONPreview)
+        } else if let rubocopJSONPreview = artifact.rubocopJSONPreview {
+            rubocopJSONContent(rubocopJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -353,6 +355,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(stylelintJSONPreview.metadataLines)
             artifactContentList(title: "Sources", labels: stylelintJSONPreview.sourcePreviewLabels)
             artifactContentList(title: "Rules", labels: stylelintJSONPreview.rulePreviewLabels)
+        }
+    }
+
+    private func rubocopJSONContent(_ rubocopJSONPreview: ToolArtifactRuboCopJSONPreview) -> some View {
+        let hasLists = !rubocopJSONPreview.filePreviewLabels.isEmpty || !rubocopJSONPreview.copPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(rubocopJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: rubocopJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Cops", labels: rubocopJSONPreview.copPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1867,6 +1867,88 @@ public struct ToolArtifactStylelintJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactRuboCopJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var fileCount: Int
+    public var offenseCount: Int
+    public var fatalCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var conventionCount: Int
+    public var refactorCount: Int
+    public var infoCount: Int
+    public var otherSeverityCount: Int
+    public var correctableCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var copPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(offenseCount) offense\(offenseCount == 1 ? "" : "s")",
+            fatalCount > 0 ? "Fatal: \(fatalCount)" : nil,
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            conventionCount > 0 ? "Convention: \(conventionCount)" : nil,
+            refactorCount > 0 ? "Refactor: \(refactorCount)" : nil,
+            infoCount > 0 ? "Info: \(infoCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            correctableCount > 0 ? "Correctable: \(correctableCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        fileCount > 0
+            || offenseCount > 0
+            || fatalCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || conventionCount > 0
+            || refactorCount > 0
+            || infoCount > 0
+            || otherSeverityCount > 0
+            || correctableCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !copPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "RuboCop JSON",
+        fileCount: Int,
+        offenseCount: Int,
+        fatalCount: Int = 0,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        conventionCount: Int = 0,
+        refactorCount: Int = 0,
+        infoCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        correctableCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        copPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.fileCount = fileCount
+        self.offenseCount = offenseCount
+        self.fatalCount = fatalCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.conventionCount = conventionCount
+        self.refactorCount = refactorCount
+        self.infoCount = infoCount
+        self.otherSeverityCount = otherSeverityCount
+        self.correctableCount = correctableCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.copPreviewLabels = copPreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3499,7 +3581,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var jsonPreview: ToolArtifactJSONPreview? {
         guard eslintJSONPreview == nil,
-              stylelintJSONPreview == nil
+              stylelintJSONPreview == nil,
+              rubocopJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -3571,6 +3654,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var stylelintJSONPreview: ToolArtifactStylelintJSONPreview? {
         ToolArtifactStylelintJSONPreviewBuilder.stylelintJSONPreview(for: value, kind: kind)
+    }
+    public var rubocopJSONPreview: ToolArtifactRuboCopJSONPreview? {
+        ToolArtifactRuboCopJSONPreviewBuilder.rubocopJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactRuboCopJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactRuboCopJSONPreviewBuilder.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+enum ToolArtifactRuboCopJSONPreviewBuilder {
+    static func rubocopJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactRuboCopJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let report = root as? [String: Any] else { return nil }
+            return preview(
+                from: report,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from report: [String: Any],
+        byteSizeLabel: String?
+    ) -> ToolArtifactRuboCopJSONPreview? {
+        guard hasRuboCopReportShape(report),
+              let files = report["files"] as? [[String: Any]],
+              !files.isEmpty,
+              files.allSatisfy(hasRuboCopFileShape)
+        else {
+            return nil
+        }
+
+        var offenseCount = 0
+        var severityCounts: [String: Int] = [:]
+        var correctableCount = 0
+        var fileLabels: [String] = []
+        var copLabels: [String] = []
+
+        for file in files {
+            if let path = stringValue(file["path"]) {
+                appendUnique(sanitizedPathLabel(path), to: &fileLabels, limit: previewLimit)
+            }
+
+            let offenses = file["offenses"] as? [[String: Any]] ?? []
+            offenseCount += offenses.count
+            for offense in offenses {
+                if let severity = stringValue(offense["severity"])?.lowercased() {
+                    severityCounts[severity, default: 0] += 1
+                }
+                if boolValue(offense["correctable"]) == true {
+                    correctableCount += 1
+                }
+                if let copName = stringValue(offense["cop_name"]) {
+                    appendUnique(sanitizedLabel(copName), to: &copLabels, limit: previewLimit)
+                }
+            }
+        }
+
+        guard offenseCount > 0 || !fileLabels.isEmpty else { return nil }
+
+        let knownSeverities = ["fatal", "error", "warning", "convention", "refactor", "info"]
+        let otherSeverityCount = severityCounts
+            .filter { !knownSeverities.contains($0.key) }
+            .map(\.value)
+            .reduce(0, +)
+
+        return ToolArtifactRuboCopJSONPreview(
+            fileCount: files.count,
+            offenseCount: offenseCount,
+            fatalCount: severityCounts["fatal"] ?? 0,
+            errorCount: severityCounts["error"] ?? 0,
+            warningCount: severityCounts["warning"] ?? 0,
+            conventionCount: severityCounts["convention"] ?? 0,
+            refactorCount: severityCounts["refactor"] ?? 0,
+            infoCount: severityCounts["info"] ?? 0,
+            otherSeverityCount: otherSeverityCount,
+            correctableCount: correctableCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            copPreviewLabels: copLabels
+        )
+    }
+
+    private static func hasRuboCopReportShape(_ report: [String: Any]) -> Bool {
+        guard report["files"] is [[String: Any]] else { return false }
+        return report["metadata"] is [String: Any]
+            || report.keys.contains("summary")
+            || (report["files"] as? [[String: Any]] ?? []).contains(where: hasRuboCopFileShape)
+    }
+
+    private static func hasRuboCopFileShape(_ file: [String: Any]) -> Bool {
+        guard stringValue(file["path"]) != nil,
+              let offenses = file["offenses"] as? [[String: Any]]
+        else {
+            return false
+        }
+        return offenses.isEmpty || offenses.contains { offense in
+            stringValue(offense["cop_name"]) != nil
+                || stringValue(offense["severity"]) != nil
+                || stringValue(offense["message"]) != nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        switch value {
+        case let bool as Bool:
+            return bool
+        case let number as NSNumber:
+            return number.boolValue
+        case let string as String:
+            switch string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "true", "yes", "1":
+                return true
+            case "false", "no", "0":
+                return false
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -224,6 +224,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let eslintJSONPreview = renderESLintJSONPreview(eslintJSONPreviewModel)
             let stylelintJSONPreviewModel = artifact.stylelintJSONPreview
             let stylelintJSONPreview = renderStylelintJSONPreview(stylelintJSONPreviewModel)
+            let rubocopJSONPreviewModel = artifact.rubocopJSONPreview
+            let rubocopJSONPreview = renderRuboCopJSONPreview(rubocopJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -306,6 +308,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && jestJSONPreviewModel == nil
                 && eslintJSONPreviewModel == nil
                 && stylelintJSONPreviewModel == nil
+                && rubocopJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -344,6 +347,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(jestJSONPreview)
               \(eslintJSONPreview)
               \(stylelintJSONPreview)
+              \(rubocopJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -879,6 +883,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(sourceList)
           \(ruleList)
+        </div>
+        """
+    }
+
+    private static func renderRuboCopJSONPreview(_ preview: ToolArtifactRuboCopJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-rubocop-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-rubocop-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-rubocop-json-preview-files">
+                <strong data-testid="tool-card-rubocop-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let cops = preview.copPreviewLabels.map {
+            #"<li data-testid="tool-card-rubocop-json-preview-cop-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let copList = cops.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-rubocop-json-preview-cops">
+                <strong data-testid="tool-card-rubocop-json-preview-cop-title">Cops</strong>
+                <ul>\(cops)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !copList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-rubocop-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(copList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2916,6 +2916,95 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteStylelint.stylelintJSONPreview)
     }
 
+    func testArtifactStateDerivesRuboCopJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("rubocop-results.json")
+        let content = """
+        {
+          "metadata": {
+            "rubocop_version": "1.64.1",
+            "ruby_engine": "ruby"
+          },
+          "files": [
+            {
+              "path": "/repo/app/models/user.rb",
+              "offenses": [
+                {
+                  "severity": "convention",
+                  "message": "Prefer single-quoted strings.",
+                  "cop_name": "Style/StringLiterals",
+                  "correctable": true
+                },
+                {
+                  "severity": "warning",
+                  "message": "Method has too many lines.",
+                  "cop_name": "Metrics/MethodLength",
+                  "correctable": false
+                }
+              ]
+            },
+            {
+              "path": "/repo/spec/models/user_spec.rb",
+              "offenses": [
+                {
+                  "severity": "refactor",
+                  "message": "Use described_class.",
+                  "cop_name": "RSpec/DescribedClass",
+                  "correctable": "true"
+                }
+              ]
+            }
+          ],
+          "summary": {
+            "offense_count": 3,
+            "target_file_count": 2
+          }
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.rubocopJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "RuboCop JSON")
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.offenseCount, 3)
+        XCTAssertEqual(preview.warningCount, 1)
+        XCTAssertEqual(preview.conventionCount, 1)
+        XCTAssertEqual(preview.refactorCount, 1)
+        XCTAssertEqual(preview.correctableCount, 2)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "app/models/user.rb",
+            "spec/models/user_spec.rb"
+        ])
+        XCTAssertEqual(preview.copPreviewLabels, [
+            "Style/StringLiterals",
+            "Metrics/MethodLength",
+            "RSpec/DescribedClass"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: RuboCop JSON",
+            "2 files",
+            "3 offenses",
+            "Warnings: 1",
+            "Convention: 1",
+            "Refactor: 1",
+            "Correctable: 2",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"files":[{"path":"/repo/app.rb","status":"ok"}]}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).rubocopJSONPreview)
+
+        let remoteRuboCop = ToolArtifactState(value: "https://example.com/rubocop-results.json")
+        XCTAssertNil(remoteRuboCop.rubocopJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2131,6 +2131,79 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesRuboCopJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("rubocop-results.json")
+        let reportText = """
+        {
+          "metadata": {"rubocop_version": "1.64.1"},
+          "files": [
+            {
+              "path": "/repo/app/models/user.rb",
+              "offenses": [
+                {
+                  "severity": "convention",
+                  "message": "Prefer single-quoted strings.",
+                  "cop_name": "Style/StringLiterals",
+                  "correctable": true
+                },
+                {
+                  "severity": "warning",
+                  "message": "Method has too many lines.",
+                  "cop_name": "Metrics/MethodLength",
+                  "correctable": false
+                }
+              ]
+            }
+          ],
+          "summary": {"offense_count": 2}
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/rubocop-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/rubocop-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "RuboCop artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">rubocop-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-meta">Format: RuboCop JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-meta">1 file"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-meta">2 offenses"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-meta">Convention: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-meta">Correctable: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-file-item">app/models/user.rb"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-cop-title">Cops"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-cop-item">Style/StringLiterals"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-rubocop-json-preview-cop-item">Metrics/MethodLength"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -209,6 +209,10 @@
   root validates as Stylelint formatter output: file/warning/error/parse-error/deprecation/invalid
   option counts, file size, capped source labels, and capped rule labels without reading stylesheet
   sources, loading plugins, or fetching remote JSON.
+- Artifact previews now include bounded local RuboCop JSON report metadata for `.json` files whose
+  root validates as RuboCop formatter output: file/offense/severity/correctable counts, file size,
+  capped file labels, and capped cop labels without reading Ruby source files, loading cops, or
+  fetching remote JSON.
 - Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render RuboCop JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as RuboCop formatter output as a
+  specialized lint report artifact rather than generic JSON.
+- **Rationale:** RuboCop JSON is common in Ruby coding sessions and CI exports. A compact card with
+  file/offense/severity/correctable counts plus capped file/cop labels gives the user useful
+  Codex-style feedback without opening a raw report.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Ruby
+  source files, load cops, expand offense messages, or fetch remote reports.
+
 ## 2026-07-19: Render PMD XML As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.xml` files with a PMD root as a specialized lint report artifact


### PR DESCRIPTION
## Summary
- add a bounded local RuboCop JSON artifact preview model/parser
- render RuboCop file/offense/severity/correctable metadata in SwiftUI and HTML tool cards
- suppress generic JSON previews when a RuboCop report is recognized and document the parity decision

## Validation
- swift test --filter testArtifactStateDerivesRuboCopJSONPreviewMetadata
- swift test --filter testHTMLRendererIncludesRuboCopJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check