### PR TITLE
Track office coworker task coverage

### DIFF
--- a/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
@@ -182,9 +182,12 @@ enum AgentPromisedWorkGuard {
     private static let unresolvedStarterPreviewCharacterLimit = 8
 
     private static let workVerbs: Set<String> = [
-        "apply", "build", "check", "commit", "create", "delete", "download",
-        "edit", "execute", "fetch", "fix", "inspect", "install", "list",
-        "merge", "open", "push", "read", "review", "run", "search", "test",
-        "update", "write"
+        "add", "analyze", "apply", "archive", "build", "chart", "check", "clean",
+        "commit", "condense", "convert", "create", "dedupe", "delete", "download",
+        "draft", "edit", "execute", "extract", "fetch", "fix", "flag", "highlight",
+        "inspect", "install", "inventory", "list", "maintain", "mark", "merge",
+        "normalize", "open", "pull", "push", "read", "review", "run", "save",
+        "search", "standardize", "summarize", "sync", "test", "triage", "update",
+        "write"
     ]
 }

--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -25,6 +25,17 @@ public struct TrustedRouterPromptBuilder: Sendable {
     - Keep API keys out of source, logs, screenshots, and prompts.
     """
 
+    static let officeCoworkerPrompt = """
+    Office coworker tasks:
+    - Treat requests to inventory, clean up, summarize, convert, merge, draft, extract, chart, \
+    standardize, highlight, update, or maintain business files/SaaS pages as real work requests.
+    - Use available file, shell, browser, Computer Use, and artifact tools immediately when the \
+    needed inputs are present; ask a concise question only for a missing folder, file, URL, login, \
+    or required business rule.
+    - Save requested CSV, PDF, Markdown, spreadsheet, or document deliverables to disk and verify \
+    them before summarizing.
+    """
+
     public func messages(
         thread: ChatThread,
         userMessage: String,
@@ -125,6 +136,8 @@ public struct TrustedRouterPromptBuilder: Sendable {
         {"type":"tool","name":"host.shell.run","arguments":{"cmd":"whoami"}}
 
         \(trustedRouterModelAdvisorPrompt)
+
+        \(officeCoworkerPrompt)
 
         \(computerUseGuidance)
 

--- a/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
@@ -14,6 +14,22 @@ final class AgentPromisedWorkGuardTests: XCTestCase {
         ))
     }
 
+    func testDetectsOfficeCoworkerFutureWorkPromises() {
+        let promisedOfficeTasks = [
+            "I'll inventory the brand assets and flag low-res logos.",
+            "I will standardize the Stage values and highlight missing close dates.",
+            "I'm going to chart kWh usage and draft the summary.",
+            "Let me pull the last eight weeks and write the trend callouts."
+        ]
+
+        for response in promisedOfficeTasks {
+            XCTAssertTrue(
+                AgentPromisedWorkGuard.shouldRequestCorrection(for: response, tools: [.shellRun]),
+                response
+            )
+        }
+    }
+
     func testDoesNotDetectCapabilityOrPermissionAnswers() {
         XCTAssertFalse(AgentPromisedWorkGuard.shouldRequestCorrection(
             for: "I can run commands, edit files, and review diffs when you ask.",

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -238,6 +238,25 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         )
     }
 
+    func testPromptIncludesCompactOfficeCoworkerGuidance() {
+        let prompt = TrustedRouterPromptBuilder.systemPrompt(tools: [
+            .shellRun,
+            .fileWrite,
+            .computerScreenshot
+        ])
+
+        XCTAssertTrue(prompt.contains("Office coworker tasks"))
+        XCTAssertTrue(prompt.contains("Treat requests to inventory, clean up, summarize"))
+        XCTAssertTrue(prompt.contains("Use available file, shell, browser, Computer Use, and artifact tools immediately"))
+        XCTAssertTrue(prompt.contains("ask a concise question only for a missing folder"))
+        XCTAssertTrue(prompt.contains("Save requested CSV, PDF, Markdown, spreadsheet, or document deliverables"))
+        XCTAssertLessThan(
+            TrustedRouterPromptBuilder.officeCoworkerPrompt.count,
+            650,
+            "Office coworker behavior belongs in compact routing guidance plus skills/tests, not a giant base prompt."
+        )
+    }
+
     func testPromptPrefersStructuredGitBranchToolsOverShell() {
         let prompt = TrustedRouterPromptBuilder.systemPrompt(tools: [
             .shellRun,

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -60,6 +60,12 @@
 
 ## Current Parity Notes
 
+- Office coworker tasks now have a canonical spreadsheet-backed tracker:
+  `docs/COWORKER_TASK_TRACKER.md` records the Google Sheet and the QuillCode coverage/evidence/gap
+  columns added to it. The base TrustedRouter prompt includes compact office-task routing guidance,
+  and the promised-work guard recognizes office verbs such as inventory, standardize, chart, draft,
+  pull, and highlight so supported coworker requests continue into tool calls instead of future-tense
+  narration.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -1,0 +1,46 @@
+# Office Coworker Task Tracker
+
+Canonical catalog:
+https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0
+
+The sheet is the product-facing catalog for office coworker tasks QuillCode should handle. Keep it
+grounded in verified QuillCode evidence, not intention.
+
+## Sheet Tracking Columns
+
+On 2026-07-27 the sheet gained formula-backed QuillCode tracking columns:
+
+| Column | Header | Purpose |
+| --- | --- | --- |
+| K | QuillCode coverage | Current QuillCode coverage/gap classification derived from the row status. |
+| L | QuillCode evidence | Existing analogue evidence for covered rows, or the repo evidence requirement for gaps. |
+| M | Next QuillCode gap | Next implementation/smoke category derived from `Capability needed`. |
+| N | Last QuillCode review | Last date this automated tracking view was refreshed. |
+
+Do not mark a row as covered until a current QuillCode source, unit test, functional test, E2E
+scenario, smoke result, or documented runtime proof covers that row's full user-facing task.
+
+## Current Gap Buckets
+
+The catalog currently maps to these implementation buckets:
+
+| Bucket | QuillCode proof expected |
+| --- | --- |
+| One-turn shell/file execution smoke | The agent emits a tool action immediately, with non-empty canonical arguments, and verifies requested files. |
+| Multi-file artifact/read-write smoke | The agent reads multiple source files, writes the requested deliverable, and renders or previews the artifact. |
+| Browser pane + Computer Use live SaaS smoke | The browser/computer-use path can inspect or act on a signed-in SaaS surface and preserve evidence. |
+| Capability-specific QuillCode smoke | A row-specific tool path exists and is verified before the row moves to covered. |
+
+## First Implementation Slice
+
+This branch hardens the immediate-action path for office wording from the catalog:
+
+- Compact prompt guidance treats inventory, cleanup, summary, conversion, merge, drafting,
+  extraction, charting, standardization, highlighting, and SaaS maintenance as real work requests.
+- The promised-work guard now recognizes office verbs such as `inventory`, `standardize`, `chart`,
+  `draft`, `pull`, and `highlight`, so a bare "I'll do it" answer is corrected into a tool action.
+- Tests cover representative office-coworker future-tense failures.
+
+Next slices should turn the spreadsheet's `Browser pane` rows into focused Playwright/native smoke
+cases using mock browser/Computer Use backends, then graduate rows by updating the sheet's Status and
+Evidence columns only after those smokes pass.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # QuillCode Decisions
 
+## 2026-07-27: Office Coworker Catalog Drives QuillCode Parity Tracking
+
+- **Decision:** Treat the office coworker task spreadsheet as the canonical QuillCode coverage
+  tracker for business-user workflows, not just a brainstorming list.
+- **Rationale:** The 206-row catalog spans file cleanup, document packets, multi-file summaries,
+  spreadsheets, browser/SaaS tasks, and Computer Use. A durable tracker makes it clear which rows are
+  covered by current code/tests and which still need focused smoke evidence.
+- **Implementation:** Columns K:N in the sheet now derive QuillCode coverage, evidence, next gap, and
+  review date from the existing row metadata. QuillCode also gained compact office-task prompt
+  guidance and broader promised-work verb detection so "inventory assets", "standardize the sheet",
+  and "chart usage" cannot silently degrade into future-tense narration when tools are available.
+- **Constraint:** The base prompt remains small; row-specific instructions belong in the sheet,
+  focused tests, and optional skills. Rows move to covered only when current source/test/smoke
+  evidence proves the actual user-facing task.
+
 ## 2026-07-19: Render Robot XML As A Bounded Artifact Preview
 
 - **Decision:** Treat local `.xml` files whose root validates as Robot Framework `robot` output as


### PR DESCRIPTION
## Summary
- add spreadsheet-backed QuillCode office coworker task tracking docs
- add compact office coworker prompt guidance for business file/SaaS work
- expand promised-work detection for office verbs like inventory, standardize, chart, draft, pull, and highlight
- updated the Google Sheet with formula-backed QuillCode coverage/evidence/gap/review columns K:N

## Validation
- swift test --filter AgentPromisedWorkGuardTests
- swift test --filter TrustedRouterPromptBuilderTests/testPromptIncludesCompactOfficeCoworkerGuidance
- swift test --filter TrustedRouterPromptBuilderTests
- git diff --check
- git diff --check --cached