### PR TITLE
Unattended runs must not dead-end: task-abandoning questions + headless approval gate

### DIFF
--- a/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
@@ -1,11 +1,71 @@
 import Foundation
 import QuillCodeCore
 
+/// Why a `.say` needs to be re-driven instead of ending the run. The two kinds have DIFFERENT
+/// failure semantics after the retry budget is spent, which is why this is a typed enum rather than
+/// a bool:
+/// - `.promisedWork` — the say claimed/started work it never did ("I'll run the tests", or a
+///   trailing-off "Step 3:" heading). If the model keeps doing this it is a hard failure — throw.
+/// - `.deferralToUser` — the say abandons a multi-step task by handing the next-action decision
+///   back to the user ("what would you like me to do next?"). Fatal for an UNATTENDED run, where
+///   nobody answers. But if, after being nudged to continue, the model still insists on asking, it
+///   probably genuinely needs input — so this is ALLOWED through rather than thrown.
+enum AgentSayCorrection: Sendable, Equatable {
+    case promisedWork
+    case deferralToUser
+
+    /// Only unmet promised work is a hard error; a persistent, specific question is legitimate.
+    var isHardFailure: Bool { self == .promisedWork }
+}
+
 enum AgentPromisedWorkGuard {
-    static func shouldRequestCorrection(for assistantText: String, tools: [ToolDefinition]) -> Bool {
-        guard !tools.isEmpty else { return false }
-        return promisesExecutableWork(assistantText) || endsWithUnfinishedNarration(assistantText)
+    /// The single classifier the resolver drives off of. `nil` = let the say end the run.
+    static func correctionNeeded(for assistantText: String, tools: [ToolDefinition]) -> AgentSayCorrection? {
+        guard !tools.isEmpty else { return nil }
+        if promisesExecutableWork(assistantText) || endsWithUnfinishedNarration(assistantText) {
+            return .promisedWork
+        }
+        if defersNextStepToUser(assistantText) {
+            return .deferralToUser
+        }
+        return nil
     }
+
+    static func shouldRequestCorrection(for assistantText: String, tools: [ToolDefinition]) -> Bool {
+        correctionNeeded(for: assistantText, tools: tools) != nil
+    }
+
+    /// A say that ABANDONS a multi-step task by asking the user to choose the next action —
+    /// "what would you like me to do next?", "how should I proceed?". In an unattended run this
+    /// stalls forever: no one answers.
+    ///
+    /// Deliberately high-precision to avoid re-driving a legitimately-finished task:
+    /// - Only strong "you choose my next step" interrogatives count. A polite completion closer
+    ///   ("let me know if you'd like anything else") is NOT here — that follows a finished task.
+    /// - `asksForPermission` ("should I delete…?") is a SPECIFIC confirmation the safety layer
+    ///   already gates; it is not a whole-task deferral and is intentionally excluded.
+    static func defersNextStepToUser(_ text: String) -> Bool {
+        let normalized = normalizedText(text)
+        return deferralPhrases.contains { normalized.contains($0) }
+    }
+
+    private static let deferralPhrases = [
+        "what would you like me to do next",
+        "what would you like me to do?",
+        "what do you want me to do next",
+        "what do you want me to do?",
+        "what should i do next",
+        "what would you like to do next",
+        "how would you like me to proceed",
+        "how would you like to proceed",
+        "how do you want me to proceed",
+        "how should i proceed",
+        "let me know how you'd like me to proceed",
+        "let me know how you would like me to proceed",
+        "let me know what you'd like me to do",
+        "let me know what you would like me to do",
+        "shall i proceed with"
+    ]
 
     static func shouldSuppressStreamingPreview(for assistantText: String) -> Bool {
         let normalized = normalizedText(assistantText)
@@ -15,7 +75,25 @@ enum AgentPromisedWorkGuard {
             || containsUnresolvedFutureWorkStarter(in: normalized)
     }
 
+    static func correctionPrompt(
+        for correction: AgentSayCorrection,
+        assistantText: String,
+        userMessage: String
+    ) -> String {
+        switch correction {
+        case .promisedWork:
+            return promisedWorkCorrectionPrompt(assistantText: assistantText, userMessage: userMessage)
+        case .deferralToUser:
+            return deferralCorrectionPrompt(assistantText: assistantText, userMessage: userMessage)
+        }
+    }
+
+    /// Back-compat overload for callers/tests that predate the typed correction.
     static func correctionPrompt(assistantText: String, userMessage: String) -> String {
+        promisedWorkCorrectionPrompt(assistantText: assistantText, userMessage: userMessage)
+    }
+
+    private static func promisedWorkCorrectionPrompt(assistantText: String, userMessage: String) -> String {
         """
         Your previous response promised to perform work but did not return a QuillCode tool action.
 
@@ -28,6 +106,26 @@ enum AgentPromisedWorkGuard {
         Return exactly one QuillCode JSON action now. If you intended to perform the promised work,
         return the appropriate {"type":"tool",...} action with complete arguments. If no tool is
         needed, return {"type":"say","text":"..."} with a direct final answer and no future-tense promise.
+        """
+    }
+
+    /// The nudge for a task-abandoning deferral. It does NOT scold; it re-establishes that the run
+    /// is autonomous and that continuing is the expectation. Crucially it leaves an escape hatch: a
+    /// GENUINE blocker, stated specifically, is allowed — which is how a real question survives the
+    /// retry (a specific blocker is not one of the deferral phrases, so it passes through).
+    private static func deferralCorrectionPrompt(assistantText: String, userMessage: String) -> String {
+        """
+        You asked what to do next, but you are running this task autonomously — the user is not
+        available to answer, so asking will stall the run. Do not ask the user to choose the next
+        step.
+
+        Original task:
+        \(userMessage)
+
+        Continue the task yourself using what you already know. Make a reasonable decision and act on
+        it. Only if a step is genuinely blocked — a required credential is missing, or an action is
+        destructive and truly needs confirmation — state the SPECIFIC blocker and exactly what you
+        tried. Otherwise return exactly one QuillCode JSON tool action that makes progress now.
         """
     }
 

--- a/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
@@ -12,22 +12,28 @@ extension AgentRunner {
         var retryThread = thread
         for _ in 0..<Self.promisedWorkCorrectionLimit {
             guard case .say(let text) = candidate,
-                  AgentPromisedWorkGuard.shouldRequestCorrection(for: text, tools: tools)
+                  let correction = AgentPromisedWorkGuard.correctionNeeded(for: text, tools: tools)
             else {
                 return candidate
             }
 
-            if let recovered = Self.recoveredPromisedWorkAction(from: text, tools: tools) {
-                return recovered
-            }
-            if let recovered = Self.recoveredPromisedUserIntentAction(
-                from: userMessage,
-                tools: tools
-            ) {
-                return recovered
+            // Local recovery only applies to promised work (an embedded tool action, or the
+            // immediate-action planner re-deriving the user's ask). A deferral has no embedded
+            // action to recover — it must be re-driven by the model.
+            if correction == .promisedWork {
+                if let recovered = Self.recoveredPromisedWorkAction(from: text, tools: tools) {
+                    return recovered
+                }
+                if let recovered = Self.recoveredPromisedUserIntentAction(
+                    from: userMessage,
+                    tools: tools
+                ) {
+                    return recovered
+                }
             }
 
             let correctionPrompt = AgentPromisedWorkGuard.correctionPrompt(
+                for: correction,
                 assistantText: text,
                 userMessage: userMessage
             )
@@ -41,8 +47,12 @@ extension AgentRunner {
             )
         }
 
+        // Budget spent. Only unmet promised work is a hard failure — a model that keeps ASKING
+        // (deferral) after being nudged to continue probably genuinely needs input, so that say is
+        // allowed through rather than turned into an error.
         if case .say(let text) = candidate,
-           AgentPromisedWorkGuard.shouldRequestCorrection(for: text, tools: tools) {
+           let correction = AgentPromisedWorkGuard.correctionNeeded(for: text, tools: tools),
+           correction.isHardFailure {
             throw AgentError.promisedWorkWithoutToolAction
         }
         return candidate

--- a/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
+++ b/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
@@ -107,12 +107,23 @@ public enum CLIRuntimeFactory {
             configuration: appConfig.skillConfiguration
         )
 
-        guard !request.ignoresPermissionRules else { return runner }
-        var gated = runner
-        gated.safety = PermissionRuleGatedSafetyReviewer(
-            base: runner.safety,
-            rules: PermissionRuleFileStore(directory: configuration.paths.permissionsDirectory)
-        )
-        return gated
+        if !request.ignoresPermissionRules {
+            runner.safety = PermissionRuleGatedSafetyReviewer(
+                base: runner.safety,
+                rules: PermissionRuleFileStore(directory: configuration.paths.permissionsDirectory)
+            )
+        }
+
+        // A headless exec run whose sandbox permits writes is autonomous — it is what --full-auto
+        // became. There is no human to answer an approval prompt, so a `.clarify` verdict must not
+        // dead-end the whole run at the first unrecognized-but-safe command (a plain `git clone` /
+        // `uv venv` during setup). This converts `.clarify` -> `.approve` while leaving hard-deny
+        // floors and the filesystem sandbox fully in force. Interactive runs are untouched: the
+        // human at the keyboard still gets the approval prompt.
+        if request.style == .exec,
+           request.sandbox == .workspaceWrite || request.sandbox == .dangerFullAccess {
+            runner.safety = AutonomousApprovalSafetyReviewer(base: runner.safety)
+        }
+        return runner
     }
 }

--- a/Sources/QuillCodeCore/ApprovalModels.swift
+++ b/Sources/QuillCodeCore/ApprovalModels.swift
@@ -122,6 +122,10 @@ public enum ApprovalReviewSource: String, Codable, Sendable, Hashable {
     case primaryModel = "primary_model"
     case fallbackModel = "fallback_model"
     case permissionRule = "permission_rule"
+    /// A headless autonomous run (--sandbox workspace-write/danger) turned a base reviewer's
+    /// `.clarify` into `.approve` because there is no human to answer. Hard-deny floors and the
+    /// filesystem sandbox are untouched; only the "ask a human" step is removed.
+    case autonomousOverride = "autonomous_override"
 }
 
 public enum ApprovalReviewFallbackReason: String, Codable, Sendable, Hashable {

--- a/Sources/QuillCodeSafety/AutonomousApprovalSafetyReviewer.swift
+++ b/Sources/QuillCodeSafety/AutonomousApprovalSafetyReviewer.swift
@@ -1,0 +1,43 @@
+import Foundation
+import QuillCodeCore
+
+/// Delivers the autonomous behavior a headless `--sandbox workspace-write` run is supposed to have
+/// (it is the flag that REPLACED `--full-auto`): a base reviewer's `.clarify` verdict — "I'm not
+/// sure this matches the request; ask the human" — becomes `.approve`, because in a headless run
+/// there is no human to ask.
+///
+/// Without this, an unattended run dead-ends on the first command the static policy does not
+/// recognize and the model reviewer is unsure about — a plain `git clone …` or `uv venv …` during
+/// task setup stalls the entire run at `approval_required`, which is exactly what broke coworker
+/// use case #1 (BFCL from scratch) after the deferral-stall fix let it get that far.
+///
+/// Safety boundary is unchanged: this NEVER converts `.deny`. The hard-deny floors (rm -rf,
+/// pipe-to-shell, sudo, system-path writes, secret reads) still block, and the workspace-write
+/// sandbox still confines filesystem writes. This only removes the "ask a human" step that has no
+/// answer in an autonomous run — it does not remove the "never do this" rules.
+///
+/// Applied ONLY to headless/exec runs whose sandbox is workspace-write or danger-full-access.
+/// Interactive runs keep their `.clarify` so the human at the keyboard can decide.
+public struct AutonomousApprovalSafetyReviewer: SafetyReviewer {
+    private let base: any SafetyReviewer
+
+    public init(base: any SafetyReviewer) {
+        self.base = base
+    }
+
+    public func review(_ context: SafetyContext) async -> SafetyReview {
+        let review = await base.review(context)
+        guard review.verdict == .clarify else { return review }
+
+        return SafetyReview(
+            verdict: .approve,
+            rationale: "Autonomous run: proceeding without a human approval step. "
+                + "Hard-deny rules and the workspace sandbox still apply. "
+                + "(Base reviewer said: \(review.rationale))",
+            reviewerModel: review.reviewerModel,
+            userIntentMatched: review.userIntentMatched,
+            riskLevel: review.riskLevel,
+            userAuthorization: review.userAuthorization
+        ).withReviewTelemetry(.init(source: .autonomousOverride))
+    }
+}

--- a/Tests/QuillCodeAgentTests/AgentDeferralContinuationTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentDeferralContinuationTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeSafety
+import QuillCodeTools
+@testable import QuillCodeAgent
+
+/// The unattended-stall fix, end to end. The live failure (BFCL setup): with real work remaining,
+/// the model emitted "…What would you like me to do next?" and, because a bare `.say` ends the run,
+/// the whole task stalled with nobody there to answer.
+///
+/// A run must NOT end on a task-abandoning deferral: it re-drives once, and if the model then makes
+/// progress the run continues to a real finish.
+final class AgentDeferralContinuationTests: XCTestCase {
+    func testRunReDrivesADeferralIntoProgressInsteadOfStalling() async throws {
+        let root = try makeTempDirectory()
+        let write = ToolCall(
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: ToolArguments.json(["path": "out.txt", "content": "done\n"])
+        )
+        // 1) deferral (must be re-driven), 2) the tool the model does after the nudge, 3) final say.
+        let runner = AgentRunner(llm: SequenceLLMClient(actions: [
+            .say("The venv is set up. What would you like me to do next — run the eval or something else?"),
+            .tool(write),
+            .say("Wrote out.txt.")
+        ]))
+
+        let result = try await runner.send(
+            "Set up the tool and write out.txt.",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        // The deferral did NOT terminate the run — the file got written and the run finished cleanly.
+        XCTAssertEqual(result.toolResults.count, 1)
+        XCTAssertTrue(result.toolResults.allSatisfy(\.ok))
+        XCTAssertEqual(
+            try String(contentsOf: root.appendingPathComponent("out.txt"), encoding: .utf8),
+            "done\n"
+        )
+        XCTAssertEqual(result.thread.messages.last?.content, "Wrote out.txt.")
+        // The stall message must not be what the run ended on.
+        XCTAssertFalse(result.thread.messages.last?.content.contains("What would you like me to do next") ?? false)
+    }
+
+    /// A model that keeps asking (genuinely wants input) is allowed through rather than looping or
+    /// erroring — the deferral is a soft correction, not a hard failure.
+    func testPersistentDeferralIsAllowedThroughNotThrown() async throws {
+        let root = try makeTempDirectory()
+        let runner = AgentRunner(llm: SequenceLLMClient(actions: [
+            .say("How would you like me to proceed?"),
+            .say("How would you like me to proceed?"),
+            .say("How would you like me to proceed?"),
+            .say("How would you like me to proceed?")
+        ]))
+
+        // Must not throw; the run ends with the (allowed) question rather than crashing.
+        let result = try await runner.send(
+            "Do the task.",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+        XCTAssertTrue(result.thread.messages.last?.content.contains("proceed") ?? false)
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-deferral-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
@@ -157,3 +157,62 @@ final class AgentPromisedWorkGuardTests: XCTestCase {
         ))
     }
 }
+
+extension AgentPromisedWorkGuardTests {
+    // MARK: - Task-abandoning deferral (the unattended-stall fix)
+
+    func testDetectsDeferralQuestions() {
+        let deferrals = [
+            "I'm ready to continue. Based on the context, we're working on the BFCL evaluation. What would you like me to do next — run a specific evaluation, analyze available models, or something else?",
+            "The venv is set up. What would you like me to do?",
+            "How would you like me to proceed?",
+            "How should I proceed with the remaining steps?",
+            "Let me know how you'd like me to proceed.",
+            "What should I do next?"
+        ]
+        for text in deferrals {
+            XCTAssertEqual(
+                AgentPromisedWorkGuard.correctionNeeded(for: text, tools: [.shellRun]),
+                .deferralToUser,
+                "should re-drive: \(text)"
+            )
+        }
+    }
+
+    func testPoliteCompletionCloserIsNotADeferral() {
+        let closers = [
+            "Done — I created report.md and verified its contents. Let me know if you'd like anything else.",
+            "All 42 tests pass. Is there anything else you need?",
+            "The summary is ready in findings.md."
+        ]
+        for text in closers {
+            XCTAssertNil(
+                AgentPromisedWorkGuard.correctionNeeded(for: text, tools: [.shellRun]),
+                "must not re-drive a finished task: \(text)"
+            )
+        }
+    }
+
+    func testSpecificPermissionQuestionIsNotAWholeTaskDeferral() {
+        XCTAssertNil(AgentPromisedWorkGuard.correctionNeeded(
+            for: "This will permanently delete 12 files. Should I proceed?",
+            tools: [.shellRun]
+        ))
+    }
+
+    func testDeferralIsNotAHardFailure() {
+        XCTAssertFalse(AgentSayCorrection.deferralToUser.isHardFailure)
+        XCTAssertTrue(AgentSayCorrection.promisedWork.isHardFailure)
+    }
+
+    func testDeferralCorrectionPromptTellsModelToContinueAutonomously() {
+        let prompt = AgentPromisedWorkGuard.correctionPrompt(
+            for: .deferralToUser,
+            assistantText: "What would you like me to do next?",
+            userMessage: "Set up BFCL and run a small eval."
+        )
+        XCTAssertTrue(prompt.contains("autonomously"))
+        XCTAssertTrue(prompt.lowercased().contains("do not ask the user"))
+        XCTAssertTrue(prompt.lowercased().contains("blocked"))
+    }
+}

--- a/Tests/QuillCodeSafetyTests/AutonomousApprovalSafetyReviewerTests.swift
+++ b/Tests/QuillCodeSafetyTests/AutonomousApprovalSafetyReviewerTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeSafety
+
+/// In a headless autonomous run (--sandbox workspace-write) there is no human to answer an approval
+/// prompt, so a `.clarify` must become `.approve` — otherwise the run dead-ends at the first
+/// unrecognized-but-safe setup command (a plain `git clone` / `uv venv`), which is what stalled
+/// coworker use case #1 after the deferral-stall fix let it get that far. The safety boundary is
+/// unchanged: `.deny` (hard-deny floors) is never converted.
+final class AutonomousApprovalSafetyReviewerTests: XCTestCase {
+    private struct FixedReviewer: SafetyReviewer {
+        let verdict: ApprovalVerdict
+        func review(_ context: SafetyContext) async -> SafetyReview {
+            SafetyReview(verdict: verdict, rationale: "base: \(verdict)")
+        }
+    }
+
+    private func context() -> SafetyContext {
+        SafetyContext(
+            mode: .auto,
+            userMessage: "set up the tool",
+            toolCall: ToolCall(name: "host.shell.run", argumentsJSON: #"{"cmd":"git clone https://x/y"}"#),
+            toolDefinition: nil,
+            recentMessages: []
+        )
+    }
+
+    func testClarifyBecomesApprove() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: FixedReviewer(verdict: .clarify))
+        let review = await reviewer.review(context())
+        XCTAssertEqual(review.verdict, .approve)
+        // Telemetry is honest about why it was approved.
+        XCTAssertEqual(review.reviewTelemetry?.source, .autonomousOverride)
+        // The base reviewer's reasoning is preserved for the audit trail.
+        XCTAssertTrue(review.rationale.contains("base: clarify"))
+    }
+
+    func testDenyIsNeverConverted() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: FixedReviewer(verdict: .deny))
+        let review = await reviewer.review(context())
+        XCTAssertEqual(review.verdict, .deny, "hard-deny floors must still block in autonomous mode")
+    }
+
+    func testApproveIsPassedThroughUnchanged() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: FixedReviewer(verdict: .approve))
+        let review = await reviewer.review(context())
+        XCTAssertEqual(review.verdict, .approve)
+        // An already-approved review is not re-stamped as an autonomous override.
+        XCTAssertNotEqual(review.reviewTelemetry?.source, .autonomousOverride)
+    }
+
+    /// End-to-end with the real static policy: a hard-denied command stays denied even under the
+    /// autonomous wrapper (defense-in-depth, not just the fixture).
+    func testRealHardDenyStaysDeniedUnderAutonomousWrapper() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: StaticSafetyReviewer())
+        let ctx = SafetyContext(
+            mode: .auto,
+            userMessage: "clean up",
+            toolCall: ToolCall(name: "host.shell.run", argumentsJSON: #"{"cmd":"rm -rf /"}"#),
+            toolDefinition: nil,
+            recentMessages: []
+        )
+        let review = await reviewer.review(ctx)
+        XCTAssertEqual(review.verdict, .deny)
+    }
+}


### PR DESCRIPTION
Two root causes, both found driving coworker use case #1 (set up BFCL from scratch), both making an unattended run **dead-end with work remaining**. Same theme, shipped together.

## 1. Task-abandoning question ends the run

With real work left, the model emitted *"…What would you like me to do next?"* and the run stalled — the loop treats **any** `.say` as terminal, and headless has no one to answer. Fix: `AgentPromisedWorkGuard` classifies a `.say` into a typed `AgentSayCorrection` (`.promisedWork` | `.deferralToUser`); a deferral is **re-driven** with a "continue autonomously" nudge (escape hatch: a *specific* blocker passes through). Unmet promised work still throws if persistent; a persistent *specific* question is allowed.

## 2. Headless approval gate has no one to approve

After #1 let it get further, the run stopped at `approval_required` on a setup `host.shell.run` (the `git clone` / `uv venv`). `--sandbox workspace-write` maps to `.auto`, and a safety `.clarify` there becomes `approval_required` — a dead end with no human. But `workspace-write` is the flag that **replaced `--full-auto`**, so it's supposed to be autonomous. Fix: `AutonomousApprovalSafetyReviewer` converts `.clarify`→`.approve` **only** for exec runs with a write-permitting sandbox. It **never** converts `.deny` — hard-deny floors and the filesystem sandbox stay fully in force; only the "ask a human" step is removed. Telemetry records an `autonomous_override` source.

## Verified live

On the fixed build, the same BFCL setup no longer hits **either** dead-end: `stall=0`, `approval_required=0`, and the clone/venv shell commands actually run (succeeding or failing on their own merits) instead of halting the task. This is the exact task that once **fabricated** a fake score; earlier fixes stopped the fabrication (31 real calls, nothing invented), and these two let it *keep going* unattended.

## Tests

24 total: deferral re-drives / closers & permission-confirms don't / scripted deferral→tool→done writes the file / persistent deferral allowed; clarify→approve, deny preserved, approve passthrough, real `rm -rf /` stays denied under the wrapper. Full agent suite green (522); safety suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)