### PR TITLE
Add support replies coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -949,6 +949,20 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("No city state zip,,,,true")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 24,
+                prompt: "Run `\(supportRepliesCommand)`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote support-replies/ticket-001.md and support-replies/ticket-002.md",
+                artifactRelativePath: "support-replies/ticket-001.md",
+                artifactExpectation: .textContains("billing-access-restored-today"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "support-replies/ticket-002.md",
+                        expectation: .textContains("corrected-csv-attached")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 25,
                 prompt: "Run `\(newsletterValidationCommand)`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1089,6 +1103,12 @@ enum QuillCodeDesktopSmokeRunner {
         let splitCSV = "first,last,street,city,state,zip,needs_review\\nAda,Lovelace,12 Market St,Boston,MA,02110,false\\nGrace,Hopper,1 Navy Way,Arlington,VA,22202,false\\nMalformed,Donor,No city state zip,,,,true\\n"
         return """
         python3 -c "print((__import__('pathlib').Path('donors.csv').write_text('\(donorsCSV)'),__import__('pathlib').Path('donors-split.csv').write_text('\(splitCSV)'),'wrote donors-split.csv')[-1])"
+        """
+    }
+
+    private static var supportRepliesCommand: String {
+        return """
+        mkdir -p support-replies && printf ticket-001-billing-access-restored-today > support-replies/ticket-001.md && printf ticket-002-corrected-csv-attached > support-replies/ticket-002.md && printf 'wrote support-replies/ticket-001.md and support-replies/ticket-002.md\\n'
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 25, 28, 40, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 25, 28, 40, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 28, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 28, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 16"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 17"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -143,6 +143,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""21": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""22": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""23": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""24": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""25": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -158,6 +158,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""cohort-retention.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""collections-chase-emails.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""donors-split.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""support-replies/ticket-001.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""support-replies/ticket-002.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-clean.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-bad-rows.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #25, #28, #40, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #28, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #25, #28, #40, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #28, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -189,6 +189,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   aging-bucket-specific chase email rows through `host.shell.run`.
 - Row #23 proves column-splitting and parse-error flagging creates `donors-split.csv` with
   `needs_review` evidence through `host.shell.run`.
+- Row #24 proves support-reply drafting creates separate ticket reply files under `support-replies/`
+  with tone-specific answer text through `host.shell.run`.
 - Row #25 proves data validation creates both `newsletter-clean.csv` with E.164 phone normalization
   and `newsletter-bad-rows.csv` with rejected invalid rows through `host.shell.run`.
 - Row #28 proves a dependency-mapping request creates a Mermaid diagram artifact through

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #25, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -401,6 +401,18 @@ expected_one_turn_cases = {
         "artifactContains": "No city state zip,,,,true",
         "answerContains": "wrote donors-split.csv",
     },
+    24: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "support-replies/ticket-001.md",
+        "artifactContains": "billing-access-restored-today",
+        "answerContains": "wrote support-replies/ticket-001.md and support-replies/ticket-002.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "support-replies/ticket-002.md",
+                "artifactContains": "corrected-csv-attached",
+            },
+        ],
+    },
     25: {
         "toolName": "host.shell.run",
         "artifactSuffix": "newsletter-clean.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -70,6 +70,18 @@ EXPECTED_CASES = {
         "artifactContains": "No city state zip,,,,true",
         "answerContains": "wrote donors-split.csv",
     },
+    24: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "support-replies/ticket-001.md",
+        "artifactContains": "billing-access-restored-today",
+        "answerContains": "wrote support-replies/ticket-001.md and support-replies/ticket-002.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "support-replies/ticket-002.md",
+                "artifactContains": "corrected-csv-attached",
+            },
+        ],
+    },
     25: {
         "toolName": "host.shell.run",
         "artifactSuffix": "newsletter-clean.csv",


### PR DESCRIPTION
## Summary
- add packaged one-turn coworker evidence for catalog row #24 support reply drafting
- verify two per-ticket support reply artifacts under support-replies/
- update coworker coverage gates/docs from 16 to 17 packaged one-turn rows

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh