### PR TITLE
Add content calendar coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -941,6 +941,14 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("Finance KPI Dashboard")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 43,
+                prompt: "Run `printf 'week,theme,type,title,owner\\n2026-Q3-W01,Migration,blog,Migration planning checklist,Ada\\n2026-Q3-W01,Migration,webinar,Modernize legacy data,Ben\\n2026-Q3-W01,Migration,social,Four migration mistakes,Cam\\n2026-Q3-W02,Security,blog,Security review guide,Ada\\n2026-Q3-W02,Security,social,Audit-ready teams,Cam\\n' > q3-content-calendar.csv && printf 'wrote q3-content-calendar.csv\\n'`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote q3-content-calendar.csv",
+                artifactRelativePath: "q3-content-calendar.csv",
+                artifactExpectation: .textContains("2026-Q3-W01,Migration,webinar,Modernize legacy data,Ben")
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 68],
-          "taskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 68],
+          "catalogTaskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 68],
+          "taskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 9"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 10"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -142,6 +142,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""25": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -157,6 +157,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-clean.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-bad-rows.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #25, #28, #40, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #25, #28, #40, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -187,6 +187,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #40 proves a KPI dashboard request creates a single-file HTML dashboard,
   `finance-kpi-dashboard.html`, with revenue, churn, headcount, and sparkline evidence through
   `host.shell.run`.
+- Row #43 proves a Q3 content-calendar spreadsheet request creates `q3-content-calendar.csv`
+  with campaign theme, content type, title, and owner columns through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #20, #21, #23, #25, #28, #40, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #20, #21, #23, #25, #28, #40, #43, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -395,6 +395,12 @@ expected_one_turn_cases = {
         "artifactContains": "Finance KPI Dashboard",
         "answerContains": "wrote finance-kpi-dashboard.html",
     },
+    43: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "q3-content-calendar.csv",
+        "artifactContains": "2026-Q3-W01,Migration,webinar,Modernize legacy data,Ben",
+        "answerContains": "wrote q3-content-calendar.csv",
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -64,6 +64,12 @@ EXPECTED_CASES = {
         "artifactContains": "Finance KPI Dashboard",
         "answerContains": "wrote finance-kpi-dashboard.html",
     },
+    43: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "q3-content-calendar.csv",
+        "artifactContains": "2026-Q3-W01,Migration,webinar,Modernize legacy data,Ben",
+        "answerContains": "wrote q3-content-calendar.csv",
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add catalog row #43 to packaged one-turn coworker smoke coverage
- verify q3-content-calendar.csv artifact generation through the desktop agent loop
- update coworker validators, parity gates, and docs to require ten packaged one-turn rows

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh