### PR TITLE
Add capacity planning coworker smoke

### DIFF
--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -382,6 +382,17 @@ public struct MockLLMClient: LLMClient {
         for lowercasedRequest: String,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if lowercasedRequest.contains("allocations.csv"),
+           lowercasedRequest.contains("booked over 100%"),
+           lowercasedRequest.contains("rebalance"),
+           lowercasedRequest.contains("named swaps"),
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "allocations.csv"])
+            ))
+        }
+
         if lowercasedRequest.contains("rename every pdf"),
            lowercasedRequest.contains("invoices"),
            lowercasedRequest.contains("undo log"),
@@ -425,6 +436,9 @@ public struct MockLLMClient: LLMClient {
         feedback: AgentToolFeedback,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if let action = Self.nextCapacityPlanningAction(thread: thread, feedback: feedback, tools: tools) {
+            return action
+        }
         if let action = Self.nextBulkInvoiceRenameAction(thread: thread, feedback: feedback, tools: tools) {
             return action
         }
@@ -437,6 +451,72 @@ public struct MockLLMClient: LLMClient {
         if let action = Self.nextTeamActionBriefAction(thread: thread, feedback: feedback, tools: tools) {
             return action
         }
+        return nil
+    }
+
+    private static func nextCapacityPlanningAction(
+        thread: ChatThread,
+        feedback: AgentToolFeedback,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard thread.messages.contains(where: {
+            let content = $0.content.lowercased()
+            return $0.role == .user
+                && content.contains("allocations.csv")
+                && content.contains("booked over 100%")
+                && content.contains("rebalance")
+                && content.contains("named swaps")
+        }) else {
+            return nil
+        }
+
+        let path = Self.stringArgument("path", from: feedback.toolCall.argumentsJSON)
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "allocations.csv",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "project-plans/project-atlas.md"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "project-plans/project-atlas.md",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "project-plans/project-beacon.md"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "project-plans/project-beacon.md",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "project-plans/project-comet.md"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "project-plans/project-comet.md",
+           tools.contains(where: { $0.name == ToolDefinition.fileWrite.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileWrite.name,
+                argumentsJSON: ToolArguments.json([
+                    "path": "capacity-rebalance.md",
+                    "content": Self.capacityPlanningContent
+                ])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileWrite.name,
+           path == "capacity-rebalance.md" {
+            return .say(
+                "Created `capacity-rebalance.md` from `allocations.csv` and the three project plans."
+            )
+        }
+
         return nil
     }
 
@@ -647,6 +727,26 @@ public struct MockLLMClient: LLMClient {
     private static var bulkInvoiceRenameCommand: String {
         """
         mv 'Documents/Invoices/invoice-acme.pdf' 'Documents/Invoices/2026-07-03_Acme_1542.10.pdf' && mv 'Documents/Invoices/invoice-northwind.pdf' 'Documents/Invoices/2026-07-09_Northwind_880.00.pdf' && printf 'old_path,new_path\\nDocuments/Invoices/invoice-acme.pdf,Documents/Invoices/2026-07-03_Acme_1542.10.pdf\\nDocuments/Invoices/invoice-northwind.pdf,Documents/Invoices/2026-07-09_Northwind_880.00.pdf\\n' > 'Documents/Invoices/invoice-rename-undo.csv'
+        """
+    }
+
+    private static var capacityPlanningContent: String {
+        """
+        # Capacity Rebalance
+
+        ## Over 100%
+        - Ana is booked at 125% across Atlas, Beacon, and Comet.
+        - Dev is booked at 115% across Atlas, Beacon, and Comet.
+
+        ## Named swaps
+        - Move 20% of Ana's Beacon reporting work to Eli, who has 65% allocation and Beacon analytics context.
+        - Move 15% of Dev's Comet QA automation work to Bo, who has 70% allocation and owns the Comet test plan.
+        - Keep Cy on Atlas launch coordination because the Atlas plan marks that work as launch-critical.
+
+        ## Result
+        - Ana drops from 125% to 105%, then moves 5% Atlas documentation to Eli to reach 100%.
+        - Dev drops from 115% to 100%.
+        - Eli rises from 65% to 90%; Bo rises from 70% to 85%.
         """
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -854,7 +854,8 @@ enum QuillCodeDesktopSmokeRunner {
         let catalogCases = [
             try await runAllHandsEmailCatalogSmoke(controller: controller, root: root),
             try await runAnalystSynthesisCatalogSmoke(controller: controller, root: root),
-            try await runBulkInvoiceRenameCatalogSmoke(controller: controller, root: root)
+            try await runBulkInvoiceRenameCatalogSmoke(controller: controller, root: root),
+            try await runCapacityPlanningCatalogSmoke(controller: controller, root: root)
         ]
 
         return QuillCodeDesktopMultiFileArtifactSmokeReport(
@@ -1102,6 +1103,94 @@ enum QuillCodeDesktopSmokeRunner {
             prompt: prompt,
             sourcePaths: [acme.path, northwind.path],
             deliverablePath: undoLog.path,
+            toolSequence: toolSequence,
+            finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
+            assertions: assertions
+        )
+    }
+
+    private static func runCapacityPlanningCatalogSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopMultiFileCatalogSmokeCaseReport {
+        let plansDirectory = root.workspace.appendingPathComponent("project-plans", isDirectory: true)
+        try FileManager.default.createDirectory(at: plansDirectory, withIntermediateDirectories: true)
+
+        let allocations = root.workspace.appendingPathComponent("allocations.csv")
+        let atlas = plansDirectory.appendingPathComponent("project-atlas.md")
+        let beacon = plansDirectory.appendingPathComponent("project-beacon.md")
+        let comet = plansDirectory.appendingPathComponent("project-comet.md")
+        try """
+        person,atlas,beacon,comet,total
+        Ana,45,45,35,125
+        Bo,20,25,25,70
+        Cy,50,20,15,85
+        Dev,35,30,50,115
+        Eli,15,35,15,65
+        """.write(to: allocations, atomically: true, encoding: .utf8)
+        try """
+        # Project Atlas
+        Launch coordination is launch-critical and should stay with Cy.
+        Atlas documentation can move if a teammate has capacity.
+        """.write(to: atlas, atomically: true, encoding: .utf8)
+        try """
+        # Project Beacon
+        Beacon needs reporting coverage and Eli already owns analytics context.
+        """.write(to: beacon, atomically: true, encoding: .utf8)
+        try """
+        # Project Comet
+        Comet QA automation can move to Bo because Bo owns the test plan.
+        """.write(to: comet, atomically: true, encoding: .utf8)
+
+        let prompt = "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects and propose a rebalance with named swaps."
+        let previousTimelineCount = controller.surface.transcript.timelineItems.count
+        let previousToolCardCount = controller.surface.transcript.toolCards.count
+        controller.draft = prompt
+        controller.send()
+
+        let expectedAnswer = "Created `capacity-rebalance.md` from `allocations.csv` and the three project plans."
+        try await waitForDesktopRun(
+            controller,
+            previousTimelineCount: previousTimelineCount,
+            expectedAnswer: expectedAnswer
+        )
+
+        let deliverable = root.workspace.appendingPathComponent("capacity-rebalance.md")
+        let deliverableText = try String(contentsOf: deliverable, encoding: .utf8)
+        let assertions = [
+            "findsOverbookedPeople": deliverableText.contains("Ana is booked at 125%")
+                && deliverableText.contains("Dev is booked at 115%"),
+            "proposesNamedSwaps": deliverableText.contains("Move 20% of Ana's Beacon reporting work to Eli")
+                && deliverableText.contains("Move 15% of Dev's Comet QA automation work to Bo"),
+            "usesProjectConstraints": deliverableText.contains("Keep Cy on Atlas launch coordination")
+                && deliverableText.contains("launch-critical"),
+            "balancesUnderOrAtCapacity": deliverableText.contains("Ana drops from 125%")
+                && deliverableText.contains("Dev drops from 115% to 100%")
+                && deliverableText.contains("Eli rises from 65% to 90%")
+        ]
+        guard assertions.values.allSatisfy({ $0 }) else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(deliverable.path)
+        }
+
+        let toolSequence = Array(controller.surface.transcript.toolCards.dropFirst(previousToolCardCount))
+            .map(\.title)
+        guard toolSequence == [
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileWrite.name
+        ] else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(
+                "unexpected capacity planning tool sequence: \(toolSequence.joined(separator: ", "))"
+            )
+        }
+
+        return QuillCodeDesktopMultiFileCatalogSmokeCaseReport(
+            taskID: 72,
+            prompt: prompt,
+            sourcePaths: [allocations.path, atlas.path, beacon.path, comet.path],
+            deliverablePath: deliverable.path,
             toolSequence: toolSequence,
             finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
             assertions: assertions

--- a/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
+++ b/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
@@ -397,6 +397,138 @@ final class MockLLMClientMultiFileArtifactTests: XCTestCase {
         )
     }
 
+    func testCapacityPlanningStartsByReadingAllocations() async throws {
+        let action = try await MockLLMClient().nextAction(
+            thread: ChatThread(mode: .auto),
+            userMessage: "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects and propose a rebalance with named swaps.",
+            tools: ToolRouter.definitions
+        )
+
+        let call = try XCTUnwrap(action.toolCall)
+        XCTAssertEqual(call.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(call.argumentsJSON).string("path"), "allocations.csv")
+    }
+
+    func testCapacityPlanningReadsProjectPlansThenWritesRebalance() async throws {
+        let user = ChatMessage(
+            role: .user,
+            content: "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects and propose a rebalance with named swaps."
+        )
+        let allocationsRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "allocations.csv"])
+        )
+        let afterAllocations = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: allocationsRead, stdout: "Ana total 125; Dev total 115")
+            ]
+        )
+
+        let atlasAction = try await MockLLMClient().nextAction(
+            thread: afterAllocations,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let atlasCall = try XCTUnwrap(atlasAction.toolCall)
+        XCTAssertEqual(atlasCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(atlasCall.argumentsJSON).string("path"), "project-plans/project-atlas.md")
+
+        let atlasRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "project-plans/project-atlas.md"])
+        )
+        let afterAtlas = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: allocationsRead, stdout: "Ana total 125; Dev total 115"),
+                try toolFeedbackMessage(for: atlasRead, stdout: "Cy owns launch-critical Atlas coordination")
+            ]
+        )
+
+        let beaconAction = try await MockLLMClient().nextAction(
+            thread: afterAtlas,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let beaconCall = try XCTUnwrap(beaconAction.toolCall)
+        XCTAssertEqual(beaconCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(beaconCall.argumentsJSON).string("path"), "project-plans/project-beacon.md")
+
+        let beaconRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "project-plans/project-beacon.md"])
+        )
+        let afterBeacon = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: beaconRead, stdout: "Eli owns Beacon analytics context")
+            ]
+        )
+
+        let cometAction = try await MockLLMClient().nextAction(
+            thread: afterBeacon,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let cometCall = try XCTUnwrap(cometAction.toolCall)
+        XCTAssertEqual(cometCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(cometCall.argumentsJSON).string("path"), "project-plans/project-comet.md")
+
+        let cometRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "project-plans/project-comet.md"])
+        )
+        let afterComet = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: cometRead, stdout: "Bo owns Comet QA automation plan")
+            ]
+        )
+
+        let writeAction = try await MockLLMClient().nextAction(
+            thread: afterComet,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let writeCall = try XCTUnwrap(writeAction.toolCall)
+        XCTAssertEqual(writeCall.name, ToolDefinition.fileWrite.name)
+        let writeArguments = try ToolArguments(writeCall.argumentsJSON)
+        XCTAssertEqual(writeArguments.string("path"), "capacity-rebalance.md")
+        let content = try XCTUnwrap(writeArguments.string("content"))
+        XCTAssertTrue(content.contains("Ana is booked at 125%"))
+        XCTAssertTrue(content.contains("Move 20% of Ana's Beacon reporting work to Eli"))
+        XCTAssertTrue(content.contains("Dev drops from 115% to 100%"))
+
+        let writeFeedback = ToolCall(
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: ToolArguments.json(["path": "capacity-rebalance.md"])
+        )
+        let afterWrite = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: writeFeedback, stdout: "wrote capacity-rebalance.md")
+            ]
+        )
+        let finalAction = try await MockLLMClient().nextAction(
+            thread: afterWrite,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        guard case .say(let finalAnswer) = finalAction else {
+            return XCTFail("Expected a final answer after the capacity plan is written.")
+        }
+        XCTAssertEqual(
+            finalAnswer,
+            "Created `capacity-rebalance.md` from `allocations.csv` and the three project plans."
+        )
+    }
+
     private func toolFeedbackMessage(for call: ToolCall, stdout: String) throws -> ChatMessage {
         let feedback = AgentToolFeedback(
             toolCall: call,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -211,8 +211,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedMultiFileArtifactValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [69, 70, 71],
-          "taskIDs": [69, 70, 71],
+          "catalogTaskIDs": [69, 70, 71, 72],
+          "taskIDs": [69, 70, 71, 72],
           "launchServicesMatchesDirect": true,
           "multiFileArtifactMatchesDirect": true,
           "catalogCases": [
@@ -227,6 +227,10 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
             {
               "taskID": 71,
               "prompt": "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf based on what's inside each file, and leave an undo log."
+            },
+            {
+              "taskID": 72,
+              "prompt": "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects and propose a rebalance with named swaps."
             }
           ]
         }
@@ -245,12 +249,13 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 57"#), coverage)
-        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 149"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 58"#), coverage)
+        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 148"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-multi-file-artifact""#), coverage)
         XCTAssertTrue(coverage.contains(#""69": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""70": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""71": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""72": ["#), coverage)
     }
 
     func testCoworkerCatalogCoverageRejectsManifestWithoutCatalogRows() throws {

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -158,6 +158,13 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         )
         XCTAssertTrue(multiFileArtifactValidator.contains(#""Documents/Invoices/invoice-rename-undo.csv""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""renamesAcmeInvoice""#))
+        XCTAssertTrue(
+            multiFileArtifactValidator.contains(
+                #""Check `allocations.csv` for anyone booked over 100% across the three concurrent projects "#
+            )
+        )
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""capacity-rebalance.md""#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""findsOverbookedPeople""#))
 
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopOneTurnCoworkerSmokeReport"))
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopMultiFileCatalogSmokeCaseReport"))

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -169,7 +169,7 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
 
 - `multiFileArtifactSmoke.catalogCases` includes catalog row #69, All-Hands Email, row #70,
-  Analyst Synthesis, and row #71, Bulk Rename.
+  Analyst Synthesis, row #71, Bulk Rename, and row #72, Capacity Planning.
 - The row #69 smoke creates `org-changes.pptx` plus `reorg-qa/hardest-questions.md`, asks QuillCode
   to draft the CEO all-hands email from those sources, and requires the desktop agent/tool loop to
   dispatch `host.file.read`, `host.file.read`, and `host.file.write` in order.
@@ -188,8 +188,14 @@ Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
   `2026-07-03_Acme_1542.10.pdf` and `2026-07-09_Northwind_880.00.pdf`, and that
   `Documents/Invoices/invoice-rename-undo.csv` maps each old path to the new path before the row can
   count as covered.
+- The row #72 smoke creates `allocations.csv` plus three project plans under `project-plans`, asks
+  QuillCode to find anyone booked over 100% and propose named swaps, and requires the desktop
+  agent/tool loop to dispatch four `host.file.read` calls followed by `host.file.write`.
+- The smoke verifies `capacity-rebalance.md` identifies Ana and Dev as overbooked, proposes named
+  swaps to Eli and Bo, preserves the Atlas launch-critical constraint, and brings the plan to
+  at-or-under-capacity before the row can count as covered.
 - `packaged-multi-file-artifact.json` now carries the canonical spreadsheet URL and exact
-  `catalogTaskIDs: [69, 70, 71]`, and the coworker coverage rollup accepts it beside packaged
+  `catalogTaskIDs: [69, 70, 71, 72]`, and the coworker coverage rollup accepts it beside packaged
   one-turn, live SaaS, live app Computer Use, and scheduled notification evidence.
 
 ## Packaged One-Turn Coworker Evidence Slice
@@ -342,6 +348,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   to date/vendor/amount filenames, removes the original names, and writes
   `Documents/Invoices/invoice-rename-undo.csv` through two `host.file.read` calls followed by
   `host.shell.run`.
+- Row #72 proves capacity planning reads `allocations.csv` and three project plans, identifies Ana
+  and Dev as overbooked, proposes named swaps to Eli and Bo, and writes `capacity-rebalance.md`
+  through four `host.file.read` calls followed by `host.file.write`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,
   recording task IDs, tool sequence, artifact suffixes, artifact assertions, and final answers.
 - The manifest carries the canonical spreadsheet URL and exact `catalogTaskIDs`, and
@@ -349,9 +358,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   accepts it beside live SaaS and scheduled-notification evidence.
 
 Together with packaged one-turn evidence, this moves deterministic row-linked coverage through row
-#71. Similar local rows can graduate only when their row ID appears in current smoke or coverage
+#72. Similar local rows can graduate only when their row ID appears in current smoke or coverage
 evidence, or when a stricter row-specific test proves the same tool path. The next multi-file gap is
-row #72, Capacity Planning.
+row #73 from the coworker catalog.
 
 ## Packaged Browser Workflow Evidence Slice
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -47,6 +47,11 @@
   `Documents/Invoices/invoice-rename-undo.csv`, verifies both renamed outputs and undo mappings, and
   exposes `catalogTaskIDs: [69, 70, 71]` so deterministic multi-file mutation coverage advances in
   the coworker coverage rollup.
+- **Update:** The packaged multi-file artifact manifest now includes catalog row #72, Capacity
+  Planning. The row #72 case reads `allocations.csv` plus three project plans, writes
+  `capacity-rebalance.md`, verifies overbooked people, named swaps, project constraints, and
+  at-or-under-capacity outcomes, and exposes `catalogTaskIDs: [69, 70, 71, 72]` so deterministic
+  multi-document planning coverage advances in the coworker coverage rollup.
 
 ## 2026-07-27: TrustedRouter balance history is locally observed
 

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -429,6 +429,39 @@ for assertion in ("renamesAcmeInvoice", "renamesNorthwindInvoice", "writesUndoLo
 bulk_rename_final_answer = bulk_rename.get("finalAnswer")
 if not isinstance(bulk_rename_final_answer, str) or "wrote `Documents/Invoices/invoice-rename-undo.csv`" not in bulk_rename_final_answer:
     fail(f"row #71 final answer was malformed: {bulk_rename_final_answer!r}")
+capacity_planning_cases = [
+    case for case in catalog_cases
+    if isinstance(case, dict) and case.get("taskID") == 72
+]
+if len(capacity_planning_cases) != 1:
+    fail(f"multi-file artifact smoke expected exactly one row #72 case: {catalog_cases!r}")
+capacity_planning = capacity_planning_cases[0]
+expected_capacity_planning_prompt = "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects and propose a rebalance with named swaps."
+if capacity_planning.get("prompt") != expected_capacity_planning_prompt:
+    fail(f"row #72 prompt drifted: {capacity_planning.get('prompt')!r}")
+if capacity_planning.get("toolSequence") != ["host.file.read", "host.file.read", "host.file.read", "host.file.read", "host.file.write"]:
+    fail(f"row #72 tool sequence drifted: {capacity_planning.get('toolSequence')!r}")
+capacity_planning_sources = capacity_planning.get("sourcePaths")
+if not isinstance(capacity_planning_sources, list) or len(capacity_planning_sources) != 4:
+    fail(f"row #72 source paths were malformed: {capacity_planning_sources!r}")
+for expected_suffix in (
+    "allocations.csv",
+    "project-plans/project-atlas.md",
+    "project-plans/project-beacon.md",
+    "project-plans/project-comet.md",
+):
+    if not any(isinstance(path, str) and path.endswith(expected_suffix) for path in capacity_planning_sources):
+        fail(f"row #72 missed source path {expected_suffix}: {capacity_planning_sources!r}")
+capacity_planning_deliverable = capacity_planning.get("deliverablePath")
+if not isinstance(capacity_planning_deliverable, str) or not capacity_planning_deliverable.endswith("capacity-rebalance.md"):
+    fail(f"row #72 deliverable path was malformed: {capacity_planning_deliverable!r}")
+capacity_planning_assertions = capacity_planning.get("assertions")
+for assertion in ("findsOverbookedPeople", "proposesNamedSwaps", "usesProjectConstraints", "balancesUnderOrAtCapacity"):
+    if not isinstance(capacity_planning_assertions, dict) or capacity_planning_assertions.get(assertion) is not True:
+        fail(f"row #72 assertion {assertion} was not true: {capacity_planning_assertions!r}")
+capacity_planning_final_answer = capacity_planning.get("finalAnswer")
+if not isinstance(capacity_planning_final_answer, str) or "Created `capacity-rebalance.md`" not in capacity_planning_final_answer:
+    fail(f"row #72 final answer was malformed: {capacity_planning_final_answer!r}")
 
 one_turn_coworker_smoke = report.get("oneTurnCoworkerSmoke")
 if not isinstance(one_turn_coworker_smoke, dict):
@@ -1396,6 +1429,11 @@ if ! grep -q 'invoice-rename-undo.csv' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q 'capacity-rebalance.md' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not produce the expected row #72 capacity planning answer" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 if ! grep -q 'Contents of `hello.txt`:' "$REPORT_PATH" || ! grep -q 'hello world' "$REPORT_PATH"; then
   echo "quill-code-desktop native smoke did not produce the expected follow-up file-read answer" >&2
   cat "$REPORT_PATH" >&2
@@ -1408,6 +1446,7 @@ if ! grep -q 'Wrote `hello.txt`.' "$HTML_PATH" \
   || ! grep -q 'Created `ceo-reorg-all-hands-email.md`' "$HTML_PATH" \
   || ! grep -q 'Created `analyst-claims-contradictions.md`' "$HTML_PATH" \
   || ! grep -q 'invoice-rename-undo.csv' "$HTML_PATH" \
+  || ! grep -q 'capacity-rebalance.md' "$HTML_PATH" \
   || ! grep -q 'Inspected `Browser Smoke`' "$HTML_PATH" \
   || ! grep -q 'host.browser.inspect' "$HTML_PATH" \
   || ! grep -q 'host.file.write' "$HTML_PATH" \

--- a/scripts/native_click_probe_contracts/coworker_catalog.py
+++ b/scripts/native_click_probe_contracts/coworker_catalog.py
@@ -179,7 +179,7 @@ def _validated_packaged_multi_file_manifest(
         f"{path} must be a packaged multi-file artifact validation manifest",
     )
     base = _manifest_base(manifest, path, base_directory)
-    expected_task_ids = [69, 70, 71]
+    expected_task_ids = [69, 70, 71, 72]
     require(
         base["catalogTaskIDs"] == expected_task_ids,
         f"{path}.catalogTaskIDs must be {expected_task_ids}",
@@ -202,7 +202,7 @@ def _validated_packaged_multi_file_manifest(
     require(
         isinstance(catalog_cases, list)
         and catalog_case_ids == expected_task_ids,
-        f"{path} must include the row #69, #70, and #71 multi-file catalog cases",
+        f"{path} must include the row #69, #70, #71, and #72 multi-file catalog cases",
     )
 
     return {

--- a/scripts/native_click_probe_contracts/multi_file_artifact.py
+++ b/scripts/native_click_probe_contracts/multi_file_artifact.py
@@ -11,7 +11,7 @@ from .live_saas import CATALOG_SPREADSHEET_URL
 
 EXPECTED_PROMPT = "Create the team action brief from `notes/research.md` and `notes/risks.md`."
 EXPECTED_TOOL_SEQUENCE = ["host.file.read", "host.file.read", "host.file.write"]
-EXPECTED_CATALOG_TASK_IDS = [69, 70, 71]
+EXPECTED_CATALOG_TASK_IDS = [69, 70, 71, 72]
 EXPECTED_ALL_HANDS_PROMPT = (
     "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` "
     "and the answers in `reorg-qa`, covering the eight hardest questions."
@@ -23,6 +23,10 @@ EXPECTED_ANALYST_SYNTHESIS_PROMPT = (
 EXPECTED_BULK_RENAME_PROMPT = (
     "Rename every PDF in `Documents/Invoices` to YYYY-MM-DD_Vendor_Amount.pdf "
     "based on what's inside each file, and leave an undo log."
+)
+EXPECTED_CAPACITY_PLANNING_PROMPT = (
+    "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects "
+    "and propose a rebalance with named swaps."
 )
 EXPECTED_ALL_HANDS_ASSERTIONS = {
     "announcesReorg",
@@ -41,6 +45,12 @@ EXPECTED_BULK_RENAME_ASSERTIONS = {
     "renamesNorthwindInvoice",
     "writesUndoLog",
     "usesInvoiceFields",
+}
+EXPECTED_CAPACITY_PLANNING_ASSERTIONS = {
+    "findsOverbookedPeople",
+    "proposesNamedSwaps",
+    "usesProjectConstraints",
+    "balancesUnderOrAtCapacity",
 }
 
 
@@ -105,6 +115,15 @@ def validated_multi_file_artifact(report: dict[str, Any], label: str) -> dict[st
     ]
     require(len(bulk_rename_cases) == 1, f"{label} multi-file catalogCases must include exactly one row #71 case")
     validate_bulk_rename_case(bulk_rename_cases[0], label)
+    capacity_planning_cases = [
+        case for case in catalog_cases
+        if isinstance(case, dict) and case.get("taskID") == 72
+    ]
+    require(
+        len(capacity_planning_cases) == 1,
+        f"{label} multi-file catalogCases must include exactly one row #72 case",
+    )
+    validate_capacity_planning_case(capacity_planning_cases[0], label)
     return smoke
 
 
@@ -211,12 +230,56 @@ def validate_bulk_rename_case(case: dict[str, Any], label: str) -> None:
     require(not missing, f"{label} row #71 assertions were not all true: {missing}")
 
 
+def validate_capacity_planning_case(case: dict[str, Any], label: str) -> None:
+    require(case.get("prompt") == EXPECTED_CAPACITY_PLANNING_PROMPT, f"{label} row #72 prompt drifted")
+    require(
+        case.get("toolSequence") == [
+            "host.file.read",
+            "host.file.read",
+            "host.file.read",
+            "host.file.read",
+            "host.file.write",
+        ],
+        f"{label} row #72 tool sequence was {case.get('toolSequence')!r}",
+    )
+    source_paths = case.get("sourcePaths")
+    require(
+        isinstance(source_paths, list) and len(source_paths) == 4,
+        f"{label} row #72 sourcePaths was malformed: {source_paths!r}",
+    )
+    for expected_suffix in (
+        "allocations.csv",
+        "project-plans/project-atlas.md",
+        "project-plans/project-beacon.md",
+        "project-plans/project-comet.md",
+    ):
+        require(
+            any(isinstance(path, str) and path.endswith(expected_suffix) for path in source_paths),
+            f"{label} row #72 missed {expected_suffix}: {source_paths!r}",
+        )
+    deliverable_path = case.get("deliverablePath")
+    require(
+        isinstance(deliverable_path, str) and deliverable_path.endswith("capacity-rebalance.md"),
+        f"{label} row #72 deliverable path was malformed: {deliverable_path!r}",
+    )
+    final_answer = case.get("finalAnswer")
+    require(
+        isinstance(final_answer, str) and "Created `capacity-rebalance.md`" in final_answer,
+        f"{label} row #72 final answer was malformed: {final_answer!r}",
+    )
+    assertions = case.get("assertions")
+    require(isinstance(assertions, dict), f"{label} row #72 assertions must be an object")
+    missing = sorted(name for name in EXPECTED_CAPACITY_PLANNING_ASSERTIONS if assertions.get(name) is not True)
+    require(not missing, f"{label} row #72 assertions were not all true: {missing}")
+
+
 def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
     source_paths = smoke["sourcePaths"]
     catalog_cases = smoke["catalogCases"]
     all_hands_case = next(case for case in catalog_cases if case["taskID"] == 69)
     analyst_case = next(case for case in catalog_cases if case["taskID"] == 70)
     bulk_rename_case = next(case for case in catalog_cases if case["taskID"] == 71)
+    capacity_planning_case = next(case for case in catalog_cases if case["taskID"] == 72)
     return {
         "prompt": smoke["prompt"],
         "toolSequence": smoke["toolSequence"],
@@ -272,6 +335,22 @@ def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
                 "deliverablePathSuffix": "Documents/Invoices/invoice-rename-undo.csv",
                 "finalAnswer": bulk_rename_case["finalAnswer"],
                 "assertions": bulk_rename_case["assertions"],
+            },
+            {
+                "taskID": 72,
+                "prompt": capacity_planning_case["prompt"],
+                "toolSequence": capacity_planning_case["toolSequence"],
+                "sourcePathSuffixes": sorted(
+                    "allocations.csv"
+                    if str(path).endswith("allocations.csv")
+                    else str(path).split("project-plans/", 1)[-1]
+                    if "project-plans/" in str(path)
+                    else str(path)
+                    for path in capacity_planning_case["sourcePaths"]
+                ),
+                "deliverablePathSuffix": "capacity-rebalance.md",
+                "finalAnswer": capacity_planning_case["finalAnswer"],
+                "assertions": capacity_planning_case["assertions"],
             }
         ],
     }


### PR DESCRIPTION
## Summary
- Add coworker catalog row #72 Capacity Planning to packaged multi-file smoke
- Drive allocations.csv plus three project-plan reads before writing capacity-rebalance.md
- Extend multi-file and coworker coverage contracts to require catalogTaskIDs [69, 70, 71, 72]
- Update docs so deterministic coworker coverage advances through row #72

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/multi_file_artifact.py scripts/native_click_probe_contracts/coworker_catalog.py
- swift test --filter MockLLMClientMultiFileArtifactTests
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- git diff --check
- scripts/native-desktop-smoke.sh