### PR TITLE
Add pip-audit JSON artifact previews

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -89,6 +89,8 @@ struct QuillCodeArtifactDocumentPreview: View {
             npmAuditJSONContent(npmAuditJSONPreview)
         } else if let cargoAuditJSONPreview = artifact.cargoAuditJSONPreview {
             cargoAuditJSONContent(cargoAuditJSONPreview)
+        } else if let pipAuditJSONPreview = artifact.pipAuditJSONPreview {
+            pipAuditJSONContent(pipAuditJSONPreview)
         } else if let eslintJSONPreview = artifact.eslintJSONPreview {
             eslintJSONContent(eslintJSONPreview)
         } else if let stylelintJSONPreview = artifact.stylelintJSONPreview {
@@ -747,6 +749,23 @@ struct QuillCodeArtifactDocumentPreview: View {
             metadataPills(cargoAuditJSONPreview.metadataLines)
             artifactContentList(title: "Packages", labels: cargoAuditJSONPreview.packagePreviewLabels)
             artifactContentList(title: "Advisories", labels: cargoAuditJSONPreview.advisoryPreviewLabels)
+        }
+    }
+
+    private func pipAuditJSONContent(_ pipAuditJSONPreview: ToolArtifactPipAuditJSONPreview) -> some View {
+        let hasLists = !pipAuditJSONPreview.packagePreviewLabels.isEmpty
+            || !pipAuditJSONPreview.vulnerabilityPreviewLabels.isEmpty
+        return previewSurface(minHeight: hasLists ? 154 : 92) {
+            header(
+                thumbnail: {
+                    iconThumbnail(width: 44, height: 52, systemImage: preview?.systemImage ?? "shield.lefthalf.filled")
+                },
+                title: artifact.label,
+                subtitle: preview?.detail ?? artifact.detail
+            )
+            metadataPills(pipAuditJSONPreview.metadataLines)
+            artifactContentList(title: "Packages", labels: pipAuditJSONPreview.packagePreviewLabels)
+            artifactContentList(title: "Vulnerabilities", labels: pipAuditJSONPreview.vulnerabilityPreviewLabels)
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeToolArtifactSurface.swift
@@ -2275,6 +2275,58 @@ public struct ToolArtifactCargoAuditJSONPreview: Codable, Sendable, Hashable {
     }
 }
 
+public struct ToolArtifactPipAuditJSONPreview: Codable, Sendable, Hashable {
+    public var formatLabel: String
+    public var dependencyCount: Int
+    public var vulnerablePackageCount: Int
+    public var vulnerabilityCount: Int
+    public var fixableVulnerabilityCount: Int
+    public var byteSizeLabel: String?
+    public var packagePreviewLabels: [String]
+    public var vulnerabilityPreviewLabels: [String]
+
+    public var metadataLines: [String] {
+        [
+            "Format: \(formatLabel)",
+            "\(dependencyCount) dependenc\(dependencyCount == 1 ? "y" : "ies")",
+            "\(vulnerablePackageCount) vulnerable package\(vulnerablePackageCount == 1 ? "" : "s")",
+            "\(vulnerabilityCount) vulnerabilit\(vulnerabilityCount == 1 ? "y" : "ies")",
+            fixableVulnerabilityCount > 0 ? "Fixable: \(fixableVulnerabilityCount)" : nil,
+            byteSizeLabel.map { "Size: \($0)" }
+        ].compactMap { $0 }
+    }
+
+    public var hasDisplayContent: Bool {
+        dependencyCount > 0
+            || vulnerablePackageCount > 0
+            || vulnerabilityCount > 0
+            || fixableVulnerabilityCount > 0
+            || byteSizeLabel != nil
+            || !packagePreviewLabels.isEmpty
+            || !vulnerabilityPreviewLabels.isEmpty
+    }
+
+    public init(
+        formatLabel: String = "pip-audit JSON",
+        dependencyCount: Int,
+        vulnerablePackageCount: Int,
+        vulnerabilityCount: Int,
+        fixableVulnerabilityCount: Int = 0,
+        byteSizeLabel: String? = nil,
+        packagePreviewLabels: [String] = [],
+        vulnerabilityPreviewLabels: [String] = []
+    ) {
+        self.formatLabel = formatLabel
+        self.dependencyCount = dependencyCount
+        self.vulnerablePackageCount = vulnerablePackageCount
+        self.vulnerabilityCount = vulnerabilityCount
+        self.fixableVulnerabilityCount = fixableVulnerabilityCount
+        self.byteSizeLabel = byteSizeLabel
+        self.packagePreviewLabels = packagePreviewLabels
+        self.vulnerabilityPreviewLabels = vulnerabilityPreviewLabels
+    }
+}
+
 public struct ToolArtifactESLintJSONPreview: Codable, Sendable, Hashable {
     public var formatLabel: String
     public var fileCount: Int
@@ -5284,7 +5336,8 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
               benchmarkDotNetJSONPreview == nil,
               hyperfineJSONPreview == nil,
               npmAuditJSONPreview == nil,
-              cargoAuditJSONPreview == nil
+              cargoAuditJSONPreview == nil,
+              pipAuditJSONPreview == nil
         else { return nil }
         return ToolArtifactJSONPreviewBuilder.jsonPreview(for: value, kind: kind)
     }
@@ -5377,6 +5430,9 @@ public struct ToolArtifactState: Codable, Sendable, Hashable, Identifiable {
     }
     public var cargoAuditJSONPreview: ToolArtifactCargoAuditJSONPreview? {
         ToolArtifactCargoAuditJSONPreviewBuilder.cargoAuditJSONPreview(for: value, kind: kind)
+    }
+    public var pipAuditJSONPreview: ToolArtifactPipAuditJSONPreview? {
+        ToolArtifactPipAuditJSONPreviewBuilder.pipAuditJSONPreview(for: value, kind: kind)
     }
     public var eslintJSONPreview: ToolArtifactESLintJSONPreview? {
         ToolArtifactESLintJSONPreviewBuilder.eslintJSONPreview(for: value, kind: kind)

--- a/Sources/QuillCodeApp/ToolArtifactPipAuditJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPipAuditJSONPreviewBuilder.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+enum ToolArtifactPipAuditJSONPreviewBuilder {
+    static func pipAuditJSONPreview(for value: String, kind: ToolArtifactKind) -> ToolArtifactPipAuditJSONPreview? {
+        guard kind == .file,
+              let documentPreview = ToolArtifactDocumentPreviewBuilder.documentPreview(for: value, kind: kind),
+              documentPreview.kind == .data,
+              documentPreview.extensionLabel.lowercased() == "json",
+              let fileURL = localArtifactFileURL(for: value)
+        else {
+            return nil
+        }
+
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard resourceValues.isRegularFile == true else { return nil }
+            let fileSize = max(resourceValues.fileSize ?? 0, 0)
+            guard fileSize > 0, fileSize <= byteLimit else { return nil }
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+            guard !data.contains(0) else { return nil }
+            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            return preview(from: root, byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize))
+        } catch {
+            return nil
+        }
+    }
+
+    private static func preview(from root: Any, byteSizeLabel: String?) -> ToolArtifactPipAuditJSONPreview? {
+        let dependencies: [[String: Any]]
+        if let object = root as? [String: Any],
+           let objectDependencies = object["dependencies"] as? [[String: Any]]
+        {
+            dependencies = objectDependencies
+        } else if let array = root as? [[String: Any]] {
+            dependencies = array
+        } else {
+            return nil
+        }
+
+        guard !dependencies.isEmpty,
+              dependencies.allSatisfy(hasPipAuditDependencyShape)
+        else {
+            return nil
+        }
+
+        var vulnerablePackageLabels: [String] = []
+        var vulnerabilityLabels: [String] = []
+        var vulnerablePackageCount = 0
+        var vulnerabilityCount = 0
+        var fixableCount = 0
+
+        for dependency in dependencies {
+            let vulnerabilities = dependency["vulns"] as? [[String: Any]] ?? []
+            guard !vulnerabilities.isEmpty else { continue }
+            vulnerablePackageCount += 1
+            vulnerabilityCount += vulnerabilities.count
+            if let package = packageLabel(from: dependency) {
+                appendUnique(package, to: &vulnerablePackageLabels, limit: previewLimit)
+            }
+            for vulnerability in vulnerabilities {
+                if hasFixVersion(vulnerability) {
+                    fixableCount += 1
+                }
+                if let label = vulnerabilityLabel(from: vulnerability) {
+                    appendUnique(label, to: &vulnerabilityLabels, limit: previewLimit)
+                }
+            }
+        }
+
+        guard vulnerabilityCount > 0 else { return nil }
+
+        return ToolArtifactPipAuditJSONPreview(
+            dependencyCount: dependencies.count,
+            vulnerablePackageCount: vulnerablePackageCount,
+            vulnerabilityCount: vulnerabilityCount,
+            fixableVulnerabilityCount: fixableCount,
+            byteSizeLabel: byteSizeLabel,
+            packagePreviewLabels: vulnerablePackageLabels,
+            vulnerabilityPreviewLabels: vulnerabilityLabels
+        )
+    }
+
+    private static func hasPipAuditDependencyShape(_ dependency: [String: Any]) -> Bool {
+        guard stringValue(dependency["name"]) != nil,
+              stringValue(dependency["version"]) != nil,
+              let vulnerabilities = dependency["vulns"] as? [[String: Any]]
+        else {
+            return false
+        }
+        return vulnerabilities.allSatisfy(hasPipAuditVulnerabilityShape)
+    }
+
+    private static func hasPipAuditVulnerabilityShape(_ vulnerability: [String: Any]) -> Bool {
+        guard stringValue(vulnerability["id"]) != nil else { return false }
+        return vulnerability["fix_versions"] == nil
+            || vulnerability["fix_versions"] is [String]
+            || vulnerability["fix_versions"] is [Any]
+    }
+
+    private static func packageLabel(from dependency: [String: Any]) -> String? {
+        guard let name = stringValue(dependency["name"]) else { return nil }
+        let version = stringValue(dependency["version"]).map { " \($0)" } ?? ""
+        let vulnerabilities = dependency["vulns"] as? [[String: Any]] ?? []
+        let vulnerabilityLabel = " · \(vulnerabilities.count) vulnerabilit\(vulnerabilities.count == 1 ? "y" : "ies")"
+        return sanitizedLabel("\(name)\(version)\(vulnerabilityLabel)")
+    }
+
+    private static func vulnerabilityLabel(from vulnerability: [String: Any]) -> String? {
+        guard let id = stringValue(vulnerability["id"]) else { return nil }
+        let aliases = stringArray(vulnerability["aliases"])
+        let aliasLabel = aliases.first.map { " · \($0)" } ?? ""
+        let fixVersions = stringArray(vulnerability["fix_versions"])
+        let fixLabel = fixVersions.first.map { " · fixed in \($0)" } ?? ""
+        return sanitizedLabel("\(id)\(aliasLabel)\(fixLabel)")
+    }
+
+    private static func hasFixVersion(_ vulnerability: [String: Any]) -> Bool {
+        !stringArray(vulnerability["fix_versions"]).isEmpty
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String], limit: Int) {
+        guard values.count < limit, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func localArtifactFileURL(for value: String) -> URL? {
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        guard let url = URL(string: value),
+              url.scheme?.lowercased() == "file"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func stringArray(_ value: Any?) -> [String] {
+        guard let values = value as? [Any] else { return [] }
+        return values.compactMap(stringValue)
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func sanitizedLabel(_ value: String) -> String {
+        let collapsedWhitespace = value
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((collapsedWhitespace.isEmpty ? "Unknown" : collapsedWhitespace).prefix(characterLimit))
+    }
+
+    private static let byteLimit = 512 * 1_024
+    private static let previewLimit = 6
+    private static let characterLimit = 96
+}

--- a/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLToolCardRenderer.swift
@@ -238,6 +238,8 @@ enum WorkspaceHTMLToolCardRenderer {
             let npmAuditJSONPreview = renderNPMAuditJSONPreview(npmAuditJSONPreviewModel)
             let cargoAuditJSONPreviewModel = artifact.cargoAuditJSONPreview
             let cargoAuditJSONPreview = renderCargoAuditJSONPreview(cargoAuditJSONPreviewModel)
+            let pipAuditJSONPreviewModel = artifact.pipAuditJSONPreview
+            let pipAuditJSONPreview = renderPipAuditJSONPreview(pipAuditJSONPreviewModel)
             let eslintJSONPreviewModel = artifact.eslintJSONPreview
             let eslintJSONPreview = renderESLintJSONPreview(eslintJSONPreviewModel)
             let stylelintJSONPreviewModel = artifact.stylelintJSONPreview
@@ -370,6 +372,7 @@ enum WorkspaceHTMLToolCardRenderer {
                 && hyperfineJSONPreviewModel == nil
                 && npmAuditJSONPreviewModel == nil
                 && cargoAuditJSONPreviewModel == nil
+                && pipAuditJSONPreviewModel == nil
                 && eslintJSONPreviewModel == nil
                 && stylelintJSONPreviewModel == nil
                 && swiftLintJSONPreviewModel == nil
@@ -429,6 +432,7 @@ enum WorkspaceHTMLToolCardRenderer {
               \(hyperfineJSONPreview)
               \(npmAuditJSONPreview)
               \(cargoAuditJSONPreview)
+              \(pipAuditJSONPreview)
               \(eslintJSONPreview)
               \(stylelintJSONPreview)
               \(swiftLintJSONPreview)
@@ -1181,6 +1185,41 @@ enum WorkspaceHTMLToolCardRenderer {
           </div>
           \(packageList)
           \(advisoryList)
+        </div>
+        """
+    }
+
+    private static func renderPipAuditJSONPreview(_ preview: ToolArtifactPipAuditJSONPreview?) -> String {
+        guard let preview, preview.hasDisplayContent else { return "" }
+        let metadata = preview.metadataLines.map {
+            #"<small data-testid="tool-card-pip-audit-json-preview-meta">\#(escape($0))</small>"#
+        }.joined(separator: "")
+        let packages = preview.packagePreviewLabels.map {
+            #"<li data-testid="tool-card-pip-audit-json-preview-package-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let packageList = packages.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pip-audit-json-preview-packages">
+                <strong data-testid="tool-card-pip-audit-json-preview-package-title">Packages</strong>
+                <ul>\(packages)</ul>
+              </section>
+        """
+        let vulnerabilities = preview.vulnerabilityPreviewLabels.map {
+            #"<li data-testid="tool-card-pip-audit-json-preview-vulnerability-item">\#(escape($0))</li>"#
+        }.joined(separator: "")
+        let vulnerabilityList = vulnerabilities.isEmpty ? "" : """
+              <section class="artifact-office-contents" data-testid="tool-card-pip-audit-json-preview-vulnerabilities">
+                <strong data-testid="tool-card-pip-audit-json-preview-vulnerability-title">Vulnerabilities</strong>
+                <ul>\(vulnerabilities)</ul>
+              </section>
+        """
+        guard !metadata.isEmpty || !packageList.isEmpty || !vulnerabilityList.isEmpty else { return "" }
+        return """
+        <div class="artifact-office-preview" data-testid="tool-card-pip-audit-json-preview">
+          <div>
+            \(metadata)
+          </div>
+          \(packageList)
+          \(vulnerabilityList)
         </div>
         """
     }

--- a/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeToolCardSurfaceTests.swift
@@ -3515,6 +3515,89 @@ final class QuillCodeToolCardSurfaceTests: XCTestCase {
         XCTAssertNil(remoteAudit.cargoAuditJSONPreview)
     }
 
+    func testArtifactStateDerivesPipAuditJSONPreviewMetadata() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let report = directory.appendingPathComponent("pip-audit.json")
+        let content = """
+        {
+          "dependencies": [
+            {
+              "name": "flask",
+              "version": "0.5",
+              "vulns": [
+                {
+                  "id": "PYSEC-2019-179",
+                  "fix_versions": ["1.0"],
+                  "aliases": ["CVE-2018-1000656"],
+                  "description": "Unexpected memory usage."
+                },
+                {
+                  "id": "PYSEC-2018-66",
+                  "fix_versions": ["0.12.3"],
+                  "aliases": ["CVE-2019-1010083"],
+                  "description": "Improper input validation."
+                }
+              ]
+            },
+            {
+              "name": "requests",
+              "version": "2.19.0",
+              "vulns": [
+                {
+                  "id": "PYSEC-2018-28",
+                  "fix_versions": [],
+                  "aliases": ["CVE-2018-18074"]
+                }
+              ]
+            },
+            {
+              "name": "safe-package",
+              "version": "1.2.3",
+              "vulns": []
+            }
+          ]
+        }
+        """
+        try content.write(to: report, atomically: true, encoding: .utf8)
+
+        let artifact = ToolArtifactState(value: report.path)
+        let preview = try XCTUnwrap(artifact.pipAuditJSONPreview)
+
+        XCTAssertEqual(artifact.documentPreview?.kind, .data)
+        XCTAssertEqual(artifact.documentPreview?.extensionLabel, "JSON")
+        XCTAssertEqual(preview.formatLabel, "pip-audit JSON")
+        XCTAssertEqual(preview.dependencyCount, 3)
+        XCTAssertEqual(preview.vulnerablePackageCount, 2)
+        XCTAssertEqual(preview.vulnerabilityCount, 3)
+        XCTAssertEqual(preview.fixableVulnerabilityCount, 2)
+        XCTAssertEqual(preview.packagePreviewLabels, [
+            "flask 0.5 · 2 vulnerabilities",
+            "requests 2.19.0 · 1 vulnerability"
+        ])
+        XCTAssertEqual(preview.vulnerabilityPreviewLabels, [
+            "PYSEC-2019-179 · CVE-2018-1000656 · fixed in 1.0",
+            "PYSEC-2018-66 · CVE-2019-1010083 · fixed in 0.12.3",
+            "PYSEC-2018-28 · CVE-2018-18074"
+        ])
+        XCTAssertEqual(preview.byteSizeLabel, "\(content.utf8.count) bytes")
+        XCTAssertEqual(preview.metadataLines, [
+            "Format: pip-audit JSON",
+            "3 dependencies",
+            "2 vulnerable packages",
+            "3 vulnerabilities",
+            "Fixable: 2",
+            "Size: \(content.utf8.count) bytes"
+        ])
+        XCTAssertNil(artifact.jsonPreview)
+
+        let generic = directory.appendingPathComponent("dependencies.json")
+        try #"{"dependencies":[{"name":"flask","version":"0.5"}]}"#.write(to: generic, atomically: true, encoding: .utf8)
+        XCTAssertNil(ToolArtifactState(value: generic.path).pipAuditJSONPreview)
+
+        let remoteAudit = ToolArtifactState(value: "https://example.com/pip-audit.json")
+        XCTAssertNil(remoteAudit.pipAuditJSONPreview)
+    }
+
     func testArtifactStateDerivesESLintJSONPreviewMetadata() throws {
         let directory = try makeQuillCodeTestDirectory()
         let report = directory.appendingPathComponent("eslint-results.json")

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLToolCardRendererTests.swift
@@ -2587,6 +2587,73 @@ final class WorkspaceHTMLToolCardRendererTests: XCTestCase {
         XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
     }
 
+    func testHTMLRendererIncludesPipAuditJSONArtifactPreview() throws {
+        let root = try makeTempDirectory()
+        let reports = root.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        let report = reports.appendingPathComponent("pip-audit.json")
+        let reportText = """
+        {
+          "dependencies": [
+            {
+              "name": "flask",
+              "version": "0.5",
+              "vulns": [
+                {
+                  "id": "PYSEC-2019-179",
+                  "fix_versions": ["1.0"],
+                  "aliases": ["CVE-2018-1000656"]
+                }
+              ]
+            },
+            {
+              "name": "safe-package",
+              "version": "1.2.3",
+              "vulns": []
+            }
+          ]
+        }
+        """
+        try reportText.write(to: report, atomically: true, encoding: .utf8)
+        let call = ToolCall(name: ToolDefinition.fileWrite.name, argumentsJSON: #"{"path":"reports/pip-audit.json"}"#)
+        let result = ToolResult(ok: true, stdout: "Wrote reports/pip-audit.json\n", artifacts: [report.path])
+        let thread = ChatThread(
+            title: "pip audit artifact",
+            events: [
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "host.file.write queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "host.file.write completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let html = WorkspaceHTMLRenderer.render(model.surface())
+
+        XCTAssertTrue(html.contains(#"data-kind="data""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-type">Data · JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-document-preview-label">pip-audit.json"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview""#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-meta">Format: pip-audit JSON"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-meta">2 dependencies"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-meta">1 vulnerable package"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-meta">1 vulnerability"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-package-title">Packages"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-package-item">flask 0.5 · 1 vulnerability"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-vulnerability-title">Vulnerabilities"#))
+        XCTAssertTrue(html.contains(#"data-testid="tool-card-pip-audit-json-preview-vulnerability-item">PYSEC-2019-179 · CVE-2018-1000656 · fixed in 1.0"#))
+        XCTAssertFalse(html.contains(#"data-testid="tool-card-json-preview""#))
+    }
+
     func testHTMLRendererIncludesESLintJSONArtifactPreview() throws {
         let root = try makeTempDirectory()
         let reports = root.appendingPathComponent("reports", isDirectory: true)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -456,3 +456,7 @@
 - Artifact parity now includes bounded cargo audit JSON cards for Rust dependency security work. Local
   `cargo audit --json` reports render vulnerability counts, yanked/unmaintained warning counts,
   package labels, and RustSec advisory labels while suppressing duplicate generic JSON previews.
+- Artifact parity now includes bounded pip-audit JSON cards for Python dependency security work.
+  Local `pip-audit --format json` reports render dependency, vulnerable package, vulnerability, and
+  fixable counts plus capped package/vulnerability labels while suppressing duplicate generic JSON
+  previews.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3142,3 +3142,24 @@
   suppression, incomplete-report exclusion, and remote exclusion.
   `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesCargoAuditJSONArtifactPreview` covers
   static HTML selectors, rendered metadata, package/advisory lists, and generic JSON suppression.
+
+## 2026-07-19: pip-audit JSON artifacts render bounded Python security summaries
+
+- **Decision:** Local `.json` artifacts with `pip-audit --format json`-compatible dependency entries
+  render as structured pip-audit cards instead of generic JSON. The preview shows dependency count,
+  vulnerable package count, vulnerability count, fixable vulnerability count, file size, capped
+  package labels, and capped vulnerability labels with aliases/fix versions when available.
+- **Why:** Python dependency security cleanup commonly emits pip-audit JSON. A Codex-style artifact
+  surface should make those findings scannable beside command output without requiring raw JSON
+  expansion or another tool run.
+- **Boundary:** The parser is local-file-only, regular-file-only, NUL-rejecting, JSON-only, and
+  capped at 512 KB. It reads only shallow `dependencies`, `name`, `version`, `vulns`, `id`,
+  `aliases`, and `fix_versions` fields; it never imports Python packages, opens requirements or lock
+  files, resolves dependency graphs, verifies exploitability, contacts vulnerability services, or
+  fetches remote reports.
+- **Evidence:** `QuillCodeToolCardSurfaceTests.testArtifactStateDerivesPipAuditJSONPreviewMetadata`
+  covers pip-audit shape detection, dependency/package/vulnerability/fix metadata, generic JSON
+  suppression, incomplete-report exclusion, and remote exclusion.
+  `WorkspaceHTMLToolCardRendererTests.testHTMLRendererIncludesPipAuditJSONArtifactPreview` covers
+  static HTML selectors, rendered metadata, package/vulnerability lists, and generic JSON
+  suppression.


### PR DESCRIPTION
## Summary
- add bounded local pip-audit JSON artifact parsing for Python vulnerability reports
- render SwiftUI and HTML tool-card summaries with dependency, vulnerable package, vulnerability, and fixability metadata
- document the parser boundary and parity coverage

## Validation
- swift test --filter QuillCodeToolCardSurfaceTests/testArtifactStateDerivesPipAuditJSONPreviewMetadata
- swift test --filter WorkspaceHTMLToolCardRendererTests/testHTMLRendererIncludesPipAuditJSONArtifactPreview
- swift test --filter QuillCodeToolCardSurfaceTests
- swift test --filter WorkspaceHTMLToolCardRendererTests
- git diff --check
- git diff --check --cached