### PR TITLE
Prompt: name-a-file deliverables go to disk; cite only fetched URLs

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -93,6 +93,18 @@ public struct TrustedRouterPromptBuilder: Sendable {
     (host.file.read / host.file.list) to confirm it exists before you report it.
     - A multi-step task is not finished until every step has a real tool call behind it. Do not stop \
     after writing a script to "check in" — keep going until the outputs actually exist.
+    Deliverables the task names go to disk, not just the chat:
+    - When the task asks you to write, produce, save, or create a named file (e.g. "write \
+    recommendation.md", "produce report.md"), you MUST create that exact file with host.file.write \
+    (or host.apply_patch) and read it back to confirm. Putting the content only in your final chat \
+    reply does NOT satisfy a request for a file — the file must exist on disk when you finish.
+    Web research and citations — cite only what you actually retrieved:
+    - Fetch only URLs that appear in your web-search results. Do NOT guess, construct, or recall a \
+    URL from memory — invented URLs 404 and poison the report.
+    - Cite a source ONLY if you fetched it successfully in this run. If host.web.fetch returned an \
+    error, a 404, or you never fetched it, do not cite that URL — find a working source or state \
+    plainly that the claim is unverified. Every price, wattage, benchmark, or figure must trace to a \
+    page you actually opened.
     """
 
     public static func systemPrompt(tools: [ToolDefinition]) -> String {


### PR DESCRIPTION
## What

Two additions to the anti-fabrication guidance block (`environmentBringUpPrompt`):
1. **Deliverables the task names go to disk** — when asked to write/produce/save a named file (`write recommendation.md`), the agent MUST create that exact file with `host.file.write`/`host.apply_patch` and read it back; putting the content only in the chat reply does not satisfy a file request.
2. **Cite only what you retrieved** — fetch only URLs that appear in search results (never guess/construct/recall a URL); cite a source only if `host.web.fetch` returned it successfully; a 404/errored/unfetched URL must not be cited.

## Why (found by driving coworker use case #7 live)

A "research X and write recommendation.md" run: the model guessed plausible source URLs, they 404'd on fetch, it **cited the dead URLs anyway** and **never wrote the file**. This guidance codifies the two honesty rules.

Note: the *primary* root cause of #7 is separate and bigger — `host.web.search` doesn't actually search (it asks the session LLM to generate `{title,url,snippet}`, so URLs are hallucinated); that's tracked as its own task. This prompt change is correct, low-risk hygiene that helps once search returns real URLs, and the deliverable-to-disk rule stands on its own for any file-producing task.

## Tests

Prompt-string change; `TrustedRouterPromptBuilderTests` green (30), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)