### PR TITLE
Open known SaaS coworker apps immediately

### DIFF
--- a/Sources/QuillCodeAgent/AgentBrowserOpenRequestParser.swift
+++ b/Sources/QuillCodeAgent/AgentBrowserOpenRequestParser.swift
@@ -3,20 +3,31 @@ import Foundation
 enum AgentBrowserOpenRequestParser {
     static func request(from text: String) -> String? {
         let lower = text.lowercased()
-        guard isBrowserIntent(lower), !isDownloadIntent(lower) else { return nil }
+        guard !isDownloadIntent(lower) else { return nil }
 
-        if let quoted = AgentRequestTextScanner.backtickQuotedValues(in: text)
-            .first(where: looksLikeBrowserTarget) {
-            return normalizedBrowserTarget(quoted)
+        if isBrowserIntent(lower) {
+            if let quoted = AgentRequestTextScanner.backtickQuotedValues(in: text)
+                .first(where: looksLikeBrowserTarget) {
+                return normalizedBrowserTarget(quoted)
+            }
+
+            if let target = browserTokens(in: text)
+                .first(where: looksLikeBrowserTarget)
+                .map(normalizedBrowserTarget) {
+                return target
+            }
         }
 
-        return browserTokens(in: text)
-            .first(where: looksLikeBrowserTarget)
-            .map(normalizedBrowserTarget)
+        return knownSaaSTarget(in: lower)
     }
 
     private static func isBrowserIntent(_ lower: String) -> Bool {
         browserIntentPhrases.contains { lower.contains($0) }
+    }
+
+    private static func knownSaaSTarget(in lower: String) -> String? {
+        guard knownSaaSIntentPhrases.contains(where: { lower.contains($0) }) else { return nil }
+        return knownSaaSTargets.first { lower.contains($0.phrase) }?.url
     }
 
     private static func isDownloadIntent(_ lower: String) -> Bool {
@@ -78,6 +89,18 @@ enum AgentBrowserOpenRequestParser {
         "use "
     ]
 
+    private static let knownSaaSIntentPhrases = browserIntentPhrases + [
+        "find ",
+        "pull ",
+        "walk through ",
+        "log into ",
+        "login to ",
+        "sign into ",
+        "sign in to ",
+        "build ",
+        "create "
+    ]
+
     private static let downloadIntentPhrases = [
         "download ",
         "save ",
@@ -86,5 +109,23 @@ enum AgentBrowserOpenRequestParser {
 
     private static let knownWebTLDs: Set<String> = [
         "ai", "app", "cloud", "co", "com", "dev", "edu", "gov", "io", "net", "org", "so"
+    ]
+
+    private static let knownSaaSTargets: [(phrase: String, url: String)] = [
+        ("linkedin campaign manager", "https://www.linkedin.com/campaignmanager/"),
+        ("google analytics", "https://analytics.google.com/"),
+        ("google ads", "https://ads.google.com/"),
+        ("google drive", "https://drive.google.com/"),
+        ("google sheet", "https://sheets.google.com/"),
+        ("google sheets", "https://sheets.google.com/"),
+        ("hubspot", "https://app.hubspot.com/"),
+        ("salesforce", "https://login.salesforce.com/"),
+        ("mailchimp", "https://login.mailchimp.com/"),
+        ("asana", "https://app.asana.com/"),
+        ("zendesk", "https://www.zendesk.com/login/"),
+        ("confluence", "https://id.atlassian.com/login"),
+        ("jira", "https://id.atlassian.com/login"),
+        ("notion", "https://www.notion.so/"),
+        ("concur", "https://www.concursolutions.com/"),
     ]
 }

--- a/Tests/QuillCodeAgentTests/AgentImmediateBrowserOpenTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateBrowserOpenTests.swift
@@ -51,9 +51,42 @@ final class AgentImmediateBrowserOpenTests: XCTestCase {
         XCTAssertTrue(command.contains("downloads/example.html"), command)
     }
 
-    func testMissingURLDoesNotInventSaaSTarget() {
-        XCTAssertNil(AgentImmediateActionPlanner.action(
+    func testKnownSaaSBrowserRequestOpensCanonicalApp() throws {
+        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
             for: "Check the Salesforce pipeline.",
+            tools: browserTools
+        ))
+
+        let call = try assertTool(action)
+        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
+        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://login.salesforce.com/"]))
+    }
+
+    func testHubSpotCoworkerRequestOpensAppWithoutURL() throws {
+        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+            for: "In HubSpot, find opportunities with no activity in 30 days.",
+            tools: browserTools
+        ))
+
+        let call = try assertTool(action)
+        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
+        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://app.hubspot.com/"]))
+    }
+
+    func testGoogleSheetCoworkerRequestOpensSheetsWithoutURL() throws {
+        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+            for: "Open the Q3 Invoice Tracker Google Sheet and add a status column.",
+            tools: browserTools
+        ))
+
+        let call = try assertTool(action)
+        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
+        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://sheets.google.com/"]))
+    }
+
+    func testUnknownSaaSWithoutURLDoesNotInventTarget() {
+        XCTAssertNil(AgentImmediateActionPlanner.action(
+            for: "Check the partner portal pipeline.",
             tools: browserTools
         ))
     }

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -67,7 +67,10 @@
   pull, and highlight so supported coworker requests continue into tool calls instead of future-tense
   narration. Terse browser/SaaS coworker requests with a URL or domain now preflight directly to
   `host.browser.open` with a canonical `url` argument, while download/save/fetch wording keeps the
-  existing workspace-artifact download path.
+  existing workspace-artifact download path. Named SaaS coworker prompts without a URL now open the
+  canonical app/login surface for common catalog tools such as Salesforce, HubSpot, Google
+  Drive/Sheets, Mailchimp, Notion, Asana, Jira/Confluence, Zendesk, Concur, Google Ads, LinkedIn
+  Campaign Manager, and Google Analytics.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -48,6 +48,11 @@ The next immediate-action gap is browser/SaaS coworker work:
 - Terse requests such as "check the Salesforce pipeline at https://..." or "open app.hubspot.com"
   now route directly to `host.browser.open` with the canonical `url` argument instead of waiting for
   a model turn that may say "I'll check..." without acting.
+- Named SaaS coworker prompts without URLs now open the canonical app/login surface for common office
+  tools in the catalog, including Salesforce, HubSpot, Google Ads, LinkedIn Campaign Manager,
+  Mailchimp, Google Drive/Sheets, Notion, Asana, Concur, Jira/Confluence, Zendesk, and Google
+  Analytics. This is intentionally a first-action route, not a claim that QuillCode has completed the
+  logged-in SaaS workflow.
 - Download/save/fetch requests keep the existing bounded `curl` download path, so "download
   LinkedIn.com" still creates a workspace artifact instead of merely opening a browser tab.
 - Multi-step browser workflows still go to the model; the preflight only handles a first obvious


### PR DESCRIPTION
## Summary
- route known SaaS coworker prompts without URLs to canonical host.browser.open targets
- keep download/save/fetch requests on the existing artifact download path
- update coworker tracker and parity docs with the first-action coverage boundary

## Validation
- swift test --filter AgentImmediateBrowserOpenTests
- swift test --filter AgentImmediate
- git diff --check