### PR TITLE
Add interview scorecard coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1133,6 +1133,20 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 38,
+                prompt: "Run `\(interviewScorecardCommand)`",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote sales-ops-analyst-scorecard.md",
+                artifactRelativePath: "sales-ops-analyst-scorecard.md",
+                artifactExpectation: .textContains("Anchored 1-4 ratings"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "sales-ops-analyst-interview-questions.md",
+                        expectation: .textContains("pipeline hygiene")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 40,
                 prompt: "Run `printf '<h1>Finance KPI Dashboard</h1><p>Revenue USD 1.24M</p><p>Churn 3.1 percent</p><p>Headcount 58</p><svg><polyline points=0,40 60,20 120,8></polyline></svg>\\n' > finance-kpi-dashboard.html && printf 'wrote finance-kpi-dashboard.html\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1318,6 +1332,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var jobDescriptionCommand: String {
         return """
         printf CSM > hiring-notes.md && printf 'Senior Customer Success Manager' > senior-csm-job-description.md && printf 'at-risk account' > senior-csm-screening-questions.md && printf 'wrote senior-csm-job-description.md\\n'
+        """
+    }
+
+    private static var interviewScorecardCommand: String {
+        return """
+        printf 'Sales Ops Analyst JD\\nPanel: RevOps, Sales, Finance\\n' > sales-ops-analyst-loop.md && printf 'Sales Ops Analyst Scorecard\\nAnchored 1-4 ratings\\nCompetency: pipeline hygiene\\nCompetency: forecasting accuracy\\n' > sales-ops-analyst-scorecard.md && printf 'pipeline hygiene question\\nforecasting question\\n' > sales-ops-analyst-interview-questions.md && printf 'wrote sales-ops-analyst-scorecard.md\\n'
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 40, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 40, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 40, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 40, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 28"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 29"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -157,6 +157,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""35": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""36": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""37": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""38": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""48": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -182,6 +182,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""ap-vendors-standardized.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""senior-csm-job-description.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""senior-csm-screening-questions.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-ops-analyst-scorecard.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-ops-analyst-interview-questions.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #40, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #40, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #40, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #40, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -217,6 +217,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   standardized vendor master that collapses Acme variants through `host.shell.run`.
 - Row #37 proves recruiting drafting creates a Senior Customer Success Manager job description
   with must-haves plus five screening questions through `host.shell.run`.
+- Row #38 proves interview scorecard drafting creates a Sales Ops Analyst scorecard with anchored
+  ratings and sample questions through `host.shell.run`.
 - Row #40 proves a KPI dashboard request creates a single-file HTML dashboard,
   `finance-kpi-dashboard.html`, with revenue, churn, headcount, and sparkline evidence through
   `host.shell.run`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #40, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -557,6 +557,18 @@ expected_one_turn_cases = {
             },
         ],
     },
+    38: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "sales-ops-analyst-scorecard.md",
+        "artifactContains": "Anchored 1-4 ratings",
+        "answerContains": "wrote sales-ops-analyst-scorecard.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "sales-ops-analyst-interview-questions.md",
+                "artifactContains": "pipeline hygiene",
+            },
+        ],
+    },
     40: {
         "toolName": "host.shell.run",
         "artifactSuffix": "finance-kpi-dashboard.html",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -226,6 +226,18 @@ EXPECTED_CASES = {
             },
         ],
     },
+    38: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "sales-ops-analyst-scorecard.md",
+        "artifactContains": "Anchored 1-4 ratings",
+        "answerContains": "wrote sales-ops-analyst-scorecard.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "sales-ops-analyst-interview-questions.md",
+                "artifactContains": "pipeline hygiene",
+            },
+        ],
+    },
     40: {
         "toolName": "host.shell.run",
         "artifactSuffix": "finance-kpi-dashboard.html",


### PR DESCRIPTION
## Summary
- add packaged one-turn coworker coverage for catalog row #38, the Sales Ops Analyst interview scorecard task
- verify scorecard and interview-question artifacts in native smoke and packaged validators
- update coworker coverage docs and parity tests from 28 to 29 proven rows

## Validation
- git diff --check
- python3 -m py_compile scripts/fixtures/app_server_environment_exec_server.py scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh