### PR TITLE
Add sales one-pager coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1405,6 +1405,24 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 57,
+                prompt: "Run \(salesOnePagerCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote customer-leave-behind.md",
+                artifactRelativePath: "customer-leave-behind.md",
+                artifactExpectation: .textContains("Three proof points"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "product-deck-20-slides.pptx",
+                        expectation: .textContains("20 slide product deck source")
+                    ),
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "approved-pricing.csv",
+                        expectation: .textContains("approved pricing")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1648,6 +1666,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var salesProposalCommand: String {
         return """
         echo Northwind Logistics discovery>discovery-call-notes.md&&echo Need cross dock scheduling warehouse analytics and carrier exception alerts>>discovery-call-notes.md&&echo Target pilot starts 2026-09-01 and executive rollout by 2026-10-15>>discovery-call-notes.md&&echo approved pricing tiers>pricing-sheet.xlsx&&echo Starter USD25000 Growth USD54000 Enterprise USD98000>>pricing-sheet.xlsx&&echo Northwind Logistics proposal>northwind-logistics-proposal.md&&echo Scope: cross dock scheduling warehouse analytics and carrier exception alerts>>northwind-logistics-proposal.md&&echo Timeline: pilot kickoff 2026-09-01 rollout 2026-10-15>>northwind-logistics-proposal.md&&echo Pricing tiers: Starter USD25000 Growth USD54000 Enterprise USD98000>>northwind-logistics-proposal.md&&echo Assumptions: Northwind provides carrier feeds warehouse contacts and pilot success metrics>>northwind-logistics-proposal.md&&echo wrote northwind-logistics-proposal.md
+        """
+    }
+
+    private static var salesOnePagerCommand: String {
+        return """
+        echo 20 slide product deck source>product-deck-20-slides.pptx&&echo Slides cover automation analytics security onboarding integrations and customer outcomes>>product-deck-20-slides.pptx&&echo approved pricing>approved-pricing.csv&&echo tier,price,fit>>approved-pricing.csv&&echo Starter,USD12000,small teams>>approved-pricing.csv&&echo Growth,USD36000,growing teams>>approved-pricing.csv&&echo Enterprise,custom,regulated teams>>approved-pricing.csv&&echo Customer leave-behind>customer-leave-behind.md&&echo Three proof points: reduce manual handoffs improve forecast accuracy and shorten onboarding>>customer-leave-behind.md&&echo Pricing tiers: Starter USD12000 Growth USD36000 Enterprise custom>>customer-leave-behind.md&&echo Call to action: schedule a 30 minute pilot planning session this week>>customer-leave-behind.md&&echo wrote customer-leave-behind.md
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 43"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 44"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -171,6 +171,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""54": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""55": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""56": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""57": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -204,6 +204,9 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""northwind-logistics-proposal.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""discovery-call-notes.md""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""pricing-sheet.xlsx""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""customer-leave-behind.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""product-deck-20-slides.pptx""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""approved-pricing.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -267,6 +267,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #56 proves sales-proposal drafting creates `northwind-logistics-proposal.md` from
   `discovery-call-notes.md` and `pricing-sheet.xlsx`, preserving scope, timeline, three pricing
   tiers, and assumptions through `host.shell.run`.
+- Row #57 proves sales one-pager drafting creates `customer-leave-behind.md` from
+  `product-deck-20-slides.pptx` and `approved-pricing.csv`, preserving three proof points, pricing
+  tiers, and a short call to action through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -784,6 +784,22 @@ expected_one_turn_cases = {
             },
         ],
     },
+    57: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "customer-leave-behind.md",
+        "artifactContains": "Three proof points",
+        "answerContains": "wrote customer-leave-behind.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "product-deck-20-slides.pptx",
+                "artifactContains": "20 slide product deck source",
+            },
+            {
+                "artifactSuffix": "approved-pricing.csv",
+                "artifactContains": "approved pricing",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -453,6 +453,22 @@ EXPECTED_CASES = {
             },
         ],
     },
+    57: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "customer-leave-behind.md",
+        "artifactContains": "Three proof points",
+        "answerContains": "wrote customer-leave-behind.md",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "product-deck-20-slides.pptx",
+                "artifactContains": "20 slide product deck source",
+            },
+            {
+                "artifactSuffix": "approved-pricing.csv",
+                "artifactContains": "approved pricing",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add catalog row #57 sales one-pager drafting to one-turn coworker smoke coverage
- validate customer-leave-behind.md plus product-deck-20-slides.pptx and approved-pricing.csv artifacts
- bump row-linked packaged coverage assertions from 43 to 44 and update tracker docs

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh