### PR TITLE
Add Go test JSONL artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -145,6 +145,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             sarifContent(sarifPreview)
         } else if let cargoCompilerJSONLinesPreview = artifact.cargoCompilerJSONLinesPreview {
             cargoCompilerJSONLinesContent(cargoCompilerJSONLinesPreview)
+        } else if let goTestJSONLinesPreview = artifact.goTestJSONLinesPreview {
+            goTestJSONLinesContent(goTestJSONLinesPreview)
         } else if let jsonLinesPreview = artifact.jsonLinesPreview {
             jsonLinesContent(jsonLinesPreview)
         } else if let tomlPreview = artifact.tomlPreview {
@@ -967,6 +969,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(cargoCompilerJSONLinesPreview.metadataLines)
             artifactContentList(title: "Files", labels: cargoCompilerJSONLinesPreview.filePreviewLabels)
             artifactContentList(title: "Codes", labels: cargoCompilerJSONLinesPreview.codePreviewLabels)
+        }
+    }
+
+    private func goTestJSONLinesContent(_ goTestJSONLinesPreview: ToolArtifactGoTestJSONLinesPreview) -> some View {
+        let hasLists = !goTestJSONLinesPreview.failedTestPreviewLabels.isEmpty
+            || !goTestJSONLinesPreview.skippedTestPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 142 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(goTestJSONLinesPreview.metadataLines)
+            artifactContentList(title: "Failed tests", labels: goTestJSONLinesPreview.failedTestPreviewLabels)
+            artifactContentList(title: "Skipped tests", labels: goTestJSONLinesPreview.skippedTestPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -3190,6 +3190,83 @@ public struct ToolArtifactCargoCompilerJSONLinesPreview: Codable, Sendable, Hash
     }
 }
 
+public struct ToolArtifactGoTestJSONLinesPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var eventCount: Int
+    public var packageCount: Int
+    public var testCount: Int
+    public var passedTestCount: Int
+    public var failedTestCount: Int
+    public var skippedTestCount: Int
+    public var packagePassCount: Int
+    public var packageFailureCount: Int
+    public var outputEventCount: Int
+    public var byteSizeLabel: String?
+    public var failedTestPreviewLabels: [String]
+    public var skippedTestPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(eventCount) event\(eventCount == 1 ? "" : "s")",
+            "\(packageCount) package\(packageCount == 1 ? "" : "s")",
+            "\(testCount) test\(testCount == 1 ? "" : "s")",
+            passedTestCount > 0 ? "Passed tests: \(passedTestCount)" : nil,
+            failedTestCount > 0 ? "Failed tests: \(failedTestCount)" : nil,
+            skippedTestCount > 0 ? "Skipped tests: \(skippedTestCount)" : nil,
+            packagePassCount > 0 ? "Passed packages: \(packagePassCount)" : nil,
+            packageFailureCount > 0 ? "Failed packages: \(packageFailureCount)" : nil,
+            outputEventCount > 0 ? "Output events: \(outputEventCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        eventCount > 0
+            || packageCount > 0
+            || testCount > 0
+            || passedTestCount > 0
+            || failedTestCount > 0
+            || skippedTestCount > 0
+            || packagePassCount > 0
+            || packageFailureCount > 0
+            || outputEventCount > 0
+            || byteSizeLabel != nil
+            || !failedTestPreviewLabels.isEmpty
+            || !skippedTestPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Go test JSONL",
+        eventCount: Int,
+        packageCount: Int,
+        testCount: Int,
+        passedTestCount: Int = 0,
+        failedTestCount: Int = 0,
+        skippedTestCount: Int = 0,
+        packagePassCount: Int = 0,
+        packageFailureCount: Int = 0,
+        outputEventCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        failedTestPreviewLabels: [String] = [],
+        skippedTestPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.eventCount = eventCount
+        self.packageCount = packageCount
+        self.testCount = testCount
+        self.passedTestCount = passedTestCount
+        self.failedTestCount = failedTestCount
+        self.skippedTestCount = skippedTestCount
+        self.packagePassCount = packagePassCount
+        self.packageFailureCount = packageFailureCount
+        self.outputEventCount = outputEventCount
+        self.byteSizeLabel = byteSizeLabel
+        self.failedTestPreviewLabels = failedTestPreviewLabels
+        self.skippedTestPreviewLabels = skippedTestPreviewLabels
+    }
+}
+
 public struct ToolArtifactTOMLPreview: Codable, Sendable, Hashable {
     public var topLevelKeyCount: Int
     public var tableCount: Int
@@ -4620,11 +4697,16 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
         ToolArtifactNotebookPreviewBuilder.notebookPreview(for: value, kind: kind)
     }
     public var jsonLinesPreview: ToolArtifactJSONLinesPreview? {
-        guard cargoCompilerJSONLinesPreview == nil else { return nil }
+        guard cargoCompilerJSONLinesPreview == nil,
+              goTestJSONLinesPreview == nil
+        else { return nil }
         return ToolArtifactJSONLinesPreviewBuilder.jsonLinesPreview(for: value, kind: kind)
     }
     public var cargoCompilerJSONLinesPreview: ToolArtifactCargoCompilerJSONLinesPreview? {
         ToolArtifactCargoCompilerJSONLinesPreviewBuilder.cargoCompilerJSONLinesPreview(for: value, kind: kind)
+    }
+    public var goTestJSONLinesPreview: ToolArtifactGoTestJSONLinesPreview? {
+        ToolArtifactGoTestJSONLinesPreviewBuilder.goTestJSONLinesPreview(for: value, kind: kind)
     }
     public var tomlPreview: ToolArtifactTOMLPreview? {
         ToolArtifactTOMLPreviewBuilder.tomlPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactGoTestJSONLinesPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactGoTestJSONLinesPreviewBuilder.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+enum ToolArtifactGoTestJSONLinesPreviewBuilder {
+    static func goTestJSONLinesPreview(
+        for value: String,
+        kind: ToolArtifactKind
+    ) -> ToolArtifactGoTestJSONLinesPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              supportedExtensions.contains(documentPreview.extensionLabel.lowercased()),
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return nil
+            }
+            let records = try decodeRecords(from: text)
+            return preview(
+                from: records,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func decodeRecords(from text: String) throws -> [[String: Any]] {
+        try text
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> [String: Any]? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return nil }
+                return try JSONSerialization.jsonObject(with: Data(trimmed.utf8), options: []) as? [String: Any]
+            }
+    }
+
+    private static func preview(
+        from records: [[String: Any]],
+        byteSizeLabel: String?
+    ) -> ToolArtifactGoTestJSONLinesPreview? {
+        let events = records.compactMap(goTestEvent)
+        guard events.count == records.count,
+              !events.isEmpty,
+              events.contains(where: { $0.testName != nil }),
+              events.contains(where: { terminalActions.contains($0.action) })
+        else {
+            return nil
+        }
+
+        var packages = Set<String>()
+        var tests = Set<TestIdentifier>()
+        var passedTests = Set<TestIdentifier>()
+        var failedTests = Set<TestIdentifier>()
+        var skippedTests = Set<TestIdentifier>()
+        var packageFailureCount = 0
+        var packagePassCount = 0
+        var outputCount = 0
+        var failedLabels: [String] = []
+        var skippedLabels: [String] = []
+
+        for event in events {
+            packages.insert(event.packageName)
+            if event.action == "output" {
+                outputCount += 1
+            }
+            guard let testName = event.testName else {
+                if event.action == "fail" {
+                    packageFailureCount += 1
+                } else if event.action == "pass" {
+                    packagePassCount += 1
+                }
+                continue
+            }
+
+            let test = TestIdentifier(packageName: event.packageName, testName: testName)
+            tests.insert(test)
+            switch event.action {
+            case "pass":
+                passedTests.insert(test)
+            case "fail":
+                failedTests.insert(test)
+                appendUnique(sanitizedLabel(test.previewLabel), to: &failedLabels, limit: previewLimit)
+            case "skip":
+                skippedTests.insert(test)
+                appendUnique(sanitizedLabel(test.previewLabel), to: &skippedLabels, limit: previewLimit)
+            default:
+                break
+            }
+        }
+
+        return ToolArtifactGoTestJSONLinesPreview(
+            eventCount: events.count,
+            packageCount: packages.count,
+            testCount: tests.count,
+            passedTestCount: passedTests.count,
+            failedTestCount: failedTests.count,
+            skippedTestCount: skippedTests.count,
+            packagePassCount: packagePassCount,
+            packageFailureCount: packageFailureCount,
+            outputEventCount: outputCount,
+            byteSizeLabel: byteSizeLabel,
+            failedTestPreviewLabels: failedLabels,
+            skippedTestPreviewLabels: skippedLabels
+        )
+    }
+
+    private static func goTestEvent(from record: [String: Any]) -> GoTestEvent? {
+        guard let action = stringValue(record["Action"])?.lowercased(),
+              recognizedActions.contains(action),
+              let packageName = stringValue(record["Package"])
+        else {
+            return nil
+        }
+        return GoTestEvent(
+            action: action,
+            packageName: packageName,
+            testName: stringValue(record["Test"])
+        )
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private struct GoTestEvent {
+        var action: String
+        var packageName: String
+        var testName: String?
+    }
+
+    private struct TestIdentifier: Hashable {
+        var packageName: String
+        var testName: String
+
+        var previewLabel: String {
+            "\(packageName).\(testName)"
+        }
+    }
+
+    private static let supportedExtensions: Set<String> = ["jsonl", "ndjson"]
+    private static let recognizedActions: Set<String> = ["run", "pause", "cont", "pass", "bench", "fail", "output", "skip"]
+    private static let terminalActions: Set<String> = ["pass", "fail", "skip"]
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -284,6 +284,7 @@ enum WorkspaceHTMLToolCardRenderer {
             let sarifPreview = renderSARIFPreview(artifact.sarifPreview)
             let cargoCompilerJSONLinesPreviewModel = artifact.cargoCompilerJSONLinesPreview
             let cargoCompilerJSONLinesPreview = renderCargoCompilerJSONLinesPreview(cargoCompilerJSONLinesPreviewModel)
+            let goTestJSONLinesPreview = renderGoTestJSONLinesPreview(artifact.goTestJSONLinesPreview)
             let jsonLinesPreview = renderJSONLinesPreview(artifact.jsonLinesPreview)
             let tomlPreview = uvLockPreviewModel == nil
                 ? renderTOMLPreview(artifact.tomlPreview)
@@ -420,6 +421,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(goCoveragePreview)
               \(sarifPreview)
               \(cargoCompilerJSONLinesPreview)
+              \(goTestJSONLinesPreview)
               \(jsonLinesPreview)
               \(tomlPreview)
               \(iniPreview)
@@ -2143,6 +2145,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(fileList)
           \(codeList)
+        </div>
+        """
+    }
+
+    private static func renderGoTestJSONLinesPreview(_ preview: ToolArtifactGoTestJSONLinesPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-go-test-jsonl-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failedTests = preview.failedTestPreviewLabels.map {
+            #"<li data-testid="tool-card-go-test-jsonl-preview-failed-test-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let skippedTests = preview.skippedTestPreviewLabels.map {
+            #"<li data-testid="tool-card-go-test-jsonl-preview-skipped-test-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failedList = failedTests.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-go-test-jsonl-preview-failed-tests">
+                <strong data-testid="tool-card-go-test-jsonl-preview-failed-test-title">Failed tests</strong>
+                <ul>\(failedTests)</ul>
+              </section>
+        """
+        let skippedList = skippedTests.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-go-test-jsonl-preview-skipped-tests">
+                <strong data-testid="tool-card-go-test-jsonl-preview-skipped-test-title">Skipped tests</strong>
+                <ul>\(skippedTests)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failedList.isEmpty || !skippedList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-go-test-jsonl-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(failedList)
+          \(skippedList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2193,6 +2193,64 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteCargo.cargoCompilerJSONLinesPreview)
     }
 
+    func testArtifactStateDerivesGoTestJSONLinesPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("go-test.jsonl")
+        let content = """
+        {"Time":"2026-07-19T17:00:00Z","Action":"run","Package":"example.com/quill/app","Test":"TestConnect"}
+        {"Time":"2026-07-19T17:00:01Z","Action":"pass","Package":"example.com/quill/app","Test":"TestConnect","Elapsed":0.12}
+        {"Time":"2026-07-19T17:00:01Z","Action":"run","Package":"example.com/quill/app","Test":"TestReconnect"}
+        {"Time":"2026-07-19T17:00:02Z","Action":"fail","Package":"example.com/quill/app","Test":"TestReconnect","Elapsed":0.18}
+        {"Time":"2026-07-19T17:00:02Z","Action":"skip","Package":"example.com/quill/app","Test":"TestBluetooth","Elapsed":0}
+        {"Time":"2026-07-19T17:00:02Z","Action":"output","Package":"example.com/quill/app","Output":"FAIL\\n"}
+        {"Time":"2026-07-19T17:00:02Z","Action":"fail","Package":"example.com/quill/app","Elapsed":0.31}
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.goTestJSONLinesPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSONL")
+        XCTAssertEqual(preview.formatLabel, "Go test JSONL")
+        XCTAssertEqual(preview.eventCount, 7)
+        XCTAssertEqual(preview.packageCount, 1)
+        XCTAssertEqual(preview.testCount, 3)
+        XCTAssertEqual(preview.passedTestCount, 1)
+        XCTAssertEqual(preview.failedTestCount, 1)
+        XCTAssertEqual(preview.skippedTestCount, 1)
+        XCTAssertEqual(preview.packagePassCount, 0)
+        XCTAssertEqual(preview.packageFailureCount, 1)
+        XCTAssertEqual(preview.outputEventCount, 1)
+        XCTAssertEqual(preview.failedTestPreviewLabels, [
+            "example.com/quill/app.TestReconnect"
+        ])
+        XCTAssertEqual(preview.skippedTestPreviewLabels, [
+            "example.com/quill/app.TestBluetooth"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Go test JSONL",
+            "7 events",
+            "1 package",
+            "3 tests",
+            "Passed tests: 1",
+            "Failed tests: 1",
+            "Skipped tests: 1",
+            "Failed packages: 1",
+            "Output events: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonLinesPreview)
+
+        let generic = directory.appendingPathComponent("events.jsonl")
+        try #"{"Action":"pass","Package":"example.com/quill/app"}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).goTestJSONLinesPreview)
+
+        let remoteGoTest = ToolArtifactState(value: "https://example.com/go-test.jsonl")
+        XCTAssertNil(remoteGoTest.goTestJSONLinesPreview)
+    }
+
     func testArtifactStateDerivesTOMLPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let config = directory.appendingPathComponent("config.toml")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -3409,6 +3409,62 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-lines-preview""#))
     }
 
+    func testHTMLRendererIncludesGoTestJSONLinesArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("go-test.jsonl")
+        let reportText = """
+        {"Time":"2026-07-19T17:00:00Z","Action":"run","Package":"example.com/quill/app","Test":"TestConnect"}
+        {"Time":"2026-07-19T17:00:01Z","Action":"pass","Package":"example.com/quill/app","Test":"TestConnect","Elapsed":0.12}
+        {"Time":"2026-07-19T17:00:01Z","Action":"run","Package":"example.com/quill/app","Test":"TestReconnect"}
+        {"Time":"2026-07-19T17:00:02Z","Action":"fail","Package":"example.com/quill/app","Test":"TestReconnect","Elapsed":0.18}
+        {"Time":"2026-07-19T17:00:02Z","Action":"skip","Package":"example.com/quill/app","Test":"TestBluetooth","Elapsed":0}
+        {"Time":"2026-07-19T17:00:02Z","Action":"output","Package":"example.com/quill/app","Output":"FAIL\\n"}
+        {"Time":"2026-07-19T17:00:02Z","Action":"fail","Package":"example.com/quill/app","Elapsed":0.31}
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/go-test.jsonl"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/go-test.jsonl\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Go test artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSONL"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">go-test.jsonl"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-meta">Format: Go test JSONL"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-meta">7 events"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-meta">1 package"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-meta">3 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-meta">Failed tests: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-meta">Skipped tests: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-failed-test-title">Failed tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-failed-test-item">example.com/quill/app.TestReconnect"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-skipped-test-title">Skipped tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-go-test-jsonl-preview-skipped-test-item">example.com/quill/app.TestBluetooth"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-lines-preview""#))
+    }
+
     func testHTMLRendererIncludesTOMLArtifactPreview() throws {
         let root = try makeTempDirectory()
         let quillDirectory = root.appendingPathComponent(".quillcode", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -155,6 +155,11 @@
   and `.ndjson` streams whose records include Cargo `compiler-message` entries: diagnostic/file/code
   and level counts, file size, capped file labels, and capped diagnostic-code labels without reading
   Rust source files, invoking Cargo, expanding spans, or fetching remote reports.
+- Artifact previews now include bounded local Go test JSONL metadata for `.jsonl` and `.ndjson`
+  streams whose records validate as `go test -json`/`test2json` output: event/package/test/pass/fail/
+  skip counts, output event counts, file size, and capped failed/skipped test labels without reading
+  Go source files, expanding output lines, invoking `go test`, loading module metadata, or fetching
+  remote reports.
 - Artifact previews now include bounded local font metadata for `.ttf`, `.otf`, `.ttc`, `.woff`,
   and `.woff2` files by validating fixed headers and rendering format, flavor, table count,
   declared size, and file size without parsing tables or decompressing webfont payloads.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Go Test JSONL As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.jsonl` and `.ndjson` files whose records validate as Go
+  `go test -json`/`test2json` output as test-result reports rather than generic JSON Lines.
+- **Rationale:** Go coding sessions commonly capture line-oriented test output. Showing
+  event/package/test/pass/fail/skip counts plus capped failed/skipped test labels gives useful
+  Codex-style feedback without opening raw NDJSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read Go
+  source files, expand output lines, run `go test`, load module metadata, or fetch remote reports.
+
 ## 2026-07-19: Render Psalm JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as Psalm JSON output as a


### PR DESCRIPTION
## Summary
- Add bounded local Go test JSONL/test2json artifact detection for .jsonl and .ndjson reports
- Render event/package/test/pass/fail/skip metadata in SwiftUI and static HTML tool-card previews
- Suppress the generic JSONL preview only for validated Go test streams and document the constraints

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesGoTestJSONLinesPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesGoTestJSONLinesArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check