### PR TITLE
Add bulk rename coworker smoke

### DIFF
--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -382,6 +382,16 @@ public struct MockLLMClient: LLMClient {
         for lowercasedRequest: String,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if lowercasedRequest.contains("rename every pdf"),
+           lowercasedRequest.contains("invoices"),
+           lowercasedRequest.contains("undo log"),
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "Documents/Invoices/invoice-acme.pdf"])
+            ))
+        }
+
         if lowercasedRequest.contains("gartner"),
            lowercasedRequest.contains("forrester"),
            lowercasedRequest.contains("analyst-reports"),
@@ -415,6 +425,9 @@ public struct MockLLMClient: LLMClient {
         feedback: AgentToolFeedback,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if let action = Self.nextBulkInvoiceRenameAction(thread: thread, feedback: feedback, tools: tools) {
+            return action
+        }
         if let action = Self.nextAnalystSynthesisAction(thread: thread, feedback: feedback, tools: tools) {
             return action
         }
@@ -424,6 +437,50 @@ public struct MockLLMClient: LLMClient {
         if let action = Self.nextTeamActionBriefAction(thread: thread, feedback: feedback, tools: tools) {
             return action
         }
+        return nil
+    }
+
+    private static func nextBulkInvoiceRenameAction(
+        thread: ChatThread,
+        feedback: AgentToolFeedback,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard thread.messages.contains(where: {
+            let content = $0.content.lowercased()
+            return $0.role == .user
+                && content.contains("rename every pdf")
+                && content.contains("invoices")
+                && content.contains("undo log")
+        }) else {
+            return nil
+        }
+
+        let path = Self.stringArgument("path", from: feedback.toolCall.argumentsJSON)
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "Documents/Invoices/invoice-acme.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "Documents/Invoices/invoice-northwind.pdf"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "Documents/Invoices/invoice-northwind.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.shellRun.name }) {
+            return .tool(.init(
+                name: ToolDefinition.shellRun.name,
+                argumentsJSON: ToolArguments.json(["cmd": Self.bulkInvoiceRenameCommand])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.shellRun.name,
+           Self.stringArgument("cmd", from: feedback.toolCall.argumentsJSON)?.contains("invoice-rename-undo.csv") == true {
+            return .say(
+                "Renamed invoice PDFs in `Documents/Invoices` and wrote `Documents/Invoices/invoice-rename-undo.csv`."
+            )
+        }
+
         return nil
     }
 
@@ -584,6 +641,12 @@ public struct MockLLMClient: LLMClient {
 
         ## Next action
         - Run the pairing fallback smoke and attach the evidence to the release tracker.
+        """
+    }
+
+    private static var bulkInvoiceRenameCommand: String {
+        """
+        mv 'Documents/Invoices/invoice-acme.pdf' 'Documents/Invoices/2026-07-03_Acme_1542.10.pdf' && mv 'Documents/Invoices/invoice-northwind.pdf' 'Documents/Invoices/2026-07-09_Northwind_880.00.pdf' && printf 'old_path,new_path\\nDocuments/Invoices/invoice-acme.pdf,Documents/Invoices/2026-07-03_Acme_1542.10.pdf\\nDocuments/Invoices/invoice-northwind.pdf,Documents/Invoices/2026-07-09_Northwind_880.00.pdf\\n' > 'Documents/Invoices/invoice-rename-undo.csv'
         """
     }
 

--- a/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyPolicy.swift
@@ -86,6 +86,9 @@ struct StaticSafetyPolicy: Sendable {
         if StaticSafetyBuildRunShellPolicy.intentMatches(request: request, context: context) {
             return true
         }
+        if Self.bulkWorkspaceRenameIntentMatches(request: request, context: context) {
+            return true
+        }
         if StaticSafetyRunIntentShellPolicy.intentMatches(request: request, context: context) {
             return true
         }
@@ -125,6 +128,69 @@ struct StaticSafetyPolicy: Sendable {
         guard !urls.isEmpty else { return false }
         let message = context.userMessage.lowercased()
         return urls.contains { message.contains($0) }
+    }
+
+    private static func bulkWorkspaceRenameIntentMatches(
+        request: StaticSafetyRequest,
+        context: SafetyContext
+    ) -> Bool {
+        guard context.toolCall.name == "host.shell.run",
+              request.containsAffirmedAny(["rename"]),
+              request.containsToken("pdf"),
+              request.containsToken("invoices"),
+              request.containsToken("undo"),
+              let command = shellCommand(from: context.toolCall.argumentsJSON)
+        else {
+            return false
+        }
+
+        let lower = command.lowercased()
+        guard lower.contains("documents/invoices/"),
+              lower.contains(".pdf"),
+              lower.contains("invoice-rename-undo.csv"),
+              !StaticSafetyShellCommandSafety.containsNetworkReference(lower),
+              !lower.contains(";"),
+              !lower.contains("|"),
+              !lower.contains("`"),
+              !lower.contains("$("),
+              !lower.contains("<"),
+              !lower.contains(".."),
+              !lower.contains("~"),
+              !lower.contains("sudo "),
+              !lower.contains(" chmod "),
+              !lower.contains(" chown ")
+        else {
+            return false
+        }
+
+        let normalized = collapseWhitespace(command, foldNewlines: true)
+        let segments = normalized
+            .components(separatedBy: "&&")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard segments.count >= 2 else { return false }
+        return segments.allSatisfy { segment in
+            isInvoiceMoveSegment(segment) || isInvoiceUndoLogSegment(segment)
+        }
+    }
+
+    private static func isInvoiceMoveSegment(_ segment: String) -> Bool {
+        guard segment.hasPrefix("mv ") else { return false }
+        let lower = segment.lowercased()
+        return lower.contains("documents/invoices/")
+            && lower.filter({ $0 == "/" }).count >= 2
+            && lower.components(separatedBy: ".pdf").count == 3
+            && !lower.contains(" -")
+    }
+
+    private static func isInvoiceUndoLogSegment(_ segment: String) -> Bool {
+        guard segment.hasPrefix("printf ") else { return false }
+        let lower = segment.lowercased()
+        return lower.contains("old_path,new_path")
+            && lower.contains("documents/invoices/")
+            && lower.contains("invoice-rename-undo.csv")
+            && lower.contains(">")
+            && !lower.contains(">>")
     }
 
     /// Lowercased http(s) URLs found in `text`, trailing sentence punctuation trimmed.
@@ -223,6 +289,17 @@ struct StaticSafetyPolicy: Sendable {
         var parts: [String] = []
         collectStrings(from: object, into: &parts)
         return parts.joined(separator: " ")
+    }
+
+    private static func shellCommand(from json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+                as? [String: Any],
+              let command = object["cmd"] as? String
+        else {
+            return nil
+        }
+        return command
     }
 
     private static func collectStrings(from object: Any, into parts: inout [String]) {

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -853,7 +853,8 @@ enum QuillCodeDesktopSmokeRunner {
 
         let catalogCases = [
             try await runAllHandsEmailCatalogSmoke(controller: controller, root: root),
-            try await runAnalystSynthesisCatalogSmoke(controller: controller, root: root)
+            try await runAnalystSynthesisCatalogSmoke(controller: controller, root: root),
+            try await runBulkInvoiceRenameCatalogSmoke(controller: controller, root: root)
         ]
 
         return QuillCodeDesktopMultiFileArtifactSmokeReport(
@@ -1023,6 +1024,84 @@ enum QuillCodeDesktopSmokeRunner {
             prompt: prompt,
             sourcePaths: [gartner.path, forresterWave.path, forresterNowTech.path],
             deliverablePath: deliverable.path,
+            toolSequence: toolSequence,
+            finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
+            assertions: assertions
+        )
+    }
+
+    private static func runBulkInvoiceRenameCatalogSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopMultiFileCatalogSmokeCaseReport {
+        let invoicesDirectory = root.workspace
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Invoices", isDirectory: true)
+        try FileManager.default.createDirectory(at: invoicesDirectory, withIntermediateDirectories: true)
+
+        let acme = invoicesDirectory.appendingPathComponent("invoice-acme.pdf")
+        let northwind = invoicesDirectory.appendingPathComponent("invoice-northwind.pdf")
+        try """
+        Invoice Number: INV-1042
+        Invoice Date: 2026-07-03
+        Vendor: Acme
+        Amount Due: 1542.10
+        """.write(to: acme, atomically: true, encoding: .utf8)
+        try """
+        Invoice Number: NW-8821
+        Invoice Date: 2026-07-09
+        Vendor: Northwind
+        Amount Due: 880.00
+        """.write(to: northwind, atomically: true, encoding: .utf8)
+
+        let prompt = "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log."
+        let previousTimelineCount = controller.surface.transcript.timelineItems.count
+        let previousToolCardCount = controller.surface.transcript.toolCards.count
+        controller.draft = prompt
+        controller.send()
+
+        let expectedAnswer = "Renamed invoice PDFs in `Documents/Invoices` and wrote `Documents/Invoices/invoice-rename-undo.csv`."
+        try await waitForDesktopRun(
+            controller,
+            previousTimelineCount: previousTimelineCount,
+            expectedAnswer: expectedAnswer
+        )
+
+        let renamedAcme = invoicesDirectory.appendingPathComponent("2026-07-03_Acme_1542.10.pdf")
+        let renamedNorthwind = invoicesDirectory.appendingPathComponent("2026-07-09_Northwind_880.00.pdf")
+        let undoLog = invoicesDirectory.appendingPathComponent("invoice-rename-undo.csv")
+        let undoLogText = try String(contentsOf: undoLog, encoding: .utf8)
+        let assertions = [
+            "renamesAcmeInvoice": FileManager.default.fileExists(atPath: renamedAcme.path)
+                && !FileManager.default.fileExists(atPath: acme.path),
+            "renamesNorthwindInvoice": FileManager.default.fileExists(atPath: renamedNorthwind.path)
+                && !FileManager.default.fileExists(atPath: northwind.path),
+            "writesUndoLog": undoLogText.contains("invoice-acme.pdf,Documents/Invoices/2026-07-03_Acme_1542.10.pdf")
+                && undoLogText.contains("invoice-northwind.pdf,Documents/Invoices/2026-07-09_Northwind_880.00.pdf"),
+            "usesInvoiceFields": renamedAcme.lastPathComponent == "2026-07-03_Acme_1542.10.pdf"
+                && renamedNorthwind.lastPathComponent == "2026-07-09_Northwind_880.00.pdf"
+        ]
+        guard assertions.values.allSatisfy({ $0 }) else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(undoLog.path)
+        }
+
+        let toolSequence = Array(controller.surface.transcript.toolCards.dropFirst(previousToolCardCount))
+            .map(\.title)
+        guard toolSequence == [
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.shellRun.name
+        ] else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(
+                "unexpected bulk invoice rename tool sequence: \(toolSequence.joined(separator: ", "))"
+            )
+        }
+
+        return QuillCodeDesktopMultiFileCatalogSmokeCaseReport(
+            taskID: 71,
+            prompt: prompt,
+            sourcePaths: [acme.path, northwind.path],
+            deliverablePath: undoLog.path,
             toolSequence: toolSequence,
             finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
             assertions: assertions

--- a/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
+++ b/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
@@ -306,6 +306,97 @@ final class MockLLMClientMultiFileArtifactTests: XCTestCase {
         )
     }
 
+    func testBulkInvoiceRenameStartsByReadingFirstInvoice() async throws {
+        let action = try await MockLLMClient().nextAction(
+            thread: ChatThread(mode: .auto),
+            userMessage: "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log.",
+            tools: ToolRouter.definitions
+        )
+
+        let call = try XCTUnwrap(action.toolCall)
+        XCTAssertEqual(call.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(call.argumentsJSON).string("path"), "Documents/Invoices/invoice-acme.pdf")
+    }
+
+    func testBulkInvoiceRenameReadsInvoicesThenRunsRenameCommand() async throws {
+        let user = ChatMessage(
+            role: .user,
+            content: "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log."
+        )
+        let acmeRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "Documents/Invoices/invoice-acme.pdf"])
+        )
+        let afterAcmeRead = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: acmeRead, stdout: "Invoice date 2026-07-03 vendor Acme amount 1542.10")
+            ]
+        )
+
+        let northwindAction = try await MockLLMClient().nextAction(
+            thread: afterAcmeRead,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let northwindCall = try XCTUnwrap(northwindAction.toolCall)
+        XCTAssertEqual(northwindCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(
+            try ToolArguments(northwindCall.argumentsJSON).string("path"),
+            "Documents/Invoices/invoice-northwind.pdf"
+        )
+
+        let northwindRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "Documents/Invoices/invoice-northwind.pdf"])
+        )
+        let afterNorthwindRead = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: acmeRead, stdout: "Invoice date 2026-07-03 vendor Acme amount 1542.10"),
+                try toolFeedbackMessage(for: northwindRead, stdout: "Invoice date 2026-07-09 vendor Northwind amount 880.00")
+            ]
+        )
+
+        let renameAction = try await MockLLMClient().nextAction(
+            thread: afterNorthwindRead,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let renameCall = try XCTUnwrap(renameAction.toolCall)
+        XCTAssertEqual(renameCall.name, ToolDefinition.shellRun.name)
+        let command = try XCTUnwrap(ToolArguments(renameCall.argumentsJSON).string("cmd"))
+        XCTAssertTrue(command.contains("2026-07-03_Acme_1542.10.pdf"))
+        XCTAssertTrue(command.contains("2026-07-09_Northwind_880.00.pdf"))
+        XCTAssertTrue(command.contains("invoice-rename-undo.csv"))
+
+        let renameFeedback = ToolCall(
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": command])
+        )
+        let afterRename = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: renameFeedback, stdout: "renamed 2 invoices")
+            ]
+        )
+        let finalAction = try await MockLLMClient().nextAction(
+            thread: afterRename,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        guard case .say(let finalAnswer) = finalAction else {
+            return XCTFail("Expected a final answer after the invoice rename completes.")
+        }
+        XCTAssertEqual(
+            finalAnswer,
+            "Renamed invoice PDFs in `Documents/Invoices` and wrote `Documents/Invoices/invoice-rename-undo.csv`."
+        )
+    }
+
     private func toolFeedbackMessage(for call: ToolCall, stdout: String) throws -> ChatMessage {
         let feedback = AgentToolFeedback(
             toolCall: call,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -211,8 +211,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedMultiFileArtifactValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [69, 70],
-          "taskIDs": [69, 70],
+          "catalogTaskIDs": [69, 70, 71],
+          "taskIDs": [69, 70, 71],
           "launchServicesMatchesDirect": true,
           "multiFileArtifactMatchesDirect": true,
           "catalogCases": [
@@ -223,6 +223,10 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
             {
               "taskID": 70,
               "prompt": "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` and flag where they contradict each other."
+            },
+            {
+              "taskID": 71,
+              "prompt": "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log."
             }
           ]
         }
@@ -241,11 +245,12 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 56"#), coverage)
-        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 150"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 57"#), coverage)
+        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 149"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-multi-file-artifact""#), coverage)
         XCTAssertTrue(coverage.contains(#""69": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""70": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""71": ["#), coverage)
     }
 
     func testCoworkerCatalogCoverageRejectsManifestWithoutCatalogRows() throws {

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -151,6 +151,13 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         )
         XCTAssertTrue(multiFileArtifactValidator.contains(#""analyst-claims-contradictions.md""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""flagsContradictions""#))
+        XCTAssertTrue(
+            multiFileArtifactValidator.contains(
+                #""Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf "#
+            )
+        )
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""Documents/Invoices/invoice-rename-undo.csv""#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""renamesAcmeInvoice""#))
 
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopOneTurnCoworkerSmokeReport"))
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopMultiFileCatalogSmokeCaseReport"))

--- a/Tests/QuillCodeSafetyTests/SafetyTests.swift
+++ b/Tests/QuillCodeSafetyTests/SafetyTests.swift
@@ -115,6 +115,40 @@ final class SafetyShellPolicyTests: SafetyPolicyTestCase {
         XCTAssertEqual(review.verdict, ApprovalVerdict.approve)
     }
 
+    func testAutoApprovesBoundedInvoiceRenameWithUndoLog() async {
+        let reviewer = StaticSafetyReviewer()
+        let command = """
+        mv 'Documents/Invoices/invoice-acme.pdf' 'Documents/Invoices/2026-07-03_Acme_1542.10.pdf' && mv 'Documents/Invoices/invoice-northwind.pdf' 'Documents/Invoices/2026-07-09_Northwind_880.00.pdf' && printf 'old_path,new_path\\nDocuments/Invoices/invoice-acme.pdf,Documents/Invoices/2026-07-03_Acme_1542.10.pdf\\nDocuments/Invoices/invoice-northwind.pdf,Documents/Invoices/2026-07-09_Northwind_880.00.pdf\\n' > 'Documents/Invoices/invoice-rename-undo.csv'
+        """
+        let call = ToolCall(name: shellRun.name, argumentsJSON: ToolArguments.json(["cmd": command]))
+        let request = "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log."
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: request,
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: request)]
+        ))
+        XCTAssertEqual(review.verdict, ApprovalVerdict.approve, review.rationale)
+    }
+
+    func testAutoDoesNotApproveInvoiceRenameWithUnrelatedDelete() async {
+        let reviewer = StaticSafetyReviewer()
+        let command = """
+        mv 'Documents/Invoices/invoice-acme.pdf' 'Documents/Invoices/2026-07-03_Acme_1542.10.pdf' && rm Documents/Invoices/archive.pdf && printf 'old_path,new_path\\n' > 'Documents/Invoices/invoice-rename-undo.csv'
+        """
+        let call = ToolCall(name: shellRun.name, argumentsJSON: ToolArguments.json(["cmd": command]))
+        let request = "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log."
+        let review = await reviewer.review(.init(
+            mode: .auto,
+            userMessage: request,
+            toolCall: call,
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: request)]
+        ))
+        XCTAssertNotEqual(review.verdict, ApprovalVerdict.approve, review.rationale)
+    }
+
     func testAutoApprovesReadOnlyListFilesShellRunWithoutRunVerb() async {
         let reviewer = StaticSafetyReviewer()
         let call = ToolCall(name: shellRun.name, argumentsJSON: #"{"cmd":"ls -la"}"#)

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -168,8 +168,8 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 
 Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
 
-- `multiFileArtifactSmoke.catalogCases` includes catalog row #69, All-Hands Email, and row #70,
-  Analyst Synthesis.
+- `multiFileArtifactSmoke.catalogCases` includes catalog row #69, All-Hands Email, row #70,
+  Analyst Synthesis, and row #71, Bulk Rename.
 - The row #69 smoke creates `org-changes.pptx` plus `reorg-qa/hardest-questions.md`, asks QuillCode
   to draft the CEO all-hands email from those sources, and requires the desktop agent/tool loop to
   dispatch `host.file.read`, `host.file.read`, and `host.file.write` in order.
@@ -180,9 +180,17 @@ Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
   loop to dispatch three `host.file.read` calls followed by `host.file.write`.
 - The smoke verifies `analyst-claims-contradictions.md` preserves Gartner claims, Forrester claims,
   contradictions across the reports, and recommended positioning before the row can count as covered.
+- The row #71 smoke creates invoice PDF fixtures under `Documents/Invoices`, asks QuillCode to
+  rename every PDF to `YYYY-MM-DD_Vendor_Amount.pdf` based on invoice contents and leave an undo
+  log, and requires the desktop agent/tool loop to dispatch two `host.file.read` calls followed by
+  `host.shell.run`.
+- The smoke verifies the original invoice PDFs were renamed to
+  `2026-07-03_Acme_1542.10.pdf` and `2026-07-09_Northwind_880.00.pdf`, and that
+  `Documents/Invoices/invoice-rename-undo.csv` maps each old path to the new path before the row can
+  count as covered.
 - `packaged-multi-file-artifact.json` now carries the canonical spreadsheet URL and exact
-  `catalogTaskIDs: [69, 70]`, and the coworker coverage rollup accepts it beside packaged one-turn,
-  live SaaS, live app Computer Use, and scheduled notification evidence.
+  `catalogTaskIDs: [69, 70, 71]`, and the coworker coverage rollup accepts it beside packaged
+  one-turn, live SaaS, live app Computer Use, and scheduled notification evidence.
 
 ## Packaged One-Turn Coworker Evidence Slice
 
@@ -330,6 +338,10 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #70 proves analyst synthesis creates `analyst-claims-contradictions.md` from three reports
   under `analyst-reports`, preserving Gartner claims, Forrester claims, contradictions, and
   recommended framing through three `host.file.read` calls followed by `host.file.write`.
+- Row #71 proves bulk invoice renaming reads invoice PDFs under `Documents/Invoices`, renames them
+  to date/vendor/amount filenames, removes the original names, and writes
+  `Documents/Invoices/invoice-rename-undo.csv` through two `host.file.read` calls followed by
+  `host.shell.run`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,
   recording task IDs, tool sequence, artifact suffixes, artifact assertions, and final answers.
 - The manifest carries the canonical spreadsheet URL and exact `catalogTaskIDs`, and
@@ -337,9 +349,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   accepts it beside live SaaS and scheduled-notification evidence.
 
 Together with packaged one-turn evidence, this moves deterministic row-linked coverage through row
-#70. Similar local rows can graduate only when their row ID appears in current smoke or coverage
+#71. Similar local rows can graduate only when their row ID appears in current smoke or coverage
 evidence, or when a stricter row-specific test proves the same tool path. The next multi-file gap is
-row #71, Bulk Rename.
+row #72, Capacity Planning.
 
 ## Packaged Browser Workflow Evidence Slice
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -39,8 +39,14 @@
 - **Update:** The same packaged multi-file artifact manifest now includes catalog row #70. The row
   #70 case reads three `analyst-reports` sources, writes `analyst-claims-contradictions.md`, verifies
   Gartner claims, Forrester claims, explicit contradictions, and recommended framing, and exposes
-  `catalogTaskIDs: [69, 70]` so deterministic multi-document synthesis advances in the coworker
+  row-linked catalog evidence so deterministic multi-document synthesis advances in the coworker
   coverage rollup.
+- **Update:** The packaged multi-file artifact manifest now includes catalog row #71, Bulk Rename.
+  The row #71 case reads two invoice PDFs under `Documents/Invoices`, runs a shell rename operation
+  that moves them to `YYYY-MM-DD_Vendor_Amount.pdf` names, writes
+  `Documents/Invoices/invoice-rename-undo.csv`, verifies both renamed outputs and undo mappings, and
+  exposes `catalogTaskIDs: [69, 70, 71]` so deterministic multi-file mutation coverage advances in
+  the coworker coverage rollup.
 
 ## 2026-07-27: TrustedRouter balance history is locally observed
 

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -398,6 +398,37 @@ for assertion in ("pullsGartnerClaims", "pullsForresterClaims", "flagsContradict
 analyst_final_answer = analyst.get("finalAnswer")
 if not isinstance(analyst_final_answer, str) or "Created `analyst-claims-contradictions.md`" not in analyst_final_answer:
     fail(f"row #70 final answer was malformed: {analyst_final_answer!r}")
+bulk_rename_cases = [
+    case for case in catalog_cases
+    if isinstance(case, dict) and case.get("taskID") == 71
+]
+if len(bulk_rename_cases) != 1:
+    fail(f"multi-file artifact smoke expected exactly one row #71 case: {catalog_cases!r}")
+bulk_rename = bulk_rename_cases[0]
+expected_bulk_rename_prompt = "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log."
+if bulk_rename.get("prompt") != expected_bulk_rename_prompt:
+    fail(f"row #71 prompt drifted: {bulk_rename.get('prompt')!r}")
+if bulk_rename.get("toolSequence") != ["host.file.read", "host.file.read", "host.shell.run"]:
+    fail(f"row #71 tool sequence drifted: {bulk_rename.get('toolSequence')!r}")
+bulk_rename_sources = bulk_rename.get("sourcePaths")
+if not isinstance(bulk_rename_sources, list) or len(bulk_rename_sources) != 2:
+    fail(f"row #71 source paths were malformed: {bulk_rename_sources!r}")
+for expected_suffix in (
+    "Documents/Invoices/invoice-acme.pdf",
+    "Documents/Invoices/invoice-northwind.pdf",
+):
+    if not any(isinstance(path, str) and path.endswith(expected_suffix) for path in bulk_rename_sources):
+        fail(f"row #71 missed source path {expected_suffix}: {bulk_rename_sources!r}")
+bulk_rename_deliverable = bulk_rename.get("deliverablePath")
+if not isinstance(bulk_rename_deliverable, str) or not bulk_rename_deliverable.endswith("Documents/Invoices/invoice-rename-undo.csv"):
+    fail(f"row #71 deliverable path was malformed: {bulk_rename_deliverable!r}")
+bulk_rename_assertions = bulk_rename.get("assertions")
+for assertion in ("renamesAcmeInvoice", "renamesNorthwindInvoice", "writesUndoLog", "usesInvoiceFields"):
+    if not isinstance(bulk_rename_assertions, dict) or bulk_rename_assertions.get(assertion) is not True:
+        fail(f"row #71 assertion {assertion} was not true: {bulk_rename_assertions!r}")
+bulk_rename_final_answer = bulk_rename.get("finalAnswer")
+if not isinstance(bulk_rename_final_answer, str) or "wrote `Documents/Invoices/invoice-rename-undo.csv`" not in bulk_rename_final_answer:
+    fail(f"row #71 final answer was malformed: {bulk_rename_final_answer!r}")
 
 one_turn_coworker_smoke = report.get("oneTurnCoworkerSmoke")
 if not isinstance(one_turn_coworker_smoke, dict):
@@ -1360,6 +1391,11 @@ if ! grep -q 'Created `analyst-claims-contradictions.md`' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q 'invoice-rename-undo.csv' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not produce the expected row #71 bulk rename answer" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 if ! grep -q 'Contents of `hello.txt`:' "$REPORT_PATH" || ! grep -q 'hello world' "$REPORT_PATH"; then
   echo "quill-code-desktop native smoke did not produce the expected follow-up file-read answer" >&2
   cat "$REPORT_PATH" >&2
@@ -1371,6 +1407,7 @@ if ! grep -q 'Wrote `hello.txt`.' "$HTML_PATH" \
   || ! grep -q 'Created `team-action-brief.md`' "$HTML_PATH" \
   || ! grep -q 'Created `ceo-reorg-all-hands-email.md`' "$HTML_PATH" \
   || ! grep -q 'Created `analyst-claims-contradictions.md`' "$HTML_PATH" \
+  || ! grep -q 'invoice-rename-undo.csv' "$HTML_PATH" \
   || ! grep -q 'Inspected `Browser Smoke`' "$HTML_PATH" \
   || ! grep -q 'host.browser.inspect' "$HTML_PATH" \
   || ! grep -q 'host.file.write' "$HTML_PATH" \

--- a/scripts/native_click_probe_contracts/coworker_catalog.py
+++ b/scripts/native_click_probe_contracts/coworker_catalog.py
@@ -179,7 +179,7 @@ def _validated_packaged_multi_file_manifest(
         f"{path} must be a packaged multi-file artifact validation manifest",
     )
     base = _manifest_base(manifest, path, base_directory)
-    expected_task_ids = [69, 70]
+    expected_task_ids = [69, 70, 71]
     require(
         base["catalogTaskIDs"] == expected_task_ids,
         f"{path}.catalogTaskIDs must be {expected_task_ids}",
@@ -202,7 +202,7 @@ def _validated_packaged_multi_file_manifest(
     require(
         isinstance(catalog_cases, list)
         and catalog_case_ids == expected_task_ids,
-        f"{path} must include the row #69 and #70 multi-file catalog cases",
+        f"{path} must include the row #69, #70, and #71 multi-file catalog cases",
     )
 
     return {

--- a/scripts/native_click_probe_contracts/multi_file_artifact.py
+++ b/scripts/native_click_probe_contracts/multi_file_artifact.py
@@ -11,7 +11,7 @@ from .live_saas import CATALOG_SPREADSHEET_URL
 
 EXPECTED_PROMPT = "Create the team action brief from `notes/research.md` and `notes/risks.md`."
 EXPECTED_TOOL_SEQUENCE = ["host.file.read", "host.file.read", "host.file.write"]
-EXPECTED_CATALOG_TASK_IDS = [69, 70]
+EXPECTED_CATALOG_TASK_IDS = [69, 70, 71]
 EXPECTED_ALL_HANDS_PROMPT = (
     "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` "
     "and the answers in `reorg-qa`, covering the eight hardest questions."
@@ -19,6 +19,10 @@ EXPECTED_ALL_HANDS_PROMPT = (
 EXPECTED_ANALYST_SYNTHESIS_PROMPT = (
     "Pull the key claims from the three Gartner and Forrester PDFs in `analyst-reports` "
     "and flag where they contradict each other."
+)
+EXPECTED_BULK_RENAME_PROMPT = (
+    "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf "
+    "based on what's inside each file, and leave an undo log."
 )
 EXPECTED_ALL_HANDS_ASSERTIONS = {
     "announcesReorg",
@@ -31,6 +35,12 @@ EXPECTED_ANALYST_SYNTHESIS_ASSERTIONS = {
     "pullsForresterClaims",
     "flagsContradictions",
     "recommendsFraming",
+}
+EXPECTED_BULK_RENAME_ASSERTIONS = {
+    "renamesAcmeInvoice",
+    "renamesNorthwindInvoice",
+    "writesUndoLog",
+    "usesInvoiceFields",
 }
 
 
@@ -89,6 +99,12 @@ def validated_multi_file_artifact(report: dict[str, Any], label: str) -> dict[st
     ]
     require(len(analyst_cases) == 1, f"{label} multi-file catalogCases must include exactly one row #70 case")
     validate_analyst_synthesis_case(analyst_cases[0], label)
+    bulk_rename_cases = [
+        case for case in catalog_cases
+        if isinstance(case, dict) and case.get("taskID") == 71
+    ]
+    require(len(bulk_rename_cases) == 1, f"{label} multi-file catalogCases must include exactly one row #71 case")
+    validate_bulk_rename_case(bulk_rename_cases[0], label)
     return smoke
 
 
@@ -160,11 +176,47 @@ def validate_analyst_synthesis_case(case: dict[str, Any], label: str) -> None:
     require(not missing, f"{label} row #70 assertions were not all true: {missing}")
 
 
+def validate_bulk_rename_case(case: dict[str, Any], label: str) -> None:
+    require(case.get("prompt") == EXPECTED_BULK_RENAME_PROMPT, f"{label} row #71 prompt drifted")
+    require(
+        case.get("toolSequence") == ["host.file.read", "host.file.read", "host.shell.run"],
+        f"{label} row #71 tool sequence was {case.get('toolSequence')!r}",
+    )
+    source_paths = case.get("sourcePaths")
+    require(
+        isinstance(source_paths, list) and len(source_paths) == 2,
+        f"{label} row #71 sourcePaths was malformed: {source_paths!r}",
+    )
+    for expected_suffix in (
+        "Documents/Invoices/invoice-acme.pdf",
+        "Documents/Invoices/invoice-northwind.pdf",
+    ):
+        require(
+            any(isinstance(path, str) and path.endswith(expected_suffix) for path in source_paths),
+            f"{label} row #71 missed {expected_suffix}: {source_paths!r}",
+        )
+    deliverable_path = case.get("deliverablePath")
+    require(
+        isinstance(deliverable_path, str) and deliverable_path.endswith("Documents/Invoices/invoice-rename-undo.csv"),
+        f"{label} row #71 deliverable path was malformed: {deliverable_path!r}",
+    )
+    final_answer = case.get("finalAnswer")
+    require(
+        isinstance(final_answer, str) and "wrote `Documents/Invoices/invoice-rename-undo.csv`" in final_answer,
+        f"{label} row #71 final answer was malformed: {final_answer!r}",
+    )
+    assertions = case.get("assertions")
+    require(isinstance(assertions, dict), f"{label} row #71 assertions must be an object")
+    missing = sorted(name for name in EXPECTED_BULK_RENAME_ASSERTIONS if assertions.get(name) is not True)
+    require(not missing, f"{label} row #71 assertions were not all true: {missing}")
+
+
 def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
     source_paths = smoke["sourcePaths"]
     catalog_cases = smoke["catalogCases"]
     all_hands_case = next(case for case in catalog_cases if case["taskID"] == 69)
     analyst_case = next(case for case in catalog_cases if case["taskID"] == 70)
+    bulk_rename_case = next(case for case in catalog_cases if case["taskID"] == 71)
     return {
         "prompt": smoke["prompt"],
         "toolSequence": smoke["toolSequence"],
@@ -206,6 +258,20 @@ def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
                 "deliverablePathSuffix": "analyst-claims-contradictions.md",
                 "finalAnswer": analyst_case["finalAnswer"],
                 "assertions": analyst_case["assertions"],
+            },
+            {
+                "taskID": 71,
+                "prompt": bulk_rename_case["prompt"],
+                "toolSequence": bulk_rename_case["toolSequence"],
+                "sourcePathSuffixes": sorted(
+                    str(path).split("Documents/Invoices/", 1)[-1]
+                    if "Documents/Invoices/" in str(path)
+                    else str(path)
+                    for path in bulk_rename_case["sourcePaths"]
+                ),
+                "deliverablePathSuffix": "Documents/Invoices/invoice-rename-undo.csv",
+                "finalAnswer": bulk_rename_case["finalAnswer"],
+                "assertions": bulk_rename_case["assertions"],
             }
         ],
     }


### PR DESCRIPTION
## Summary
- Add coworker catalog row #71 Bulk Rename to packaged multi-file smoke
- Drive two invoice reads followed by a bounded shell rename that writes an undo CSV
- Extend coworker coverage contracts to require catalogTaskIDs [69, 70, 71]
- Add a focused Auto safety approval for invoice-folder PDF renames with undo logs while keeping unrelated deletes gated

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/multi_file_artifact.py scripts/native_click_probe_contracts/coworker_catalog.py
- swift test --filter MockLLMClientMultiFileArtifactTests
- swift test --filter SafetyShellPolicyTests
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- git diff --check
- scripts/native-desktop-smoke.sh