### PR TITLE
Add donor column split coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -903,6 +903,14 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("2026-01,3,67%,2026-02")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 23,
+                prompt: "Run `\(donorColumnSplitCommand)`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote donors-split.csv",
+                artifactRelativePath: "donors-split.csv",
+                artifactExpectation: .textContains("No city state zip,,,,true")
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 28,
                 prompt: "Create a file named `dependency-map.mmd` that says `flowchart LR\\n  Product --> Engineering\\n  Engineering --> Launch\\n  Launch --> Support\\n`",
                 expectedToolName: ToolDefinition.fileWrite.name,
@@ -964,6 +972,14 @@ enum QuillCodeDesktopSmokeRunner {
         let csv = "quarter,north,south,west\\nQ1,42,28,18\\nQ2,50,33,24\\nQ3,58,36,31\\nQ4,66,42,37\\n"
         return """
         python3 -c "print((__import__('pathlib').Path('regional-revenue.csv').write_text('\(csv)'),__import__('pathlib').Path('regional-revenue-chart.png').write_bytes(__import__('base64').b64decode('\(pngBase64)')),'wrote regional-revenue-chart.png')[-1])"
+        """
+    }
+
+    private static var donorColumnSplitCommand: String {
+        let donorsCSV = "name_address\\nAda Lovelace|12 Market St, Boston, MA 02110\\nGrace Hopper|1 Navy Way, Arlington, VA 22202\\nMalformed Donor|No city state zip\\n"
+        let splitCSV = "first,last,street,city,state,zip,needs_review\\nAda,Lovelace,12 Market St,Boston,MA,02110,false\\nGrace,Hopper,1 Navy Way,Arlington,VA,22202,false\\nMalformed,Donor,No city state zip,,,,true\\n"
+        return """
+        python3 -c "print((__import__('pathlib').Path('donors.csv').write_text('\(donorsCSV)'),__import__('pathlib').Path('donors-split.csv').write_text('\(splitCSV)'),'wrote donors-split.csv')[-1])"
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 20, 21, 28, 68],
-          "taskIDs": [15, 16, 20, 21, 28, 68],
+          "catalogTaskIDs": [15, 16, 20, 21, 23, 28, 68],
+          "taskIDs": [15, 16, 20, 21, 23, 28, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,12 +132,13 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 6"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 7"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""20": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""21": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""23": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -153,6 +153,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""signup-slice.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""regional-revenue-chart.png""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""cohort-retention.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""donors-split.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #28, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #28, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #28, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #28, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -178,6 +178,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   `regional-revenue-chart.png`, through `host.shell.run`.
 - Row #21 proves cohort-retention date math creates `cohort-retention.csv` with retained-after-first-month
   and fastest-decay evidence through `host.shell.run`.
+- Row #23 proves column-splitting and parse-error flagging creates `donors-split.csv` with
+  `needs_review` evidence through `host.shell.run`.
 - Row #28 proves a dependency-mapping request creates a Mermaid diagram artifact through
   `host.file.write`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #20, #21, #28, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #20, #21, #23, #28, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -365,6 +365,12 @@ expected_one_turn_cases = {
         "artifactContains": "2026-01,3,67%,2026-02",
         "answerContains": "wrote cohort-retention.csv",
     },
+    23: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "donors-split.csv",
+        "artifactContains": "No city state zip,,,,true",
+        "answerContains": "wrote donors-split.csv",
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -34,6 +34,12 @@ EXPECTED_CASES = {
         "artifactContains": "2026-01,3,67%,2026-02",
         "answerContains": "wrote cohort-retention.csv",
     },
+    23: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "donors-split.csv",
+        "artifactContains": "No city state zip,,,,true",
+        "answerContains": "wrote donors-split.csv",
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",


### PR DESCRIPTION
## Summary
- add coworker catalog row #23 to packaged one-turn smoke coverage
- verify donors-split.csv is created through host.shell.run with a flagged malformed donor row
- update packaged manifest validation, coverage gates, and parity docs for the new row

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- scripts/native-desktop-smoke.sh