### PR TITLE
Add Pylint JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -81,6 +81,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             golangCILintJSONContent(golangCILintJSONPreview)
         } else if let ruffJSONPreview = artifact.ruffJSONPreview {
             ruffJSONContent(ruffJSONPreview)
+        } else if let pylintJSONPreview = artifact.pylintJSONPreview {
+            pylintJSONContent(pylintJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -410,6 +412,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(ruffJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: ruffJSONPreview.filePreviewLabels)
             artifactContentList(title: "Rules", labels: ruffJSONPreview.rulePreviewLabels)
+        }
+    }
+
+    private func pylintJSONContent(_ pylintJSONPreview: ToolArtifactPylintJSONPreview) -> some View {
+        let hasLists = !pylintJSONPreview.filePreviewLabels.isEmpty || !pylintJSONPreview.symbolPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(pylintJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: pylintJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Symbols", labels: pylintJSONPreview.symbolPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2068,6 +2068,88 @@ public struct ToolArtifactRuffJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPylintJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var messageCount: Int
+    public var fileCount: Int
+    public var symbolCount: Int
+    public var fatalCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var refactorCount: Int
+    public var conventionCount: Int
+    public var infoCount: Int
+    public var otherTypeCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var symbolPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(messageCount) message\(messageCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(symbolCount) symbol\(symbolCount == 1 ? "" : "s")",
+            fatalCount > 0 ? "Fatal: \(fatalCount)" : nil,
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            refactorCount > 0 ? "Refactor: \(refactorCount)" : nil,
+            conventionCount > 0 ? "Convention: \(conventionCount)" : nil,
+            infoCount > 0 ? "Info: \(infoCount)" : nil,
+            otherTypeCount > 0 ? "Other types: \(otherTypeCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        messageCount > 0
+            || fileCount > 0
+            || symbolCount > 0
+            || fatalCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || refactorCount > 0
+            || conventionCount > 0
+            || infoCount > 0
+            || otherTypeCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !symbolPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Pylint JSON",
+        messageCount: Int,
+        fileCount: Int,
+        symbolCount: Int,
+        fatalCount: Int = 0,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        refactorCount: Int = 0,
+        conventionCount: Int = 0,
+        infoCount: Int = 0,
+        otherTypeCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        symbolPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.messageCount = messageCount
+        self.fileCount = fileCount
+        self.symbolCount = symbolCount
+        self.fatalCount = fatalCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.refactorCount = refactorCount
+        self.conventionCount = conventionCount
+        self.infoCount = infoCount
+        self.otherTypeCount = otherTypeCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.symbolPreviewLabels = symbolPreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3764,7 +3846,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               stylelintJSONPreview == nil,
               rubocopJSONPreview == nil,
               golangCILintJSONPreview == nil,
-              ruffJSONPreview == nil
+              ruffJSONPreview == nil,
+              pylintJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -3845,6 +3928,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var ruffJSONPreview: ToolArtifactRuffJSONPreview? {
         ToolArtifactRuffJSONPreviewBuilder.ruffJSONPreview(for: value, kind: kind)
+    }
+    public var pylintJSONPreview: ToolArtifactPylintJSONPreview? {
+        ToolArtifactPylintJSONPreviewBuilder.pylintJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactPylintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPylintJSONPreviewBuilder.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+enum ToolArtifactPylintJSONPreviewBuilder {
+    static func pylintJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPylintJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let messages = root as? [[String: Any]] else { return nil }
+            return preview(
+                from: messages,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from messages: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactPylintJSONPreview? {
+        guard !messages.isEmpty, messages.allSatisfy(hasPylintMessageShape) else { return nil }
+
+        var fileLabels: [String] = []
+        var symbolLabels: [String] = []
+        var fatalCount = 0
+        var errorCount = 0
+        var warningCount = 0
+        var refactorCount = 0
+        var conventionCount = 0
+        var infoCount = 0
+        var otherTypeCount = 0
+
+        for message in messages {
+            if let path = stringValue(message["path"]) {
+                appendUnique(sanitizedPathLabel(path), to: &fileLabels, limit: previewLimit)
+            }
+            if let symbol = stringValue(message["symbol"]) {
+                appendUnique(sanitizedLabel(symbol), to: &symbolLabels, limit: previewLimit)
+            }
+
+            switch stringValue(message["type"])?.lowercased() {
+            case "fatal":
+                fatalCount += 1
+            case "error":
+                errorCount += 1
+            case "warning":
+                warningCount += 1
+            case "refactor":
+                refactorCount += 1
+            case "convention":
+                conventionCount += 1
+            case "info":
+                infoCount += 1
+            default:
+                otherTypeCount += 1
+            }
+        }
+
+        guard !fileLabels.isEmpty || !symbolLabels.isEmpty else { return nil }
+
+        return ToolArtifactPylintJSONPreview(
+            messageCount: messages.count,
+            fileCount: uniqueCount(in: messages, key: "path"),
+            symbolCount: uniqueCount(in: messages, key: "symbol"),
+            fatalCount: fatalCount,
+            errorCount: errorCount,
+            warningCount: warningCount,
+            refactorCount: refactorCount,
+            conventionCount: conventionCount,
+            infoCount: infoCount,
+            otherTypeCount: otherTypeCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            symbolPreviewLabels: symbolLabels
+        )
+    }
+
+    private static func hasPylintMessageShape(_ message: [String: Any]) -> Bool {
+        guard stringValue(message["type"]) != nil,
+              stringValue(message["module"]) != nil,
+              stringValue(message["message"]) != nil,
+              stringValue(message["message-id"]) != nil,
+              stringValue(message["path"]) != nil,
+              stringValue(message["symbol"]) != nil
+        else {
+            return false
+        }
+        return numericValue(message["line"]) != nil
+    }
+
+    private static func uniqueCount(in messages: [[String: Any]], key: String) -> Int {
+        Set(messages.compactMap { stringValue($0[key]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func numericValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = stringValue(value) {
+            return Double(string)
+        }
+        return nil
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -230,6 +230,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let golangCILintJSONPreview = renderGolangCILintJSONPreview(golangCILintJSONPreviewModel)
             let ruffJSONPreviewModel = artifact.ruffJSONPreview
             let ruffJSONPreview = renderRuffJSONPreview(ruffJSONPreviewModel)
+            let pylintJSONPreviewModel = artifact.pylintJSONPreview
+            let pylintJSONPreview = renderPylintJSONPreview(pylintJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -318,6 +320,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && rubocopJSONPreviewModel == nil
                 && golangCILintJSONPreviewModel == nil
                 && ruffJSONPreviewModel == nil
+                && pylintJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -359,6 +362,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(rubocopJSONPreview)
               \(golangCILintJSONPreview)
               \(ruffJSONPreview)
+              \(pylintJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -1000,6 +1004,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(ruleList)
+        </div>
+        """
+    }
+
+    private static func renderPylintJSONPreview(_ preview: ToolArtifactPylintJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-pylint-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-pylint-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pylint-json-preview-files">
+                <strong data-testid="tool-card-pylint-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let symbols = preview.symbolPreviewLabels.map {
+            #"<li data-testid="tool-card-pylint-json-preview-symbol-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let symbolList = symbols.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pylint-json-preview-symbols">
+                <strong data-testid="tool-card-pylint-json-preview-symbol-title">Symbols</strong>
+                <ul>\(symbols)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !symbolList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-pylint-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(symbolList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3171,6 +3171,97 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteRuff.ruffJSONPreview)
     }
 
+    func testArtifactStateDerivesPylintJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("pylint-results.json")
+        let content = """
+        [
+          {
+            "type": "warning",
+            "module": "app.main",
+            "obj": "",
+            "line": 1,
+            "column": 0,
+            "endLine": 1,
+            "endColumn": 9,
+            "path": "/repo/app/main.py",
+            "symbol": "unused-import",
+            "message": "Unused import os",
+            "message-id": "W0611"
+          },
+          {
+            "type": "convention",
+            "module": "tests.test_app",
+            "obj": "test_smoke",
+            "line": "12",
+            "column": 0,
+            "endLine": 12,
+            "endColumn": 15,
+            "path": "/repo/tests/test_app.py",
+            "symbol": "missing-function-docstring",
+            "message": "Missing function or method docstring",
+            "message-id": "C0116"
+          },
+          {
+            "type": "error",
+            "module": "tests.test_app",
+            "obj": "",
+            "line": 18,
+            "column": 4,
+            "endLine": 18,
+            "endColumn": 9,
+            "path": "/repo/tests/test_app.py",
+            "symbol": "undefined-variable",
+            "message": "Undefined variable 'value'",
+            "message-id": "E0602"
+          }
+        ]
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.pylintJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Pylint JSON")
+        XCTAssertEqual(preview.messageCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.symbolCount, 3)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 1)
+        XCTAssertEqual(preview.conventionCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/app/main.py",
+            "repo/tests/test_app.py"
+        ])
+        XCTAssertEqual(preview.symbolPreviewLabels, [
+            "unused-import",
+            "missing-function-docstring",
+            "undefined-variable"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Pylint JSON",
+            "3 messages",
+            "2 files",
+            "3 symbols",
+            "Errors: 1",
+            "Warnings: 1",
+            "Convention: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"[{"type":"warning","path":"/repo/app.py","symbol":"unused-import","message":"missing module and id","line":1}]"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).pylintJSONPreview)
+
+        let remotePylint = ToolArtifactState(value: "https://example.com/pylint-results.json")
+        XCTAssertNil(remotePylint.pylintJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2346,6 +2346,85 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesPylintJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("pylint-results.json")
+        let reportText = """
+        [
+          {
+            "type": "warning",
+            "module": "app.main",
+            "obj": "",
+            "line": 1,
+            "column": 0,
+            "endLine": 1,
+            "endColumn": 9,
+            "path": "/repo/app/main.py",
+            "symbol": "unused-import",
+            "message": "Unused import os",
+            "message-id": "W0611"
+          },
+          {
+            "type": "error",
+            "module": "tests.test_app",
+            "obj": "",
+            "line": 18,
+            "column": 4,
+            "endLine": 18,
+            "endColumn": 9,
+            "path": "/repo/tests/test_app.py",
+            "symbol": "undefined-variable",
+            "message": "Undefined variable 'value'",
+            "message-id": "E0602"
+          }
+        ]
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/pylint-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/pylint-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Pylint artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">pylint-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-meta">Format: Pylint JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-meta">2 messages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-meta">2 symbols"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-file-item">repo/app/main.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-file-item">repo/tests/test_app.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-symbol-title">Symbols"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-symbol-item">unused-import"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pylint-json-preview-symbol-item">undefined-variable"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -221,6 +221,10 @@
   root validates as Ruff output: violation/file/rule/fixable counts, file size, capped file labels,
   and capped rule labels without reading Python source files, loading rules, or fetching remote
   JSON.
+- Artifact previews now include bounded local Pylint JSON report metadata for `.json` files whose
+  root validates as Pylint output: message/file/symbol/type counts, file size, capped file labels,
+  and capped symbol labels without reading Python source files, loading plugins, or fetching remote
+  JSON.
 - Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Pylint JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Pylint JSON output as a
+  specialized lint report artifact rather than generic JSON.
+- **Rationale:** Pylint reports are common in Python coding sessions and CI exports. Showing
+  message/file/symbol/type counts plus capped file/symbol labels gives useful Codex-style feedback
+  without opening the raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Python
+  source files, load Pylint plugins, expand messages, or fetch remote reports.
+
 ## 2026-07-19: Render Ruff JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as Ruff formatter output as a


### PR DESCRIPTION
## Summary
- add bounded local Pylint JSON report detection for artifact cards
- render message/file/symbol/type metadata in native SwiftUI and HTML harness previews
- suppress generic JSON previews when a Pylint report is recognized
- document the parity slice and decision constraints

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesPylintJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesPylintJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check