### PR TITLE
Prove packaged multi-file coworker smoke

### DIFF
--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -49,8 +49,13 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(
             packagedSmoke.contains("SCHEDULED_COWORKER_MANIFEST=\"$SMOKE_ROOT/packaged-scheduled-coworker.json\"")
         )
+        XCTAssertTrue(
+            packagedSmoke.contains("MULTI_FILE_ARTIFACT_MANIFEST=\"$SMOKE_ROOT/packaged-multi-file-artifact.json\"")
+        )
         XCTAssertTrue(packagedSmoke.contains("scheduled_coworker_manifest=packaged-scheduled-coworker.json"))
+        XCTAssertTrue(packagedSmoke.contains("multi_file_artifact_manifest=packaged-multi-file-artifact.json"))
         XCTAssertTrue(packagedSmoke.contains(" scheduled-coworker \\"))
+        XCTAssertTrue(packagedSmoke.contains(" multi-file-artifact \\"))
         XCTAssertTrue(packagedSmoke.contains(" frames \\"))
         XCTAssertTrue(packagedSmoke.contains("$WINDOW_REPORT_PATH"))
         XCTAssertTrue(packagedSmoke.contains("$WINDOW_SCREENSHOT_PATH"))
@@ -87,6 +92,21 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(scheduledCoworkerValidator.contains(#""QuillCode scheduled task ready""#))
         XCTAssertTrue(scheduledCoworkerValidator.contains(#""Every Monday at 8:00 AM""#))
         XCTAssertTrue(scheduledCoworkerValidator.contains(#""scheduledCoworkerMatchesDirect": True"#))
+
+        let multiFileArtifactValidator = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("scripts/native_click_probe_contracts/multi_file_artifact.py"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""multiFileArtifactSmoke""#))
+        XCTAssertTrue(
+            multiFileArtifactValidator.contains(
+                #""Create the team action brief from `notes/research.md` and `notes/risks.md`.""#
+            )
+        )
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""host.file.read", "host.file.read", "host.file.write""#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""team-action-brief.md""#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""multiFileArtifactMatchesDirect": True"#))
     }
 
 }

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -83,7 +83,8 @@
   evidence survives both direct packaged executable launch and Launch Services launch. Native desktop
   smoke now also records `multiFileArtifactSmoke`, proving a coworker-style deliverable can read two
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
-  render that artifact workflow into the transcript HTML evidence.
+  render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
+  the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -144,6 +144,9 @@ The native desktop smoke now records deterministic multi-file deliverable eviden
   the older single-file `hello.txt` write/read proof.
 - `scripts/native-desktop-smoke.sh` fails if the report loses the source paths, deliverable path,
   exact tool sequence, final answer, or rendered HTML transcript evidence.
+- Packaged macOS smoke also preserves `packaged-multi-file-artifact.json`, proving the same
+  multi-file artifact evidence survives both direct packaged executable launch and Launch Services
+  launch.
 
 This covers the deterministic local-artifact version of multi-file coworker deliverables. Rows that
 depend on live SaaS data, proprietary document formats, or a logged-in browser session should remain

--- a/scripts/native_click_probe_contracts/cli.py
+++ b/scripts/native_click_probe_contracts/cli.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 
 from .accessibility_frames import write_accessibility_frames_manifest
+from .multi_file_artifact import write_multi_file_artifact_manifest
 from .packaged_window import (
     validate_packaged_window_report,
     write_accessibility_readiness_manifest,
@@ -40,6 +41,14 @@ def main() -> None:
     scheduled_parser.add_argument("launch_services_report", type=Path)
     scheduled_parser.add_argument("--manifest", required=True, type=Path)
 
+    multi_file_parser = subparsers.add_parser(
+        "multi-file-artifact",
+        help="write packaged multi-file artifact evidence",
+    )
+    multi_file_parser.add_argument("direct_report", type=Path)
+    multi_file_parser.add_argument("launch_services_report", type=Path)
+    multi_file_parser.add_argument("--manifest", required=True, type=Path)
+
     window_parser = subparsers.add_parser("window", help="validate packaged live-window smoke report and screenshot")
     window_parser.add_argument("report", type=Path)
     window_parser.add_argument("screenshot", type=Path)
@@ -59,6 +68,12 @@ def main() -> None:
         write_accessibility_readiness_manifest(args.artifact_root, args.manifest)
     elif args.command == "scheduled-coworker":
         write_scheduled_coworker_manifest(
+            args.direct_report,
+            args.launch_services_report,
+            args.manifest,
+        )
+    elif args.command == "multi-file-artifact":
+        write_multi_file_artifact_manifest(
             args.direct_report,
             args.launch_services_report,
             args.manifest,

--- a/scripts/native_click_probe_contracts/multi_file_artifact.py
+++ b/scripts/native_click_probe_contracts/multi_file_artifact.py
@@ -1,0 +1,102 @@
+"""Validate packaged multi-file artifact smoke evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .json_io import load_report, require
+
+EXPECTED_PROMPT = "Create the team action brief from `notes/research.md` and `notes/risks.md`."
+EXPECTED_TOOL_SEQUENCE = ["host.file.read", "host.file.read", "host.file.write"]
+
+
+def validated_multi_file_artifact(report: dict[str, Any], label: str) -> dict[str, Any]:
+    smoke = report.get("multiFileArtifactSmoke")
+    require(isinstance(smoke, dict), f"{label} report is missing multiFileArtifactSmoke")
+
+    require(
+        smoke.get("prompt") == EXPECTED_PROMPT,
+        f"{label} multi-file prompt was {smoke.get('prompt')!r}, expected {EXPECTED_PROMPT!r}",
+    )
+    require(
+        smoke.get("toolSequence") == EXPECTED_TOOL_SEQUENCE,
+        f"{label} multi-file tool sequence was {smoke.get('toolSequence')!r}",
+    )
+    for field in (
+        "deliverableContainsResearch",
+        "deliverableContainsRisk",
+        "deliverableContainsNextAction",
+    ):
+        require(smoke.get(field) is True, f"{label} multi-file artifact did not satisfy {field}")
+
+    source_paths = smoke.get("sourcePaths")
+    require(
+        isinstance(source_paths, list) and len(source_paths) == 2,
+        f"{label} multi-file artifact sourcePaths was malformed: {source_paths!r}",
+    )
+    for expected_suffix in ("notes/research.md", "notes/risks.md"):
+        require(
+            any(isinstance(path, str) and path.endswith(expected_suffix) for path in source_paths),
+            f"{label} multi-file artifact missed {expected_suffix}: {source_paths!r}",
+        )
+
+    deliverable_path = smoke.get("deliverablePath")
+    require(
+        isinstance(deliverable_path, str) and deliverable_path.endswith("team-action-brief.md"),
+        f"{label} multi-file deliverable path was malformed: {deliverable_path!r}",
+    )
+    final_answer = smoke.get("finalAnswer")
+    require(
+        isinstance(final_answer, str) and "Created `team-action-brief.md`" in final_answer,
+        f"{label} multi-file final answer was malformed: {final_answer!r}",
+    )
+    return smoke
+
+
+def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
+    source_paths = smoke["sourcePaths"]
+    return {
+        "prompt": smoke["prompt"],
+        "toolSequence": smoke["toolSequence"],
+        "sourcePathSuffixes": sorted(
+            "notes/research.md" if str(path).endswith("notes/research.md") else "notes/risks.md"
+            for path in source_paths
+        ),
+        "deliverablePathSuffix": "team-action-brief.md",
+        "deliverableContainsResearch": smoke["deliverableContainsResearch"],
+        "deliverableContainsRisk": smoke["deliverableContainsRisk"],
+        "deliverableContainsNextAction": smoke["deliverableContainsNextAction"],
+        "finalAnswer": smoke["finalAnswer"],
+    }
+
+
+def write_multi_file_artifact_manifest(
+    direct_report_path: Path,
+    launch_services_report_path: Path,
+    manifest_path: Path,
+) -> None:
+    direct = validated_multi_file_artifact(load_report(direct_report_path), "direct executable")
+    launch_services = validated_multi_file_artifact(
+        load_report(launch_services_report_path),
+        "Launch Services",
+    )
+    direct_semantic = semantic_multi_file_artifact(direct)
+    launch_services_semantic = semantic_multi_file_artifact(launch_services)
+    require(
+        direct_semantic == launch_services_semantic,
+        "Packaged app Launch Services multi-file artifact smoke drifted from direct executable smoke",
+    )
+
+    manifest = {
+        "ok": True,
+        "directReport": "direct-executable/report.json",
+        "launchServicesReport": "launch-services/report.json",
+        "launchServicesMatchesDirect": True,
+        "multiFileArtifactMatchesDirect": True,
+        **direct_semantic,
+    }
+    with manifest_path.open("w", encoding="utf-8") as manifest_file:
+        json.dump(manifest, manifest_file, indent=2, sort_keys=True)
+        manifest_file.write("\n")

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -10,6 +10,7 @@ CLICK_PROBE_MANIFEST="$SMOKE_ROOT/packaged-click-probes.json"
 ACCESSIBILITY_READINESS_MANIFEST="$SMOKE_ROOT/packaged-accessibility-readiness.json"
 ACCESSIBILITY_FRAMES_MANIFEST="$SMOKE_ROOT/packaged-accessibility-frames.json"
 SCHEDULED_COWORKER_MANIFEST="$SMOKE_ROOT/packaged-scheduled-coworker.json"
+MULTI_FILE_ARTIFACT_MANIFEST="$SMOKE_ROOT/packaged-multi-file-artifact.json"
 WINDOW_REPORT_PATH="$SMOKE_ROOT/window-report.json"
 WINDOW_SCREENSHOT_PATH="$SMOKE_ROOT/window.png"
 WINDOW_STATE_ROOT="$SMOKE_ROOT/window-state"
@@ -44,6 +45,9 @@ cleanup() {
     if [[ -e "$SCHEDULED_COWORKER_MANIFEST" ]]; then
       cp "$SCHEDULED_COWORKER_MANIFEST" "$ARTIFACT_DIR/packaged-scheduled-coworker.json"
     fi
+    if [[ -e "$MULTI_FILE_ARTIFACT_MANIFEST" ]]; then
+      cp "$MULTI_FILE_ARTIFACT_MANIFEST" "$ARTIFACT_DIR/packaged-multi-file-artifact.json"
+    fi
     if [[ -e "$WINDOW_REPORT_PATH" ]]; then
       cp "$WINDOW_REPORT_PATH" "$ARTIFACT_DIR/window-report.json"
     fi
@@ -63,6 +67,7 @@ cleanup() {
       printf 'accessibility_readiness_manifest=packaged-accessibility-readiness.json\n'
       printf 'accessibility_frames_manifest=packaged-accessibility-frames.json\n'
       printf 'scheduled_coworker_manifest=packaged-scheduled-coworker.json\n'
+      printf 'multi_file_artifact_manifest=packaged-multi-file-artifact.json\n'
       printf 'window_smoke=window-report.json\n'
       printf 'window_screenshot=window.png\n'
     } > "$ARTIFACT_DIR/manifest.txt"
@@ -158,6 +163,11 @@ QUILLCODE_NATIVE_DESKTOP_SMOKE_ARTIFACT_DIR="$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR
   "$DIRECT_SMOKE_ARTIFACT_DIR/report.json" \
   "$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR/report.json" \
   --manifest "$SCHEDULED_COWORKER_MANIFEST"
+
+"$ROOT_DIR/scripts/native-click-probe-contracts.py" multi-file-artifact \
+  "$DIRECT_SMOKE_ARTIFACT_DIR/report.json" \
+  "$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR/report.json" \
+  --manifest "$MULTI_FILE_ARTIFACT_MANIFEST"
 
 echo "==> Running packaged macOS app live-window smoke"
 (


### PR DESCRIPTION
## Summary
- add packaged multi-file artifact manifest generation for native smoke reports
- require direct packaged executable and Launch Services smoke to match semantically for multiFileArtifactSmoke
- preserve packaged-multi-file-artifact.json in packaged smoke artifacts and parity docs

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/multi_file_artifact.py scripts/native_click_probe_contracts/cli.py
- synthetic scripts/native-click-probe-contracts.py multi-file-artifact manifest exercise
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/packaged-macos-smoke.sh
- git diff --check