### PR TITLE
Add Playwright JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -71,6 +71,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             pytestJSONContent(pytestJSONPreview)
         } else if let jestJSONPreview = artifact.jestJSONPreview {
             jestJSONContent(jestJSONPreview)
+        } else if let playwrightJSONPreview = artifact.playwrightJSONPreview {
+            playwrightJSONContent(playwrightJSONPreview)
         } else if let mochaJSONPreview = artifact.mochaJSONPreview {
             mochaJSONContent(mochaJSONPreview)
         } else if let eslintJSONPreview = artifact.eslintJSONPreview {
@@ -353,6 +355,20 @@ struct QuillCodeArtifactDocumentPreview: View {
             )
             metadataPills(jestJSONPreview.metadataLines)
             artifactContentList(title: "Failures", labels: jestJSONPreview.failurePreviewLabels)
+        }
+    }
+
+    private func playwrightJSONContent(_ playwrightJSONPreview: ToolArtifactPlaywrightJSONPreview) -> some View {
+        previewSurface(minHeight: playwrightJSONPreview.failurePreviewLabels.isEmpty ? 92 : 126) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "checklist")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(playwrightJSONPreview.metadataLines)
+            artifactContentList(title: "Failures", labels: playwrightJSONPreview.failurePreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -1748,6 +1748,64 @@ public struct ToolArtifactJestJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPlaywrightJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var totalTestCount: Int?
+    public var expectedTestCount: Int?
+    public var unexpectedTestCount: Int?
+    public var flakyTestCount: Int?
+    public var skippedTestCount: Int?
+    public var durationLabel: String?
+    public var byteSizeLabel: String?
+    public var failurePreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            durationLabel.map { "Runtime: \($0)" },
+            totalTestCount.map { "\($0) test\($0 == 1 ? "" : "s")" },
+            expectedTestCount.map { "Expected: \($0)" },
+            unexpectedTestCount.map { "Unexpected: \($0)" },
+            flakyTestCount.map { "Flaky: \($0)" },
+            skippedTestCount.map { "Skipped: \($0)" },
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        totalTestCount != nil
+            || expectedTestCount != nil
+            || unexpectedTestCount != nil
+            || flakyTestCount != nil
+            || skippedTestCount != nil
+            || durationLabel != nil
+            || byteSizeLabel != nil
+            || !failurePreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "Playwright JSON",
+        totalTestCount: Int? = nil,
+        expectedTestCount: Int? = nil,
+        unexpectedTestCount: Int? = nil,
+        flakyTestCount: Int? = nil,
+        skippedTestCount: Int? = nil,
+        durationLabel: String? = nil,
+        byteSizeLabel: String? = nil,
+        failurePreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.totalTestCount = totalTestCount
+        self.expectedTestCount = expectedTestCount
+        self.unexpectedTestCount = unexpectedTestCount
+        self.flakyTestCount = flakyTestCount
+        self.skippedTestCount = skippedTestCount
+        self.durationLabel = durationLabel
+        self.byteSizeLabel = byteSizeLabel
+        self.failurePreviewLabels = failurePreviewLabels
+    }
+}
+
 public struct ToolArtifactMochaJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var totalTestCount: Int?
@@ -4627,6 +4685,7 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               banditJSONPreview == nil,
               semgrepJSONPreview == nil,
               codeClimateJSONPreview == nil,
+              playwrightJSONPreview == nil,
               mochaJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
@@ -4693,6 +4752,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var jestJSONPreview: ToolArtifactJestJSONPreview? {
         ToolArtifactJestJSONPreviewBuilder.jestJSONPreview(for: value, kind: kind)
+    }
+    public var playwrightJSONPreview: ToolArtifactPlaywrightJSONPreview? {
+        ToolArtifactPlaywrightJSONPreviewBuilder.playwrightJSONPreview(for: value, kind: kind)
     }
     public var mochaJSONPreview: ToolArtifactMochaJSONPreview? {
         ToolArtifactMochaJSONPreviewBuilder.mochaJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactPlaywrightJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPlaywrightJSONPreviewBuilder.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+enum ToolArtifactPlaywrightJSONPreviewBuilder {
+    static func playwrightJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPlaywrightJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let object = root as? [String: Any] else { return nil }
+            return preview(
+                from: object,
+                byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from object: [String: Any], byteSizeLabel: String?) -> ToolArtifactPlaywrightJSONPreview? {
+        guard let suites = object["suites"] as? [[String: Any]] else { return nil }
+        let stats = object["stats"] as? [String: Any]
+        let counts = Counts(stats: stats)
+        let failedSpecLabels = suites
+            .flatMap { failureLabels(in: $0, inheritedTitles: []) }
+            .prefix(previewLimit)
+
+        guard counts.hasPlaywrightShape || !suites.isEmpty && suites.contains(where: containsSpecsOrNestedSuites) else {
+            return nil
+        }
+
+        return ToolArtifactPlaywrightJSONPreview(
+            totalTestCount: counts.totalTests,
+            expectedTestCount: counts.expected,
+            unexpectedTestCount: counts.unexpected,
+            flakyTestCount: counts.flaky,
+            skippedTestCount: counts.skipped,
+            durationLabel: durationLabel(milliseconds: counts.durationMilliseconds),
+            byteSizeLabel: byteSizeLabel,
+            failurePreviewLabels: Array(failedSpecLabels)
+        )
+    }
+
+    private static func containsSpecsOrNestedSuites(_ suite: [String: Any]) -> Bool {
+        if let specs = suite["specs"] as? [[String: Any]], !specs.isEmpty {
+            return true
+        }
+        let nestedSuites = suite["suites"] as? [[String: Any]] ?? []
+        return nestedSuites.contains(where: containsSpecsOrNestedSuites)
+    }
+
+    private static func failureLabels(in suite: [String: Any], inheritedTitles: [String]) -> [String] {
+        let title = stringValue(suite["title"])
+        let titles = title.map { inheritedTitles + [$0] } ?? inheritedTitles
+        let specs = suite["specs"] as? [[String: Any]] ?? []
+        let specLabels = specs.compactMap { failureLabel(from: $0, inheritedTitles: titles) }
+        let nestedSuites = suite["suites"] as? [[String: Any]] ?? []
+        return specLabels + nestedSuites.flatMap { failureLabels(in: $0, inheritedTitles: titles) }
+    }
+
+    private static func failureLabel(from spec: [String: Any], inheritedTitles: [String]) -> String? {
+        let tests = spec["tests"] as? [[String: Any]] ?? []
+        let hasFailedResult = tests.contains { test in
+            let results = test["results"] as? [[String: Any]] ?? []
+            return results.contains { result in
+                guard let status = stringValue(result["status"])?.lowercased() else { return false }
+                return failedResultStatuses.contains(status)
+            }
+        }
+        let specOK = boolValue(spec["ok"])
+        guard hasFailedResult || specOK == false else { return nil }
+        var pieces = inheritedTitles
+        if let title = stringValue(spec["title"]) {
+            pieces.append(title)
+        }
+        if pieces.isEmpty, let file = stringValue(spec["file"]) {
+            pieces.append(file)
+        }
+        return sanitizedLabel(pieces.isEmpty ? "Unknown test" : pieces.joined(separator: " > "))
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
+        }
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        switch value {
+        case let bool as Bool:
+            return bool
+        case let number as NSNumber:
+            return number.boolValue
+        case let string as String:
+            let normalized = string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if normalized == "true" { return true }
+            if normalized == "false" { return false }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func durationLabel(milliseconds: Int?) -> String? {
+        guard let milliseconds, milliseconds >= 0 else { return nil }
+        let seconds = Double(milliseconds) / 1_000
+        if seconds < 10 {
+            return String(format: "%.2fs", seconds)
+        }
+        if seconds < 60 {
+            return String(format: "%.1fs", seconds)
+        }
+        let minutes = Int(seconds / 60)
+        let remainder = Int(seconds.rounded()) % 60
+        return "\(minutes)m \(remainder)s"
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown test" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private struct Counts {
+        var expected: Int?
+        var unexpected: Int?
+        var flaky: Int?
+        var skipped: Int?
+        var durationMilliseconds: Int?
+
+        var totalTests: Int? {
+            let values = [expected, unexpected, flaky, skipped].compactMap { $0 }
+            return values.isEmpty ? nil : values.reduce(0, +)
+        }
+
+        var hasPlaywrightShape: Bool {
+            expected != nil || unexpected != nil || flaky != nil || skipped != nil
+        }
+
+        init(stats: [String: Any]?) {
+            expected = ToolArtifactPlaywrightJSONPreviewBuilder.intValue(stats?["expected"])
+            unexpected = ToolArtifactPlaywrightJSONPreviewBuilder.intValue(stats?["unexpected"])
+            flaky = ToolArtifactPlaywrightJSONPreviewBuilder.intValue(stats?["flaky"])
+            skipped = ToolArtifactPlaywrightJSONPreviewBuilder.intValue(stats?["skipped"])
+            durationMilliseconds = ToolArtifactPlaywrightJSONPreviewBuilder.intValue(stats?["duration"])
+        }
+    }
+
+    private static let failedResultStatuses: Set<String> = ["failed", "timedout", "timed_out", "interrupted"]
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -220,6 +220,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let pytestJSONPreview = renderPytestJSONPreview(pytestJSONPreviewModel)
             let jestJSONPreviewModel = artifact.jestJSONPreview
             let jestJSONPreview = renderJestJSONPreview(jestJSONPreviewModel)
+            let playwrightJSONPreviewModel = artifact.playwrightJSONPreview
+            let playwrightJSONPreview = renderPlaywrightJSONPreview(playwrightJSONPreviewModel)
             let mochaJSONPreviewModel = artifact.mochaJSONPreview
             let mochaJSONPreview = renderMochaJSONPreview(mochaJSONPreviewModel)
             let eslintJSONPreviewModel = artifact.eslintJSONPreview
@@ -336,6 +338,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && coveragePyPreviewModel == nil
                 && pytestJSONPreviewModel == nil
                 && jestJSONPreviewModel == nil
+                && playwrightJSONPreviewModel == nil
                 && mochaJSONPreviewModel == nil
                 && eslintJSONPreviewModel == nil
                 && stylelintJSONPreviewModel == nil
@@ -387,6 +390,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(coveragePyPreview)
               \(pytestJSONPreview)
               \(jestJSONPreview)
+              \(playwrightJSONPreview)
               \(mochaJSONPreview)
               \(eslintJSONPreview)
               \(stylelintJSONPreview)
@@ -866,6 +870,31 @@ enum WorkspaceHTMLToolCardRenderer {
         guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
         return """
         <div class="artifact-office-preview" data-testid="tool-card-jest-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(failureList)
+        </div>
+        """
+    }
+
+    private static func renderPlaywrightJSONPreview(_ preview: ToolArtifactPlaywrightJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-playwright-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let failures = preview.failurePreviewLabels.map {
+            #"<li data-testid="tool-card-playwright-json-preview-failure-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let failureList = failures.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-playwright-json-preview-failures">
+                <strong data-testid="tool-card-playwright-json-preview-failure-title">Failures</strong>
+                <ul>\(failures)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !failureList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-playwright-json-preview">
           <div>
             \(metadata)
           </div>

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -2859,6 +2859,80 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteJest.jestJSONPreview)
     }
 
+    func testArtifactStateDerivesPlaywrightJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("playwright-results.json")
+        let content = """
+        {
+          "config": {"rootDir": "/repo"},
+          "stats": {
+            "expected": 2,
+            "skipped": 1,
+            "unexpected": 1,
+            "flaky": 1,
+            "duration": 3456
+          },
+          "suites": [
+            {
+              "title": "chromium",
+              "suites": [
+                {
+                  "title": "tests/app.spec.ts",
+                  "specs": [
+                    {
+                      "title": "loads dashboard",
+                      "ok": true,
+                      "tests": [{"results": [{"status": "passed", "duration": 100}]}]
+                    },
+                    {
+                      "title": "saves settings",
+                      "ok": false,
+                      "tests": [{"results": [{"status": "failed", "duration": 250}]}]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "errors": []
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.playwrightJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "Playwright JSON")
+        XCTAssertEqual(preview.totalTestCount, 5)
+        XCTAssertEqual(preview.expectedTestCount, 2)
+        XCTAssertEqual(preview.unexpectedTestCount, 1)
+        XCTAssertEqual(preview.flakyTestCount, 1)
+        XCTAssertEqual(preview.skippedTestCount, 1)
+        XCTAssertEqual(preview.durationLabel, "3.46s")
+        XCTAssertEqual(preview.failurePreviewLabels, ["chromium > tests/app.spec.ts > saves settings"])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: Playwright JSON",
+            "Runtime: 3.46s",
+            "5 tests",
+            "Expected: 2",
+            "Unexpected: 1",
+            "Flaky: 1",
+            "Skipped: 1",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("suite-summary.json")
+        try #"{"suites":[],"stats":{"duration":0}}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).playwrightJSONPreview)
+
+        let remotePlaywright = ToolArtifactState(value: "https://example.com/playwright-results.json")
+        XCTAssertNil(remotePlaywright.playwrightJSONPreview)
+    }
+
     func testArtifactStateDerivesMochaJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("mocha-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2006,6 +2006,73 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesPlaywrightJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("playwright-results.json")
+        let reportText = """
+        {
+          "config": {"rootDir": "/repo"},
+          "stats": {"expected": 2, "skipped": 1, "unexpected": 1, "flaky": 0, "duration": 2500},
+          "suites": [
+            {
+              "title": "webkit",
+              "specs": [
+                {
+                  "title": "opens inbox",
+                  "ok": true,
+                  "tests": [{"results": [{"status": "passed", "duration": 120}]}]
+                },
+                {
+                  "title": "uploads attachment",
+                  "ok": false,
+                  "tests": [{"results": [{"status": "timedOut", "duration": 30000}]}]
+                }
+              ]
+            }
+          ],
+          "errors": []
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/playwright-results.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/playwright-results.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "Playwright artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">playwright-results.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-playwright-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-playwright-json-preview-meta">Format: Playwright JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-playwright-json-preview-meta">Runtime: 2.50s"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-playwright-json-preview-meta">4 tests"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-playwright-json-preview-meta">Unexpected: 1"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-playwright-json-preview-failure-title">Failures"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-playwright-json-preview-failure-item">webkit &gt; uploads attachment"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesMochaJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -210,6 +210,10 @@
   files with Jest-compatible `numTotalTests`/`testResults` shape: result, runtime, test/suite
   counts, file size, and capped failing assertion labels without expanding failure messages or
   fetching remote JSON.
+- Artifact previews now include bounded local Playwright JSON report metadata for `.json` files
+  whose root validates as Playwright reporter output: expected/unexpected/flaky/skipped counts,
+  runtime, file size, and capped failing spec labels without reading Playwright config or source
+  files, expanding stacks, running browsers, resolving traces/videos, or fetching remote JSON.
 - Artifact previews now include bounded local Mocha JSON report metadata for `.json` files whose
   root validates as Mocha reporter output: test/pass/fail/pending counts, runtime, file size, and
   capped failure/pending labels without reading JavaScript source files, expanding stack traces,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,16 @@
 # QuillCode Decisions
 
+## 2026-07-19: Render Playwright JSON As A Bounded Artifact Preview
+
+- **Decision:** Treat local `.json` files whose root validates as Playwright JSON reporter output
+  as browser/E2E test reports rather than generic JSON.
+- **Rationale:** Playwright is a common way Codex-style coding sessions verify UI behavior. Showing
+  expected/unexpected/flaky/skipped counts, runtime, and capped failing spec labels gives useful
+  feedback without opening raw reporter JSON.
+- **Constraints:** Only local regular files under 512 KB are parsed; QuillCode does not read
+  Playwright config or source files, expand error stacks, run browsers, resolve traces/videos, or
+  fetch remote reports.
+
 ## 2026-07-19: Render Mocha JSON As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.json` files whose root validates as Mocha JSON reporter output as


### PR DESCRIPTION
## Summary
- Add bounded local Playwright JSON artifact detection for browser/E2E test reports
- Render expected/unexpected/flaky/skipped/runtime metadata in SwiftUI and static HTML tool-card previews
- Suppress generic JSON preview only for validated Playwright reports and document the constraints

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesPlaywrightJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesPlaywrightJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check