### PR TITLE
Add roadmap drafting coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1373,6 +1373,20 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 55,
+                prompt: "Run \(roadmapDraftingCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote roadmap.md",
+                artifactRelativePath: "roadmap.md",
+                artifactExpectation: .textContains("Theme: Retention-led Q3"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "Q3-OKRs.docx",
+                        expectation: .textContains("Q3 OKR source")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1604,6 +1618,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var riskRegisterCommand: String {
         return """
         echo Project charter source>project-charter.pdf&&echo Risks include data migration delay vendor API outage and stakeholder training gaps>>project-charter.pdf&&echo risk,likelihood,impact,mitigation,owner>project-risk-register.csv&&echo Data migration delay,4,5,stage dry runs weekly,Ben>>project-risk-register.csv&&echo Vendor API outage,3,4,confirm rollback plan,Ada>>project-risk-register.csv&&echo Training adoption gap,3,3,schedule role-based walkthroughs,Cam>>project-risk-register.csv&&echo wrote project-risk-register.csv
+        """
+    }
+
+    private static var roadmapDraftingCommand: String {
+        return """
+        echo Q3 OKR source>Q3-OKRs.docx&&echo Objective improve retention through onboarding activation and reporting>>Q3-OKRs.docx&&echo Objective expand enterprise readiness with permissions and audit trails>>Q3-OKRs.docx&&echo Q3 Roadmap>roadmap.md&&echo Theme: Retention-led Q3>>roadmap.md&&echo Milestone: Onboarding activation by 2026-07-31>>roadmap.md&&echo Milestone: Usage reporting by 2026-08-21>>roadmap.md&&echo Milestone: Enterprise permissions by 2026-09-11>>roadmap.md&&echo Milestone: Audit trail beta by 2026-09-25>>roadmap.md&&echo wrote roadmap.md
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 41"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 42"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -169,6 +169,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""52": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""53": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""54": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""55": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -199,6 +199,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""release-notes-2026-08.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""rfp-compliance-matrix.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""project-risk-register.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""roadmap.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""Q3-OKRs.docx""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -260,6 +260,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   workstreams through `host.shell.run`.
 - Row #54 proves risk-register generation creates `project-risk-register.csv` from
   `project-charter.pdf`, preserving likelihood, impact, mitigation, and owner columns through
+  `host.shell.run`.
+- Row #55 proves roadmap drafting creates `roadmap.md` from `Q3-OKRs.docx`, preserving a quarterly
+  theme plus dated onboarding, reporting, permissions, and audit-trail milestones through
   `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -756,6 +756,18 @@ expected_one_turn_cases = {
             },
         ],
     },
+    55: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "roadmap.md",
+        "artifactContains": "Theme: Retention-led Q3",
+        "answerContains": "wrote roadmap.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "Q3-OKRs.docx",
+                "artifactContains": "Q3 OKR source",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -425,6 +425,18 @@ EXPECTED_CASES = {
             },
         ],
     },
+    55: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "roadmap.md",
+        "artifactContains": "Theme: Retention-led Q3",
+        "answerContains": "wrote roadmap.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "Q3-OKRs.docx",
+                "artifactContains": "Q3 OKR source",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add catalog row #55 roadmap drafting to one-turn coworker smoke coverage
- validate roadmap.md and Q3-OKRs.docx artifacts in packaged/native smoke contracts
- bump row-linked coverage assertions from 41 to 42 and update tracker docs

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh