### PR TITLE
Add SpotBugs XML artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -137,6 +137,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             checkstyleContent(checkstylePreview)
         } else if let pmdPreview = artifact.pmdPreview {
             pmdContent(pmdPreview)
+        } else if let spotBugsPreview = artifact.spotBugsPreview {
+            spotBugsContent(spotBugsPreview)
         } else if let trxPreview = artifact.trxPreview {
             trxContent(trxPreview)
         } else if let xunitPreview = artifact.xunitPreview {
@@ -856,6 +858,25 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(pmdPreview.metadataLines)
             artifactContentList(title: "Files", labels: pmdPreview.filePreviewLabels)
             artifactContentList(title: "Rules", labels: pmdPreview.rulePreviewLabels)
+        }
+    }
+
+    private func spotBugsContent(_ spotBugsPreview: ToolArtifactSpotBugsPreview) -> some View {
+        let hasLists = !spotBugsPreview.typePreviewLabels.isEmpty
+            || !spotBugsPreview.categoryPreviewLabels.isEmpty
+            || !spotBugsPreview.classPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 166 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "exclamationmark.triangle")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(spotBugsPreview.metadataLines)
+            artifactContentList(title: "Types", labels: spotBugsPreview.typePreviewLabels)
+            artifactContentList(title: "Categories", labels: spotBugsPreview.categoryPreviewLabels)
+            artifactContentList(title: "Classes", labels: spotBugsPreview.classPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2759,6 +2759,67 @@ public struct ToolArtifactPMDPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactSpotBugsPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var bugCount: Int
+    public var classCount: Int
+    public var priorityOneCount: Int
+    public var priorityTwoCount: Int
+    public var priorityThreeCount: Int
+    public var otherPriorityCount: Int
+    public var byteSizeLabel: String?
+    public var typePreviewLabels: [String]
+    public var categoryPreviewLabels: [String]
+    public var classPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(bugCount) bug\(bugCount == 1 ? "" : "s")",
+            classCount > 0 ? "\(classCount) class\(classCount == 1 ? "" : "es")" : nil,
+            priorityOneCount > 0 ? "Priority 1: \(priorityOneCount)" : nil,
+            priorityTwoCount > 0 ? "Priority 2: \(priorityTwoCount)" : nil,
+            priorityThreeCount > 0 ? "Priority 3: \(priorityThreeCount)" : nil,
+            otherPriorityCount > 0 ? "Other priority: \(otherPriorityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        bugCount > 0
+            || classCount > 0
+            || !typePreviewLabels.isEmpty
+            || !categoryPreviewLabels.isEmpty
+            || !classPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "SpotBugs XML",
+        bugCount: Int,
+        classCount: Int = 0,
+        priorityOneCount: Int = 0,
+        priorityTwoCount: Int = 0,
+        priorityThreeCount: Int = 0,
+        otherPriorityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        typePreviewLabels: [String] = [],
+        categoryPreviewLabels: [String] = [],
+        classPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.bugCount = bugCount
+        self.classCount = classCount
+        self.priorityOneCount = priorityOneCount
+        self.priorityTwoCount = priorityTwoCount
+        self.priorityThreeCount = priorityThreeCount
+        self.otherPriorityCount = otherPriorityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.typePreviewLabels = typePreviewLabels
+        self.categoryPreviewLabels = categoryPreviewLabels
+        self.classPreviewLabels = classPreviewLabels
+    }
+}
+
 public struct ToolArtifactTRXPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var testRunName: String?
@@ -3700,6 +3761,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     public var pmdPreview: ToolArtifactPMDPreview? {
         ToolArtifactPMDPreviewBuilder.pmdPreview(for: value, kind: kind)
     }
+    public var spotBugsPreview: ToolArtifactSpotBugsPreview? {
+        ToolArtifactSpotBugsPreviewBuilder.spotBugsPreview(for: value, kind: kind)
+    }
     public var trxPreview: ToolArtifactTRXPreview? {
         ToolArtifactTRXPreviewBuilder.trxPreview(for: value, kind: kind)
     }
@@ -3720,7 +3784,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var xmlPreview: ToolArtifactXMLPreview? {
         guard checkstylePreview == nil,
-              pmdPreview == nil
+              pmdPreview == nil,
+              spotBugsPreview == nil
         else { return nil }
         return ToolArtifactXMLPreviewBuilder.xmlPreview(for: value, kind: kind)
     }

--- a/Sources/QuillCodeApp/ToolArtifactSpotBugsPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSpotBugsPreviewBuilder.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+enum ToolArtifactSpotBugsPreviewBuilder {
+    static func spotBugsPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactSpotBugsPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "xml",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+
+            let collector = SpotBugsPreviewCollector()
+            let parser = XMLParser(data: data)
+            parser.delegate = collector
+            parser.shouldProcessNamespaces = false
+            parser.shouldReportNamespacePrefixes = true
+            guard parser.parse(),
+                  let preview = collector.preview(fileSize: fileSize)
+            else {
+                return nil
+            }
+            return preview.hasDisplayContent ? preview : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static let byteLimit = 512 * 1_024
+}
+
+private final class SpotBugsPreviewCollector: NSObject, XMLParserDelegate {
+    private var depth = 0
+    private var rootElementLabel: String?
+    private var bugCount = 0
+    private var classLabels: [String] = []
+    private var typeLabels: [String] = []
+    private var categoryLabels: [String] = []
+    private var priorityOneCount = 0
+    private var priorityTwoCount = 0
+    private var priorityThreeCount = 0
+    private var otherPriorityCount = 0
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let label = qualifiedElementName(elementName: elementName, qName: qName)
+        if depth == 0 {
+            rootElementLabel = label
+        }
+        if label == "BugInstance" {
+            recordBug(attributeDict)
+        } else if label == "Class" {
+            recordClass(attributeDict)
+        }
+        depth += 1
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        depth = max(0, depth - 1)
+    }
+
+    func preview(fileSize: Int) -> ToolArtifactSpotBugsPreview? {
+        guard rootElementLabel == "BugCollection",
+              bugCount > 0 || !classLabels.isEmpty
+        else {
+            return nil
+        }
+
+        return ToolArtifactSpotBugsPreview(
+            bugCount: bugCount,
+            classCount: classLabels.count,
+            priorityOneCount: priorityOneCount,
+            priorityTwoCount: priorityTwoCount,
+            priorityThreeCount: priorityThreeCount,
+            otherPriorityCount: otherPriorityCount,
+            byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize),
+            typePreviewLabels: Array(typeLabels.prefix(previewLabelLimit)),
+            categoryPreviewLabels: Array(categoryLabels.prefix(previewLabelLimit)),
+            classPreviewLabels: Array(classLabels.prefix(previewLabelLimit))
+        )
+    }
+
+    private func recordBug(_ attributes: [String: String]) {
+        bugCount += 1
+        switch sanitizedLabel(attributes["priority"]).flatMap(Int.init) {
+        case 1:
+            priorityOneCount += 1
+        case 2:
+            priorityTwoCount += 1
+        case 3:
+            priorityThreeCount += 1
+        default:
+            otherPriorityCount += 1
+        }
+        appendUnique(sanitizedLabel(attributes["type"]), to: &typeLabels)
+        appendUnique(sanitizedLabel(attributes["category"]), to: &categoryLabels)
+    }
+
+    private func recordClass(_ attributes: [String: String]) {
+        appendUnique(sanitizedClassLabel(attributes["classname"]), to: &classLabels)
+    }
+
+    private func appendUnique(_ label: String?, to labels: inout [String]) {
+        guard let label, !labels.contains(label) else { return }
+        labels.append(label)
+    }
+
+    private func sanitizedClassLabel(_ label: String?) -> String? {
+        guard let label = sanitizedLabel(label) else { return nil }
+        let components = label.split(separator: ".").map(String.init)
+        guard components.count > 3 else { return label }
+        return components.suffix(3).joined(separator: ".")
+    }
+
+    private func sanitizedLabel(_ label: String?) -> String? {
+        guard let label else { return nil }
+        let collapsedWhitespace = label
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsedWhitespace.isEmpty else { return nil }
+        return String(collapsedWhitespace.prefix(characterLimit))
+    }
+
+    private func qualifiedElementName(elementName: String, qName: String?) -> String {
+        guard let qName, !qName.isEmpty else { return elementName }
+        return qName
+    }
+
+    private let previewLabelLimit = 6
+    private let characterLimit = 80
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -275,6 +275,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let checkstylePreview = renderCheckstylePreview(checkstylePreviewModel)
             let pmdPreviewModel = artifact.pmdPreview
             let pmdPreview = renderPMDPreview(pmdPreviewModel)
+            let spotBugsPreviewModel = artifact.spotBugsPreview
+            let spotBugsPreview = renderSpotBugsPreview(spotBugsPreviewModel)
             let trxPreview = renderTRXPreview(artifact.trxPreview)
             let xunitPreviewModel = artifact.xunitPreview
             let xunitPreview = renderXUnitPreview(xunitPreviewModel)
@@ -289,6 +291,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let xmlPreview = junitPreviewModel == nil
                 && checkstylePreviewModel == nil
                 && pmdPreviewModel == nil
+                && spotBugsPreviewModel == nil
                 && xunitPreviewModel == nil
                 && nunitPreviewModel == nil
                 && coberturaPreviewModel == nil
@@ -378,6 +381,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(junitPreview)
               \(checkstylePreview)
               \(pmdPreview)
+              \(spotBugsPreview)
               \(trxPreview)
               \(xunitPreview)
               \(nunitPreview)
@@ -1890,6 +1894,51 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(ruleList)
+        </div>
+        """
+    }
+
+    private static func renderSpotBugsPreview(_ preview: ToolArtifactSpotBugsPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-spotbugs-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let types = preview.typePreviewLabels.map {
+            #"<li data-testid="tool-card-spotbugs-preview-type-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let categories = preview.categoryPreviewLabels.map {
+            #"<li data-testid="tool-card-spotbugs-preview-category-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let classes = preview.classPreviewLabels.map {
+            #"<li data-testid="tool-card-spotbugs-preview-class-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let typeList = types.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-spotbugs-preview-types">
+                <strong data-testid="tool-card-spotbugs-preview-type-title">Types</strong>
+                <ul>\(types)</ul>
+              </section>
+        """
+        let categoryList = categories.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-spotbugs-preview-categories">
+                <strong data-testid="tool-card-spotbugs-preview-category-title">Categories</strong>
+                <ul>\(categories)</ul>
+              </section>
+        """
+        let classList = classes.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-spotbugs-preview-classes">
+                <strong data-testid="tool-card-spotbugs-preview-class-title">Classes</strong>
+                <ul>\(classes)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !typeList.isEmpty || !categoryList.isEmpty || !classList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-spotbugs-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(typeList)
+          \(categoryList)
+          \(classList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3268,6 +3268,80 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePMD.pmdPreview)
     }
 
+    func testArtifactStateDerivesSpotBugsPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("spotbugs-result.xml")
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <BugCollection version="4.8.6">
+          <BugInstance type="NP_NULL_ON_SOME_PATH" priority="1" category="CORRECTNESS">
+            <Class classname="com.example.service.UserService" />
+            <Method classname="com.example.service.UserService" name="loadUser" />
+            <SourceLine classname="com.example.service.UserService" sourcefile="UserService.java" />
+          </BugInstance>
+          <BugInstance type="DM_DEFAULT_ENCODING" priority="2" category="I18N">
+            <Class classname="com.example.web.AdminController" />
+          </BugInstance>
+          <BugInstance type="DLS_DEAD_LOCAL_STORE" priority="3" category="STYLE">
+            <Class classname="com.example.web.AdminController" />
+          </BugInstance>
+          <BugInstance type="UNKNOWN_PRIORITY" priority="experimental" category="PERFORMANCE">
+            <Class classname="com.example.jobs.ReportWorker" />
+          </BugInstance>
+        </BugCollection>
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.spotBugsPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "XML")
+        XCTAssertEqual(preview.formatLabel, "SpotBugs XML")
+        XCTAssertEqual(preview.bugCount, 4)
+        XCTAssertEqual(preview.classCount, 3)
+        XCTAssertEqual(preview.priorityOneCount, 1)
+        XCTAssertEqual(preview.priorityTwoCount, 1)
+        XCTAssertEqual(preview.priorityThreeCount, 1)
+        XCTAssertEqual(preview.otherPriorityCount, 1)
+        XCTAssertEqual(preview.typePreviewLabels, [
+            "NP_NULL_ON_SOME_PATH",
+            "DM_DEFAULT_ENCODING",
+            "DLS_DEAD_LOCAL_STORE",
+            "UNKNOWN_PRIORITY"
+        ])
+        XCTAssertEqual(preview.categoryPreviewLabels, [
+            "CORRECTNESS",
+            "I18N",
+            "STYLE",
+            "PERFORMANCE"
+        ])
+        XCTAssertEqual(preview.classPreviewLabels, [
+            "example.service.UserService",
+            "example.web.AdminController",
+            "example.jobs.ReportWorker"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: SpotBugs XML",
+            "4 bugs",
+            "3 classes",
+            "Priority 1: 1",
+            "Priority 2: 1",
+            "Priority 3: 1",
+            "Other priority: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.xmlPreview)
+
+        let generic = directory.appendingPathComponent("manifest.xml")
+        try "<BugCollection><Project /></BugCollection>".write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).spotBugsPreview)
+
+        let remoteSpotBugs = ToolArtifactState(value: "https://example.com/spotbugs-result.xml")
+        XCTAssertNil(remoteSpotBugs.spotBugsPreview)
+    }
+
     func testArtifactStateDerivesTRXPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("results.trx")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -3044,6 +3044,65 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
     }
 
+    func testHTMLRendererIncludesSpotBugsArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let report = root.appendingPathComponent("spotbugs-result.xml")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <BugCollection version="4.8.6">
+          <BugInstance type="NP_NULL_ON_SOME_PATH" priority="1" category="CORRECTNESS">
+            <Class classname="com.example.service.UserService" />
+          </BugInstance>
+          <BugInstance type="DM_DEFAULT_ENCODING" priority="2" category="I18N">
+            <Class classname="com.example.web.AdminController" />
+          </BugInstance>
+        </BugCollection>
+        """.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"spotbugs-result.xml"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote spotbugs-result.xml\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "SpotBugs artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">spotbugs-result.xml"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-meta">Format: SpotBugs XML"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-meta">2 bugs"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-meta">2 classes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-meta">Priority 1: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-meta">Priority 2: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-type-title">Types"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-type-item">NP_NULL_ON_SOME_PATH"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-type-item">DM_DEFAULT_ENCODING"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-category-title">Categories"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-category-item">CORRECTNESS"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-category-item">I18N"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-class-title">Classes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-class-item">example.service.UserService"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-spotbugs-preview-class-item">example.web.AdminController"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-xml-preview""#))
+    }
+
     func testHTMLRendererIncludesTRXArtifactPreview() throws {
         let root = try makeTempDirectory()
         let report = root.appendingPathComponent("results.trx")

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -220,6 +220,10 @@
 - Artifact previews now include bounded local PMD XML report metadata for `.xml` files whose root
   validates as PMD output: file/violation/priority counts, file size, capped file labels, and capped
   rule labels without reading source files, running PMD, or fetching remote reports.
+- Artifact previews now include bounded local SpotBugs XML report metadata for `.xml` files whose
+  root validates as SpotBugs output: bug/class/priority counts, file size, capped bug-type labels,
+  capped category labels, and capped class labels without reading bytecode/source files, loading
+  detectors, or fetching remote reports.
 - Artifact previews now include bounded local TAP report metadata for `.tap` files: plan, assertion
   counts, pass/fail/skip/TODO counts, bailout reason, file size, and capped failing assertion labels
   without expanding diagnostics or fetching remote reports.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render SpotBugs XML As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.xml` files with a SpotBugs `BugCollection` root as a specialized
+  lint report artifact rather than generic XML.
+- **Rationale:** SpotBugs reports are common in Java coding sessions and CI exports. Showing
+  bug/class/priority counts plus capped bug-type/category/class labels gives a useful Codex-style
+  summary without opening the raw XML.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read
+  bytecode, source files, expand bug messages, load detectors, or fetch remote reports.
+
 ## 2026-07-19: Render RuboCop JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as RuboCop formatter output as a


### PR DESCRIPTION
## Summary
- add a bounded local SpotBugs XML artifact preview model/parser
- render SpotBugs bug/class/priority metadata in SwiftUI and HTML tool cards
- suppress generic XML previews when a SpotBugs report is recognized and document the parity decision

## Validation
- swift test --filter testArtifactStateDerivesSpotBugsPreviewMetadata
- swift test --filter testHTMLRendererIncludesSpotBugsArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check