### PR TITLE
Add mypy JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -83,6 +83,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             ruffJSONContent(ruffJSONPreview)
         } else if let pylintJSONPreview = artifact.pylintJSONPreview {
             pylintJSONContent(pylintJSONPreview)
+        } else if let mypyJSONPreview = artifact.mypyJSONPreview {
+            mypyJSONContent(mypyJSONPreview)
         } else if let banditJSONPreview = artifact.banditJSONPreview {
             banditJSONContent(banditJSONPreview)
         } else if let semgrepJSONPreview = artifact.semgrepJSONPreview {
@@ -434,6 +436,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(pylintJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: pylintJSONPreview.filePreviewLabels)
             artifactContentList(title: "Symbols", labels: pylintJSONPreview.symbolPreviewLabels)
+        }
+    }
+
+    private func mypyJSONContent(_ mypyJSONPreview: ToolArtifactMypyJSONPreview) -> some View {
+        let hasLists = !mypyJSONPreview.filePreviewLabels.isEmpty || !mypyJSONPreview.codePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(mypyJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: mypyJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Codes", labels: mypyJSONPreview.codePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2150,6 +2150,68 @@ public struct ToolArtifactPylintJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactMypyJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var diagnosticCount: Int
+    public var fileCount: Int
+    public var codeCount: Int
+    public var errorCount: Int
+    public var noteCount: Int
+    public var otherSeverityCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var codePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(diagnosticCount) diagnostic\(diagnosticCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(codeCount) code\(codeCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            noteCount > 0 ? "Notes: \(noteCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        diagnosticCount > 0
+            || fileCount > 0
+            || codeCount > 0
+            || errorCount > 0
+            || noteCount > 0
+            || otherSeverityCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !codePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "mypy JSON",
+        diagnosticCount: Int,
+        fileCount: Int,
+        codeCount: Int,
+        errorCount: Int = 0,
+        noteCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        codePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.diagnosticCount = diagnosticCount
+        self.fileCount = fileCount
+        self.codeCount = codeCount
+        self.errorCount = errorCount
+        self.noteCount = noteCount
+        self.otherSeverityCount = otherSeverityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.codePreviewLabels = codePreviewLabels
+    }
+}
+
 public struct ToolArtifactBanditJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var issueCount: Int
@@ -4093,6 +4155,7 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               golangCILintJSONPreview == nil,
               ruffJSONPreview == nil,
               pylintJSONPreview == nil,
+              mypyJSONPreview == nil,
               banditJSONPreview == nil,
               semgrepJSONPreview == nil,
               codeClimateJSONPreview == nil
@@ -4179,6 +4242,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var pylintJSONPreview: ToolArtifactPylintJSONPreview? {
         ToolArtifactPylintJSONPreviewBuilder.pylintJSONPreview(for: value, kind: kind)
+    }
+    public var mypyJSONPreview: ToolArtifactMypyJSONPreview? {
+        ToolArtifactMypyJSONPreviewBuilder.mypyJSONPreview(for: value, kind: kind)
     }
     public var banditJSONPreview: ToolArtifactBanditJSONPreview? {
         ToolArtifactBanditJSONPreviewBuilder.banditJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactMypyJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactMypyJSONPreviewBuilder.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+enum ToolArtifactMypyJSONPreviewBuilder {
+    static func mypyJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactMypyJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              ["json", "jsonl"].contains(documentPreview.extensionLabel.lowercased()),
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let diagnostics = try decodeDiagnostics(from: data)
+            return preview(
+                from: diagnostics,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func decodeDiagnostics(from data: Data) throws -> [[String: Any]] {
+        if let root = try? JSONSerialization.jsonObject(with: data, options: []),
+           let diagnostics = root as? [[String: Any]] {
+            return diagnostics
+        }
+
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+        return try text
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> [String: Any]? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return nil }
+                let lineData = Data(trimmed.utf8)
+                return try JSONSerialization.jsonObject(with: lineData, options: []) as? [String: Any]
+            }
+    }
+
+    private static func preview(
+        from diagnostics: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactMypyJSONPreview? {
+        guard !diagnostics.isEmpty, diagnostics.allSatisfy(hasMypyDiagnosticShape) else { return nil }
+
+        var fileLabels: [String] = []
+        var codeLabels: [String] = []
+        var errorCount = 0
+        var noteCount = 0
+        var otherSeverityCount = 0
+
+        for diagnostic in diagnostics {
+            if let path = stringValue(diagnostic["file"]) {
+                appendUnique(sanitizedPathLabel(path), to: &fileLabels, limit: previewLimit)
+            }
+            if let code = stringValue(diagnostic["code"]) {
+                appendUnique(sanitizedLabel(code), to: &codeLabels, limit: previewLimit)
+            }
+
+            switch stringValue(diagnostic["severity"])?.lowercased() {
+            case "error":
+                errorCount += 1
+            case "note":
+                noteCount += 1
+            default:
+                otherSeverityCount += 1
+            }
+        }
+
+        guard !fileLabels.isEmpty else { return nil }
+
+        return ToolArtifactMypyJSONPreview(
+            diagnosticCount: diagnostics.count,
+            fileCount: uniqueCount(in: diagnostics, key: "file"),
+            codeCount: uniqueCount(in: diagnostics, key: "code"),
+            errorCount: errorCount,
+            noteCount: noteCount,
+            otherSeverityCount: otherSeverityCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            codePreviewLabels: codeLabels
+        )
+    }
+
+    private static func hasMypyDiagnosticShape(_ diagnostic: [String: Any]) -> Bool {
+        guard stringValue(diagnostic["file"]) != nil,
+              stringValue(diagnostic["message"]) != nil,
+              stringValue(diagnostic["severity"]) != nil
+        else {
+            return false
+        }
+        return numericValue(diagnostic["line"]) != nil
+    }
+
+    private static func uniqueCount(in diagnostics: [[String: Any]], key: String) -> Int {
+        Set(diagnostics.compactMap { stringValue($0[key]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func numericValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = stringValue(value) {
+            return Double(string)
+        }
+        return nil
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -232,6 +232,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let ruffJSONPreview = renderRuffJSONPreview(ruffJSONPreviewModel)
             let pylintJSONPreviewModel = artifact.pylintJSONPreview
             let pylintJSONPreview = renderPylintJSONPreview(pylintJSONPreviewModel)
+            let mypyJSONPreviewModel = artifact.mypyJSONPreview
+            let mypyJSONPreview = renderMypyJSONPreview(mypyJSONPreviewModel)
             let banditJSONPreviewModel = artifact.banditJSONPreview
             let banditJSONPreview = renderBanditJSONPreview(banditJSONPreviewModel)
             let semgrepJSONPreviewModel = artifact.semgrepJSONPreview
@@ -327,6 +329,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && golangCILintJSONPreviewModel == nil
                 && ruffJSONPreviewModel == nil
                 && pylintJSONPreviewModel == nil
+                && mypyJSONPreviewModel == nil
                 && banditJSONPreviewModel == nil
                 && semgrepJSONPreviewModel == nil
                 && codeClimateJSONPreviewModel == nil
@@ -372,6 +375,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(golangCILintJSONPreview)
               \(ruffJSONPreview)
               \(pylintJSONPreview)
+              \(mypyJSONPreview)
               \(banditJSONPreview)
               \(semgrepJSONPreview)
               \(codeClimateJSONPreview)
@@ -1051,6 +1055,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(symbolList)
+        </div>
+        """
+    }
+
+    private static func renderMypyJSONPreview(_ preview: ToolArtifactMypyJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-mypy-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-mypy-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-mypy-json-preview-files">
+                <strong data-testid="tool-card-mypy-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let codes = preview.codePreviewLabels.map {
+            #"<li data-testid="tool-card-mypy-json-preview-code-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let codeList = codes.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-mypy-json-preview-codes">
+                <strong data-testid="tool-card-mypy-json-preview-code-title">Codes</strong>
+                <ul>\(codes)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !codeList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-mypy-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(codeList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3262,6 +3262,91 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePylint.pylintJSONPreview)
     }
 
+    func testArtifactStateDerivesMypyJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("mypy-results.json")
+        let content = """
+        [
+          {
+            "file": "/repo/app/models.py",
+            "line": 7,
+            "column": 12,
+            "message": "Incompatible return value type",
+            "severity": "error",
+            "code": "return-value"
+          },
+          {
+            "file": "/repo/app/views.py",
+            "line": "22",
+            "column": 4,
+            "message": "Call to untyped function",
+            "severity": "note",
+            "code": "no-untyped-call"
+          },
+          {
+            "file": "/repo/app/models.py",
+            "line": 30,
+            "column": 8,
+            "message": "Unsupported operand types",
+            "severity": "error",
+            "code": "operator"
+          }
+        ]
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.mypyJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "mypy JSON")
+        XCTAssertEqual(preview.diagnosticCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.codeCount, 3)
+        XCTAssertEqual(preview.errorCount, 2)
+        XCTAssertEqual(preview.noteCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/app/models.py",
+            "repo/app/views.py"
+        ])
+        XCTAssertEqual(preview.codePreviewLabels, [
+            "return-value",
+            "no-untyped-call",
+            "operator"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: mypy JSON",
+            "3 diagnostics",
+            "2 files",
+            "3 codes",
+            "Errors: 2",
+            "Notes: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let jsonl = directory.appendingPathComponent("mypy-results.jsonl")
+        let jsonlContent = """
+        {"file":"/repo/pkg/a.py","line":1,"message":"Missing type annotation","severity":"error","code":"var-annotated"}
+        {"file":"/repo/pkg/b.py","line":2,"message":"Revealed type is Any","severity":"note"}
+        """
+        try jsonlContent.write(to: jsonl, atomically: true, encoding: .utf8)
+        let jsonlPreview = try XCTUnwrap(ToolArtifactState(value: jsonl.path).mypyJSONPreview)
+        XCTAssertEqual(jsonlPreview.diagnosticCount, 2)
+        XCTAssertEqual(jsonlPreview.fileCount, 2)
+        XCTAssertEqual(jsonlPreview.codeCount, 1)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"[{"file":"/repo/app.py","message":"missing severity and line"}]"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).mypyJSONPreview)
+
+        let remoteMypy = ToolArtifactState(value: "https://example.com/mypy-results.json")
+        XCTAssertNil(remoteMypy.mypyJSONPreview)
+    }
+
     func testArtifactStateDerivesBanditJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bandit-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2425,6 +2425,75 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesMypyJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("mypy-results.json")
+        let reportText = """
+        [
+          {
+            "file": "/repo/app/models.py",
+            "line": 7,
+            "column": 12,
+            "message": "Incompatible return value type",
+            "severity": "error",
+            "code": "return-value"
+          },
+          {
+            "file": "/repo/app/views.py",
+            "line": 22,
+            "column": 4,
+            "message": "Call to untyped function",
+            "severity": "note",
+            "code": "no-untyped-call"
+          }
+        ]
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/mypy-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/mypy-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "mypy artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">mypy-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-meta">Format: mypy JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-meta">2 diagnostics"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-meta">2 codes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-meta">Notes: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-file-item">repo/app/models.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-file-item">repo/app/views.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-code-title">Codes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-code-item">return-value"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mypy-json-preview-code-item">no-untyped-call"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesBanditJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -225,6 +225,10 @@
   root validates as Pylint output: message/file/symbol/type counts, file size, capped file labels,
   and capped symbol labels without reading Python source files, loading plugins, or fetching remote
   JSON.
+- Artifact previews now include bounded local mypy JSON report metadata for `.json` and `.jsonl`
+  files whose records validate as mypy output: diagnostic/file/code/severity counts, file size,
+  capped file labels, and capped code labels without reading Python source files, loading mypy
+  configuration, shelling out, or fetching remote JSON.
 - Artifact previews now include bounded local Bandit JSON security-report metadata for `.json`
   files whose root validates as Bandit output: issue/file/test, severity, and confidence counts,
   file size, capped file labels, and capped test labels without reading Python source files,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,16 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render mypy JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` and `.jsonl` files whose records validate as mypy JSON output
+  as a specialized Python type-check report rather than generic JSON or JSON Lines.
+- **Rationale:** mypy reports are common in Python coding sessions and CI exports. Showing
+  diagnostic/file/code/severity counts plus capped file/code labels gives useful Codex-style
+  feedback without opening the raw report.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Python
+  source files, expand diagnostic messages, load mypy configuration, shell out, or fetch remote
+  reports.
+
 ## 2026-07-19: Render Code Climate JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as Code Climate issue JSON output as


### PR DESCRIPTION
## Summary
- add bounded local mypy JSON/JSONL artifact preview detection
- render mypy diagnostic/file/code/severity metadata in SwiftUI and static HTML
- document the bounded-local safety boundary in parity docs and decisions

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesMypyJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesMypyJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check