### PR TITLE
Add Code Climate JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -87,6 +87,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             banditJSONContent(banditJSONPreview)
         } else if let semgrepJSONPreview = artifact.semgrepJSONPreview {
             semgrepJSONContent(semgrepJSONPreview)
+        } else if let codeClimateJSONPreview = artifact.codeClimateJSONPreview {
+            codeClimateJSONContent(codeClimateJSONPreview)
         } else if let npmLockfilePreview = artifact.npmLockfilePreview {
             npmLockfileContent(npmLockfilePreview)
         } else if let denoLockPreview = artifact.denoLockPreview {
@@ -464,6 +466,25 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(semgrepJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: semgrepJSONPreview.filePreviewLabels)
             artifactContentList(title: "Rules", labels: semgrepJSONPreview.rulePreviewLabels)
+        }
+    }
+
+    private func codeClimateJSONContent(_ codeClimateJSONPreview: ToolArtifactCodeClimateJSONPreview) -> some View {
+        let hasLists = !codeClimateJSONPreview.filePreviewLabels.isEmpty
+            || !codeClimateJSONPreview.checkPreviewLabels.isEmpty
+            || !codeClimateJSONPreview.categoryPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 176 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "exclamationmark.triangle")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(codeClimateJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: codeClimateJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Checks", labels: codeClimateJSONPreview.checkPreviewLabels)
+            artifactContentList(title: "Categories", labels: codeClimateJSONPreview.categoryPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2309,6 +2309,92 @@ public struct ToolArtifactSemgrepJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactCodeClimateJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var issueCount: Int
+    public var fileCount: Int
+    public var checkCount: Int
+    public var categoryCount: Int
+    public var blockerCount: Int
+    public var criticalCount: Int
+    public var majorCount: Int
+    public var minorCount: Int
+    public var infoCount: Int
+    public var otherSeverityCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var checkPreviewLabels: [String]
+    public var categoryPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(issueCount) issue\(issueCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(checkCount) check\(checkCount == 1 ? "" : "s")",
+            "\(categoryCount) categor\(categoryCount == 1 ? "y" : "ies")",
+            blockerCount > 0 ? "Blocker: \(blockerCount)" : nil,
+            criticalCount > 0 ? "Critical: \(criticalCount)" : nil,
+            majorCount > 0 ? "Major: \(majorCount)" : nil,
+            minorCount > 0 ? "Minor: \(minorCount)" : nil,
+            infoCount > 0 ? "Info: \(infoCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        issueCount > 0
+            || fileCount > 0
+            || checkCount > 0
+            || categoryCount > 0
+            || blockerCount > 0
+            || criticalCount > 0
+            || majorCount > 0
+            || minorCount > 0
+            || infoCount > 0
+            || otherSeverityCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !checkPreviewLabels.isEmpty
+            || !categoryPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Code Climate JSON",
+        issueCount: Int,
+        fileCount: Int,
+        checkCount: Int,
+        categoryCount: Int,
+        blockerCount: Int = 0,
+        criticalCount: Int = 0,
+        majorCount: Int = 0,
+        minorCount: Int = 0,
+        infoCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        checkPreviewLabels: [String] = [],
+        categoryPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.issueCount = issueCount
+        self.fileCount = fileCount
+        self.checkCount = checkCount
+        self.categoryCount = categoryCount
+        self.blockerCount = blockerCount
+        self.criticalCount = criticalCount
+        self.majorCount = majorCount
+        self.minorCount = minorCount
+        self.infoCount = infoCount
+        self.otherSeverityCount = otherSeverityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.checkPreviewLabels = checkPreviewLabels
+        self.categoryPreviewLabels = categoryPreviewLabels
+    }
+}
+
 public struct ToolArtifactTAPPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var planLabel: String?
@@ -4008,7 +4094,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               ruffJSONPreview == nil,
               pylintJSONPreview == nil,
               banditJSONPreview == nil,
-              semgrepJSONPreview == nil
+              semgrepJSONPreview == nil,
+              codeClimateJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -4098,6 +4185,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var semgrepJSONPreview: ToolArtifactSemgrepJSONPreview? {
         ToolArtifactSemgrepJSONPreviewBuilder.semgrepJSONPreview(for: value, kind: kind)
+    }
+    public var codeClimateJSONPreview: ToolArtifactCodeClimateJSONPreview? {
+        ToolArtifactCodeClimateJSONPreviewBuilder.codeClimateJSONPreview(for: value, kind: kind)
     }
     public var tapPreview: ToolArtifactTAPPreview? {
         ToolArtifactTAPPreviewBuilder.tapPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactCodeClimateJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCodeClimateJSONPreviewBuilder.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+enum ToolArtifactCodeClimateJSONPreviewBuilder {
+    static func codeClimateJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactCodeClimateJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let issues = root as? [[String: Any]] else { return nil }
+            return preview(
+                from: issues,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from issues: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactCodeClimateJSONPreview? {
+        guard !issues.isEmpty, issues.allSatisfy(hasCodeClimateIssueShape) else { return nil }
+
+        var fileLabels: [String] = []
+        var checkLabels: [String] = []
+        var categoryLabels: [String] = []
+        var blockerCount = 0
+        var criticalCount = 0
+        var majorCount = 0
+        var minorCount = 0
+        var infoCount = 0
+        var otherSeverityCount = 0
+
+        for issue in issues {
+            if let path = locationPath(in: issue) {
+                appendUnique(sanitizedPathLabel(path), to: &fileLabels, limit: previewLimit)
+            }
+            if let checkName = stringValue(issue["check_name"]) {
+                appendUnique(sanitizedLabel(checkName), to: &checkLabels, limit: previewLimit)
+            }
+            for category in issue["categories"] as? [String] ?? [] {
+                appendUnique(sanitizedLabel(category), to: &categoryLabels, limit: previewLimit)
+            }
+
+            switch stringValue(issue["severity"])?.lowercased() {
+            case "blocker":
+                blockerCount += 1
+            case "critical":
+                criticalCount += 1
+            case "major":
+                majorCount += 1
+            case "minor":
+                minorCount += 1
+            case "info":
+                infoCount += 1
+            default:
+                otherSeverityCount += 1
+            }
+        }
+
+        return ToolArtifactCodeClimateJSONPreview(
+            issueCount: issues.count,
+            fileCount: uniqueCount(in: issues, value: locationPath),
+            checkCount: uniqueCount(in: issues) { stringValue($0["check_name"]) },
+            categoryCount: Set(issues.flatMap { $0["categories"] as? [String] ?? [] }).count,
+            blockerCount: blockerCount,
+            criticalCount: criticalCount,
+            majorCount: majorCount,
+            minorCount: minorCount,
+            infoCount: infoCount,
+            otherSeverityCount: otherSeverityCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            checkPreviewLabels: checkLabels,
+            categoryPreviewLabels: categoryLabels
+        )
+    }
+
+    private static func hasCodeClimateIssueShape(_ issue: [String: Any]) -> Bool {
+        guard stringValue(issue["type"]) == "issue",
+              stringValue(issue["check_name"]) != nil,
+              stringValue(issue["description"]) != nil,
+              locationPath(in: issue) != nil
+        else {
+            return false
+        }
+        return issue["categories"] is [String]
+            || issue.keys.contains("severity")
+            || stringValue(issue["fingerprint"]) != nil
+    }
+
+    private static func locationPath(in issue: [String: Any]) -> String? {
+        guard let location = issue["location"] as? [String: Any] else { return nil }
+        return stringValue(location["path"])
+    }
+
+    private static func uniqueCount(
+        in issues: [[String: Any]],
+        value: ([String: Any]) -> String?
+    ) -> Int {
+        Set(issues.compactMap(value)).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -236,6 +236,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let banditJSONPreview = renderBanditJSONPreview(banditJSONPreviewModel)
             let semgrepJSONPreviewModel = artifact.semgrepJSONPreview
             let semgrepJSONPreview = renderSemgrepJSONPreview(semgrepJSONPreviewModel)
+            let codeClimateJSONPreviewModel = artifact.codeClimateJSONPreview
+            let codeClimateJSONPreview = renderCodeClimateJSONPreview(codeClimateJSONPreviewModel)
             let npmLockfilePreviewModel = artifact.npmLockfilePreview
             let npmLockfilePreview = renderNPMLockfilePreview(npmLockfilePreviewModel)
             let denoLockPreviewModel = artifact.denoLockPreview
@@ -327,6 +329,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && pylintJSONPreviewModel == nil
                 && banditJSONPreviewModel == nil
                 && semgrepJSONPreviewModel == nil
+                && codeClimateJSONPreviewModel == nil
                 && npmLockfilePreviewModel == nil
                 && denoLockPreviewModel == nil
                 && bunLockfilePreviewModel == nil
@@ -371,6 +374,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(pylintJSONPreview)
               \(banditJSONPreview)
               \(semgrepJSONPreview)
+              \(codeClimateJSONPreview)
               \(npmLockfilePreview)
               \(denoLockPreview)
               \(bunLockfilePreview)
@@ -1117,6 +1121,51 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(ruleList)
+        </div>
+        """
+    }
+
+    private static func renderCodeClimateJSONPreview(_ preview: ToolArtifactCodeClimateJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-code-climate-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-code-climate-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-code-climate-json-preview-files">
+                <strong data-testid="tool-card-code-climate-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let checks = preview.checkPreviewLabels.map {
+            #"<li data-testid="tool-card-code-climate-json-preview-check-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let checkList = checks.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-code-climate-json-preview-checks">
+                <strong data-testid="tool-card-code-climate-json-preview-check-title">Checks</strong>
+                <ul>\(checks)</ul>
+              </section>
+        """
+        let categories = preview.categoryPreviewLabels.map {
+            #"<li data-testid="tool-card-code-climate-json-preview-category-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let categoryList = categories.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-code-climate-json-preview-categories">
+                <strong data-testid="tool-card-code-climate-json-preview-category-title">Categories</strong>
+                <ul>\(categories)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !checkList.isEmpty || !categoryList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-code-climate-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(checkList)
+          \(categoryList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3461,6 +3461,92 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteSemgrep.semgrepJSONPreview)
     }
 
+    func testArtifactStateDerivesCodeClimateJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("codeclimate-results.json")
+        let content = """
+        [
+          {
+            "type": "issue",
+            "check_name": "Rubocop/Metrics/MethodLength",
+            "description": "Method has too many lines.",
+            "categories": ["Complexity"],
+            "location": {"path": "/repo/app/services/report.rb", "lines": {"begin": 12, "end": 48}},
+            "severity": "major",
+            "fingerprint": "abc123"
+          },
+          {
+            "type": "issue",
+            "check_name": "ESLint/no-console",
+            "description": "Unexpected console statement.",
+            "categories": ["Bug Risk", "Style"],
+            "location": {"path": "/repo/web/src/main.ts", "lines": {"begin": 8, "end": 8}},
+            "severity": "minor",
+            "fingerprint": "def456"
+          },
+          {
+            "type": "issue",
+            "check_name": "Rubocop/Metrics/MethodLength",
+            "description": "Another method is too long.",
+            "categories": ["Complexity"],
+            "location": {"path": "/repo/app/models/user.rb", "lines": {"begin": 20, "end": 70}},
+            "severity": "critical",
+            "fingerprint": "ghi789"
+          }
+        ]
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.codeClimateJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Code Climate JSON")
+        XCTAssertEqual(preview.issueCount, 3)
+        XCTAssertEqual(preview.fileCount, 3)
+        XCTAssertEqual(preview.checkCount, 2)
+        XCTAssertEqual(preview.categoryCount, 3)
+        XCTAssertEqual(preview.criticalCount, 1)
+        XCTAssertEqual(preview.majorCount, 1)
+        XCTAssertEqual(preview.minorCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "app/services/report.rb",
+            "web/src/main.ts",
+            "app/models/user.rb"
+        ])
+        XCTAssertEqual(preview.checkPreviewLabels, [
+            "Rubocop/Metrics/MethodLength",
+            "ESLint/no-console"
+        ])
+        XCTAssertEqual(preview.categoryPreviewLabels, [
+            "Complexity",
+            "Bug Risk",
+            "Style"
+        ])
+        let byteSizeLabel = try XCTUnwrap(preview.byteSizeLabel)
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Code Climate JSON",
+            "3 issues",
+            "3 files",
+            "2 checks",
+            "3 categories",
+            "Critical: 1",
+            "Major: 1",
+            "Minor: 1",
+            "Size: \(byteSizeLabel)"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("generic-codeclimate-like.json")
+        try #"[{"type":"issue","check_name":"x","description":"missing location"}]"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).codeClimateJSONPreview)
+
+        let remoteCodeClimate = ToolArtifactState(value: "https://example.com/codeclimate-results.json")
+        XCTAssertNil(remoteCodeClimate.codeClimateJSONPreview)
+    }
+
     func testArtifactStateDerivesTAPPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("test.tap")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2577,6 +2577,82 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesCodeClimateJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("codeclimate-results.json")
+        let reportText = """
+        [
+          {
+            "type": "issue",
+            "check_name": "Rubocop/Metrics/MethodLength",
+            "description": "Method has too many lines.",
+            "categories": ["Complexity"],
+            "location": {"path": "/repo/app/services/report.rb", "lines": {"begin": 12, "end": 48}},
+            "severity": "major",
+            "fingerprint": "abc123"
+          },
+          {
+            "type": "issue",
+            "check_name": "ESLint/no-console",
+            "description": "Unexpected console statement.",
+            "categories": ["Bug Risk", "Style"],
+            "location": {"path": "/repo/web/src/main.ts", "lines": {"begin": 8, "end": 8}},
+            "severity": "minor",
+            "fingerprint": "def456"
+          }
+        ]
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/codeclimate-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/codeclimate-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Code Climate artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">codeclimate-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-meta">Format: Code Climate JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-meta">2 issues"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-meta">2 checks"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-meta">3 categories"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-meta">Major: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-meta">Minor: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-file-item">app/services/report.rb"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-file-item">web/src/main.ts"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-check-title">Checks"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-check-item">Rubocop/Metrics/MethodLength"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-check-item">ESLint/no-console"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-category-title">Categories"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-category-item">Complexity"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-category-item">Bug Risk"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-code-climate-json-preview-category-item">Style"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesTAPArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -233,6 +233,10 @@
   files whose root validates as native Semgrep output: finding/file/rule/severity and scanner-error
   counts, file size, capped file labels, and capped rule labels without reading source files,
   expanding match snippets, loading rules, shelling out, or fetching remote JSON.
+- Artifact previews now include bounded local Code Climate JSON issue metadata for `.json` files
+  whose root validates as Code Climate output: issue/file/check/category/severity counts, file size,
+  capped file labels, capped check labels, and capped category labels without reading source files,
+  expanding issue locations, calling Code Climate tooling, or fetching remote JSON.
 - Artifact previews now include bounded local Checkstyle XML report metadata for `.xml` files whose
   root validates as Checkstyle output: file/issue/severity counts, file size, capped file labels,
   and capped rule/source labels without reading source files, loading lint plugins, or fetching

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Code Climate JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Code Climate issue JSON output as
+  a specialized review/static-analysis artifact rather than generic JSON.
+- **Rationale:** Code Climate JSON is a common interchange format for CI quality reports across
+  linters. Showing issue/file/check/category/severity counts plus capped file/check/category labels
+  gives useful Codex-style feedback without opening the raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read source
+  files, expand issue locations, fetch remote reports, or call Code Climate tooling.
+
 ## 2026-07-19: Render Semgrep JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as native Semgrep JSON output as a


### PR DESCRIPTION
## Summary
- add bounded local Code Climate JSON artifact detection and metadata previews
- render issue/file/check/category/severity summaries in SwiftUI and static HTML surfaces
- document the artifact-preview parity decision and matrix entry

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesCodeClimateJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesCodeClimateJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check