### PR TITLE
Add delay notice coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -985,6 +985,14 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("Cam,2026-07-14,text date")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 27,
+                prompt: "Create a file named `delay-notice.md` that says `Subject: Delivery delay notice\\n\\nHi customer, your order is delayed until Friday because the carrier missed pickup. We are sorry for the delay and will send tracking as soon as it moves.\\n`",
+                expectedToolName: ToolDefinition.fileWrite.name,
+                expectedAnswer: "Wrote `delay-notice.md`.",
+                artifactRelativePath: "delay-notice.md",
+                artifactExpectation: .textContains("your order is delayed until Friday")
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 28,
                 prompt: "Create a file named `dependency-map.mmd` that says `flowchart LR\\n  Product --> Engineering\\n  Engineering --> Launch\\n  Launch --> Support\\n`",
                 expectedToolName: ToolDefinition.fileWrite.name,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28, 40, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28, 40, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 18"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 19"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -146,6 +146,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""24": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""25": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""26": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""27": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -163,6 +163,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-clean.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-bad-rows.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""members-normalized.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""delay-notice.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #28, #40, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #28, #40, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -195,6 +195,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   and `newsletter-bad-rows.csv` with rejected invalid rows through `host.shell.run`.
 - Row #26 proves mixed-format membership date normalization creates `members-normalized.csv` with
   ISO `YYYY-MM-DD` date evidence through `host.shell.run`.
+- Row #27 proves a customer delay notice creates `delay-notice.md` with the promised new delivery
+  date through `host.file.write`.
 - Row #28 proves a dependency-mapping request creates a Mermaid diagram artifact through
   `host.file.write`.
 - Row #40 proves a KPI dashboard request creates a single-file HTML dashboard,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -431,6 +431,12 @@ expected_one_turn_cases = {
         "artifactContains": "Cam,2026-07-14,text date",
         "answerContains": "wrote members-normalized.csv",
     },
+    27: {
+        "toolName": "host.file.write",
+        "artifactSuffix": "delay-notice.md",
+        "artifactContains": "your order is delayed until Friday",
+        "answerContains": "Wrote `delay-notice.md`.",
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -100,6 +100,12 @@ EXPECTED_CASES = {
         "artifactContains": "Cam,2026-07-14,text date",
         "answerContains": "wrote members-normalized.csv",
     },
+    27: {
+        "toolName": "host.file.write",
+        "artifactSuffix": "delay-notice.md",
+        "artifactContains": "your order is delayed until Friday",
+        "answerContains": "Wrote `delay-notice.md`.",
+    },
     28: {
         "toolName": "host.file.write",
         "artifactSuffix": "dependency-map.mmd",


### PR DESCRIPTION
## Summary
- Add row #27 delay-notice packaged one-turn coworker smoke.
- Verify the actual desktop agent/tool loop writes delay-notice.md through host.file.write.
- Update row-linked coworker coverage docs, parity tests, and native smoke contracts.

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh