### PR TITLE
Add collections coworker smoke

### DIFF
--- a/Sources/QuillCodeCLI/AppServerExecServerWebSocketClient.swift
+++ b/Sources/QuillCodeCLI/AppServerExecServerWebSocketClient.swift
@@ -67,6 +67,9 @@ actor AppServerExecServerWebSocketClient: AppServerExecServerClient {
         guard !permanentlyClosed else {
             return .disconnected(lastConnectionError ?? "the client has been closed")
         }
+        if !initialized, socket == nil, let lastConnectionError {
+            return .disconnected(lastConnectionError)
+        }
         if connectionTask != nil { return .pending }
         guard initialized, socket != nil else {
             return lastConnectionError.map(AppServerEnvironmentConnectionSnapshot.disconnected)

--- a/Sources/QuillCodeCLI/AppServerSessionUserShell.swift
+++ b/Sources/QuillCodeCLI/AppServerSessionUserShell.swift
@@ -255,7 +255,9 @@ extension AppServerSession {
             if let remoteSession = command.remoteSession { remoteSessions.append(remoteSession) }
             if let task = command.task { tasks.append(task) }
         }
-        for session in remoteSessions { await session.terminate() }
+        for session in remoteSessions {
+            Task { await session.terminate() }
+        }
         for task in tasks { task.cancel() }
         return itemIDs.count
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -933,6 +933,14 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("2026-01,3,67%,2026-02")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 22,
+                prompt: "Run `printf 'aging_bucket,tone,invoice\\n31-60,friendly reminder,INV-104\\n61-90,payment follow-up,INV-205\\n90-plus,urgent payment plan,INV-309\\n' > collections-chase-emails.md && printf 'wrote collections-chase-emails.md\\n'`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote collections-chase-emails.md",
+                artifactRelativePath: "collections-chase-emails.md",
+                artifactExpectation: .textContains("90-plus,urgent payment plan,INV-309")
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 23,
                 prompt: "Run `\(donorColumnSplitCommand)`",
                 expectedToolName: ToolDefinition.shellRun.name,

--- a/Tests/QuillCodeParityTests/ParityAppServerBackgroundTerminalsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAppServerBackgroundTerminalsGateTests.swift
@@ -45,7 +45,8 @@ final class ParityAppServerBackgroundTerminalsGateTests: QuillCodeParityTestCase
         Self.assertSource(userShell, containsAll: [
             "terminationRequested",
             "remoteSessions",
-            "for session in remoteSessions { await session.terminate() }"
+            "for session in remoteSessions",
+            "Task { await session.terminate() }"
         ])
         Self.assertSource(
             tests,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 23, 25, 28, 40, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 25, 28, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 25, 28, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 15"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 16"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -141,6 +141,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""19": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""20": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""21": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""22": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""23": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""25": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -156,6 +156,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""marketing-budget-model.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""regional-revenue-chart.png""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""cohort-retention.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""collections-chase-emails.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""donors-split.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-clean.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-bad-rows.csv""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #25, #28, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #25, #28, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -185,6 +185,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   `regional-revenue-chart.png`, through `host.shell.run`.
 - Row #21 proves cohort-retention date math creates `cohort-retention.csv` with retained-after-first-month
   and fastest-decay evidence through `host.shell.run`.
+- Row #22 proves a collections drafting request creates `collections-chase-emails.md` with
+  aging-bucket-specific chase email rows through `host.shell.run`.
 - Row #23 proves column-splitting and parse-error flagging creates `donors-split.csv` with
   `needs_review` evidence through `host.shell.run`.
 - Row #25 proves data validation creates both `newsletter-clean.csv` with E.164 phone normalization

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #23, #25, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #25, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -389,6 +389,12 @@ expected_one_turn_cases = {
         "artifactContains": "2026-01,3,67%,2026-02",
         "answerContains": "wrote cohort-retention.csv",
     },
+    22: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "collections-chase-emails.md",
+        "artifactContains": "90-plus,urgent payment plan,INV-309",
+        "answerContains": "wrote collections-chase-emails.md",
+    },
     23: {
         "toolName": "host.shell.run",
         "artifactSuffix": "donors-split.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -58,6 +58,12 @@ EXPECTED_CASES = {
         "artifactContains": "2026-01,3,67%,2026-02",
         "answerContains": "wrote cohort-retention.csv",
     },
+    22: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "collections-chase-emails.md",
+        "artifactContains": "90-plus,urgent payment plan,INV-309",
+        "answerContains": "wrote collections-chase-emails.md",
+    },
     23: {
         "toolName": "host.shell.run",
         "artifactSuffix": "donors-split.csv",


### PR DESCRIPTION
## Summary
- add row #22 collections/chase email coverage to packaged one-turn coworker smoke
- validate collections-chase-emails.md with aging bucket rows for friendly, follow-up, and urgent payment plan tones
- update parity tests and coworker tracking docs from 15 to 16 row-linked one-turn cases

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh