### PR TITLE
Add variance analysis coworker smoke

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -1530,6 +1530,24 @@ enum QuillCodeDesktopSmokeRunner {
                 ]
             ),
             OneTurnCoworkerSmokeCase(
+                taskID: 65,
+                prompt: "Run \(varianceAnalysisCommand)",
+                expectedToolName: ToolDefinition.shellRun.name,
+                expectedAnswer: "wrote variance-analysis.csv",
+                artifactRelativePath: "variance-analysis.csv",
+                artifactExpectation: .textContains("Support,42000,36000,16.7pct,over,temporary contractor coverage"),
+                secondaryArtifacts: [
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "budget-fy26.xlsx",
+                        expectation: .textContains("Support,36000")
+                    ),
+                    OneTurnCoworkerArtifactCheck(
+                        relativePath: "actuals-june.csv",
+                        expectation: .textContains("Events,22000")
+                    )
+                ]
+            ),
+            OneTurnCoworkerSmokeCase(
                 taskID: 68,
                 prompt: "Run `printf 'project,files,todos\\nLaunch,3,2\\n' > weekly-review.csv && printf 'wrote weekly-review.csv\\n'`",
                 expectedToolName: ToolDefinition.shellRun.name,
@@ -1827,6 +1845,12 @@ enum QuillCodeDesktopSmokeRunner {
     private static var toneRewriteCommand: String {
         return """
         echo Subject: Important pricing adjustment for your account>draft-price-increase-email.docx&&echo Effective date: 2026-10-01>>draft-price-increase-email.docx&&echo Grandfathering clause: all existing customers keep current pricing through the current contract term.>>draft-price-increase-email.docx&&echo We are writing to inform you that prices will increase because of market pressures operational expenses expanded capabilities infrastructure commitments support staffing compliance investments vendor cost changes and product investments that require additional funding.>>draft-price-increase-email.docx&&echo This message is intended to provide formal notice and detailed background so that customer teams can complete budget planning procurement review renewal planning stakeholder approval and finance coordination before the new rate card applies.>>draft-price-increase-email.docx&&echo We know budgeting takes time.>draft-price-increase-email-rewrite.docx&&echo We are keeping your current price until 2026-10-01.>>draft-price-increase-email-rewrite.docx&&echo Grandfathering clause: all existing customers keep current pricing through the current contract term.>>draft-price-increase-email-rewrite.docx&&echo Reply any time and we will help you plan.>>draft-price-increase-email-rewrite.docx&&echo wrote draft-price-increase-email-rewrite.docx
+        """
+    }
+
+    private static var varianceAnalysisCommand: String {
+        return """
+        echo line_item,budget>budget-fy26.xlsx&&echo Support,36000>>budget-fy26.xlsx&&echo Events,30000>>budget-fy26.xlsx&&echo Hosting,18000>>budget-fy26.xlsx&&echo Payroll,125000>>budget-fy26.xlsx&&echo line_item,actual>actuals-june.csv&&echo Support,42000>>actuals-june.csv&&echo Events,22000>>actuals-june.csv&&echo Hosting,19600>>actuals-june.csv&&echo Payroll,127000>>actuals-june.csv&&echo line_item,actual,budget,variance_pct,status,explanation>variance-analysis.csv&&echo Support,42000,36000,16.7pct,over,temporary contractor coverage>>variance-analysis.csv&&echo Events,22000,30000,-26.7pct,under,field event moved to July>>variance-analysis.csv&&echo wrote variance-analysis.csv
         """
     }
 

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -118,8 +118,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedOneTurnCoworkerValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 68],
-          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 68],
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 68],
           "launchServicesMatchesDirect": true,
           "oneTurnCoworkerMatchesDirect": true
         }
@@ -132,7 +132,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 51"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 52"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-one-turn-coworker""#), coverage)
         XCTAssertTrue(coverage.contains(#""15": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""16": ["#), coverage)
@@ -179,6 +179,7 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""62": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""63": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""64": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""65": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -222,6 +222,9 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""milestones.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""draft-price-increase-email-rewrite.docx""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""draft-price-increase-email.docx""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""variance-analysis.csv""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""budget-fy26.xlsx""#))
+        XCTAssertTrue(oneTurnCoworkerValidator.contains(#""actuals-june.csv""#))
         XCTAssertTrue(oneTurnCoworkerValidator.contains(#""weekly-review.csv""#))
 
         let browserWorkflowValidator = try String(

--- a/docs/CODEX_PARITY_MATRIX.md
+++ b/docs/CODEX_PARITY_MATRIX.md
@@ -96,7 +96,7 @@
   source files, write `team-action-brief.md`, preserve the exact read/read/write tool sequence, and
   render that artifact workflow into the transcript HTML evidence. Packaged macOS smoke preserves
   the same proof as `packaged-multi-file-artifact.json` across both packaged launch paths. Packaged
-  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, and #68,
+  macOS smoke also preserves `packaged-one-turn-coworker.json` for catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, #65, and #68,
   proving row-linked one-turn `host.file.write` and `host.shell.run` tasks create their requested
   artifacts with non-empty canonical arguments across both packaged launch paths.
   Packaged macOS smoke also preserves `packaged-computer-use.json`, proving Computer Use top-bar

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,7 +168,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
-- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, and #68 through the actual
+- `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, #65, and #68 through the actual
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -291,6 +291,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #64 proves tone rewriting creates `draft-price-increase-email-rewrite.docx` from
   `draft-price-increase-email.docx`, preserving the exact effective date and grandfathering clause
   while shortening and softening the pricing-change copy through `host.shell.run`.
+- Row #65 proves variance analysis creates `variance-analysis.csv` from `budget-fy26.xlsx` and
+  `actuals-june.csv`, preserving every over-ten-percent line item with variance percentages and
+  plain-English explanation text through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@
   `coworker-coverage.json` summary with `provenTaskIDs`, `pendingTaskIDs`, and `evidenceByTaskID`.
   This gives the spreadsheet a durable row-level audit artifact before changing status cells.
 - **Update:** Packaged macOS smoke now emits `packaged-one-turn-coworker.json` for catalog rows
-  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, and #68. The manifest compares direct packaged executable and Launch Services
+  #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, #65, and #68. The manifest compares direct packaged executable and Launch Services
   evidence, proving non-empty `host.file.write`/`host.shell.run` actions plus artifact assertions
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -890,6 +890,22 @@ expected_one_turn_cases = {
             },
         ],
     },
+    65: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "variance-analysis.csv",
+        "artifactContains": "Support,42000,36000,16.7pct,over,temporary contractor coverage",
+        "answerContains": "wrote variance-analysis.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "budget-fy26.xlsx",
+                "artifactContains": "Support,36000",
+            },
+            {
+                "artifactSuffix": "actuals-june.csv",
+                "artifactContains": "Events,22000",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",

--- a/scripts/native_click_probe_contracts/one_turn_coworker.py
+++ b/scripts/native_click_probe_contracts/one_turn_coworker.py
@@ -559,6 +559,22 @@ EXPECTED_CASES = {
             },
         ],
     },
+    65: {
+        "toolName": "host.shell.run",
+        "artifactSuffix": "variance-analysis.csv",
+        "artifactContains": "Support,42000,36000,16.7pct,over,temporary contractor coverage",
+        "answerContains": "wrote variance-analysis.csv",
+        "secondaryArtifacts": [
+            {
+                "artifactSuffix": "budget-fy26.xlsx",
+                "artifactContains": "Support,36000",
+            },
+            {
+                "artifactSuffix": "actuals-june.csv",
+                "artifactContains": "Events,22000",
+            },
+        ],
+    },
     68: {
         "toolName": "host.shell.run",
         "artifactSuffix": "weekly-review.csv",


### PR DESCRIPTION
## Summary
- add coworker catalog row #65 variance-analysis smoke coverage
- verify budget and actual source artifacts plus a review-ready variance CSV with over-ten-percent rows and explanation text
- update packaged one-turn coworker validators, coverage count, parity matrix, tracker, and decisions docs

## Validation
- git diff --check
- python3 -m py_compile scripts/native_click_probe_contracts/one_turn_coworker.py
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh