### PR TITLE
Prompt: drafted communications must never assert unverified system facts (F19)

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -119,6 +119,13 @@ public struct TrustedRouterPromptBuilder: Sendable {
     error, a 404, or you never fetched it, do not cite that URL — find a working source or state \
     plainly that the claim is unverified. Every price, wattage, benchmark, or figure must trace to a \
     page you actually opened.
+    Drafted communications (emails, replies, notices) — never assert facts you did not verify:
+    - A draft that claims "I checked the logs", "your data is safe", "your account shows X", or any \
+    other account/system-specific fact is honest only if a tool call in THIS run verified it. In a \
+    draft someone may send verbatim, an invented reassurance becomes a lie to a customer.
+    - When you cannot verify, write the draft with a bracketed placeholder \
+    ("[engineering to confirm: project recoverable?]") or phrase it as intent \
+    ("I'm escalating this to engineering to check") — never as an already-established fact.
     """
 
     public static func systemPrompt(tools: [ToolDefinition]) -> String {

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -261,6 +261,19 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         )
     }
 
+    func testPromptForbidsInventedFactsInDraftedCommunications() {
+        // Live UC-24 finding: an angry-customer draft asserted "I've checked the recent logs …
+        // the project still exists" with zero tool calls behind it — an invented reassurance a
+        // human might send verbatim. Drafts must verify or use placeholders/intent phrasing.
+        let prompt = TrustedRouterPromptBuilder.systemPrompt(tools: [.shellRun, .fileWrite])
+
+        XCTAssertTrue(prompt.contains("Drafted communications"))
+        XCTAssertTrue(prompt.contains("never assert facts you did not verify"))
+        XCTAssertTrue(prompt.contains("an invented reassurance becomes a lie to a customer"))
+        XCTAssertTrue(prompt.contains("bracketed placeholder"))
+        XCTAssertTrue(prompt.contains("never as an already-established fact"))
+    }
+
     func testPromptPrefersStructuredGitBranchToolsOverShell() {
         let prompt = TrustedRouterPromptBuilder.systemPrompt(tools: [
             .shellRun,


### PR DESCRIPTION
## Live finding (coworker catalog row #24)

Support-reply drafting on dsv4-pro: 11/12 replies fully tone-compliant, but the angry-customer draft asserted *"I've checked the recent logs for your account and I can see the project still exists on our side"* — **zero tool calls behind it**. In a draft a human might send verbatim, an invented reassurance becomes a lie to a customer. Same fabrication failure mode as eval-result invention (RunIntegrity 2b/2c), surfacing in prose deliverables.

## Fix

Compact "Drafted communications" rule appended to the execution-integrity guidance block: account/system-specific claims in drafts are honest only when a tool call in this run verified them; otherwise bracketed placeholder (`[engineering to confirm: …]`) or intent phrasing — never an already-established fact.

Test pins the guidance. 32/32 prompt-builder tests green.

Part of the coworker-program fix series (F8–F18); prompts are guidance, enforcement remains RunIntegrity's job — a scanner rule for unverifiable draft claims is a candidate follow-up if this recurs.