### PR TITLE
Add RFP compliance coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1345,6 +1345,20 @@ enum QuillCodeDesktopSmokeRunner {
                 artifactExpectation: .textContains("## Collaboration")
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 53,
+                prompt: "Run \(rfpComplianceMatrixCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote rfp-compliance-matrix.csv",
+                artifactRelativePath: "rfp-compliance-matrix.csv",
+                artifactExpectation: .textContains("3.2,shall encrypt data at rest,,Security"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "RFP-2026-DOT.pdf",
+                        expectation: .textContains("RFP 2026 DOT source")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1564,6 +1578,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var redlineAnalysisCommand: String {
         return """
         echo Executed MSA baseline>executed-msa.pdf&&echo Section 8 limitation of liability cap equals 12 months fees>>executed-msa.pdf&&echo Section 11 termination notice requires 60 days>>executed-msa.pdf&&echo Vendor Amendment Two>vendor-amendment-2.pdf&&echo Section 8 limitation of liability cap equals 24 months fees>>vendor-amendment-2.pdf&&echo Section 11 termination notice requires 30 days>>vendor-amendment-2.pdf&&echo clause,change,business_impact>amendment-redline-impact.csv&&echo Limitation of liability,cap increased from 12 months fees to 24 months fees,raises maximum exposure>>amendment-redline-impact.csv&&echo Termination notice,notice period shortened from 60 days to 30 days,reduces time to plan exit>>amendment-redline-impact.csv&&echo wrote amendment-redline-impact.csv
+        """
+    }
+
+    private static var rfpComplianceMatrixCommand: String {
+        return """
+        echo RFP 2026 DOT source>RFP-2026-DOT.pdf&&echo Section 3.2 Contractor shall encrypt data at rest>>RFP-2026-DOT.pdf&&echo Section 4.1 Vendor must provide monthly status reports>>RFP-2026-DOT.pdf&&echo section,requirement,owner,workstream>rfp-compliance-matrix.csv&&echo 3.2,shall encrypt data at rest,,Security>>rfp-compliance-matrix.csv&&echo 4.1,must provide monthly status reports,,Program Management>>rfp-compliance-matrix.csv&&echo wrote rfp-compliance-matrix.csv
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 39"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 40"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -167,6 +167,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""50": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""51": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""52": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""53": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -197,6 +197,7 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""invoice-reconciliation.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""amendment-redline-impact.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""release-notes-2026-08.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""rfp-compliance-matrix.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -255,6 +255,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   `host.shell.run`.
 - Row #52 proves a customer-facing release-notes request creates `release-notes-2026-08.md`
   with grouped feature-area prose through `host.shell.run`.
+- Row #53 proves an RFP response request creates `rfp-compliance-matrix.csv` from
+  `RFP-2026-DOT.pdf`, preserving shall/must requirements, section numbers, blank owners, and
+  workstreams through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -732,6 +732,18 @@ expected_one_turn_cases = {
         "artifactContains": "## Collaboration",
         "answerContains": "wrote release-notes-2026-08.md",
     },
+    53: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "rfp-compliance-matrix.csv",
+        "artifactContains": "3.2,shall encrypt data at rest,,Security",
+        "answerContains": "wrote rfp-compliance-matrix.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "RFP-2026-DOT.pdf",
+                "artifactContains": "RFP 2026 DOT source",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -401,6 +401,18 @@ EXPECTED_CASES = {
         "artifactContains": "## Collaboration",
         "answerContains": "wrote release-notes-2026-08.md",
     },
+    53: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "rfp-compliance-matrix.csv",
+        "artifactContains": "3.2,shall encrypt data at rest,,Security",
+        "answerContains": "wrote rfp-compliance-matrix.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "RFP-2026-DOT.pdf",
+                "artifactContains": "RFP 2026 DOT source",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add coworker catalog row #53 RFP compliance-matrix proof to the packaged one-turn smoke
- verify the RFP source fixture plus generated shall/must compliance matrix with blank owner column
- update coworker coverage docs and gates from 39 to 40 proven packaged rows

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh