### PR TITLE
Add release notes coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -957,6 +957,14 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("top_deal,Ada,West,Q2,92000")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 52,
+                prompt: "Run `printf '# August 2026 Release Notes\\n\\n## Billing\\n- Customers can now export invoices from the billing portal.\\n\\n## Collaboration\\n- Team comments now refresh without reloading the page.\\n\\n## Admin\\n- Workspace owners can see seat-change history.\\n' > release-notes-2026-08.md && printf 'wrote release-notes-2026-08.md\\n'`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote release-notes-2026-08.md",
+                artifactRelativePath: "release-notes-2026-08.md",
+                artifactExpectation: .textContains("## Collaboration")
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 48, 68],
-          "taskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 48, 68],
+          "catalogTaskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 11"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 12"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -144,6 +144,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""48": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""52": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -159,6 +159,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""release-notes-2026-08.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -191,6 +191,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   with campaign theme, content type, title, and owner columns through `host.shell.run`.
 - Row #48 proves a pivot-style sales summary request creates `sales-pivot-summary.csv`
   with revenue grouped by rep, region, quarter, and top-deal evidence through `host.shell.run`.
+- Row #52 proves a customer-facing release-notes request creates `release-notes-2026-08.md`
+  with grouped feature-area prose through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -407,6 +407,12 @@ expected_one_turn_cases = {
         "artifactContains": "top_deal,Ada,West,Q2,92000",
         "answerContains": "wrote sales-pivot-summary.csv",
     },
+    52: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "release-notes-2026-08.md",
+        "artifactContains": "## Collaboration",
+        "answerContains": "wrote release-notes-2026-08.md",
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -76,6 +76,12 @@ EXPECTED_CASES = {
         "artifactContains": "top_deal,Ada,West,Q2,92000",
         "answerContains": "wrote sales-pivot-summary.csv",
     },
+    52: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "release-notes-2026-08.md",
+        "artifactContains": "## Collaboration",
+        "answerContains": "wrote release-notes-2026-08.md",
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add catalog row #52 to packaged one-turn coworker smoke coverage
- verify release-notes-2026-08.md artifact generation through the desktop agent loop
- update coworker validators, parity gates, and docs to require twelve packaged one-turn rows

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh