### PR TITLE
Add Mocha JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -71,6 +71,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pytestJSONContent(pytestJSONPreview)
         } else if let jestJSONPreview = artifact.jestJSONPreview {
             jestJSONContent(jestJSONPreview)
+        } else if let mochaJSONPreview = artifact.mochaJSONPreview {
+            mochaJSONContent(mochaJSONPreview)
         } else if let eslintJSONPreview = artifact.eslintJSONPreview {
             eslintJSONContent(eslintJSONPreview)
         } else if let stylelintJSONPreview = artifact.stylelintJSONPreview {
@@ -351,6 +353,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(jestJSONPreview.metadataLines)
             artifactContentList(title: "Failures", labels: jestJSONPreview.failurePreviewLabels)
+        }
+    }
+
+    private func mochaJSONContent(_ mochaJSONPreview: ToolArtifactMochaJSONPreview) -> some View {
+        let hasLists = !mochaJSONPreview.failurePreviewLabels.isEmpty
+            || !mochaJSONPreview.pendingPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 142 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(mochaJSONPreview.metadataLines)
+            artifactContentList(title: "Failures", labels: mochaJSONPreview.failurePreviewLabels)
+            artifactContentList(title: "Pending", labels: mochaJSONPreview.pendingPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1748,6 +1748,63 @@ public struct ToolArtifactJestJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactMochaJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var totalTestCount: Int?
+    public var passedTestCount: Int?
+    public var failedTestCount: Int?
+    public var pendingTestCount: Int?
+    public var durationLabel: String?
+    public var byteSizeLabel: String?
+    public var failurePreviewLabels: [String]
+    public var pendingPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            durationLabel.map { "Runtime: \($0)" },
+            totalTestCount.map { "\($0) test\($0 == 1 ? "" : "s")" },
+            passedTestCount.map { "Passed: \($0)" },
+            failedTestCount.map { "Failed: \($0)" },
+            pendingTestCount.map { "Pending: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        totalTestCount != nil
+            || passedTestCount != nil
+            || failedTestCount != nil
+            || pendingTestCount != nil
+            || durationLabel != nil
+            || byteSizeLabel != nil
+            || !failurePreviewLabels.isEmpty
+            || !pendingPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Mocha JSON",
+        totalTestCount: Int? = nil,
+        passedTestCount: Int? = nil,
+        failedTestCount: Int? = nil,
+        pendingTestCount: Int? = nil,
+        durationLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        failurePreviewLabels: [String] = [],
+        pendingPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.totalTestCount = totalTestCount
+        self.passedTestCount = passedTestCount
+        self.failedTestCount = failedTestCount
+        self.pendingTestCount = pendingTestCount
+        self.durationLabel = durationLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.failurePreviewLabels = failurePreviewLabels
+        self.pendingPreviewLabels = pendingPreviewLabels
+    }
+}
+
 public struct ToolArtifactESLintJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var fileCount: Int
@@ -4569,7 +4626,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               psalmJSONPreview == nil,
               banditJSONPreview == nil,
               semgrepJSONPreview == nil,
-              codeClimateJSONPreview == nil
+              codeClimateJSONPreview == nil,
+              mochaJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -4635,6 +4693,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var jestJSONPreview: ToolArtifactJestJSONPreview? {
         ToolArtifactJestJSONPreviewBuilder.jestJSONPreview(for: value, kind: kind)
+    }
+    public var mochaJSONPreview: ToolArtifactMochaJSONPreview? {
+        ToolArtifactMochaJSONPreviewBuilder.mochaJSONPreview(for: value, kind: kind)
     }
     public var eslintJSONPreview: ToolArtifactESLintJSONPreview? {
         ToolArtifactESLintJSONPreviewBuilder.eslintJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactMochaJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactMochaJSONPreviewBuilder.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+enum ToolArtifactMochaJSONPreviewBuilder {
+    static func mochaJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactMochaJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let object = root as? [String: Any] else { return nil }
+            return preview(
+                from: object,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from object: [String: Any], byteSizeLabel: String?) -> ToolArtifactMochaJSONPreview? {
+        guard let stats = object["stats"] as? [String: Any] else { return nil }
+        let tests = object["tests"] as? [[String: Any]] ?? []
+        let failures = object["failures"] as? [[String: Any]] ?? []
+        let pending = object["pending"] as? [[String: Any]] ?? []
+        let passes = object["passes"] as? [[String: Any]] ?? []
+        let counts = Counts(stats: stats, tests: tests, passes: passes, failures: failures, pending: pending)
+        guard counts.hasMochaShape || !tests.isEmpty || !failures.isEmpty || !pending.isEmpty || !passes.isEmpty else {
+            return nil
+        }
+
+        let failureLabels = failures.compactMap(testLabel)
+            .prefix(previewLimit)
+        let pendingLabels = pending.compactMap(testLabel)
+            .prefix(previewLimit)
+        return ToolArtifactMochaJSONPreview(
+            totalTestCount: counts.totalTests,
+            passedTestCount: counts.passes,
+            failedTestCount: counts.failures,
+            pendingTestCount: counts.pending,
+            durationLabel: durationLabel(milliseconds: counts.durationMilliseconds),
+            byteSizeLabel: byteSizeLabel,
+            failurePreviewLabels: Array(failureLabels),
+            pendingPreviewLabels: Array(pendingLabels)
+        )
+    }
+
+    private static func testLabel(from test: [String: Any]) -> String? {
+        (stringValue(test["fullTitle"]) ?? stringValue(test["title"]))
+            .map(sanitizedLabel)
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func durationLabel(milliseconds: Int?) -> String? {
+        guard let milliseconds, milliseconds >= 0 else { return nil }
+        let seconds = Double(milliseconds) / 1_000
+        if seconds < 10 {
+            return String(format: "%.2fs", seconds)
+        }
+        if seconds < 60 {
+            return String(format: "%.1fs", seconds)
+        }
+        let minutes = Int(seconds / 60)
+        let remainder = Int(seconds.rounded()) % 60
+        return "\(minutes)m \(remainder)s"
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown test" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private struct Counts {
+        var totalTests: Int?
+        var passes: Int?
+        var failures: Int?
+        var pending: Int?
+        var durationMilliseconds: Int?
+
+        var hasMochaShape: Bool {
+            totalTests != nil || passes != nil || failures != nil || pending != nil
+        }
+
+        init(
+            stats: [String: Any],
+            tests: [[String: Any]],
+            passes passList: [[String: Any]],
+            failures failureList: [[String: Any]],
+            pending pendingList: [[String: Any]]
+        ) {
+            totalTests = ToolArtifactMochaJSONPreviewBuilder.intValue(stats["tests"])
+                ?? (tests.isEmpty ? nil : tests.count)
+            passes = ToolArtifactMochaJSONPreviewBuilder.intValue(stats["passes"])
+                ?? (passList.isEmpty ? nil : passList.count)
+            failures = ToolArtifactMochaJSONPreviewBuilder.intValue(stats["failures"])
+                ?? (failureList.isEmpty ? nil : failureList.count)
+            pending = ToolArtifactMochaJSONPreviewBuilder.intValue(stats["pending"])
+                ?? ToolArtifactMochaJSONPreviewBuilder.intValue(stats["skipped"])
+                ?? (pendingList.isEmpty ? nil : pendingList.count)
+            durationMilliseconds = ToolArtifactMochaJSONPreviewBuilder.intValue(stats["duration"])
+        }
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -220,6 +220,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
             let jestJSONPreviewModel = artifact.jestJSONPreview
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
+            let mochaJSONPreviewModel = artifact.mochaJSONPreview
+            let mochaJSONPreview = renderMochaJSONPreview(mochaJSONPreviewModel)
             let eslintJSONPreviewModel = artifact.eslintJSONPreview
             let eslintJSONPreview = renderESLintJSONPreview(eslintJSONPreviewModel)
             let stylelintJSONPreviewModel = artifact.stylelintJSONPreview
@@ -334,6 +336,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && coveragePyPreviewModel == nil
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
+                && mochaJSONPreviewModel == nil
                 && eslintJSONPreviewModel == nil
                 && stylelintJSONPreviewModel == nil
                 && swiftLintJSONPreviewModel == nil
@@ -384,6 +387,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(coveragePyPreview)
               \(pytestJSONPreview)
               \(jestJSONPreview)
+              \(mochaJSONPreview)
               \(eslintJSONPreview)
               \(stylelintJSONPreview)
               \(swiftLintJSONPreview)
@@ -866,6 +870,41 @@ enum WorkspaceHTMLToolCardRenderer {
             \(metadata)
           </div>
           \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderMochaJSONPreview(_ preview: ToolArtifactMochaJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-mocha-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-mocha-json-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let pending = preview.pendingPreviewLabels.map {
+            #"<li data-testid="tool-card-mocha-json-preview-pending-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-mocha-json-preview-failures">
+                <strong data-testid="tool-card-mocha-json-preview-failure-title">Failures</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        let pendingList = pending.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-mocha-json-preview-pending">
+                <strong data-testid="tool-card-mocha-json-preview-pending-title">Pending</strong>
+                <ul>\(pending)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failureList.isEmpty || !pendingList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-mocha-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(failureList)
+          \(pendingList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2859,6 +2859,76 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJest.jestJSONPreview)
     }
 
+    func testArtifactStateDerivesMochaJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("mocha-results.json")
+        let content = """
+        {
+          "stats": {
+            "suites": 2,
+            "tests": 4,
+            "passes": 2,
+            "pending": 1,
+            "failures": 1,
+            "duration": 1234
+          },
+          "tests": [
+            {"title": "renders home", "fullTitle": "Home page renders home"},
+            {"title": "saves user", "fullTitle": "User service saves user"},
+            {"title": "syncs cache", "fullTitle": "Cache sync syncs cache"},
+            {"title": "exports csv", "fullTitle": "Reports exports csv"}
+          ],
+          "passes": [
+            {"title": "renders home", "fullTitle": "Home page renders home"},
+            {"title": "saves user", "fullTitle": "User service saves user"}
+          ],
+          "pending": [
+            {"title": "exports csv", "fullTitle": "Reports exports csv"}
+          ],
+          "failures": [
+            {
+              "title": "syncs cache",
+              "fullTitle": "Cache sync syncs cache",
+              "err": {"message": "expected cache to be warm", "stack": "not expanded"}
+            }
+          ]
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.mochaJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Mocha JSON")
+        XCTAssertEqual(preview.totalTestCount, 4)
+        XCTAssertEqual(preview.passedTestCount, 2)
+        XCTAssertEqual(preview.failedTestCount, 1)
+        XCTAssertEqual(preview.pendingTestCount, 1)
+        XCTAssertEqual(preview.durationLabel, "1.23s")
+        XCTAssertEqual(preview.failurePreviewLabels, ["Cache sync syncs cache"])
+        XCTAssertEqual(preview.pendingPreviewLabels, ["Reports exports csv"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Mocha JSON",
+            "Runtime: 1.23s",
+            "4 tests",
+            "Passed: 2",
+            "Failed: 1",
+            "Pending: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("test-results.json")
+        try #"{"stats":{"duration":0},"tests":[]}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).mochaJSONPreview)
+
+        let remoteMocha = ToolArtifactState(value: "https://example.com/mocha-results.json")
+        XCTAssertNil(remoteMocha.mochaJSONPreview)
+    }
+
     func testArtifactStateDerivesESLintJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("eslint-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2006,6 +2006,64 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesMochaJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("mocha-results.json")
+        let reportText = """
+        {
+          "stats": {"tests": 3, "passes": 1, "pending": 1, "failures": 1, "duration": 1500},
+          "passes": [{"title": "renders home", "fullTitle": "Home page renders home"}],
+          "pending": [{"title": "exports csv", "fullTitle": "Reports exports csv"}],
+          "failures": [{"title": "syncs cache", "fullTitle": "Cache sync syncs cache"}],
+          "tests": [
+            {"title": "renders home", "fullTitle": "Home page renders home"},
+            {"title": "exports csv", "fullTitle": "Reports exports csv"},
+            {"title": "syncs cache", "fullTitle": "Cache sync syncs cache"}
+          ]
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/mocha-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/mocha-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Mocha artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">mocha-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-meta">Format: Mocha JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-meta">Runtime: 1.50s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-meta">3 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-meta">Failed: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-failure-title">Failures"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-failure-item">Cache sync syncs cache"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-pending-title">Pending"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-mocha-json-preview-pending-item">Reports exports csv"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesESLintJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -210,6 +210,10 @@
   files with Jest-compatible `numTotalTests`/`testResults` shape: result, runtime, test/suite
   counts, file size, and capped failing assertion labels without expanding failure messages or
   fetching remote JSON.
+- Artifact previews now include bounded local Mocha JSON report metadata for `.json` files whose
+  root validates as Mocha reporter output: test/pass/fail/pending counts, runtime, file size, and
+  capped failure/pending labels without reading JavaScript source files, expanding stack traces,
+  running Mocha, loading test configuration, or fetching remote JSON.
 - Artifact previews now include bounded local ESLint JSON report metadata for `.json` files whose
   root validates as ESLint formatter output: file/message/error/warning/fixable counts, file size,
   capped file labels, and capped rule labels without reading source files, loading lint rules, or

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,16 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Mocha JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Mocha JSON reporter output as
+  JavaScript test reports rather than generic JSON.
+- **Rationale:** Node coding sessions commonly export Mocha JSON. Showing test/pass/fail/pending
+  counts, runtime, and capped failure/pending labels gives useful Codex-style feedback without
+  opening raw JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read
+  JavaScript source files, expand stack traces, run Mocha, load test configuration, or fetch remote
+  reports.
+
 ## 2026-07-19: Render Go Test JSONL As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.jsonl` and `.ndjson` files whose records validate as Go


### PR DESCRIPTION
## Summary
- Add bounded local Mocha JSON artifact detection for JavaScript test reports
- Render test/pass/fail/pending/runtime metadata in SwiftUI and static HTML tool-card previews
- Suppress generic JSON preview only for validated Mocha reports and document the constraints

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesMochaJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesMochaJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check