### PR TITLE
Keep SaaS coworker workflows out of one-shot preflight

### DIFF
--- a/Sources/QuillCodeAgent/AgentBrowserOpenRequestParser.swift
+++ b/Sources/QuillCodeAgent/AgentBrowserOpenRequestParser.swift
@@ -26,7 +26,7 @@ enum AgentBrowserOpenRequestParser {
     }
 
     private static func knownSaaSTarget(in lower: String) -> String? {
-        guard knownSaaSIntentPhrases.contains(where: { lower.contains($0) }) else { return nil }
+        guard knownSaaSNavigationPhrases.contains(where: { lower.contains($0) }) else { return nil }
         return knownSaaSTargets.first { lower.contains($0.phrase) }?.url
     }
 
@@ -89,16 +89,15 @@ enum AgentBrowserOpenRequestParser {
         "use "
     ]
 
-    private static let knownSaaSIntentPhrases = browserIntentPhrases + [
-        "find ",
-        "pull ",
-        "walk through ",
+    private static let knownSaaSNavigationPhrases = [
+        "open ",
+        "visit ",
+        "go to ",
+        "navigate to ",
         "log into ",
         "login to ",
         "sign into ",
-        "sign in to ",
-        "build ",
-        "create "
+        "sign in to "
     ]
 
     private static let downloadIntentPhrases = [

--- a/Sources/QuillCodeAgent/AgentImmediateActionPlanner.swift
+++ b/Sources/QuillCodeAgent/AgentImmediateActionPlanner.swift
@@ -64,6 +64,8 @@ enum AgentImmediateActionPlanner {
         "turn", "write", "create", "make", "run", "fix", "update", "summarize",
         "produce", "generate", "draft", "convert", "then", "read", "list",
         "delete", "rename", "move", "install", "build", "test", "commit", "push", "open",
+        "add", "archive", "correct", "fill", "highlight", "mark", "merge", "pull",
+        "standardize",
     ]
 
     private static func thenConnectorCount(in lower: String) -> Int {

--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -32,6 +32,8 @@ public struct TrustedRouterPromptBuilder: Sendable {
     - Use available file, shell, browser, Computer Use, and artifact tools immediately when the \
     needed inputs are present; ask a concise question only for a missing folder, file, URL, login, \
     or required business rule.
+    - For named SaaS workflows without a URL, open the named app/login surface first, then inspect \
+    and interact with it; do not stop after saying you will do it or after only opening the page.
     - Save requested CSV, PDF, Markdown, spreadsheet, or document deliverables to disk and verify \
     them before summarizing.
     """

--- a/Tests/QuillCodeAgentTests/AgentImmediateActionMultiStepGateTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateActionMultiStepGateTests.swift
@@ -95,6 +95,25 @@ final class AgentImmediateActionMultiStepGateTests: XCTestCase {
         XCTAssertFalse(AgentImmediateActionPlanner.isMultiStepTaskPrompt("list files and folders here"))
     }
 
+    func testCoworkerBrowserContinuationsAreNeverPreflighted() {
+        let prompts = [
+            "Open the Q3 Invoice Tracker Google Sheet and add a status column.",
+            "In HubSpot, find opportunities with no activity in 30 days, add a follow-up task, and correct the stage.",
+            "Open our shared Q3 Pipeline Google Sheet, merge duplicate account rows, standardize Stage, and highlight missing close dates.",
+            "Open our Google Drive Marketing 2026 folder and rename campaign files, then list every change you made.",
+        ]
+        for prompt in prompts {
+            XCTAssertTrue(
+                AgentImmediateActionPlanner.isMultiStepTaskPrompt(prompt),
+                "Expected coworker workflow to stay with the model: \(prompt)"
+            )
+            XCTAssertNil(
+                AgentImmediateActionPlanner.action(for: prompt, tools: tools + [.browserOpen, .browserInspect]),
+                "Expected no one-shot preflight: \(prompt)"
+            )
+        }
+    }
+
     /// Nobody types a 200-character message to run one terse command; long prompts are tasks.
     func testLongPromptsAreNeverPreflighted() {
         let long = "Read the service log and figure out why the collector keeps restarting "

--- a/Tests/QuillCodeAgentTests/AgentImmediateBrowserOpenTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateBrowserOpenTests.swift
@@ -51,9 +51,9 @@ final class AgentImmediateBrowserOpenTests: XCTestCase {
         XCTAssertTrue(command.contains("downloads/example.html"), command)
     }
 
-    func testKnownSaaSBrowserRequestOpensCanonicalApp() throws {
+    func testKnownSaaSNavigationRequestOpensCanonicalApp() throws {
         let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
-            for: "Check the Salesforce pipeline.",
+            for: "Open Salesforce.",
             tools: browserTools
         ))
 
@@ -62,26 +62,18 @@ final class AgentImmediateBrowserOpenTests: XCTestCase {
         XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://login.salesforce.com/"]))
     }
 
-    func testHubSpotCoworkerRequestOpensAppWithoutURL() throws {
-        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+    func testHubSpotCoworkerWorkflowDoesNotStopAtOpeningApp() {
+        XCTAssertNil(AgentImmediateActionPlanner.action(
             for: "In HubSpot, find opportunities with no activity in 30 days.",
             tools: browserTools
         ))
-
-        let call = try assertTool(action)
-        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
-        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://app.hubspot.com/"]))
     }
 
-    func testGoogleSheetCoworkerRequestOpensSheetsWithoutURL() throws {
-        let action = try XCTUnwrap(AgentImmediateActionPlanner.action(
+    func testGoogleSheetCoworkerWorkflowDoesNotStopAtOpeningSheets() {
+        XCTAssertNil(AgentImmediateActionPlanner.action(
             for: "Open the Q3 Invoice Tracker Google Sheet and add a status column.",
             tools: browserTools
         ))
-
-        let call = try assertTool(action)
-        XCTAssertEqual(call.name, ToolDefinition.browserOpen.name)
-        XCTAssertEqual(call.argumentsJSON, ToolArguments.json(["url": "https://sheets.google.com/"]))
     }
 
     func testUnknownSaaSWithoutURLDoesNotInventTarget() {

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -251,10 +251,12 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         XCTAssertTrue(prompt.contains("Treat requests to inventory, clean up, summarize"))
         XCTAssertTrue(prompt.contains("Use available file, shell, browser, Computer Use, and artifact tools immediately"))
         XCTAssertTrue(prompt.contains("ask a concise question only for a missing folder"))
+        XCTAssertTrue(prompt.contains("For named SaaS workflows without a URL"))
+        XCTAssertTrue(prompt.contains("do not stop after saying you will do it or after only opening the page"))
         XCTAssertTrue(prompt.contains("Save requested CSV, PDF, Markdown, spreadsheet, or document deliverables"))
         XCTAssertLessThan(
             TrustedRouterPromptBuilder.officeCoworkerPrompt.count,
-            650,
+            800,
             "Office coworker behavior belongs in compact routing guidance plus skills/tests, not a giant base prompt."
         )
     }

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -67,10 +67,11 @@
   pull, and highlight so supported coworker requests continue into tool calls instead of future-tense
   narration. Terse browser/SaaS coworker requests with a URL or domain now preflight directly to
   `host.browser.open` with a canonical `url` argument, while download/save/fetch wording keeps the
-  existing workspace-artifact download path. Named SaaS coworker prompts without a URL now open the
-  canonical app/login surface for common catalog tools such as Salesforce, HubSpot, Google
+  existing workspace-artifact download path. Simple SaaS navigation prompts without a URL now open
+  the canonical app/login surface for common catalog tools such as Salesforce, HubSpot, Google
   Drive/Sheets, Mailchimp, Notion, Asana, Jira/Confluence, Zendesk, Concur, Google Ads, LinkedIn
-  Campaign Manager, and Google Analytics.
+  Campaign Manager, and Google Analytics, while actionful catalog workflows stay with the model loop
+  so they can continue through browser/Computer Use instead of stopping after a single open.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -48,11 +48,13 @@ The next immediate-action gap is browser/SaaS coworker work:
 - Terse requests such as "check the Salesforce pipeline at https://..." or "open app.hubspot.com"
   now route directly to `host.browser.open` with the canonical `url` argument instead of waiting for
   a model turn that may say "I'll check..." without acting.
-- Named SaaS coworker prompts without URLs now open the canonical app/login surface for common office
-  tools in the catalog, including Salesforce, HubSpot, Google Ads, LinkedIn Campaign Manager,
+- Simple SaaS navigation prompts without URLs now open the canonical app/login surface for common
+  office tools in the catalog, including Salesforce, HubSpot, Google Ads, LinkedIn Campaign Manager,
   Mailchimp, Google Drive/Sheets, Notion, Asana, Concur, Jira/Confluence, Zendesk, and Google
-  Analytics. This is intentionally a first-action route, not a claim that QuillCode has completed the
-  logged-in SaaS workflow.
+  Analytics.
+- Actionful catalog workflows such as adding HubSpot tasks, filling Google Sheets, renaming Drive
+  files, merging rows, or correcting stages deliberately stay out of the one-shot preflight path so
+  the model can continue with browser/Computer Use tools instead of stopping after a single open.
 - Download/save/fetch requests keep the existing bounded `curl` download path, so "download
   LinkedIn.com" still creates a workspace artifact instead of merely opening a browser tab.
 - Multi-step browser workflows still go to the model; the preflight only handles a first obvious


### PR DESCRIPTION
## Summary
- restrict known-SaaS URL-less preflight to simple navigation prompts
- keep actionful coworker workflows with the model loop so browser/Computer Use can continue after opening a SaaS app
- expand multi-step guard verbs for catalog wording like add, correct, merge, rename, standardize, and highlight
- add compact prompt guidance for named SaaS workflows without URLs

## Validation
- swift test --filter AgentImmediate
- swift test --filter TrustedRouterPromptBuilderTests/testPromptIncludesCompactOfficeCoworkerGuidance
- git diff --check