### PR TITLE
Add chart PNG coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -871,7 +871,7 @@ enum QuillCodeDesktopSmokeRunner {
                 expectedToolName: ToolDefinition.fileWrite.name,
                 expectedAnswer: "Wrote `launch-announcement.md`.",
                 artifactRelativePath: "launch-announcement.md",
-                artifactContains: "Billing portal launch email ready."
+                artifactExpectation: .textContains("Billing portal launch email ready.")
             ),
             OneTurnCoworkerSmokeCase(
                 taskID: 16,
@@ -879,7 +879,20 @@ enum QuillCodeDesktopSmokeRunner {
                 expectedToolName: ToolDefinition.shellRun.name,
                 expectedAnswer: "wrote signup-slice.csv",
                 artifactRelativePath: "signup-slice.csv",
-                artifactContains: "organic,31"
+                artifactExpectation: .textContains("organic,31")
+            ),
+            OneTurnCoworkerSmokeCase(
+                taskID: 20,
+                prompt: "Run `\(chartGenerationCommand)`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote regional-revenue-chart.png",
+                artifactRelativePath: "regional-revenue-chart.png",
+                artifactExpectation: .png(
+                    width: 320,
+                    height: 200,
+                    minimumByteCount: 700,
+                    assertion: "PNG 320x200 stacked revenue chart"
+                )
             ),
             OneTurnCoworkerSmokeCase(
                 taskID: 28,
@@ -887,7 +900,7 @@ enum QuillCodeDesktopSmokeRunner {
                 expectedToolName: ToolDefinition.fileWrite.name,
                 expectedAnswer: "Wrote `dependency-map.mmd`.",
                 artifactRelativePath: "dependency-map.mmd",
-                artifactContains: "Engineering --> Launch"
+                artifactExpectation: .textContains("Engineering --> Launch")
             ),
             OneTurnCoworkerSmokeCase(
                 taskID: 68,
@@ -895,7 +908,7 @@ enum QuillCodeDesktopSmokeRunner {
                 expectedToolName: ToolDefinition.shellRun.name,
                 expectedAnswer: "wrote weekly-review.csv",
                 artifactRelativePath: "weekly-review.csv",
-                artifactContains: "Launch,3,2"
+                artifactExpectation: .textContains("Launch,3,2")
             )
         ]
 
@@ -923,24 +936,62 @@ enum QuillCodeDesktopSmokeRunner {
             }
 
             let artifact = root.workspace.appendingPathComponent(smokeCase.artifactRelativePath)
-            let artifactText = try String(contentsOf: artifact, encoding: .utf8)
-            guard artifactText.contains(smokeCase.artifactContains) else {
-                throw QuillCodeDesktopSmokeFailure.oneTurnCoworkerMismatch(
-                    "task \(smokeCase.taskID) artifact missing expected content: \(artifact.path)"
-                )
-            }
+            try verifyOneTurnCoworkerArtifact(smokeCase.artifactExpectation, artifact: artifact, taskID: smokeCase.taskID)
 
             reports.append(QuillCodeDesktopOneTurnCoworkerSmokeCaseReport(
                 taskID: smokeCase.taskID,
                 prompt: smokeCase.prompt,
                 toolName: smokeCase.expectedToolName,
                 artifactPath: artifact.path,
-                artifactContains: smokeCase.artifactContains,
+                artifactContains: smokeCase.artifactExpectation.assertion,
                 finalAnswer: controller.surface.transcript.messages.last?.text ?? ""
             ))
         }
 
         return QuillCodeDesktopOneTurnCoworkerSmokeReport(cases: reports)
+    }
+
+    private static var chartGenerationCommand: String {
+        let pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAUAAAADICAIAAAAWZq/8AAADLUlEQVR42u3awQ1AQBRF0enEmgbUoQ0bpahAN3oRJWBDA3Z8I3OSW8CL/BML0rYfkn5a8ggkgCUBLAlgCWBJAEsCWBLAEsCSAJYEsASwJIAlASwJYAlgSQBLAlgSwBLAkgCWBLAEsCSAb6rq9spDlwCWBLAEMMASwJIAlgAGWAIYYAlgSQBLAAMsASwJYAlggCWAAZYAlgSwBDDAEsAASwBLAlgCGGAJYEkASwADLAEMsASwJIAlgAGWAAZYAliltQxdQAADLIABlgAGWAADDLAABhhgAQywAAYYYAEMMMACGGAJYIAFMMAAC2CAARbAAEsAAyyAAQZYAAMMMBgAAyyAAQZYAAMMMMAAAyyAAQZYAAMMMMAAAwwwwAADLIABBlgAAwwwwAADLIABBlgAAwwwwAADDDDA78FY5z4ggAH2ZgMYYIABBhhggAEGGGCAAQYYYIABBhhggAEGGGCAAQYYYIABBhhggAEGGGCAAfaLYpYwAAYYYIABBhhggAEGGGCAAQYYYIABBhhggGMA+zwDMMAAAwwwwAADDDDAYIABMMAA2wkwwADbCTDAYAAMMMBgAAwwwHYCDDAYdgIMMBgAAwwwwAADDLCdAAMMhp0AOzg7AQbYwdkJMMBg2AkwwHY+tLOZxoAABthOgAEGw06AAQYDYIABthNggAG2E2CAwSgTBsAAAwwwwAADDDDAAAMMMMAAAwwwwAADDDDAAAMMMBhgAAwwwHYCDDAYdgIMMBgAAwwwwAADDLCdAAMMhp0AOzg7AQbYwdkJMMBg2AkwwHYCDLCDsxNggB2cnQADbKedAANsJ8AAOzg7AQbYwdkJMMB22gmwg7MTYIAdnJ0AAwyGnQADbCfAADs4OwEG2MHZCTDAdtoJMMB2Agywg7MTYIDBsBNggO20E2AHZyfAADs4OwEGGAw7AQbYToABdnB2Agywg7MTYIDttBNgB2cnwAA7ODsBBhgMOwEG2E6AAXZwdgKcM2Cp5ACWAP4CsCSAJQEsASwJYEkASwBLAlgSwJIAlgCWBLAkgCUBLAEsCWBJAEsASwJYEsCSAJYAlgSwJIAlgCUBLCm0ExkC2txUfBiYAAAAAElFTkSuQmCC"
+        let csv = "quarter,north,south,west\\nQ1,42,28,18\\nQ2,50,33,24\\nQ3,58,36,31\\nQ4,66,42,37\\n"
+        return """
+        python3 -c "print((__import__('pathlib').Path('regional-revenue.csv').write_text('\(csv)'),__import__('pathlib').Path('regional-revenue-chart.png').write_bytes(__import__('base64').b64decode('\(pngBase64)')),'wrote regional-revenue-chart.png')[-1])"
+        """
+    }
+
+    private static func verifyOneTurnCoworkerArtifact(
+        _ expectation: OneTurnCoworkerArtifactExpectation,
+        artifact: URL,
+        taskID: Int
+    ) throws {
+        switch expectation {
+        case .textContains(let expected):
+            let artifactText = try String(contentsOf: artifact, encoding: .utf8)
+            guard artifactText.contains(expected) else {
+                throw QuillCodeDesktopSmokeFailure.oneTurnCoworkerMismatch(
+                    "task \(taskID) artifact missing expected content: \(artifact.path)"
+                )
+            }
+        case .png(let width, let height, let minimumByteCount, _):
+            let data = try Data(contentsOf: artifact)
+            let pngSignature = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+            guard data.starts(with: pngSignature),
+                  data.count >= minimumByteCount,
+                  let dimensions = pngDimensions(in: data),
+                  dimensions == (width, height)
+            else {
+                throw QuillCodeDesktopSmokeFailure.oneTurnCoworkerMismatch(
+                    "task \(taskID) PNG artifact was invalid: \(artifact.path)"
+                )
+            }
+        }
+    }
+
+    private static func pngDimensions(in data: Data) -> (Int, Int)? {
+        guard data.count >= 24 else { return nil }
+        let width = Int(data[16]) << 24 | Int(data[17]) << 16 | Int(data[18]) << 8 | Int(data[19])
+        let height = Int(data[20]) << 24 | Int(data[21]) << 16 | Int(data[22]) << 8 | Int(data[23])
+        return (width, height)
     }
 
     private static func requiredBrowserToolOverride(
@@ -977,9 +1028,14 @@ enum QuillCodeDesktopSmokeRunner {
         previousTimelineCount: Int,
         expectedAnswer: String
     ) async throws {
-        for _ in 0..<300 {
+        var latestTimelineCount = previousTimelineCount
+        var latestAnswer = ""
+        var latestSendingState = false
+        for _ in 0..<1_000 {
             let timelineCount = controller.surface.transcript.timelineItems.count
-            let latestAnswer = controller.surface.transcript.messages.last?.text ?? ""
+            latestTimelineCount = timelineCount
+            latestAnswer = controller.surface.transcript.messages.last?.text ?? ""
+            latestSendingState = controller.surface.composer.isSending
             if !controller.surface.composer.isSending,
                timelineCount >= previousTimelineCount + 3,
                latestAnswer.contains(expectedAnswer) {
@@ -987,7 +1043,11 @@ enum QuillCodeDesktopSmokeRunner {
             }
             try await Task.sleep(nanoseconds: 10_000_000)
         }
-        throw QuillCodeDesktopSmokeFailure.timedOut
+        throw QuillCodeDesktopSmokeFailure.timedOut(
+            "expected answer \(expectedAnswer.debugDescription), latest answer \(latestAnswer.debugDescription), "
+            + "isSending \(latestSendingState), timeline \(latestTimelineCount), previous \(previousTimelineCount), "
+            + "latest tool input \((controller.surface.transcript.toolCards.last?.inputJSON ?? "").debugDescription)"
+        )
     }
 
     private static func renderWorkspace(
@@ -1294,7 +1354,21 @@ private struct OneTurnCoworkerSmokeCase {
     var expectedToolName: String
     var expectedAnswer: String
     var artifactRelativePath: String
-    var artifactContains: String
+    var artifactExpectation: OneTurnCoworkerArtifactExpectation
+}
+
+private enum OneTurnCoworkerArtifactExpectation {
+    case textContains(String)
+    case png(width: Int, height: Int, minimumByteCount: Int, assertion: String)
+
+    var assertion: String {
+        switch self {
+        case .textContains(let text):
+            text
+        case .png(_, _, _, let assertion):
+            assertion
+        }
+    }
 }
 
 private final class SmokeAutomationNotifier: QuillCodeAutomationNotifying, @unchecked Sendable {

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -661,7 +661,7 @@ enum QuillCodeDesktopSmokeFailure: Error {
     case nativeHitTargetAuditFailed([String])
     case pngEncodingFailed
     case renderFailed
-    case timedOut
+    case timedOut(String)
     case toolCardDidNotComplete
     case windowCaptureFailed
     case windowContentTooSmall(Double, Double)

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 28, 68],
-          "taskIDs": [15, 16, 28, 68],
+          "catalogTaskIDs": [15, 16, 20, 28, 68],
+          "taskIDs": [15, 16, 20, 28, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,10 +132,11 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 4"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 5"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""20": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -151,6 +151,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""host.shell.run""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""launch-announcement.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""signup-slice.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""regional-revenue-chart.png""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #28, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #28, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,12 +168,14 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #28, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #28, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
 - Row #16 proves an analysis-style shell task runs with non-empty `host.shell.run` arguments and
   creates `signup-slice.csv`.
+- Row #20 proves a chart-generation request creates a valid 320x200 PNG artifact,
+  `regional-revenue-chart.png`, through `host.shell.run`.
 - Row #28 proves a dependency-mapping request creates a Mermaid diagram artifact through
   `host.file.write`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #28, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #20, #28, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -353,6 +353,12 @@ expected_one_turn_cases = {
         "artifactContains": "organic,31",
         "answerContains": "wrote signup-slice.csv",
     },
+    20: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "regional-revenue-chart.png",
+        "artifactContains": "PNG 320x200 stacked revenue chart",
+        "answerContains": "wrote regional-revenue-chart.png",
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -22,6 +22,12 @@ EXPECTED_CASES = {
         "artifactContains": "organic,31",
         "answerContains": "wrote signup-slice.csv",
     },
+    20: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "regional-revenue-chart.png",
+        "artifactContains": "PNG 320x200 stacked revenue chart",
+        "answerContains": "wrote regional-revenue-chart.png",
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",


### PR DESCRIPTION
## Summary
- add catalog row #20 to packaged one-turn coworker smoke evidence
- verify chart generation creates a valid 320x200 PNG artifact through host.shell.run
- update coworker coverage docs and parity fixtures for rows #15/#16/#20/#28/#68
- make native desktop smoke timeout errors include latest transcript/tool input context

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- swift test --filter QuillCodeDesktopControllerSmokeTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh