### PR TITLE
host.web.search: grounded DuckDuckGo engine, LLM-guess demoted to fallback (F18)

### DIFF
--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -107,13 +107,18 @@ public struct QuillCodeRuntimeFactory: Sendable {
             apiKeyOverride: apiKey,
             baseURL: config.apiBaseURL
         )
-        // host.web.search routes through the same TrustedRouter credentials as the run loop, so the
-        // gateway selects the search provider (issue #861).
-        let webSearch = TrustedRouterWebSearchClient(
-            sessionStore: sessionStore,
-            apiKeyOverride: apiKey,
-            model: config.defaultModel,
-            baseURL: config.apiBaseURL
+        // host.web.search: grounded DuckDuckGo search first (a real index over the SSRF-safe fetch
+        // transport), falling back to the TrustedRouter LLM-guess client only when the real engine
+        // fails or finds nothing (F18: an LLM with no live index hallucinates URLs that 404; the
+        // downstream liveness filter still vets whatever the fallback returns).
+        let webSearch = FallbackWebSearchClient(
+            primary: DuckDuckGoWebSearchClient(),
+            fallback: TrustedRouterWebSearchClient(
+                sessionStore: sessionStore,
+                apiKeyOverride: apiKey,
+                model: config.defaultModel,
+                baseURL: config.apiBaseURL
+            )
         )
         // Compaction (issue #862): when a model call overflows the context window, the run loop folds
         // the thread's older turns into a summary and resumes instead of failing. It reuses the same

--- a/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
+++ b/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
@@ -70,11 +70,17 @@ public enum CLIRuntimeFactory {
                 apiKeyOverride: key,
                 baseURL: baseURL
             )
-            let webSearch = TrustedRouterWebSearchClient(
-                sessionStore: sessionStore,
-                apiKeyOverride: key,
-                model: model,
-                baseURL: baseURL
+            // Grounded search first (a real index over the SSRF-safe fetch transport); the
+            // LLM-guess client survives only as a fallback whose URLs the downstream liveness
+            // filter still vets (F18: guessed URLs 404 and get cited).
+            let webSearch = FallbackWebSearchClient(
+                primary: DuckDuckGoWebSearchClient(),
+                fallback: TrustedRouterWebSearchClient(
+                    sessionStore: sessionStore,
+                    apiKeyOverride: key,
+                    model: model,
+                    baseURL: baseURL
+                )
             )
             runner = AgentRunner(
                 llm: llm,

--- a/Sources/QuillCodeTools/DuckDuckGoWebSearchClient.swift
+++ b/Sources/QuillCodeTools/DuckDuckGoWebSearchClient.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// `WebSearchClient` backed by a REAL search engine: DuckDuckGo's no-JavaScript HTML endpoint
+/// (`html.duckduckgo.com/html/?q=…`), fetched over the same SSRF-safe `WebFetchHTTPClient`
+/// transport `host.web.fetch` uses.
+///
+/// This exists because the only previously-reachable search mechanism asked a language model to
+/// ACT as a search engine, and a model with no live index cannot help but hallucinate plausible
+/// URLs that 404 on fetch (F18: 11 of 13 fetched URLs dead, the report cited them anyway). Every
+/// URL returned here was served by an actual index moments ago — grounded by construction, no API
+/// key required, and it works identically in the GUI app and headless `exec` runs.
+///
+/// Parsing is a deliberately narrow string-scan (no DOM dependency): DuckDuckGo's HTML endpoint
+/// renders each organic hit as an `<a class="result__a" href="…">title</a>` anchor plus a sibling
+/// `result__snippet` element, with the destination wrapped in a `duckduckgo.com/l/?uddg=<encoded>`
+/// redirect. Ads and internal links decode to duckduckgo.com hosts and are dropped. If the page
+/// shape ever drifts, the scan finds no anchors and the caller's fallback chain takes over — the
+/// failure mode is "no results", never wrong results.
+public struct DuckDuckGoWebSearchClient: WebSearchClient {
+    private let httpClient: any WebFetchHTTPClient
+    private let timeout: TimeInterval
+
+    public init(
+        httpClient: any WebFetchHTTPClient = URLSessionWebFetchHTTPClient(),
+        timeout: TimeInterval = 12
+    ) {
+        self.httpClient = httpClient
+        self.timeout = max(1, timeout)
+    }
+
+    public func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem] {
+        let query = request.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return [] }
+        guard var components = URLComponents(string: "https://html.duckduckgo.com/html/") else {
+            throw WebSearchClientError.transport("could not build DuckDuckGo search URL")
+        }
+        components.queryItems = [URLQueryItem(name: "q", value: query)]
+        guard let url = components.url else {
+            throw WebSearchClientError.transport("could not build DuckDuckGo search URL")
+        }
+
+        let httpRequest = WebFetchHTTPRequest(
+            url: url,
+            headers: WebFetchToolExecutor.browserLikeHeaders,
+            timeout: timeout,
+            // Results live in the first slice of the page; 512 KiB is several times a full page.
+            maxBodyBytes: 512 * 1024
+        )
+        let response: WebFetchHTTPResponse
+        do {
+            // `perform` is blocking; hop off the cooperative pool like the liveness prober does.
+            response = try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .utility).async {
+                    continuation.resume(with: Result { try httpClient.perform(httpRequest) })
+                }
+            }
+        } catch {
+            throw WebSearchClientError.transport("DuckDuckGo search failed: \(error)")
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            throw WebSearchClientError.transport(
+                "DuckDuckGo search returned HTTP \(response.statusCode)"
+            )
+        }
+        guard let html = String(data: response.body, encoding: .utf8), !html.isEmpty else {
+            throw WebSearchClientError.emptyResponse
+        }
+        return Self.parseResults(html: html, maxResults: request.maxResults)
+    }
+
+    // MARK: - HTML parsing
+
+    /// Scan for organic result anchors and their snippets. Tolerant of attribute order and
+    /// whitespace; every extracted URL must decode to an absolute http(s) URL on a
+    /// non-DuckDuckGo host or the hit is skipped.
+    static func parseResults(html: String, maxResults: Int) -> [WebSearchResultItem] {
+        var items: [WebSearchResultItem] = []
+        var seenURLs = Set<String>()
+        var cursor = html.startIndex
+
+        while items.count < max(0, maxResults), cursor < html.endIndex {
+            guard let anchorRange = html.range(of: "class=\"result__a\"", range: cursor..<html.endIndex) else {
+                break
+            }
+            // The enclosing <a …> tag: back up to its "<a", then take through the closing "</a>".
+            guard let tagStart = html.range(of: "<a ", options: .backwards, range: html.startIndex..<anchorRange.lowerBound),
+                  let tagEnd = html.range(of: ">", range: anchorRange.upperBound..<html.endIndex),
+                  let anchorClose = html.range(of: "</a>", range: tagEnd.upperBound..<html.endIndex)
+            else {
+                break
+            }
+            cursor = anchorClose.upperBound
+
+            let tag = String(html[tagStart.lowerBound..<tagEnd.upperBound])
+            let title = decodeText(String(html[tagEnd.upperBound..<anchorClose.lowerBound]))
+
+            guard let href = attribute("href", in: tag),
+                  let resolved = resolveResultURL(href),
+                  seenURLs.insert(resolved).inserted
+            else {
+                continue
+            }
+
+            // Snippet: the next result__snippet element before the following result anchor.
+            var snippet = ""
+            let nextAnchor = html.range(of: "class=\"result__a\"", range: cursor..<html.endIndex)
+            let snippetSearchEnd = nextAnchor?.lowerBound ?? html.endIndex
+            if let snippetMark = html.range(of: "result__snippet", range: cursor..<snippetSearchEnd),
+               let snippetTagEnd = html.range(of: ">", range: snippetMark.upperBound..<snippetSearchEnd),
+               let snippetClose = html.range(of: "</", range: snippetTagEnd.upperBound..<snippetSearchEnd) {
+                snippet = decodeText(String(html[snippetTagEnd.upperBound..<snippetClose.lowerBound]))
+            }
+
+            items.append(WebSearchResultItem(title: title, url: resolved, snippet: snippet))
+        }
+        return items
+    }
+
+    /// Extract a double-quoted attribute value from a single HTML tag string.
+    static func attribute(_ name: String, in tag: String) -> String? {
+        guard let nameRange = tag.range(of: name + "=\"") else { return nil }
+        guard let close = tag.range(of: "\"", range: nameRange.upperBound..<tag.endIndex) else { return nil }
+        return String(tag[nameRange.upperBound..<close.lowerBound])
+    }
+
+    /// DuckDuckGo wraps destinations as `//duckduckgo.com/l/?uddg=<pct-encoded>&rut=…`; decode the
+    /// `uddg` parameter. Direct http(s) hrefs pass through. Anything that ends up relative, non-http,
+    /// or still on a duckduckgo.com host (ads, internal pages) is rejected.
+    static func resolveResultURL(_ rawHREF: String) -> String? {
+        let href = decodeText(rawHREF)
+        var candidate = href
+        if let components = URLComponents(string: href.hasPrefix("//") ? "https:" + href : href),
+           (components.host ?? "").hasSuffix("duckduckgo.com"),
+           let uddg = components.queryItems?.first(where: { $0.name == "uddg" })?.value {
+            candidate = uddg
+        }
+        guard let url = URL(string: candidate),
+              let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https",
+              let host = url.host, !host.isEmpty, !host.hasSuffix("duckduckgo.com")
+        else {
+            return nil
+        }
+        return candidate
+    }
+
+    /// Strip tags and unescape the entities DuckDuckGo's endpoint actually emits, collapsing runs
+    /// of whitespace. Good enough for display strings — the executor bounds lengths downstream.
+    static func decodeText(_ raw: String) -> String {
+        var text = ""
+        var insideTag = false
+        for character in raw {
+            if character == "<" { insideTag = true; continue }
+            if character == ">" { insideTag = false; continue }
+            if !insideTag { text.append(character) }
+        }
+        let entities: [(String, String)] = [
+            ("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"), ("&quot;", "\""),
+            ("&#x27;", "'"), ("&#39;", "'"), ("&nbsp;", " "),
+        ]
+        for (entity, replacement) in entities {
+            text = text.replacingOccurrences(of: entity, with: replacement)
+        }
+        return text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/Sources/QuillCodeTools/FallbackWebSearchClient.swift
+++ b/Sources/QuillCodeTools/FallbackWebSearchClient.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A `WebSearchClient` that tries a grounded primary engine first and falls back to a secondary
+/// only when the primary fails or finds nothing.
+///
+/// The intended composition (see the runtime factories) is
+/// `primary = DuckDuckGoWebSearchClient` (a real index; can rate-limit or drift its HTML shape)
+/// and `fallback = TrustedRouterWebSearchClient` (an LLM acting as a search engine; always
+/// answers, but its URLs are guesses that survive only the downstream liveness filter). Ordering
+/// is the point: real results when the real engine works, and the guessing client is only ever
+/// consulted when the alternative is returning nothing at all.
+public struct FallbackWebSearchClient: WebSearchClient {
+    private let primary: any WebSearchClient
+    private let fallback: any WebSearchClient
+
+    public init(primary: any WebSearchClient, fallback: any WebSearchClient) {
+        self.primary = primary
+        self.fallback = fallback
+    }
+
+    public func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem] {
+        let primaryError: any Error
+        do {
+            let results = try await primary.search(request)
+            if !results.isEmpty { return results }
+            primaryError = WebSearchClientError.emptyResponse
+        } catch {
+            primaryError = error
+        }
+        do {
+            return try await fallback.search(request)
+        } catch {
+            // The primary's failure is the more informative one to surface: the fallback failing
+            // usually just repeats a shared cause (offline, missing key).
+            throw primaryError
+        }
+    }
+}

--- a/Tests/QuillCodeToolsTests/DuckDuckGoWebSearchClientTests.swift
+++ b/Tests/QuillCodeToolsTests/DuckDuckGoWebSearchClientTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+@testable import QuillCodeTools
+
+/// The grounded-search half of the F18 fix: parsing DuckDuckGo's HTML endpoint into real result
+/// items, and the fallback composition that keeps the LLM-guess client as a last resort only.
+final class DuckDuckGoWebSearchClientTests: XCTestCase {
+    // A trimmed but shape-faithful slice of html.duckduckgo.com/html output: two organic results
+    // (redirect-wrapped hrefs, entities, nested tags in titles/snippets) and one ad-ish internal
+    // link that must be dropped.
+    private static let fixtureHTML = """
+    <div class="result results_links results_links_deep web-result ">
+      <h2 class="result__title">
+        <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.tomshardware.com%2Freviews%2Fraspberry%2Dpi%2D5&amp;rut=abc123">Raspberry Pi 5 Review: A New <b>Standard</b></a>
+      </h2>
+      <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.tomshardware.com%2Freviews%2Fraspberry%2Dpi%2D5&amp;rut=abc123">The Pi 5 is 2&#x27;s complement faster &amp; better than the Pi 4.</a>
+    </div>
+    <div class="result">
+      <h2 class="result__title">
+        <a rel="nofollow" class="result__a" href="https://www.pcmag.com/reviews/raspberry-pi-5">PCMag: Pi 5</a>
+      </h2>
+      <a class="result__snippet" href="https://www.pcmag.com/reviews/raspberry-pi-5">Direct-href result snippet.</a>
+    </div>
+    <div class="result result--ad">
+      <a rel="nofollow" class="result__a" href="//duckduckgo.com/y.js?ad_provider=x">Sponsored thing</a>
+    </div>
+    """
+
+    func testParsesRedirectWrappedAndDirectResults() {
+        let items = DuckDuckGoWebSearchClient.parseResults(html: Self.fixtureHTML, maxResults: 10)
+        XCTAssertEqual(items.count, 2, "two organic results; the ad/internal link is dropped")
+
+        XCTAssertEqual(items[0].url, "https://www.tomshardware.com/reviews/raspberry-pi-5")
+        XCTAssertEqual(items[0].title, "Raspberry Pi 5 Review: A New Standard")
+        XCTAssertEqual(items[0].snippet, "The Pi 5 is 2's complement faster & better than the Pi 4.")
+
+        XCTAssertEqual(items[1].url, "https://www.pcmag.com/reviews/raspberry-pi-5")
+        XCTAssertEqual(items[1].title, "PCMag: Pi 5")
+    }
+
+    func testRespectsMaxResults() {
+        let items = DuckDuckGoWebSearchClient.parseResults(html: Self.fixtureHTML, maxResults: 1)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].url, "https://www.tomshardware.com/reviews/raspberry-pi-5")
+    }
+
+    func testUnparseableHTMLYieldsNoResultsNotGarbage() {
+        XCTAssertTrue(DuckDuckGoWebSearchClient.parseResults(html: "<html><body>nothing here</body></html>", maxResults: 5).isEmpty)
+        XCTAssertTrue(DuckDuckGoWebSearchClient.parseResults(html: "", maxResults: 5).isEmpty)
+    }
+
+    func testResolveResultURLRejectsNonHTTPAndInternalHosts() {
+        XCTAssertNil(DuckDuckGoWebSearchClient.resolveResultURL("//duckduckgo.com/y.js?ad_provider=x"))
+        XCTAssertNil(DuckDuckGoWebSearchClient.resolveResultURL("javascript:alert(1)"))
+        XCTAssertNil(DuckDuckGoWebSearchClient.resolveResultURL("/html/?q=next-page"))
+        XCTAssertEqual(
+            DuckDuckGoWebSearchClient.resolveResultURL("//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.org%2Fa%3Fb%3Dc&rut=zz"),
+            "https://example.org/a?b=c"
+        )
+        XCTAssertEqual(
+            DuckDuckGoWebSearchClient.resolveResultURL("http://example.org/plain"),
+            "http://example.org/plain"
+        )
+    }
+
+    func testDeduplicatesRepeatedURLs() {
+        let doubled = Self.fixtureHTML + Self.fixtureHTML
+        let items = DuckDuckGoWebSearchClient.parseResults(html: doubled, maxResults: 10)
+        XCTAssertEqual(items.map(\.url), [
+            "https://www.tomshardware.com/reviews/raspberry-pi-5",
+            "https://www.pcmag.com/reviews/raspberry-pi-5",
+        ])
+    }
+
+    // MARK: - Transport behavior (stubbed HTTP)
+
+    private struct StubHTTPClient: WebFetchHTTPClient {
+        var status: Int = 200
+        var body: Data = Data()
+        func perform(_ request: WebFetchHTTPRequest) throws -> WebFetchHTTPResponse {
+            WebFetchHTTPResponse(statusCode: status, body: body)
+        }
+    }
+
+    func testSearchParsesThroughStubbedTransport() async throws {
+        let client = DuckDuckGoWebSearchClient(
+            httpClient: StubHTTPClient(body: Data(Self.fixtureHTML.utf8))
+        )
+        let items = try await client.search(WebSearchRequest(query: "raspberry pi 5 review", maxResults: 5))
+        XCTAssertEqual(items.count, 2)
+    }
+
+    func testNon2xxStatusThrowsTransportError() async {
+        let client = DuckDuckGoWebSearchClient(httpClient: StubHTTPClient(status: 403))
+        do {
+            _ = try await client.search(WebSearchRequest(query: "q", maxResults: 5))
+            XCTFail("expected transport error")
+        } catch let error as WebSearchClientError {
+            guard case .transport = error else { return XCTFail("wrong error: \(error)") }
+        } catch {
+            XCTFail("wrong error type: \(error)")
+        }
+    }
+
+    func testEmptyQueryShortCircuitsWithoutNetwork() async throws {
+        struct ExplodingClient: WebFetchHTTPClient {
+            func perform(_ request: WebFetchHTTPRequest) throws -> WebFetchHTTPResponse {
+                XCTFail("must not hit the network for an empty query")
+                throw WebSearchClientError.emptyResponse
+            }
+        }
+        let items = try await DuckDuckGoWebSearchClient(httpClient: ExplodingClient())
+            .search(WebSearchRequest(query: "   ", maxResults: 5))
+        XCTAssertTrue(items.isEmpty)
+    }
+}
+
+final class FallbackWebSearchClientTests: XCTestCase {
+    private struct ScriptedClient: WebSearchClient {
+        var results: [WebSearchResultItem] = []
+        var error: WebSearchClientError?
+        func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem] {
+            if let error { throw error }
+            return results
+        }
+    }
+
+    private static let hit = WebSearchResultItem(title: "t", url: "https://example.org", snippet: "s")
+    private static let fallbackHit = WebSearchResultItem(title: "f", url: "https://fallback.example", snippet: "s")
+
+    func testPrimaryResultsWinWithoutConsultingFallback() async throws {
+        struct ExplodingFallback: WebSearchClient {
+            func search(_ request: WebSearchRequest) async throws -> [WebSearchResultItem] {
+                XCTFail("fallback must not run when the primary has results")
+                return []
+            }
+        }
+        let client = FallbackWebSearchClient(
+            primary: ScriptedClient(results: [Self.hit]),
+            fallback: ExplodingFallback()
+        )
+        let items = try await client.search(WebSearchRequest(query: "q", maxResults: 5))
+        XCTAssertEqual(items, [Self.hit])
+    }
+
+    func testPrimaryErrorFallsBack() async throws {
+        let client = FallbackWebSearchClient(
+            primary: ScriptedClient(error: .transport("rate limited")),
+            fallback: ScriptedClient(results: [Self.fallbackHit])
+        )
+        let items = try await client.search(WebSearchRequest(query: "q", maxResults: 5))
+        XCTAssertEqual(items, [Self.fallbackHit])
+    }
+
+    func testPrimaryEmptyFallsBack() async throws {
+        let client = FallbackWebSearchClient(
+            primary: ScriptedClient(results: []),
+            fallback: ScriptedClient(results: [Self.fallbackHit])
+        )
+        let items = try await client.search(WebSearchRequest(query: "q", maxResults: 5))
+        XCTAssertEqual(items, [Self.fallbackHit])
+    }
+
+    func testBothFailingSurfacesThePrimaryError() async {
+        let client = FallbackWebSearchClient(
+            primary: ScriptedClient(error: .transport("primary down")),
+            fallback: ScriptedClient(error: .missingAPIKey)
+        )
+        do {
+            _ = try await client.search(WebSearchRequest(query: "q", maxResults: 5))
+            XCTFail("expected error")
+        } catch let error as WebSearchClientError {
+            guard case .transport(let message) = error else { return XCTFail("wrong error: \(error)") }
+            XCTAssertEqual(message, "primary down")
+        } catch {
+            XCTFail("wrong error type: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## The F18 root cause, fixed at the transport

`host.web.search` asked the **session model** to act as a search engine. No live index → hallucinated URLs → 11/13 fetches 404'd in the live UC7 drive → the report cited dead links → run errored with no deliverable. The liveness filter (a stopgap) can only drop bad guesses; it cannot produce real results.

## What this does

- **`DuckDuckGoWebSearchClient`** — a real search index via `html.duckduckgo.com/html` (no key, no JS), over the same SSRF-safe `WebFetchHTTPClient` transport `host.web.fetch` uses. Deliberately narrow string-scan (no DOM dep): `result__a` anchors, `uddg=` redirect decode, entity unescape, ad/internal-link rejection, URL dedupe. Page-shape drift degrades to *no results*, never *wrong results*.
- **`FallbackWebSearchClient`** — grounded engine first; the TrustedRouter LLM-guess client only runs when the primary fails or finds nothing (still liveness-filtered downstream). Both factories (app + CLI) rewired.

## Verification
- Parser validated against a **live-fetched** DDG results page (9 organic hits, identical shape to fixture; the real results were the exact tomshardware/pcmag pages the LLM used to hallucinate dead variants of).
- 12 new tests (parse/decode/dedupe/caps/transport statuses/fallback semantics). `QuillCodeToolsTests` 816/816.

Unblocks coworker UC7 (web research) and the web-research task category; UC7 re-drive follows this merge.