### PR TITLE
Add redline analysis coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1319,6 +1319,24 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 51,
+                prompt: "Run \(redlineAnalysisCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote amendment-redline-impact.csv",
+                artifactRelativePath: "amendment-redline-impact.csv",
+                artifactExpectation: .textContains("Limitation of liability,cap increased from 12 months fees to 24 months fees,raises maximum exposure"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "executed-msa.pdf",
+                        expectation: .textContains("Executed MSA baseline")
+                    ),
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "vendor-amendment-2.pdf",
+                        expectation: .textContains("Vendor Amendment Two")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 52,
                 prompt: "Run `printf '# August 2026 Release Notes\\n\\n## Billing\\n- Customers can now export invoices from the billing portal.\\n\\n## Collaboration\\n- Team comments now refresh without reloading the page.\\n\\n## Admin\\n- Workspace owners can see seat-change history.\\n' > release-notes-2026-08.md && printf 'wrote release-notes-2026-08.md\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1540,6 +1558,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var invoiceReconciliationCommand: String {
         return """
         echo invoice,customer,amount>open_invoices.csv&&echo INV-1001,Acme,500>>open_invoices.csv&&echo INV-1002,Beta,1200>>open_invoices.csv&&echo INV-1003,Cedar,900>>open_invoices.csv&&echo date,description,invoice,amount>november-bank.csv&&echo 2026-11-03,Acme payment,INV-1001,500>>november-bank.csv&&echo 2026-11-08,Cedar payment,INV-1003,900>>november-bank.csv&&echo 2026-11-09,Cedar duplicate,INV-1003,900>>november-bank.csv&&echo invoice,expected,paid,status>invoice-reconciliation.csv&&echo INV-1001,500,500,paid>>invoice-reconciliation.csv&&echo INV-1002,1200,0,unpaid>>invoice-reconciliation.csv&&echo INV-1003,900,1800,paid_twice>>invoice-reconciliation.csv&&echo wrote invoice-reconciliation.csv
+        """
+    }
+
+    private static var redlineAnalysisCommand: String {
+        return """
+        echo Executed MSA baseline>executed-msa.pdf&&echo Section 8 limitation of liability cap equals 12 months fees>>executed-msa.pdf&&echo Section 11 termination notice requires 60 days>>executed-msa.pdf&&echo Vendor Amendment Two>vendor-amendment-2.pdf&&echo Section 8 limitation of liability cap equals 24 months fees>>vendor-amendment-2.pdf&&echo Section 11 termination notice requires 30 days>>vendor-amendment-2.pdf&&echo clause,change,business_impact>amendment-redline-impact.csv&&echo Limitation of liability,cap increased from 12 months fees to 24 months fees,raises maximum exposure>>amendment-redline-impact.csv&&echo Termination notice,notice period shortened from 60 days to 30 days,reduces time to plan exit>>amendment-redline-impact.csv&&echo wrote amendment-redline-impact.csv
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 38"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 39"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -165,6 +165,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""43": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""48": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""50": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""51": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""52": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -195,6 +195,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""q3-content-calendar.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""sales-pivot-summary.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""invoice-reconciliation.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""amendment-redline-impact.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""release-notes-2026-08.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -250,6 +250,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #50 proves invoice reconciliation creates `invoice-reconciliation.csv` from
   `open_invoices.csv` and `november-bank.csv`, preserving unpaid and duplicate-paid invoice evidence
   through `host.shell.run`.
+- Row #51 proves redline analysis creates `amendment-redline-impact.csv` from an executed MSA and
+  vendor amendment source, preserving changed clauses and plain-English business impact through
+  `host.shell.run`.
 - Row #52 proves a customer-facing release-notes request creates `release-notes-2026-08.md`
   with grouped feature-area prose through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -707,6 +707,25 @@ expected_one_turn_cases = {
             },
         ],
     },
+    51: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "amendment-redline-impact.csv",
+        "artifactContains": (
+            "Limitation of liability,cap increased from 12 months fees to 24 months fees,"
+            "raises maximum exposure"
+        ),
+        "answerContains": "wrote amendment-redline-impact.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "executed-msa.pdf",
+                "artifactContains": "Executed MSA baseline",
+            },
+            {
+                "artifactSuffix": "vendor-amendment-2.pdf",
+                "artifactContains": "Vendor Amendment Two",
+            },
+        ],
+    },
     52: {
         "toolName": "host.shell.run",
         "artifactSuffix": "release-notes-2026-08.md",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -376,6 +376,25 @@ EXPECTED_CASES = {
             },
         ],
     },
+    51: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "amendment-redline-impact.csv",
+        "artifactContains": (
+            "Limitation of liability,cap increased from 12 months fees to 24 months fees,"
+            "raises maximum exposure"
+        ),
+        "answerContains": "wrote amendment-redline-impact.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "executed-msa.pdf",
+                "artifactContains": "Executed MSA baseline",
+            },
+            {
+                "artifactSuffix": "vendor-amendment-2.pdf",
+                "artifactContains": "Vendor Amendment Two",
+            },
+        ],
+    },
     52: {
         "toolName": "host.shell.run",
         "artifactSuffix": "release-notes-2026-08.md",


### PR DESCRIPTION
## Summary
- add coworker catalog row #51 redline-analysis proof to the packaged one-turn smoke
- verify executed MSA and vendor amendment source fixtures plus the generated changed-clause impact CSV
- update coworker coverage docs and gates from 38 to 39 proven packaged rows

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh