### PR TITLE
host.web.search: drop hallucinated (non-resolving) URLs before the model sees them

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -50,6 +50,11 @@ public struct AgentRunner: Sendable {
     /// a first-class runner dependency — rather than folded into `toolExecutionOverride` — so both
     /// the CLI and desktop wire it through one place and `configuredRunner(from:)` preserves it.
     public var webSearch: (any WebSearchClient)?
+    /// Probes `host.web.search` result URLs and drops the ones that don't resolve before the model
+    /// sees them. Set by the live runtime (a `WebFetchURLLivenessChecker`); nil in mock/test runs,
+    /// where results pass through unfiltered. This is what stops the LLM-as-search-engine backend
+    /// from surfacing hallucinated 404 URLs the model would otherwise fetch and cite.
+    public var webSearchLivenessChecker: (any WebSearchURLLivenessChecking)?
     public var maxToolSteps: Int
     public var enablesImmediateActionPreflight: Bool
     /// Computes an opaque signature of the workspace state, sampled around tool steps to feed the
@@ -87,6 +92,7 @@ public struct AgentRunner: Sendable {
         toolFeedbackAttachmentProvider: AgentToolFeedbackAttachmentProvider? = nil,
         skillResolver: SkillResolver? = nil,
         webSearch: (any WebSearchClient)? = nil,
+        webSearchLivenessChecker: (any WebSearchURLLivenessChecking)? = nil,
         maxToolSteps: Int = AgentRunner.defaultMaxToolSteps,
         enablesImmediateActionPreflight: Bool = false,
         workspaceStateSignature: (@Sendable (URL) -> String)? = nil,
@@ -110,6 +116,7 @@ public struct AgentRunner: Sendable {
         self.toolFeedbackAttachmentProvider = toolFeedbackAttachmentProvider
         self.skillResolver = skillResolver
         self.webSearch = webSearch
+        self.webSearchLivenessChecker = webSearchLivenessChecker
         self.maxToolSteps = maxToolSteps
         self.enablesImmediateActionPreflight = enablesImmediateActionPreflight
         self.workspaceStateSignature = workspaceStateSignature

--- a/Sources/QuillCodeAgent/AgentToolStepRunner.swift
+++ b/Sources/QuillCodeAgent/AgentToolStepRunner.swift
@@ -385,7 +385,7 @@ extension AgentRunner {
         do {
             let args = try ToolArguments(call.argumentsJSON)
             let query = try args.requiredString("query")
-            return await WebSearchToolExecutor(client: webSearch)
+            return await WebSearchToolExecutor(client: webSearch, livenessChecker: webSearchLivenessChecker)
                 .search(query: query, maxResults: args.int("maxResults"))
         } catch {
             return ToolResult(ok: false, error: String(describing: error))

--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -3,6 +3,7 @@ import QuillCodeAgent
 import QuillCodeCore
 import QuillCodePersistence
 import QuillCodeSafety
+import QuillCodeTools
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -131,6 +132,7 @@ public struct QuillCodeRuntimeFactory: Sendable {
                 llm: llm,
                 safety: AutoSafetyReviewer(client: safetyClient),
                 webSearch: webSearch,
+                webSearchLivenessChecker: WebFetchURLLivenessChecker(),
                 maxToolSteps: config.maxToolSteps,
                 enablesImmediateActionPreflight: true,
                 compaction: AgentCompactionPolicy(compactor: compactor)

--- a/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
+++ b/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
@@ -80,6 +80,7 @@ public enum CLIRuntimeFactory {
                 llm: llm,
                 safety: AutoSafetyReviewer(client: safety),
                 webSearch: webSearch,
+                webSearchLivenessChecker: WebFetchURLLivenessChecker(),
                 maxToolSteps: appConfig.maxToolSteps,
                 enablesImmediateActionPreflight: true,
                 compaction: AgentCompactionPolicy(compactor: ThreadCompactor.llmBacked(

--- a/Sources/QuillCodeTools/WebFetchToolExecutor.swift
+++ b/Sources/QuillCodeTools/WebFetchToolExecutor.swift
@@ -352,13 +352,17 @@ public struct WebFetchToolExecutor: Sendable {
     try host.browser.open with the same URL]
     """
 
-    private static let defaultHeaders: [String: String] = [
+    /// Internal (not private) so the search liveness checker can probe with the EXACT same headers
+    /// and two-attempt strategy `host.web.fetch` uses — otherwise a URL could pass a liveness probe
+    /// under one User-Agent but 403 the real fetch under another (or vice-versa), making
+    /// "probe-live" not imply "fetchable".
+    static let defaultHeaders: [String: String] = [
         "Accept": "text/html, application/xhtml+xml;q=0.9, text/markdown;q=0.8, text/plain;q=0.7, */*;q=0.1",
         "Accept-Language": "en-US,en;q=0.9",
         "User-Agent": "QuillCode/1.0 WebFetch (+https://lorehex.co)"
     ]
 
-    private static let browserLikeHeaders: [String: String] = [
+    static let browserLikeHeaders: [String: String] = [
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
         "Accept-Language": "en-US,en;q=0.9",
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +

--- a/Sources/QuillCodeTools/WebSearchToolExecutor.swift
+++ b/Sources/QuillCodeTools/WebSearchToolExecutor.swift
@@ -12,6 +12,12 @@ import QuillCodeCore
 /// numeric conversion, so a hostile/empty/oversized result set degrades to a clear message.
 public struct WebSearchToolExecutor: Sendable {
     public var client: any WebSearchClient
+    /// Probes candidate URLs and keeps only the ones that actually resolve. Injected (and
+    /// optional) so the executor stays deterministic in tests; `nil` skips liveness filtering
+    /// entirely (the pre-existing behavior). In production this is a `WebFetchURLLivenessChecker`,
+    /// which is what stops the LLM-as-search-engine backend from surfacing hallucinated 404 URLs
+    /// the model would otherwise fetch and cite.
+    public var livenessChecker: (any WebSearchURLLivenessChecking)?
     /// Hard ceiling on results, independent of what the caller asks for or the provider returns.
     public var maxResults: Int
     /// Default result count when the caller omits `maxResults`.
@@ -25,6 +31,7 @@ public struct WebSearchToolExecutor: Sendable {
 
     public init(
         client: any WebSearchClient,
+        livenessChecker: (any WebSearchURLLivenessChecking)? = nil,
         maxResults: Int = 10,
         defaultResults: Int = 5,
         maxQueryLength: Int = 400,
@@ -32,6 +39,7 @@ public struct WebSearchToolExecutor: Sendable {
         maxSnippetLength: Int = 500
     ) {
         self.client = client
+        self.livenessChecker = livenessChecker
         self.maxResults = max(1, maxResults)
         self.defaultResults = min(max(1, defaultResults), max(1, maxResults))
         self.maxQueryLength = max(1, maxQueryLength)
@@ -70,7 +78,37 @@ public struct WebSearchToolExecutor: Sendable {
             """)
         }
 
-        return ToolResult(ok: true, stdout: Self.render(query: query, results: sanitized))
+        // Liveness filter: the search backend is a language model asked to act as a search engine,
+        // so a fraction of the URLs it returns do not exist. Probe each one and keep only those that
+        // resolve — the model must never receive (and then cite) a dead URL. `droppedUnreachable`
+        // records how many were removed so a thin result set is not mistaken for "nothing found".
+        let (live, droppedUnreachable) = await filterReachable(sanitized)
+        guard !live.isEmpty else {
+            return Self.failure("""
+            Web search for \"\(query)\" found \(sanitized.count) candidate\(sanitized.count == 1 ? "" : "s"), \
+            but none were reachable (every URL failed a liveness check — the search backend likely \
+            returned URLs that do not exist). Rephrase the query, or open the browser pane with \
+            host.browser.open for an interactive search. Do NOT cite a URL you could not open.
+            """)
+        }
+
+        return ToolResult(ok: true, stdout: Self.render(
+            query: query,
+            results: live,
+            droppedUnreachable: droppedUnreachable
+        ))
+    }
+
+    /// Drops results whose URL does not resolve, preserving the original ranking of the survivors.
+    /// Returns the live results and how many were dropped. With no injected checker, everything
+    /// passes through unchanged (`0` dropped) — the pre-liveness behavior.
+    func filterReachable(
+        _ results: [WebSearchResultItem]
+    ) async -> (live: [WebSearchResultItem], dropped: Int) {
+        guard let livenessChecker else { return (results, 0) }
+        let liveURLs = await livenessChecker.liveURLs(among: results.map(\.url))
+        let live = results.filter { liveURLs.contains($0.url) }
+        return (live, results.count - live.count)
     }
 
     // MARK: - Input normalization
@@ -139,9 +177,12 @@ public struct WebSearchToolExecutor: Sendable {
 
     // MARK: - Rendering
 
-    static func render(query: String, results: [WebSearchResultItem]) -> String {
+    static func render(query: String, results: [WebSearchResultItem], droppedUnreachable: Int = 0) -> String {
         var lines: [String] = []
         lines.append("Search results for \"\(query)\" (\(results.count) result\(results.count == 1 ? "" : "s")). Use host.web.fetch on a URL to read the full page.")
+        if droppedUnreachable > 0 {
+            lines.append("(\(droppedUnreachable) other candidate URL\(droppedUnreachable == 1 ? " was" : "s were") dropped as unreachable — only URLs that resolved are listed. Cite only these.)")
+        }
         lines.append("")
         for (index, result) in results.enumerated() {
             lines.append("\(index + 1). \(result.title)")

--- a/Sources/QuillCodeTools/WebSearchURLLiveness.swift
+++ b/Sources/QuillCodeTools/WebSearchURLLiveness.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Checks whether candidate search-result URLs actually resolve, so `host.web.search` can drop the
+/// ones that don't before handing the list to the model.
+///
+/// This exists because the TrustedRouter-backed search asks a language model to ACT as a search
+/// engine (TrustedRouter has no real search endpoint). A model with no live index cannot help but
+/// hallucinate plausible URLs — `tomshardware.com/reviews/raspberry-pi-5-review`,
+/// `jeffgeerling.com/blog/2023/raspberry-pi-5-vs-intel-n100`, … — that 404 the moment the agent
+/// fetches them. Left unchecked the model then CITES those dead URLs. A cheap liveness probe turns
+/// "validated guesses" into the only results the model ever sees: every surfaced URL was reachable
+/// at search time.
+public protocol WebSearchURLLivenessChecking: Sendable {
+    /// Returns the subset of `urls` that responded with a reachable status. Order is irrelevant —
+    /// the caller re-filters its own ordered list against this set. Must never throw: an
+    /// unreachable/erroring URL is simply absent from the result.
+    func liveURLs(among urls: [String]) async -> Set<String>
+}
+
+/// `WebSearchURLLivenessChecking` backed by the same SSRF-safe, redirect-refusing
+/// `WebFetchHTTPClient` transport `host.web.fetch` uses. A URL counts as live when it answers with
+/// a 2xx, or a 3xx (a redirect is a live target — the fetch tool re-gates the hop separately). The
+/// probe reads at most a handful of body bytes and uses a short timeout, and the URLs are already
+/// host-gated by `WebSearchToolExecutor.sanitize` before they arrive here.
+public struct WebFetchURLLivenessChecker: WebSearchURLLivenessChecking {
+    private let httpClient: any WebFetchHTTPClient
+    private let timeout: TimeInterval
+
+    public init(
+        httpClient: any WebFetchHTTPClient = URLSessionWebFetchHTTPClient(),
+        timeout: TimeInterval = 6
+    ) {
+        self.httpClient = httpClient
+        self.timeout = max(1, timeout)
+    }
+
+    public func liveURLs(among urls: [String]) async -> Set<String> {
+        guard !urls.isEmpty else { return [] }
+        return await withTaskGroup(of: String?.self) { group in
+            for url in urls {
+                group.addTask { await self.isReachable(url) ? url : nil }
+            }
+            var live = Set<String>()
+            for await result in group {
+                if let url = result { live.insert(url) }
+            }
+            return live
+        }
+    }
+
+    private func isReachable(_ raw: String) async -> Bool {
+        guard let url = URL(string: raw), url.host != nil else { return false }
+        // Probe with the SAME two-attempt header strategy host.web.fetch uses: the default UA first,
+        // then the browser-like UA on a non-success status. A URL is "live" iff at least one of the
+        // two header sets — the exact ones the real fetch will try — reaches it, so a surfaced URL
+        // is genuinely fetchable and a browser-gated site is not falsely dropped.
+        if await status(for: url, headers: WebFetchToolExecutor.defaultHeaders).map(Self.isReachableStatus) == true {
+            return true
+        }
+        return await status(for: url, headers: WebFetchToolExecutor.browserLikeHeaders).map(Self.isReachableStatus) == true
+    }
+
+    private static func isReachableStatus(_ code: Int) -> Bool { (200..<400).contains(code) }
+
+    private func status(for url: URL, headers: [String: String]) async -> Int? {
+        let request = WebFetchHTTPRequest(
+            url: url,
+            headers: headers,
+            timeout: timeout,
+            // We only need the status line; a few bytes is plenty and keeps the probe cheap.
+            maxBodyBytes: 64
+        )
+        // `perform` is blocking; run it off the cooperative pool so probing N URLs concurrently
+        // never starves other async work.
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: (try? httpClient.perform(request))?.statusCode)
+            }
+        }
+    }
+}

--- a/Tests/QuillCodeToolsTests/WebSearchURLLivenessTests.swift
+++ b/Tests/QuillCodeToolsTests/WebSearchURLLivenessTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeTools
+
+/// A scripted liveness checker: exactly the URLs in `liveSet` are "reachable". Records what it was
+/// asked to probe so tests can assert every candidate got checked. Never touches the network.
+final class StubURLLivenessChecker: WebSearchURLLivenessChecking, @unchecked Sendable {
+    private let lock = NSLock()
+    private let liveSet: Set<String>
+    private var probed: [String] = []
+
+    init(live: Set<String>) { self.liveSet = live }
+
+    var probedURLs: [String] { lock.withLock { probed } }
+
+    func liveURLs(among urls: [String]) async -> Set<String> {
+        lock.withLock { probed.append(contentsOf: urls) }
+        return liveSet.intersection(urls)
+    }
+}
+
+final class WebSearchURLLivenessTests: XCTestCase {
+    private func item(_ title: String, _ url: String) -> WebSearchResultItem {
+        WebSearchResultItem(title: title, url: url, snippet: "snippet")
+    }
+
+    /// The core fix: a search that returns a mix of live and dead (hallucinated) URLs surfaces ONLY
+    /// the live ones. The dead URLs never reach the model, so they can never be fetched or cited.
+    func testOnlyLiveURLsSurface() async {
+        let live = "https://www.jeffgeerling.com/"
+        let client = StubWebSearchClient(results: [
+            item("Dead review", "https://www.tomshardware.com/reviews/raspberry-pi-5-review"),
+            item("Live blog", live),
+            item("Dead product", "https://www.bee-link.com/products/beelink-mini-s12-pro"),
+        ])
+        let executor = WebSearchToolExecutor(
+            client: client,
+            livenessChecker: StubURLLivenessChecker(live: [live])
+        )
+        let result = await executor.search(query: "raspberry pi 5 vs n100", maxResults: nil)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertTrue(result.stdout.contains(live), "the live URL must be listed")
+        XCTAssertFalse(result.stdout.contains("tomshardware"), "a dead URL must not be listed")
+        XCTAssertFalse(result.stdout.contains("bee-link"), "a dead URL must not be listed")
+        // The user-facing note tells the model results were dropped, so a thin list is not read as
+        // "nothing found".
+        XCTAssertTrue(result.stdout.contains("2 other candidate URLs were dropped as unreachable"))
+    }
+
+    /// When EVERY candidate is dead (the pure-hallucination case that broke use case #7), the tool
+    /// fails with an explicit "none were reachable" message instead of handing the model dead URLs.
+    func testAllDeadURLsFailsLoudly() async {
+        let client = StubWebSearchClient(results: [
+            item("Dead 1", "https://www.tomshardware.com/reviews/raspberry-pi-5-review"),
+            item("Dead 2", "https://www.bee-link.com/products/beelink-mini-s12-pro"),
+        ])
+        let executor = WebSearchToolExecutor(
+            client: client,
+            livenessChecker: StubURLLivenessChecker(live: [])
+        )
+        let result = await executor.search(query: "q", maxResults: nil)
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("none were reachable") == true, result.error ?? "")
+        XCTAssertTrue(result.error?.contains("Do NOT cite a URL you could not open") == true)
+    }
+
+    /// Every candidate that survives host-gating must be probed — no silent skipping.
+    func testAllCandidatesAreProbed() async {
+        let checker = StubURLLivenessChecker(live: ["https://a.example/"])
+        let client = StubWebSearchClient(results: [
+            item("A", "https://a.example/"),
+            item("B", "https://b.example/"),
+        ])
+        _ = await WebSearchToolExecutor(client: client, livenessChecker: checker)
+            .search(query: "q", maxResults: nil)
+        XCTAssertEqual(Set(checker.probedURLs), ["https://a.example/", "https://b.example/"])
+    }
+
+    /// Ranking of the survivors is preserved (liveness filtering must not reorder results).
+    func testSurvivingOrderIsPreserved() async {
+        let client = StubWebSearchClient(results: [
+            item("first", "https://one.example/"),
+            item("dead", "https://dead.example/"),
+            item("second", "https://two.example/"),
+        ])
+        let executor = WebSearchToolExecutor(
+            client: client,
+            livenessChecker: StubURLLivenessChecker(live: ["https://one.example/", "https://two.example/"])
+        )
+        let out = await executor.search(query: "q", maxResults: nil)
+        let firstIndex = out.stdout.range(of: "one.example")?.lowerBound
+        let secondIndex = out.stdout.range(of: "two.example")?.lowerBound
+        XCTAssertNotNil(firstIndex); XCTAssertNotNil(secondIndex)
+        if let f = firstIndex, let s = secondIndex { XCTAssertTrue(f < s) }
+    }
+
+    /// With NO checker injected (mock/test runtime), results pass through unfiltered — the
+    /// pre-liveness behavior is preserved exactly.
+    func testNoCheckerLeavesResultsUnfiltered() async {
+        let client = StubWebSearchClient(results: [
+            item("Anything", "https://whatever.example/x"),
+        ])
+        let result = await WebSearchToolExecutor(client: client).search(query: "q", maxResults: nil)
+        XCTAssertTrue(result.ok)
+        XCTAssertTrue(result.stdout.contains("whatever.example"))
+        XCTAssertFalse(result.stdout.contains("dropped as unreachable"))
+    }
+}
+
+/// Unit tests for the real checker's status→reachable classification, driven by a stub HTTP client
+/// so no network is touched.
+final class WebFetchURLLivenessCheckerTests: XCTestCase {
+    /// A stub `WebFetchHTTPClient` mapping URL → status code (or a thrown transport error).
+    struct StubHTTPClient: WebFetchHTTPClient {
+        var statusByHost: [String: Int]
+        func perform(_ request: WebFetchHTTPRequest) throws -> WebFetchHTTPResponse {
+            guard let host = request.url.host, let code = statusByHost[host] else {
+                throw WebFetchHTTPClientError.transport("no route")
+            }
+            return WebFetchHTTPResponse(statusCode: code)
+        }
+    }
+
+    private func checker(_ map: [String: Int]) -> WebFetchURLLivenessChecker {
+        WebFetchURLLivenessChecker(httpClient: StubHTTPClient(statusByHost: map))
+    }
+
+    func test2xxAnd3xxAreLive_4xx5xxAndErrorsAreNot() async {
+        let live = await checker([
+            "ok.example": 200,
+            "created.example": 201,
+            "redirect.example": 301,
+            "temp.example": 307,
+            "notfound.example": 404,
+            "gone.example": 410,
+            "boom.example": 500,
+        ]).liveURLs(among: [
+            "https://ok.example/a",
+            "https://created.example/a",
+            "https://redirect.example/a",
+            "https://temp.example/a",
+            "https://notfound.example/a",
+            "https://gone.example/a",
+            "https://boom.example/a",
+            "https://unreachable.example/a",   // stub throws (no mapping)
+        ])
+        XCTAssertEqual(live, [
+            "https://ok.example/a",
+            "https://created.example/a",
+            "https://redirect.example/a",
+            "https://temp.example/a",
+        ])
+    }
+
+    func testEmptyInputReturnsEmpty() async {
+        let live = await checker(["x.example": 200]).liveURLs(among: [])
+        XCTAssertTrue(live.isEmpty)
+    }
+}


### PR DESCRIPTION
## Root cause (found driving use case #7 live)

`host.web.search` isn't a search engine. TrustedRouter has no real search endpoint, so `TrustedRouterWebSearchClient` asks the **session model** to *act* as one and emit `{title,url,snippet}`. A model with no live index hallucinates plausible URLs (`tomshardware.com/reviews/raspberry-pi-5-review`, `jeffgeerling.com/blog/2023/…`) that **404 on fetch**. Live, this produced 11-of-13 dead fetches, a report citing the dead URLs, and a crashed run with no deliverable.

## Fix (the cheap first mitigation — option 3)

Probe every candidate URL and **drop the ones that don't resolve** before returning them, so the model never receives — and never cites — a dead URL.

- `WebSearchToolExecutor` runs each host-gated candidate through an injected `WebSearchURLLivenessChecking`, keeping only reachable ones (ranking preserved).
- `WebFetchURLLivenessChecker` probes with the **same two-attempt header strategy `host.web.fetch` uses** (default UA → browser UA), so *surfaced ⟹ fetchable* — a browser-gated site isn't falsely dropped, and a probe-live URL won't 403 the real fetch. `2xx`/`3xx` = live.
- All candidates dead → the tool **fails loudly** (`none were reachable … Do NOT cite a URL you could not open`) instead of handing over garbage. Some dropped → a note so a thin list isn't read as "nothing found".
- `nil` checker (mock/test runtime) = pass-through, behavior unchanged. Real checker wired at both prod factories (CLI + desktop).

## Scope / honesty

This eliminates dead **search** results. It does **not** make results truly *relevant* (still validated guesses, not real search), nor stop a model that invents URLs and passes them straight to `host.web.fetch` (prompt guidance #1448 helps there). The correct long-term fix — a real search provider (Brave/Tavily/SearXNG) or TR-gateway grounding — is a **product decision surfaced separately**.

## Verification

- **7 new deterministic tests** (mixed live/dead → only live surface; all-dead fails loudly; every candidate probed; order preserved; nil = pass-through; 2xx/3xx-live vs 4xx/5xx/error-dead; empty input). Full suite green (5202).
- **Live:** a single `host.web.search` now returns only URLs that passed a liveness probe (down from a dozen hallucinated candidates). A full #7 research run also needs the still-cascading #1446 (echo-storm fix) to avoid the reasoner malformed-storm; that's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)