### PR TITLE
Add Pyright JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -85,6 +85,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pylintJSONContent(pylintJSONPreview)
         } else if let mypyJSONPreview = artifact.mypyJSONPreview {
             mypyJSONContent(mypyJSONPreview)
+        } else if let pyrightJSONPreview = artifact.pyrightJSONPreview {
+            pyrightJSONContent(pyrightJSONPreview)
         } else if let banditJSONPreview = artifact.banditJSONPreview {
             banditJSONContent(banditJSONPreview)
         } else if let semgrepJSONPreview = artifact.semgrepJSONPreview {
@@ -452,6 +454,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(mypyJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: mypyJSONPreview.filePreviewLabels)
             artifactContentList(title: "Codes", labels: mypyJSONPreview.codePreviewLabels)
+        }
+    }
+
+    private func pyrightJSONContent(_ pyrightJSONPreview: ToolArtifactPyrightJSONPreview) -> some View {
+        let hasLists = !pyrightJSONPreview.filePreviewLabels.isEmpty || !pyrightJSONPreview.rulePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(pyrightJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: pyrightJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Rules", labels: pyrightJSONPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2212,6 +2212,73 @@ public struct ToolArtifactMypyJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPyrightJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var diagnosticCount: Int
+    public var fileCount: Int
+    public var ruleCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var informationCount: Int
+    public var otherSeverityCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(diagnosticCount) diagnostic\(diagnosticCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(ruleCount) rule\(ruleCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            informationCount > 0 ? "Information: \(informationCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        diagnosticCount > 0
+            || fileCount > 0
+            || ruleCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || informationCount > 0
+            || otherSeverityCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Pyright JSON",
+        diagnosticCount: Int,
+        fileCount: Int,
+        ruleCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        informationCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.diagnosticCount = diagnosticCount
+        self.fileCount = fileCount
+        self.ruleCount = ruleCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.informationCount = informationCount
+        self.otherSeverityCount = otherSeverityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactBanditJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var issueCount: Int
@@ -4156,6 +4223,7 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               ruffJSONPreview == nil,
               pylintJSONPreview == nil,
               mypyJSONPreview == nil,
+              pyrightJSONPreview == nil,
               banditJSONPreview == nil,
               semgrepJSONPreview == nil,
               codeClimateJSONPreview == nil
@@ -4245,6 +4313,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var mypyJSONPreview: ToolArtifactMypyJSONPreview? {
         ToolArtifactMypyJSONPreviewBuilder.mypyJSONPreview(for: value, kind: kind)
+    }
+    public var pyrightJSONPreview: ToolArtifactPyrightJSONPreview? {
+        ToolArtifactPyrightJSONPreviewBuilder.pyrightJSONPreview(for: value, kind: kind)
     }
     public var banditJSONPreview: ToolArtifactBanditJSONPreview? {
         ToolArtifactBanditJSONPreviewBuilder.banditJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactPyrightJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPyrightJSONPreviewBuilder.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+enum ToolArtifactPyrightJSONPreviewBuilder {
+    static func pyrightJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPyrightJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let report = root as? [String: Any],
+                  let diagnostics = report["generalDiagnostics"] as? [[String: Any]]
+            else { return nil }
+            return preview(
+                from: diagnostics,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from diagnostics: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactPyrightJSONPreview? {
+        guard !diagnostics.isEmpty, diagnostics.allSatisfy(hasPyrightDiagnosticShape) else { return nil }
+
+        var fileLabels: [String] = []
+        var ruleLabels: [String] = []
+        var errorCount = 0
+        var warningCount = 0
+        var informationCount = 0
+        var otherSeverityCount = 0
+
+        for diagnostic in diagnostics {
+            if let file = stringValue(diagnostic["file"]) {
+                appendUnique(sanitizedPathLabel(file), to: &fileLabels, limit: previewLimit)
+            }
+            if let rule = stringValue(diagnostic["rule"]) {
+                appendUnique(sanitizedLabel(rule), to: &ruleLabels, limit: previewLimit)
+            }
+
+            switch stringValue(diagnostic["severity"])?.lowercased() {
+            case "error":
+                errorCount += 1
+            case "warning":
+                warningCount += 1
+            case "information":
+                informationCount += 1
+            default:
+                otherSeverityCount += 1
+            }
+        }
+
+        guard !fileLabels.isEmpty else { return nil }
+
+        return ToolArtifactPyrightJSONPreview(
+            diagnosticCount: diagnostics.count,
+            fileCount: uniqueCount(in: diagnostics, key: "file"),
+            ruleCount: uniqueCount(in: diagnostics, key: "rule"),
+            errorCount: errorCount,
+            warningCount: warningCount,
+            informationCount: informationCount,
+            otherSeverityCount: otherSeverityCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            rulePreviewLabels: ruleLabels
+        )
+    }
+
+    private static func hasPyrightDiagnosticShape(_ diagnostic: [String: Any]) -> Bool {
+        guard stringValue(diagnostic["file"]) != nil,
+              stringValue(diagnostic["message"]) != nil,
+              stringValue(diagnostic["severity"]) != nil,
+              diagnostic["range"] is [String: Any]
+        else {
+            return false
+        }
+        return true
+    }
+
+    private static func uniqueCount(in diagnostics: [[String: Any]], key: String) -> Int {
+        Set(diagnostics.compactMap { stringValue($0[key]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -234,6 +234,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pylintJSONPreview = renderPylintJSONPreview(pylintJSONPreviewModel)
             let mypyJSONPreviewModel = artifact.mypyJSONPreview
             let mypyJSONPreview = renderMypyJSONPreview(mypyJSONPreviewModel)
+            let pyrightJSONPreviewModel = artifact.pyrightJSONPreview
+            let pyrightJSONPreview = renderPyrightJSONPreview(pyrightJSONPreviewModel)
             let banditJSONPreviewModel = artifact.banditJSONPreview
             let banditJSONPreview = renderBanditJSONPreview(banditJSONPreviewModel)
             let semgrepJSONPreviewModel = artifact.semgrepJSONPreview
@@ -330,6 +332,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && ruffJSONPreviewModel == nil
                 && pylintJSONPreviewModel == nil
                 && mypyJSONPreviewModel == nil
+                && pyrightJSONPreviewModel == nil
                 && banditJSONPreviewModel == nil
                 && semgrepJSONPreviewModel == nil
                 && codeClimateJSONPreviewModel == nil
@@ -376,6 +379,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(ruffJSONPreview)
               \(pylintJSONPreview)
               \(mypyJSONPreview)
+              \(pyrightJSONPreview)
               \(banditJSONPreview)
               \(semgrepJSONPreview)
               \(codeClimateJSONPreview)
@@ -1090,6 +1094,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(codeList)
+        </div>
+        """
+    }
+
+    private static func renderPyrightJSONPreview(_ preview: ToolArtifactPyrightJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-pyright-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-pyright-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pyright-json-preview-files">
+                <strong data-testid="tool-card-pyright-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-pyright-json-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let ruleList = rules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pyright-json-preview-rules">
+                <strong data-testid="tool-card-pyright-json-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-pyright-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(ruleList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3347,6 +3347,82 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteMypy.mypyJSONPreview)
     }
 
+    func testArtifactStateDerivesPyrightJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("pyright-results.json")
+        let content = """
+        {
+          "version": "1.1.380",
+          "time": "2026-07-19T23:05:00Z",
+          "generalDiagnostics": [
+            {
+              "file": "/repo/app/models.py",
+              "severity": "error",
+              "message": "Type \\\"str\\\" is not assignable to return type \\\"int\\\"",
+              "range": {"start": {"line": 7, "character": 12}, "end": {"line": 7, "character": 22}},
+              "rule": "reportReturnType"
+            },
+            {
+              "file": "/repo/app/views.py",
+              "severity": "warning",
+              "message": "Type of parameter is unknown",
+              "range": {"start": {"line": 22, "character": 4}, "end": {"line": 22, "character": 10}},
+              "rule": "reportUnknownParameterType"
+            },
+            {
+              "file": "/repo/app/models.py",
+              "severity": "information",
+              "message": "Type is Any",
+              "range": {"start": {"line": 30, "character": 8}, "end": {"line": 30, "character": 12}}
+            }
+          ],
+          "summary": {"filesAnalyzed": 12, "errorCount": 1, "warningCount": 1, "informationCount": 1}
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.pyrightJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Pyright JSON")
+        XCTAssertEqual(preview.diagnosticCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.ruleCount, 2)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 1)
+        XCTAssertEqual(preview.informationCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/app/models.py",
+            "repo/app/views.py"
+        ])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "reportReturnType",
+            "reportUnknownParameterType"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Pyright JSON",
+            "3 diagnostics",
+            "2 files",
+            "2 rules",
+            "Errors: 1",
+            "Warnings: 1",
+            "Information: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"generalDiagnostics":[{"file":"/repo/app.py","message":"missing severity and range"}]}"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).pyrightJSONPreview)
+
+        let remotePyright = ToolArtifactState(value: "https://example.com/pyright-results.json")
+        XCTAssertNil(remotePyright.pyrightJSONPreview)
+    }
+
     func testArtifactStateDerivesBanditJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bandit-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2494,6 +2494,77 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesPyrightJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("pyright-results.json")
+        let reportText = """
+        {
+          "version": "1.1.380",
+          "generalDiagnostics": [
+            {
+              "file": "/repo/app/models.py",
+              "severity": "error",
+              "message": "Type \\\"str\\\" is not assignable to return type \\\"int\\\"",
+              "range": {"start": {"line": 7, "character": 12}, "end": {"line": 7, "character": 22}},
+              "rule": "reportReturnType"
+            },
+            {
+              "file": "/repo/app/views.py",
+              "severity": "warning",
+              "message": "Type of parameter is unknown",
+              "range": {"start": {"line": 22, "character": 4}, "end": {"line": 22, "character": 10}},
+              "rule": "reportUnknownParameterType"
+            }
+          ],
+          "summary": {"filesAnalyzed": 12, "errorCount": 1, "warningCount": 1}
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/pyright-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/pyright-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Pyright artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">pyright-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-meta">Format: Pyright JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-meta">2 diagnostics"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-meta">2 rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-file-item">repo/app/models.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-file-item">repo/app/views.py"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-rule-item">reportReturnType"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pyright-json-preview-rule-item">reportUnknownParameterType"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesBanditJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -229,6 +229,10 @@
   files whose records validate as mypy output: diagnostic/file/code/severity counts, file size,
   capped file labels, and capped code labels without reading Python source files, loading mypy
   configuration, shelling out, or fetching remote JSON.
+- Artifact previews now include bounded local Pyright JSON report metadata for `.json` files whose
+  root validates as Pyright output: diagnostic/file/rule/severity counts, file size, capped file
+  labels, and capped rule labels without reading Python source files, loading Pyright
+  configuration, shelling out, or fetching remote JSON.
 - Artifact previews now include bounded local Bandit JSON security-report metadata for `.json`
   files whose root validates as Bandit output: issue/file/test, severity, and confidence counts,
   file size, capped file labels, and capped test labels without reading Python source files,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,16 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Pyright JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as native Pyright JSON output as a
+  specialized Python type-check report rather than generic JSON.
+- **Rationale:** Pyright reports are common in Python coding sessions and CI exports. Showing
+  diagnostic/file/rule/severity counts plus capped file/rule labels gives useful Codex-style
+  feedback without opening the raw report.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Python
+  source files, expand diagnostic messages, load Pyright configuration, shell out, or fetch remote
+  reports.
+
 ## 2026-07-19: Render mypy JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` and `.jsonl` files whose records validate as mypy JSON output


### PR DESCRIPTION
## Summary
- add bounded Pyright JSON artifact detection for local report files
- render Pyright diagnostics/files/rules/severity metadata in native and HTML tool cards
- document the bounded parsing decision and parity matrix entry

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check
- git diff --check --cached