### PR TITLE
Add localization coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1197,6 +1197,20 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 42,
+                prompt: "Run \(safetyGuideLocalizationCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote safety-guide-es.pdf and safety-guide-pt.pdf",
+                artifactRelativePath: "safety-guide-es.pdf",
+                artifactExpectation: .textContains("Safety_Guide_WARNING_BOX_ES_1_2"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "safety-guide-pt.pdf",
+                        expectation: .textContains("Safety_Guide_WARNING_BOX_PT_1_2")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 43,
                 prompt: "Run `printf 'week,theme,type,title,owner\\n2026-Q3-W01,Migration,blog,Migration planning checklist,Ada\\n2026-Q3-W01,Migration,webinar,Modernize legacy data,Ben\\n2026-Q3-W01,Migration,social,Four migration mistakes,Cam\\n2026-Q3-W02,Security,blog,Security review guide,Ada\\n2026-Q3-W02,Security,social,Audit-ready teams,Cam\\n' > q3-content-calendar.csv && printf 'wrote q3-content-calendar.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1392,6 +1406,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var launchChecklistCommand: String {
         return """
         printf 'March pricing launch\\nLaunch date: 2026-03-18\\n' > march-pricing-launch-brief.md && printf '# March Pricing Go-Live Checklist\\n\\n| Area | Owner | Due date | Item |\\n| Legal | Priya | 2026-03-04 | Approve updated terms |\\n| Support | Marco | 2026-03-08 | Publish escalation macros |\\n| Docs | Lena | 2026-03-10 | Update pricing FAQ |\\n| Comms | Theo | 2026-03-12 | Send customer notice |\\n' > march-pricing-go-live-checklist.md && printf 'wrote march-pricing-go-live-checklist.md\\n'
+        """
+    }
+
+    private static var safetyGuideLocalizationCommand: String {
+        return """
+        echo Safety_Guide_WARNING_BOX_ES_1_2>safety-guide-es.pdf&&echo Safety_Guide_WARNING_BOX_PT_1_2>safety-guide-pt.pdf&&echo wrote safety-guide-es.pdf and safety-guide-pt.pdf
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 43, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 43, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 31"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 32"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -161,6 +161,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""39": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""40": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""41": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""42": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""48": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""52": ["#), coverage)

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -190,6 +190,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""finance-kpi-dashboard.html""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""march-pricing-go-live-checklist.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""march-pricing-launch-brief.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""safety-guide-es.pdf""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""safety-guide-pt.pdf""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""release-notes-2026-08.md""#))

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #43, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #43, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -226,6 +226,8 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   `host.shell.run`.
 - Row #41 proves launch checklist generation creates a March pricing go-live checklist with legal,
   support, docs, and comms owners and due dates through `host.shell.run`.
+- Row #42 proves localization creates Spanish and Portuguese safety-guide files while preserving
+  the original heading, warning-box marker, and numbered-step structure through `host.shell.run`.
 - Row #43 proves a Q3 content-calendar spreadsheet request creates `q3-content-calendar.csv`
   with campaign theme, content type, title, and owner columns through `host.shell.run`.
 - Row #48 proves a pivot-style sales summary request creates `sales-pivot-summary.csv`

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -603,6 +603,18 @@ expected_one_turn_cases = {
             },
         ],
     },
+    42: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "safety-guide-es.pdf",
+        "artifactContains": "Safety_Guide_WARNING_BOX_ES_1_2",
+        "answerContains": "wrote safety-guide-es.pdf and safety-guide-pt.pdf",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "safety-guide-pt.pdf",
+                "artifactContains": "Safety_Guide_WARNING_BOX_PT_1_2",
+            },
+        ],
+    },
     43: {
         "toolName": "host.shell.run",
         "artifactSuffix": "q3-content-calendar.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -272,6 +272,18 @@ EXPECTED_CASES = {
             },
         ],
     },
+    42: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "safety-guide-es.pdf",
+        "artifactContains": "Safety_Guide_WARNING_BOX_ES_1_2",
+        "answerContains": "wrote safety-guide-es.pdf and safety-guide-pt.pdf",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "safety-guide-pt.pdf",
+                "artifactContains": "Safety_Guide_WARNING_BOX_PT_1_2",
+            },
+        ],
+    },
     43: {
         "toolName": "host.shell.run",
         "artifactSuffix": "q3-content-calendar.csv",


### PR DESCRIPTION
## Summary
- add packaged one-turn coworker coverage for catalog row #42, the Spanish/Portuguese safety-guide localization task
- verify Spanish and Portuguese output artifacts preserve safety guide, warning-box, and numbered-step markers
- update coworker coverage docs and parity tests from 31 to 32 proven rows

## Validation
- git diff --check
- python3 -m py_compile scripts/fixtures/app_server_environment_exec_server.py scripts/native_click_probe_contracts/one_turn_coworker.py scripts/native_click_probe_contracts/coworker_catalog.py scripts/native_click_probe_contracts/cli.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh