### PR TITLE
Prove scheduled coworker native smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -37,12 +37,13 @@ enum QuillCodeDesktopSmokeRunner {
             environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
         )
         let bootstrap = QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory)
+        let automationNotifier = SmokeAutomationNotifier()
         let controller = QuillCodeDesktopController(
             bootstrap: bootstrap,
             browserPageFetcher: URLSessionBrowserPageFetcher(),
             browserLiveDOMCapturer: nil,
             browserSessionPresenter: SmokeBrowserSessionPresenter(),
-            automationNotifier: SmokeAutomationNotifier(),
+            automationNotifier: automationNotifier,
             workspaceRoot: root.workspace
         )
 
@@ -158,6 +159,11 @@ enum QuillCodeDesktopSmokeRunner {
         }
         try html.write(to: htmlURL, atomically: true, encoding: .utf8)
 
+        let scheduledCoworkerSmoke = try runScheduledCoworkerSmoke(
+            controller: controller,
+            notifier: automationNotifier
+        )
+
         return QuillCodeDesktopSmokeReport(
             ok: true,
             prompt: writePrompt,
@@ -183,6 +189,7 @@ enum QuillCodeDesktopSmokeRunner {
             browserSmoke: browserSmoke,
             browserWorkflowSmoke: browserWorkflowSmoke,
             browserSpreadsheetWorkflowSmoke: browserSpreadsheetWorkflowSmoke,
+            scheduledCoworkerSmoke: scheduledCoworkerSmoke,
             nativeHitTargets: nativeHitTargets
         )
     }
@@ -489,6 +496,97 @@ enum QuillCodeDesktopSmokeRunner {
         )
     }
 
+    private static func runScheduledCoworkerSmoke(
+        controller: QuillCodeDesktopController,
+        notifier: SmokeAutomationNotifier
+    ) throws -> QuillCodeDesktopScheduledCoworkerSmokeReport {
+        guard let project = controller.model.selectedProject else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed("scheduled coworker smoke missing selected project")
+        }
+
+        let taskText = "check competitor pricing pages and notify me with a diff"
+        let scheduleDescription = "Every Monday at 8:00 AM"
+        let runAt = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970))
+        let recurrence = QuillAutomationRecurrence(
+            interval: 1,
+            unit: .weeks,
+            weekdays: [2],
+            hour: 8,
+            minute: 0
+        )
+        let automation = QuillAutomation(
+            title: "Scheduled task: check competitor pricing pages and notify me with a diff",
+            detail: taskText,
+            kind: .workspaceSchedule,
+            scheduleKind: .cron,
+            scheduleDescription: scheduleDescription,
+            projectID: project.id,
+            createdAt: runAt.addingTimeInterval(-3_600),
+            updatedAt: runAt.addingTimeInterval(-3_600),
+            nextRunAt: runAt.addingTimeInterval(-10),
+            recurrence: recurrence
+        )
+
+        let startingNotificationCount = notifier.automationReports.count
+        controller.model.setAutomations([automation])
+        controller.automationCoordinator.runDueAutomations(
+            model: controller.model,
+            notifier: notifier,
+            refresh: { controller.refresh() }
+        )
+
+        let deliveredReports = Array(notifier.automationReports.dropFirst(startingNotificationCount))
+        guard deliveredReports.count == 1, let report = deliveredReports.first else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed(
+                "scheduled coworker smoke did not deliver exactly one automation notification"
+            )
+        }
+        guard report.automationID == automation.id,
+              report.title == "QuillCode scheduled task ready",
+              report.body.contains(taskText)
+        else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed(
+                "scheduled coworker smoke delivered the wrong notification report"
+            )
+        }
+
+        guard let thread = controller.model.root.threads.first(where: { $0.id == report.followUpThreadID }),
+              thread.projectID == project.id,
+              thread.title == "Scheduled check: \(project.name)",
+              thread.messages.first?.content.contains("Run the scheduled coworker task for \(project.name).") == true,
+              thread.messages.first?.content.contains("Task: \(taskText)") == true
+        else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed(
+                "scheduled coworker smoke did not create the expected follow-up thread"
+            )
+        }
+
+        guard let savedAutomation = controller.model.automations.items.first(where: { $0.id == automation.id }),
+              savedAutomation.lastRunAt != nil,
+              savedAutomation.nextRunAt != nil,
+              savedAutomation.nextRunAt != automation.nextRunAt,
+              controller.surface.automations.isVisible
+        else {
+            throw QuillCodeDesktopSmokeFailure.browserSmokeFailed(
+                "scheduled coworker smoke did not persist run state and reveal automation history"
+            )
+        }
+
+        return QuillCodeDesktopScheduledCoworkerSmokeReport(
+            automationTitle: savedAutomation.title,
+            taskText: taskText,
+            scheduleDescription: savedAutomation.scheduleDescription,
+            reportTitle: report.title,
+            reportBody: report.body,
+            notificationCount: deliveredReports.count,
+            followUpThreadTitle: thread.title,
+            followUpPrompt: thread.messages.first?.content ?? "",
+            automationsVisible: controller.surface.automations.isVisible,
+            lastRunRecorded: savedAutomation.lastRunAt != nil,
+            nextRunRecorded: savedAutomation.nextRunAt != nil
+        )
+    }
+
     private static func requiredBrowserToolOverride(
         _ controller: QuillCodeDesktopController
     ) throws -> AgentToolExecutionOverride {
@@ -787,6 +885,19 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
     }
 }
 
-private struct SmokeAutomationNotifier: QuillCodeAutomationNotifying {
-    func deliver(_ report: AutomationRunReport) {}
+private final class SmokeAutomationNotifier: QuillCodeAutomationNotifying, @unchecked Sendable {
+    private let lock = NSLock()
+    private var deliveredAutomationReports: [AutomationRunReport] = []
+
+    var automationReports: [AutomationRunReport] {
+        lock.lock()
+        defer { lock.unlock() }
+        return deliveredAutomationReports
+    }
+
+    func deliver(_ report: AutomationRunReport) {
+        lock.lock()
+        deliveredAutomationReports.append(report)
+        lock.unlock()
+    }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -162,6 +162,7 @@ struct QuillCodeDesktopSmokeReport {
     var browserSmoke: QuillCodeDesktopBrowserSmokeReport
     var browserWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
     var browserSpreadsheetWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
+    var scheduledCoworkerSmoke: QuillCodeDesktopScheduledCoworkerSmokeReport
     var nativeHitTargets: QuillCodeNativeHitTargetAuditReport
 
     func prettyJSON() throws -> Data {
@@ -191,6 +192,7 @@ struct QuillCodeDesktopSmokeReport {
                 "browserSmoke": browserSmoke.dictionary,
                 "browserWorkflowSmoke": browserWorkflowSmoke.dictionary,
                 "browserSpreadsheetWorkflowSmoke": browserSpreadsheetWorkflowSmoke.dictionary,
+                "scheduledCoworkerSmoke": scheduledCoworkerSmoke.dictionary,
                 "nativeHitTargets": nativeHitTargets.dictionary
             ],
             options: [.prettyPrinted, .sortedKeys]
@@ -337,6 +339,36 @@ struct QuillCodeDesktopBrowserWorkflowSmokeReport {
             "sourceLabel": sourceLabel,
             "outline": outline,
             "textSnippet": textSnippet
+        ]
+    }
+}
+
+struct QuillCodeDesktopScheduledCoworkerSmokeReport {
+    var automationTitle: String
+    var taskText: String
+    var scheduleDescription: String
+    var reportTitle: String
+    var reportBody: String
+    var notificationCount: Int
+    var followUpThreadTitle: String
+    var followUpPrompt: String
+    var automationsVisible: Bool
+    var lastRunRecorded: Bool
+    var nextRunRecorded: Bool
+
+    var dictionary: [String: Any] {
+        [
+            "automationTitle": automationTitle,
+            "taskText": taskText,
+            "scheduleDescription": scheduleDescription,
+            "reportTitle": reportTitle,
+            "reportBody": reportBody,
+            "notificationCount": notificationCount,
+            "followUpThreadTitle": followUpThreadTitle,
+            "followUpPrompt": followUpPrompt,
+            "automationsVisible": automationsVisible,
+            "lastRunRecorded": lastRunRecorded,
+            "nextRunRecorded": nextRunRecorded
         ]
     }
 }

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -76,7 +76,9 @@
   `browserSpreadsheetWorkflowSmoke` evidence for SaaS-like CRM and shared-sheet pages by routing
   `host.browser.type`, `host.browser.click`, `host.browser.script`, and `host.browser.inspect`
   through the visible browser-session override and proving typed/saved row state survives into a
-  live-DOM inspection report.
+  live-DOM inspection report. Native desktop smoke also records `scheduledCoworkerSmoke`, proving a
+  due recurring coworker automation creates the task-specific scheduled thread, records recurrence
+  run state, reveals the automation surface, and reaches the desktop automation notifier.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -108,6 +108,10 @@ Scheduled coworker due-runs now carry task-specific notification evidence:
   recurring coworker task produced the follow-up thread.
 - Tests cover the app-level due-run report and the desktop automation coordinator delivering that
   report through the notifier when automation notifications are enabled.
+- The native desktop smoke now records `scheduledCoworkerSmoke`, installing a due recurring coworker
+  automation, running it through `QuillCodeDesktopAutomationCoordinator`, verifying the follow-up
+  scheduled thread contains the original task, checking recurrence run state, and confirming the
+  desktop automation notifier receives exactly one task-specific report.
 
-The remaining scheduling evidence gap is packaged-app smoke that observes the native notification and
-visible automation management surface together.
+The remaining scheduling evidence gap is packaged-app smoke that observes the real OS notification
+banner/action and visible automation management surface together.

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -167,6 +167,11 @@ if ! grep -q '"browserSpreadsheetWorkflowSmoke"' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q '"scheduledCoworkerSmoke"' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not report scheduled coworker smoke evidence" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 python3 - "$REPORT_PATH" <<'PY'
 import json
 import math
@@ -295,6 +300,44 @@ require_browser_workflow_smoke(
     script_state="done=true",
     text_state="Done",
 )
+
+scheduled_coworker_smoke = report.get("scheduledCoworkerSmoke")
+if not isinstance(scheduled_coworker_smoke, dict):
+    fail("did not include scheduled coworker smoke evidence")
+
+expected_scheduled_coworker_fields = {
+    "automationTitle": "Scheduled task: check competitor pricing pages and notify me with a diff",
+    "taskText": "check competitor pricing pages and notify me with a diff",
+    "scheduleDescription": "Every Monday at 8:00 AM",
+    "reportTitle": "QuillCode scheduled task ready",
+    "notificationCount": 1,
+    "automationsVisible": True,
+    "lastRunRecorded": True,
+    "nextRunRecorded": True,
+}
+for field, expected in expected_scheduled_coworker_fields.items():
+    if scheduled_coworker_smoke.get(field) != expected:
+        fail(
+            "scheduled coworker smoke field "
+            f"{field} was {scheduled_coworker_smoke.get(field)!r}, expected {expected!r}"
+        )
+
+scheduled_report_body = scheduled_coworker_smoke.get("reportBody")
+if not isinstance(scheduled_report_body, str) or "check competitor pricing pages" not in scheduled_report_body:
+    fail(f"scheduled coworker report body did not identify the original task: {scheduled_report_body!r}")
+scheduled_thread_title = scheduled_coworker_smoke.get("followUpThreadTitle")
+if not isinstance(scheduled_thread_title, str) or not scheduled_thread_title.startswith("Scheduled check: "):
+    fail(f"scheduled coworker follow-up thread title was malformed: {scheduled_thread_title!r}")
+scheduled_prompt = scheduled_coworker_smoke.get("followUpPrompt")
+if not isinstance(scheduled_prompt, str):
+    fail(f"scheduled coworker follow-up prompt was malformed: {scheduled_prompt!r}")
+for expected_snippet in (
+    "Run the scheduled coworker task for ",
+    "Task: check competitor pricing pages and notify me with a diff",
+    "Report what changed, whether action is needed, and the next concrete step.",
+):
+    if expected_snippet not in scheduled_prompt:
+        fail(f"scheduled coworker follow-up prompt missed {expected_snippet!r}: {scheduled_prompt!r}")
 
 
 native_targets = report.get("nativeHitTargets")


### PR DESCRIPTION
## Summary
- add scheduledCoworkerSmoke to the native desktop smoke report
- install a due recurring coworker automation, run it through QuillCodeDesktopAutomationCoordinator, and verify the created scheduled thread, recurrence state, automation visibility, and delivered desktop automation report
- update the native smoke validator plus coworker/parity docs with the new scheduling evidence boundary

## Validation
- swift build --product quill-code-desktop
- swift test --filter WorkspaceAutomationRunIntegrationTests/testDueScheduledCoworkerReportIdentifiesOriginalTask
- swift test --filter DesktopNotificationPolicyTests/testAutomationCoordinatorDeliversScheduledCoworkerReport
- git diff --check
- scripts/native-desktop-smoke.sh