### PR TITLE
Prove packaged scheduled coworker smoke

### DIFF
--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -46,6 +46,11 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(packagedSmoke.contains("window.png"))
         XCTAssertTrue(packagedSmoke.contains("packaged-accessibility-frames.json"))
         XCTAssertTrue(packagedSmoke.contains("accessibility_frames_manifest=packaged-accessibility-frames.json"))
+        XCTAssertTrue(
+            packagedSmoke.contains("SCHEDULED_COWORKER_MANIFEST=\"$SMOKE_ROOT/packaged-scheduled-coworker.json\"")
+        )
+        XCTAssertTrue(packagedSmoke.contains("scheduled_coworker_manifest=packaged-scheduled-coworker.json"))
+        XCTAssertTrue(packagedSmoke.contains(" scheduled-coworker \\"))
         XCTAssertTrue(packagedSmoke.contains(" frames \\"))
         XCTAssertTrue(packagedSmoke.contains("$WINDOW_REPORT_PATH"))
         XCTAssertTrue(packagedSmoke.contains("$WINDOW_SCREENSHOT_PATH"))
@@ -54,6 +59,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         Self.assertSource(packagedSmoke, excludes: "python3 - \"$WINDOW_REPORT_PATH\"")
         XCTAssertTrue(clickProbeValidator.contains(#"def validate_packaged_window_report"#))
         XCTAssertTrue(clickProbeValidator.contains(#"def write_accessibility_frames_manifest"#))
+        XCTAssertTrue(clickProbeValidator.contains(#"write_scheduled_coworker_manifest"#))
         XCTAssertTrue(clickProbeValidator.contains(#"live-accessibility-frame-sampled"#))
         XCTAssertTrue(clickProbeValidator.contains(#"REQUIRED_LIVE_ACCESSIBILITY_CONTRACT_IDS"#))
         XCTAssertTrue(clickProbeValidator.contains(#"windowTitle") == "QuillCode""#))
@@ -66,6 +72,21 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         for actionID in ["review-changes", "run-tests", "explain-project"] {
             Self.assertSource(clickProbeValidator, contains: actionID)
         }
+
+        let scheduledCoworkerValidator = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("scripts/native_click_probe_contracts/scheduled_coworker.py"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(scheduledCoworkerValidator.contains(#""scheduledCoworkerSmoke""#))
+        XCTAssertTrue(
+            scheduledCoworkerValidator.contains(
+                #""Scheduled task: check competitor pricing pages and notify me with a diff""#
+            )
+        )
+        XCTAssertTrue(scheduledCoworkerValidator.contains(#""QuillCode scheduled task ready""#))
+        XCTAssertTrue(scheduledCoworkerValidator.contains(#""Every Monday at 8:00 AM""#))
+        XCTAssertTrue(scheduledCoworkerValidator.contains(#""scheduledCoworkerMatchesDirect": True"#))
     }
 
 }

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -78,7 +78,9 @@
   through the visible browser-session override and proving typed/saved row state survives into a
   live-DOM inspection report. Native desktop smoke also records `scheduledCoworkerSmoke`, proving a
   due recurring coworker automation creates the task-specific scheduled thread, records recurrence
-  run state, reveals the automation surface, and reaches the desktop automation notifier.
+  run state, reveals the automation surface, and reaches the desktop automation notifier. Packaged
+  macOS smoke now preserves `packaged-scheduled-coworker.json`, proving the same scheduled coworker
+  evidence survives both direct packaged executable launch and Launch Services launch.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -115,3 +115,19 @@ Scheduled coworker due-runs now carry task-specific notification evidence:
 
 The remaining scheduling evidence gap is packaged-app smoke that observes the real OS notification
 banner/action and visible automation management surface together.
+
+## Packaged Scheduling Evidence Slice
+
+Packaged macOS smoke now preserves explicit scheduled-coworker release evidence:
+
+- The packaged direct-executable smoke and the Launch Services smoke must both include identical
+  `scheduledCoworkerSmoke` reports.
+- `packaged-scheduled-coworker.json` records the recurring task, schedule, notification report title,
+  one delivered automation report, follow-up scheduled thread evidence, recurrence state, and visible
+  Automations surface.
+- This makes the `.app` packaging boundary fail CI if scheduled coworker automation evidence is lost
+  in either packaged launch path.
+
+The remaining scheduling evidence gap is narrower: observing the real OS notification banner/action
+from the packaged app, rather than only the app-level notification report delivered to the desktop
+notifier boundary.

--- a/scripts/native_click_probe_contracts/cli.py
+++ b/scripts/native_click_probe_contracts/cli.py
@@ -12,6 +12,7 @@ from .packaged_window import (
     write_comparison_manifest,
 )
 from .probe_contracts import validate_report
+from .scheduled_coworker import write_scheduled_coworker_manifest
 
 
 def main() -> None:
@@ -31,6 +32,14 @@ def main() -> None:
     readiness_parser.add_argument("artifact_root", type=Path)
     readiness_parser.add_argument("--manifest", required=True, type=Path)
 
+    scheduled_parser = subparsers.add_parser(
+        "scheduled-coworker",
+        help="write packaged scheduled coworker evidence",
+    )
+    scheduled_parser.add_argument("direct_report", type=Path)
+    scheduled_parser.add_argument("launch_services_report", type=Path)
+    scheduled_parser.add_argument("--manifest", required=True, type=Path)
+
     window_parser = subparsers.add_parser("window", help="validate packaged live-window smoke report and screenshot")
     window_parser.add_argument("report", type=Path)
     window_parser.add_argument("screenshot", type=Path)
@@ -48,6 +57,12 @@ def main() -> None:
         write_comparison_manifest(args.direct_report, args.launch_services_report, args.manifest)
     elif args.command == "readiness":
         write_accessibility_readiness_manifest(args.artifact_root, args.manifest)
+    elif args.command == "scheduled-coworker":
+        write_scheduled_coworker_manifest(
+            args.direct_report,
+            args.launch_services_report,
+            args.manifest,
+        )
     elif args.command == "window":
         validate_packaged_window_report(args.report, args.screenshot)
     elif args.command == "frames":

--- a/scripts/native_click_probe_contracts/scheduled_coworker.py
+++ b/scripts/native_click_probe_contracts/scheduled_coworker.py
@@ -1,0 +1,100 @@
+"""Validate packaged scheduled-coworker smoke evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .json_io import load_report, require
+
+EXPECTED_SCHEDULED_COWORKER = {
+    "automationTitle": "Scheduled task: check competitor pricing pages and notify me with a diff",
+    "taskText": "check competitor pricing pages and notify me with a diff",
+    "scheduleDescription": "Every Monday at 8:00 AM",
+    "reportTitle": "QuillCode scheduled task ready",
+    "notificationCount": 1,
+    "automationsVisible": True,
+    "lastRunRecorded": True,
+    "nextRunRecorded": True,
+}
+
+REQUIRED_PROMPT_SNIPPETS = (
+    "Run the scheduled coworker task for ",
+    "Task: check competitor pricing pages and notify me with a diff",
+    "Report what changed, whether action is needed, and the next concrete step.",
+)
+
+
+def validated_scheduled_coworker(report: dict[str, Any], label: str) -> dict[str, Any]:
+    smoke = report.get("scheduledCoworkerSmoke")
+    require(isinstance(smoke, dict), f"{label} report is missing scheduledCoworkerSmoke")
+
+    for field, expected in EXPECTED_SCHEDULED_COWORKER.items():
+        actual = smoke.get(field)
+        require(
+            actual == expected,
+            f"{label} scheduled coworker field {field} was {actual!r}, expected {expected!r}",
+        )
+
+    report_body = smoke.get("reportBody")
+    require(
+        isinstance(report_body, str) and EXPECTED_SCHEDULED_COWORKER["taskText"] in report_body,
+        f"{label} scheduled coworker report body missed the original task: {report_body!r}",
+    )
+
+    thread_title = smoke.get("followUpThreadTitle")
+    require(
+        isinstance(thread_title, str) and thread_title.startswith("Scheduled check: "),
+        f"{label} scheduled coworker follow-up thread title was malformed: {thread_title!r}",
+    )
+
+    follow_up_prompt = smoke.get("followUpPrompt")
+    require(
+        isinstance(follow_up_prompt, str),
+        f"{label} scheduled coworker follow-up prompt was malformed",
+    )
+    for snippet in REQUIRED_PROMPT_SNIPPETS:
+        require(
+            snippet in follow_up_prompt,
+            f"{label} scheduled coworker follow-up prompt missed {snippet!r}: {follow_up_prompt!r}",
+        )
+
+    return smoke
+
+
+def write_scheduled_coworker_manifest(
+    direct_report_path: Path,
+    launch_services_report_path: Path,
+    manifest_path: Path,
+) -> None:
+    direct = validated_scheduled_coworker(load_report(direct_report_path), "direct executable")
+    launch_services = validated_scheduled_coworker(
+        load_report(launch_services_report_path),
+        "Launch Services",
+    )
+    require(
+        direct == launch_services,
+        "Packaged app Launch Services scheduled coworker smoke drifted from direct executable smoke",
+    )
+
+    manifest = {
+        "ok": True,
+        "directReport": "direct-executable/report.json",
+        "launchServicesReport": "launch-services/report.json",
+        "launchServicesMatchesDirect": True,
+        "scheduledCoworkerMatchesDirect": True,
+        "automationTitle": direct["automationTitle"],
+        "taskText": direct["taskText"],
+        "scheduleDescription": direct["scheduleDescription"],
+        "reportTitle": direct["reportTitle"],
+        "notificationCount": direct["notificationCount"],
+        "automationsVisible": direct["automationsVisible"],
+        "lastRunRecorded": direct["lastRunRecorded"],
+        "nextRunRecorded": direct["nextRunRecorded"],
+        "followUpThreadTitle": direct["followUpThreadTitle"],
+        "requiredPromptSnippets": list(REQUIRED_PROMPT_SNIPPETS),
+    }
+    with manifest_path.open("w", encoding="utf-8") as manifest_file:
+        json.dump(manifest, manifest_file, indent=2, sort_keys=True)
+        manifest_file.write("\n")

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -9,6 +9,7 @@ LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR="$SMOKE_ROOT/launch-services"
 CLICK_PROBE_MANIFEST="$SMOKE_ROOT/packaged-click-probes.json"
 ACCESSIBILITY_READINESS_MANIFEST="$SMOKE_ROOT/packaged-accessibility-readiness.json"
 ACCESSIBILITY_FRAMES_MANIFEST="$SMOKE_ROOT/packaged-accessibility-frames.json"
+SCHEDULED_COWORKER_MANIFEST="$SMOKE_ROOT/packaged-scheduled-coworker.json"
 WINDOW_REPORT_PATH="$SMOKE_ROOT/window-report.json"
 WINDOW_SCREENSHOT_PATH="$SMOKE_ROOT/window.png"
 WINDOW_STATE_ROOT="$SMOKE_ROOT/window-state"
@@ -40,6 +41,9 @@ cleanup() {
     if [[ -e "$ACCESSIBILITY_FRAMES_MANIFEST" ]]; then
       cp "$ACCESSIBILITY_FRAMES_MANIFEST" "$ARTIFACT_DIR/packaged-accessibility-frames.json"
     fi
+    if [[ -e "$SCHEDULED_COWORKER_MANIFEST" ]]; then
+      cp "$SCHEDULED_COWORKER_MANIFEST" "$ARTIFACT_DIR/packaged-scheduled-coworker.json"
+    fi
     if [[ -e "$WINDOW_REPORT_PATH" ]]; then
       cp "$WINDOW_REPORT_PATH" "$ARTIFACT_DIR/window-report.json"
     fi
@@ -58,6 +62,7 @@ cleanup() {
       printf 'click_probe_manifest=packaged-click-probes.json\n'
       printf 'accessibility_readiness_manifest=packaged-accessibility-readiness.json\n'
       printf 'accessibility_frames_manifest=packaged-accessibility-frames.json\n'
+      printf 'scheduled_coworker_manifest=packaged-scheduled-coworker.json\n'
       printf 'window_smoke=window-report.json\n'
       printf 'window_screenshot=window.png\n'
     } > "$ARTIFACT_DIR/manifest.txt"
@@ -148,6 +153,11 @@ QUILLCODE_NATIVE_DESKTOP_SMOKE_ARTIFACT_DIR="$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR
 "$ROOT_DIR/scripts/native-click-probe-contracts.py" readiness \
   "$SMOKE_ROOT" \
   --manifest "$ACCESSIBILITY_READINESS_MANIFEST"
+
+"$ROOT_DIR/scripts/native-click-probe-contracts.py" scheduled-coworker \
+  "$DIRECT_SMOKE_ARTIFACT_DIR/report.json" \
+  "$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR/report.json" \
+  --manifest "$SCHEDULED_COWORKER_MANIFEST"
 
 echo "==> Running packaged macOS app live-window smoke"
 (


### PR DESCRIPTION
## Summary
- add a packaged scheduled-coworker validator and manifest writer
- make packaged macOS smoke preserve packaged-scheduled-coworker.json
- document that scheduled coworker evidence now crosses direct packaged executable and Launch Services launch paths

## Validation
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/scheduled_coworker.py scripts/native_click_probe_contracts/cli.py
- synthetic scheduled-coworker manifest validator exercise
- git diff --check
- scripts/packaged-macos-smoke.sh