### PR TITLE
Add dependency-map coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -882,6 +882,14 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactContains: "organic,31"
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 28,
+                prompt: "Create a file named `dependency-map.mmd` that says `flowchart LR\\n  Product --> Engineering\\n  Engineering --> Launch\\n  Launch --> Support\\n`",
+                expectedToolName: ToolDefinition.fileWrite.name,
+                expectedAnswer: "Wrote `dependency-map.mmd`.",
+                artifactRelativePath: "dependency-map.mmd",
+                artifactContains: "Engineering --> Launch"
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 68],
-          "taskIDs": [15, 16, 68],
+          "catalogTaskIDs": [15, 16, 28, 68],
+          "taskIDs": [15, 16, 28, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,10 +132,11 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 3"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 4"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #28, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,12 +168,14 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #28, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
 - Row #16 proves an analysis-style shell task runs with non-empty `host.shell.run` arguments and
   creates `signup-slice.csv`.
+- Row #28 proves a dependency-mapping request creates a Mermaid diagram artifact through
+  `host.file.write`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,10 +26,10 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, and #68. The manifest compares direct packaged executable and Launch Services evidence,
-  proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions before those
-  rows can be treated as row-linked one-turn coworker coverage. The manifest now carries the
-  canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as
+  #15, #16, #28, and #68. The manifest compares direct packaged executable and Launch Services
+  evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
+  before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
+  the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as
   first-class row evidence.
 
 ## 2026-07-27: TrustedRouter balance history is locally observed

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -353,6 +353,12 @@ expected_one_turn_cases = {
         "artifactContains": "organic,31",
         "answerContains": "wrote signup-slice.csv",
     },
+    28: {
+        "toolName": "host.file.write",
+        "artifactSuffix": "dependency-map.mmd",
+        "artifactContains": "Engineering --> Launch",
+        "answerContains": "Wrote `dependency-map.mmd`.",
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -22,6 +22,12 @@ EXPECTED_CASES = {
         "artifactContains": "organic,31",
         "answerContains": "wrote signup-slice.csv",
     },
+    28: {
+        "toolName": "host.file.write",
+        "artifactSuffix": "dependency-map.mmd",
+        "artifactContains": "Engineering --> Launch",
+        "answerContains": "Wrote `dependency-map.mmd`.",
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add catalog row #28 dependency mapping to packaged one-turn coworker smoke evidence
- update native smoke and packaged manifest validators to require the new Mermaid artifact case
- update coworker tracker docs and parity matrix row coverage notes

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/cli.py
- swift test --filter QuillCodeDesktopControllerSmokeTests
- synthetic one-turn-coworker manifest validation includes catalogTaskIDs [15, 16, 28, 68]
- scripts/native-desktop-smoke.sh
- git diff --check