### PR TITLE
Guard: re-drive on readiness-declaration and "Let's …" stalls

### DIFF
--- a/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkGuard.swift
@@ -134,7 +134,40 @@ enum AgentPromisedWorkGuard {
         guard canContainActionablePromise(normalized) else { return false }
 
         return containsFutureWorkPhrase(in: normalized)
+            || declaresReadinessToProceed(in: normalized)
     }
+
+    /// A say that ENDS the turn by announcing the model is ABOUT to work rather than working — the
+    /// verbose-planner stall a fast orchestrator falls into: after exploring the repo it wrote
+    /// "I am fully prepared to proceed with the execution steps" and stopped, with no tool call.
+    /// No "I'll…"/"Let's…" starter appears, so the promise lexicon misses it; the signal is the
+    /// readiness-to-<act> phrase itself.
+    ///
+    /// Matched on the "ready/prepared/about + to + <act>" shape, so "the report is ready to send"
+    /// (a completed result) does NOT fire — only readiness to PROCEED / BEGIN / EXECUTE / RUN /
+    /// START / CONTINUE the task does.
+    private static func declaresReadinessToProceed(in normalizedText: String) -> Bool {
+        readinessToProceedPhrases.contains { normalizedText.contains($0) }
+    }
+
+    private static let readinessToProceedPhrases = [
+        "ready to proceed",
+        "prepared to proceed",
+        "ready to begin",
+        "prepared to begin",
+        "ready to execute",
+        "ready to run the",
+        "ready to start",
+        "ready to continue",
+        "about to proceed",
+        "about to begin",
+        "about to run the",
+        "will now proceed",
+        "will now begin",
+        "will now execute",
+        "proceeding to run",
+        "proceeding to execute"
+    ]
 
     // MARK: - Trailing-off narration (structural, no first-person phrase required)
 
@@ -274,7 +307,12 @@ enum AgentPromisedWorkGuard {
         "i will",
         "i'm going to",
         "i am going to",
-        "let me"
+        "let me",
+        // Collaborative framing is the same stall in a different voice: "Let's design and run the
+        // evaluation…" is a promise of work with no tool action. The trailing work-verb requirement
+        // (containsWorkVerb) keeps a bare "Let's see …" final answer from firing.
+        "let's",
+        "let us"
     ]
 
     private static let unresolvedStarterPreviewCharacterLimit = 8

--- a/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentPromisedWorkGuardTests.swift
@@ -216,3 +216,59 @@ extension AgentPromisedWorkGuardTests {
         XCTAssertTrue(prompt.lowercased().contains("blocked"))
     }
 }
+
+extension AgentPromisedWorkGuardTests {
+    // MARK: - "Let's …" + readiness-to-proceed (the gemini verbose-planner stalls)
+
+    func testDetectsLetsWorkPromise() {
+        XCTAssertEqual(
+            AgentPromisedWorkGuard.correctionNeeded(
+                for: "I verified the catalog. Let's design and run a budget-friendly evaluation within the $5 ceiling.",
+                tools: [.shellRun]
+            ),
+            .promisedWork
+        )
+    }
+
+    func testLetsWithoutWorkVerbIsNotAPromise() {
+        // The work-verb gate: "Let's see …" is a final answer, not a promise to do work.
+        XCTAssertNil(
+            AgentPromisedWorkGuard.correctionNeeded(
+                for: "Let's see — the totals reconcile, so the ledger is balanced.",
+                tools: [.shellRun]
+            )
+        )
+    }
+
+    func testDetectsReadinessToProceedDeclaration() {
+        // The exact live gem3 stall: explored everything, then declared readiness with no action.
+        let readiness = [
+            "I have reviewed the handlers and configs. I am fully prepared to proceed with the execution steps under the $5 ceiling.",
+            "The environment is set up. I am ready to proceed.",
+            "I will now proceed to run the evaluation.",
+            "Ready to begin the benchmark."
+        ]
+        for text in readiness {
+            XCTAssertEqual(
+                AgentPromisedWorkGuard.correctionNeeded(for: text, tools: [.shellRun]),
+                .promisedWork,
+                "readiness declaration should re-drive: \(text)"
+            )
+        }
+    }
+
+    func testCompletedResultReadyIsNotAReadinessStall() {
+        // "X is ready" (a finished artifact) must NOT fire — only "ready to <proceed/begin/...>".
+        let closers = [
+            "The report is ready to send whenever you are.",
+            "Your cleaned CSV is ready in output.csv.",
+            "Done — the summary is ready."
+        ]
+        for text in closers {
+            XCTAssertNil(
+                AgentPromisedWorkGuard.correctionNeeded(for: text, tools: [.shellRun]),
+                "a finished-artifact 'ready' must not re-drive: \(text)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Two more masks of the same unattended-run dead-end

Both surfaced live while driving a fast orchestrator (gemini-3.5-flash) through the BFCL-from-scratch coworker task. Each is a `.say` that **ends the turn announcing work instead of doing it** — the guard should re-drive, not stop.

**1. Readiness declaration.** After exploring the repo the model wrote *"I am fully prepared to proceed with the execution steps"* and stopped, no tool call. No `I'll…`/`Let me…` starter, so the promise lexicon missed it. Added `declaresReadinessToProceed` matching the **"ready/prepared/about + to + proceed/begin/execute/run/start/continue"** shape — so a completed-artifact *"the report is ready to send"* does **not** fire.

**2. Collaborative framing.** *"Let's design and run the evaluation…"* is the same promise in a different voice. Added `let's`/`let us` to the future-work starters; the existing trailing **work-verb gate** keeps *"Let's see — the totals reconcile"* (a final answer) from firing.

## Tests
+3 cases: readiness declarations and `Let's <verb>` re-drive (`.promisedWork`); finished-artifact "ready" and verb-less "Let's see" return nil. **22/22** guard tests green.

Continues the stall-shape series (#1538 deferral + autonomous-approval). Supersedes the "let's"-only #1539.