### PR TITLE
Add newsletter validation coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -911,6 +911,20 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("No city state zip,,,,true")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 25,
+                prompt: "Run `\(newsletterValidationCommand)`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote newsletter-clean.csv and newsletter-bad-rows.csv",
+                artifactRelativePath: "newsletter-clean.csv",
+                artifactExpectation: .textContains("+14155550100"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "newsletter-bad-rows.csv",
+                        expectation: .textContains("invalid-email,not-a-phone")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 28,
                 prompt: "Create a file named `dependency-map.mmd` that says `flowchart LR\\n  Product --> Engineering\\n  Engineering --> Launch\\n  Launch --> Support\\n`",
                 expectedToolName: ToolDefinition.fileWrite.name,
@@ -953,6 +967,14 @@ enum QuillCodeDesktopSmokeRunner {
 
             let artifact = root.workspace.appendingPathComponent(smokeCase.artifactRelativePath)
             try verifyOneTurnCoworkerArtifact(smokeCase.artifactExpectation, artifact: artifact, taskID: smokeCase.taskID)
+            for secondaryArtifact in smokeCase.secondaryArtifacts {
+                let secondaryURL = root.workspace.appendingPathComponent(secondaryArtifact.relativePath)
+                try verifyOneTurnCoworkerArtifact(
+                    secondaryArtifact.expectation,
+                    artifact: secondaryURL,
+                    taskID: smokeCase.taskID
+                )
+            }
 
             reports.append(QuillCodeDesktopOneTurnCoworkerSmokeCaseReport(
                 taskID: smokeCase.taskID,
@@ -960,6 +982,14 @@ enum QuillCodeDesktopSmokeRunner {
                 toolName: smokeCase.expectedToolName,
                 artifactPath: artifact.path,
                 artifactContains: smokeCase.artifactExpectation.assertion,
+                secondaryArtifacts: smokeCase.secondaryArtifacts.map { secondaryArtifact in
+                    [
+                        "artifactPath": root.workspace
+                            .appendingPathComponent(secondaryArtifact.relativePath)
+                            .path,
+                        "artifactContains": secondaryArtifact.expectation.assertion
+                    ]
+                },
                 finalAnswer: controller.surface.transcript.messages.last?.text ?? ""
             ))
         }
@@ -972,6 +1002,15 @@ enum QuillCodeDesktopSmokeRunner {
         let csv = "quarter,north,south,west\\nQ1,42,28,18\\nQ2,50,33,24\\nQ3,58,36,31\\nQ4,66,42,37\\n"
         return """
         python3 -c "print((__import__('pathlib').Path('regional-revenue.csv').write_text('\(csv)'),__import__('pathlib').Path('regional-revenue-chart.png').write_bytes(__import__('base64').b64decode('\(pngBase64)')),'wrote regional-revenue-chart.png')[-1])"
+        """
+    }
+
+    private static var newsletterValidationCommand: String {
+        let sourceCSV = "email,phone\\nvalid@example.com,(415) 555-0100\\ninvalid-email,not-a-phone\\nmissingphone@example.com,\\n"
+        let cleanCSV = "email,phone_e164\\nvalid@example.com,+14155550100\\n"
+        let badRowsCSV = "email,phone,reason\\ninvalid-email,not-a-phone,invalid email and phone\\nmissingphone@example.com,,missing phone\\n"
+        return """
+        python3 -c "print((__import__('pathlib').Path('newsletter_list.csv').write_text('\(sourceCSV)'),__import__('pathlib').Path('newsletter-clean.csv').write_text('\(cleanCSV)'),__import__('pathlib').Path('newsletter-bad-rows.csv').write_text('\(badRowsCSV)'),'wrote newsletter-clean.csv and newsletter-bad-rows.csv')[-1])"
         """
     }
 
@@ -1387,6 +1426,12 @@ private struct OneTurnCoworkerSmokeCase {
     var expectedAnswer: String
     var artifactRelativePath: String
     var artifactExpectation: OneTurnCoworkerArtifactExpectation
+    var secondaryArtifacts: [OneTurnCoworkerArtifactCheck] = []
+}
+
+private struct OneTurnCoworkerArtifactCheck {
+    var relativePath: String
+    var expectation: OneTurnCoworkerArtifactExpectation
 }
 
 private enum OneTurnCoworkerArtifactExpectation {

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -448,6 +448,7 @@ struct QuillCodeDesktopOneTurnCoworkerSmokeCaseReport {
     var toolName: String
     var artifactPath: String
     var artifactContains: String
+    var secondaryArtifacts: [[String: String]] = []
     var finalAnswer: String
 
     var dictionary: [String: Any] {
@@ -457,6 +458,7 @@ struct QuillCodeDesktopOneTurnCoworkerSmokeCaseReport {
             "toolName": toolName,
             "artifactPath": artifactPath,
             "artifactContains": artifactContains,
+            "secondaryArtifacts": secondaryArtifacts,
             "finalAnswer": finalAnswer
         ]
     }

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 20, 21, 23, 28, 68],
-          "taskIDs": [15, 16, 20, 21, 23, 28, 68],
+          "catalogTaskIDs": [15, 16, 20, 21, 23, 25, 28, 68],
+          "taskIDs": [15, 16, 20, 21, 23, 25, 28, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,13 +132,14 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 7"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 8"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""20": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""21": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""23": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""25": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -154,6 +154,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""regional-revenue-chart.png""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""cohort-retention.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""donors-split.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-clean.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-bad-rows.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #28, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #25, #28, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #28, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #25, #28, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -180,6 +180,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   and fastest-decay evidence through `host.shell.run`.
 - Row #23 proves column-splitting and parse-error flagging creates `donors-split.csv` with
   `needs_review` evidence through `host.shell.run`.
+- Row #25 proves data validation creates both `newsletter-clean.csv` with E.164 phone normalization
+  and `newsletter-bad-rows.csv` with rejected invalid rows through `host.shell.run`.
 - Row #28 proves a dependency-mapping request creates a Mermaid diagram artifact through
   `host.file.write`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #20, #21, #23, #28, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #20, #21, #23, #25, #28, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -371,6 +371,18 @@ expected_one_turn_cases = {
         "artifactContains": "No city state zip,,,,true",
         "answerContains": "wrote donors-split.csv",
     },
+    25: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "newsletter-clean.csv",
+        "artifactContains": "+14155550100",
+        "answerContains": "wrote newsletter-clean.csv and newsletter-bad-rows.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "newsletter-bad-rows.csv",
+                "artifactContains": "invalid-email,not-a-phone",
+            },
+        ],
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",
@@ -409,6 +421,30 @@ for task_id, expected in expected_one_turn_cases.items():
             "one-turn coworker task "
             f"{task_id} artifact assertion was {case.get('artifactContains')!r}"
         )
+    expected_secondary = expected.get("secondaryArtifacts", [])
+    secondary_artifacts = case.get("secondaryArtifacts", [])
+    if not isinstance(secondary_artifacts, list):
+        fail(f"one-turn coworker task {task_id} secondary artifacts were malformed: {secondary_artifacts!r}")
+    if len(secondary_artifacts) != len(expected_secondary):
+        fail(
+            f"one-turn coworker task {task_id} secondary artifact count was "
+            f"{len(secondary_artifacts)}, expected {len(expected_secondary)}"
+        )
+    for index, expected_artifact in enumerate(expected_secondary):
+        artifact = secondary_artifacts[index]
+        if not isinstance(artifact, dict):
+            fail(f"one-turn coworker task {task_id} secondary artifact {index} was malformed")
+        secondary_path = artifact.get("artifactPath")
+        if not isinstance(secondary_path, str) or not secondary_path.endswith(expected_artifact["artifactSuffix"]):
+            fail(
+                f"one-turn coworker task {task_id} secondary artifact {index} path was "
+                f"{secondary_path!r}, expected suffix {expected_artifact['artifactSuffix']!r}"
+            )
+        if artifact.get("artifactContains") != expected_artifact["artifactContains"]:
+            fail(
+                f"one-turn coworker task {task_id} secondary artifact {index} assertion was "
+                f"{artifact.get('artifactContains')!r}, expected {expected_artifact['artifactContains']!r}"
+            )
     final_answer = case.get("finalAnswer")
     if not isinstance(final_answer, str) or expected["answerContains"] not in final_answer:
         fail(f"one-turn coworker task {task_id} final answer was malformed: {final_answer!r}")

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -40,6 +40,18 @@ EXPECTED_CASES = {
         "artifactContains": "No city state zip,,,,true",
         "answerContains": "wrote donors-split.csv",
     },
+    25: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "newsletter-clean.csv",
+        "artifactContains": "+14155550100",
+        "answerContains": "wrote newsletter-clean.csv and newsletter-bad-rows.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "newsletter-bad-rows.csv",
+                "artifactContains": "invalid-email,not-a-phone",
+            },
+        ],
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",
@@ -86,6 +98,30 @@ def validated_one_turn_coworker(report: dict[str, Any], label: str) -> dict[str,
             case.get("artifactContains") == expected["artifactContains"],
             f"{label} task {task_id} artifact assertion was {case.get('artifactContains')!r}",
         )
+        expected_secondary = expected.get("secondaryArtifacts", [])
+        secondary_artifacts = case.get("secondaryArtifacts", [])
+        require(
+            isinstance(secondary_artifacts, list),
+            f"{label} task {task_id} secondary artifacts were malformed: {secondary_artifacts!r}",
+        )
+        require(
+            len(secondary_artifacts) == len(expected_secondary),
+            f"{label} task {task_id} secondary artifact count was {len(secondary_artifacts)}, "
+            f"expected {len(expected_secondary)}",
+        )
+        for index, expected_artifact in enumerate(expected_secondary):
+            artifact = secondary_artifacts[index]
+            require(isinstance(artifact, dict), f"{label} task {task_id} secondary artifact {index} was malformed")
+            artifact_path = artifact.get("artifactPath")
+            require(
+                isinstance(artifact_path, str) and artifact_path.endswith(expected_artifact["artifactSuffix"]),
+                f"{label} task {task_id} secondary artifact {index} path was malformed: {artifact_path!r}",
+            )
+            require(
+                artifact.get("artifactContains") == expected_artifact["artifactContains"],
+                f"{label} task {task_id} secondary artifact {index} assertion was "
+                f"{artifact.get('artifactContains')!r}",
+            )
         final_answer = case.get("finalAnswer")
         require(
             isinstance(final_answer, str) and expected["answerContains"] in final_answer,
@@ -105,6 +141,19 @@ def semantic_one_turn_coworker(smoke: dict[str, Any]) -> dict[str, Any]:
             for case in cases
         ],
         "artifactContains": [case["artifactContains"] for case in cases],
+        "secondaryArtifacts": [
+            [
+                {
+                    "artifactSuffix": expected_artifact["artifactSuffix"],
+                    "artifactContains": artifact["artifactContains"],
+                }
+                for artifact, expected_artifact in zip(
+                    case.get("secondaryArtifacts", []),
+                    EXPECTED_CASES[case["taskID"]].get("secondaryArtifacts", []),
+                )
+            ]
+            for case in cases
+        ],
         "finalAnswers": [case["finalAnswer"] for case in cases],
     }
 


### PR DESCRIPTION
## Summary
- add coworker catalog row #25 to packaged one-turn smoke coverage
- preserve primary artifact fields while adding secondary artifact checks for multi-output tasks
- verify newsletter-clean.csv and newsletter-bad-rows.csv are both created through host.shell.run
- update packaged manifest validation, coverage gates, and parity docs for the new row

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- scripts/native-desktop-smoke.sh