### PR TITLE
Add PHPStan JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -89,6 +89,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             mypyJSONContent(mypyJSONPreview)
         } else if let pyrightJSONPreview = artifact.pyrightJSONPreview {
             pyrightJSONContent(pyrightJSONPreview)
+        } else if let phpstanJSONPreview = artifact.phpstanJSONPreview {
+            phpstanJSONContent(phpstanJSONPreview)
         } else if let banditJSONPreview = artifact.banditJSONPreview {
             banditJSONContent(banditJSONPreview)
         } else if let semgrepJSONPreview = artifact.semgrepJSONPreview {
@@ -490,6 +492,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(pyrightJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: pyrightJSONPreview.filePreviewLabels)
             artifactContentList(title: "Rules", labels: pyrightJSONPreview.rulePreviewLabels)
+        }
+    }
+
+    private func phpstanJSONContent(_ phpstanJSONPreview: ToolArtifactPHPStanJSONPreview) -> some View {
+        let hasLists = !phpstanJSONPreview.filePreviewLabels.isEmpty
+            || !phpstanJSONPreview.identifierPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(phpstanJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: phpstanJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Identifiers", labels: phpstanJSONPreview.identifierPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2341,6 +2341,68 @@ public struct ToolArtifactPyrightJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPHPStanJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var errorCount: Int
+    public var fileCount: Int
+    public var identifierCount: Int
+    public var generalErrorCount: Int
+    public var ignorableCount: Int
+    public var nonIgnorableCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var identifierPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(errorCount) error\(errorCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(identifierCount) identifier\(identifierCount == 1 ? "" : "s")",
+            generalErrorCount > 0 ? "General errors: \(generalErrorCount)" : nil,
+            ignorableCount > 0 ? "Ignorable: \(ignorableCount)" : nil,
+            nonIgnorableCount > 0 ? "Non-ignorable: \(nonIgnorableCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        errorCount > 0
+            || fileCount > 0
+            || identifierCount > 0
+            || generalErrorCount > 0
+            || ignorableCount > 0
+            || nonIgnorableCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !identifierPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "PHPStan JSON",
+        errorCount: Int,
+        fileCount: Int,
+        identifierCount: Int,
+        generalErrorCount: Int = 0,
+        ignorableCount: Int = 0,
+        nonIgnorableCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        identifierPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.errorCount = errorCount
+        self.fileCount = fileCount
+        self.identifierCount = identifierCount
+        self.generalErrorCount = generalErrorCount
+        self.ignorableCount = ignorableCount
+        self.nonIgnorableCount = nonIgnorableCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.identifierPreviewLabels = identifierPreviewLabels
+    }
+}
+
 public struct ToolArtifactBanditJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var issueCount: Int
@@ -4359,6 +4421,7 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               pylintJSONPreview == nil,
               mypyJSONPreview == nil,
               pyrightJSONPreview == nil,
+              phpstanJSONPreview == nil,
               banditJSONPreview == nil,
               semgrepJSONPreview == nil,
               codeClimateJSONPreview == nil
@@ -4454,6 +4517,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var pyrightJSONPreview: ToolArtifactPyrightJSONPreview? {
         ToolArtifactPyrightJSONPreviewBuilder.pyrightJSONPreview(for: value, kind: kind)
+    }
+    public var phpstanJSONPreview: ToolArtifactPHPStanJSONPreview? {
+        ToolArtifactPHPStanJSONPreviewBuilder.phpstanJSONPreview(for: value, kind: kind)
     }
     public var banditJSONPreview: ToolArtifactBanditJSONPreview? {
         ToolArtifactBanditJSONPreviewBuilder.banditJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactPHPStanJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPHPStanJSONPreviewBuilder.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+enum ToolArtifactPHPStanJSONPreviewBuilder {
+    static func phpstanJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPHPStanJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let report = root as? [String: Any] else { return nil }
+            return preview(
+                from: report,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from report: [String: Any],
+        byteSizeLabel: String?
+    ) -> ToolArtifactPHPStanJSONPreview? {
+        guard let files = report["files"] as? [String: Any],
+              hasPHPStanTotals(report["totals"]),
+              !files.isEmpty
+        else {
+            return nil
+        }
+
+        var fileLabels: [String] = []
+        var identifierLabels: [String] = []
+        var fileErrorCount = 0
+        var ignorableCount = 0
+        var nonIgnorableCount = 0
+
+        for path in files.keys.sorted() {
+            guard let value = files[path] else { continue }
+            guard let fileReport = value as? [String: Any],
+                  let messages = fileReport["messages"] as? [[String: Any]],
+                  !messages.isEmpty,
+                  messages.allSatisfy(hasPHPStanMessageShape)
+            else {
+                return nil
+            }
+
+            appendUnique(sanitizedPathLabel(path), to: &fileLabels, limit: previewLimit)
+            fileErrorCount += messages.count
+            for message in messages {
+                if boolValue(message["ignorable"]) == true {
+                    ignorableCount += 1
+                } else {
+                    nonIgnorableCount += 1
+                }
+                if let identifier = stringValue(message["identifier"]) {
+                    appendUnique(sanitizedLabel(identifier), to: &identifierLabels, limit: previewLimit)
+                }
+            }
+        }
+
+        let generalErrorCount = (report["errors"] as? [Any])?.count ?? 0
+        guard fileErrorCount > 0 || generalErrorCount > 0 else { return nil }
+
+        return ToolArtifactPHPStanJSONPreview(
+            errorCount: fileErrorCount + generalErrorCount,
+            fileCount: files.count,
+            identifierCount: uniqueIdentifierCount(in: files),
+            generalErrorCount: generalErrorCount,
+            ignorableCount: ignorableCount,
+            nonIgnorableCount: nonIgnorableCount,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            identifierPreviewLabels: identifierLabels
+        )
+    }
+
+    private static func hasPHPStanTotals(_ value: Any?) -> Bool {
+        guard let totals = value as? [String: Any] else { return false }
+        return numericValue(totals["errors"]) != nil
+            && numericValue(totals["file_errors"]) != nil
+    }
+
+    private static func hasPHPStanMessageShape(_ message: [String: Any]) -> Bool {
+        guard stringValue(message["message"]) != nil else { return false }
+        return numericValue(message["line"]) != nil
+            || stringValue(message["identifier"]) != nil
+            || message.keys.contains("ignorable")
+    }
+
+    private static func uniqueIdentifierCount(in files: [String: Any]) -> Int {
+        var identifiers = Set<String>()
+        for value in files.values {
+            guard let fileReport = value as? [String: Any],
+                  let messages = fileReport["messages"] as? [[String: Any]]
+            else { continue }
+            for message in messages {
+                if let identifier = stringValue(message["identifier"]) {
+                    identifiers.insert(identifier)
+                }
+            }
+        }
+        return identifiers.count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func numericValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = stringValue(value) {
+            return Double(string)
+        }
+        return nil
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        if let bool = value as? Bool {
+            return bool
+        }
+        if let number = value as? NSNumber {
+            return number.boolValue
+        }
+        return nil
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -238,6 +238,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let mypyJSONPreview = renderMypyJSONPreview(mypyJSONPreviewModel)
             let pyrightJSONPreviewModel = artifact.pyrightJSONPreview
             let pyrightJSONPreview = renderPyrightJSONPreview(pyrightJSONPreviewModel)
+            let phpstanJSONPreviewModel = artifact.phpstanJSONPreview
+            let phpstanJSONPreview = renderPHPStanJSONPreview(phpstanJSONPreviewModel)
             let banditJSONPreviewModel = artifact.banditJSONPreview
             let banditJSONPreview = renderBanditJSONPreview(banditJSONPreviewModel)
             let semgrepJSONPreviewModel = artifact.semgrepJSONPreview
@@ -338,6 +340,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && pylintJSONPreviewModel == nil
                 && mypyJSONPreviewModel == nil
                 && pyrightJSONPreviewModel == nil
+                && phpstanJSONPreviewModel == nil
                 && banditJSONPreviewModel == nil
                 && semgrepJSONPreviewModel == nil
                 && codeClimateJSONPreviewModel == nil
@@ -386,6 +389,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(pylintJSONPreview)
               \(mypyJSONPreview)
               \(pyrightJSONPreview)
+              \(phpstanJSONPreview)
               \(banditJSONPreview)
               \(semgrepJSONPreview)
               \(codeClimateJSONPreview)
@@ -1171,6 +1175,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(ruleList)
+        </div>
+        """
+    }
+
+    private static func renderPHPStanJSONPreview(_ preview: ToolArtifactPHPStanJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-phpstan-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-phpstan-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-phpstan-json-preview-files">
+                <strong data-testid="tool-card-phpstan-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let identifiers = preview.identifierPreviewLabels.map {
+            #"<li data-testid="tool-card-phpstan-json-preview-identifier-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let identifierList = identifiers.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-phpstan-json-preview-identifiers">
+                <strong data-testid="tool-card-phpstan-json-preview-identifier-title">Identifiers</strong>
+                <ul>\(identifiers)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !identifierList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-phpstan-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(identifierList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3551,6 +3551,89 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePyright.pyrightJSONPreview)
     }
 
+    func testArtifactStateDerivesPHPStanJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("phpstan-results.json")
+        let content = """
+        {
+          "totals": {"errors": 0, "file_errors": 3},
+          "files": {
+            "/repo/src/Controller/HomeController.php": {
+              "errors": 2,
+              "messages": [
+                {
+                  "message": "Method App\\\\Controller\\\\HomeController::index() should return Response but returns string.",
+                  "line": 12,
+                  "ignorable": true,
+                  "identifier": "return.type"
+                },
+                {
+                  "message": "Access to an undefined property.",
+                  "line": 18,
+                  "ignorable": false,
+                  "identifier": "property.notFound"
+                }
+              ]
+            },
+            "/repo/src/Entity/User.php": {
+              "errors": 1,
+              "messages": [
+                {
+                  "message": "Parameter #1 expects non-empty-string, string given.",
+                  "line": 44,
+                  "ignorable": true,
+                  "identifier": "argument.type"
+                }
+              ]
+            }
+          },
+          "errors": []
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.phpstanJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "PHPStan JSON")
+        XCTAssertEqual(preview.errorCount, 3)
+        XCTAssertEqual(preview.fileCount, 2)
+        XCTAssertEqual(preview.identifierCount, 3)
+        XCTAssertEqual(preview.generalErrorCount, 0)
+        XCTAssertEqual(preview.ignorableCount, 2)
+        XCTAssertEqual(preview.nonIgnorableCount, 1)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "src/Controller/HomeController.php",
+            "src/Entity/User.php"
+        ])
+        XCTAssertEqual(preview.identifierPreviewLabels, [
+            "return.type",
+            "property.notFound",
+            "argument.type"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: PHPStan JSON",
+            "3 errors",
+            "2 files",
+            "3 identifiers",
+            "Ignorable: 2",
+            "Non-ignorable: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"totals":{"errors":0,"file_errors":1},"files":{"/repo/src/A.php":{"messages":[{"message":"missing PHPStan location"}]}}}"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).phpstanJSONPreview)
+
+        let remotePHPStan = ToolArtifactState(value: "https://example.com/phpstan-results.json")
+        XCTAssertNil(remotePHPStan.phpstanJSONPreview)
+    }
+
     func testArtifactStateDerivesBanditJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bandit-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2636,6 +2636,85 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesPHPStanJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("phpstan-results.json")
+        let reportText = """
+        {
+          "totals": {"errors": 0, "file_errors": 2},
+          "files": {
+            "/repo/src/Controller/HomeController.php": {
+              "errors": 1,
+              "messages": [
+                {
+                  "message": "Method should return Response but returns string.",
+                  "line": 12,
+                  "ignorable": true,
+                  "identifier": "return.type"
+                }
+              ]
+            },
+            "/repo/src/Entity/User.php": {
+              "errors": 1,
+              "messages": [
+                {
+                  "message": "Access to an undefined property.",
+                  "line": 18,
+                  "ignorable": false,
+                  "identifier": "property.notFound"
+                }
+              ]
+            }
+          },
+          "errors": []
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/phpstan-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/phpstan-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "PHPStan artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">phpstan-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-meta">Format: PHPStan JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-meta">2 errors"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-meta">2 identifiers"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-meta">Ignorable: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-meta">Non-ignorable: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-file-item">src/Controller/HomeController.php"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-file-item">src/Entity/User.php"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-identifier-title">Identifiers"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-identifier-item">return.type"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-phpstan-json-preview-identifier-item">property.notFound"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesBanditJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -241,6 +241,10 @@
   root validates as Pyright output: diagnostic/file/rule/severity counts, file size, capped file
   labels, and capped rule labels without reading Python source files, loading Pyright
   configuration, shelling out, or fetching remote JSON.
+- Artifact previews now include bounded local PHPStan JSON report metadata for `.json` files whose
+  root validates as PHPStan output: error/file/identifier/ignorable counts, file size, capped file
+  labels, and capped identifier labels without reading PHP source files, expanding diagnostic
+  messages, running PHPStan, loading PHPStan configuration, or fetching remote JSON.
 - Artifact previews now include bounded local Bandit JSON security-report metadata for `.json`
   files whose root validates as Bandit output: issue/file/test, severity, and confidence counts,
   file size, capped file labels, and capped test labels without reading Python source files,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,16 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render PHPStan JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as PHPStan JSON output as a
+  specialized PHP static-analysis report rather than generic JSON.
+- **Rationale:** PHPStan reports are common in PHP coding sessions and CI exports. Showing
+  error/file/identifier counts plus capped file/identifier labels gives useful Codex-style feedback
+  without opening raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read PHP
+  source files, expand diagnostic messages, run PHPStan, load PHPStan configuration, or fetch remote
+  reports.
+
 ## 2026-07-19: Render SwiftLint JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as SwiftLint JSON output as a


### PR DESCRIPTION
## Summary
- Add bounded local PHPStan JSON artifact detection for PHP static-analysis reports
- Render error/file/identifier/ignorable metadata in SwiftUI and static HTML tool-card previews
- Document the parity matrix and decision constraints

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesPHPStanJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesPHPStanJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check