### PR TITLE
Add folder organization coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1041,6 +1041,24 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("Support,42000,36500,15.1%,over,billing backlog temporary contractors")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 32,
+                prompt: "Run `\(folderOrganizationCommand)`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote downloads-organization-report.md",
+                artifactRelativePath: "downloads-organization-report.md",
+                artifactExpectation: .textContains("Junk pile: Downloads/Junk/installer.tmp"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "Downloads/Receipts/receipt-1042.pdf",
+                        expectation: .textContains("Receipt 1042")
+                    ),
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "Downloads/Screenshots/screenshot-launch.png",
+                        expectation: .textContains("Screenshot launch")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 40,
                 prompt: "Run `printf '<h1>Finance KPI Dashboard</h1><p>Revenue USD 1.24M</p><p>Churn 3.1 percent</p><p>Headcount 58</p><svg><polyline points=0,40 60,20 120,8></polyline></svg>\\n' > finance-kpi-dashboard.html && printf 'wrote finance-kpi-dashboard.html\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1190,6 +1208,12 @@ enum QuillCodeDesktopSmokeRunner {
         let varianceCSV = "cost_center,actual,budget,variance_pct,status,explanation\\nEngineering,118000,112000,5.4%,within,contractor timing within tolerance\\nSupport,42000,36500,15.1%,over,billing backlog temporary contractors\\nMarketing,27800,32000,-13.1%,under,event spend moved to July\\n"
         return """
         python3 -c "print((__import__('pathlib').Path('june-variance-pack.csv').write_text('\(varianceCSV)'),'wrote june-variance-pack.csv')[-1])"
+        """
+    }
+
+    private static var folderOrganizationCommand: String {
+        return """
+        mkdir -p Downloads && printf 'Receipt 1042\\n' > Downloads/receipt-1042.pdf && printf 'Screenshot launch\\n' > Downloads/screenshot-launch.png && printf 'Old temp installer\\n' > Downloads/installer.tmp && mkdir -p Downloads/Installers Downloads/Receipts Downloads/'Client Files' Downloads/Screenshots Downloads/Junk && mv Downloads/receipt-1042.pdf Downloads/Receipts/receipt-1042.pdf && mv Downloads/screenshot-launch.png Downloads/Screenshots/screenshot-launch.png && mv Downloads/installer.tmp Downloads/Junk/installer.tmp && printf 'Moved receipt-1042.pdf to Downloads/Receipts\\nMoved screenshot-launch.png to Downloads/Screenshots\\nJunk pile: Downloads/Junk/installer.tmp\\nNo files deleted.\\n' > downloads-organization-report.md && printf 'wrote downloads-organization-report.md\\n'
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 40, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 40, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 22"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 23"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -151,6 +151,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""29": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""30": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""31": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""32": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""48": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -169,6 +169,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""amex_q3-categorized.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""amex_q3-review.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""june-variance-pack.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""downloads-organization-report.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""Downloads/Receipts/receipt-1042.pdf""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #40, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #40, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -205,6 +205,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   rows through `host.shell.run`.
 - Row #31 proves finance variance analysis creates `june-variance-pack.csv` with variance
   percentages, over/under status, and explanation text through `host.shell.run`.
+- Row #32 proves folder organization creates categorized Downloads folders and a junk review report
+  without deleting files through `host.shell.run`.
 - Row #40 proves a KPI dashboard request creates a single-file HTML dashboard,
   `finance-kpi-dashboard.html`, with revenue, churn, headcount, and sparkline evidence through
   `host.shell.run`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -477,6 +477,22 @@ expected_one_turn_cases = {
         "artifactContains": "Support,42000,36500,15.1%,over,billing backlog temporary contractors",
         "answerContains": "wrote june-variance-pack.csv",
     },
+    32: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "downloads-organization-report.md",
+        "artifactContains": "Junk pile: Downloads/Junk/installer.tmp",
+        "answerContains": "wrote downloads-organization-report.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "Downloads/Receipts/receipt-1042.pdf",
+                "artifactContains": "Receipt 1042",
+            },
+            {
+                "artifactSuffix": "Downloads/Screenshots/screenshot-launch.png",
+                "artifactContains": "Screenshot launch",
+            },
+        ],
+    },
     40: {
         "toolName": "host.shell.run",
         "artifactSuffix": "finance-kpi-dashboard.html",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -146,6 +146,22 @@ EXPECTED_CASES = {
         "artifactContains": "Support,42000,36500,15.1%,over,billing backlog temporary contractors",
         "answerContains": "wrote june-variance-pack.csv",
     },
+    32: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "downloads-organization-report.md",
+        "artifactContains": "Junk pile: Downloads/Junk/installer.tmp",
+        "answerContains": "wrote downloads-organization-report.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "Downloads/Receipts/receipt-1042.pdf",
+                "artifactContains": "Receipt 1042",
+            },
+            {
+                "artifactSuffix": "Downloads/Screenshots/screenshot-launch.png",
+                "artifactContains": "Screenshot launch",
+            },
+        ],
+    },
     40: {
         "toolName": "host.shell.run",
         "artifactSuffix": "finance-kpi-dashboard.html",


### PR DESCRIPTION
## Summary
- Add row #32 folder-organization packaged one-turn coworker smoke.
- Verify the desktop agent/tool loop creates categorized Downloads folders, moves sample files, and writes a junk-review report without deleting files through host.shell.run.
- Update coworker coverage docs, parity tests, and native smoke contracts.

## Validation
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- git diff --check
- scripts/native-desktop-smoke.sh