### PR TITLE
Shell tool: put Homebrew + dev tools on PATH (fixes exit-127 for uv/python3/node on GUI-launched app)

### DIFF
--- a/Sources/QuillCodeTools/ShellEnvironmentPath.swift
+++ b/Sources/QuillCodeTools/ShellEnvironmentPath.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Ensures the agent's shell can find developer tools even when QuillCode was launched as a GUI `.app`.
+///
+/// A `.app` opened from Finder/Dock/launchd inherits only launchd's minimal environment — its `PATH`
+/// is the bare `path_helper` default (`/usr/bin:/bin:/usr/sbin:/sbin` plus a couple of Apple dirs).
+/// On Apple-Silicon macOS, Homebrew installs to `/opt/homebrew/bin` and adds it to `PATH` per-user via
+/// `brew shellenv` in `~/.zprofile` — which a non-interactive, non-login `/bin/sh` never sources. The
+/// net effect: the agent's shell tool cannot see `uv`, `python3`, `node`, `rg`, `cargo`, or anything
+/// else installed through Homebrew or a language toolchain, and every command that needs them fails
+/// with `exit code 127` — observed live driving a repo-onboarding task where `uv pip install` 127'd
+/// even though `uv` was installed at `/opt/homebrew/bin/uv`.
+///
+/// This augments `PATH` with the standard developer-tool locations, APPENDING them so anything already
+/// resolvable keeps its existing priority (a task that relied on `/usr/bin/python3` still gets it) —
+/// the augmentation only fills the gaps a minimal launchd `PATH` leaves.
+public enum ShellEnvironmentPath {
+    /// Absolute tool directories a GUI-launched app's minimal `PATH` omits.
+    public static let developerToolDirectories = [
+        "/opt/homebrew/bin",   // Apple-Silicon Homebrew
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",      // Intel Homebrew / manual installs
+        "/usr/local/sbin",
+    ]
+
+    /// Per-user tool directories, resolved against `HOME`.
+    public static let homeRelativeToolDirectories = [
+        ".local/bin",   // pipx, uv tools, pip --user
+        ".cargo/bin",   // Rust
+        "go/bin",       // Go
+    ]
+
+    /// `base` PATH with the developer-tool directories appended (de-duplicated, order-preserving).
+    /// The existing entries keep their priority; only missing dev-tool dirs are added.
+    public static func augmentedPATH(base: String?, home: String?) -> String {
+        var seen = Set<String>()
+        var entries: [String] = []
+        func add(_ candidate: String) {
+            guard !candidate.isEmpty, !seen.contains(candidate) else { return }
+            seen.insert(candidate)
+            entries.append(candidate)
+        }
+        for segment in (base ?? "").split(separator: ":", omittingEmptySubsequences: true) {
+            add(String(segment))
+        }
+        for directory in developerToolDirectories { add(directory) }
+        if let home, !home.isEmpty {
+            let root = home.hasSuffix("/") ? String(home.dropLast()) : home
+            for relative in homeRelativeToolDirectories { add("\(root)/\(relative)") }
+        }
+        return entries.joined(separator: ":")
+    }
+}

--- a/Sources/QuillCodeTools/ShellToolCallDispatcher.swift
+++ b/Sources/QuillCodeTools/ShellToolCallDispatcher.swift
@@ -123,13 +123,20 @@ struct ShellToolCallDispatcher: Sendable {
         let rawEnvironment = args.stringDictionary("environment") ?? args.stringDictionary("env")
         switch EnvironmentOverridePolicy.validateOverrides(rawEnvironment) {
         case let .allowed(overrides):
-            guard !overrides.isEmpty else {
-                return .allowed(nil)
-            }
+            // Start from the process environment (what the child would inherit) and layer any explicit
+            // overrides on top. We ALWAYS return a resolved environment — even with no overrides — so
+            // the PATH augmentation below runs on every shell command.
             var environment = ProcessInfo.processInfo.environment
             for (key, value) in overrides {
                 environment[key] = value
             }
+            // A GUI-launched `.app` inherits only launchd's minimal PATH, so Homebrew and toolchain
+            // binaries (uv, python3, node, rg, cargo…) are invisible and every command that needs them
+            // 127s. Augment PATH with the standard developer-tool locations. See ``ShellEnvironmentPath``.
+            environment["PATH"] = ShellEnvironmentPath.augmentedPATH(
+                base: environment["PATH"],
+                home: environment["HOME"]
+            )
             return .allowed(environment)
         case let .denied(error):
             return .denied(error)

--- a/Tests/QuillCodeToolsTests/ShellEnvironmentPathTests.swift
+++ b/Tests/QuillCodeToolsTests/ShellEnvironmentPathTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+/// Guards the fix for the "GUI app can't find Homebrew" bug: a `.app` launched from Finder inherits
+/// only launchd's minimal PATH, so `uv`/`python3`/`node`/`rg` 127 in the agent's shell. `augmentedPATH`
+/// must make those resolvable without disturbing an already-working PATH.
+final class ShellEnvironmentPathTests: XCTestCase {
+    /// The exact minimal PATH a GUI-launched app sees (from the live `env -i … /bin/sh -lc` repro).
+    private let launchdMinimalPATH =
+        "/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin"
+
+    func testHomebrewBinIsAddedToAMinimalLaunchdPath() {
+        let path = ShellEnvironmentPath.augmentedPATH(base: launchdMinimalPATH, home: "/Users/dev")
+        let dirs = path.split(separator: ":").map(String.init)
+        XCTAssertTrue(dirs.contains("/opt/homebrew/bin"), "Homebrew bin must be reachable: \(path)")
+        XCTAssertTrue(dirs.contains("/opt/homebrew/sbin"))
+    }
+
+    func testExistingEntriesKeepPriorityAndAugmentationIsAppended() {
+        let path = ShellEnvironmentPath.augmentedPATH(base: "/usr/bin:/bin", home: nil)
+        let dirs = path.split(separator: ":").map(String.init)
+        // Base entries come first (so a task relying on /usr/bin/python3 still gets it), dev dirs after.
+        XCTAssertEqual(Array(dirs.prefix(2)), ["/usr/bin", "/bin"])
+        XCTAssertLessThan(dirs.firstIndex(of: "/usr/bin")!, dirs.firstIndex(of: "/opt/homebrew/bin")!)
+    }
+
+    func testNoDuplicateWhenHomebrewAlreadyPresent() {
+        let base = "/opt/homebrew/bin:/usr/bin:/bin"
+        let path = ShellEnvironmentPath.augmentedPATH(base: base, home: nil)
+        let occurrences = path.split(separator: ":").filter { $0 == "/opt/homebrew/bin" }.count
+        XCTAssertEqual(occurrences, 1, "must not duplicate an already-present dir: \(path)")
+        // And it keeps its original (front) position, not re-appended.
+        XCTAssertEqual(path.split(separator: ":").first.map(String.init), "/opt/homebrew/bin")
+    }
+
+    func testHomeRelativeToolDirsResolvedAgainstHome() {
+        let path = ShellEnvironmentPath.augmentedPATH(base: "/usr/bin", home: "/Users/dev")
+        let dirs = path.split(separator: ":").map(String.init)
+        XCTAssertTrue(dirs.contains("/Users/dev/.local/bin"))
+        XCTAssertTrue(dirs.contains("/Users/dev/.cargo/bin"))
+        XCTAssertTrue(dirs.contains("/Users/dev/go/bin"))
+    }
+
+    func testTrailingSlashOnHomeDoesNotDoubleSlash() {
+        let path = ShellEnvironmentPath.augmentedPATH(base: "/usr/bin", home: "/Users/dev/")
+        XCTAssertTrue(path.contains("/Users/dev/.local/bin"))
+        XCTAssertFalse(path.contains("//"), "no double slashes: \(path)")
+    }
+
+    func testNilOrEmptyBaseStillYieldsDevTooling() {
+        for base in [nil, ""] as [String?] {
+            let path = ShellEnvironmentPath.augmentedPATH(base: base, home: "/Users/dev")
+            XCTAssertTrue(path.split(separator: ":").contains("/opt/homebrew/bin"))
+            XCTAssertFalse(path.hasPrefix(":"), "no leading empty segment: \(path)")
+        }
+    }
+
+    /// End-to-end: a command dispatched through the real shell tool must see the augmented PATH, so the
+    /// fix works through the whole `ShellToolCallDispatcher` → `ShellToolExecutor` → child `/bin/sh`
+    /// path, not just in the pure helper. Asserts the directory is PRESENT in the child's `$PATH`
+    /// (env-independent: the augmentation always adds it, whether or not Homebrew is installed on CI).
+    func testDispatchedShellCommandReceivesAugmentedPathEndToEnd() throws {
+        let dispatcher = ShellToolCallDispatcher(
+            workspaceRoot: URL(fileURLWithPath: NSTemporaryDirectory()),
+            shell: ShellToolExecutor(),
+            accessScope: .unrestricted
+        )
+        let result = try dispatcher.execute(
+            name: "host.shell.run",
+            arguments: try ToolArguments(#"{"cmd":"echo \"$PATH\""}"#)
+        )
+        XCTAssertTrue(result.ok, "shell should run: \(result.error ?? "")")
+        XCTAssertTrue(
+            result.stdout.contains("/opt/homebrew/bin"),
+            "the augmented developer PATH must reach the child shell: \(result.stdout)"
+        )
+    }
+}


### PR DESCRIPTION
## The bug (found driving a coworker task)

Onboarding a repo, the agent ran `uv pip install` → **`exit code 127`** — yet `uv` is installed at `/opt/homebrew/bin/uv`. It wasn't lying about wanting to run tests; it genuinely couldn't find the tool.

**Five-whys root cause:** a GUI-launched `.app` (Finder/Dock/launchd) inherits only launchd's minimal environment. Its `PATH` is the bare `path_helper` default (`/usr/bin:/bin:/usr/sbin:/sbin` + a couple Apple dirs) — **no `/opt/homebrew/bin`**. On Apple-Silicon macOS, Homebrew adds itself to `PATH` per-user via `brew shellenv` in `~/.zprofile`, which the shell tool's non-interactive `/bin/sh -lc` never sources. So on essentially **every Apple-Silicon dev Mac**, the agent's shell can't see `uv`, `python3`, `node`, `rg`, `cargo`, or anything Homebrew-installed — every command that needs them 127s.

Confirmed by replicating the minimal env:
```
$ env -i HOME=$HOME /bin/sh -lc 'which uv'
UV-NOT-FOUND      # PATH had no /opt/homebrew/bin
```

Compounding it: `ShellToolCallDispatcher.environment` only built an environment when the model passed explicit `env` overrides — otherwise the child inherited the app's minimal PATH untouched.

## Fix

The dispatcher now **always** resolves an environment and augments `PATH` with the standard developer-tool directories (`/opt/homebrew/{bin,sbin}`, `/usr/local/{bin,sbin}`, `~/.local/bin`, `~/.cargo/bin`, `~/go/bin`). Directories are **appended**, so anything already resolvable keeps its original priority — the augmentation only fills the gaps a minimal launchd `PATH` leaves (e.g. `/usr/bin/python3` still wins if a task relied on it; `uv` becomes findable).

`ShellEnvironmentPath.augmentedPATH` is a pure, order-preserving, de-duplicating helper.

## Tests
7 tests: the pure merge behavior (minimal env gets Homebrew, existing entries keep priority, no dupes, HOME-relative dirs, trailing-slash, empty base) **plus a CI-safe end-to-end check** that dispatches a real `echo "$PATH"` through `ShellToolCallDispatcher` → `ShellToolExecutor` → child shell and asserts the augmented dir arrives. Full suite green (5178).

This is likely the single highest-impact fix for the coworker program — it unblocks the entire class of tasks that need a Homebrew-installed toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)