### PR TITLE
Add SwiftLint JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -75,6 +75,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             eslintJSONContent(eslintJSONPreview)
         } else if let stylelintJSONPreview = artifact.stylelintJSONPreview {
             stylelintJSONContent(stylelintJSONPreview)
+        } else if let swiftLintJSONPreview = artifact.swiftLintJSONPreview {
+            swiftLintJSONContent(swiftLintJSONPreview)
         } else if let rubocopJSONPreview = artifact.rubocopJSONPreview {
             rubocopJSONContent(rubocopJSONPreview)
         } else if let golangCILintJSONPreview = artifact.golangCILintJSONPreview {
@@ -375,6 +377,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(stylelintJSONPreview.metadataLines)
             artifactContentList(title: "Sources", labels: stylelintJSONPreview.sourcePreviewLabels)
             artifactContentList(title: "Rules", labels: stylelintJSONPreview.rulePreviewLabels)
+        }
+    }
+
+    private func swiftLintJSONContent(_ swiftLintJSONPreview: ToolArtifactSwiftLintJSONPreview) -> some View {
+        let hasLists = !swiftLintJSONPreview.filePreviewLabels.isEmpty || !swiftLintJSONPreview.rulePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 142 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(swiftLintJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: swiftLintJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Rules", labels: swiftLintJSONPreview.rulePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1867,6 +1867,68 @@ public struct ToolArtifactStylelintJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactSwiftLintJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var violationCount: Int
+    public var fileCount: Int
+    public var ruleCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var otherSeverityCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var rulePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(violationCount) violation\(violationCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(ruleCount) rule\(ruleCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            otherSeverityCount > 0 ? "Other severities: \(otherSeverityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        violationCount > 0
+            || fileCount > 0
+            || ruleCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || otherSeverityCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !rulePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "SwiftLint JSON",
+        violationCount: Int,
+        fileCount: Int,
+        ruleCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        otherSeverityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        rulePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.violationCount = violationCount
+        self.fileCount = fileCount
+        self.ruleCount = ruleCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.otherSeverityCount = otherSeverityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.rulePreviewLabels = rulePreviewLabels
+    }
+}
+
 public struct ToolArtifactRuboCopJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var fileCount: Int
@@ -4290,6 +4352,7 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     public var jsonPreview: ToolArtifactJSONPreview? {
         guard eslintJSONPreview == nil,
               stylelintJSONPreview == nil,
+              swiftLintJSONPreview == nil,
               rubocopJSONPreview == nil,
               golangCILintJSONPreview == nil,
               ruffJSONPreview == nil,
@@ -4370,6 +4433,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var stylelintJSONPreview: ToolArtifactStylelintJSONPreview? {
         ToolArtifactStylelintJSONPreviewBuilder.stylelintJSONPreview(for: value, kind: kind)
+    }
+    public var swiftLintJSONPreview: ToolArtifactSwiftLintJSONPreview? {
+        ToolArtifactSwiftLintJSONPreviewBuilder.swiftLintJSONPreview(for: value, kind: kind)
     }
     public var rubocopJSONPreview: ToolArtifactRuboCopJSONPreview? {
         ToolArtifactRuboCopJSONPreviewBuilder.rubocopJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactSwiftLintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSwiftLintJSONPreviewBuilder.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+enum ToolArtifactSwiftLintJSONPreviewBuilder {
+    static func swiftLintJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactSwiftLintJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let violations = root as? [[String: Any]] else { return nil }
+            return preview(
+                from: violations,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from violations: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactSwiftLintJSONPreview? {
+        guard !violations.isEmpty, violations.allSatisfy(hasSwiftLintViolationShape) else { return nil }
+
+        var fileLabels: [String] = []
+        var ruleLabels: [String] = []
+        var errorCount = 0
+        var warningCount = 0
+        var otherSeverityCount = 0
+
+        for violation in violations {
+            if let file = stringValue(violation["file"]) {
+                appendUnique(sanitizedPathLabel(file), to: &fileLabels, limit: previewLimit)
+            }
+            if let rule = stringValue(violation["rule_id"]) ?? stringValue(violation["type"]) {
+                appendUnique(sanitizedLabel(rule), to: &ruleLabels, limit: previewLimit)
+            }
+
+            switch stringValue(violation["severity"])?.lowercased() {
+            case "error":
+                errorCount += 1
+            case "warning":
+                warningCount += 1
+            default:
+                otherSeverityCount += 1
+            }
+        }
+
+        guard !fileLabels.isEmpty else { return nil }
+
+        return ToolArtifactSwiftLintJSONPreview(
+            violationCount: violations.count,
+            fileCount: uniqueCount(in: violations, key: "file"),
+            ruleCount: uniqueRuleCount(in: violations),
+            errorCount: errorCount,
+            warningCount: warningCount,
+            otherSeverityCount: otherSeverityCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            rulePreviewLabels: ruleLabels
+        )
+    }
+
+    private static func hasSwiftLintViolationShape(_ violation: [String: Any]) -> Bool {
+        guard stringValue(violation["file"]) != nil,
+              stringValue(violation["reason"]) != nil,
+              stringValue(violation["severity"]) != nil
+        else {
+            return false
+        }
+        return stringValue(violation["rule_id"]) != nil
+            || stringValue(violation["type"]) != nil
+            || numericValue(violation["line"]) != nil
+    }
+
+    private static func uniqueCount(in violations: [[String: Any]], key: String) -> Int {
+        Set(violations.compactMap { stringValue($0[key]) }).count
+    }
+
+    private static func uniqueRuleCount(in violations: [[String: Any]]) -> Int {
+        Set(violations.compactMap { stringValue($0["rule_id"]) ?? stringValue($0["type"]) }).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func numericValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = stringValue(value) {
+            return Double(string)
+        }
+        return nil
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -224,6 +224,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let eslintJSONPreview = renderESLintJSONPreview(eslintJSONPreviewModel)
             let stylelintJSONPreviewModel = artifact.stylelintJSONPreview
             let stylelintJSONPreview = renderStylelintJSONPreview(stylelintJSONPreviewModel)
+            let swiftLintJSONPreviewModel = artifact.swiftLintJSONPreview
+            let swiftLintJSONPreview = renderSwiftLintJSONPreview(swiftLintJSONPreviewModel)
             let rubocopJSONPreviewModel = artifact.rubocopJSONPreview
             let rubocopJSONPreview = renderRuboCopJSONPreview(rubocopJSONPreviewModel)
             let golangCILintJSONPreviewModel = artifact.golangCILintJSONPreview
@@ -329,6 +331,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && jestJSONPreviewModel == nil
                 && eslintJSONPreviewModel == nil
                 && stylelintJSONPreviewModel == nil
+                && swiftLintJSONPreviewModel == nil
                 && rubocopJSONPreviewModel == nil
                 && golangCILintJSONPreviewModel == nil
                 && ruffJSONPreviewModel == nil
@@ -376,6 +379,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(jestJSONPreview)
               \(eslintJSONPreview)
               \(stylelintJSONPreview)
+              \(swiftLintJSONPreview)
               \(rubocopJSONPreview)
               \(golangCILintJSONPreview)
               \(ruffJSONPreview)
@@ -921,6 +925,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(sourceList)
+          \(ruleList)
+        </div>
+        """
+    }
+
+    private static func renderSwiftLintJSONPreview(_ preview: ToolArtifactSwiftLintJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-swiftlint-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-swiftlint-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-swiftlint-json-preview-files">
+                <strong data-testid="tool-card-swiftlint-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let rules = preview.rulePreviewLabels.map {
+            #"<li data-testid="tool-card-swiftlint-json-preview-rule-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let ruleList = rules.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-swiftlint-json-preview-rules">
+                <strong data-testid="tool-card-swiftlint-json-preview-rule-title">Rules</strong>
+                <ul>\(rules)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !ruleList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-swiftlint-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
           \(ruleList)
         </div>
         """

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2968,6 +2968,82 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteStylelint.stylelintJSONPreview)
     }
 
+    func testArtifactStateDerivesSwiftLintJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("swiftlint-results.json")
+        let content = """
+        [
+          {
+            "file": "/repo/Sources/App/WorkspaceView.swift",
+            "line": 42,
+            "character": 18,
+            "severity": "Warning",
+            "type": "Line Length",
+            "rule_id": "line_length",
+            "reason": "Line should be 120 characters or less"
+          },
+          {
+            "file": "/repo/Sources/App/WorkspaceView.swift",
+            "line": 57,
+            "character": 8,
+            "severity": "Error",
+            "type": "Force Cast",
+            "rule_id": "force_cast",
+            "reason": "Force casts should be avoided"
+          },
+          {
+            "file": "/repo/Tests/AppTests/WorkspaceViewTests.swift",
+            "line": 13,
+            "character": 1,
+            "severity": "warning",
+            "type": "Trailing Whitespace",
+            "rule_id": "trailing_whitespace",
+            "reason": "Lines should not have trailing whitespace"
+          }
+        ]
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.swiftLintJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "SwiftLint JSON")
+        XCTAssertEqual(preview.violationCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.ruleCount, 3)
+        XCTAssertEqual(preview.errorCount, 1)
+        XCTAssertEqual(preview.warningCount, 2)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "Sources/App/WorkspaceView.swift",
+            "Tests/AppTests/WorkspaceViewTests.swift"
+        ])
+        XCTAssertEqual(preview.rulePreviewLabels, [
+            "line_length",
+            "force_cast",
+            "trailing_whitespace"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: SwiftLint JSON",
+            "3 violations",
+            "2 files",
+            "3 rules",
+            "Errors: 1",
+            "Warnings: 2",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"[{"file":"/repo/file.swift","status":"ok"}]"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).swiftLintJSONPreview)
+
+        let remoteSwiftLint = ToolArtifactState(value: "https://example.com/swiftlint-results.json")
+        XCTAssertNil(remoteSwiftLint.swiftLintJSONPreview)
+    }
+
     func testArtifactStateDerivesRuboCopJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("rubocop-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2131,6 +2131,77 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesSwiftLintJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("swiftlint-results.json")
+        let reportText = """
+        [
+          {
+            "file": "/repo/Sources/App/WorkspaceView.swift",
+            "line": 42,
+            "character": 18,
+            "severity": "Warning",
+            "type": "Line Length",
+            "rule_id": "line_length",
+            "reason": "Line should be 120 characters or less"
+          },
+          {
+            "file": "/repo/Tests/AppTests/WorkspaceViewTests.swift",
+            "line": 13,
+            "character": 1,
+            "severity": "Error",
+            "type": "Force Cast",
+            "rule_id": "force_cast",
+            "reason": "Force casts should be avoided"
+          }
+        ]
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/swiftlint-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/swiftlint-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "SwiftLint artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">swiftlint-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-meta">Format: SwiftLint JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-meta">2 violations"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-meta">2 rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-file-item">Sources/App/WorkspaceView.swift"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-file-item">Tests/AppTests/WorkspaceViewTests.swift"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-rule-title">Rules"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-rule-item">line_length"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-swiftlint-json-preview-rule-item">force_cast"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesRuboCopJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -213,6 +213,10 @@
   root validates as Stylelint formatter output: file/warning/error/parse-error/deprecation/invalid
   option counts, file size, capped source labels, and capped rule labels without reading stylesheet
   sources, loading plugins, or fetching remote JSON.
+- Artifact previews now include bounded local SwiftLint JSON report metadata for `.json` files whose
+  root validates as SwiftLint formatter output: violation/file/rule/severity counts, file size,
+  capped file labels, and capped rule labels without reading Swift source files, loading rule
+  configuration, invoking SwiftLint, or fetching remote JSON.
 - Artifact previews now include bounded local RuboCop JSON report metadata for `.json` files whose
   root validates as RuboCop formatter output: file/offense/severity/correctable counts, file size,
   capped file labels, and capped cop labels without reading Ruby source files, loading cops, or

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,16 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render SwiftLint JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as SwiftLint JSON output as a
+  specialized Swift lint report rather than generic JSON.
+- **Rationale:** SwiftLint JSON is the common native report format for Swift projects. Showing
+  violation/file/rule/severity counts plus capped file/rule labels gives useful Codex-style feedback
+  without opening raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Swift
+  source files, expand violation reasons, invoke SwiftLint, load rule configuration, or fetch remote
+  reports.
+
 ## 2026-07-19: Render Cargo Compiler JSONL As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.jsonl` and `.ndjson` files whose records include Cargo


### PR DESCRIPTION
## Summary
- Add bounded local SwiftLint JSON artifact detection for SwiftLint formatter output
- Render violation/file/rule/severity metadata in native and HTML tool-card previews
- Document the parity decision and matrix entry

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesSwiftLintJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesSwiftLintJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check