### PR TITLE
Add Ruff JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -79,6 +79,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             rubocopJSONContent(rubocopJSONPreview)
         } else if let golangCILintJSONPreview = artifact.golangCILintJSONPreview {
             golangCILintJSONContent(golangCILintJSONPreview)
+        } else if let ruffJSONPreview = artifact.ruffJSONPreview {
+            ruffJSONContent(ruffJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -392,6 +394,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(golangCILintJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: golangCILintJSONPreview.filePreviewLabels)
             artifactContentList(title: "Linters", labels: golangCILintJSONPreview.linterPreviewLabels)
+        }
+    }
+
+    private func ruffJSONContent(_ ruffJSONPreview: ToolArtifactRuffJSONPreview) -> some View {
+        let hasLists = !ruffJSONPreview.filePreviewLabels.isEmpty || !ruffJSONPreview.rulePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(ruffJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: ruffJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Rules", labels: ruffJSONPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2016,6 +2016,58 @@ public struct ToolArtifactGolangCILintJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactRuffJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var violationCount: Int
+    public var fileCount: Int
+    public var ruleCount: Int
+    public var fixableCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(violationCount) violation\(violationCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(ruleCount) rule\(ruleCount == 1 ? "" : "s")",
+            fixableCount > 0 ? "Fixable: \(fixableCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        violationCount > 0
+            || fileCount > 0
+            || ruleCount > 0
+            || fixableCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Ruff JSON",
+        violationCount: Int,
+        fileCount: Int,
+        ruleCount: Int,
+        fixableCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.violationCount = violationCount
+        self.fileCount = fileCount
+        self.ruleCount = ruleCount
+        self.fixableCount = fixableCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3711,7 +3763,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
         guard eslintJSONPreview == nil,
               stylelintJSONPreview == nil,
               rubocopJSONPreview == nil,
-              golangCILintJSONPreview == nil
+              golangCILintJSONPreview == nil,
+              ruffJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -3789,6 +3842,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var golangCILintJSONPreview: ToolArtifactGolangCILintJSONPreview? {
         ToolArtifactGolangCILintJSONPreviewBuilder.golangCILintJSONPreview(for: value, kind: kind)
+    }
+    public var ruffJSONPreview: ToolArtifactRuffJSONPreview? {
+        ToolArtifactRuffJSONPreviewBuilder.ruffJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactRuffJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactRuffJSONPreviewBuilder.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+enum ToolArtifactRuffJSONPreviewBuilder {
+    static func ruffJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactRuffJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let violations = root as? [[String: Any]] else { return nil }
+            return preview(
+                from: violations,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from violations: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactRuffJSONPreview? {
+        guard !violations.isEmpty, violations.allSatisfy(hasRuffViolationShape) else { return nil }
+
+        var fileLabels: [String] = []
+        var ruleLabels: [String] = []
+        var fixableCount = 0
+
+        for violation in violations {
+            if let filename = stringValue(violation["filename"]) {
+                appendUnique(sanitizedPathLabel(filename), to: &fileLabels, limit: previewLimit)
+            }
+            if let code = stringValue(violation["code"]) {
+                appendUnique(sanitizedLabel(code), to: &ruleLabels, limit: previewLimit)
+            }
+            if let fix = violation["fix"], !(fix is NSNull) {
+                fixableCount += 1
+            }
+        }
+
+        guard !fileLabels.isEmpty || !ruleLabels.isEmpty else { return nil }
+
+        return ToolArtifactRuffJSONPreview(
+            violationCount: violations.count,
+            fileCount: uniqueFileCount(in: violations),
+            ruleCount: uniqueRuleCount(in: violations),
+            fixableCount: fixableCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            rulePreviewLabels: ruleLabels
+        )
+    }
+
+    private static func hasRuffViolationShape(_ violation: [String: Any]) -> Bool {
+        guard stringValue(violation["code"]) != nil,
+              stringValue(violation["message"]) != nil,
+              stringValue(violation["filename"]) != nil,
+              let location = violation["location"] as? [String: Any]
+        else {
+            return false
+        }
+        return location.keys.contains("row") && location.keys.contains("column")
+    }
+
+    private static func uniqueFileCount(in violations: [[String: Any]]) -> Int {
+        Set(violations.compactMap { stringValue($0["filename"]) }).count
+    }
+
+    private static func uniqueRuleCount(in violations: [[String: Any]]) -> Int {
+        Set(violations.compactMap { stringValue($0["code"]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -228,6 +228,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let rubocopJSONPreview = renderRuboCopJSONPreview(rubocopJSONPreviewModel)
             let golangCILintJSONPreviewModel = artifact.golangCILintJSONPreview
             let golangCILintJSONPreview = renderGolangCILintJSONPreview(golangCILintJSONPreviewModel)
+            let ruffJSONPreviewModel = artifact.ruffJSONPreview
+            let ruffJSONPreview = renderRuffJSONPreview(ruffJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -315,6 +317,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && stylelintJSONPreviewModel == nil
                 && rubocopJSONPreviewModel == nil
                 && golangCILintJSONPreviewModel == nil
+                && ruffJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -355,6 +358,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(stylelintJSONPreview)
               \(rubocopJSONPreview)
               \(golangCILintJSONPreview)
+              \(ruffJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -961,6 +965,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(linterList)
+        </div>
+        """
+    }
+
+    private static func renderRuffJSONPreview(_ preview: ToolArtifactRuffJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-ruff-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-ruff-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-ruff-json-preview-files">
+                <strong data-testid="tool-card-ruff-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-ruff-json-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let ruleList = rules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-ruff-json-preview-rules">
+                <strong data-testid="tool-card-ruff-json-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-ruff-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(ruleList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3092,6 +3092,85 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteGolangCILint.golangCILintJSONPreview)
     }
 
+    func testArtifactStateDerivesRuffJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("ruff-results.json")
+        let content = """
+        [
+          {
+            "cell": null,
+            "code": "F401",
+            "end_location": {"row": 1, "column": 10},
+            "filename": "/repo/app/main.py",
+            "fix": {
+              "applicability": "safe",
+              "edits": []
+            },
+            "location": {"row": 1, "column": 1},
+            "message": "`os` imported but unused",
+            "noqa_row": 1,
+            "url": "https://docs.astral.sh/ruff/rules/unused-import"
+          },
+          {
+            "cell": null,
+            "code": "E501",
+            "end_location": {"row": 12, "column": 104},
+            "filename": "/repo/tests/test_app.py",
+            "fix": null,
+            "location": {"row": 12, "column": 89},
+            "message": "Line too long"
+          },
+          {
+            "cell": null,
+            "code": "F401",
+            "end_location": {"row": 3, "column": 10},
+            "filename": "/repo/tests/test_app.py",
+            "fix": null,
+            "location": {"row": 3, "column": 1},
+            "message": "`sys` imported but unused"
+          }
+        ]
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.ruffJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Ruff JSON")
+        XCTAssertEqual(preview.violationCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.ruleCount, 2)
+        XCTAssertEqual(preview.fixableCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/app/main.py",
+            "repo/tests/test_app.py"
+        ])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "F401",
+            "E501"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Ruff JSON",
+            "3 violations",
+            "2 files",
+            "2 rules",
+            "Fixable: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"[{"code":"F401","filename":"/repo/app.py","message":"missing location"}]"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).ruffJSONPreview)
+
+        let remoteRuff = ToolArtifactState(value: "https://example.com/ruff-results.json")
+        XCTAssertNil(remoteRuff.ruffJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2280,6 +2280,72 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesRuffJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("ruff-results.json")
+        let reportText = """
+        [
+          {
+            "code": "F401",
+            "filename": "/repo/app/main.py",
+            "fix": {"applicability": "safe", "edits": []},
+            "location": {"row": 1, "column": 1},
+            "message": "`os` imported but unused"
+          },
+          {
+            "code": "E501",
+            "filename": "/repo/tests/test_app.py",
+            "fix": null,
+            "location": {"row": 12, "column": 89},
+            "message": "Line too long"
+          }
+        ]
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/ruff-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/ruff-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Ruff artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">ruff-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-meta">Format: Ruff JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-meta">2 violations"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-meta">2 rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-meta">Fixable: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-file-item">repo/app/main.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-file-item">repo/tests/test_app.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-rule-item">F401"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-ruff-json-preview-rule-item">E501"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -217,6 +217,10 @@
   whose root validates as golangci-lint output: issue/file/linter/severity counts, file size, capped
   file labels, and capped linter labels without reading Go source files, loading linters, or
   fetching remote JSON.
+- Artifact previews now include bounded local Ruff JSON report metadata for `.json` files whose
+  root validates as Ruff output: violation/file/rule/fixable counts, file size, capped file labels,
+  and capped rule labels without reading Python source files, loading rules, or fetching remote
+  JSON.
 - Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Ruff JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Ruff formatter output as a
+  specialized lint report artifact rather than generic JSON.
+- **Rationale:** Ruff reports are common in Python coding sessions. Showing violation/file/rule and
+  fixable counts plus capped file/rule labels gives useful Codex-style feedback without opening the
+  raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Python
+  source files, load rules, expand violation bodies, or fetch remote reports.
+
 ## 2026-07-19: Render golangci-lint JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as golangci-lint output as a


### PR DESCRIPTION
## Summary
- add bounded local Ruff JSON artifact preview detection and metadata
- render violation/file/rule/fixable summaries in SwiftUI and static HTML tool cards
- document the artifact parity slice and design constraints

## Validation
- swift test --filter testArtifactStateDerivesRuffJSONPreviewMetadata
- swift test --filter testHTMLRendererIncludesRuffJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check