### PR TITLE
Add invoice reconciliation coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1301,6 +1301,24 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 50,
+                prompt: "Run \(invoiceReconciliationCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote invoice-reconciliation.csv",
+                artifactRelativePath: "invoice-reconciliation.csv",
+                artifactExpectation: .textContains("INV-1002,1200,0,unpaid"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "open_invoices.csv",
+                        expectation: .textContains("INV-1003,Cedar,900")
+                    ),
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "november-bank.csv",
+                        expectation: .textContains("INV-1003,900")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 52,
                 prompt: "Run `printf '# August 2026 Release Notes\\n\\n## Billing\\n- Customers can now export invoices from the billing portal.\\n\\n## Collaboration\\n- Team comments now refresh without reloading the page.\\n\\n## Admin\\n- Workspace owners can see seat-change history.\\n' > release-notes-2026-08.md && printf 'wrote release-notes-2026-08.md\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1516,6 +1534,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var raciChartCommand: String {
         return """
         echo name,role>stakeholders.csv&&echo Ada,Migration Lead>>stakeholders.csv&&echo Ben,Engineering Owner>>stakeholders.csv&&echo Cam,Finance Approver>>stakeholders.csv&&echo Dee,Operations Consulted>>stakeholders.csv&&echo Discovery>phase-plan.md&&echo Data migration>>phase-plan.md&&echo Testing>>phase-plan.md&&echo Cutover>>phase-plan.md&&echo Stabilization>>phase-plan.md&&echo phase,responsible,accountable,consulted,informed>erp-migration-raci.csv&&echo Data migration,Ada,Ben,Cam,Dee>>erp-migration-raci.csv&&echo Testing,Ben,Ada,Cam,Dee>>erp-migration-raci.csv&&echo Cutover,Ada,Cam,Ben,Dee>>erp-migration-raci.csv&&echo wrote erp-migration-raci.csv
+        """
+    }
+
+    private static var invoiceReconciliationCommand: String {
+        return """
+        echo invoice,customer,amount>open_invoices.csv&&echo INV-1001,Acme,500>>open_invoices.csv&&echo INV-1002,Beta,1200>>open_invoices.csv&&echo INV-1003,Cedar,900>>open_invoices.csv&&echo date,description,invoice,amount>november-bank.csv&&echo 2026-11-03,Acme payment,INV-1001,500>>november-bank.csv&&echo 2026-11-08,Cedar payment,INV-1003,900>>november-bank.csv&&echo 2026-11-09,Cedar duplicate,INV-1003,900>>november-bank.csv&&echo invoice,expected,paid,status>invoice-reconciliation.csv&&echo INV-1001,500,500,paid>>invoice-reconciliation.csv&&echo INV-1002,1200,0,unpaid>>invoice-reconciliation.csv&&echo INV-1003,900,1800,paid_twice>>invoice-reconciliation.csv&&echo wrote invoice-reconciliation.csv
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 37"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 38"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -164,6 +164,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""42": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""48": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""50": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""52": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -194,6 +194,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""safety-guide-pt.pdf""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""invoice-reconciliation.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""release-notes-2026-08.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -247,6 +247,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #49 proves an ERP migration RACI request creates `erp-migration-raci.csv` from
   `stakeholders.csv` and `phase-plan.md`, preserving responsible, accountable, consulted, and
   informed assignments through `host.shell.run`.
+- Row #50 proves invoice reconciliation creates `invoice-reconciliation.csv` from
+  `open_invoices.csv` and `november-bank.csv`, preserving unpaid and duplicate-paid invoice evidence
+  through `host.shell.run`.
 - Row #52 proves a customer-facing release-notes request creates `release-notes-2026-08.md`
   with grouped feature-area prose through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -691,6 +691,22 @@ expected_one_turn_cases = {
             },
         ],
     },
+    50: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "invoice-reconciliation.csv",
+        "artifactContains": "INV-1002,1200,0,unpaid",
+        "answerContains": "wrote invoice-reconciliation.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "open_invoices.csv",
+                "artifactContains": "INV-1003,Cedar,900",
+            },
+            {
+                "artifactSuffix": "november-bank.csv",
+                "artifactContains": "INV-1003,900",
+            },
+        ],
+    },
     52: {
         "toolName": "host.shell.run",
         "artifactSuffix": "release-notes-2026-08.md",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -360,6 +360,22 @@ EXPECTED_CASES = {
             },
         ],
     },
+    50: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "invoice-reconciliation.csv",
+        "artifactContains": "INV-1002,1200,0,unpaid",
+        "answerContains": "wrote invoice-reconciliation.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "open_invoices.csv",
+                "artifactContains": "INV-1003,Cedar,900",
+            },
+            {
+                "artifactSuffix": "november-bank.csv",
+                "artifactContains": "INV-1003,900",
+            },
+        ],
+    },
     52: {
         "toolName": "host.shell.run",
         "artifactSuffix": "release-notes-2026-08.md",


### PR DESCRIPTION
## Summary
- add coworker catalog row #50 invoice reconciliation to the packaged one-turn smoke
- validate source invoice and bank CSV artifacts plus the generated reconciliation output
- update coworker coverage docs and gates from 37 to 38 proven packaged rows

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh