### PR TITLE
Add Cargo compiler JSONL artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -137,6 +137,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             goCoverageContent(goCoveragePreview)
         } else if let sarifPreview = artifact.sarifPreview {
             sarifContent(sarifPreview)
+        } else if let cargoCompilerJSONLinesPreview = artifact.cargoCompilerJSONLinesPreview {
+            cargoCompilerJSONLinesContent(cargoCompilerJSONLinesPreview)
         } else if let jsonLinesPreview = artifact.jsonLinesPreview {
             jsonLinesContent(jsonLinesPreview)
         } else if let tomlPreview = artifact.tomlPreview {
@@ -891,6 +893,25 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(jsonLinesPreview.metadataLines)
             artifactContentList(title: "Observed keys", labels: jsonLinesPreview.keyPreviewLabels)
+        }
+    }
+
+    private func cargoCompilerJSONLinesContent(
+        _ cargoCompilerJSONLinesPreview: ToolArtifactCargoCompilerJSONLinesPreview
+    ) -> some View {
+        let hasLists = !cargoCompilerJSONLinesPreview.filePreviewLabels.isEmpty
+            || !cargoCompilerJSONLinesPreview.codePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 142 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(cargoCompilerJSONLinesPreview.metadataLines)
+            artifactContentList(title: "Files", labels: cargoCompilerJSONLinesPreview.filePreviewLabels)
+            artifactContentList(title: "Codes", labels: cargoCompilerJSONLinesPreview.codePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2927,6 +2927,78 @@ public struct ToolArtifactJSONLinesPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactCargoCompilerJSONLinesPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var diagnosticCount: Int
+    public var fileCount: Int
+    public var codeCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var noteCount: Int
+    public var helpCount: Int
+    public var otherLevelCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var codePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(diagnosticCount) diagnostic\(diagnosticCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(codeCount) code\(codeCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            noteCount > 0 ? "Notes: \(noteCount)" : nil,
+            helpCount > 0 ? "Help: \(helpCount)" : nil,
+            otherLevelCount > 0 ? "Other levels: \(otherLevelCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        diagnosticCount > 0
+            || fileCount > 0
+            || codeCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || noteCount > 0
+            || helpCount > 0
+            || otherLevelCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !codePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Cargo Compiler JSONL",
+        diagnosticCount: Int,
+        fileCount: Int,
+        codeCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        noteCount: Int = 0,
+        helpCount: Int = 0,
+        otherLevelCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        codePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.diagnosticCount = diagnosticCount
+        self.fileCount = fileCount
+        self.codeCount = codeCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.noteCount = noteCount
+        self.helpCount = helpCount
+        self.otherLevelCount = otherLevelCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.codePreviewLabels = codePreviewLabels
+    }
+}
+
 public struct ToolArtifactTOMLPreview: Codable, Sendable, Hashable {
     public var topLevelKeyCount: Int
     public var tableCount: Int
@@ -4345,7 +4417,11 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
         ToolArtifactNotebookPreviewBuilder.notebookPreview(for: value, kind: kind)
     }
     public var jsonLinesPreview: ToolArtifactJSONLinesPreview? {
-        ToolArtifactJSONLinesPreviewBuilder.jsonLinesPreview(for: value, kind: kind)
+        guard cargoCompilerJSONLinesPreview == nil else { return nil }
+        return ToolArtifactJSONLinesPreviewBuilder.jsonLinesPreview(for: value, kind: kind)
+    }
+    public var cargoCompilerJSONLinesPreview: ToolArtifactCargoCompilerJSONLinesPreview? {
+        ToolArtifactCargoCompilerJSONLinesPreviewBuilder.cargoCompilerJSONLinesPreview(for: value, kind: kind)
     }
     public var tomlPreview: ToolArtifactTOMLPreview? {
         ToolArtifactTOMLPreviewBuilder.tomlPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactCargoCompilerJSONLinesPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCargoCompilerJSONLinesPreviewBuilder.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+enum ToolArtifactCargoCompilerJSONLinesPreviewBuilder {
+    static func cargoCompilerJSONLinesPreview(
+        for value: String,
+        kind: ToolArtifactKind
+    ) -> ToolArtifactCargoCompilerJSONLinesPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              supportedExtensions.contains(documentPreview.extensionLabel.lowercased()),
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+            let records = try decodeRecords(from: text)
+            return preview(
+                from: records,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func decodeRecords(from text: String) throws -> [[String: Any]] {
+        try text
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> [String: Any]? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return nil }
+                return try JSONSerialization.jsonObject(with: Data(trimmed.utf8), options: []) as? [String: Any]
+            }
+    }
+
+    private static func preview(
+        from records: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactCargoCompilerJSONLinesPreview? {
+        let diagnostics = records.compactMap(cargoDiagnostic)
+        guard !diagnostics.isEmpty else { return nil }
+
+        var fileLabels: [String] = []
+        var codeLabels: [String] = []
+        var errorCount = 0
+        var warningCount = 0
+        var noteCount = 0
+        var helpCount = 0
+        var otherLevelCount = 0
+
+        for diagnostic in diagnostics {
+            appendUnique(sanitizedPathLabel(diagnostic.file), to: &fileLabels, limit: previewLimit)
+            if let code = diagnostic.code {
+                appendUnique(sanitizedLabel(code), to: &codeLabels, limit: previewLimit)
+            }
+
+            switch diagnostic.level.lowercased() {
+            case "error":
+                errorCount += 1
+            case "warning":
+                warningCount += 1
+            case "note":
+                noteCount += 1
+            case "help":
+                helpCount += 1
+            default:
+                otherLevelCount += 1
+            }
+        }
+
+        guard !fileLabels.isEmpty else { return nil }
+
+        return ToolArtifactCargoCompilerJSONLinesPreview(
+            diagnosticCount: diagnostics.count,
+            fileCount: Set(diagnostics.map(\.file)).count,
+            codeCount: Set(diagnostics.compactMap(\.code)).count,
+            errorCount: errorCount,
+            warningCount: warningCount,
+            noteCount: noteCount,
+            helpCount: helpCount,
+            otherLevelCount: otherLevelCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            codePreviewLabels: codeLabels
+        )
+    }
+
+    private static func cargoDiagnostic(from record: [String: Any]) -> CargoDiagnostic? {
+        guard stringValue(record["reason"]) == "compiler-message",
+              let message = record["message"] as? [String: Any],
+              let level = stringValue(message["level"]),
+              stringValue(message["message"]) != nil,
+              let file = primarySpanFile(in: message)
+        else {
+            return nil
+        }
+
+        let code = (message["code"] as? [String: Any]).flatMap { stringValue($0["code"]) }
+        return CargoDiagnostic(file: file, level: level, code: code)
+    }
+
+    private static func primarySpanFile(in message: [String: Any]) -> String? {
+        guard let spans = message["spans"] as? [[String: Any]] else { return nil }
+        if let primary = spans.first(where: { boolValue($0["is_primary"]) == true }),
+           let file = stringValue(primary["file_name"]) {
+            return file
+        }
+        return spans.compactMap { stringValue($0["file_name"]) }.first
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        if let bool = value as? Bool { return bool }
+        if let number = value as? NSNumber { return number.boolValue }
+        return nil
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private struct CargoDiagnostic {
+        var file: String
+        var level: String
+        var code: String?
+    }
+
+    private static let supportedExtensions: Set<String> = ["jsonl", "ndjson"]
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -276,6 +276,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let lcovPreview = renderLCOVPreview(artifact.lcovPreview)
             let goCoveragePreview = renderGoCoveragePreview(artifact.goCoveragePreview)
             let sarifPreview = renderSARIFPreview(artifact.sarifPreview)
+            let cargoCompilerJSONLinesPreviewModel = artifact.cargoCompilerJSONLinesPreview
+            let cargoCompilerJSONLinesPreview = renderCargoCompilerJSONLinesPreview(cargoCompilerJSONLinesPreviewModel)
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = uvLockPreviewModel == nil
                 ? renderTOMLPreview(artifact.tomlPreview)
@@ -405,6 +407,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(lcovPreview)
               \(goCoveragePreview)
               \(sarifPreview)
+              \(cargoCompilerJSONLinesPreview)
               \(jsonLinesPreview)
               \(tomlPreview)
               \(iniPreview)
@@ -1986,6 +1989,43 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(keyList)
+        </div>
+        """
+    }
+
+    private static func renderCargoCompilerJSONLinesPreview(
+        _ preview: ToolArtifactCargoCompilerJSONLinesPreview?
+    ) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-cargo-compiler-jsonl-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-cargo-compiler-jsonl-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let codes = preview.codePreviewLabels.map {
+            #"<li data-testid="tool-card-cargo-compiler-jsonl-preview-code-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-cargo-compiler-jsonl-preview-files">
+                <strong data-testid="tool-card-cargo-compiler-jsonl-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let codeList = codes.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-cargo-compiler-jsonl-preview-codes">
+                <strong data-testid="tool-card-cargo-compiler-jsonl-preview-code-title">Codes</strong>
+                <ul>\(codes)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !codeList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-cargo-compiler-jsonl-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(codeList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2141,6 +2141,58 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJSONLines.jsonLinesPreview)
     }
 
+    func testArtifactStateDerivesCargoCompilerJSONLinesPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("cargo-clippy.jsonl")
+        let content = """
+        {"reason":"compiler-message","package_id":"pkg 0.1.0","message":{"message":"unused variable: `value`","code":{"code":"unused_variables"},"level":"warning","spans":[{"file_name":"/repo/src/lib.rs","is_primary":true}]}}
+        {"reason":"compiler-artifact","package_id":"pkg 0.1.0"}
+        {"reason":"compiler-message","package_id":"pkg 0.1.0","message":{"message":"mismatched types","code":{"code":"E0308"},"level":"error","spans":[{"file_name":"/repo/src/main.rs","is_primary":true}]}}
+        {"reason":"compiler-message","package_id":"pkg 0.1.0","message":{"message":"consider borrowing here","level":"help","spans":[{"file_name":"/repo/src/main.rs","is_primary":false}]}}
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.cargoCompilerJSONLinesPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSONL")
+        XCTAssertEqual(preview.formatLabel, "Cargo Compiler JSONL")
+        XCTAssertEqual(preview.diagnosticCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.codeCount, 2)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 1)
+        XCTAssertEqual(preview.helpCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "repo/src/lib.rs",
+            "repo/src/main.rs"
+        ])
+        XCTAssertEqual(preview.codePreviewLabels, [
+            "unused_variables",
+            "E0308"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Cargo Compiler JSONL",
+            "3 diagnostics",
+            "2 files",
+            "2 codes",
+            "Errors: 1",
+            "Warnings: 1",
+            "Help: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonLinesPreview)
+
+        let generic = directory.appendingPathComponent("events.jsonl")
+        try #"{"event":"started","level":"info"}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).cargoCompilerJSONLinesPreview)
+
+        let remoteCargo = ToolArtifactState(value: "https://example.com/cargo-clippy.jsonl")
+        XCTAssertNil(remoteCargo.cargoCompilerJSONLinesPreview)
+    }
+
     func testArtifactStateDerivesTOMLPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let config = directory.appendingPathComponent("config.toml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -3136,6 +3136,60 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertTrue(html.contains(#"data-testid="tool-card-text-preview-content">"#))
     }
 
+    func testHTMLRendererIncludesCargoCompilerJSONLinesArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("cargo-clippy.jsonl")
+        let reportText = """
+        {"reason":"compiler-message","package_id":"pkg 0.1.0","message":{"message":"unused variable: `value`","code":{"code":"unused_variables"},"level":"warning","spans":[{"file_name":"/repo/src/lib.rs","is_primary":true}]}}
+        {"reason":"compiler-artifact","package_id":"pkg 0.1.0"}
+        {"reason":"compiler-message","package_id":"pkg 0.1.0","message":{"message":"mismatched types","code":{"code":"E0308"},"level":"error","spans":[{"file_name":"/repo/src/main.rs","is_primary":true}]}}
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/cargo-clippy.jsonl"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/cargo-clippy.jsonl\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Cargo artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSONL"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">cargo-clippy.jsonl"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-meta">Format: Cargo Compiler JSONL"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-meta">2 diagnostics"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-meta">2 codes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-file-item">repo/src/lib.rs"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-file-item">repo/src/main.rs"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-code-title">Codes"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-code-item">unused_variables"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-cargo-compiler-jsonl-preview-code-item">E0308"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-lines-preview""#))
+    }
+
     func testHTMLRendererIncludesTOMLArtifactPreview() throws {
         let root = try makeTempDirectory()
         let quillDirectory = root.appendingPathComponent(".quillcode", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -151,6 +151,10 @@
   package/version/source/checksum counts, file size, capped package labels, and capped source labels
   without expanding dependency arrays, full checksums, manifests, crates, or fetching remote
   registries/repositories.
+- Artifact previews now include bounded local Cargo compiler/Clippy JSONL metadata for `.jsonl`
+  and `.ndjson` streams whose records include Cargo `compiler-message` entries: diagnostic/file/code
+  and level counts, file size, capped file labels, and capped diagnostic-code labels without reading
+  Rust source files, invoking Cargo, expanding spans, or fetching remote reports.
 - Artifact previews now include bounded local font metadata for `.ttf`, `.otf`, `.ttc`, `.woff`,
   and `.woff2` files by validating fixed headers and rendering format, flavor, table count,
   declared size, and file size without parsing tables or decompressing webfont payloads.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Cargo Compiler JSONL As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.jsonl` and `.ndjson` files whose records include Cargo
+  `compiler-message` entries as Rust compiler/Clippy diagnostics rather than generic JSON Lines.
+- **Rationale:** Rust coding sessions commonly capture `cargo check --message-format=json` and
+  Clippy output. Showing diagnostic/file/code/level counts plus capped file/code labels gives useful
+  Codex-style feedback without opening raw line-oriented JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Rust
+  source files, expand spans, invoke Cargo, load Cargo metadata, or fetch remote reports.
+
 ## 2026-07-19: Render Pyright JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as native Pyright JSON output as a


### PR DESCRIPTION
## Summary
- add bounded Cargo compiler/Clippy JSONL artifact detection for local report streams
- render diagnostics/files/codes/level metadata in native and HTML tool cards
- document the local-only parsing boundary in the parity matrix and decisions log

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesCargoCompilerJSONLinesPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesCargoCompilerJSONLinesArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check
- git diff --check --cached