### PR TITLE
Add all-hands email coworker smoke

### DIFF
--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -382,6 +382,15 @@ public struct MockLLMClient: LLMClient {
         for lowercasedRequest: String,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if lowercasedRequest.contains("all-hands email"),
+           lowercasedRequest.contains("org-changes.pptx"),
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "org-changes.pptx"])
+            ))
+        }
+
         guard lowercasedRequest.contains("team action brief"),
               tools.contains(where: { $0.name == ToolDefinition.fileRead.name })
         else { return nil }
@@ -392,6 +401,20 @@ public struct MockLLMClient: LLMClient {
     }
 
     private static func nextMultiFileArtifactAction(
+        thread: ChatThread,
+        feedback: AgentToolFeedback,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        if let action = Self.nextAllHandsEmailAction(thread: thread, feedback: feedback, tools: tools) {
+            return action
+        }
+        if let action = Self.nextTeamActionBriefAction(thread: thread, feedback: feedback, tools: tools) {
+            return action
+        }
+        return nil
+    }
+
+    private static func nextTeamActionBriefAction(
         thread: ChatThread,
         feedback: AgentToolFeedback,
         tools: [ToolDefinition]
@@ -432,6 +455,52 @@ public struct MockLLMClient: LLMClient {
         return nil
     }
 
+    private static func nextAllHandsEmailAction(
+        thread: ChatThread,
+        feedback: AgentToolFeedback,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard thread.messages.contains(where: {
+            let content = $0.content.lowercased()
+            return $0.role == .user
+                && content.contains("all-hands email")
+                && content.contains("org-changes.pptx")
+        }) else {
+            return nil
+        }
+
+        let path = Self.stringArgument("path", from: feedback.toolCall.argumentsJSON)
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "org-changes.pptx",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "reorg-qa/hardest-questions.md"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "reorg-qa/hardest-questions.md",
+           tools.contains(where: { $0.name == ToolDefinition.fileWrite.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileWrite.name,
+                argumentsJSON: ToolArguments.json([
+                    "path": "ceo-reorg-all-hands-email.md",
+                    "content": Self.allHandsEmailContent
+                ])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileWrite.name,
+           path == "ceo-reorg-all-hands-email.md" {
+            return .say(
+                "Created `ceo-reorg-all-hands-email.md` from `org-changes.pptx` and `reorg-qa/hardest-questions.md`."
+            )
+        }
+
+        return nil
+    }
+
     private static var teamActionBriefContent: String {
         """
         # Team Action Brief
@@ -446,6 +515,31 @@ public struct MockLLMClient: LLMClient {
 
         ## Next action
         - Run the pairing fallback smoke and attach the evidence to the release tracker.
+        """
+    }
+
+    private static var allHandsEmailContent: String {
+        """
+        # CEO All-Hands Email: Customer-Response Reorg
+
+        Team,
+
+        We are reorganizing around a simpler customer-response operating model. Product Operations moves under Engineering, and Customer Success and Support will become one Customer Experience team. The transition starts August 12 and finishes September 30.
+
+        No layoffs are planned. Pay and benefits stay the same, and managers will support every employee through the change.
+
+        ## Eight hardest questions
+
+        1. Why now? Customer handoff delays need one accountable operating model.
+        2. Are there layoffs? No layoffs are planned.
+        3. Will compensation change? Pay and benefits stay the same.
+        4. Who changes managers? Product Operations and Support have the listed reporting changes.
+        5. What happens to current projects? Customer commitments remain funded.
+        6. How will decisions be made? Weekly escalation review with Engineering and Customer Experience.
+        7. What should managers say today? Use the provided team script and collect concerns.
+        8. Where do questions go? Send questions to reorg-qa@quill.example by Friday.
+
+        Thank you for helping make this transition clear and calm for customers and teams.
         """
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -158,6 +158,7 @@ enum QuillCodeDesktopSmokeRunner {
         guard html.contains("Wrote `hello.txt`."),
               html.contains("Contents of `hello.txt`:"),
               html.contains("hello world"),
+              html.contains("Created `ceo-reorg-all-hands-email.md`"),
               html.contains("Inspected `Browser Smoke`"),
               html.contains("host.browser.inspect"),
               html.contains("host.file.read"),
@@ -847,16 +848,103 @@ enum QuillCodeDesktopSmokeRunner {
                 "unexpected tool sequence: \(toolSequence.joined(separator: ", "))"
             )
         }
+        let finalAnswer = controller.surface.transcript.messages.last?.text ?? ""
+
+        let catalogCases = [
+            try await runAllHandsEmailCatalogSmoke(controller: controller, root: root)
+        ]
 
         return QuillCodeDesktopMultiFileArtifactSmokeReport(
             prompt: prompt,
             sourcePaths: [researchFile.path, risksFile.path],
             deliverablePath: deliverable.path,
             toolSequence: toolSequence,
-            finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
+            finalAnswer: finalAnswer,
             deliverableContainsResearch: containsResearch,
             deliverableContainsRisk: containsRisk,
-            deliverableContainsNextAction: containsNextAction
+            deliverableContainsNextAction: containsNextAction,
+            catalogCases: catalogCases
+        )
+    }
+
+    private static func runAllHandsEmailCatalogSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopMultiFileCatalogSmokeCaseReport {
+        let qaDirectory = root.workspace.appendingPathComponent("reorg-qa", isDirectory: true)
+        try FileManager.default.createDirectory(at: qaDirectory, withIntermediateDirectories: true)
+
+        let orgChanges = root.workspace.appendingPathComponent("org-changes.pptx")
+        let qaNotes = qaDirectory.appendingPathComponent("hardest-questions.md")
+        try """
+        Slide 1: Announce the reorg as a customer-response operating model.
+        Slide 2: Product Operations moves under Engineering; Customer Success and Support form one Customer Experience team.
+        Slide 3: No layoffs are planned; every employee keeps pay and manager support through the transition.
+        Slide 4: The transition starts August 12 and finishes September 30.
+        """.write(to: orgChanges, atomically: true, encoding: .utf8)
+        try """
+        # Eight hardest questions
+
+        1. Why now? Customer handoff delays need one accountable operating model.
+        2. Are there layoffs? No layoffs are planned.
+        3. Will compensation change? Pay and benefits stay the same.
+        4. Who changes managers? Product Operations and Support have the listed reporting changes.
+        5. What happens to current projects? Customer commitments remain funded.
+        6. How will decisions be made? Weekly escalation review with Engineering and Customer Experience.
+        7. What should managers say today? Use the provided team script and collect concerns.
+        8. Where do questions go? Send questions to reorg-qa@quill.example by Friday.
+        """.write(to: qaNotes, atomically: true, encoding: .utf8)
+
+        let prompt = "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` and the answers in `reorg-qa`, covering the eight hardest questions."
+        let previousTimelineCount = controller.surface.transcript.timelineItems.count
+        let previousToolCardCount = controller.surface.transcript.toolCards.count
+        controller.draft = prompt
+        controller.send()
+
+        let expectedAnswer = "Created `ceo-reorg-all-hands-email.md` from `org-changes.pptx` and `reorg-qa/hardest-questions.md`."
+        try await waitForDesktopRun(
+            controller,
+            previousTimelineCount: previousTimelineCount,
+            expectedAnswer: expectedAnswer
+        )
+
+        let deliverable = root.workspace.appendingPathComponent("ceo-reorg-all-hands-email.md")
+        let deliverableText = try String(contentsOf: deliverable, encoding: .utf8)
+        let assertions = [
+            "announcesReorg": deliverableText.contains("Customer Experience")
+                && deliverableText.contains("Product Operations moves under Engineering"),
+            "preservesTimeline": deliverableText.contains("August 12")
+                && deliverableText.contains("September 30"),
+            "coversEightQuestions": deliverableText.contains("1. Why now?")
+                && deliverableText.contains("8. Where do questions go?"),
+            "answersHardestQuestions": deliverableText.contains("No layoffs are planned")
+                && deliverableText.contains("Pay and benefits stay the same")
+                && deliverableText.contains("reorg-qa@quill.example")
+        ]
+        guard assertions.values.allSatisfy({ $0 }) else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(deliverable.path)
+        }
+
+        let toolSequence = Array(controller.surface.transcript.toolCards.dropFirst(previousToolCardCount))
+            .map(\.title)
+        guard toolSequence == [
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileWrite.name
+        ] else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(
+                "unexpected all-hands email tool sequence: \(toolSequence.joined(separator: ", "))"
+            )
+        }
+
+        return QuillCodeDesktopMultiFileCatalogSmokeCaseReport(
+            taskID: 69,
+            prompt: prompt,
+            sourcePaths: [orgChanges.path, qaNotes.path],
+            deliverablePath: deliverable.path,
+            toolSequence: toolSequence,
+            finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
+            assertions: assertions
         )
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -414,6 +414,7 @@ struct QuillCodeDesktopMultiFileArtifactSmokeReport {
     var deliverableContainsResearch: Bool
     var deliverableContainsRisk: Bool
     var deliverableContainsNextAction: Bool
+    var catalogCases: [QuillCodeDesktopMultiFileCatalogSmokeCaseReport] = []
 
     var dictionary: [String: Any] {
         [
@@ -424,7 +425,31 @@ struct QuillCodeDesktopMultiFileArtifactSmokeReport {
             "finalAnswer": finalAnswer,
             "deliverableContainsResearch": deliverableContainsResearch,
             "deliverableContainsRisk": deliverableContainsRisk,
-            "deliverableContainsNextAction": deliverableContainsNextAction
+            "deliverableContainsNextAction": deliverableContainsNextAction,
+            "catalogCases": catalogCases.map(\.dictionary),
+            "catalogTaskIDs": catalogCases.map(\.taskID)
+        ]
+    }
+}
+
+struct QuillCodeDesktopMultiFileCatalogSmokeCaseReport {
+    var taskID: Int
+    var prompt: String
+    var sourcePaths: [String]
+    var deliverablePath: String
+    var toolSequence: [String]
+    var finalAnswer: String
+    var assertions: [String: Bool]
+
+    var dictionary: [String: Any] {
+        [
+            "taskID": taskID,
+            "prompt": prompt,
+            "sourcePaths": sourcePaths,
+            "deliverablePath": deliverablePath,
+            "toolSequence": toolSequence,
+            "finalAnswer": finalAnswer,
+            "assertions": assertions
         ]
     }
 }

--- a/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
+++ b/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
@@ -98,6 +98,97 @@ final class MockLLMClientMultiFileArtifactTests: XCTestCase {
         )
     }
 
+    func testAllHandsEmailStartsByReadingOrgChangesDeck() async throws {
+        let action = try await MockLLMClient().nextAction(
+            thread: ChatThread(mode: .auto),
+            userMessage: "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` and the answers in `reorg-qa`, covering the eight hardest questions.",
+            tools: ToolRouter.definitions
+        )
+
+        let call = try XCTUnwrap(action.toolCall)
+        XCTAssertEqual(call.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(call.argumentsJSON).string("path"), "org-changes.pptx")
+    }
+
+    func testAllHandsEmailReadsQANotesThenWritesDraft() async throws {
+        let user = ChatMessage(
+            role: .user,
+            content: "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` and the answers in `reorg-qa`, covering the eight hardest questions."
+        )
+        let orgRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "org-changes.pptx"])
+        )
+        let afterOrgRead = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(
+                    for: orgRead,
+                    stdout: "Product Operations moves under Engineering."
+                )
+            ]
+        )
+
+        let qaAction = try await MockLLMClient().nextAction(
+            thread: afterOrgRead,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let qaCall = try XCTUnwrap(qaAction.toolCall)
+        XCTAssertEqual(qaCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(qaCall.argumentsJSON).string("path"), "reorg-qa/hardest-questions.md")
+
+        let qaRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "reorg-qa/hardest-questions.md"])
+        )
+        let afterQARead = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: orgRead, stdout: "Product Operations moves under Engineering."),
+                try toolFeedbackMessage(for: qaRead, stdout: "1. Why now? 2. Are there layoffs?")
+            ]
+        )
+
+        let writeAction = try await MockLLMClient().nextAction(
+            thread: afterQARead,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let writeCall = try XCTUnwrap(writeAction.toolCall)
+        XCTAssertEqual(writeCall.name, ToolDefinition.fileWrite.name)
+        let writeArguments = try ToolArguments(writeCall.argumentsJSON)
+        XCTAssertEqual(writeArguments.string("path"), "ceo-reorg-all-hands-email.md")
+        XCTAssertTrue(writeArguments.string("content")?.contains("Product Operations moves under Engineering") == true)
+        XCTAssertTrue(writeArguments.string("content")?.contains("8. Where do questions go?") == true)
+
+        let writeFeedback = ToolCall(
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: ToolArguments.json(["path": "ceo-reorg-all-hands-email.md"])
+        )
+        let afterWrite = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: writeFeedback, stdout: "wrote ceo-reorg-all-hands-email.md")
+            ]
+        )
+        let finalAction = try await MockLLMClient().nextAction(
+            thread: afterWrite,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        guard case .say(let finalAnswer) = finalAction else {
+            return XCTFail("Expected a final answer after the all-hands email write completes.")
+        }
+        XCTAssertEqual(
+            finalAnswer,
+            "Created `ceo-reorg-all-hands-email.md` from `org-changes.pptx` and `reorg-qa/hardest-questions.md`."
+        )
+    }
+
     private func toolFeedbackMessage(for call: ToolCall, stdout: String) throws -> ChatMessage {
         let feedback = AgentToolFeedback(
             toolCall: call,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -185,6 +185,64 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(coverage.contains(#""68": ["#), coverage)
     }
 
+    func testCoworkerCatalogCoverageAcceptsPackagedMultiFileArtifactRows() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-coworker-catalog-multi-file-tests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let oneTurnManifestURL = temporaryDirectory.appendingPathComponent("packaged-one-turn-coworker.json")
+        let multiFileManifestURL = temporaryDirectory.appendingPathComponent("packaged-multi-file-artifact.json")
+        let coverageURL = temporaryDirectory.appendingPathComponent("coworker-coverage.json")
+        try """
+        {
+          "ok": true,
+          "packagedOneTurnCoworkerValidated": true,
+          "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
+          "catalogTaskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68],
+          "taskIDs": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68],
+          "launchServicesMatchesDirect": true,
+          "oneTurnCoworkerMatchesDirect": true
+        }
+        """.write(to: oneTurnManifestURL, atomically: true, encoding: .utf8)
+        try """
+        {
+          "ok": true,
+          "packagedMultiFileArtifactValidated": true,
+          "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
+          "catalogTaskIDs": [69],
+          "taskIDs": [69],
+          "launchServicesMatchesDirect": true,
+          "multiFileArtifactMatchesDirect": true,
+          "catalogCases": [
+            {
+              "taskID": 69,
+              "prompt": "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` and the answers in `reorg-qa`, covering the eight hardest questions."
+            }
+          ]
+        }
+        """.write(to: multiFileManifestURL, atomically: true, encoding: .utf8)
+
+        let result = try Self.runPython(
+            Self.packageRoot().appendingPathComponent("scripts/native-click-probe-contracts.py"),
+            arguments: [
+                "coworker-catalog",
+                oneTurnManifestURL.path,
+                multiFileManifestURL.path,
+                "--output",
+                coverageURL.path,
+            ]
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 55"#), coverage)
+        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 151"#), coverage)
+        XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-multi-file-artifact""#), coverage)
+        XCTAssertTrue(coverage.contains(#""69": ["#), coverage)
+    }
+
     func testCoworkerCatalogCoverageRejectsManifestWithoutCatalogRows() throws {
         let temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("quillcode-coworker-catalog-rejection-tests")

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -134,8 +134,19 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(multiFileArtifactValidator.contains(#""host.file.read", "host.file.read", "host.file.write""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""team-action-brief.md""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""multiFileArtifactMatchesDirect": True"#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""packagedMultiFileArtifactValidated": True"#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""catalogSpreadsheetURL": CATALOG_SPREADSHEET_URL"#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""catalogTaskIDs": EXPECTED_CATALOG_TASK_IDS"#))
+        XCTAssertTrue(
+            multiFileArtifactValidator.contains(
+                #""Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` "#
+            )
+        )
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""ceo-reorg-all-hands-email.md""#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""coversEightQuestions""#))
 
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopOneTurnCoworkerSmokeReport"))
+        XCTAssertTrue(supportText.contains("struct QuillCodeDesktopMultiFileCatalogSmokeCaseReport"))
         XCTAssertTrue(supportText.contains(#""oneTurnCoworkerSmoke": oneTurnCoworkerSmoke.dictionary"#))
         let oneTurnCoworkerValidator = try String(
             contentsOf: Self.packageRoot()

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -164,11 +164,26 @@ This covers the deterministic local-artifact version of multi-file coworker deli
 depend on live SaaS data, proprietary document formats, or a logged-in browser session should remain
 gated until a row-specific live or packaged smoke proves the same workflow on that surface.
 
+## Packaged Multi-File Coworker Evidence Slice
+
+Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
+
+- `multiFileArtifactSmoke.catalogCases` includes catalog row #69, All-Hands Email.
+- The row #69 smoke creates `org-changes.pptx` plus `reorg-qa/hardest-questions.md`, asks QuillCode
+  to draft the CEO all-hands email from those sources, and requires the desktop agent/tool loop to
+  dispatch `host.file.read`, `host.file.read`, and `host.file.write` in order.
+- The smoke verifies `ceo-reorg-all-hands-email.md` preserves the reorg announcement, transition
+  dates, and answers to all eight hard questions before the row can count as covered.
+- `packaged-multi-file-artifact.json` now carries the canonical spreadsheet URL and exact
+  `catalogTaskIDs: [69]`, and the coworker coverage rollup accepts it beside packaged one-turn,
+  live SaaS, live app Computer Use, and scheduled notification evidence.
+
 ## Packaged One-Turn Coworker Evidence Slice
 
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
 - `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, #65, #66, #67, and #68 through the actual
+  desktop agent/tool loop. `multiFileArtifactSmoke.catalogCases` drives row #69 through the same
   desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
@@ -302,15 +317,20 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   anomaly callout through `host.shell.run`.
 - Row #68 proves a weekly-review shell task runs with non-empty `host.shell.run` arguments and
   creates `weekly-review.csv`.
+- Row #69 proves all-hands reorg email drafting creates `ceo-reorg-all-hands-email.md` from
+  `org-changes.pptx` and `reorg-qa/hardest-questions.md`, preserving the reorg details, transition
+  dates, and answers to the eight hardest questions through `host.file.read`, `host.file.read`, and
+  `host.file.write`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,
   recording task IDs, tool sequence, artifact suffixes, artifact assertions, and final answers.
 - The manifest carries the canonical spreadsheet URL and exact `catalogTaskIDs`, and
   `scripts/native-click-probe-contracts.py coworker-catalog ... --output coworker-coverage.json`
   accepts it beside live SaaS and scheduled-notification evidence.
 
-This moves the one-turn local shell/file bucket from analogue evidence toward row-linked packaged
-evidence. Similar local rows can graduate only when their row ID appears in current smoke or coverage
-evidence, or when a stricter row-specific test proves the same tool path.
+Together with packaged one-turn evidence, this moves deterministic row-linked coverage through row
+#69. Similar local rows can graduate only when their row ID appears in current smoke or coverage
+evidence, or when a stricter row-specific test proves the same tool path. The next multi-file gap is
+row #70, Analyst Synthesis.
 
 ## Packaged Browser Workflow Evidence Slice
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -31,6 +31,12 @@
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as
   first-class row evidence.
+- **Update:** Packaged macOS smoke now emits row-linked multi-file artifact evidence for catalog row
+  #69 in `packaged-multi-file-artifact.json`. The row #69 case reads `org-changes.pptx` and
+  `reorg-qa/hardest-questions.md`, writes `ceo-reorg-all-hands-email.md`, verifies the reorg details,
+  transition dates, and eight hard questions, and exposes `catalogTaskIDs: [69]` so the coworker
+  coverage rollup can count deterministic multi-source deliverables independently from one-turn shell
+  rows.
 
 ## 2026-07-27: TrustedRouter balance history is locally observed
 

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -335,6 +335,37 @@ if not isinstance(deliverable_path, str) or not deliverable_path.endswith("team-
 final_answer = multi_file_smoke.get("finalAnswer")
 if not isinstance(final_answer, str) or "Created `team-action-brief.md`" not in final_answer:
     fail(f"multi-file artifact smoke reported malformed final answer: {final_answer!r}")
+catalog_cases = multi_file_smoke.get("catalogCases")
+if not isinstance(catalog_cases, list):
+    fail(f"multi-file artifact smoke catalogCases was malformed: {catalog_cases!r}")
+all_hands_cases = [
+    case for case in catalog_cases
+    if isinstance(case, dict) and case.get("taskID") == 69
+]
+if len(all_hands_cases) != 1:
+    fail(f"multi-file artifact smoke expected exactly one row #69 case: {catalog_cases!r}")
+all_hands = all_hands_cases[0]
+expected_all_hands_prompt = "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` and the answers in `reorg-qa`, covering the eight hardest questions."
+if all_hands.get("prompt") != expected_all_hands_prompt:
+    fail(f"row #69 prompt drifted: {all_hands.get('prompt')!r}")
+if all_hands.get("toolSequence") != ["host.file.read", "host.file.read", "host.file.write"]:
+    fail(f"row #69 tool sequence drifted: {all_hands.get('toolSequence')!r}")
+all_hands_sources = all_hands.get("sourcePaths")
+if not isinstance(all_hands_sources, list) or len(all_hands_sources) != 2:
+    fail(f"row #69 source paths were malformed: {all_hands_sources!r}")
+for expected_suffix in ("org-changes.pptx", "reorg-qa/hardest-questions.md"):
+    if not any(isinstance(path, str) and path.endswith(expected_suffix) for path in all_hands_sources):
+        fail(f"row #69 missed source path {expected_suffix}: {all_hands_sources!r}")
+all_hands_deliverable = all_hands.get("deliverablePath")
+if not isinstance(all_hands_deliverable, str) or not all_hands_deliverable.endswith("ceo-reorg-all-hands-email.md"):
+    fail(f"row #69 deliverable path was malformed: {all_hands_deliverable!r}")
+all_hands_assertions = all_hands.get("assertions")
+for assertion in ("announcesReorg", "preservesTimeline", "coversEightQuestions", "answersHardestQuestions"):
+    if not isinstance(all_hands_assertions, dict) or all_hands_assertions.get(assertion) is not True:
+        fail(f"row #69 assertion {assertion} was not true: {all_hands_assertions!r}")
+all_hands_final_answer = all_hands.get("finalAnswer")
+if not isinstance(all_hands_final_answer, str) or "Created `ceo-reorg-all-hands-email.md`" not in all_hands_final_answer:
+    fail(f"row #69 final answer was malformed: {all_hands_final_answer!r}")
 
 one_turn_coworker_smoke = report.get("oneTurnCoworkerSmoke")
 if not isinstance(one_turn_coworker_smoke, dict):
@@ -1287,6 +1318,11 @@ if ! grep -q 'Created `team-action-brief.md`' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q 'Created `ceo-reorg-all-hands-email.md`' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not produce the expected row #69 multi-file artifact answer" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 if ! grep -q 'Contents of `hello.txt`:' "$REPORT_PATH" || ! grep -q 'hello world' "$REPORT_PATH"; then
   echo "quill-code-desktop native smoke did not produce the expected follow-up file-read answer" >&2
   cat "$REPORT_PATH" >&2
@@ -1296,6 +1332,7 @@ if ! grep -q 'Wrote `hello.txt`.' "$HTML_PATH" \
   || ! grep -q 'Contents of `hello.txt`:' "$HTML_PATH" \
   || ! grep -q 'hello world' "$HTML_PATH" \
   || ! grep -q 'Created `team-action-brief.md`' "$HTML_PATH" \
+  || ! grep -q 'Created `ceo-reorg-all-hands-email.md`' "$HTML_PATH" \
   || ! grep -q 'Inspected `Browser Smoke`' "$HTML_PATH" \
   || ! grep -q 'host.browser.inspect' "$HTML_PATH" \
   || ! grep -q 'host.file.write' "$HTML_PATH" \

--- a/scripts/native_click_probe_contracts/coworker_catalog.py
+++ b/scripts/native_click_probe_contracts/coworker_catalog.py
@@ -169,6 +169,48 @@ def _validated_packaged_one_turn_manifest(
     }
 
 
+def _validated_packaged_multi_file_manifest(
+    manifest: dict[str, Any],
+    path: Path,
+    base_directory: Path,
+) -> dict[str, Any]:
+    require(
+        manifest.get("packagedMultiFileArtifactValidated") is True,
+        f"{path} must be a packaged multi-file artifact validation manifest",
+    )
+    base = _manifest_base(manifest, path, base_directory)
+    expected_task_ids = [69]
+    require(
+        base["catalogTaskIDs"] == expected_task_ids,
+        f"{path}.catalogTaskIDs must be {expected_task_ids}",
+    )
+    require(
+        manifest.get("taskIDs") == expected_task_ids,
+        f"{path}.taskIDs must match catalogTaskIDs",
+    )
+    require(
+        manifest.get("multiFileArtifactMatchesDirect") is True
+        and manifest.get("launchServicesMatchesDirect") is True,
+        f"{path} must prove direct executable and Launch Services multi-file smoke match",
+    )
+    catalog_cases = manifest.get("catalogCases")
+    require(
+        isinstance(catalog_cases, list)
+        and len(catalog_cases) == 1
+        and isinstance(catalog_cases[0], dict)
+        and catalog_cases[0].get("taskID") == 69,
+        f"{path} must include the row #69 multi-file catalog case",
+    )
+
+    return {
+        **base,
+        "evidenceType": "packaged-multi-file-artifact",
+        "serviceName": "QuillCode Packaged Smoke",
+        "taskName": "All-hands email multi-file artifact smoke",
+        "urlHost": "local-packaged-app",
+    }
+
+
 def _validated_manifest(manifest: dict[str, Any], path: Path, base_directory: Path) -> dict[str, Any]:
     if manifest.get("liveSaaSValidated") is True:
         return _validated_live_saas_manifest(manifest, path, base_directory)
@@ -178,9 +220,12 @@ def _validated_manifest(manifest: dict[str, Any], path: Path, base_directory: Pa
         return _validated_live_app_computer_use_manifest(manifest, path, base_directory)
     if manifest.get("packagedOneTurnCoworkerValidated") is True:
         return _validated_packaged_one_turn_manifest(manifest, path, base_directory)
+    if manifest.get("packagedMultiFileArtifactValidated") is True:
+        return _validated_packaged_multi_file_manifest(manifest, path, base_directory)
     raise SystemExit(
         f"{path} must be a supported coworker evidence manifest "
-        "(live SaaS, live app Computer Use, scheduled notification observation, or packaged one-turn coworker)"
+        "(live SaaS, live app Computer Use, scheduled notification observation, "
+        "packaged one-turn coworker, or packaged multi-file artifact)"
     )
 
 

--- a/scripts/native_click_probe_contracts/multi_file_artifact.py
+++ b/scripts/native_click_probe_contracts/multi_file_artifact.py
@@ -7,9 +7,21 @@ from pathlib import Path
 from typing import Any
 
 from .json_io import load_report, require
+from .live_saas import CATALOG_SPREADSHEET_URL
 
 EXPECTED_PROMPT = "Create the team action brief from `notes/research.md` and `notes/risks.md`."
 EXPECTED_TOOL_SEQUENCE = ["host.file.read", "host.file.read", "host.file.write"]
+EXPECTED_CATALOG_TASK_IDS = [69]
+EXPECTED_ALL_HANDS_PROMPT = (
+    "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` "
+    "and the answers in `reorg-qa`, covering the eight hardest questions."
+)
+EXPECTED_ALL_HANDS_ASSERTIONS = {
+    "announcesReorg",
+    "preservesTimeline",
+    "coversEightQuestions",
+    "answersHardestQuestions",
+}
 
 
 def validated_multi_file_artifact(report: dict[str, Any], label: str) -> dict[str, Any]:
@@ -52,11 +64,54 @@ def validated_multi_file_artifact(report: dict[str, Any], label: str) -> dict[st
         isinstance(final_answer, str) and "Created `team-action-brief.md`" in final_answer,
         f"{label} multi-file final answer was malformed: {final_answer!r}",
     )
+
+    catalog_cases = smoke.get("catalogCases")
+    require(isinstance(catalog_cases, list), f"{label} multi-file catalogCases must be a list")
+    all_hands_cases = [
+        case for case in catalog_cases
+        if isinstance(case, dict) and case.get("taskID") == 69
+    ]
+    require(len(all_hands_cases) == 1, f"{label} multi-file catalogCases must include exactly one row #69 case")
+    validate_all_hands_email_case(all_hands_cases[0], label)
     return smoke
+
+
+def validate_all_hands_email_case(case: dict[str, Any], label: str) -> None:
+    require(case.get("prompt") == EXPECTED_ALL_HANDS_PROMPT, f"{label} row #69 prompt drifted")
+    require(
+        case.get("toolSequence") == EXPECTED_TOOL_SEQUENCE,
+        f"{label} row #69 tool sequence was {case.get('toolSequence')!r}",
+    )
+    source_paths = case.get("sourcePaths")
+    require(
+        isinstance(source_paths, list) and len(source_paths) == 2,
+        f"{label} row #69 sourcePaths was malformed: {source_paths!r}",
+    )
+    for expected_suffix in ("org-changes.pptx", "reorg-qa/hardest-questions.md"):
+        require(
+            any(isinstance(path, str) and path.endswith(expected_suffix) for path in source_paths),
+            f"{label} row #69 missed {expected_suffix}: {source_paths!r}",
+        )
+    deliverable_path = case.get("deliverablePath")
+    require(
+        isinstance(deliverable_path, str) and deliverable_path.endswith("ceo-reorg-all-hands-email.md"),
+        f"{label} row #69 deliverable path was malformed: {deliverable_path!r}",
+    )
+    final_answer = case.get("finalAnswer")
+    require(
+        isinstance(final_answer, str) and "Created `ceo-reorg-all-hands-email.md`" in final_answer,
+        f"{label} row #69 final answer was malformed: {final_answer!r}",
+    )
+    assertions = case.get("assertions")
+    require(isinstance(assertions, dict), f"{label} row #69 assertions must be an object")
+    missing = sorted(name for name in EXPECTED_ALL_HANDS_ASSERTIONS if assertions.get(name) is not True)
+    require(not missing, f"{label} row #69 assertions were not all true: {missing}")
 
 
 def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
     source_paths = smoke["sourcePaths"]
+    catalog_cases = smoke["catalogCases"]
+    all_hands_case = next(case for case in catalog_cases if case["taskID"] == 69)
     return {
         "prompt": smoke["prompt"],
         "toolSequence": smoke["toolSequence"],
@@ -69,6 +124,23 @@ def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
         "deliverableContainsRisk": smoke["deliverableContainsRisk"],
         "deliverableContainsNextAction": smoke["deliverableContainsNextAction"],
         "finalAnswer": smoke["finalAnswer"],
+        "catalogTaskIDs": [69],
+        "catalogCases": [
+            {
+                "taskID": 69,
+                "prompt": all_hands_case["prompt"],
+                "toolSequence": all_hands_case["toolSequence"],
+                "sourcePathSuffixes": sorted(
+                    "org-changes.pptx"
+                    if str(path).endswith("org-changes.pptx")
+                    else "reorg-qa/hardest-questions.md"
+                    for path in all_hands_case["sourcePaths"]
+                ),
+                "deliverablePathSuffix": "ceo-reorg-all-hands-email.md",
+                "finalAnswer": all_hands_case["finalAnswer"],
+                "assertions": all_hands_case["assertions"],
+            }
+        ],
     }
 
 
@@ -91,6 +163,10 @@ def write_multi_file_artifact_manifest(
 
     manifest = {
         "ok": True,
+        "packagedMultiFileArtifactValidated": True,
+        "catalogSpreadsheetURL": CATALOG_SPREADSHEET_URL,
+        "catalogTaskIDs": EXPECTED_CATALOG_TASK_IDS,
+        "taskIDs": EXPECTED_CATALOG_TASK_IDS,
         "directReport": "direct-executable/report.json",
         "launchServicesReport": "launch-services/report.json",
         "launchServicesMatchesDirect": True,


### PR DESCRIPTION
## Summary
- add row #69 all-hands email coverage to multi-file desktop smoke
- emit row-linked packaged multi-file artifact manifests for coworker catalog coverage
- update mock LLM, validators, parity gates, and tracker docs

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/multi_file_artifact.py scripts/native_click_probe_contracts/coworker_catalog.py
- swift test --filter MockLLMClientMultiFileArtifactTests
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- scripts/native-desktop-smoke.sh