### PR TITLE
Route browser coworker tasks immediately

### DIFF
--- a/Sources/QuillCodeAgent/AgentBrowserOpenRequestParser.swift
+++ b/Sources/QuillCodeAgent/AgentBrowserOpenRequestParser.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+enum AgentBrowserOpenRequestParser {
+    static func request(from text: String) -> String? {
+        let lower = text.lowercased()
+        guard isBrowserIntent(lower), !isDownloadIntent(lower) else { return nil }
+
+        if let quoted = AgentRequestTextScanner.backtickQuotedValues(in: text)
+            .first(where: looksLikeBrowserTarget) {
+            return normalizedBrowserTarget(quoted)
+        }
+
+        return browserTokens(in: text)
+            .first(where: looksLikeBrowserTarget)
+            .map(normalizedBrowserTarget)
+    }
+
+    private static func isBrowserIntent(_ lower: String) -> Bool {
+        browserIntentPhrases.contains { lower.contains($0) }
+    }
+
+    private static func isDownloadIntent(_ lower: String) -> Bool {
+        downloadIntentPhrases.contains { lower.contains($0) }
+    }
+
+    private static func browserTokens(in text: String) -> [String] {
+        let separators = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet(charactersIn: "`\"'(),<>[]{}"))
+        return text
+            .components(separatedBy: separators)
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: ".:;!?")) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func looksLikeBrowserTarget(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        if lower.hasPrefix("http://")
+            || lower.hasPrefix("https://")
+            || lower.hasPrefix("file://")
+            || lower.hasPrefix("localhost")
+            || lower.hasPrefix("127.0.0.1")
+            || lower.hasPrefix("./") {
+            return true
+        }
+        guard !lower.hasPrefix("/"),
+              !lower.contains("@")
+        else {
+            return false
+        }
+        let firstPathComponent = lower.split(separator: "/", maxSplits: 1).first ?? ""
+        return firstPathComponent.split(separator: ".").last.map { knownWebTLDs.contains(String($0)) } == true
+    }
+
+    private static func normalizedBrowserTarget(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        if lower.hasPrefix("http://")
+            || lower.hasPrefix("https://")
+            || lower.hasPrefix("file://")
+            || lower.hasPrefix("localhost")
+            || lower.hasPrefix("127.0.0.1")
+            || lower.hasPrefix("./") {
+            return trimmed
+        }
+        return "https://\(trimmed)"
+    }
+
+    private static let browserIntentPhrases = [
+        "open ",
+        "inspect ",
+        "check ",
+        "view ",
+        "look at ",
+        "review ",
+        "visit ",
+        "go to ",
+        "navigate to ",
+        "use "
+    ]
+
+    private static let downloadIntentPhrases = [
+        "download ",
+        "save ",
+        "fetch "
+    ]
+
+    private static let knownWebTLDs: Set<String> = [
+        "ai", "app", "cloud", "co", "com", "dev", "edu", "gov", "io", "net", "org", "so"
+    ]
+}

--- a/Sources/QuillCodeAgent/AgentImmediateActionPlanner.swift
+++ b/Sources/QuillCodeAgent/AgentImmediateActionPlanner.swift
@@ -120,6 +120,14 @@ enum AgentImmediateActionPlanner {
             return shell(downloadCommand)
         }
 
+        if let browserTarget = AgentBrowserOpenRequestParser.request(from: request),
+           hasTool(ToolDefinition.browserOpen.name, in: tools) {
+            return .tool(.init(
+                name: ToolDefinition.browserOpen.name,
+                argumentsJSON: ToolArguments.json(["url": browserTarget])
+            ))
+        }
+
         if isDiskUsageRequest(lower),
            hasTool(ToolDefinition.shellRun.name, in: tools) {
             return shell("df -h / /Quill 2>/dev/null || df -h /")

--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -159,6 +159,9 @@ public struct TrustedRouterPromptBuilder: Sendable {
         - If the user asks to download, save, or fetch a URL or domain, use host.shell.run immediately \
         with curl or wget, save into a relative workspace path such as downloads/example.com.html, create \
         parent directories first with mkdir -p when needed, and do not pipe remote content into a shell.
+        - If the user asks to open, inspect, check, view, or maintain a browser/SaaS page and gives a URL \
+        or domain, use host.browser.open immediately with "url"; then inspect or interact with the page \
+        using browser or Computer Use tools as needed.
         - If the user asks to fetch git refs or remote updates, use host.git.fetch instead of host.shell.run.
         - If the user asks to pull, sync, or update the current git branch from a remote, use \
         host.git.pull instead of host.shell.run. Omit "ffOnly" unless the user explicitly requests a \

--- a/Tests/QuillCodeAgentTests/AgentImmediateBrowserOpenTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateBrowserOpenTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+final class AgentImmediateBrowserOpenTests: XCTestCase {
+    func testBrowserCoworkerPageOpensImmediately() throws {
+        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+            for: "Can you check the Salesforce pipeline at https://example.com/dashboard?",
+            tools: browserTools
+        ))
+
+        let call = try assertTool(action)
+        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
+        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://example.com/dashboard"]))
+    }
+
+    func testBareDomainBrowserRequestNormalizesToHTTPS() throws {
+        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+            for: "Open app.hubspot.com and inspect the dashboard.",
+            tools: browserTools
+        ))
+
+        let call = try assertTool(action)
+        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
+        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://app.hubspot.com"]))
+    }
+
+    func testLocalBrowserPreviewRequestKeepsLocalhost() throws {
+        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+            for: "View localhost:5173 before I review it.",
+            tools: browserTools
+        ))
+
+        let call = try assertTool(action)
+        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
+        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "localhost:5173"]))
+    }
+
+    func testDownloadKeepsDownloadPlannerPriority() throws {
+        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+            for: "Download https://example.com into `downloads/example.html`.",
+            tools: [.browserOpen, .shellRun]
+        ))
+
+        let call = try assertTool(action)
+        XCTAssertEqual(call.name, ToolDefinition.shellRun.name)
+        let command = try shellCommand(from: call)
+        XCTAssertTrue(command.contains("curl -L"), command)
+        XCTAssertTrue(command.contains("downloads/example.html"), command)
+    }
+
+    func testMissingURLDoesNotInventSaaSTarget() {
+        XCTAssertNil(AgentImmediateActionPlanner.action(
+            for: "Check the Salesforce pipeline.",
+            tools: browserTools
+        ))
+    }
+
+    func testFileReviewRequestDoesNotBecomeBrowserDomain() {
+        XCTAssertNil(AgentImmediateActionPlanner.action(
+            for: "Review package.json",
+            tools: browserTools
+        ))
+    }
+
+    func testMultiStepBrowserTaskStillGoesToModel() {
+        XCTAssertNil(AgentImmediateActionPlanner.action(
+            for: "Open https://example.com, then export the table, then make a CSV summary.",
+            tools: browserTools
+        ))
+    }
+
+    private var browserTools: [ToolDefinition] {
+        [.browserOpen, .browserInspect, .browserClick, .browserType, .computerScreenshot]
+    }
+
+    private func assertTool(_ action: AgentAction) throws -> ToolCall {
+        guard case .tool(let call) = action else {
+            throw XCTSkip("Expected tool action")
+        }
+        return call
+    }
+
+    private func shellCommand(from call: ToolCall) throws -> String {
+        let data = Data(call.argumentsJSON.utf8)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return try XCTUnwrap(object?["cmd"] as? String)
+    }
+}

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -196,6 +196,8 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         XCTAssertTrue(prompt.contains("save into a relative workspace path"))
         XCTAssertTrue(prompt.contains("create parent directories first with mkdir -p"))
         XCTAssertTrue(prompt.contains("do not pipe remote content into a shell"))
+        XCTAssertTrue(prompt.contains("use host.browser.open immediately with \"url\""))
+        XCTAssertTrue(prompt.contains("browser/SaaS page"))
         XCTAssertTrue(prompt.contains("call host.skill.load immediately"))
         XCTAssertTrue(prompt.contains("with a non-empty \"name\" string"))
     }

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -65,7 +65,9 @@
   columns added to it. The base TrustedRouter prompt includes compact office-task routing guidance,
   and the promised-work guard recognizes office verbs such as inventory, standardize, chart, draft,
   pull, and highlight so supported coworker requests continue into tool calls instead of future-tense
-  narration.
+  narration. Terse browser/SaaS coworker requests with a URL or domain now preflight directly to
+  `host.browser.open` with a canonical `url` argument, while download/save/fetch wording keeps the
+  existing workspace-artifact download path.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -41,6 +41,15 @@ This branch hardens the immediate-action path for office wording from the catalo
   `draft`, `pull`, and `highlight`, so a bare "I'll do it" answer is corrected into a tool action.
 - Tests cover representative office-coworker future-tense failures.
 
-Next slices should turn the spreadsheet's `Browser pane` rows into focused Playwright/native smoke
-cases using mock browser/Computer Use backends, then graduate rows by updating the sheet's Status and
-Evidence columns only after those smokes pass.
+## Browser/SaaS Routing Slice
+
+The next immediate-action gap is browser/SaaS coworker work:
+
+- Terse requests such as "check the Salesforce pipeline at https://..." or "open app.hubspot.com"
+  now route directly to `host.browser.open` with the canonical `url` argument instead of waiting for
+  a model turn that may say "I'll check..." without acting.
+- Download/save/fetch requests keep the existing bounded `curl` download path, so "download
+  LinkedIn.com" still creates a workspace artifact instead of merely opening a browser tab.
+- Multi-step browser workflows still go to the model; the preflight only handles a first obvious
+  page-open action. Follow-up slices should add focused browser/Computer Use smoke cases for logged-in
+  SaaS interaction and only then graduate spreadsheet rows to covered.


### PR DESCRIPTION
## Summary
- add a deterministic browser-open parser for terse office coworker/SaaS URL tasks
- route obvious browser page requests to host.browser.open with canonical url arguments before model narration
- keep download/save/fetch requests on the existing workspace artifact download path and document the tracker slice

## Validation
- swift test --filter AgentImmediateBrowserOpenTests
- swift test --filter AgentDownloadRequestParserTests
- swift test --filter AgentImmediateShellActionTests/testDownloadDomainExecutesImmediatelyWithWorkspaceBoundedPath
- swift test --filter TrustedRouterPromptBuilderTests/testPromptRequiresNonEmptyShellCommand
- git diff --check --cached