### PR TITLE
Add tone rewrite coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1511,6 +1511,25 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 64,
+                prompt: "Run \(toneRewriteCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote draft-price-increase-email-rewrite.docx",
+                artifactRelativePath: "draft-price-increase-email-rewrite.docx",
+                artifactExpectation: .textContainsAndShorterThan(
+                    "We are keeping your current price until 2026-10-01.",
+                    sourceRelativePath: "draft-price-increase-email.docx",
+                    maximumLengthRatio: 0.70,
+                    assertion: "warmer rewrite keeps protected date and is at least 30 pct shorter"
+                ),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "draft-price-increase-email.docx",
+                        expectation: .textContains("Grandfathering clause: all existing customers keep current pricing")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1544,12 +1563,18 @@ enum QuillCodeDesktopSmokeRunner {
             }
 
             let artifact = root.workspace.appendingPathComponent(smokeCase.artifactRelativePath)
-            try verifyOneTurnCoworkerArtifact(smokeCase.artifactExpectation, artifact: artifact, taskID: smokeCase.taskID)
+            try verifyOneTurnCoworkerArtifact(
+                smokeCase.artifactExpectation,
+                artifact: artifact,
+                root: root.workspace,
+                taskID: smokeCase.taskID
+            )
             for secondaryArtifact in smokeCase.secondaryArtifacts {
                 let secondaryURL = root.workspace.appendingPathComponent(secondaryArtifact.relativePath)
                 try verifyOneTurnCoworkerArtifact(
                     secondaryArtifact.expectation,
                     artifact: secondaryURL,
+                    root: root.workspace,
                     taskID: smokeCase.taskID
                 )
             }
@@ -1799,6 +1824,12 @@ enum QuillCodeDesktopSmokeRunner {
         """
     }
 
+    private static var toneRewriteCommand: String {
+        return """
+        echo Subject: Important pricing adjustment for your account>draft-price-increase-email.docx&&echo Effective date: 2026-10-01>>draft-price-increase-email.docx&&echo Grandfathering clause: all existing customers keep current pricing through the current contract term.>>draft-price-increase-email.docx&&echo We are writing to inform you that prices will increase because of market pressures operational expenses expanded capabilities infrastructure commitments support staffing compliance investments vendor cost changes and product investments that require additional funding.>>draft-price-increase-email.docx&&echo This message is intended to provide formal notice and detailed background so that customer teams can complete budget planning procurement review renewal planning stakeholder approval and finance coordination before the new rate card applies.>>draft-price-increase-email.docx&&echo We know budgeting takes time.>draft-price-increase-email-rewrite.docx&&echo We are keeping your current price until 2026-10-01.>>draft-price-increase-email-rewrite.docx&&echo Grandfathering clause: all existing customers keep current pricing through the current contract term.>>draft-price-increase-email-rewrite.docx&&echo Reply any time and we will help you plan.>>draft-price-increase-email-rewrite.docx&&echo wrote draft-price-increase-email-rewrite.docx
+        """
+    }
+
     private static var cohortRetentionCommand: String {
         let subscriptionsCSV = "customer,signup_month,paid_month,canceled_month\\nA,2026-01,2026-01,\\nB,2026-01,2026-01,2026-02\\nC,2026-01,2026-02,\\nD,2026-02,2026-02,2026-03\\nE,2026-02,2026-02,\\n"
         let retentionCSV = "cohort,signup_count,retained_after_first_month,fastest_decay_month\\n2026-01,3,67%,2026-02\\n2026-02,2,50%,2026-03\\n"
@@ -1810,6 +1841,7 @@ enum QuillCodeDesktopSmokeRunner {
     private static func verifyOneTurnCoworkerArtifact(
         _ expectation: OneTurnCoworkerArtifactExpectation,
         artifact: URL,
+        root: URL,
         taskID: Int
     ) throws {
         switch expectation {
@@ -1818,6 +1850,16 @@ enum QuillCodeDesktopSmokeRunner {
             guard artifactText.contains(expected) else {
                 throw QuillCodeDesktopSmokeFailure.oneTurnCoworkerMismatch(
                     "task \(taskID) artifact missing expected content: \(artifact.path)"
+                )
+            }
+        case .textContainsAndShorterThan(let expected, let sourceRelativePath, let maximumLengthRatio, _):
+            let artifactText = try String(contentsOf: artifact, encoding: .utf8)
+            let sourceURL = root.appendingPathComponent(sourceRelativePath)
+            let sourceText = try String(contentsOf: sourceURL, encoding: .utf8)
+            let maximumLength = Int((Double(sourceText.count) * maximumLengthRatio).rounded(.down))
+            guard artifactText.contains(expected), artifactText.count <= maximumLength else {
+                throw QuillCodeDesktopSmokeFailure.oneTurnCoworkerMismatch(
+                    "task \(taskID) rewrite did not preserve expected text or shrink enough: \(artifact.path)"
                 )
             }
         case .png(let width, let height, let minimumByteCount, _):
@@ -2213,12 +2255,20 @@ private struct OneTurnCoworkerArtifactCheck {
 
 private enum OneTurnCoworkerArtifactExpectation {
     case textContains(String)
+    case textContainsAndShorterThan(
+        String,
+        sourceRelativePath: String,
+        maximumLengthRatio: Double,
+        assertion: String
+    )
     case png(width: Int, height: Int, minimumByteCount: Int, assertion: String)
 
     var assertion: String {
         switch self {
         case .textContains(let text):
             text
+        case .textContainsAndShorterThan(_, _, _, let assertion):
+            assertion
         case .png(_, _, _, let assertion):
             assertion
         }

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 50"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 51"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -178,6 +178,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""61": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""62": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""63": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""64": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -220,6 +220,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""team-roster.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""timeline.xlsx""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""milestones.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""draft-price-increase-email-rewrite.docx""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""draft-price-increase-email.docx""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -288,6 +288,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #63 proves timeline building creates `timeline.xlsx` from `milestones.csv`, preserving
   Gantt-style start dates, end dates, durations, dependencies, and the November 3 launch milestone
   through `host.shell.run`.
+- Row #64 proves tone rewriting creates `draft-price-increase-email-rewrite.docx` from
+  `draft-price-increase-email.docx`, preserving the exact effective date and grandfathering clause
+  while shortening and softening the pricing-change copy through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -876,6 +876,20 @@ expected_one_turn_cases = {
             },
         ],
     },
+    64: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "draft-price-increase-email-rewrite.docx",
+        "artifactContains": "warmer rewrite keeps protected date and is at least 30 pct shorter",
+        "answerContains": "wrote draft-price-increase-email-rewrite.docx",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "draft-price-increase-email.docx",
+                "artifactContains": (
+                    "Grandfathering clause: all existing customers keep current pricing"
+                ),
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -545,6 +545,20 @@ EXPECTED_CASES = {
             },
         ],
     },
+    64: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "draft-price-increase-email-rewrite.docx",
+        "artifactContains": "warmer rewrite keeps protected date and is at least 30 pct shorter",
+        "answerContains": "wrote draft-price-increase-email-rewrite.docx",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "draft-price-increase-email.docx",
+                "artifactContains": (
+                    "Grandfathering clause: all existing customers keep current pricing"
+                ),
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add coworker catalog row #64 tone-rewrite smoke coverage
- verify the rewrite preserves the protected effective date wording and is shorter than the source draft
- update packaged one-turn coworker validators, coverage count, parity matrix, tracker, and decisions docs

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh