### PR TITLE
Prove multi-file coworker artifact smoke

### DIFF
--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -16,6 +16,13 @@ public struct MockLLMClient: LLMClient {
         if thread.messages.last?.role == .tool,
            let lastToolOutput = thread.messages.last?.content,
            let feedback = try? JSONHelpers.decode(AgentToolFeedback.self, from: lastToolOutput) {
+            if let action = Self.nextMultiFileArtifactAction(
+                thread: thread,
+                feedback: feedback,
+                tools: tools
+            ) {
+                return action
+            }
             return .say(AgentRunner.finalAnswer(
                 for: feedback.toolCall,
                 result: feedback.result,
@@ -144,6 +151,10 @@ public struct MockLLMClient: LLMClient {
                     "cmd": "df -h / /Quill 2>/dev/null || df -h /"
                 ])
             ))
+        }
+
+        if let action = Self.startMultiFileArtifactAction(for: lower, tools: tools) {
+            return action
         }
 
         if let fileWrite = AgentFileWriteRequestParser.request(from: request) {
@@ -365,6 +376,86 @@ public struct MockLLMClient: LLMClient {
             return tokens[nextIndex]
         }
         return nil
+    }
+
+    private static func startMultiFileArtifactAction(
+        for lowercasedRequest: String,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard lowercasedRequest.contains("team action brief"),
+              tools.contains(where: { $0.name == ToolDefinition.fileRead.name })
+        else { return nil }
+        return .tool(.init(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "notes/research.md"])
+        ))
+    }
+
+    private static func nextMultiFileArtifactAction(
+        thread: ChatThread,
+        feedback: AgentToolFeedback,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard thread.messages.contains(where: {
+            $0.role == .user && $0.content.lowercased().contains("team action brief")
+        }) else {
+            return nil
+        }
+
+        let path = Self.stringArgument("path", from: feedback.toolCall.argumentsJSON)
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "notes/research.md",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "notes/risks.md"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "notes/risks.md",
+           tools.contains(where: { $0.name == ToolDefinition.fileWrite.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileWrite.name,
+                argumentsJSON: ToolArguments.json([
+                    "path": "team-action-brief.md",
+                    "content": Self.teamActionBriefContent
+                ])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileWrite.name,
+           path == "team-action-brief.md" {
+            return .say("Created `team-action-brief.md` from `notes/research.md` and `notes/risks.md`.")
+        }
+
+        return nil
+    }
+
+    private static var teamActionBriefContent: String {
+        """
+        # Team Action Brief
+
+        ## Key facts
+        - Customers asked for QuillCloud relay reliability before shipment.
+        - The launch owner is Maya.
+
+        ## Risks
+        - The top risk is pairing fallback after a bad Wi-Fi password.
+        - The mitigation is a deterministic AP fallback smoke before shipping.
+
+        ## Next action
+        - Run the pairing fallback smoke and attach the evidence to the release tracker.
+        """
+    }
+
+    private static func stringArgument(_ key: String, from json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return object[key] as? String
     }
 
     private static func parentDirectory(for path: String) -> String {

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -96,6 +96,7 @@ enum QuillCodeDesktopSmokeRunner {
             controller: controller,
             root: root
         )
+        let multiFileArtifactSmoke = try await runMultiFileArtifactSmoke(controller: controller, root: root)
         let surface = controller.surface
         let nativeHitTargets = try QuillCodeDesktopNativeHitTargetSmoke.validatedReport(for: surface)
         guard surface.transcript.messages.count >= 4,
@@ -189,6 +190,7 @@ enum QuillCodeDesktopSmokeRunner {
             browserSmoke: browserSmoke,
             browserWorkflowSmoke: browserWorkflowSmoke,
             browserSpreadsheetWorkflowSmoke: browserSpreadsheetWorkflowSmoke,
+            multiFileArtifactSmoke: multiFileArtifactSmoke,
             scheduledCoworkerSmoke: scheduledCoworkerSmoke,
             nativeHitTargets: nativeHitTargets
         )
@@ -584,6 +586,76 @@ enum QuillCodeDesktopSmokeRunner {
             automationsVisible: controller.surface.automations.isVisible,
             lastRunRecorded: savedAutomation.lastRunAt != nil,
             nextRunRecorded: savedAutomation.nextRunAt != nil
+        )
+    }
+
+    private static func runMultiFileArtifactSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopMultiFileArtifactSmokeReport {
+        let notesDirectory = root.workspace.appendingPathComponent("notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: notesDirectory, withIntermediateDirectories: true)
+
+        let researchFile = notesDirectory.appendingPathComponent("research.md")
+        let risksFile = notesDirectory.appendingPathComponent("risks.md")
+        try """
+        # Research
+
+        Customers asked for QuillCloud relay reliability before shipment.
+        The launch owner is Maya.
+        """.write(to: researchFile, atomically: true, encoding: .utf8)
+        try """
+        # Risks
+
+        The top risk is pairing fallback after a bad Wi-Fi password.
+        The mitigation is a deterministic AP fallback smoke before shipping.
+        """.write(to: risksFile, atomically: true, encoding: .utf8)
+
+        let prompt = "Create the team action brief from `notes/research.md` and `notes/risks.md`."
+        let previousTimelineCount = controller.surface.transcript.timelineItems.count
+        let previousToolCardCount = controller.surface.transcript.toolCards.count
+        controller.draft = prompt
+        controller.send()
+
+        let expectedAnswer = "Created `team-action-brief.md` from `notes/research.md` and `notes/risks.md`."
+        try await waitForDesktopRun(
+            controller,
+            previousTimelineCount: previousTimelineCount,
+            expectedAnswer: expectedAnswer
+        )
+
+        let deliverable = root.workspace.appendingPathComponent("team-action-brief.md")
+        let deliverableText = try String(contentsOf: deliverable, encoding: .utf8)
+        let containsResearch = deliverableText.contains("QuillCloud relay reliability")
+            && deliverableText.contains("Maya")
+        let containsRisk = deliverableText.contains("pairing fallback")
+            && deliverableText.contains("bad Wi-Fi password")
+        let containsNextAction = deliverableText.contains("Run the pairing fallback smoke")
+        guard containsResearch, containsRisk, containsNextAction else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(deliverable.path)
+        }
+
+        let toolSequence = Array(controller.surface.transcript.toolCards.dropFirst(previousToolCardCount))
+            .map(\.title)
+        guard toolSequence == [
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileWrite.name
+        ] else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(
+                "unexpected tool sequence: \(toolSequence.joined(separator: ", "))"
+            )
+        }
+
+        return QuillCodeDesktopMultiFileArtifactSmokeReport(
+            prompt: prompt,
+            sourcePaths: [researchFile.path, risksFile.path],
+            deliverablePath: deliverable.path,
+            toolSequence: toolSequence,
+            finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
+            deliverableContainsResearch: containsResearch,
+            deliverableContainsRisk: containsRisk,
+            deliverableContainsNextAction: containsNextAction
         )
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -162,6 +162,7 @@ struct QuillCodeDesktopSmokeReport {
     var browserSmoke: QuillCodeDesktopBrowserSmokeReport
     var browserWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
     var browserSpreadsheetWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
+    var multiFileArtifactSmoke: QuillCodeDesktopMultiFileArtifactSmokeReport
     var scheduledCoworkerSmoke: QuillCodeDesktopScheduledCoworkerSmokeReport
     var nativeHitTargets: QuillCodeNativeHitTargetAuditReport
 
@@ -192,6 +193,7 @@ struct QuillCodeDesktopSmokeReport {
                 "browserSmoke": browserSmoke.dictionary,
                 "browserWorkflowSmoke": browserWorkflowSmoke.dictionary,
                 "browserSpreadsheetWorkflowSmoke": browserSpreadsheetWorkflowSmoke.dictionary,
+                "multiFileArtifactSmoke": multiFileArtifactSmoke.dictionary,
                 "scheduledCoworkerSmoke": scheduledCoworkerSmoke.dictionary,
                 "nativeHitTargets": nativeHitTargets.dictionary
             ],
@@ -369,6 +371,30 @@ struct QuillCodeDesktopScheduledCoworkerSmokeReport {
             "automationsVisible": automationsVisible,
             "lastRunRecorded": lastRunRecorded,
             "nextRunRecorded": nextRunRecorded
+        ]
+    }
+}
+
+struct QuillCodeDesktopMultiFileArtifactSmokeReport {
+    var prompt: String
+    var sourcePaths: [String]
+    var deliverablePath: String
+    var toolSequence: [String]
+    var finalAnswer: String
+    var deliverableContainsResearch: Bool
+    var deliverableContainsRisk: Bool
+    var deliverableContainsNextAction: Bool
+
+    var dictionary: [String: Any] {
+        [
+            "prompt": prompt,
+            "sourcePaths": sourcePaths,
+            "deliverablePath": deliverablePath,
+            "toolSequence": toolSequence,
+            "finalAnswer": finalAnswer,
+            "deliverableContainsResearch": deliverableContainsResearch,
+            "deliverableContainsRisk": deliverableContainsRisk,
+            "deliverableContainsNextAction": deliverableContainsNextAction
         ]
     }
 }
@@ -560,6 +586,7 @@ enum QuillCodeDesktopSmokeFailure: Error {
     case htmlMissingResult
     case incompleteTranscript
     case invalidImageSize(Int, Int)
+    case multiFileArtifactMismatch(String)
     case nativeAccessibilityActivationFailed([String])
     case nativeAccessibilityFrameSamplingFailed([String])
     case nativeHitTargetAuditFailed([String])

--- a/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
+++ b/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+final class MockLLMClientMultiFileArtifactTests: XCTestCase {
+    func testTeamActionBriefStartsByReadingResearchFile() async throws {
+        let action = try await MockLLMClient().nextAction(
+            thread: ChatThread(mode: .auto),
+            userMessage: "Create the team action brief from `notes/research.md` and `notes/risks.md`.",
+            tools: ToolRouter.definitions
+        )
+
+        let call = try XCTUnwrap(action.toolCall)
+        XCTAssertEqual(call.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(call.argumentsJSON).string("path"), "notes/research.md")
+    }
+
+    func testTeamActionBriefContinuesThroughSecondReadAndWrite() async throws {
+        let user = ChatMessage(
+            role: .user,
+            content: "Create the team action brief from `notes/research.md` and `notes/risks.md`."
+        )
+        let researchRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "notes/research.md"])
+        )
+        let afterResearch = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(
+                    for: researchRead,
+                    stdout: "Customers asked for QuillCloud relay reliability."
+                )
+            ]
+        )
+
+        let secondAction = try await MockLLMClient().nextAction(
+            thread: afterResearch,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let secondCall = try XCTUnwrap(secondAction.toolCall)
+        XCTAssertEqual(secondCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(secondCall.argumentsJSON).string("path"), "notes/risks.md")
+
+        let risksRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "notes/risks.md"])
+        )
+        let afterRisks = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(
+                    for: researchRead,
+                    stdout: "Customers asked for QuillCloud relay reliability."
+                ),
+                try toolFeedbackMessage(for: risksRead, stdout: "The top risk is pairing fallback.")
+            ]
+        )
+
+        let writeAction = try await MockLLMClient().nextAction(
+            thread: afterRisks,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let writeCall = try XCTUnwrap(writeAction.toolCall)
+        XCTAssertEqual(writeCall.name, ToolDefinition.fileWrite.name)
+        let writeArguments = try ToolArguments(writeCall.argumentsJSON)
+        XCTAssertEqual(writeArguments.string("path"), "team-action-brief.md")
+        XCTAssertTrue(writeArguments.string("content")?.contains("QuillCloud relay reliability") == true)
+        XCTAssertTrue(writeArguments.string("content")?.contains("pairing fallback") == true)
+
+        let writeFeedback = ToolCall(
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: ToolArguments.json(["path": "team-action-brief.md"])
+        )
+        let afterWrite = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: writeFeedback, stdout: "wrote team-action-brief.md")
+            ]
+        )
+        let finalAction = try await MockLLMClient().nextAction(
+            thread: afterWrite,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        guard case .say(let finalAnswer) = finalAction else {
+            return XCTFail("Expected a final answer after the write completes.")
+        }
+        XCTAssertEqual(
+            finalAnswer,
+            "Created `team-action-brief.md` from `notes/research.md` and `notes/risks.md`."
+        )
+    }
+
+    private func toolFeedbackMessage(for call: ToolCall, stdout: String) throws -> ChatMessage {
+        let feedback = AgentToolFeedback(
+            toolCall: call,
+            result: ToolResult(ok: true, stdout: stdout)
+        )
+        return ChatMessage(role: .tool, content: try JSONHelpers.encodePretty(feedback))
+    }
+}
+
+private extension AgentAction {
+    var toolCall: ToolCall? {
+        guard case .tool(let call) = self else { return nil }
+        return call
+    }
+}

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -80,7 +80,10 @@
   due recurring coworker automation creates the task-specific scheduled thread, records recurrence
   run state, reveals the automation surface, and reaches the desktop automation notifier. Packaged
   macOS smoke now preserves `packaged-scheduled-coworker.json`, proving the same scheduled coworker
-  evidence survives both direct packaged executable launch and Launch Services launch.
+  evidence survives both direct packaged executable launch and Launch Services launch. Native desktop
+  smoke now also records `multiFileArtifactSmoke`, proving a coworker-style deliverable can read two
+  source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
+  render that artifact workflow into the transcript HTML evidence.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -131,3 +131,20 @@ Packaged macOS smoke now preserves explicit scheduled-coworker release evidence:
 The remaining scheduling evidence gap is narrower: observing the real OS notification banner/action
 from the packaged app, rather than only the app-level notification report delivered to the desktop
 notifier boundary.
+
+## Multi-File Artifact Smoke Slice
+
+The native desktop smoke now records deterministic multi-file deliverable evidence:
+
+- `multiFileArtifactSmoke` creates two source notes, asks QuillCode to create a team action brief
+  from both files, and requires the actual agent/tool loop to dispatch
+  `host.file.read`, `host.file.read`, and `host.file.write` in order.
+- The smoke verifies `team-action-brief.md` exists in the workspace and contains facts from both
+  source files plus a concrete next action, so artifact-generation rows are no longer backed only by
+  the older single-file `hello.txt` write/read proof.
+- `scripts/native-desktop-smoke.sh` fails if the report loses the source paths, deliverable path,
+  exact tool sequence, final answer, or rendered HTML transcript evidence.
+
+This covers the deterministic local-artifact version of multi-file coworker deliverables. Rows that
+depend on live SaaS data, proprietary document formats, or a logged-in browser session should remain
+gated until a row-specific live or packaged smoke proves the same workflow on that surface.

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -167,6 +167,11 @@ if ! grep -q '"browserSpreadsheetWorkflowSmoke"' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q '"multiFileArtifactSmoke"' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not report multi-file artifact smoke evidence" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 if ! grep -q '"scheduledCoworkerSmoke"' "$REPORT_PATH"; then
   echo "quill-code-desktop native smoke did not report scheduled coworker smoke evidence" >&2
   cat "$REPORT_PATH" >&2
@@ -300,6 +305,36 @@ require_browser_workflow_smoke(
     script_state="done=true",
     text_state="Done",
 )
+
+multi_file_smoke = report.get("multiFileArtifactSmoke")
+if not isinstance(multi_file_smoke, dict):
+    fail("did not include multi-file artifact smoke evidence")
+
+expected_multi_file_fields = {
+    "prompt": "Create the team action brief from `notes/research.md` and `notes/risks.md`.",
+    "toolSequence": ["host.file.read", "host.file.read", "host.file.write"],
+    "deliverableContainsResearch": True,
+    "deliverableContainsRisk": True,
+    "deliverableContainsNextAction": True,
+}
+for field, expected in expected_multi_file_fields.items():
+    if multi_file_smoke.get(field) != expected:
+        fail(
+            "multi-file artifact smoke field "
+            f"{field} was {multi_file_smoke.get(field)!r}, expected {expected!r}"
+        )
+source_paths = multi_file_smoke.get("sourcePaths")
+if not isinstance(source_paths, list) or len(source_paths) != 2:
+    fail(f"multi-file artifact smoke did not report two source paths: {source_paths!r}")
+for expected_suffix in ("notes/research.md", "notes/risks.md"):
+    if not any(isinstance(path, str) and path.endswith(expected_suffix) for path in source_paths):
+        fail(f"multi-file artifact smoke missed source path {expected_suffix}: {source_paths!r}")
+deliverable_path = multi_file_smoke.get("deliverablePath")
+if not isinstance(deliverable_path, str) or not deliverable_path.endswith("team-action-brief.md"):
+    fail(f"multi-file artifact smoke reported malformed deliverable path: {deliverable_path!r}")
+final_answer = multi_file_smoke.get("finalAnswer")
+if not isinstance(final_answer, str) or "Created `team-action-brief.md`" not in final_answer:
+    fail(f"multi-file artifact smoke reported malformed final answer: {final_answer!r}")
 
 scheduled_coworker_smoke = report.get("scheduledCoworkerSmoke")
 if not isinstance(scheduled_coworker_smoke, dict):
@@ -559,13 +594,27 @@ if ! grep -Eq '"messageCount" : [2-9][0-9]*' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
-if ! grep -Eq '"timelineItemCount" : [3-9][0-9]*' "$REPORT_PATH"; then
-  echo "quill-code-desktop native smoke did not record enough timeline items" >&2
+python3 - "$REPORT_PATH" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as report_file:
+    report = json.load(report_file)
+
+timeline_count = report.get("timelineItemCount")
+if not isinstance(timeline_count, int) or timeline_count < 14:
+    raise SystemExit(
+        "quill-code-desktop native smoke did not record enough timeline items: "
+        f"{timeline_count!r}"
+    )
+PY
+if ! grep -q 'Wrote `hello.txt`.' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not produce the expected final answer" >&2
   cat "$REPORT_PATH" >&2
   exit 1
 fi
-if ! grep -q 'Wrote `hello.txt`.' "$REPORT_PATH"; then
-  echo "quill-code-desktop native smoke did not produce the expected final answer" >&2
+if ! grep -q 'Created `team-action-brief.md`' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not produce the expected multi-file artifact answer" >&2
   cat "$REPORT_PATH" >&2
   exit 1
 fi
@@ -577,6 +626,7 @@ fi
 if ! grep -q 'Wrote `hello.txt`.' "$HTML_PATH" \
   || ! grep -q 'Contents of `hello.txt`:' "$HTML_PATH" \
   || ! grep -q 'hello world' "$HTML_PATH" \
+  || ! grep -q 'Created `team-action-brief.md`' "$HTML_PATH" \
   || ! grep -q 'Inspected `Browser Smoke`' "$HTML_PATH" \
   || ! grep -q 'host.browser.inspect' "$HTML_PATH" \
   || ! grep -q 'host.file.write' "$HTML_PATH" \


### PR DESCRIPTION
## Summary
- add a mock multi-file coworker artifact workflow that reads notes/research.md, reads notes/risks.md, writes team-action-brief.md, and returns a final answer
- record multiFileArtifactSmoke in native desktop smoke reports and require the read/read/write sequence in scripts/native-desktop-smoke.sh
- update coworker tracker docs and parity notes with the new deterministic artifact evidence

## Validation
- swift test --filter MockLLMClientMultiFileArtifactTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh
- python3 -m py_compile scripts/native_click_probe_contracts/scheduled_coworker.py scripts/native_click_probe_contracts/cli.py
- git diff --check