### PR TITLE
Prompt: merges/transforms must reconcile per-source invariants (F21)

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -119,6 +119,12 @@ public struct TrustedRouterPromptBuilder: Sendable {
     error, a 404, or you never fetched it, do not cite that URL — find a working source or state \
     plainly that the claim is unverified. Every price, wattage, benchmark, or figure must trace to a \
     page you actually opened.
+    Merges and transformations — verify per-source invariants before reporting:
+    - When you merge, convert, or reshape data files, the output can be silently wrong while looking \
+    plausible (dropped columns, mis-mapped headers, lost rows). Before reporting, reconcile the \
+    output against EVERY input: per-source row counts and numeric column sums must match the \
+    corresponding slice of the output. If any source mismatches, fix the mapping and re-check — \
+    never report totals you did not reconcile.
     Drafted communications (emails, replies, notices) — never assert facts you did not verify:
     - A draft that claims "I checked the logs", "your data is safe", "your account shows X", or any \
     other account/system-specific fact is honest only if a tool call in THIS run verified it. In a \

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -261,6 +261,19 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         )
     }
 
+    func testPromptRequiresMergeInvariantSelfCheck() {
+        // Live UC-81 finding: a 12-file schema-drift merge silently lost months 5-12's dates and
+        // misread their amounts (ledger total 84,206.52 vs true 120,805.90) while the summary
+        // reported the wrong numbers confidently. The re-drive with an explicit per-source
+        // reconciliation instruction produced the exact correct ledger — so the guidance works.
+        let prompt = TrustedRouterPromptBuilder.systemPrompt(tools: [.shellRun, .fileWrite])
+
+        XCTAssertTrue(prompt.contains("Merges and transformations"))
+        XCTAssertTrue(prompt.contains("verify per-source invariants"))
+        XCTAssertTrue(prompt.contains("row counts and numeric column sums must match"))
+        XCTAssertTrue(prompt.contains("never report totals you did not reconcile"))
+    }
+
     func testPromptForbidsInventedFactsInDraftedCommunications() {
         // Live UC-24 finding: an angry-customer draft asserted "I've checked the recent logs …
         // the project still exists" with zero tool calls behind it — an invented reassurance a


### PR DESCRIPTION
## Live finding (coworker catalog row #81)

12 monthly CSVs with three header schemes → one ledger. First drive (gemini-3.5-flash): row count correct, but **months 5–12 lost their dates and their amounts were misread** — total \$84,206.52 vs the true \$120,805.90 — and the summary reported the wrong numbers confidently. Silent, plausible corruption; worse than a crash.

## Fix

Compact "Merges and transformations" rule in the execution-integrity guidance: reconcile the output against **every** input (per-source row counts + numeric column sums vs the matching output slice) before reporting; mismatch → fix mapping, re-check.

## Efficacy proven before landing

Same task re-driven with exactly this instruction: **53 rows, \$120,805.90 (exact), zero lost dates**, reconciliation table in the summary.

Fix series: F19 (#1542 draft-comms honesty) → F21 (this). 33/33 prompt-builder tests green.