### PR TITLE
Add maintenance notice coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1247,6 +1247,20 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 46,
+                prompt: "Run \(maintenanceNoticeCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote maintenance-notice-variants.md",
+                artifactRelativePath: "maintenance-notice-variants.md",
+                artifactExpectation: .textContains("Enterprise admins: Scheduled maintenance starts 2026-08-14 22:00 UTC"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "maintenance-window-notice.md",
+                        expectation: .textContains("Original maintenance window notice")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 48,
                 prompt: "Run `printf 'view,rep,region,quarter,revenue\\nby_rep,Ada,All,All,184000\\nby_rep,Ben,All,All,132000\\nby_region,All,West,All,201000\\nby_region,All,East,All,115000\\nby_quarter,All,All,Q1,146000\\nby_quarter,All,All,Q2,170000\\ntop_deal,Ada,West,Q2,92000\\n' > sales-pivot-summary.csv && printf 'wrote sales-pivot-summary.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1452,6 +1466,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var meetingRecapCommand: String {
         return """
         printf 'Raw board prep call transcript\\nPriya will send final board deck by August 2\\nMarco will refresh ARR bridge by August 1\\nAda will confirm customer quote approvals by July 31\\n' > board-prep-call.txt && printf 'Subject: Board prep recap and commitments\\n\\nHi team,\\n\\nHere are the commitments from the board prep call.\\n\\n| Owner | Commitment | Due date |\\n| Priya | Final board deck | 2026-08-02 |\\n| Marco | Refresh ARR bridge | 2026-08-01 |\\n| Ada | Confirm customer quote approvals | 2026-07-31 |\\n\\nPlease reply with changes today so the board packet stays on schedule.\\n' > board-prep-recap-email.md && printf 'wrote board-prep-recap-email.md\\n'
+        """
+    }
+
+    private static var maintenanceNoticeCommand: String {
+        return """
+        echo Original maintenance window notice>maintenance-window-notice.md&&echo Enterprise admins: Scheduled maintenance starts 2026-08-14 22:00 UTC for 45 minutes>maintenance-notice-variants.md&&echo End users: QuillCode maintenance starts 2026-08-14 22:00 UTC for 45 minutes>>maintenance-notice-variants.md&&echo Status page post: Planned maintenance begins 2026-08-14 22:00 UTC>>maintenance-notice-variants.md&&echo wrote maintenance-notice-variants.md
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 48, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 48, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 34"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 35"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #48, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #48, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #48, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #48, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -236,6 +236,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #45 proves a meeting recap request creates `board-prep-recap-email.md` with every
   transcript commitment, owner, and due date while retaining the raw `board-prep-call.txt` source
   through `host.shell.run`.
+- Row #46 proves a multi-audience maintenance notice request creates enterprise-admin, end-user,
+  and status-page versions under the original `maintenance-window-notice.md` source through
+  `host.shell.run`.
 - Row #48 proves a pivot-style sales summary request creates `sales-pivot-summary.csv`
   with revenue grouped by rep, region, quarter, and top-deal evidence through `host.shell.run`.
 - Row #52 proves a customer-facing release-notes request creates `release-notes-2026-08.md`

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #48, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -645,6 +645,18 @@ expected_one_turn_cases = {
             },
         ],
     },
+    46: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "maintenance-notice-variants.md",
+        "artifactContains": "Enterprise admins: Scheduled maintenance starts 2026-08-14 22:00 UTC",
+        "answerContains": "wrote maintenance-notice-variants.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "maintenance-window-notice.md",
+                "artifactContains": "Original maintenance window notice",
+            },
+        ],
+    },
     48: {
         "toolName": "host.shell.run",
         "artifactSuffix": "sales-pivot-summary.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -314,6 +314,18 @@ EXPECTED_CASES = {
             },
         ],
     },
+    46: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "maintenance-notice-variants.md",
+        "artifactContains": "Enterprise admins: Scheduled maintenance starts 2026-08-14 22:00 UTC",
+        "answerContains": "wrote maintenance-notice-variants.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "maintenance-window-notice.md",
+                "artifactContains": "Original maintenance window notice",
+            },
+        ],
+    },
     48: {
         "toolName": "host.shell.run",
         "artifactSuffix": "sales-pivot-summary.csv",


### PR DESCRIPTION
## Summary
- add coworker catalog row #46 to packaged one-turn smoke coverage
- prove maintenance-window notice rewriting creates enterprise-admin, end-user, and status-page variants
- update validators, parity count, tracker, parity matrix, and decisions docs to expect 35 proven one-turn rows

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh