### PR TITLE
Prove packaged one-turn coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -103,6 +103,7 @@ enum QuillCodeDesktopSmokeRunner {
         )
         let computerUseActionSmoke = try await runComputerUseActionSmoke(root: root)
         let multiFileArtifactSmoke = try await runMultiFileArtifactSmoke(controller: controller, root: root)
+        let oneTurnCoworkerSmoke = try await runOneTurnCoworkerSmoke(controller: controller, root: root)
         let surface = controller.surface
         let nativeHitTargets = try QuillCodeDesktopNativeHitTargetSmoke.validatedReport(for: surface)
         guard surface.transcript.messages.count >= 4,
@@ -199,6 +200,7 @@ enum QuillCodeDesktopSmokeRunner {
             browserAuthenticatedWorkflowSmoke: browserAuthenticatedWorkflowSmoke,
             computerUseActionSmoke: computerUseActionSmoke,
             multiFileArtifactSmoke: multiFileArtifactSmoke,
+            oneTurnCoworkerSmoke: oneTurnCoworkerSmoke,
             scheduledCoworkerSmoke: scheduledCoworkerSmoke,
             nativeHitTargets: nativeHitTargets
         )
@@ -858,6 +860,81 @@ enum QuillCodeDesktopSmokeRunner {
         )
     }
 
+    private static func runOneTurnCoworkerSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopOneTurnCoworkerSmokeReport {
+        let cases = [
+            OneTurnCoworkerSmokeCase(
+                taskID: 15,
+                prompt: "Create a file named `launch-announcement.md` that says `Billing portal launch email ready.`",
+                expectedToolName: ToolDefinition.fileWrite.name,
+                expectedAnswer: "Wrote `launch-announcement.md`.",
+                artifactRelativePath: "launch-announcement.md",
+                artifactContains: "Billing portal launch email ready."
+            ),
+            OneTurnCoworkerSmokeCase(
+                taskID: 16,
+                prompt: "Run `printf 'source,signups\\nads,42\\norganic,31\\n' > signup-slice.csv && printf 'wrote signup-slice.csv\\n'`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote signup-slice.csv",
+                artifactRelativePath: "signup-slice.csv",
+                artifactContains: "organic,31"
+            ),
+            OneTurnCoworkerSmokeCase(
+                taskID: 68,
+                prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote weekly-review.csv",
+                artifactRelativePath: "weekly-review.csv",
+                artifactContains: "Launch,3,2"
+            )
+        ]
+
+        var reports: [QuillCodeDesktopOneTurnCoworkerSmokeCaseReport] = []
+        for smokeCase in cases {
+            let previousTimelineCount = controller.surface.transcript.timelineItems.count
+            let previousToolCardCount = controller.surface.transcript.toolCards.count
+            controller.draft = smokeCase.prompt
+            controller.send()
+
+            try await waitForDesktopRun(
+                controller,
+                previousTimelineCount: previousTimelineCount,
+                expectedAnswer: smokeCase.expectedAnswer
+            )
+
+            let newToolCards = Array(controller.surface.transcript.toolCards.dropFirst(previousToolCardCount))
+            guard newToolCards.count == 1,
+                  newToolCards.first?.title == smokeCase.expectedToolName,
+                  newToolCards.first?.status == .done
+            else {
+                throw QuillCodeDesktopSmokeFailure.oneTurnCoworkerMismatch(
+                    "task \(smokeCase.taskID) unexpected tool cards: \(newToolCards.map(\.title).joined(separator: ", "))"
+                )
+            }
+
+            let artifact = root.workspace.appendingPathComponent(smokeCase.artifactRelativePath)
+            let artifactText = try String(contentsOf: artifact, encoding: .utf8)
+            guard artifactText.contains(smokeCase.artifactContains) else {
+                throw QuillCodeDesktopSmokeFailure.oneTurnCoworkerMismatch(
+                    "task \(smokeCase.taskID) artifact missing expected content: \(artifact.path)"
+                )
+            }
+
+            reports.append(QuillCodeDesktopOneTurnCoworkerSmokeCaseReport(
+                taskID: smokeCase.taskID,
+                prompt: smokeCase.prompt,
+                toolName: smokeCase.expectedToolName,
+                artifactPath: artifact.path,
+                artifactContains: smokeCase.artifactContains,
+                finalAnswer: controller.surface.transcript.messages.last?.text ?? ""
+            ))
+        }
+
+        return QuillCodeDesktopOneTurnCoworkerSmokeReport(cases: reports)
+    }
+
     private static func requiredBrowserToolOverride(
         _ controller: QuillCodeDesktopController
     ) throws -> AgentToolExecutionOverride {
@@ -1201,6 +1278,15 @@ private final class SmokeBrowserSessionPresenter: DesktopBrowserSessionPresentin
             activeTabID: tab.id
         ))
     }
+}
+
+private struct OneTurnCoworkerSmokeCase {
+    var taskID: Int
+    var prompt: String
+    var expectedToolName: String
+    var expectedAnswer: String
+    var artifactRelativePath: String
+    var artifactContains: String
 }
 
 private final class SmokeAutomationNotifier: QuillCodeAutomationNotifying, @unchecked Sendable {

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -165,6 +165,7 @@ struct QuillCodeDesktopSmokeReport {
     var browserAuthenticatedWorkflowSmoke: QuillCodeDesktopBrowserWorkflowSmokeReport
     var computerUseActionSmoke: QuillCodeDesktopComputerUseActionSmokeReport
     var multiFileArtifactSmoke: QuillCodeDesktopMultiFileArtifactSmokeReport
+    var oneTurnCoworkerSmoke: QuillCodeDesktopOneTurnCoworkerSmokeReport
     var scheduledCoworkerSmoke: QuillCodeDesktopScheduledCoworkerSmokeReport
     var nativeHitTargets: QuillCodeNativeHitTargetAuditReport
 
@@ -198,6 +199,7 @@ struct QuillCodeDesktopSmokeReport {
                 "browserAuthenticatedWorkflowSmoke": browserAuthenticatedWorkflowSmoke.dictionary,
                 "computerUseActionSmoke": computerUseActionSmoke.dictionary,
                 "multiFileArtifactSmoke": multiFileArtifactSmoke.dictionary,
+                "oneTurnCoworkerSmoke": oneTurnCoworkerSmoke.dictionary,
                 "scheduledCoworkerSmoke": scheduledCoworkerSmoke.dictionary,
                 "nativeHitTargets": nativeHitTargets.dictionary
             ],
@@ -427,6 +429,39 @@ struct QuillCodeDesktopMultiFileArtifactSmokeReport {
     }
 }
 
+struct QuillCodeDesktopOneTurnCoworkerSmokeReport {
+    var cases: [QuillCodeDesktopOneTurnCoworkerSmokeCaseReport]
+
+    var dictionary: [String: Any] {
+        [
+            "cases": cases.map(\.dictionary),
+            "taskIDs": cases.map(\.taskID),
+            "toolSequence": cases.map(\.toolName),
+            "artifactPaths": cases.map(\.artifactPath)
+        ]
+    }
+}
+
+struct QuillCodeDesktopOneTurnCoworkerSmokeCaseReport {
+    var taskID: Int
+    var prompt: String
+    var toolName: String
+    var artifactPath: String
+    var artifactContains: String
+    var finalAnswer: String
+
+    var dictionary: [String: Any] {
+        [
+            "taskID": taskID,
+            "prompt": prompt,
+            "toolName": toolName,
+            "artifactPath": artifactPath,
+            "artifactContains": artifactContains,
+            "finalAnswer": finalAnswer
+        ]
+    }
+}
+
 struct QuillCodeDesktopWindowSmokeReport {
     var ok: Bool
     var appName: String
@@ -620,6 +655,7 @@ enum QuillCodeDesktopSmokeFailure: Error {
     case invalidImageSize(Int, Int)
     case computerUseActionMismatch(String)
     case multiFileArtifactMismatch(String)
+    case oneTurnCoworkerMismatch(String)
     case nativeAccessibilityActivationFailed([String])
     case nativeAccessibilityFrameSamplingFailed([String])
     case nativeHitTargetAuditFailed([String])

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -53,6 +53,9 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
             packagedSmoke.contains("MULTI_FILE_ARTIFACT_MANIFEST=\"$SMOKE_ROOT/packaged-multi-file-artifact.json\"")
         )
         XCTAssertTrue(
+            packagedSmoke.contains("ONE_TURN_COWORKER_MANIFEST=\"$SMOKE_ROOT/packaged-one-turn-coworker.json\"")
+        )
+        XCTAssertTrue(
             packagedSmoke.contains("BROWSER_WORKFLOW_MANIFEST=\"$SMOKE_ROOT/packaged-browser-workflow.json\"")
         )
         XCTAssertTrue(packagedSmoke.contains("COMPUTER_USE_MANIFEST=\"$SMOKE_ROOT/packaged-computer-use.json\""))
@@ -61,11 +64,13 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         )
         XCTAssertTrue(packagedSmoke.contains("scheduled_coworker_manifest=packaged-scheduled-coworker.json"))
         XCTAssertTrue(packagedSmoke.contains("multi_file_artifact_manifest=packaged-multi-file-artifact.json"))
+        XCTAssertTrue(packagedSmoke.contains("one_turn_coworker_manifest=packaged-one-turn-coworker.json"))
         XCTAssertTrue(packagedSmoke.contains("browser_workflow_manifest=packaged-browser-workflow.json"))
         XCTAssertTrue(packagedSmoke.contains("computer_use_manifest=packaged-computer-use.json"))
         XCTAssertTrue(packagedSmoke.contains("computer_use_action_manifest=packaged-computer-use-action.json"))
         XCTAssertTrue(packagedSmoke.contains(" scheduled-coworker \\"))
         XCTAssertTrue(packagedSmoke.contains(" multi-file-artifact \\"))
+        XCTAssertTrue(packagedSmoke.contains(" one-turn-coworker \\"))
         XCTAssertTrue(packagedSmoke.contains(" browser-workflow \\"))
         XCTAssertTrue(packagedSmoke.contains(" computer-use \\"))
         XCTAssertTrue(packagedSmoke.contains(" computer-use-action \\"))
@@ -129,6 +134,21 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(multiFileArtifactValidator.contains(#""host.file.read", "host.file.read", "host.file.write""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""team-action-brief.md""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""multiFileArtifactMatchesDirect": True"#))
+
+        XCTAssertTrue(supportText.contains("struct QuillCodeDesktopOneTurnCoworkerSmokeReport"))
+        XCTAssertTrue(supportText.contains(#""oneTurnCoworkerSmoke": oneTurnCoworkerSmoke.dictionary"#))
+        let oneTurnCoworkerValidator = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("scripts/native_click_probe_contracts/one_turn_coworker.py"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""oneTurnCoworkerSmoke""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""oneTurnCoworkerMatchesDirect": True"#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""host.file.write""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""host.shell.run""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""launch-announcement.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""signup-slice.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(
             contentsOf: Self.packageRoot()

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -89,7 +89,10 @@
   smoke now also records `multiFileArtifactSmoke`, proving a coworker-style deliverable can read two
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
-  the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths.
+  the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, and #68,
+  proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
+  artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar
   status plus setup/permission/refresh command contracts survive the package boundary. Optional
   `scripts/live-saas-smoke.sh` now gives real signed-in SaaS runs a fail-closed manifest contract for

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -155,6 +155,25 @@ This covers the deterministic local-artifact version of multi-file coworker deli
 depend on live SaaS data, proprietary document formats, or a logged-in browser session should remain
 gated until a row-specific live or packaged smoke proves the same workflow on that surface.
 
+## Packaged One-Turn Coworker Evidence Slice
+
+Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
+
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, and #68 through the actual
+  desktop agent/tool loop.
+- Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
+  customer-comms text through `host.file.write`.
+- Row #16 proves an analysis-style shell task runs with non-empty `host.shell.run` arguments and
+  creates `signup-slice.csv`.
+- Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
+  creates `weekly-review.csv`.
+- `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,
+  recording task IDs, tool sequence, artifact suffixes, artifact assertions, and final answers.
+
+This moves the one-turn local shell/file bucket from analogue evidence toward row-linked packaged
+evidence. Similar local rows can graduate only when their row ID appears in current smoke or coverage
+evidence, or when a stricter row-specific test proves the same tool path.
+
 ## Packaged Browser Workflow Evidence Slice
 
 Packaged macOS smoke now preserves browser coworker workflow evidence at the `.app` boundary:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -21,6 +21,10 @@
 - **Update:** The native smoke contract CLI can now roll validated live SaaS manifests into a
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
+- **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
+  #15, #16, and #68. The manifest compares direct packaged executable and Launch Services evidence,
+  proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions before those
+  rows can be treated as row-linked one-turn coworker coverage.
 
 ## 2026-07-27: TrustedRouter balance history is locally observed
 

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -336,6 +336,59 @@ final_answer = multi_file_smoke.get("finalAnswer")
 if not isinstance(final_answer, str) or "Created `team-action-brief.md`" not in final_answer:
     fail(f"multi-file artifact smoke reported malformed final answer: {final_answer!r}")
 
+one_turn_coworker_smoke = report.get("oneTurnCoworkerSmoke")
+if not isinstance(one_turn_coworker_smoke, dict):
+    fail("did not include one-turn coworker smoke evidence")
+
+expected_one_turn_cases = {
+    15: {
+        "toolName": "host.file.write",
+        "artifactSuffix": "launch-announcement.md",
+        "artifactContains": "Billing portal launch email ready.",
+        "answerContains": "Wrote `launch-announcement.md`.",
+    },
+    16: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "signup-slice.csv",
+        "artifactContains": "organic,31",
+        "answerContains": "wrote signup-slice.csv",
+    },
+    68: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "weekly-review.csv",
+        "artifactContains": "Launch,3,2",
+        "answerContains": "wrote weekly-review.csv",
+    },
+}
+one_turn_cases = one_turn_coworker_smoke.get("cases")
+if not isinstance(one_turn_cases, list):
+    fail(f"one-turn coworker smoke cases were malformed: {one_turn_cases!r}")
+one_turn_by_id = {
+    case.get("taskID"): case
+    for case in one_turn_cases
+    if isinstance(case, dict) and isinstance(case.get("taskID"), int)
+}
+if set(one_turn_by_id) != set(expected_one_turn_cases):
+    fail(
+        "one-turn coworker task IDs were "
+        f"{sorted(one_turn_by_id)}, expected {sorted(expected_one_turn_cases)}"
+    )
+for task_id, expected in expected_one_turn_cases.items():
+    case = one_turn_by_id[task_id]
+    if case.get("toolName") != expected["toolName"]:
+        fail(f"one-turn coworker task {task_id} tool was {case.get('toolName')!r}")
+    artifact_path = case.get("artifactPath")
+    if not isinstance(artifact_path, str) or not artifact_path.endswith(expected["artifactSuffix"]):
+        fail(f"one-turn coworker task {task_id} artifact path was malformed: {artifact_path!r}")
+    if case.get("artifactContains") != expected["artifactContains"]:
+        fail(
+            "one-turn coworker task "
+            f"{task_id} artifact assertion was {case.get('artifactContains')!r}"
+        )
+    final_answer = case.get("finalAnswer")
+    if not isinstance(final_answer, str) or expected["answerContains"] not in final_answer:
+        fail(f"one-turn coworker task {task_id} final answer was malformed: {final_answer!r}")
+
 scheduled_coworker_smoke = report.get("scheduledCoworkerSmoke")
 if not isinstance(scheduled_coworker_smoke, dict):
     fail("did not include scheduled coworker smoke evidence")
@@ -589,11 +642,6 @@ for command_id in command-palette keyboard-shortcuts settings toggle-terminal to
     exit 1
   fi
 done
-if ! grep -Eq '"messageCount" : [2-9][0-9]*' "$REPORT_PATH"; then
-  echo "quill-code-desktop native smoke did not record enough transcript messages" >&2
-  cat "$REPORT_PATH" >&2
-  exit 1
-fi
 python3 - "$REPORT_PATH" <<'PY'
 import json
 import sys
@@ -601,8 +649,20 @@ import sys
 with open(sys.argv[1], "r", encoding="utf-8") as report_file:
     report = json.load(report_file)
 
+message_count = report.get("messageCount")
+if not isinstance(message_count, int) or message_count < 14:
+    raise SystemExit(
+        "quill-code-desktop native smoke did not record enough transcript messages: "
+        f"{message_count!r}"
+    )
+tool_card_count = report.get("toolCardCount")
+if not isinstance(tool_card_count, int) or tool_card_count < 9:
+    raise SystemExit(
+        "quill-code-desktop native smoke did not record enough tool cards: "
+        f"{tool_card_count!r}"
+    )
 timeline_count = report.get("timelineItemCount")
-if not isinstance(timeline_count, int) or timeline_count < 14:
+if not isinstance(timeline_count, int) or timeline_count < 23:
     raise SystemExit(
         "quill-code-desktop native smoke did not record enough timeline items: "
         f"{timeline_count!r}"

--- a/scripts/native_click_probe_contracts/cli.py
+++ b/scripts/native_click_probe_contracts/cli.py
@@ -12,6 +12,7 @@ from .computer_use_action import write_computer_use_action_manifest
 from .coworker_catalog import write_coworker_catalog_coverage
 from .live_saas import write_live_saas_manifest
 from .multi_file_artifact import write_multi_file_artifact_manifest
+from .one_turn_coworker import write_one_turn_coworker_manifest
 from .packaged_window import (
     validate_packaged_window_report,
     write_accessibility_readiness_manifest,
@@ -53,6 +54,14 @@ def main() -> None:
     multi_file_parser.add_argument("direct_report", type=Path)
     multi_file_parser.add_argument("launch_services_report", type=Path)
     multi_file_parser.add_argument("--manifest", required=True, type=Path)
+
+    one_turn_coworker_parser = subparsers.add_parser(
+        "one-turn-coworker",
+        help="write packaged one-turn office coworker evidence",
+    )
+    one_turn_coworker_parser.add_argument("direct_report", type=Path)
+    one_turn_coworker_parser.add_argument("launch_services_report", type=Path)
+    one_turn_coworker_parser.add_argument("--manifest", required=True, type=Path)
 
     browser_workflow_parser = subparsers.add_parser(
         "browser-workflow",
@@ -120,6 +129,12 @@ def main() -> None:
         )
     elif args.command == "multi-file-artifact":
         write_multi_file_artifact_manifest(
+            args.direct_report,
+            args.launch_services_report,
+            args.manifest,
+        )
+    elif args.command == "one-turn-coworker":
+        write_one_turn_coworker_manifest(
             args.direct_report,
             args.launch_services_report,
             args.manifest,

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -1,0 +1,114 @@
+"""Validate packaged one-turn office coworker smoke evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .json_io import load_report, require
+
+EXPECTED_CASES = {
+    15: {
+        "toolName": "host.file.write",
+        "artifactSuffix": "launch-announcement.md",
+        "artifactContains": "Billing portal launch email ready.",
+        "answerContains": "Wrote `launch-announcement.md`.",
+    },
+    16: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "signup-slice.csv",
+        "artifactContains": "organic,31",
+        "answerContains": "wrote signup-slice.csv",
+    },
+    68: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "weekly-review.csv",
+        "artifactContains": "Launch,3,2",
+        "answerContains": "wrote weekly-review.csv",
+    },
+}
+
+
+def validated_one_turn_coworker(report: dict[str, Any], label: str) -> dict[str, Any]:
+    smoke = report.get("oneTurnCoworkerSmoke")
+    require(isinstance(smoke, dict), f"{label} report is missing oneTurnCoworkerSmoke")
+
+    cases = smoke.get("cases")
+    require(isinstance(cases, list), f"{label} one-turn coworker cases were malformed")
+    by_id = {
+        case.get("taskID"): case
+        for case in cases
+        if isinstance(case, dict) and isinstance(case.get("taskID"), int)
+    }
+    require(
+        set(by_id) == set(EXPECTED_CASES),
+        f"{label} one-turn coworker task IDs were {sorted(by_id)}, expected {sorted(EXPECTED_CASES)}",
+    )
+
+    for task_id, expected in EXPECTED_CASES.items():
+        case = by_id[task_id]
+        require(
+            case.get("toolName") == expected["toolName"],
+            f"{label} task {task_id} tool was {case.get('toolName')!r}",
+        )
+        artifact_path = case.get("artifactPath")
+        require(
+            isinstance(artifact_path, str) and artifact_path.endswith(expected["artifactSuffix"]),
+            f"{label} task {task_id} artifact path was malformed: {artifact_path!r}",
+        )
+        require(
+            case.get("artifactContains") == expected["artifactContains"],
+            f"{label} task {task_id} artifact assertion was {case.get('artifactContains')!r}",
+        )
+        final_answer = case.get("finalAnswer")
+        require(
+            isinstance(final_answer, str) and expected["answerContains"] in final_answer,
+            f"{label} task {task_id} final answer was malformed: {final_answer!r}",
+        )
+
+    return smoke
+
+
+def semantic_one_turn_coworker(smoke: dict[str, Any]) -> dict[str, Any]:
+    cases = sorted(smoke["cases"], key=lambda case: case["taskID"])
+    return {
+        "taskIDs": [case["taskID"] for case in cases],
+        "toolSequence": [case["toolName"] for case in cases],
+        "artifactPathSuffixes": [
+            EXPECTED_CASES[case["taskID"]]["artifactSuffix"]
+            for case in cases
+        ],
+        "artifactContains": [case["artifactContains"] for case in cases],
+        "finalAnswers": [case["finalAnswer"] for case in cases],
+    }
+
+
+def write_one_turn_coworker_manifest(
+    direct_report_path: Path,
+    launch_services_report_path: Path,
+    manifest_path: Path,
+) -> None:
+    direct = validated_one_turn_coworker(load_report(direct_report_path), "direct executable")
+    launch_services = validated_one_turn_coworker(
+        load_report(launch_services_report_path),
+        "Launch Services",
+    )
+    direct_semantic = semantic_one_turn_coworker(direct)
+    launch_services_semantic = semantic_one_turn_coworker(launch_services)
+    require(
+        direct_semantic == launch_services_semantic,
+        "Packaged app Launch Services one-turn coworker smoke drifted from direct executable smoke",
+    )
+
+    manifest = {
+        "ok": True,
+        "directReport": "direct-executable/report.json",
+        "launchServicesReport": "launch-services/report.json",
+        "launchServicesMatchesDirect": True,
+        "oneTurnCoworkerMatchesDirect": True,
+        **direct_semantic,
+    }
+    with manifest_path.open("w", encoding="utf-8") as manifest_file:
+        json.dump(manifest, manifest_file, indent=2, sort_keys=True)
+        manifest_file.write("\n")

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -11,6 +11,7 @@ ACCESSIBILITY_READINESS_MANIFEST="$SMOKE_ROOT/packaged-accessibility-readiness.j
 ACCESSIBILITY_FRAMES_MANIFEST="$SMOKE_ROOT/packaged-accessibility-frames.json"
 SCHEDULED_COWORKER_MANIFEST="$SMOKE_ROOT/packaged-scheduled-coworker.json"
 MULTI_FILE_ARTIFACT_MANIFEST="$SMOKE_ROOT/packaged-multi-file-artifact.json"
+ONE_TURN_COWORKER_MANIFEST="$SMOKE_ROOT/packaged-one-turn-coworker.json"
 BROWSER_WORKFLOW_MANIFEST="$SMOKE_ROOT/packaged-browser-workflow.json"
 COMPUTER_USE_MANIFEST="$SMOKE_ROOT/packaged-computer-use.json"
 COMPUTER_USE_ACTION_MANIFEST="$SMOKE_ROOT/packaged-computer-use-action.json"
@@ -51,6 +52,9 @@ cleanup() {
     if [[ -e "$MULTI_FILE_ARTIFACT_MANIFEST" ]]; then
       cp "$MULTI_FILE_ARTIFACT_MANIFEST" "$ARTIFACT_DIR/packaged-multi-file-artifact.json"
     fi
+    if [[ -e "$ONE_TURN_COWORKER_MANIFEST" ]]; then
+      cp "$ONE_TURN_COWORKER_MANIFEST" "$ARTIFACT_DIR/packaged-one-turn-coworker.json"
+    fi
     if [[ -e "$BROWSER_WORKFLOW_MANIFEST" ]]; then
       cp "$BROWSER_WORKFLOW_MANIFEST" "$ARTIFACT_DIR/packaged-browser-workflow.json"
     fi
@@ -80,6 +84,7 @@ cleanup() {
       printf 'accessibility_frames_manifest=packaged-accessibility-frames.json\n'
       printf 'scheduled_coworker_manifest=packaged-scheduled-coworker.json\n'
       printf 'multi_file_artifact_manifest=packaged-multi-file-artifact.json\n'
+      printf 'one_turn_coworker_manifest=packaged-one-turn-coworker.json\n'
       printf 'browser_workflow_manifest=packaged-browser-workflow.json\n'
       printf 'computer_use_manifest=packaged-computer-use.json\n'
       printf 'computer_use_action_manifest=packaged-computer-use-action.json\n'
@@ -183,6 +188,11 @@ QUILLCODE_NATIVE_DESKTOP_SMOKE_ARTIFACT_DIR="$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR
   "$DIRECT_SMOKE_ARTIFACT_DIR/report.json" \
   "$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR/report.json" \
   --manifest "$MULTI_FILE_ARTIFACT_MANIFEST"
+
+"$ROOT_DIR/scripts/native-click-probe-contracts.py" one-turn-coworker \
+  "$DIRECT_SMOKE_ARTIFACT_DIR/report.json" \
+  "$LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR/report.json" \
+  --manifest "$ONE_TURN_COWORKER_MANIFEST"
 
 "$ROOT_DIR/scripts/native-click-probe-contracts.py" browser-workflow \
   "$DIRECT_SMOKE_ARTIFACT_DIR/report.json" \


### PR DESCRIPTION
## Summary

- add `oneTurnCoworkerSmoke` to the native desktop smoke report for catalog rows 15, 16, and 68
- validate direct packaged executable vs Launch Services evidence as `packaged-one-turn-coworker.json`
- update the coworker tracker docs/parity notes so the spreadsheet has row-linked evidence to reference

## Validation

- `swift test --filter QuillCodeDesktopControllerSmokeTests`
- `swift test --filter ParityPackagedMacOSSmokeGateTests`
- `python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/cli.py`
- `scripts/native-desktop-smoke.sh`
- `git diff --check`
