### PR TITLE
Add golangci-lint JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -77,6 +77,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             stylelintJSONContent(stylelintJSONPreview)
         } else if let rubocopJSONPreview = artifact.rubocopJSONPreview {
             rubocopJSONContent(rubocopJSONPreview)
+        } else if let golangCILintJSONPreview = artifact.golangCILintJSONPreview {
+            golangCILintJSONContent(golangCILintJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -373,6 +375,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(rubocopJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: rubocopJSONPreview.filePreviewLabels)
             artifactContentList(title: "Cops", labels: rubocopJSONPreview.copPreviewLabels)
+        }
+    }
+
+    private func golangCILintJSONContent(_ golangCILintJSONPreview: ToolArtifactGolangCILintJSONPreview) -> some View {
+        let hasLists = !golangCILintJSONPreview.filePreviewLabels.isEmpty
+            || !golangCILintJSONPreview.linterPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(golangCILintJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: golangCILintJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Linters", labels: golangCILintJSONPreview.linterPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1949,6 +1949,73 @@ public struct ToolArtifactRuboCopJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactGolangCILintJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var issueCount: Int
+    public var fileCount: Int
+    public var linterCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var infoCount: Int
+    public var otherSeverityCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var linterPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(issueCount) issue\(issueCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(linterCount) linter\(linterCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            infoCount > 0 ? "Info: \(infoCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        issueCount > 0
+            || fileCount > 0
+            || linterCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || infoCount > 0
+            || otherSeverityCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !linterPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "golangci-lint JSON",
+        issueCount: Int,
+        fileCount: Int,
+        linterCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        infoCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        linterPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.issueCount = issueCount
+        self.fileCount = fileCount
+        self.linterCount = linterCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.infoCount = infoCount
+        self.otherSeverityCount = otherSeverityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.linterPreviewLabels = linterPreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3643,7 +3710,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     public var jsonPreview: ToolArtifactJSONPreview? {
         guard eslintJSONPreview == nil,
               stylelintJSONPreview == nil,
-              rubocopJSONPreview == nil
+              rubocopJSONPreview == nil,
+              golangCILintJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -3718,6 +3786,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var rubocopJSONPreview: ToolArtifactRuboCopJSONPreview? {
         ToolArtifactRuboCopJSONPreviewBuilder.rubocopJSONPreview(for: value, kind: kind)
+    }
+    public var golangCILintJSONPreview: ToolArtifactGolangCILintJSONPreview? {
+        ToolArtifactGolangCILintJSONPreviewBuilder.golangCILintJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactGolangCILintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactGolangCILintJSONPreviewBuilder.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+enum ToolArtifactGolangCILintJSONPreviewBuilder {
+    static func golangCILintJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactGolangCILintJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let report = root as? [String: Any] else { return nil }
+            return preview(
+                from: report,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from report: [String: Any],
+        byteSizeLabel: String?
+    ) -> ToolArtifactGolangCILintJSONPreview? {
+        guard let issues = report["Issues"] as? [[String: Any]],
+              !issues.isEmpty,
+              issues.allSatisfy(hasGolangCILintIssueShape)
+        else {
+            return nil
+        }
+
+        var severityCounts: [String: Int] = [:]
+        var fileLabels: [String] = []
+        var linterLabels: [String] = []
+
+        for issue in issues {
+            if let linter = stringValue(issue["FromLinter"]) {
+                appendUnique(sanitizedLabel(linter), to: &linterLabels, limit: previewLimit)
+            }
+            if let severity = stringValue(issue["Severity"])?.lowercased() {
+                severityCounts[severity, default: 0] += 1
+            }
+            if let position = issue["Pos"] as? [String: Any],
+               let filename = stringValue(position["Filename"]) {
+                appendUnique(sanitizedPathLabel(filename), to: &fileLabels, limit: previewLimit)
+            }
+        }
+
+        guard !fileLabels.isEmpty || !linterLabels.isEmpty else { return nil }
+
+        let knownSeverities = ["error", "warning", "info"]
+        let otherSeverityCount = severityCounts
+            .filter { !knownSeverities.contains($0.key) }
+            .map(\.value)
+            .reduce(0, +)
+
+        return ToolArtifactGolangCILintJSONPreview(
+            issueCount: issues.count,
+            fileCount: uniqueFileCount(in: issues),
+            linterCount: uniqueLinterCount(in: issues),
+            errorCount: severityCounts["error"] ?? 0,
+            warningCount: severityCounts["warning"] ?? 0,
+            infoCount: severityCounts["info"] ?? 0,
+            otherSeverityCount: otherSeverityCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            linterPreviewLabels: linterLabels
+        )
+    }
+
+    private static func hasGolangCILintIssueShape(_ issue: [String: Any]) -> Bool {
+        guard stringValue(issue["FromLinter"]) != nil,
+              stringValue(issue["Text"]) != nil,
+              let position = issue["Pos"] as? [String: Any],
+              stringValue(position["Filename"]) != nil
+        else {
+            return false
+        }
+        return position.keys.contains("Line")
+            || position.keys.contains("Column")
+            || position.keys.contains("Offset")
+    }
+
+    private static func uniqueFileCount(in issues: [[String: Any]]) -> Int {
+        Set(issues.compactMap { issue in
+            (issue["Pos"] as? [String: Any]).flatMap { stringValue($0["Filename"]) }
+        }).count
+    }
+
+    private static func uniqueLinterCount(in issues: [[String: Any]]) -> Int {
+        Set(issues.compactMap { stringValue($0["FromLinter"]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -226,6 +226,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let stylelintJSONPreview = renderStylelintJSONPreview(stylelintJSONPreviewModel)
             let rubocopJSONPreviewModel = artifact.rubocopJSONPreview
             let rubocopJSONPreview = renderRuboCopJSONPreview(rubocopJSONPreviewModel)
+            let golangCILintJSONPreviewModel = artifact.golangCILintJSONPreview
+            let golangCILintJSONPreview = renderGolangCILintJSONPreview(golangCILintJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -312,6 +314,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && eslintJSONPreviewModel == nil
                 && stylelintJSONPreviewModel == nil
                 && rubocopJSONPreviewModel == nil
+                && golangCILintJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -351,6 +354,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(eslintJSONPreview)
               \(stylelintJSONPreview)
               \(rubocopJSONPreview)
+              \(golangCILintJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -922,6 +926,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(copList)
+        </div>
+        """
+    }
+
+    private static func renderGolangCILintJSONPreview(_ preview: ToolArtifactGolangCILintJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-golangci-lint-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-golangci-lint-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-golangci-lint-json-preview-files">
+                <strong data-testid="tool-card-golangci-lint-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let linters = preview.linterPreviewLabels.map {
+            #"<li data-testid="tool-card-golangci-lint-json-preview-linter-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let linterList = linters.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-golangci-lint-json-preview-linters">
+                <strong data-testid="tool-card-golangci-lint-json-preview-linter-title">Linters</strong>
+                <ul>\(linters)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !linterList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-golangci-lint-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(linterList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3005,6 +3005,93 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteRuboCop.rubocopJSONPreview)
     }
 
+    func testArtifactStateDerivesGolangCILintJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("golangci-lint-results.json")
+        let content = """
+        {
+          "Issues": [
+            {
+              "FromLinter": "errcheck",
+              "Text": "Error return value is not checked",
+              "Severity": "error",
+              "Pos": {
+                "Filename": "/repo/cmd/server/main.go",
+                "Line": 42,
+                "Column": 5
+              }
+            },
+            {
+              "FromLinter": "govet",
+              "Text": "printf call has possible formatting directive",
+              "Severity": "warning",
+              "Pos": {
+                "Filename": "/repo/internal/http/handler.go",
+                "Line": 17,
+                "Column": 12
+              }
+            },
+            {
+              "FromLinter": "errcheck",
+              "Text": "Error return value is not checked",
+              "Severity": "",
+              "Pos": {
+                "Filename": "/repo/internal/http/handler.go",
+                "Line": 24,
+                "Column": 8
+              }
+            }
+          ],
+          "Report": {
+            "Linters": [
+              {"Name": "errcheck", "Enabled": true},
+              {"Name": "govet", "Enabled": true}
+            ]
+          }
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.golangCILintJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "golangci-lint JSON")
+        XCTAssertEqual(preview.issueCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.linterCount, 2)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "cmd/server/main.go",
+            "internal/http/handler.go"
+        ])
+        XCTAssertEqual(preview.linterPreviewLabels, [
+            "errcheck",
+            "govet"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: golangci-lint JSON",
+            "3 issues",
+            "2 files",
+            "2 linters",
+            "Errors: 1",
+            "Warnings: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"Issues":[{"Text":"plain build issue","Pos":{"Filename":"/repo/main.go","Line":1}}]}"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).golangCILintJSONPreview)
+
+        let remoteGolangCILint = ToolArtifactState(value: "https://example.com/golangci-lint-results.json")
+        XCTAssertNil(remoteGolangCILint.golangCILintJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2204,6 +2204,82 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesGolangCILintJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("golangci-lint-results.json")
+        let reportText = """
+        {
+          "Issues": [
+            {
+              "FromLinter": "errcheck",
+              "Text": "Error return value is not checked",
+              "Severity": "error",
+              "Pos": {
+                "Filename": "/repo/cmd/server/main.go",
+                "Line": 42,
+                "Column": 5
+              }
+            },
+            {
+              "FromLinter": "govet",
+              "Text": "printf call has possible formatting directive",
+              "Severity": "warning",
+              "Pos": {
+                "Filename": "/repo/internal/http/handler.go",
+                "Line": 17,
+                "Column": 12
+              }
+            }
+          ],
+          "Report": {"Error": ""}
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/golangci-lint-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/golangci-lint-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "golangci-lint artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">golangci-lint-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-meta">Format: golangci-lint JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-meta">2 issues"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-meta">2 linters"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-file-item">cmd/server/main.go"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-file-item">internal/http/handler.go"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-linter-title">Linters"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-linter-item">errcheck"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-golangci-lint-json-preview-linter-item">govet"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -213,6 +213,10 @@
   root validates as RuboCop formatter output: file/offense/severity/correctable counts, file size,
   capped file labels, and capped cop labels without reading Ruby source files, loading cops, or
   fetching remote JSON.
+- Artifact previews now include bounded local golangci-lint JSON report metadata for `.json` files
+  whose root validates as golangci-lint output: issue/file/linter/severity counts, file size, capped
+  file labels, and capped linter labels without reading Go source files, loading linters, or
+  fetching remote JSON.
 - Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render golangci-lint JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as golangci-lint output as a
+  specialized lint report artifact rather than generic JSON.
+- **Rationale:** Go coding sessions often produce `golangci-lint run --out-format json` reports.
+  Showing issue/file/linter/severity counts plus capped file/linter labels gives useful Codex-style
+  feedback without opening the raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Go
+  source files, load linters, expand issue text, or fetch remote reports.
+
 ## 2026-07-19: Render SpotBugs XML As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.xml` files with a SpotBugs `BugCollection` root as a specialized


### PR DESCRIPTION
## Summary
- add bounded local golangci-lint JSON artifact preview detection and metadata
- render issue/file/linter/severity summaries in SwiftUI and static HTML tool cards
- document the artifact parity slice and design constraints

## Validation
- swift test --filter testArtifactStateDerivesGolangCILintJSONPreviewMetadata
- swift test --filter testHTMLRendererIncludesGolangCILintJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check