### PR TITLE
Add Bandit JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -83,6 +83,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             ruffJSONContent(ruffJSONPreview)
         } else if let pylintJSONPreview = artifact.pylintJSONPreview {
             pylintJSONContent(pylintJSONPreview)
+        } else if let banditJSONPreview = artifact.banditJSONPreview {
+            banditJSONContent(banditJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -428,6 +430,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(pylintJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: pylintJSONPreview.filePreviewLabels)
             artifactContentList(title: "Symbols", labels: pylintJSONPreview.symbolPreviewLabels)
+        }
+    }
+
+    private func banditJSONContent(_ banditJSONPreview: ToolArtifactBanditJSONPreview) -> some View {
+        let hasLists = !banditJSONPreview.filePreviewLabels.isEmpty || !banditJSONPreview.testPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(banditJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: banditJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Tests", labels: banditJSONPreview.testPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2150,6 +2150,93 @@ public struct ToolArtifactPylintJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactBanditJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var issueCount: Int
+    public var fileCount: Int
+    public var testCount: Int
+    public var highSeverityCount: Int
+    public var mediumSeverityCount: Int
+    public var lowSeverityCount: Int
+    public var otherSeverityCount: Int
+    public var highConfidenceCount: Int
+    public var mediumConfidenceCount: Int
+    public var lowConfidenceCount: Int
+    public var otherConfidenceCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var testPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(issueCount) issue\(issueCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(testCount) test\(testCount == 1 ? "" : "s")",
+            highSeverityCount > 0 ? "High severity: \(highSeverityCount)" : nil,
+            mediumSeverityCount > 0 ? "Medium severity: \(mediumSeverityCount)" : nil,
+            lowSeverityCount > 0 ? "Low severity: \(lowSeverityCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            highConfidenceCount > 0 ? "High confidence: \(highConfidenceCount)" : nil,
+            mediumConfidenceCount > 0 ? "Medium confidence: \(mediumConfidenceCount)" : nil,
+            lowConfidenceCount > 0 ? "Low confidence: \(lowConfidenceCount)" : nil,
+            otherConfidenceCount > 0 ? "Other confidence: \(otherConfidenceCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        issueCount > 0
+            || fileCount > 0
+            || testCount > 0
+            || highSeverityCount > 0
+            || mediumSeverityCount > 0
+            || lowSeverityCount > 0
+            || otherSeverityCount > 0
+            || highConfidenceCount > 0
+            || mediumConfidenceCount > 0
+            || lowConfidenceCount > 0
+            || otherConfidenceCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !testPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Bandit JSON",
+        issueCount: Int,
+        fileCount: Int,
+        testCount: Int,
+        highSeverityCount: Int = 0,
+        mediumSeverityCount: Int = 0,
+        lowSeverityCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        highConfidenceCount: Int = 0,
+        mediumConfidenceCount: Int = 0,
+        lowConfidenceCount: Int = 0,
+        otherConfidenceCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        testPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.issueCount = issueCount
+        self.fileCount = fileCount
+        self.testCount = testCount
+        self.highSeverityCount = highSeverityCount
+        self.mediumSeverityCount = mediumSeverityCount
+        self.lowSeverityCount = lowSeverityCount
+        self.otherSeverityCount = otherSeverityCount
+        self.highConfidenceCount = highConfidenceCount
+        self.mediumConfidenceCount = mediumConfidenceCount
+        self.lowConfidenceCount = lowConfidenceCount
+        self.otherConfidenceCount = otherConfidenceCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.testPreviewLabels = testPreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3847,7 +3934,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               rubocopJSONPreview == nil,
               golangCILintJSONPreview == nil,
               ruffJSONPreview == nil,
-              pylintJSONPreview == nil
+              pylintJSONPreview == nil,
+              banditJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -3931,6 +4019,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var pylintJSONPreview: ToolArtifactPylintJSONPreview? {
         ToolArtifactPylintJSONPreviewBuilder.pylintJSONPreview(for: value, kind: kind)
+    }
+    public var banditJSONPreview: ToolArtifactBanditJSONPreview? {
+        ToolArtifactBanditJSONPreviewBuilder.banditJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactBanditJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactBanditJSONPreviewBuilder.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+enum ToolArtifactBanditJSONPreviewBuilder {
+    static func banditJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactBanditJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let report = root as? [String: Any],
+                  let results = report["results"] as? [[String: Any]]
+            else {
+                return nil
+            }
+            return preview(
+                from: report,
+                results: results,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from report: [String: Any],
+        results: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactBanditJSONPreview? {
+        guard !results.isEmpty,
+              stringValue(report["generated_at"]) != nil || report["metrics"] is [String: Any],
+              results.allSatisfy(hasBanditIssueShape)
+        else {
+            return nil
+        }
+
+        var fileLabels: [String] = []
+        var testLabels: [String] = []
+        var highSeverityCount = 0
+        var mediumSeverityCount = 0
+        var lowSeverityCount = 0
+        var otherSeverityCount = 0
+        var highConfidenceCount = 0
+        var mediumConfidenceCount = 0
+        var lowConfidenceCount = 0
+        var otherConfidenceCount = 0
+
+        for result in results {
+            if let filename = stringValue(result["filename"]) {
+                appendUnique(sanitizedPathLabel(filename), to: &fileLabels, limit: previewLimit)
+            }
+            if let testID = stringValue(result["test_id"]) {
+                let testName = stringValue(result["test_name"])
+                appendUnique(testLabel(id: testID, name: testName), to: &testLabels, limit: previewLimit)
+            }
+
+            switch stringValue(result["issue_severity"])?.uppercased() {
+            case "HIGH":
+                highSeverityCount += 1
+            case "MEDIUM":
+                mediumSeverityCount += 1
+            case "LOW":
+                lowSeverityCount += 1
+            default:
+                otherSeverityCount += 1
+            }
+
+            switch stringValue(result["issue_confidence"])?.uppercased() {
+            case "HIGH":
+                highConfidenceCount += 1
+            case "MEDIUM":
+                mediumConfidenceCount += 1
+            case "LOW":
+                lowConfidenceCount += 1
+            default:
+                otherConfidenceCount += 1
+            }
+        }
+
+        guard !fileLabels.isEmpty || !testLabels.isEmpty else { return nil }
+
+        return ToolArtifactBanditJSONPreview(
+            issueCount: results.count,
+            fileCount: uniqueCount(in: results, key: "filename"),
+            testCount: uniqueCount(in: results, key: "test_id"),
+            highSeverityCount: highSeverityCount,
+            mediumSeverityCount: mediumSeverityCount,
+            lowSeverityCount: lowSeverityCount,
+            otherSeverityCount: otherSeverityCount,
+            highConfidenceCount: highConfidenceCount,
+            mediumConfidenceCount: mediumConfidenceCount,
+            lowConfidenceCount: lowConfidenceCount,
+            otherConfidenceCount: otherConfidenceCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            testPreviewLabels: testLabels
+        )
+    }
+
+    private static func hasBanditIssueShape(_ result: [String: Any]) -> Bool {
+        guard stringValue(result["filename"]) != nil,
+              stringValue(result["issue_confidence"]) != nil,
+              stringValue(result["issue_severity"]) != nil,
+              stringValue(result["issue_text"]) != nil,
+              stringValue(result["test_id"]) != nil,
+              stringValue(result["test_name"]) != nil
+        else {
+            return false
+        }
+        return numericValue(result["line_number"]) != nil
+    }
+
+    private static func uniqueCount(in results: [[String: Any]], key: String) -> Int {
+        Set(results.compactMap { stringValue($0[key]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func numericValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = stringValue(value) {
+            return Double(string)
+        }
+        return nil
+    }
+
+    private static func testLabel(id: String, name: String?) -> String {
+        guard let name else { return sanitizedLabel(id) }
+        return sanitizedLabel("\(id) \(name)")
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -232,6 +232,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let ruffJSONPreview = renderRuffJSONPreview(ruffJSONPreviewModel)
             let pylintJSONPreviewModel = artifact.pylintJSONPreview
             let pylintJSONPreview = renderPylintJSONPreview(pylintJSONPreviewModel)
+            let banditJSONPreviewModel = artifact.banditJSONPreview
+            let banditJSONPreview = renderBanditJSONPreview(banditJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -321,6 +323,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && golangCILintJSONPreviewModel == nil
                 && ruffJSONPreviewModel == nil
                 && pylintJSONPreviewModel == nil
+                && banditJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -363,6 +366,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(golangCILintJSONPreview)
               \(ruffJSONPreview)
               \(pylintJSONPreview)
+              \(banditJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -1039,6 +1043,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(symbolList)
+        </div>
+        """
+    }
+
+    private static func renderBanditJSONPreview(_ preview: ToolArtifactBanditJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-bandit-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-bandit-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-bandit-json-preview-files">
+                <strong data-testid="tool-card-bandit-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let tests = preview.testPreviewLabels.map {
+            #"<li data-testid="tool-card-bandit-json-preview-test-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let testList = tests.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-bandit-json-preview-tests">
+                <strong data-testid="tool-card-bandit-json-preview-test-title">Tests</strong>
+                <ul>\(tests)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !testList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-bandit-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(testList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3262,6 +3262,99 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePylint.pylintJSONPreview)
     }
 
+    func testArtifactStateDerivesBanditJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("bandit-results.json")
+        let content = """
+        {
+          "generated_at": "2026-07-19T21:45:00Z",
+          "metrics": {
+            "_totals": {
+              "CONFIDENCE.HIGH": 1,
+              "CONFIDENCE.MEDIUM": 1,
+              "SEVERITY.HIGH": 1,
+              "SEVERITY.MEDIUM": 1,
+              "loc": 42,
+              "nosec": 0,
+              "skipped_tests": 0
+            }
+          },
+          "results": [
+            {
+              "code": "1 import subprocess",
+              "filename": "/repo/app/main.py",
+              "issue_confidence": "HIGH",
+              "issue_cwe": {"id": 78, "link": "https://cwe.mitre.org/data/definitions/78.html"},
+              "issue_severity": "HIGH",
+              "issue_text": "subprocess call with shell=True identified",
+              "line_number": 14,
+              "line_range": [14],
+              "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html",
+              "test_id": "B602",
+              "test_name": "subprocess_popen_with_shell_equals_true"
+            },
+            {
+              "code": "2 password = 'secret'",
+              "filename": "/repo/tests/test_app.py",
+              "issue_confidence": "MEDIUM",
+              "issue_severity": "MEDIUM",
+              "issue_text": "Possible hardcoded password",
+              "line_number": "7",
+              "line_range": [7],
+              "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html",
+              "test_id": "B105",
+              "test_name": "hardcoded_password_string"
+            }
+          ]
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.banditJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Bandit JSON")
+        XCTAssertEqual(preview.issueCount, 2)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.testCount, 2)
+        XCTAssertEqual(preview.highSeverityCount, 1)
+        XCTAssertEqual(preview.mediumSeverityCount, 1)
+        XCTAssertEqual(preview.highConfidenceCount, 1)
+        XCTAssertEqual(preview.mediumConfidenceCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/app/main.py",
+            "repo/tests/test_app.py"
+        ])
+        XCTAssertEqual(preview.testPreviewLabels, [
+            "B602 subprocess_popen_with_shell_equals_true",
+            "B105 hardcoded_password_string"
+        ])
+        let byteSizeLabel = try XCTUnwrap(preview.byteSizeLabel)
+        XCTAssertEqual(byteSizeLabel, "1.3 KB")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Bandit JSON",
+            "2 issues",
+            "2 files",
+            "2 tests",
+            "High severity: 1",
+            "Medium severity: 1",
+            "High confidence: 1",
+            "Medium confidence: 1",
+            "Size: \(byteSizeLabel)"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("security-report.json")
+        try #"{"results":[{"filename":"/repo/app.py","issue_severity":"HIGH","issue_text":"missing confidence","test_id":"B602","test_name":"x","line_number":1}]}"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).banditJSONPreview)
+
+        let remoteBandit = ToolArtifactState(value: "https://example.com/bandit-results.json")
+        XCTAssertNil(remoteBandit.banditJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2425,6 +2425,81 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesBanditJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("bandit-results.json")
+        let reportText = """
+        {
+          "generated_at": "2026-07-19T21:45:00Z",
+          "metrics": {"_totals": {"SEVERITY.HIGH": 1, "SEVERITY.LOW": 1}},
+          "results": [
+            {
+              "filename": "/repo/app/main.py",
+              "issue_confidence": "HIGH",
+              "issue_severity": "HIGH",
+              "issue_text": "subprocess call with shell=True identified",
+              "line_number": 14,
+              "test_id": "B602",
+              "test_name": "subprocess_popen_with_shell_equals_true"
+            },
+            {
+              "filename": "/repo/tests/test_app.py",
+              "issue_confidence": "LOW",
+              "issue_severity": "LOW",
+              "issue_text": "Possible hardcoded password",
+              "line_number": 7,
+              "test_id": "B105",
+              "test_name": "hardcoded_password_string"
+            }
+          ]
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/bandit-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/bandit-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Bandit artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">bandit-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-meta">Format: Bandit JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-meta">2 issues"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-meta">2 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-meta">High severity: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-meta">Low severity: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-file-item">repo/app/main.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-file-item">repo/tests/test_app.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-test-title">Tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-test-item">B602 subprocess_popen_with_shell_equals_true"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-bandit-json-preview-test-item">B105 hardcoded_password_string"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -225,6 +225,10 @@
   root validates as Pylint output: message/file/symbol/type counts, file size, capped file labels,
   and capped symbol labels without reading Python source files, loading plugins, or fetching remote
   JSON.
+- Artifact previews now include bounded local Bandit JSON security-report metadata for `.json`
+  files whose root validates as Bandit output: issue/file/test, severity, and confidence counts,
+  file size, capped file labels, and capped test labels without reading Python source files,
+  expanding issue code snippets, loading plugins, or fetching remote JSON.
 - Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Bandit JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Bandit JSON output as a
+  specialized security report artifact rather than generic JSON.
+- **Rationale:** Bandit is a common Python security scanner. Showing issue/file/test,
+  severity, and confidence counts plus capped file/test labels gives useful Codex-style feedback
+  without opening the raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Python
+  source files, expand issue code snippets, load Bandit plugins, or fetch remote reports.
+
 ## 2026-07-19: Render Pylint JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as Pylint JSON output as a


### PR DESCRIPTION
## Summary
- add bounded local Bandit JSON security report detection for artifact cards
- render issue/file/test severity and confidence metadata in native SwiftUI and HTML harness previews
- suppress generic JSON previews when a Bandit report is recognized
- document the parity slice and decision constraints

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesBanditJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesBanditJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check