### PR TITLE
Add Psalm JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -91,6 +91,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pyrightJSONContent(pyrightJSONPreview)
         } else if let phpstanJSONPreview = artifact.phpstanJSONPreview {
             phpstanJSONContent(phpstanJSONPreview)
+        } else if let psalmJSONPreview = artifact.psalmJSONPreview {
+            psalmJSONContent(psalmJSONPreview)
         } else if let banditJSONPreview = artifact.banditJSONPreview {
             banditJSONContent(banditJSONPreview)
         } else if let semgrepJSONPreview = artifact.semgrepJSONPreview {
@@ -509,6 +511,22 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(phpstanJSONPreview.metadataLines)
             artifactContentList(title: "Files", labels: phpstanJSONPreview.filePreviewLabels)
             artifactContentList(title: "Identifiers", labels: phpstanJSONPreview.identifierPreviewLabels)
+        }
+    }
+
+    private func psalmJSONContent(_ psalmJSONPreview: ToolArtifactPsalmJSONPreview) -> some View {
+        let hasLists = !psalmJSONPreview.filePreviewLabels.isEmpty || !psalmJSONPreview.typePreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(psalmJSONPreview.metadataLines)
+            artifactContentList(title: "Files", labels: psalmJSONPreview.filePreviewLabels)
+            artifactContentList(title: "Types", labels: psalmJSONPreview.typePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2403,6 +2403,73 @@ public struct ToolArtifactPHPStanJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPsalmJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var issueCount: Int
+    public var fileCount: Int
+    public var typeCount: Int
+    public var errorCount: Int
+    public var warningCount: Int
+    public var deprecationCount: Int
+    public var infoCount: Int
+    public var byteSizeLabel: String?
+    public var filePreviewLabels: [String]
+    public var typePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(issueCount) issue\(issueCount == 1 ? "" : "s")",
+            "\(fileCount) file\(fileCount == 1 ? "" : "s")",
+            "\(typeCount) type\(typeCount == 1 ? "" : "s")",
+            errorCount > 0 ? "Errors: \(errorCount)" : nil,
+            warningCount > 0 ? "Warnings: \(warningCount)" : nil,
+            deprecationCount > 0 ? "Deprecations: \(deprecationCount)" : nil,
+            infoCount > 0 ? "Info: \(infoCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        issueCount > 0
+            || fileCount > 0
+            || typeCount > 0
+            || errorCount > 0
+            || warningCount > 0
+            || deprecationCount > 0
+            || infoCount > 0
+            || byteSizeLabel != nil
+            || !filePreviewLabels.isEmpty
+            || !typePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Psalm JSON",
+        issueCount: Int,
+        fileCount: Int,
+        typeCount: Int,
+        errorCount: Int = 0,
+        warningCount: Int = 0,
+        deprecationCount: Int = 0,
+        infoCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        filePreviewLabels: [String] = [],
+        typePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.issueCount = issueCount
+        self.fileCount = fileCount
+        self.typeCount = typeCount
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+        self.deprecationCount = deprecationCount
+        self.infoCount = infoCount
+        self.byteSizeLabel = byteSizeLabel
+        self.filePreviewLabels = filePreviewLabels
+        self.typePreviewLabels = typePreviewLabels
+    }
+}
+
 public struct ToolArtifactBanditJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var issueCount: Int
@@ -4422,6 +4489,7 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               mypyJSONPreview == nil,
               pyrightJSONPreview == nil,
               phpstanJSONPreview == nil,
+              psalmJSONPreview == nil,
               banditJSONPreview == nil,
               semgrepJSONPreview == nil,
               codeClimateJSONPreview == nil
@@ -4520,6 +4588,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var phpstanJSONPreview: ToolArtifactPHPStanJSONPreview? {
         ToolArtifactPHPStanJSONPreviewBuilder.phpstanJSONPreview(for: value, kind: kind)
+    }
+    public var psalmJSONPreview: ToolArtifactPsalmJSONPreview? {
+        ToolArtifactPsalmJSONPreviewBuilder.psalmJSONPreview(for: value, kind: kind)
     }
     public var banditJSONPreview: ToolArtifactBanditJSONPreview? {
         ToolArtifactBanditJSONPreviewBuilder.banditJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactPsalmJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPsalmJSONPreviewBuilder.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+enum ToolArtifactPsalmJSONPreviewBuilder {
+    static func psalmJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPsalmJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let report = root as? [String: Any] else { return nil }
+            return preview(
+                from: report,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(
+        from report: [String: Any],
+        byteSizeLabel: String?
+    ) -> ToolArtifactPsalmJSONPreview? {
+        let errors = issueList(in: report, key: "error")
+        let warnings = issueList(in: report, key: "warning")
+        let deprecations = issueList(in: report, key: "deprecation")
+        let infos = issueList(in: report, key: "info")
+        let allIssues = errors + warnings + deprecations + infos
+
+        guard !allIssues.isEmpty,
+              report.keys.contains(where: recognizedSeverityKeys.contains),
+              allIssues.allSatisfy(hasPsalmIssueShape)
+        else {
+            return nil
+        }
+
+        var fileLabels: [String] = []
+        var typeLabels: [String] = []
+        for issue in allIssues {
+            if let file = filePath(in: issue) {
+                appendUnique(sanitizedPathLabel(file), to: &fileLabels, limit: previewLimit)
+            }
+            if let type = stringValue(issue["type"]) {
+                appendUnique(sanitizedLabel(type), to: &typeLabels, limit: previewLimit)
+            }
+        }
+
+        guard !fileLabels.isEmpty else { return nil }
+
+        return ToolArtifactPsalmJSONPreview(
+            issueCount: allIssues.count,
+            fileCount: uniqueCount(in: allIssues, value: filePath),
+            typeCount: uniqueCount(in: allIssues) { stringValue($0["type"]) },
+            errorCount: errors.count,
+            warningCount: warnings.count,
+            deprecationCount: deprecations.count,
+            infoCount: infos.count,
+            byteSizeLabel: byteSizeLabel,
+            filePreviewLabels: fileLabels,
+            typePreviewLabels: typeLabels
+        )
+    }
+
+    private static func issueList(in report: [String: Any], key: String) -> [[String: Any]] {
+        report[key] as? [[String: Any]] ?? []
+    }
+
+    private static func hasPsalmIssueShape(_ issue: [String: Any]) -> Bool {
+        guard stringValue(issue["message"]) != nil,
+              filePath(in: issue) != nil
+        else {
+            return false
+        }
+        return stringValue(issue["type"]) != nil
+            || numericValue(issue["line_from"]) != nil
+            || numericValue(issue["line"]) != nil
+    }
+
+    private static func filePath(in issue: [String: Any]) -> String? {
+        stringValue(issue["file_name"])
+            ?? stringValue(issue["file_path"])
+            ?? stringValue(issue["file"])
+    }
+
+    private static func uniqueCount(
+        in issues: [[String: Any]],
+        value: ([String: Any]) -> String?
+    ) -> Int {
+        Set(issues.compactMap(value)).count
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func numericValue(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = stringValue(value) {
+            return Double(string)
+        }
+        return nil
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedPathLabel(_ value: String) -> String {
+        let trimmed = sanitizedLabel(value)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let components = trimmed.split(separator: "/")
+        return components.suffix(3).joined(separator: "/")
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let recognizedSeverityKeys: Set<String> = ["error", "warning", "deprecation", "info"]
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -240,6 +240,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pyrightJSONPreview = renderPyrightJSONPreview(pyrightJSONPreviewModel)
             let phpstanJSONPreviewModel = artifact.phpstanJSONPreview
             let phpstanJSONPreview = renderPHPStanJSONPreview(phpstanJSONPreviewModel)
+            let psalmJSONPreviewModel = artifact.psalmJSONPreview
+            let psalmJSONPreview = renderPsalmJSONPreview(psalmJSONPreviewModel)
             let banditJSONPreviewModel = artifact.banditJSONPreview
             let banditJSONPreview = renderBanditJSONPreview(banditJSONPreviewModel)
             let semgrepJSONPreviewModel = artifact.semgrepJSONPreview
@@ -341,6 +343,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && mypyJSONPreviewModel == nil
                 && pyrightJSONPreviewModel == nil
                 && phpstanJSONPreviewModel == nil
+                && psalmJSONPreviewModel == nil
                 && banditJSONPreviewModel == nil
                 && semgrepJSONPreviewModel == nil
                 && codeClimateJSONPreviewModel == nil
@@ -390,6 +393,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(mypyJSONPreview)
               \(pyrightJSONPreview)
               \(phpstanJSONPreview)
+              \(psalmJSONPreview)
               \(banditJSONPreview)
               \(semgrepJSONPreview)
               \(codeClimateJSONPreview)
@@ -1210,6 +1214,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(identifierList)
+        </div>
+        """
+    }
+
+    private static func renderPsalmJSONPreview(_ preview: ToolArtifactPsalmJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-psalm-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let files = preview.filePreviewLabels.map {
+            #"<li data-testid="tool-card-psalm-json-preview-file-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let fileList = files.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-psalm-json-preview-files">
+                <strong data-testid="tool-card-psalm-json-preview-file-title">Files</strong>
+                <ul>\(files)</ul>
+              </section>
+        """
+        let types = preview.typePreviewLabels.map {
+            #"<li data-testid="tool-card-psalm-json-preview-type-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let typeList = types.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-psalm-json-preview-types">
+                <strong data-testid="tool-card-psalm-json-preview-type-title">Types</strong>
+                <ul>\(types)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !fileList.isEmpty || !typeList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-psalm-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(fileList)
+          \(typeList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3634,6 +3634,94 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remotePHPStan.phpstanJSONPreview)
     }
 
+    func testArtifactStateDerivesPsalmJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("psalm-results.json")
+        let content = """
+        {
+          "error": [
+            {
+              "severity": "error",
+              "line_from": 12,
+              "type": "InvalidReturnType",
+              "message": "The declared return type is incorrect",
+              "file_name": "/repo/src/Controller/HomeController.php"
+            },
+            {
+              "severity": "error",
+              "line_from": 18,
+              "type": "UndefinedPropertyFetch",
+              "message": "Instance property does not exist",
+              "file_name": "/repo/src/Entity/User.php"
+            }
+          ],
+          "warning": [
+            {
+              "severity": "info",
+              "line_from": 44,
+              "type": "PossiblyNullArgument",
+              "message": "Argument may be null",
+              "file_name": "/repo/src/Entity/User.php"
+            }
+          ],
+          "deprecation": [
+            {
+              "line": 8,
+              "type": "DeprecatedMethod",
+              "message": "Deprecated method call",
+              "file_path": "/repo/src/Legacy/Adapter.php"
+            }
+          ]
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.psalmJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Psalm JSON")
+        XCTAssertEqual(preview.issueCount, 4)
+        XCTAssertEqual(preview.fileCount, 3)
+        XCTAssertEqual(preview.typeCount, 4)
+        XCTAssertEqual(preview.errorCount, 2)
+        XCTAssertEqual(preview.warningCount, 1)
+        XCTAssertEqual(preview.deprecationCount, 1)
+        XCTAssertEqual(preview.infoCount, 0)
+        XCTAssertEqual(preview.filePreviewLabels, [
+            "src/Controller/HomeController.php",
+            "src/Entity/User.php",
+            "src/Legacy/Adapter.php"
+        ])
+        XCTAssertEqual(preview.typePreviewLabels, [
+            "InvalidReturnType",
+            "UndefinedPropertyFetch",
+            "PossiblyNullArgument",
+            "DeprecatedMethod"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Psalm JSON",
+            "4 issues",
+            "3 files",
+            "4 types",
+            "Errors: 2",
+            "Warnings: 1",
+            "Deprecations: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("build-report.json")
+        try #"{"error":[{"message":"missing Psalm file and location"}]}"#
+            .write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).psalmJSONPreview)
+
+        let remotePsalm = ToolArtifactState(value: "https://example.com/psalm-results.json")
+        XCTAssertNil(remotePsalm.psalmJSONPreview)
+    }
+
     func testArtifactStateDerivesBanditJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("bandit-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2715,6 +2715,75 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesPsalmJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("psalm-results.json")
+        let reportText = """
+        {
+          "error": [
+            {
+              "line_from": 12,
+              "type": "InvalidReturnType",
+              "message": "The declared return type is incorrect",
+              "file_name": "/repo/src/Controller/HomeController.php"
+            }
+          ],
+          "warning": [
+            {
+              "line_from": 18,
+              "type": "PossiblyNullArgument",
+              "message": "Argument may be null",
+              "file_name": "/repo/src/Entity/User.php"
+            }
+          ]
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/psalm-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/psalm-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Psalm artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">psalm-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-meta">Format: Psalm JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-meta">2 issues"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-meta">2 files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-meta">2 types"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-meta">Errors: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-meta">Warnings: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-file-title">Files"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-file-item">src/Controller/HomeController.php"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-file-item">src/Entity/User.php"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-type-title">Types"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-type-item">InvalidReturnType"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-psalm-json-preview-type-item">PossiblyNullArgument"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesBanditJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -245,6 +245,10 @@
   root validates as PHPStan output: error/file/identifier/ignorable counts, file size, capped file
   labels, and capped identifier labels without reading PHP source files, expanding diagnostic
   messages, running PHPStan, loading PHPStan configuration, or fetching remote JSON.
+- Artifact previews now include bounded local Psalm JSON report metadata for `.json` files whose
+  root validates as Psalm output: issue/file/type/severity-bucket counts, file size, capped file
+  labels, and capped type labels without reading PHP source files, expanding diagnostic messages,
+  running Psalm, loading Psalm configuration, or fetching remote JSON.
 - Artifact previews now include bounded local Bandit JSON security-report metadata for `.json`
   files whose root validates as Bandit output: issue/file/test, severity, and confidence counts,
   file size, capped file labels, and capped test labels without reading Python source files,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,16 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Psalm JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Psalm JSON output as a
+  specialized PHP static-analysis report rather than generic JSON.
+- **Rationale:** Psalm reports are common in PHP coding sessions and CI exports. Showing
+  issue/file/type/severity-bucket counts plus capped file/type labels gives useful Codex-style
+  feedback without opening raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read PHP
+  source files, expand diagnostic messages, run Psalm, load Psalm configuration, or fetch remote
+  reports.
+
 ## 2026-07-19: Render PHPStan JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as PHPStan JSON output as a


### PR DESCRIPTION
## Summary
- Add bounded local Psalm JSON artifact detection for PHP static-analysis reports
- Render issue/file/type/severity-bucket metadata in SwiftUI and static HTML tool-card previews
- Document the parity matrix and decision constraints

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesPsalmJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesPsalmJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check