### PR TITLE
Add coworker coverage markdown report

### DIFF
--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -62,6 +62,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         let secondEvidenceURL = temporaryDirectory.appendingPathComponent("sheets-evidence.json")
         let secondManifestURL = temporaryDirectory.appendingPathComponent("sheets-manifest.json")
         let coverageURL = temporaryDirectory.appendingPathComponent("coworker-coverage.json")
+        let markdownURL = temporaryDirectory.appendingPathComponent("coworker-coverage.md")
 
         try validLiveSaaSEvidence.write(to: firstEvidenceURL, atomically: true, encoding: .utf8)
         try validLiveSaaSEvidence
@@ -82,6 +83,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
                 secondManifestURL.path,
                 "--output",
                 coverageURL.path,
+                "--markdown-output",
+                markdownURL.path,
             ]
         )
 
@@ -94,6 +97,11 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#"199"#), coverage)
         XCTAssertTrue(coverage.contains(#"200"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceByTaskID": {"#), coverage)
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("# QuillCode Coworker Coverage"), markdown)
+        XCTAssertTrue(markdown.contains("| Row | Evidence | Service | Task | Source |"), markdown)
+        XCTAssertTrue(markdown.contains("| 199 | live-saas | Salesforce | Update CRM status |"), markdown)
+        XCTAssertTrue(markdown.contains("Rows not listed here remain unproven"), markdown)
     }
 
     func testCoworkerCatalogCoverageAcceptsPackagedOneTurnRows() throws {
@@ -223,6 +231,11 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         let script = try Self.scriptText(named: "live-saas-smoke.sh")
         let templateScript = try Self.scriptText(named: "live-saas-template.sh")
         let validator = try Self.nativeClickProbeValidatorText()
+        let catalogReporter = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("scripts/native_click_probe_contracts/coworker_catalog.py"),
+            encoding: .utf8
+        )
         let coworkerDocs = try Self.docsText(named: "COWORKER_TASK_TRACKER.md")
 
         XCTAssertTrue(script.contains("QUILLCODE_LIVE_SAAS_EVIDENCE"))
@@ -232,6 +245,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(validator.contains("coworker-catalog"))
         XCTAssertTrue(validator.contains("live-saas-template"))
         XCTAssertTrue(validator.contains("def write_live_saas_manifest"))
+        XCTAssertTrue(validator.contains("--markdown-output"))
+        XCTAssertTrue(catalogReporter.contains("def coworker_catalog_markdown"))
         XCTAssertTrue(validator.contains("accountState must be signed-in"))
         XCTAssertTrue(validator.contains("catalogTaskIDs must be a non-empty list"))
         XCTAssertTrue(coworkerDocs.contains("live-saas-template.sh"))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -104,9 +104,10 @@
   `scripts/live-saas-smoke.sh` now gives real signed-in SaaS runs a fail-closed manifest contract for
   spreadsheet `catalogTaskIDs`, HTTPS URL, signed-in state, live DOM inspection, browser/Computer Use
   actions, and captured-secret rejection; real SaaS rows remain gated until a row-specific live
-  manifest exists. `scripts/native-click-probe-contracts.py coworker-catalog` rolls one or more
-  validated live SaaS manifests into `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID` across
-  the full 1-206 catalog, so row coverage can be reviewed from durable evidence.
+  manifest exists. `scripts/native-click-probe-contracts.py coworker-catalog` rolls validated live
+  SaaS, scheduled-notification, and packaged one-turn coworker manifests into `provenTaskIDs`,
+  `pendingTaskIDs`, and `evidenceByTaskID` across the full 1-206 catalog, with an optional Markdown
+  row report for reviewing spreadsheet updates from durable evidence.
 - Artifact previews now include bounded local YAML/YML metadata using the existing Yams parser:
   root kind, top-level keys, sequence/mapping/value counts, file size, and capped key previews.
 - Artifact previews now include bounded local Apple property-list metadata using Foundation parsing:

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -249,11 +249,13 @@ Multiple validated live SaaS manifests can be rolled up with:
 scripts/native-click-probe-contracts.py coworker-catalog \
   path/to/live-saas-manifest-1.json \
   path/to/live-saas-manifest-2.json \
-  --output path/to/coworker-coverage.json
+  --output path/to/coworker-coverage.json \
+  --markdown-output path/to/coworker-coverage.md
 ```
 
 The coverage summary records `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID` for the full
-1-206 catalog range, so spreadsheet updates can be reviewed from row-linked evidence rather than
+1-206 catalog range. The optional Markdown report lists proven rows, evidence type, service, task,
+and source manifest, so spreadsheet updates can be reviewed from row-linked evidence rather than
 manual memory.
 
 ## Packaged Computer Use Evidence Slice

--- a/scripts/native_click_probe_contracts/cli.py
+++ b/scripts/native_click_probe_contracts/cli.py
@@ -127,6 +127,7 @@ def main() -> None:
     )
     coworker_catalog_parser.add_argument("manifests", nargs="+", type=Path)
     coworker_catalog_parser.add_argument("--output", required=True, type=Path)
+    coworker_catalog_parser.add_argument("--markdown-output", type=Path)
 
     safety_reviewer_parser = subparsers.add_parser(
         "safety-reviewer-calibration",
@@ -215,7 +216,7 @@ def main() -> None:
             url=args.url,
         )
     elif args.command == "coworker-catalog":
-        write_coworker_catalog_coverage(args.manifests, args.output)
+        write_coworker_catalog_coverage(args.manifests, args.output, args.markdown_output)
     elif args.command == "safety-reviewer-calibration":
         write_safety_reviewer_calibration_manifest(args.evidence, args.manifest)
     elif args.command == "scheduled-notification-observation":

--- a/scripts/native_click_probe_contracts/coworker_catalog.py
+++ b/scripts/native_click_probe_contracts/coworker_catalog.py
@@ -191,9 +191,61 @@ def build_coworker_catalog_coverage(manifest_paths: list[Path], base_directory: 
     }
 
 
-def write_coworker_catalog_coverage(manifest_paths: list[Path], output_path: Path) -> None:
+def coworker_catalog_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# QuillCode Coworker Coverage",
+        "",
+        f"- Catalog: {summary['catalogSpreadsheetURL']}",
+        f"- Evidence manifests: {summary['evidenceManifestCount']}",
+        f"- Proven rows: {summary['provenTaskCount']}",
+        f"- Pending rows: {summary['pendingTaskCount']}",
+        "",
+        "| Row | Evidence | Service | Task | Source |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+
+    evidence_by_task_id = summary["evidenceByTaskID"]
+    for task_id in summary["provenTaskIDs"]:
+        row_entries = evidence_by_task_id[str(task_id)]
+        first_entry = row_entries[0]
+        extra_count = len(row_entries) - 1
+        evidence_label = first_entry["evidenceType"]
+        if extra_count:
+            evidence_label = f"{evidence_label} (+{extra_count})"
+        lines.append(
+            "| {row} | {evidence} | {service} | {task} | `{source}` |".format(
+                row=task_id,
+                evidence=_markdown_table_cell(evidence_label),
+                service=_markdown_table_cell(first_entry["serviceName"]),
+                task=_markdown_table_cell(first_entry["taskName"]),
+                source=str(first_entry["manifestPath"]).replace("`", "\\`"),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "Rows not listed here remain unproven until a row-linked manifest is validated.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _markdown_table_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def write_coworker_catalog_coverage(
+    manifest_paths: list[Path],
+    output_path: Path,
+    markdown_output_path: Path | None = None,
+) -> None:
     base_directory = output_path.parent
     summary = build_coworker_catalog_coverage(manifest_paths, base_directory)
     with output_path.open("w", encoding="utf-8") as output_file:
         json.dump(summary, output_file, indent=2, sort_keys=True)
         output_file.write("\n")
+    if markdown_output_path is not None:
+        with markdown_output_path.open("w", encoding="utf-8") as output_file:
+            output_file.write(coworker_catalog_markdown(summary))


### PR DESCRIPTION
## Summary
- add optional Markdown output to the coworker catalog coverage rollup
- list proven rows with evidence type, service, task, and source manifest for sheet review
- update parity docs to reflect live SaaS, scheduled notification, and packaged one-turn rollup inputs

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- git diff --check