### PR TITLE
Prove visible browser workflow smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
@@ -181,6 +181,9 @@ struct QuillCodeDesktopBrowserCoordinator {
     }
 
     private func sourceLabel(for url: URL) -> String {
+        if url.isFileURL {
+            return "Local HTML"
+        }
         let host = url.host ?? url.absoluteString
         return ["localhost", "127.0.0.1", "::1"].contains(host) ? "Local web app" : "Web page"
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import SwiftUI
+import QuillCodeAgent
 import QuillCodeApp
 import QuillCodeCore
 import QuillCodePersistence
@@ -89,6 +90,7 @@ enum QuillCodeDesktopSmokeRunner {
         }
 
         let browserSmoke = try await runBrowserSmoke(controller: controller, root: root)
+        let browserWorkflowSmoke = try await runBrowserWorkflowSmoke(controller: controller, root: root)
         let surface = controller.surface
         let nativeHitTargets = try QuillCodeDesktopNativeHitTargetSmoke.validatedReport(for: surface)
         guard surface.transcript.messages.count >= 4,
@@ -175,6 +177,7 @@ enum QuillCodeDesktopSmokeRunner {
             chromeImage: chromeStats.report,
             chrome: chrome,
             browserSmoke: browserSmoke,
+            browserWorkflowSmoke: browserWorkflowSmoke,
             nativeHitTargets: nativeHitTargets
         )
     }
@@ -251,6 +254,144 @@ enum QuillCodeDesktopSmokeRunner {
             toolName: toolCard?.title ?? "",
             finalAnswer: finalAnswer
         )
+    }
+
+    private static func runBrowserWorkflowSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopBrowserWorkflowSmokeReport {
+        let previewFile = root.workspace.appendingPathComponent("browser-crm-smoke.html")
+        try """
+        <!doctype html>
+        <html>
+          <head><title>CRM Workflow Smoke</title></head>
+          <body>
+            <main>
+              <h1>CRM Workflow Smoke</h1>
+              <label>Status <input name="status" value="Open"></label>
+              <button data-action="save">Save</button>
+              <p data-testid="status">Status: Open</p>
+            </main>
+          </body>
+        </html>
+        """.write(to: previewFile, atomically: true, encoding: .utf8)
+
+        controller.browserAddressDraft = "browser-crm-smoke.html"
+        controller.openBrowserPreview()
+        controller.openBrowserSession()
+
+        let override = try requiredBrowserToolOverride(controller)
+        let workspace = root.workspace
+        let typeTool = try requiredToolResult(
+            await override(
+                ToolCall(
+                    name: ToolDefinition.browserType.name,
+                    argumentsJSON: ToolArguments.json([
+                        "selector": "input[name='status']",
+                        "text": "Qualified",
+                        "submit": false
+                    ])
+                ),
+                workspace
+            ),
+            toolName: ToolDefinition.browserType.name
+        )
+        let clickTool = try requiredToolResult(
+            await override(
+                ToolCall(
+                    name: ToolDefinition.browserClick.name,
+                    argumentsJSON: ToolArguments.json(["selector": "button[data-action='save']"])
+                ),
+                workspace
+            ),
+            toolName: ToolDefinition.browserClick.name
+        )
+        let scriptTool = try requiredToolResult(
+            await override(
+                ToolCall(
+                    name: ToolDefinition.browserScript.name,
+                    argumentsJSON: ToolArguments.json([
+                        "source": "document.querySelector('[data-testid=\"status\"]').textContent"
+                    ])
+                ),
+                workspace
+            ),
+            toolName: ToolDefinition.browserScript.name
+        )
+        let inspectTool = try requiredToolResult(
+            await override(
+                ToolCall(name: ToolDefinition.browserInspect.name, argumentsJSON: "{}"),
+                workspace
+            ),
+            toolName: ToolDefinition.browserInspect.name
+        )
+
+        let typeOutput = try decodeSmokeOutput(BrowserActionToolOutput.self, from: typeTool)
+        let clickOutput = try decodeSmokeOutput(BrowserActionToolOutput.self, from: clickTool)
+        let scriptOutput = try decodeSmokeOutput(BrowserScriptToolOutput.self, from: scriptTool)
+        let inspectOutput = try decodeSmokeOutput(BrowserInspectionToolOutput.self, from: inspectTool)
+
+        guard typeOutput.selector == "input[name='status']",
+              typeOutput.action == "type",
+              clickOutput.selector == "button[data-action='save']",
+              clickOutput.action == "click",
+              scriptOutput.value.contains("Qualified"),
+              scriptOutput.value.contains("saved=true"),
+              inspectOutput.inspectionDepth == .liveDOMSnapshot,
+              inspectOutput.outline.contains("H1: CRM Workflow Smoke"),
+              inspectOutput.textSnippet?.contains("Qualified") == true,
+              inspectOutput.textSnippet?.contains("Saved") == true
+        else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed(
+                "browser workflow smoke did not preserve typed/clicked live DOM state"
+            )
+        }
+
+        return QuillCodeDesktopBrowserWorkflowSmokeReport(
+            previewPath: previewFile.path,
+            url: inspectOutput.url,
+            typedSelector: typeOutput.selector,
+            typedText: "Qualified",
+            clickedSelector: clickOutput.selector,
+            typeToolName: ToolDefinition.browserType.name,
+            clickToolName: ToolDefinition.browserClick.name,
+            scriptToolName: ToolDefinition.browserScript.name,
+            inspectToolName: ToolDefinition.browserInspect.name,
+            scriptValue: scriptOutput.value,
+            inspectionDepth: inspectOutput.inspectionDepth.label,
+            sourceLabel: inspectOutput.sourceLabel,
+            outline: inspectOutput.outline,
+            textSnippet: inspectOutput.textSnippet ?? ""
+        )
+    }
+
+    private static func requiredBrowserToolOverride(
+        _ controller: QuillCodeDesktopController
+    ) throws -> AgentToolExecutionOverride {
+        guard let override = controller.model.visibleBrowserToolOverride else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed("missing visible browser tool override")
+        }
+        return override
+    }
+
+    private static func requiredToolResult(_ result: ToolResult?, toolName: String) throws -> ToolResult {
+        guard let result else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed("\(toolName) was not routed")
+        }
+        guard result.ok else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed(result.error ?? "\(toolName) failed")
+        }
+        return result
+    }
+
+    private static func decodeSmokeOutput<Value: Decodable>(
+        _ type: Value.Type,
+        from result: ToolResult
+    ) throws -> Value {
+        guard let data = result.stdout.data(using: .utf8) else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed("tool output was not UTF-8")
+        }
+        return try JSONDecoder().decode(type, from: data)
     }
 
     private static func waitForDesktopRun(
@@ -334,23 +475,116 @@ enum QuillCodeDesktopSmokeRunner {
 private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresenting {
     var onSessionUpdate: (@MainActor (BrowserSessionUpdate) -> Void)?
 
-    func presentSession(_ snapshot: BrowserSessionSyncSnapshot) {}
-    func syncSession(_ snapshot: BrowserSessionSyncSnapshot) {}
+    private var selectedTab: BrowserSessionTabSnapshot?
+    private var isSessionOpen = false
+    private var typedStatus = "Open"
+    private var didSave = false
+
+    func presentSession(_ snapshot: BrowserSessionSyncSnapshot) {
+        isSessionOpen = true
+        syncSession(snapshot)
+    }
+
+    func syncSession(_ snapshot: BrowserSessionSyncSnapshot) {
+        guard isSessionOpen else { return }
+        selectedTab = snapshot.tabs.first { $0.id == snapshot.activeTabID } ?? snapshot.tabs.first
+    }
+
     func goBackSession(fallback snapshot: BrowserSessionSyncSnapshot) {}
     func goForwardSession(fallback snapshot: BrowserSessionSyncSnapshot) {}
+
     func evaluateJavaScriptInSelectedTab(_ source: String) async throws -> DesktopBrowserSessionScriptResult {
-        throw DesktopBrowserSessionScriptError.noOpenSession
+        let trimmedSource = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSource.isEmpty else { throw DesktopBrowserSessionScriptError.emptySource }
+        guard let selectedTab else { throw DesktopBrowserSessionScriptError.noSelectedTab }
+        emitSnapshotUpdate(for: selectedTab)
+        return DesktopBrowserSessionScriptResult(
+            title: "CRM Workflow Smoke",
+            url: selectedTab.url,
+            valueDescription: statusText
+        )
     }
+
     func captureLiveDOMSnapshotInSelectedTab() async throws -> BrowserLiveDOMSnapshot {
-        throw DesktopBrowserSessionScriptError.noOpenSession
+        guard let selectedTab else { throw DesktopBrowserSessionScriptError.noSelectedTab }
+        let snapshot = liveDOMSnapshot(for: selectedTab)
+        onSessionUpdate?(BrowserSessionUpdate(
+            tabs: [
+                BrowserSessionTabUpdate(
+                    id: selectedTab.id,
+                    title: "CRM Workflow Smoke",
+                    url: selectedTab.url,
+                    isActive: true,
+                    liveDOMSnapshot: snapshot
+                )
+            ],
+            activeTabID: selectedTab.id
+        ))
+        return snapshot
     }
+
     func clickInSelectedTab(selector: String) async throws -> DesktopBrowserSessionActionResult {
-        throw DesktopBrowserSessionActionError.noOpenSession
+        let trimmedSelector = selector.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSelector.isEmpty else { throw DesktopBrowserSessionActionError.emptySelector }
+        guard let selectedTab else { throw DesktopBrowserSessionActionError.noSelectedTab }
+        guard trimmedSelector == "button[data-action='save']" else {
+            throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+        }
+        didSave = true
+        emitSnapshotUpdate(for: selectedTab)
+        return DesktopBrowserSessionActionResult(ok: true, summary: "Clicked \(trimmedSelector)", error: nil)
     }
+
     func typeInSelectedTab(selector: String, text: String, submit: Bool) async throws -> DesktopBrowserSessionActionResult {
-        throw DesktopBrowserSessionActionError.noOpenSession
+        let trimmedSelector = selector.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSelector.isEmpty else { throw DesktopBrowserSessionActionError.emptySelector }
+        guard !text.isEmpty else { throw DesktopBrowserSessionActionError.emptyText }
+        guard let selectedTab else { throw DesktopBrowserSessionActionError.noSelectedTab }
+        guard trimmedSelector == "input[name='status']" else {
+            throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+        }
+        typedStatus = text
+        emitSnapshotUpdate(for: selectedTab)
+        return DesktopBrowserSessionActionResult(ok: true, summary: "Typed into \(trimmedSelector)", error: nil)
     }
+
     func reloadSession() {}
+
+    private var statusText: String {
+        "Status: \(typedStatus); saved=\(didSave)"
+    }
+
+    private func liveDOMSnapshot(for tab: BrowserSessionTabSnapshot) -> BrowserLiveDOMSnapshot {
+        BrowserLiveDOMSnapshot(
+            finalURL: tab.url,
+            title: "CRM Workflow Smoke",
+            visibleText: "CRM Workflow Smoke Status \(typedStatus) \(didSave ? "Saved" : "Unsaved")",
+            outline: ["H1: CRM Workflow Smoke", "Button: Save", "Field: Status"],
+            html: """
+            <!doctype html><title>CRM Workflow Smoke</title>
+            <h1>CRM Workflow Smoke</h1>
+            <input name="status" value="\(typedStatus)">
+            <button data-action="save">Save</button>
+            <p data-testid="status">\(statusText)</p>
+            """,
+            viewportDescription: "1120x760 smoke browser"
+        )
+    }
+
+    private func emitSnapshotUpdate(for tab: BrowserSessionTabSnapshot) {
+        onSessionUpdate?(BrowserSessionUpdate(
+            tabs: [
+                BrowserSessionTabUpdate(
+                    id: tab.id,
+                    title: "CRM Workflow Smoke",
+                    url: tab.url,
+                    isActive: true,
+                    liveDOMSnapshot: liveDOMSnapshot(for: tab)
+                )
+            ],
+            activeTabID: tab.id
+        ))
+    }
 }
 
 private struct SmokeAutomationNotifier: QuillCodeAutomationNotifying {

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -160,6 +160,7 @@ struct QuillCodeDesktopSmokeReport {
     var chromeImage: QuillCodeDesktopSmokePixelReport
     var chrome: QuillCodeDesktopChromeSmokeReport
     var browserSmoke: QuillCodeDesktopBrowserSmokeReport
+    var browserWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
     var nativeHitTargets: QuillCodeNativeHitTargetAuditReport
 
     func prettyJSON() throws -> Data {
@@ -187,6 +188,7 @@ struct QuillCodeDesktopSmokeReport {
                 "chromeImage": chromeImage.dictionary,
                 "chrome": chrome.dictionary,
                 "browserSmoke": browserSmoke.dictionary,
+                "browserWorkflowSmoke": browserWorkflowSmoke.dictionary,
                 "nativeHitTargets": nativeHitTargets.dictionary
             ],
             options: [.prettyPrinted, .sortedKeys]
@@ -298,6 +300,42 @@ struct QuillCodeDesktopSmokePixelStats {
         guard minBlueAccentPixelRatio <= 0 || report.blueAccentPixelRatio > minBlueAccentPixelRatio else {
             throw QuillCodeDesktopSmokeFailure.imageMissingAccentPixels(report.blueAccentPixelRatio)
         }
+    }
+}
+
+struct QuillCodeDesktopBrowserWorkflowSmokeReport {
+    var previewPath: String
+    var url: String
+    var typedSelector: String
+    var typedText: String
+    var clickedSelector: String
+    var typeToolName: String
+    var clickToolName: String
+    var scriptToolName: String
+    var inspectToolName: String
+    var scriptValue: String
+    var inspectionDepth: String
+    var sourceLabel: String
+    var outline: [String]
+    var textSnippet: String
+
+    var dictionary: [String: Any] {
+        [
+            "previewPath": previewPath,
+            "url": url,
+            "typedSelector": typedSelector,
+            "typedText": typedText,
+            "clickedSelector": clickedSelector,
+            "typeToolName": typeToolName,
+            "clickToolName": clickToolName,
+            "scriptToolName": scriptToolName,
+            "inspectToolName": inspectToolName,
+            "scriptValue": scriptValue,
+            "inspectionDepth": inspectionDepth,
+            "sourceLabel": sourceLabel,
+            "outline": outline,
+            "textSnippet": textSnippet
+        ]
     }
 }
 

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -72,6 +72,10 @@
   Drive/Sheets, Mailchimp, Notion, Asana, Jira/Confluence, Zendesk, Concur, Google Ads, LinkedIn
   Campaign Manager, and Google Analytics, while actionful catalog workflows stay with the model loop
   so they can continue through browser/Computer Use instead of stopping after a single open.
+  Deterministic native desktop smoke now also records `browserWorkflowSmoke` evidence for a SaaS-like
+  CRM page by routing `host.browser.type`, `host.browser.click`, `host.browser.script`, and
+  `host.browser.inspect` through the visible browser-session override and proving the typed/saved
+  state survives into a live-DOM inspection report.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -61,6 +61,23 @@ The next immediate-action gap is browser/SaaS coworker work:
   page-open action. Follow-up slices should add focused browser/Computer Use smoke cases for logged-in
   SaaS interaction and only then graduate spreadsheet rows to covered.
 
+## Browser Workflow Smoke Slice
+
+The native desktop smoke now leaves deterministic browser-workflow evidence for a SaaS-like page:
+
+- `browserSmoke` still proves local HTML preview, browser comments, and `host.browser.inspect`
+  final-answer rendering.
+- `browserWorkflowSmoke` now opens a mock CRM page through the visible browser-session path, dispatches
+  `host.browser.type`, `host.browser.click`, `host.browser.script`, and `host.browser.inspect`, and
+  records the typed status, clicked save selector, script value, live-DOM inspection depth, outline,
+  and text snippet in the smoke report.
+- The smoke presenter only exposes a visible session after `openBrowserSession()`, so ordinary preview
+  inspection still exercises the snapshot fallback path and the workflow smoke exercises the explicit
+  visible-session path.
+- This upgrades browser/SaaS evidence from first-open routing to stateful browser action routing. Keep
+  real SaaS rows gated until a signed-in packaged-app smoke proves equivalent interaction on a live
+  SaaS surface.
+
 ## Scheduling Coworker Slice
 
 Plain recurring coworker prompts now create real workspace automations without requiring slash syntax:

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -157,6 +157,11 @@ if ! grep -q '"browserSmoke"' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q '"browserWorkflowSmoke"' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not report browser workflow smoke evidence" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 python3 - "$REPORT_PATH" <<'PY'
 import json
 import math
@@ -222,6 +227,40 @@ for field in ("textSnippet", "finalAnswer"):
         fail(f"browser smoke {field} did not include rendered page text: {value!r}")
 if "Check the smoke hero" not in browser_smoke.get("finalAnswer", ""):
     fail("browser smoke final answer did not include the browser comment")
+
+browser_workflow_smoke = report.get("browserWorkflowSmoke")
+if not isinstance(browser_workflow_smoke, dict):
+    fail("did not include browser workflow smoke evidence")
+
+expected_browser_workflow_fields = {
+    "typeToolName": "host.browser.type",
+    "clickToolName": "host.browser.click",
+    "scriptToolName": "host.browser.script",
+    "inspectToolName": "host.browser.inspect",
+    "typedSelector": "input[name='status']",
+    "clickedSelector": "button[data-action='save']",
+    "typedText": "Qualified",
+    "inspectionDepth": "Live DOM snapshot",
+    "sourceLabel": "Local HTML",
+}
+for field, expected in expected_browser_workflow_fields.items():
+    if browser_workflow_smoke.get(field) != expected:
+        fail(
+            "browser workflow smoke field "
+            f"{field} was {browser_workflow_smoke.get(field)!r}, expected {expected!r}"
+        )
+
+workflow_outline = browser_workflow_smoke.get("outline")
+if not isinstance(workflow_outline, list) or "H1: CRM Workflow Smoke" not in workflow_outline:
+    fail(f"browser workflow outline did not include the CRM heading: {workflow_outline}")
+for field in ("scriptValue", "textSnippet"):
+    value = browser_workflow_smoke.get(field)
+    if not isinstance(value, str) or "Qualified" not in value:
+        fail(f"browser workflow {field} did not include the typed status: {value!r}")
+if "saved=true" not in browser_workflow_smoke.get("scriptValue", ""):
+    fail("browser workflow script value did not include saved=true after click")
+if "Saved" not in browser_workflow_smoke.get("textSnippet", ""):
+    fail("browser workflow text snippet did not include Saved after click")
 
 
 native_targets = report.get("nativeHitTargets")


### PR DESCRIPTION
## Summary
- add native desktop smoke evidence for a SaaS-like browser workflow using the visible browser-session tool override
- route host.browser.type, host.browser.click, host.browser.script, and host.browser.inspect in the smoke and persist typed/saved state into browserWorkflowSmoke
- label visible local file inspections as Local HTML and document the improved coworker tracker boundary

## Validation
- swift build --product quill-code-desktop
- swift test --filter QuillCodeDesktopControllerSmokeTests/testDesktopAgentBrowser
- swift test --filter QuillCodeDesktopRenderedSmokeTests
- git diff --check
- scripts/native-desktop-smoke.sh