### PR TITLE
Add work breakdown coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1483,6 +1483,20 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 62,
+                prompt: "Run \(workBreakdownCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote wbs.xlsx",
+                artifactRelativePath: "wbs.xlsx",
+                artifactExpectation: .textContains("Implementation,Onboarding checklist,Ada,5d"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "team-roster.csv",
+                        expectation: .textContains("Ada,Product")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1756,6 +1770,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var npsSurveyAnalysisCommand: String {
         return """
         echo survey export q2>customer-survey-q2.csv&&echo respondent,plan_tier,score,comment>>customer-survey-q2.csv&&echo C-001,Enterprise,10,Great support and uptime>>customer-survey-q2.csv&&echo C-002,Enterprise,9,Admin controls are strong>>customer-survey-q2.csv&&echo C-003,Enterprise,4,Reporting is slow>>customer-survey-q2.csv&&echo C-004,Growth,8,Useful but onboarding took effort>>customer-survey-q2.csv&&echo C-005,Growth,3,Mobile app crashes during upload>>customer-survey-q2.csv&&echo C-006,Growth,10,Fast answers from support>>customer-survey-q2.csv&&echo C-007,Starter,2,Too expensive for small teams>>customer-survey-q2.csv&&echo C-008,Starter,7,Setup docs need examples>>customer-survey-q2.csv&&echo C-009,Starter,9,Simple and reliable>>customer-survey-q2.csv&&echo C-010,Enterprise,6,Permissions are confusing>>customer-survey-q2.csv&&echo C-011,Growth,5,Billing invoices are unclear>>customer-survey-q2.csv&&echo C-012,Starter,1,Integrations are missing>>customer-survey-q2.csv&&echo plan_tier,nps,total,promoters,passives,detractors>nps-plan-tier-summary.csv&&echo Enterprise,67,3,2,1,detractors0>>nps-plan-tier-summary.csv&&echo Growth,0,4,1,1,detractors2>>nps-plan-tier-summary.csv&&echo Starter,-25,4,1,1,detractors2>>nps-plan-tier-summary.csv&&echo complaint,theme>nps-detractor-complaints.md&&echo complaint_1,Reporting is slow>>nps-detractor-complaints.md&&echo complaint_2,Mobile app crashes during upload>>nps-detractor-complaints.md&&echo complaint_3,Too expensive for small teams>>nps-detractor-complaints.md&&echo complaint_4,Billing invoices are unclear>>nps-detractor-complaints.md&&echo complaint_5,Integrations are missing>>nps-detractor-complaints.md&&echo wrote nps-plan-tier-summary.csv
+        """
+    }
+
+    private static var workBreakdownCommand: String {
+        return """
+        echo name,role>team-roster.csv&&echo Ada,Product>>team-roster.csv&&echo Ben,Engineering>>team-roster.csv&&echo Cam,Design>>team-roster.csv&&echo Dee,Customer Success>>team-roster.csv&&echo Goal launch self serve onboarding by October>onboarding-goal.md&&echo phase,workstream,owner,effort_estimate,due_month>wbs.xlsx&&echo Discovery,Current signup audit,Ada,3d,July>>wbs.xlsx&&echo Design,Activation path mockups,Cam,4d,August>>wbs.xlsx&&echo Implementation,Onboarding checklist,Ada,5d,August>>wbs.xlsx&&echo Implementation,In app guide builder,Ben,8d,September>>wbs.xlsx&&echo Enablement,Help center refresh,Dee,3d,September>>wbs.xlsx&&echo Launch,October rollout readiness,Ada,2d,October>>wbs.xlsx&&echo wrote wbs.xlsx
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 48"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 49"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -176,6 +176,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""59": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""60": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""61": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""62": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -216,6 +216,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""nps-plan-tier-summary.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""customer-survey-q2.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""nps-detractor-complaints.md""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""wbs.xlsx""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""team-roster.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -282,6 +282,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #61 proves NPS survey analysis creates `nps-plan-tier-summary.csv` from
   `customer-survey-q2.csv`, preserving plan-tier NPS scores and the five most common detractor
   complaints in `nps-detractor-complaints.md` through `host.shell.run`.
+- Row #62 proves task-breakdown planning creates `wbs.xlsx` from `team-roster.csv`, preserving
+  phases, owners, and effort estimates for launching self-serve onboarding by October through
+  `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -852,6 +852,18 @@ expected_one_turn_cases = {
             },
         ],
     },
+    62: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "wbs.xlsx",
+        "artifactContains": "Implementation,Onboarding checklist,Ada,5d",
+        "answerContains": "wrote wbs.xlsx",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "team-roster.csv",
+                "artifactContains": "Ada,Product",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -521,6 +521,18 @@ EXPECTED_CASES = {
             },
         ],
     },
+    62: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "wbs.xlsx",
+        "artifactContains": "Implementation,Onboarding checklist,Ada,5d",
+        "answerContains": "wrote wbs.xlsx",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "team-roster.csv",
+                "artifactContains": "Ada,Product",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add catalog row #62 one-turn coworker smoke for self-serve onboarding work breakdown planning
- verify team-roster.csv source retention and wbs.xlsx with phase, owner, and effort estimate evidence
- update packaged/native validators, coverage count to 49, and tracker/parity docs

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh