### PR TITLE
Add analyst synthesis coworker smoke

### DIFF
--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -382,6 +382,16 @@ public struct MockLLMClient: LLMClient {
         for lowercasedRequest: String,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if lowercasedRequest.contains("gartner"),
+           lowercasedRequest.contains("forrester"),
+           lowercasedRequest.contains("analyst-reports"),
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "analyst-reports/gartner-market-guide.pdf"])
+            ))
+        }
+
         if lowercasedRequest.contains("all-hands email"),
            lowercasedRequest.contains("org-changes.pptx"),
            tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
@@ -405,6 +415,9 @@ public struct MockLLMClient: LLMClient {
         feedback: AgentToolFeedback,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if let action = Self.nextAnalystSynthesisAction(thread: thread, feedback: feedback, tools: tools) {
+            return action
+        }
         if let action = Self.nextAllHandsEmailAction(thread: thread, feedback: feedback, tools: tools) {
             return action
         }
@@ -450,6 +463,62 @@ public struct MockLLMClient: LLMClient {
         if feedback.toolCall.name == ToolDefinition.fileWrite.name,
            path == "team-action-brief.md" {
             return .say("Created `team-action-brief.md` from `notes/research.md` and `notes/risks.md`.")
+        }
+
+        return nil
+    }
+
+    private static func nextAnalystSynthesisAction(
+        thread: ChatThread,
+        feedback: AgentToolFeedback,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard thread.messages.contains(where: {
+            let content = $0.content.lowercased()
+            return $0.role == .user
+                && content.contains("gartner")
+                && content.contains("forrester")
+                && content.contains("analyst-reports")
+        }) else {
+            return nil
+        }
+
+        let path = Self.stringArgument("path", from: feedback.toolCall.argumentsJSON)
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "analyst-reports/gartner-market-guide.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "analyst-reports/forrester-wave.pdf"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "analyst-reports/forrester-wave.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "analyst-reports/forrester-now-tech.pdf"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "analyst-reports/forrester-now-tech.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.fileWrite.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileWrite.name,
+                argumentsJSON: ToolArguments.json([
+                    "path": "analyst-claims-contradictions.md",
+                    "content": Self.analystSynthesisContent
+                ])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileWrite.name,
+           path == "analyst-claims-contradictions.md" {
+            return .say(
+                "Created `analyst-claims-contradictions.md` from the three reports in `analyst-reports`."
+            )
         }
 
         return nil
@@ -515,6 +584,25 @@ public struct MockLLMClient: LLMClient {
 
         ## Next action
         - Run the pairing fallback smoke and attach the evidence to the release tracker.
+        """
+    }
+
+    private static var analystSynthesisContent: String {
+        """
+        # Analyst Claims And Contradictions
+
+        ## Key claims
+        - Gartner says the market is consolidating around orchestration layers and values governance depth.
+        - Forrester Wave says buyers prioritize fast time-to-value and gives CloudSync the highest execution score.
+        - Forrester Now Tech says open-source extensibility is a key evaluation filter for platform teams.
+
+        ## Contradictions
+        - Gartner expects suite consolidation, while Forrester Now Tech says extensibility keeps best-of-breed tools viable.
+        - Forrester Wave ranks CloudSync highest on execution, while Gartner warns CloudSync has weaker governance controls.
+        - Gartner frames regulated enterprises as governance-first buyers, while Forrester Wave says mid-market buyers accept lighter governance for faster deployment.
+
+        ## Recommended framing
+        Lead with governance depth for regulated enterprise accounts, but keep open extensibility and fast onboarding as proof points for platform and mid-market buyers.
         """
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -159,6 +159,7 @@ enum QuillCodeDesktopSmokeRunner {
               html.contains("Contents of `hello.txt`:"),
               html.contains("hello world"),
               html.contains("Created `ceo-reorg-all-hands-email.md`"),
+              html.contains("Created `analyst-claims-contradictions.md`"),
               html.contains("Inspected `Browser Smoke`"),
               html.contains("host.browser.inspect"),
               html.contains("host.file.read"),
@@ -851,7 +852,8 @@ enum QuillCodeDesktopSmokeRunner {
         let finalAnswer = controller.surface.transcript.messages.last?.text ?? ""
 
         let catalogCases = [
-            try await runAllHandsEmailCatalogSmoke(controller: controller, root: root)
+            try await runAllHandsEmailCatalogSmoke(controller: controller, root: root),
+            try await runAnalystSynthesisCatalogSmoke(controller: controller, root: root)
         ]
 
         return QuillCodeDesktopMultiFileArtifactSmokeReport(
@@ -941,6 +943,85 @@ enum QuillCodeDesktopSmokeRunner {
             taskID: 69,
             prompt: prompt,
             sourcePaths: [orgChanges.path, qaNotes.path],
+            deliverablePath: deliverable.path,
+            toolSequence: toolSequence,
+            finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
+            assertions: assertions
+        )
+    }
+
+    private static func runAnalystSynthesisCatalogSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopMultiFileCatalogSmokeCaseReport {
+        let reportsDirectory = root.workspace.appendingPathComponent("analyst-reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reportsDirectory, withIntermediateDirectories: true)
+
+        let gartner = reportsDirectory.appendingPathComponent("gartner-market-guide.pdf")
+        let forresterWave = reportsDirectory.appendingPathComponent("forrester-wave.pdf")
+        let forresterNowTech = reportsDirectory.appendingPathComponent("forrester-now-tech.pdf")
+        try """
+        Gartner market guide: the market is consolidating around orchestration layers.
+        Gartner claim: regulated enterprises value governance depth first.
+        Gartner caution: CloudSync has weaker governance controls.
+        """.write(to: gartner, atomically: true, encoding: .utf8)
+        try """
+        Forrester Wave: buyers prioritize fast time-to-value.
+        Forrester Wave claim: CloudSync has the highest execution score.
+        Forrester Wave claim: mid-market buyers accept lighter governance for faster deployment.
+        """.write(to: forresterWave, atomically: true, encoding: .utf8)
+        try """
+        Forrester Now Tech: open-source extensibility is a key evaluation filter.
+        Forrester Now Tech claim: best-of-breed tools remain viable when extension points are open.
+        """.write(to: forresterNowTech, atomically: true, encoding: .utf8)
+
+        let prompt = "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` and flag where they contradict each other."
+        let previousTimelineCount = controller.surface.transcript.timelineItems.count
+        let previousToolCardCount = controller.surface.transcript.toolCards.count
+        controller.draft = prompt
+        controller.send()
+
+        let expectedAnswer = "Created `analyst-claims-contradictions.md` from the three reports in `analyst-reports`."
+        try await waitForDesktopRun(
+            controller,
+            previousTimelineCount: previousTimelineCount,
+            expectedAnswer: expectedAnswer
+        )
+
+        let deliverable = root.workspace.appendingPathComponent("analyst-claims-contradictions.md")
+        let deliverableText = try String(contentsOf: deliverable, encoding: .utf8)
+        let assertions = [
+            "pullsGartnerClaims": deliverableText.contains("Gartner says")
+                && deliverableText.contains("governance depth"),
+            "pullsForresterClaims": deliverableText.contains("Forrester Wave says")
+                && deliverableText.contains("Forrester Now Tech says"),
+            "flagsContradictions": deliverableText.contains("Contradictions")
+                && deliverableText.contains("CloudSync")
+                && deliverableText.contains("suite consolidation"),
+            "recommendsFraming": deliverableText.contains("Recommended framing")
+                && deliverableText.contains("regulated enterprise accounts")
+        ]
+        guard assertions.values.allSatisfy({ $0 }) else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(deliverable.path)
+        }
+
+        let toolSequence = Array(controller.surface.transcript.toolCards.dropFirst(previousToolCardCount))
+            .map(\.title)
+        guard toolSequence == [
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileWrite.name
+        ] else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(
+                "unexpected analyst synthesis tool sequence: \(toolSequence.joined(separator: ", "))"
+            )
+        }
+
+        return QuillCodeDesktopMultiFileCatalogSmokeCaseReport(
+            taskID: 70,
+            prompt: prompt,
+            sourcePaths: [gartner.path, forresterWave.path, forresterNowTech.path],
             deliverablePath: deliverable.path,
             toolSequence: toolSequence,
             finalAnswer: controller.surface.transcript.messages.last?.text ?? "",

--- a/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
+++ b/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
@@ -189,6 +189,123 @@ final class MockLLMClientMultiFileArtifactTests: XCTestCase {
         )
     }
 
+    func testAnalystSynthesisStartsByReadingFirstAnalystReport() async throws {
+        let action = try await MockLLMClient().nextAction(
+            thread: ChatThread(mode: .auto),
+            userMessage: "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` and flag where they contradict each other.",
+            tools: ToolRouter.definitions
+        )
+
+        let call = try XCTUnwrap(action.toolCall)
+        XCTAssertEqual(call.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(call.argumentsJSON).string("path"), "analyst-reports/gartner-market-guide.pdf")
+    }
+
+    func testAnalystSynthesisReadsAllReportsThenWritesContradictions() async throws {
+        let user = ChatMessage(
+            role: .user,
+            content: "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` and flag where they contradict each other."
+        )
+        let gartnerRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "analyst-reports/gartner-market-guide.pdf"])
+        )
+        let afterGartnerRead = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: gartnerRead, stdout: "Gartner says governance depth matters.")
+            ]
+        )
+
+        let forresterWaveAction = try await MockLLMClient().nextAction(
+            thread: afterGartnerRead,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let forresterWaveCall = try XCTUnwrap(forresterWaveAction.toolCall)
+        XCTAssertEqual(forresterWaveCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(
+            try ToolArguments(forresterWaveCall.argumentsJSON).string("path"),
+            "analyst-reports/forrester-wave.pdf"
+        )
+
+        let forresterWaveRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "analyst-reports/forrester-wave.pdf"])
+        )
+        let afterWaveRead = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: gartnerRead, stdout: "Gartner says governance depth matters."),
+                try toolFeedbackMessage(for: forresterWaveRead, stdout: "Forrester says fast time-to-value matters.")
+            ]
+        )
+
+        let nowTechAction = try await MockLLMClient().nextAction(
+            thread: afterWaveRead,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let nowTechCall = try XCTUnwrap(nowTechAction.toolCall)
+        XCTAssertEqual(nowTechCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(
+            try ToolArguments(nowTechCall.argumentsJSON).string("path"),
+            "analyst-reports/forrester-now-tech.pdf"
+        )
+
+        let nowTechRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "analyst-reports/forrester-now-tech.pdf"])
+        )
+        let afterNowTechRead = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: gartnerRead, stdout: "Gartner says governance depth matters."),
+                try toolFeedbackMessage(for: forresterWaveRead, stdout: "Forrester says fast time-to-value matters."),
+                try toolFeedbackMessage(for: nowTechRead, stdout: "Forrester says extensibility matters.")
+            ]
+        )
+
+        let writeAction = try await MockLLMClient().nextAction(
+            thread: afterNowTechRead,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let writeCall = try XCTUnwrap(writeAction.toolCall)
+        XCTAssertEqual(writeCall.name, ToolDefinition.fileWrite.name)
+        let writeArguments = try ToolArguments(writeCall.argumentsJSON)
+        XCTAssertEqual(writeArguments.string("path"), "analyst-claims-contradictions.md")
+        XCTAssertTrue(writeArguments.string("content")?.contains("Gartner says") == true)
+        XCTAssertTrue(writeArguments.string("content")?.contains("Contradictions") == true)
+
+        let writeFeedback = ToolCall(
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: ToolArguments.json(["path": "analyst-claims-contradictions.md"])
+        )
+        let afterWrite = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: writeFeedback, stdout: "wrote analyst-claims-contradictions.md")
+            ]
+        )
+        let finalAction = try await MockLLMClient().nextAction(
+            thread: afterWrite,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        guard case .say(let finalAnswer) = finalAction else {
+            return XCTFail("Expected a final answer after the analyst synthesis write completes.")
+        }
+        XCTAssertEqual(
+            finalAnswer,
+            "Created `analyst-claims-contradictions.md` from the three reports in `analyst-reports`."
+        )
+    }
+
     private func toolFeedbackMessage(for call: ToolCall, stdout: String) throws -> ChatMessage {
         let feedback = AgentToolFeedback(
             toolCall: call,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -211,14 +211,18 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedMultiFileArtifactValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [69],
-          "taskIDs": [69],
+          "catalogTaskIDs": [69, 70],
+          "taskIDs": [69, 70],
           "launchServicesMatchesDirect": true,
           "multiFileArtifactMatchesDirect": true,
           "catalogCases": [
             {
               "taskID": 69,
               "prompt": "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` and the answers in `reorg-qa`, covering the eight hardest questions."
+            },
+            {
+              "taskID": 70,
+              "prompt": "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` and flag where they contradict each other."
             }
           ]
         }
@@ -237,10 +241,11 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 55"#), coverage)
-        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 151"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 56"#), coverage)
+        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 150"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-multi-file-artifact""#), coverage)
         XCTAssertTrue(coverage.contains(#""69": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""70": ["#), coverage)
     }
 
     func testCoworkerCatalogCoverageRejectsManifestWithoutCatalogRows() throws {

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -144,6 +144,13 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         )
         XCTAssertTrue(multiFileArtifactValidator.contains(#""ceo-reorg-all-hands-email.md""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""coversEightQuestions""#))
+        XCTAssertTrue(
+            multiFileArtifactValidator.contains(
+                #""Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` "#
+            )
+        )
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""analyst-claims-contradictions.md""#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""flagsContradictions""#))
 
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopOneTurnCoworkerSmokeReport"))
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopMultiFileCatalogSmokeCaseReport"))

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,14 +168,20 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
 
-- `multiFileArtifactSmoke.catalogCases` includes catalog row #69, All-Hands Email.
+- `multiFileArtifactSmoke.catalogCases` includes catalog row #69, All-Hands Email, and row #70,
+  Analyst Synthesis.
 - The row #69 smoke creates `org-changes.pptx` plus `reorg-qa/hardest-questions.md`, asks QuillCode
   to draft the CEO all-hands email from those sources, and requires the desktop agent/tool loop to
   dispatch `host.file.read`, `host.file.read`, and `host.file.write` in order.
 - The smoke verifies `ceo-reorg-all-hands-email.md` preserves the reorg announcement, transition
   dates, and answers to all eight hard questions before the row can count as covered.
+- The row #70 smoke creates three analyst-report sources under `analyst-reports`, asks QuillCode to
+  pull key Gartner and Forrester claims and flag contradictions, and requires the desktop agent/tool
+  loop to dispatch three `host.file.read` calls followed by `host.file.write`.
+- The smoke verifies `analyst-claims-contradictions.md` preserves Gartner claims, Forrester claims,
+  contradictions across the reports, and recommended positioning before the row can count as covered.
 - `packaged-multi-file-artifact.json` now carries the canonical spreadsheet URL and exact
-  `catalogTaskIDs: [69]`, and the coworker coverage rollup accepts it beside packaged one-turn,
+  `catalogTaskIDs: [69, 70]`, and the coworker coverage rollup accepts it beside packaged one-turn,
   live SaaS, live app Computer Use, and scheduled notification evidence.
 
 ## Packaged One-Turn Coworker Evidence Slice
@@ -183,8 +189,8 @@ Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
 Packaged macOS smoke now preserves task-specific one-turn office coworker evidence:
 
 - `oneTurnCoworkerSmoke` drives representative catalog rows #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, #65, #66, #67, and #68 through the actual
-  desktop agent/tool loop. `multiFileArtifactSmoke.catalogCases` drives row #69 through the same
-  desktop agent/tool loop.
+  desktop agent/tool loop. `multiFileArtifactSmoke.catalogCases` drives rows #69 and #70 through the
+  same desktop agent/tool loop.
 - Row #15 proves a clear file-write request creates `launch-announcement.md` with the requested
   customer-comms text through `host.file.write`.
 - Row #16 proves an analysis-style shell task runs with non-empty `host.shell.run` arguments and
@@ -321,6 +327,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   `org-changes.pptx` and `reorg-qa/hardest-questions.md`, preserving the reorg details, transition
   dates, and answers to the eight hardest questions through `host.file.read`, `host.file.read`, and
   `host.file.write`.
+- Row #70 proves analyst synthesis creates `analyst-claims-contradictions.md` from three reports
+  under `analyst-reports`, preserving Gartner claims, Forrester claims, contradictions, and
+  recommended framing through three `host.file.read` calls followed by `host.file.write`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,
   recording task IDs, tool sequence, artifact suffixes, artifact assertions, and final answers.
 - The manifest carries the canonical spreadsheet URL and exact `catalogTaskIDs`, and
@@ -328,9 +337,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   accepts it beside live SaaS and scheduled-notification evidence.
 
 Together with packaged one-turn evidence, this moves deterministic row-linked coverage through row
-#69. Similar local rows can graduate only when their row ID appears in current smoke or coverage
+#70. Similar local rows can graduate only when their row ID appears in current smoke or coverage
 evidence, or when a stricter row-specific test proves the same tool path. The next multi-file gap is
-row #70, Analyst Synthesis.
+row #71, Bulk Rename.
 
 ## Packaged Browser Workflow Evidence Slice
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -31,12 +31,16 @@
   before those rows can be treated as row-linked one-turn coworker coverage. The manifest now carries
   the canonical spreadsheet URL and `catalogTaskIDs`, and the coworker coverage rollup accepts it as
   first-class row evidence.
-- **Update:** Packaged macOS smoke now emits row-linked multi-file artifact evidence for catalog row
-  #69 in `packaged-multi-file-artifact.json`. The row #69 case reads `org-changes.pptx` and
+- **Update:** Packaged macOS smoke now emits row-linked multi-file artifact evidence in
+  `packaged-multi-file-artifact.json`. The row #69 case reads `org-changes.pptx` and
   `reorg-qa/hardest-questions.md`, writes `ceo-reorg-all-hands-email.md`, verifies the reorg details,
-  transition dates, and eight hard questions, and exposes `catalogTaskIDs: [69]` so the coworker
-  coverage rollup can count deterministic multi-source deliverables independently from one-turn shell
-  rows.
+  transition dates, and eight hard questions, so the coworker coverage rollup can count deterministic
+  multi-source deliverables independently from one-turn shell rows.
+- **Update:** The same packaged multi-file artifact manifest now includes catalog row #70. The row
+  #70 case reads three `analyst-reports` sources, writes `analyst-claims-contradictions.md`, verifies
+  Gartner claims, Forrester claims, explicit contradictions, and recommended framing, and exposes
+  `catalogTaskIDs: [69, 70]` so deterministic multi-document synthesis advances in the coworker
+  coverage rollup.
 
 ## 2026-07-27: TrustedRouter balance history is locally observed
 

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -366,6 +366,38 @@ for assertion in ("announcesReorg", "preservesTimeline", "coversEightQuestions",
 all_hands_final_answer = all_hands.get("finalAnswer")
 if not isinstance(all_hands_final_answer, str) or "Created `ceo-reorg-all-hands-email.md`" not in all_hands_final_answer:
     fail(f"row #69 final answer was malformed: {all_hands_final_answer!r}")
+analyst_cases = [
+    case for case in catalog_cases
+    if isinstance(case, dict) and case.get("taskID") == 70
+]
+if len(analyst_cases) != 1:
+    fail(f"multi-file artifact smoke expected exactly one row #70 case: {catalog_cases!r}")
+analyst = analyst_cases[0]
+expected_analyst_prompt = "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` and flag where they contradict each other."
+if analyst.get("prompt") != expected_analyst_prompt:
+    fail(f"row #70 prompt drifted: {analyst.get('prompt')!r}")
+if analyst.get("toolSequence") != ["host.file.read", "host.file.read", "host.file.read", "host.file.write"]:
+    fail(f"row #70 tool sequence drifted: {analyst.get('toolSequence')!r}")
+analyst_sources = analyst.get("sourcePaths")
+if not isinstance(analyst_sources, list) or len(analyst_sources) != 3:
+    fail(f"row #70 source paths were malformed: {analyst_sources!r}")
+for expected_suffix in (
+    "analyst-reports/gartner-market-guide.pdf",
+    "analyst-reports/forrester-wave.pdf",
+    "analyst-reports/forrester-now-tech.pdf",
+):
+    if not any(isinstance(path, str) and path.endswith(expected_suffix) for path in analyst_sources):
+        fail(f"row #70 missed source path {expected_suffix}: {analyst_sources!r}")
+analyst_deliverable = analyst.get("deliverablePath")
+if not isinstance(analyst_deliverable, str) or not analyst_deliverable.endswith("analyst-claims-contradictions.md"):
+    fail(f"row #70 deliverable path was malformed: {analyst_deliverable!r}")
+analyst_assertions = analyst.get("assertions")
+for assertion in ("pullsGartnerClaims", "pullsForresterClaims", "flagsContradictions", "recommendsFraming"):
+    if not isinstance(analyst_assertions, dict) or analyst_assertions.get(assertion) is not True:
+        fail(f"row #70 assertion {assertion} was not true: {analyst_assertions!r}")
+analyst_final_answer = analyst.get("finalAnswer")
+if not isinstance(analyst_final_answer, str) or "Created `analyst-claims-contradictions.md`" not in analyst_final_answer:
+    fail(f"row #70 final answer was malformed: {analyst_final_answer!r}")
 
 one_turn_coworker_smoke = report.get("oneTurnCoworkerSmoke")
 if not isinstance(one_turn_coworker_smoke, dict):
@@ -1323,6 +1355,11 @@ if ! grep -q 'Created `ceo-reorg-all-hands-email.md`' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q 'Created `analyst-claims-contradictions.md`' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not produce the expected row #70 multi-file artifact answer" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 if ! grep -q 'Contents of `hello.txt`:' "$REPORT_PATH" || ! grep -q 'hello world' "$REPORT_PATH"; then
   echo "quill-code-desktop native smoke did not produce the expected follow-up file-read answer" >&2
   cat "$REPORT_PATH" >&2
@@ -1333,6 +1370,7 @@ if ! grep -q 'Wrote `hello.txt`.' "$HTML_PATH" \
   || ! grep -q 'hello world' "$HTML_PATH" \
   || ! grep -q 'Created `team-action-brief.md`' "$HTML_PATH" \
   || ! grep -q 'Created `ceo-reorg-all-hands-email.md`' "$HTML_PATH" \
+  || ! grep -q 'Created `analyst-claims-contradictions.md`' "$HTML_PATH" \
   || ! grep -q 'Inspected `Browser Smoke`' "$HTML_PATH" \
   || ! grep -q 'host.browser.inspect' "$HTML_PATH" \
   || ! grep -q 'host.file.write' "$HTML_PATH" \

--- a/scripts/native_click_probe_contracts/coworker_catalog.py
+++ b/scripts/native_click_probe_contracts/coworker_catalog.py
@@ -179,7 +179,7 @@ def _validated_packaged_multi_file_manifest(
         f"{path} must be a packaged multi-file artifact validation manifest",
     )
     base = _manifest_base(manifest, path, base_directory)
-    expected_task_ids = [69]
+    expected_task_ids = [69, 70]
     require(
         base["catalogTaskIDs"] == expected_task_ids,
         f"{path}.catalogTaskIDs must be {expected_task_ids}",
@@ -194,19 +194,22 @@ def _validated_packaged_multi_file_manifest(
         f"{path} must prove direct executable and Launch Services multi-file smoke match",
     )
     catalog_cases = manifest.get("catalogCases")
+    catalog_case_ids = sorted(
+        case.get("taskID")
+        for case in catalog_cases
+        if isinstance(case, dict)
+    ) if isinstance(catalog_cases, list) else []
     require(
         isinstance(catalog_cases, list)
-        and len(catalog_cases) == 1
-        and isinstance(catalog_cases[0], dict)
-        and catalog_cases[0].get("taskID") == 69,
-        f"{path} must include the row #69 multi-file catalog case",
+        and catalog_case_ids == expected_task_ids,
+        f"{path} must include the row #69 and #70 multi-file catalog cases",
     )
 
     return {
         **base,
         "evidenceType": "packaged-multi-file-artifact",
         "serviceName": "QuillCode Packaged Smoke",
-        "taskName": "All-hands email multi-file artifact smoke",
+        "taskName": "Multi-file artifact coworker smoke",
         "urlHost": "local-packaged-app",
     }
 

--- a/scripts/native_click_probe_contracts/multi_file_artifact.py
+++ b/scripts/native_click_probe_contracts/multi_file_artifact.py
@@ -11,16 +11,26 @@ from .live_saas import CATALOG_SPREADSHEET_URL
 
 EXPECTED_PROMPT = "Create the team action brief from `notes/research.md` and `notes/risks.md`."
 EXPECTED_TOOL_SEQUENCE = ["host.file.read", "host.file.read", "host.file.write"]
-EXPECTED_CATALOG_TASK_IDS = [69]
+EXPECTED_CATALOG_TASK_IDS = [69, 70]
 EXPECTED_ALL_HANDS_PROMPT = (
     "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` "
     "and the answers in `reorg-qa`, covering the eight hardest questions."
+)
+EXPECTED_ANALYST_SYNTHESIS_PROMPT = (
+    "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` "
+    "and flag where they contradict each other."
 )
 EXPECTED_ALL_HANDS_ASSERTIONS = {
     "announcesReorg",
     "preservesTimeline",
     "coversEightQuestions",
     "answersHardestQuestions",
+}
+EXPECTED_ANALYST_SYNTHESIS_ASSERTIONS = {
+    "pullsGartnerClaims",
+    "pullsForresterClaims",
+    "flagsContradictions",
+    "recommendsFraming",
 }
 
 
@@ -73,6 +83,12 @@ def validated_multi_file_artifact(report: dict[str, Any], label: str) -> dict[st
     ]
     require(len(all_hands_cases) == 1, f"{label} multi-file catalogCases must include exactly one row #69 case")
     validate_all_hands_email_case(all_hands_cases[0], label)
+    analyst_cases = [
+        case for case in catalog_cases
+        if isinstance(case, dict) and case.get("taskID") == 70
+    ]
+    require(len(analyst_cases) == 1, f"{label} multi-file catalogCases must include exactly one row #70 case")
+    validate_analyst_synthesis_case(analyst_cases[0], label)
     return smoke
 
 
@@ -108,10 +124,47 @@ def validate_all_hands_email_case(case: dict[str, Any], label: str) -> None:
     require(not missing, f"{label} row #69 assertions were not all true: {missing}")
 
 
+def validate_analyst_synthesis_case(case: dict[str, Any], label: str) -> None:
+    require(case.get("prompt") == EXPECTED_ANALYST_SYNTHESIS_PROMPT, f"{label} row #70 prompt drifted")
+    require(
+        case.get("toolSequence") == ["host.file.read", "host.file.read", "host.file.read", "host.file.write"],
+        f"{label} row #70 tool sequence was {case.get('toolSequence')!r}",
+    )
+    source_paths = case.get("sourcePaths")
+    require(
+        isinstance(source_paths, list) and len(source_paths) == 3,
+        f"{label} row #70 sourcePaths was malformed: {source_paths!r}",
+    )
+    for expected_suffix in (
+        "analyst-reports/gartner-market-guide.pdf",
+        "analyst-reports/forrester-wave.pdf",
+        "analyst-reports/forrester-now-tech.pdf",
+    ):
+        require(
+            any(isinstance(path, str) and path.endswith(expected_suffix) for path in source_paths),
+            f"{label} row #70 missed {expected_suffix}: {source_paths!r}",
+        )
+    deliverable_path = case.get("deliverablePath")
+    require(
+        isinstance(deliverable_path, str) and deliverable_path.endswith("analyst-claims-contradictions.md"),
+        f"{label} row #70 deliverable path was malformed: {deliverable_path!r}",
+    )
+    final_answer = case.get("finalAnswer")
+    require(
+        isinstance(final_answer, str) and "Created `analyst-claims-contradictions.md`" in final_answer,
+        f"{label} row #70 final answer was malformed: {final_answer!r}",
+    )
+    assertions = case.get("assertions")
+    require(isinstance(assertions, dict), f"{label} row #70 assertions must be an object")
+    missing = sorted(name for name in EXPECTED_ANALYST_SYNTHESIS_ASSERTIONS if assertions.get(name) is not True)
+    require(not missing, f"{label} row #70 assertions were not all true: {missing}")
+
+
 def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
     source_paths = smoke["sourcePaths"]
     catalog_cases = smoke["catalogCases"]
     all_hands_case = next(case for case in catalog_cases if case["taskID"] == 69)
+    analyst_case = next(case for case in catalog_cases if case["taskID"] == 70)
     return {
         "prompt": smoke["prompt"],
         "toolSequence": smoke["toolSequence"],
@@ -124,7 +177,7 @@ def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
         "deliverableContainsRisk": smoke["deliverableContainsRisk"],
         "deliverableContainsNextAction": smoke["deliverableContainsNextAction"],
         "finalAnswer": smoke["finalAnswer"],
-        "catalogTaskIDs": [69],
+        "catalogTaskIDs": EXPECTED_CATALOG_TASK_IDS,
         "catalogCases": [
             {
                 "taskID": 69,
@@ -139,6 +192,20 @@ def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
                 "deliverablePathSuffix": "ceo-reorg-all-hands-email.md",
                 "finalAnswer": all_hands_case["finalAnswer"],
                 "assertions": all_hands_case["assertions"],
+            },
+            {
+                "taskID": 70,
+                "prompt": analyst_case["prompt"],
+                "toolSequence": analyst_case["toolSequence"],
+                "sourcePathSuffixes": sorted(
+                    str(path).split("analyst-reports/", 1)[-1]
+                    if "analyst-reports/" in str(path)
+                    else str(path)
+                    for path in analyst_case["sourcePaths"]
+                ),
+                "deliverablePathSuffix": "analyst-claims-contradictions.md",
+                "finalAnswer": analyst_case["finalAnswer"],
+                "assertions": analyst_case["assertions"],
             }
         ],
     }


### PR DESCRIPTION
## Summary
- Add coworker catalog row #70 Analyst Synthesis to the multi-file artifact smoke
- Read three analyst report fixtures under analyst-reports and write analyst-claims-contradictions.md
- Extend packaged coworker coverage contracts so multi-file evidence now carries catalogTaskIDs [69, 70]

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/multi_file_artifact.py scripts/native_click_probe_contracts/coworker_catalog.py
- swift test --filter MockLLMClientMultiFileArtifactTests
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- git diff --check
- scripts/native-desktop-smoke.sh