### PR TITLE
Add Semgrep JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -85,6 +85,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pylintJSONContent(pylintJSONPreview)
         } else if let banditJSONPreview = artifact.banditJSONPreview {
             banditJSONContent(banditJSONPreview)
+        } else if let semgrepJSONPreview = artifact.semgrepJSONPreview {
+            semgrepJSONContent(semgrepJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -446,6 +448,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(banditJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: banditJSONPreview.filePreviewLabels)
             artifactContentList(title: "Tests", labels: banditJSONPreview.testPreviewLabels)
+        }
+    }
+
+    private func semgrepJSONContent(_ semgrepJSONPreview: ToolArtifactSemgrepJSONPreview) -> some View {
+        let hasLists = !semgrepJSONPreview.filePreviewLabels.isEmpty || !semgrepJSONPreview.rulePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(semgrepJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: semgrepJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Rules", labels: semgrepJSONPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2237,6 +2237,78 @@ public struct ToolArtifactBanditJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactSemgrepJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var findingCount: Int
+    public var fileCount: Int
+    public var ruleCount: Int
+    public var errorSeverityCount: Int
+    public var warningSeverityCount: Int
+    public var infoSeverityCount: Int
+    public var otherSeverityCount: Int
+    public var errorCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(findingCount) finding\(findingCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(ruleCount) rule\(ruleCount == 1 ? "" : "s")",
+            errorSeverityCount > 0 ? "Error severity: \(errorSeverityCount)" : nil,
+            warningSeverityCount > 0 ? "Warning severity: \(warningSeverityCount)" : nil,
+            infoSeverityCount > 0 ? "Info severity: \(infoSeverityCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            errorCount > 0 ? "Scanner errors: \(errorCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        findingCount > 0
+            || fileCount > 0
+            || ruleCount > 0
+            || errorSeverityCount > 0
+            || warningSeverityCount > 0
+            || infoSeverityCount > 0
+            || otherSeverityCount > 0
+            || errorCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Semgrep JSON",
+        findingCount: Int,
+        fileCount: Int,
+        ruleCount: Int,
+        errorSeverityCount: Int = 0,
+        warningSeverityCount: Int = 0,
+        infoSeverityCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        errorCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.findingCount = findingCount
+        self.fileCount = fileCount
+        self.ruleCount = ruleCount
+        self.errorSeverityCount = errorSeverityCount
+        self.warningSeverityCount = warningSeverityCount
+        self.infoSeverityCount = infoSeverityCount
+        self.otherSeverityCount = otherSeverityCount
+        self.errorCount = errorCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -3935,7 +4007,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               golangCILintJSONPreview == nil,
               ruffJSONPreview == nil,
               pylintJSONPreview == nil,
-              banditJSONPreview == nil
+              banditJSONPreview == nil,
+              semgrepJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -4022,6 +4095,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var banditJSONPreview: ToolArtifactBanditJSONPreview? {
         ToolArtifactBanditJSONPreviewBuilder.banditJSONPreview(for: value, kind: kind)
+    }
+    public var semgrepJSONPreview: ToolArtifactSemgrepJSONPreview? {
+        ToolArtifactSemgrepJSONPreviewBuilder.semgrepJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactSemgrepJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSemgrepJSONPreviewBuilder.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+enum ToolArtifactSemgrepJSONPreviewBuilder {
+    static func semgrepJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactSemgrepJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let report = root as? [String: Any],
+                  let results = report["results"] as? [[String: Any]]
+            else {
+                return nil
+            }
+            return preview(
+                from: report,
+                results: results,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from report: [String: Any],
+        results: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactSemgrepJSONPreview? {
+        guard hasSemgrepReportShape(report),
+              results.allSatisfy(hasSemgrepResultShape)
+        else {
+            return nil
+        }
+
+        var fileLabels: [String] = []
+        var ruleLabels: [String] = []
+        var errorSeverityCount = 0
+        var warningSeverityCount = 0
+        var infoSeverityCount = 0
+        var otherSeverityCount = 0
+
+        for result in results {
+            if let path = stringValue(result["path"]) {
+                appendUnique(sanitizedPathLabel(path), to: &fileLabels, limit: previewLimit)
+            }
+            if let checkID = stringValue(result["check_id"]) {
+                appendUnique(sanitizedLabel(checkID), to: &ruleLabels, limit: previewLimit)
+            }
+
+            switch severity(in: result)?.uppercased() {
+            case "ERROR":
+                errorSeverityCount += 1
+            case "WARNING":
+                warningSeverityCount += 1
+            case "INFO":
+                infoSeverityCount += 1
+            default:
+                otherSeverityCount += 1
+            }
+        }
+
+        return ToolArtifactSemgrepJSONPreview(
+            findingCount: results.count,
+            fileCount: uniqueCount(in: results, key: "path"),
+            ruleCount: uniqueCount(in: results, key: "check_id"),
+            errorSeverityCount: errorSeverityCount,
+            warningSeverityCount: warningSeverityCount,
+            infoSeverityCount: infoSeverityCount,
+            otherSeverityCount: otherSeverityCount,
+            errorCount: (report["errors"] as? [Any])?.count ?? 0,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            rulePreviewLabels: ruleLabels
+        )
+    }
+
+    private static func hasSemgrepReportShape(_ report: [String: Any]) -> Bool {
+        stringValue(report["version"]) != nil
+            && (report["paths"] is [String: Any] || report["errors"] is [Any])
+    }
+
+    private static func hasSemgrepResultShape(_ result: [String: Any]) -> Bool {
+        guard stringValue(result["check_id"]) != nil,
+              stringValue(result["path"]) != nil,
+              result["start"] is [String: Any],
+              result["end"] is [String: Any],
+              let extra = result["extra"] as? [String: Any],
+              stringValue(extra["message"]) != nil
+        else {
+            return false
+        }
+        return severity(in: result) != nil
+    }
+
+    private static func severity(in result: [String: Any]) -> String? {
+        guard let extra = result["extra"] as? [String: Any] else { return nil }
+        return stringValue(extra["severity"])
+    }
+
+    private static func uniqueCount(in results: [[String: Any]], key: String) -> Int {
+        Set(results.compactMap { stringValue($0[key]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -234,6 +234,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pylintJSONPreview = renderPylintJSONPreview(pylintJSONPreviewModel)
             let banditJSONPreviewModel = artifact.banditJSONPreview
             let banditJSONPreview = renderBanditJSONPreview(banditJSONPreviewModel)
+            let semgrepJSONPreviewModel = artifact.semgrepJSONPreview
+            let semgrepJSONPreview = renderSemgrepJSONPreview(semgrepJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -324,6 +326,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && ruffJSONPreviewModel == nil
                 && pylintJSONPreviewModel == nil
                 && banditJSONPreviewModel == nil
+                && semgrepJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -367,6 +370,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(ruffJSONPreview)
               \(pylintJSONPreview)
               \(banditJSONPreview)
+              \(semgrepJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -1078,6 +1082,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(testList)
+        </div>
+        """
+    }
+
+    private static func renderSemgrepJSONPreview(_ preview: ToolArtifactSemgrepJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-semgrep-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-semgrep-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-semgrep-json-preview-files">
+                <strong data-testid="tool-card-semgrep-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-semgrep-json-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let ruleList = rules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-semgrep-json-preview-rules">
+                <strong data-testid="tool-card-semgrep-json-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-semgrep-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(ruleList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3355,6 +3355,112 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteBandit.banditJSONPreview)
     }
 
+    func testArtifactStateDerivesSemgrepJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("semgrep-results.json")
+        let content = """
+        {
+          "version": "1.128.0",
+          "paths": {"scanned": ["app/main.py", "tests/test_app.py"]},
+          "results": [
+            {
+              "check_id": "python.lang.security.audit.subprocess-shell-true",
+              "path": "/repo/app/main.py",
+              "start": {"line": 14, "col": 5, "offset": 120},
+              "end": {"line": 14, "col": 36, "offset": 151},
+              "extra": {
+                "message": "Found subprocess call with shell=True",
+                "severity": "ERROR",
+                "metadata": {"category": "security"}
+              }
+            },
+            {
+              "check_id": "python.django.security.audit.xss.template-var",
+              "path": "/repo/tests/test_app.py",
+              "start": {"line": 8, "col": 1, "offset": 70},
+              "end": {"line": 8, "col": 21, "offset": 90},
+              "extra": {
+                "message": "Potential template escaping issue",
+                "severity": "WARNING",
+                "metadata": {"category": "security"}
+              }
+            },
+            {
+              "check_id": "python.lang.security.audit.subprocess-shell-true",
+              "path": "/repo/tests/test_app.py",
+              "start": {"line": 18, "col": 5, "offset": 170},
+              "end": {"line": 18, "col": 36, "offset": 201},
+              "extra": {
+                "message": "Found subprocess call with shell=True",
+                "severity": "INFO",
+                "metadata": {"category": "security"}
+              }
+            }
+          ],
+          "errors": [{"type": "PartialParsing", "message": "One file skipped"}]
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.semgrepJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Semgrep JSON")
+        XCTAssertEqual(preview.findingCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.ruleCount, 2)
+        XCTAssertEqual(preview.errorSeverityCount, 1)
+        XCTAssertEqual(preview.warningSeverityCount, 1)
+        XCTAssertEqual(preview.infoSeverityCount, 1)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/app/main.py",
+            "repo/tests/test_app.py"
+        ])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "python.lang.security.audit.subprocess-shell-true",
+            "python.django.security.audit.xss.template-var"
+        ])
+        let byteSizeLabel = try XCTUnwrap(preview.byteSizeLabel)
+        XCTAssertEqual(byteSizeLabel, "1.3 KB")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Semgrep JSON",
+            "3 findings",
+            "2 files",
+            "2 rules",
+            "Error severity: 1",
+            "Warning severity: 1",
+            "Info severity: 1",
+            "Scanner errors: 1",
+            "Size: \(byteSizeLabel)"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("generic-results.json")
+        try #"{"results":[{"check_id":"x","path":"/repo/app.py","start":{},"end":{},"extra":{"message":"missing severity"}}],"version":"1"}"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).semgrepJSONPreview)
+
+        let clean = directory.appendingPathComponent("semgrep-clean.json")
+        try #"{"version":"1.128.0","paths":{"scanned":["app/main.py"]},"results":[],"errors":[]}"#
+            .write(to: clean, atomically: true, encoding: .utf8)
+        let cleanPreview = try XCTUnwrap(ToolArtifactState(value: clean.path).semgrepJSONPreview)
+        XCTAssertEqual(cleanPreview.findingCount, 0)
+        XCTAssertEqual(cleanPreview.fileCount, 0)
+        XCTAssertEqual(cleanPreview.ruleCount, 0)
+        XCTAssertEqual(cleanPreview.metadataLines.prefix(4), [
+            "Format: Semgrep JSON",
+            "0 findings",
+            "0 files",
+            "0 rules"
+        ])
+
+        let remoteSemgrep = ToolArtifactState(value: "https://example.com/semgrep-results.json")
+        XCTAssertNil(remoteSemgrep.semgrepJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2500,6 +2500,83 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesSemgrepJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("semgrep-results.json")
+        let reportText = """
+        {
+          "version": "1.128.0",
+          "results": [
+            {
+              "check_id": "python.lang.security.audit.subprocess-shell-true",
+              "path": "/repo/app/main.py",
+              "start": {"line": 14, "col": 5},
+              "end": {"line": 14, "col": 36},
+              "extra": {
+                "message": "Found subprocess call with shell=True",
+                "severity": "ERROR"
+              }
+            },
+            {
+              "check_id": "python.django.security.audit.xss.template-var",
+              "path": "/repo/tests/test_app.py",
+              "start": {"line": 8, "col": 1},
+              "end": {"line": 8, "col": 21},
+              "extra": {
+                "message": "Potential template escaping issue",
+                "severity": "WARNING"
+              }
+            }
+          ],
+          "errors": []
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/semgrep-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/semgrep-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Semgrep artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">semgrep-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-meta">Format: Semgrep JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-meta">2 findings"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-meta">2 rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-meta">Error severity: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-meta">Warning severity: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-file-item">repo/app/main.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-file-item">repo/tests/test_app.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-rule-item">python.lang.security.audit.subprocess-shell-true"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-semgrep-json-preview-rule-item">python.django.security.audit.xss.template-var"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -229,6 +229,10 @@
   files whose root validates as Bandit output: issue/file/test, severity, and confidence counts,
   file size, capped file labels, and capped test labels without reading Python source files,
   expanding issue code snippets, loading plugins, or fetching remote JSON.
+- Artifact previews now include bounded local Semgrep JSON static-analysis metadata for `.json`
+  files whose root validates as native Semgrep output: finding/file/rule/severity and scanner-error
+  counts, file size, capped file labels, and capped rule labels without reading source files,
+  expanding match snippets, loading rules, shelling out, or fetching remote JSON.
 - Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Semgrep JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as native Semgrep JSON output as a
+  specialized static-analysis artifact rather than generic JSON.
+- **Rationale:** Semgrep reports are common in security and code-review sessions. Showing finding,
+  file, rule, severity, and scanner-error counts plus capped file/rule labels gives useful
+  Codex-style feedback without opening the raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read source
+  files, expand match snippets, load Semgrep rules, shell out, or fetch remote reports.
+
 ## 2026-07-19: Render Bandit JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as Bandit JSON output as a


### PR DESCRIPTION
## Summary
- add bounded local Semgrep JSON artifact detection and metadata previews
- render Semgrep finding/file/rule/severity summaries in SwiftUI and static HTML surfaces
- document the artifact-preview parity decision and matrix entry

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesSemgrepJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesSemgrepJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check