### PR TITLE
Add document splitting coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1001,6 +1001,24 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("Engineering --> Launch")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 29,
+                prompt: "Run `\(documentSplittingCommand)`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote exhibits/Exhibit-A-Purchase-Agreement.pdf and exhibits/Exhibit-B-Disclosure-Schedule.pdf",
+                artifactRelativePath: "exhibits/Exhibit-A-Purchase-Agreement.pdf",
+                artifactExpectation: .textContains("Exhibit A - Purchase Agreement"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "exhibits/Exhibit-B-Disclosure-Schedule.pdf",
+                        expectation: .textContains("Exhibit B - Disclosure Schedule")
+                    ),
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "exhibits/exhibit-index.csv",
+                        expectation: .textContains("B,Disclosure Schedule,Exhibit-B-Disclosure-Schedule.pdf")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 40,
                 prompt: "Run `printf '<h1>Finance KPI Dashboard</h1><p>Revenue USD 1.24M</p><p>Churn 3.1 percent</p><p>Headcount 58</p><svg><polyline points=0,40 60,20 120,8></polyline></svg>\\n' > finance-kpi-dashboard.html && printf 'wrote finance-kpi-dashboard.html\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1131,6 +1149,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var dateNormalizationCommand: String {
         return """
         printf 'member,date_joined,source_format\\nAda,2026-07-04,US\\nBen,2026-04-07,EU\\nCam,2026-07-14,text date\\n' > members-normalized.csv && printf 'wrote members-normalized.csv\\n'
+        """
+    }
+
+    private static var documentSplittingCommand: String {
+        return """
+        mkdir -p exhibits && printf 'Exhibit A - Purchase Agreement\\n' > exhibits/Exhibit-A-Purchase-Agreement.pdf && printf 'Exhibit B - Disclosure Schedule\\n' > exhibits/Exhibit-B-Disclosure-Schedule.pdf && printf 'exhibit,title,file\\nA,Purchase Agreement,Exhibit-A-Purchase-Agreement.pdf\\nB,Disclosure Schedule,Exhibit-B-Disclosure-Schedule.pdf\\n' > exhibits/exhibit-index.csv && printf 'wrote exhibits/Exhibit-A-Purchase-Agreement.pdf and exhibits/Exhibit-B-Disclosure-Schedule.pdf\\n'
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 40, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 40, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 19"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 20"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -148,6 +148,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""26": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""27": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""28": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""29": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""48": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -164,6 +164,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""newsletter-bad-rows.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""members-normalized.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""delay-notice.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""exhibits/Exhibit-A-Purchase-Agreement.pdf""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""exhibits/Exhibit-B-Disclosure-Schedule.pdf""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #40, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #40, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -199,6 +199,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   date through `host.file.write`.
 - Row #28 proves a dependency-mapping request creates a Mermaid diagram artifact through
   `host.file.write`.
+- Row #29 proves a document-splitting request creates separate exhibit files plus an exhibit index
+  through `host.shell.run`.
 - Row #40 proves a KPI dashboard request creates a single-file HTML dashboard,
   `finance-kpi-dashboard.html`, with revenue, churn, headcount, and sparkline evidence through
   `host.shell.run`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -443,6 +443,22 @@ expected_one_turn_cases = {
         "artifactContains": "Engineering --> Launch",
         "answerContains": "Wrote `dependency-map.mmd`.",
     },
+    29: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "exhibits/Exhibit-A-Purchase-Agreement.pdf",
+        "artifactContains": "Exhibit A - Purchase Agreement",
+        "answerContains": "wrote exhibits/Exhibit-A-Purchase-Agreement.pdf and exhibits/Exhibit-B-Disclosure-Schedule.pdf",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "exhibits/Exhibit-B-Disclosure-Schedule.pdf",
+                "artifactContains": "Exhibit B - Disclosure Schedule",
+            },
+            {
+                "artifactSuffix": "exhibits/exhibit-index.csv",
+                "artifactContains": "B,Disclosure Schedule,Exhibit-B-Disclosure-Schedule.pdf",
+            },
+        ],
+    },
     40: {
         "toolName": "host.shell.run",
         "artifactSuffix": "finance-kpi-dashboard.html",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -112,6 +112,22 @@ EXPECTED_CASES = {
         "artifactContains": "Engineering --> Launch",
         "answerContains": "Wrote `dependency-map.mmd`.",
     },
+    29: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "exhibits/Exhibit-A-Purchase-Agreement.pdf",
+        "artifactContains": "Exhibit A - Purchase Agreement",
+        "answerContains": "wrote exhibits/Exhibit-A-Purchase-Agreement.pdf and exhibits/Exhibit-B-Disclosure-Schedule.pdf",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "exhibits/Exhibit-B-Disclosure-Schedule.pdf",
+                "artifactContains": "Exhibit B - Disclosure Schedule",
+            },
+            {
+                "artifactSuffix": "exhibits/exhibit-index.csv",
+                "artifactContains": "B,Disclosure Schedule,Exhibit-B-Disclosure-Schedule.pdf",
+            },
+        ],
+    },
     40: {
         "toolName": "host.shell.run",
         "artifactSuffix": "finance-kpi-dashboard.html",


### PR DESCRIPTION
## Summary
- Add row #29 document-splitting packaged one-turn coworker smoke.
- Verify the desktop agent/tool loop writes separate exhibit files and an exhibit index through host.shell.run.
- Update coworker coverage docs, parity tests, and native smoke contracts.

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh