### PR TITLE
Add spreadsheet browser workflow smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -91,6 +91,10 @@ enum QuillCodeDesktopSmokeRunner {
 
         let browserSmoke = try await runBrowserSmoke(controller: controller, root: root)
         let browserWorkflowSmoke = try await runBrowserWorkflowSmoke(controller: controller, root: root)
+        let browserSpreadsheetWorkflowSmoke = try await runBrowserSpreadsheetWorkflowSmoke(
+            controller: controller,
+            root: root
+        )
         let surface = controller.surface
         let nativeHitTargets = try QuillCodeDesktopNativeHitTargetSmoke.validatedReport(for: surface)
         guard surface.transcript.messages.count >= 4,
@@ -178,6 +182,7 @@ enum QuillCodeDesktopSmokeRunner {
             chrome: chrome,
             browserSmoke: browserSmoke,
             browserWorkflowSmoke: browserWorkflowSmoke,
+            browserSpreadsheetWorkflowSmoke: browserSpreadsheetWorkflowSmoke,
             nativeHitTargets: nativeHitTargets
         )
     }
@@ -365,6 +370,125 @@ enum QuillCodeDesktopSmokeRunner {
         )
     }
 
+    private static func runBrowserSpreadsheetWorkflowSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopBrowserWorkflowSmokeReport {
+        let previewFile = root.workspace.appendingPathComponent("browser-sheet-smoke.html")
+        try """
+        <!doctype html>
+        <html>
+          <head><title>Shared Sheet Workflow Smoke</title></head>
+          <body>
+            <main>
+              <h1>Shared Sheet Workflow Smoke</h1>
+              <table aria-label="Launch tracker">
+                <tr>
+                  <th>Item</th>
+                  <th>Date</th>
+                  <th>Status</th>
+                </tr>
+                <tr>
+                  <td>Launch checklist</td>
+                  <td><input data-cell="launch-date" value="TBD"></td>
+                  <td><button data-action="mark-done">Mark done</button></td>
+                </tr>
+              </table>
+              <p data-testid="row-state">Launch checklist: TBD; done=false</p>
+            </main>
+          </body>
+        </html>
+        """.write(to: previewFile, atomically: true, encoding: .utf8)
+
+        controller.browserAddressDraft = "browser-sheet-smoke.html"
+        controller.openBrowserPreview()
+        controller.openBrowserSession()
+
+        let override = try requiredBrowserToolOverride(controller)
+        let workspace = root.workspace
+        let typeTool = try requiredToolResult(
+            await override(
+                ToolCall(
+                    name: ToolDefinition.browserType.name,
+                    argumentsJSON: ToolArguments.json([
+                        "selector": "[data-cell='launch-date']",
+                        "text": "2026-09-15",
+                        "submit": false
+                    ])
+                ),
+                workspace
+            ),
+            toolName: ToolDefinition.browserType.name
+        )
+        let clickTool = try requiredToolResult(
+            await override(
+                ToolCall(
+                    name: ToolDefinition.browserClick.name,
+                    argumentsJSON: ToolArguments.json(["selector": "button[data-action='mark-done']"])
+                ),
+                workspace
+            ),
+            toolName: ToolDefinition.browserClick.name
+        )
+        let scriptTool = try requiredToolResult(
+            await override(
+                ToolCall(
+                    name: ToolDefinition.browserScript.name,
+                    argumentsJSON: ToolArguments.json([
+                        "source": "document.querySelector('[data-testid=\"row-state\"]').textContent"
+                    ])
+                ),
+                workspace
+            ),
+            toolName: ToolDefinition.browserScript.name
+        )
+        let inspectTool = try requiredToolResult(
+            await override(
+                ToolCall(name: ToolDefinition.browserInspect.name, argumentsJSON: "{}"),
+                workspace
+            ),
+            toolName: ToolDefinition.browserInspect.name
+        )
+
+        let typeOutput = try decodeSmokeOutput(BrowserActionToolOutput.self, from: typeTool)
+        let clickOutput = try decodeSmokeOutput(BrowserActionToolOutput.self, from: clickTool)
+        let scriptOutput = try decodeSmokeOutput(BrowserScriptToolOutput.self, from: scriptTool)
+        let inspectOutput = try decodeSmokeOutput(BrowserInspectionToolOutput.self, from: inspectTool)
+
+        guard typeOutput.selector == "[data-cell='launch-date']",
+              typeOutput.action == "type",
+              clickOutput.selector == "button[data-action='mark-done']",
+              clickOutput.action == "click",
+              scriptOutput.value.contains("2026-09-15"),
+              scriptOutput.value.contains("done=true"),
+              inspectOutput.inspectionDepth == .liveDOMSnapshot,
+              inspectOutput.outline.contains("H1: Shared Sheet Workflow Smoke"),
+              inspectOutput.textSnippet?.contains("2026-09-15") == true,
+              inspectOutput.textSnippet?.contains("Done") == true
+        else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed(
+                "browser spreadsheet workflow smoke did not preserve edited row state"
+            )
+        }
+
+        return QuillCodeDesktopBrowserWorkflowSmokeReport(
+            previewPath: previewFile.path,
+            url: inspectOutput.url,
+            typedSelector: typeOutput.selector,
+            typedText: "2026-09-15",
+            clickedSelector: clickOutput.selector,
+            typeToolName: ToolDefinition.browserType.name,
+            clickToolName: ToolDefinition.browserClick.name,
+            scriptToolName: ToolDefinition.browserScript.name,
+            inspectToolName: ToolDefinition.browserInspect.name,
+            scriptValue: scriptOutput.value,
+            inspectionDepth: inspectOutput.inspectionDepth.label,
+            sourceLabel: inspectOutput.sourceLabel,
+            outline: inspectOutput.outline,
+            textSnippet: inspectOutput.textSnippet ?? ""
+        )
+    }
+
     private static func requiredBrowserToolOverride(
         _ controller: QuillCodeDesktopController
     ) throws -> AgentToolExecutionOverride {
@@ -479,6 +603,8 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
     private var isSessionOpen = false
     private var typedStatus = "Open"
     private var didSave = false
+    private var typedLaunchDate = "TBD"
+    private var didMarkDone = false
 
     func presentSession(_ snapshot: BrowserSessionSyncSnapshot) {
         isSessionOpen = true
@@ -499,9 +625,9 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
         guard let selectedTab else { throw DesktopBrowserSessionScriptError.noSelectedTab }
         emitSnapshotUpdate(for: selectedTab)
         return DesktopBrowserSessionScriptResult(
-            title: "CRM Workflow Smoke",
+            title: page(for: selectedTab).title,
             url: selectedTab.url,
-            valueDescription: statusText
+            valueDescription: scriptValue(for: selectedTab)
         )
     }
 
@@ -512,7 +638,7 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
             tabs: [
                 BrowserSessionTabUpdate(
                     id: selectedTab.id,
-                    title: "CRM Workflow Smoke",
+                    title: page(for: selectedTab).title,
                     url: selectedTab.url,
                     isActive: true,
                     liveDOMSnapshot: snapshot
@@ -527,10 +653,18 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
         let trimmedSelector = selector.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSelector.isEmpty else { throw DesktopBrowserSessionActionError.emptySelector }
         guard let selectedTab else { throw DesktopBrowserSessionActionError.noSelectedTab }
-        guard trimmedSelector == "button[data-action='save']" else {
-            throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+        switch page(for: selectedTab) {
+        case .crm:
+            guard trimmedSelector == "button[data-action='save']" else {
+                throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+            }
+            didSave = true
+        case .spreadsheet:
+            guard trimmedSelector == "button[data-action='mark-done']" else {
+                throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+            }
+            didMarkDone = true
         }
-        didSave = true
         emitSnapshotUpdate(for: selectedTab)
         return DesktopBrowserSessionActionResult(ok: true, summary: "Clicked \(trimmedSelector)", error: nil)
     }
@@ -540,10 +674,18 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
         guard !trimmedSelector.isEmpty else { throw DesktopBrowserSessionActionError.emptySelector }
         guard !text.isEmpty else { throw DesktopBrowserSessionActionError.emptyText }
         guard let selectedTab else { throw DesktopBrowserSessionActionError.noSelectedTab }
-        guard trimmedSelector == "input[name='status']" else {
-            throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+        switch page(for: selectedTab) {
+        case .crm:
+            guard trimmedSelector == "input[name='status']" else {
+                throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+            }
+            typedStatus = text
+        case .spreadsheet:
+            guard trimmedSelector == "[data-cell='launch-date']" else {
+                throw DesktopBrowserSessionActionError.actionFailed("Smoke page has no element for \(trimmedSelector)")
+            }
+            typedLaunchDate = text
         }
-        typedStatus = text
         emitSnapshotUpdate(for: selectedTab)
         return DesktopBrowserSessionActionResult(ok: true, summary: "Typed into \(trimmedSelector)", error: nil)
     }
@@ -554,21 +696,79 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
         "Status: \(typedStatus); saved=\(didSave)"
     }
 
+    private var rowStateText: String {
+        "Launch checklist: \(typedLaunchDate); done=\(didMarkDone)"
+    }
+
+    private func scriptValue(for tab: BrowserSessionTabSnapshot) -> String {
+        switch page(for: tab) {
+        case .crm:
+            return statusText
+        case .spreadsheet:
+            return rowStateText
+        }
+    }
+
     private func liveDOMSnapshot(for tab: BrowserSessionTabSnapshot) -> BrowserLiveDOMSnapshot {
-        BrowserLiveDOMSnapshot(
-            finalURL: tab.url,
-            title: "CRM Workflow Smoke",
-            visibleText: "CRM Workflow Smoke Status \(typedStatus) \(didSave ? "Saved" : "Unsaved")",
-            outline: ["H1: CRM Workflow Smoke", "Button: Save", "Field: Status"],
-            html: """
-            <!doctype html><title>CRM Workflow Smoke</title>
-            <h1>CRM Workflow Smoke</h1>
-            <input name="status" value="\(typedStatus)">
-            <button data-action="save">Save</button>
-            <p data-testid="status">\(statusText)</p>
-            """,
-            viewportDescription: "1120x760 smoke browser"
-        )
+        switch page(for: tab) {
+        case .crm:
+            return BrowserLiveDOMSnapshot(
+                finalURL: tab.url,
+                title: "CRM Workflow Smoke",
+                visibleText: "CRM Workflow Smoke Status \(typedStatus) \(didSave ? "Saved" : "Unsaved")",
+                outline: ["H1: CRM Workflow Smoke", "Button: Save", "Field: Status"],
+                html: """
+                <!doctype html><title>CRM Workflow Smoke</title>
+                <h1>CRM Workflow Smoke</h1>
+                <input name="status" value="\(typedStatus)">
+                <button data-action="save">Save</button>
+                <p data-testid="status">\(statusText)</p>
+                """,
+                viewportDescription: "1120x760 smoke browser"
+            )
+        case .spreadsheet:
+            return BrowserLiveDOMSnapshot(
+                finalURL: tab.url,
+                title: "Shared Sheet Workflow Smoke",
+                visibleText: """
+                Shared Sheet Workflow Smoke Launch checklist \(typedLaunchDate) \(didMarkDone ? "Done" : "Open")
+                """,
+                outline: [
+                    "H1: Shared Sheet Workflow Smoke",
+                    "Table: Launch tracker",
+                    "Field: Launch date",
+                    "Button: Mark done"
+                ],
+                html: """
+                <!doctype html><title>Shared Sheet Workflow Smoke</title>
+                <h1>Shared Sheet Workflow Smoke</h1>
+                <table aria-label="Launch tracker">
+                  <tr><td>Launch checklist</td><td><input data-cell="launch-date" value="\(typedLaunchDate)"></td></tr>
+                </table>
+                <button data-action="mark-done">Mark done</button>
+                <p data-testid="row-state">\(rowStateText)</p>
+                """,
+                viewportDescription: "1120x760 smoke browser"
+            )
+        }
+    }
+
+    private func page(for tab: BrowserSessionTabSnapshot) -> SmokeBrowserPage {
+        tab.url.absoluteString.contains("browser-sheet-smoke.html") ? .spreadsheet : .crm
+    }
+
+    private enum SmokeBrowserPage {
+        case crm
+        case spreadsheet
+
+        var title: String {
+            switch self {
+            case .crm:
+                return "CRM Workflow Smoke"
+            case .spreadsheet:
+                return "Shared Sheet Workflow Smoke"
+            }
+        }
     }
 
     private func emitSnapshotUpdate(for tab: BrowserSessionTabSnapshot) {
@@ -576,7 +776,7 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
             tabs: [
                 BrowserSessionTabUpdate(
                     id: tab.id,
-                    title: "CRM Workflow Smoke",
+                    title: page(for: tab).title,
                     url: tab.url,
                     isActive: true,
                     liveDOMSnapshot: liveDOMSnapshot(for: tab)

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -161,6 +161,7 @@ struct QuillCodeDesktopSmokeReport {
     var chrome: QuillCodeDesktopChromeSmokeReport
     var browserSmoke: QuillCodeDesktopBrowserSmokeReport
     var browserWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
+    var browserSpreadsheetWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
     var nativeHitTargets: QuillCodeNativeHitTargetAuditReport
 
     func prettyJSON() throws -> Data {
@@ -189,6 +190,7 @@ struct QuillCodeDesktopSmokeReport {
                 "chrome": chrome.dictionary,
                 "browserSmoke": browserSmoke.dictionary,
                 "browserWorkflowSmoke": browserWorkflowSmoke.dictionary,
+                "browserSpreadsheetWorkflowSmoke": browserSpreadsheetWorkflowSmoke.dictionary,
                 "nativeHitTargets": nativeHitTargets.dictionary
             ],
             options: [.prettyPrinted, .sortedKeys]

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -72,10 +72,11 @@
   Drive/Sheets, Mailchimp, Notion, Asana, Jira/Confluence, Zendesk, Concur, Google Ads, LinkedIn
   Campaign Manager, and Google Analytics, while actionful catalog workflows stay with the model loop
   so they can continue through browser/Computer Use instead of stopping after a single open.
-  Deterministic native desktop smoke now also records `browserWorkflowSmoke` evidence for a SaaS-like
-  CRM page by routing `host.browser.type`, `host.browser.click`, `host.browser.script`, and
-  `host.browser.inspect` through the visible browser-session override and proving the typed/saved
-  state survives into a live-DOM inspection report.
+  Deterministic native desktop smoke now also records `browserWorkflowSmoke` and
+  `browserSpreadsheetWorkflowSmoke` evidence for SaaS-like CRM and shared-sheet pages by routing
+  `host.browser.type`, `host.browser.click`, `host.browser.script`, and `host.browser.inspect`
+  through the visible browser-session override and proving typed/saved row state survives into a
+  live-DOM inspection report.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -67,16 +67,20 @@ The native desktop smoke now leaves deterministic browser-workflow evidence for 
 
 - `browserSmoke` still proves local HTML preview, browser comments, and `host.browser.inspect`
   final-answer rendering.
-- `browserWorkflowSmoke` now opens a mock CRM page through the visible browser-session path, dispatches
+- `browserWorkflowSmoke` opens a mock CRM page through the visible browser-session path, dispatches
   `host.browser.type`, `host.browser.click`, `host.browser.script`, and `host.browser.inspect`, and
   records the typed status, clicked save selector, script value, live-DOM inspection depth, outline,
   and text snippet in the smoke report.
+- `browserSpreadsheetWorkflowSmoke` repeats the same real browser-tool override path on a
+  spreadsheet-like launch tracker: it types a launch date into a cell-style input, clicks Mark done,
+  and proves the edited row state survives through script output and live DOM inspection. This maps
+  more directly to shared-sheet cleanup and tracker-maintenance coworker tasks.
 - The smoke presenter only exposes a visible session after `openBrowserSession()`, so ordinary preview
   inspection still exercises the snapshot fallback path and the workflow smoke exercises the explicit
   visible-session path.
-- This upgrades browser/SaaS evidence from first-open routing to stateful browser action routing. Keep
-  real SaaS rows gated until a signed-in packaged-app smoke proves equivalent interaction on a live
-  SaaS surface.
+- This upgrades browser/SaaS evidence from first-open routing to stateful browser action routing across
+  CRM-like and shared-sheet-like page shapes. Keep real SaaS rows gated until a signed-in packaged-app
+  smoke proves equivalent interaction on a live SaaS surface.
 
 ## Scheduling Coworker Slice
 

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -162,6 +162,11 @@ if ! grep -q '"browserWorkflowSmoke"' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q '"browserSpreadsheetWorkflowSmoke"' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not report browser spreadsheet workflow smoke evidence" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 python3 - "$REPORT_PATH" <<'PY'
 import json
 import math
@@ -228,39 +233,68 @@ for field in ("textSnippet", "finalAnswer"):
 if "Check the smoke hero" not in browser_smoke.get("finalAnswer", ""):
     fail("browser smoke final answer did not include the browser comment")
 
-browser_workflow_smoke = report.get("browserWorkflowSmoke")
-if not isinstance(browser_workflow_smoke, dict):
-    fail("did not include browser workflow smoke evidence")
+def require_browser_workflow_smoke(
+    key,
+    typed_selector,
+    typed_text,
+    clicked_selector,
+    heading,
+    script_state,
+    text_state,
+):
+    browser_workflow_smoke = report.get(key)
+    if not isinstance(browser_workflow_smoke, dict):
+        fail(f"did not include {key} evidence")
 
-expected_browser_workflow_fields = {
-    "typeToolName": "host.browser.type",
-    "clickToolName": "host.browser.click",
-    "scriptToolName": "host.browser.script",
-    "inspectToolName": "host.browser.inspect",
-    "typedSelector": "input[name='status']",
-    "clickedSelector": "button[data-action='save']",
-    "typedText": "Qualified",
-    "inspectionDepth": "Live DOM snapshot",
-    "sourceLabel": "Local HTML",
-}
-for field, expected in expected_browser_workflow_fields.items():
-    if browser_workflow_smoke.get(field) != expected:
-        fail(
-            "browser workflow smoke field "
-            f"{field} was {browser_workflow_smoke.get(field)!r}, expected {expected!r}"
-        )
+    expected_browser_workflow_fields = {
+        "typeToolName": "host.browser.type",
+        "clickToolName": "host.browser.click",
+        "scriptToolName": "host.browser.script",
+        "inspectToolName": "host.browser.inspect",
+        "typedSelector": typed_selector,
+        "clickedSelector": clicked_selector,
+        "typedText": typed_text,
+        "inspectionDepth": "Live DOM snapshot",
+        "sourceLabel": "Local HTML",
+    }
+    for field, expected in expected_browser_workflow_fields.items():
+        if browser_workflow_smoke.get(field) != expected:
+            fail(
+                f"{key} field "
+                f"{field} was {browser_workflow_smoke.get(field)!r}, expected {expected!r}"
+            )
 
-workflow_outline = browser_workflow_smoke.get("outline")
-if not isinstance(workflow_outline, list) or "H1: CRM Workflow Smoke" not in workflow_outline:
-    fail(f"browser workflow outline did not include the CRM heading: {workflow_outline}")
-for field in ("scriptValue", "textSnippet"):
-    value = browser_workflow_smoke.get(field)
-    if not isinstance(value, str) or "Qualified" not in value:
-        fail(f"browser workflow {field} did not include the typed status: {value!r}")
-if "saved=true" not in browser_workflow_smoke.get("scriptValue", ""):
-    fail("browser workflow script value did not include saved=true after click")
-if "Saved" not in browser_workflow_smoke.get("textSnippet", ""):
-    fail("browser workflow text snippet did not include Saved after click")
+    workflow_outline = browser_workflow_smoke.get("outline")
+    if not isinstance(workflow_outline, list) or heading not in workflow_outline:
+        fail(f"{key} outline did not include {heading!r}: {workflow_outline}")
+    for field in ("scriptValue", "textSnippet"):
+        value = browser_workflow_smoke.get(field)
+        if not isinstance(value, str) or typed_text not in value:
+            fail(f"{key} {field} did not include the typed value: {value!r}")
+    if script_state not in browser_workflow_smoke.get("scriptValue", ""):
+        fail(f"{key} script value did not include {script_state} after click")
+    if text_state not in browser_workflow_smoke.get("textSnippet", ""):
+        fail(f"{key} text snippet did not include {text_state} after click")
+
+
+require_browser_workflow_smoke(
+    key="browserWorkflowSmoke",
+    typed_selector="input[name='status']",
+    typed_text="Qualified",
+    clicked_selector="button[data-action='save']",
+    heading="H1: CRM Workflow Smoke",
+    script_state="saved=true",
+    text_state="Saved",
+)
+require_browser_workflow_smoke(
+    key="browserSpreadsheetWorkflowSmoke",
+    typed_selector="[data-cell='launch-date']",
+    typed_text="2026-09-15",
+    clicked_selector="button[data-action='mark-done']",
+    heading="H1: Shared Sheet Workflow Smoke",
+    script_state="done=true",
+    text_state="Done",
+)
 
 
 native_targets = report.get("nativeHitTargets")


### PR DESCRIPTION
## Summary
- add browserSpreadsheetWorkflowSmoke to the native desktop smoke report
- exercise the real visible-browser type/click/script/inspect override path on a spreadsheet-like launch tracker page
- update the native smoke validator and coworker/parity docs with the new evidence boundary

## Validation
- swift build --product quill-code-desktop
- swift test --filter QuillCodeDesktopControllerSmokeTests/testDesktopAgentBrowser
- git diff --check
- scripts/native-desktop-smoke.sh