### PR TITLE
Add archive coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -882,6 +882,20 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("organic,31")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 17,
+                prompt: "Run `mkdir -p 'Client Files' Archive/2024-Q4 && printf 'Acme contract\\n' > 'Client Files/Acme-old.txt' && printf 'Current plan\\n' > 'Client Files/Current-plan.txt' && mv 'Client Files/Acme-old.txt' Archive/2024-Q4/Acme-old.txt && printf 'Archived Client Files/Acme-old.txt -> Archive/2024-Q4/Acme-old.txt\\nKept Client Files/Current-plan.txt\\n' > archive-readme.md && printf 'wrote archive-readme.md\\n'`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote archive-readme.md",
+                artifactRelativePath: "archive-readme.md",
+                artifactExpectation: .textContains("Archive/2024-Q4/Acme-old.txt"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "Archive/2024-Q4/Acme-old.txt",
+                        expectation: .textContains("Acme contract")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 20,
                 prompt: "Run `\(chartGenerationCommand)`",
                 expectedToolName: ToolDefinition.shellRun.name,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,10 +132,11 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 12"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 13"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""17": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""20": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""21": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""23": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -151,6 +151,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""host.shell.run""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""launch-announcement.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""signup-slice.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""archive-readme.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""regional-revenue-chart.png""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""cohort-retention.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""donors-split.csv""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,12 +168,14 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
 - Row #16 proves an analysis-style shell task runs with non-empty `host.shell.run` arguments and
   creates `signup-slice.csv`.
+- Row #17 proves a file-archiving request moves an old client file into a quarterly archive folder
+  and writes `archive-readme.md` with an audit trail through `host.shell.run`.
 - Row #20 proves a chart-generation request creates a valid 320x200 PNG artifact,
   `regional-revenue-chart.png`, through `host.shell.run`.
 - Row #21 proves cohort-retention date math creates `cohort-retention.csv` with retained-after-first-month

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -353,6 +353,18 @@ expected_one_turn_cases = {
         "artifactContains": "organic,31",
         "answerContains": "wrote signup-slice.csv",
     },
+    17: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "archive-readme.md",
+        "artifactContains": "Archive/2024-Q4/Acme-old.txt",
+        "answerContains": "wrote archive-readme.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "Archive/2024-Q4/Acme-old.txt",
+                "artifactContains": "Acme contract",
+            },
+        ],
+    },
     20: {
         "toolName": "host.shell.run",
         "artifactSuffix": "regional-revenue-chart.png",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -22,6 +22,18 @@ EXPECTED_CASES = {
         "artifactContains": "organic,31",
         "answerContains": "wrote signup-slice.csv",
     },
+    17: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "archive-readme.md",
+        "artifactContains": "Archive/2024-Q4/Acme-old.txt",
+        "answerContains": "wrote archive-readme.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "Archive/2024-Q4/Acme-old.txt",
+                "artifactContains": "Acme contract",
+            },
+        ],
+    },
     20: {
         "toolName": "host.shell.run",
         "artifactSuffix": "regional-revenue-chart.png",


### PR DESCRIPTION
## Summary
- add row #17 archive/file-organization coverage to the packaged one-turn coworker smoke
- validate the archive README plus the moved archived file as a secondary artifact
- update parity tests and coworker tracking docs from 12 to 13 row-linked one-turn cases

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh