### PR TITLE
Engine: wall-clock turn deadline breaks unbounded thinking spirals (F20)

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -10,6 +10,11 @@ public struct AgentRunner: Sendable {
     /// `AppConfig.maxToolSteps` (default 64): real coding tasks need dozens of tool steps, and the
     /// spend fuse is the runaway guard. Bare `AgentRunner()` (tests, ad-hoc embedding) stays tight.
     public static let defaultMaxToolSteps = 6
+    /// Wall-clock cap for ONE model turn (first token → completed action). Generous on purpose:
+    /// legitimate turns finish in seconds-to-a-couple-minutes even for verbose reasoners; the F20
+    /// spiral streamed thinking for 25 minutes without ever acting. Overrun → bounded corrective
+    /// re-prompt, not a dead run.
+    public static let defaultTurnDeadlineSeconds: TimeInterval = 300
     static let promisedWorkCorrectionLimit = 2
     /// Bounded recovery for a malformed model action (garbage/mojibake tokens) or a mid-stream
     /// transport reset: re-prompt/re-request up to this many times before the failure is terminal.
@@ -74,6 +79,11 @@ public struct AgentRunner: Sendable {
     /// Optional cost-control gate. When configured with a positive fuse and priced model catalog,
     /// provider usage events pause the run before the next model/tool step once spend crosses a bucket.
     public var runSpendFusePolicy: RunSpendFusePolicy?
+    /// Wall-clock budget for a SINGLE model turn (first token to completed action), in seconds.
+    /// Exceeding it cancels the stream and triggers the bounded "stop planning — emit the next
+    /// action" correction (F20: a reasoner can stream thinking tokens indefinitely without ever
+    /// acting; no terminal say means the phrase guards never see it). nil disables the deadline.
+    public var turnDeadlineSeconds: TimeInterval?
 
     public init(
         llm: LLMClient = MockLLMClient(),
@@ -98,7 +108,8 @@ public struct AgentRunner: Sendable {
         workspaceStateSignature: (@Sendable (URL) -> String)? = nil,
         compaction: AgentCompactionPolicy? = nil,
         lsp: LSPCoordinator? = nil,
-        runSpendFusePolicy: RunSpendFusePolicy? = nil
+        runSpendFusePolicy: RunSpendFusePolicy? = nil,
+        turnDeadlineSeconds: TimeInterval? = AgentRunner.defaultTurnDeadlineSeconds
     ) {
         self.llm = llm
         self.safety = safety
@@ -123,6 +134,7 @@ public struct AgentRunner: Sendable {
         self.compaction = compaction
         self.lsp = lsp
         self.runSpendFusePolicy = runSpendFusePolicy
+        self.turnDeadlineSeconds = turnDeadlineSeconds
     }
 
     public func send(

--- a/Sources/QuillCodeAgent/AgentActionResolver.swift
+++ b/Sources/QuillCodeAgent/AgentActionResolver.swift
@@ -100,6 +100,28 @@ extension AgentRunner {
                 ))
                 thread.updatedAt = Date()
                 await onProgress?(thread)
+            } catch let overrun as AgentTurnDeadlineExceededError {
+                // F20: a reasoner streamed thinking past the turn budget without ever completing an
+                // action (no terminal say — the phrase guards cannot see this shape). Honor a stop
+                // first, then spend a bounded corrective attempt telling the model to stop planning
+                // and emit the next action grounded in the tool output it actually has.
+                try Task.checkCancellation()
+                guard attempt < Self.malformedActionCorrectionLimit else {
+                    throw overrun
+                }
+                attempt += 1
+                let correctionPrompt = AgentTurnDeadline.correctionPrompt
+                correctiveThread.messages.append(.init(role: .user, content: correctionPrompt))
+                correctiveThread.updatedAt = Date()
+                pendingCorrectionPrompt = correctionPrompt
+                thread.events.append(.init(
+                    kind: .notice,
+                    summary: "Self-healing: the model reasoned past the turn deadline without acting; "
+                        + "asked it to emit the next action "
+                        + "(attempt \(attempt) of \(Self.malformedActionCorrectionLimit))."
+                ))
+                thread.updatedAt = Date()
+                await onProgress?(thread)
             } catch let interrupted as AgentStreamInterruptedError {
                 // Honor a stop before the exhaustion guard — see the invalidActionJSON arm.
                 try Task.checkCancellation()

--- a/Sources/QuillCodeAgent/AgentTextStreamActionRunner.swift
+++ b/Sources/QuillCodeAgent/AgentTextStreamActionRunner.swift
@@ -10,11 +10,14 @@ extension AgentRunner {
         onProgress: AgentRunProgressHandler?
     ) async throws -> AgentAction {
         await publishStreamingNotice(in: &thread, onProgress: onProgress)
-        let stream = try await streamingLLM.actionTextStream(
+        var stream = try await streamingLLM.actionTextStream(
             thread: thread,
             userMessage: userMessage,
             tools: tools
         )
+        if let deadline = turnDeadlineSeconds {
+            stream = AgentTurnDeadline.enforcing(seconds: deadline, on: stream)
+        }
         do {
             return try await Self.collectStreamingAction(
                 from: stream,

--- a/Sources/QuillCodeAgent/AgentTurnDeadline.swift
+++ b/Sources/QuillCodeAgent/AgentTurnDeadline.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A single model turn exceeded the wall-clock budget without completing an action.
+///
+/// The live failure this guards (F20): on a trivial 13-file folder-sort, a reasoner model made two
+/// real tool calls and then streamed 27k log lines of pure "thinking" — classifying hundreds of
+/// files that did not exist — never emitting another action until the process-level timeout killed
+/// the run 25 minutes later. No terminal `.say` ever happened, so the promised-work/deferral
+/// guards (which inspect terminal says) cannot see this shape; the defense has to live on the
+/// stream clock itself.
+struct AgentTurnDeadlineExceededError: Error, CustomStringConvertible {
+    let seconds: TimeInterval
+
+    var description: String {
+        "The model spent more than \(Int(seconds))s on one turn without completing an action."
+    }
+}
+
+enum AgentTurnDeadline {
+    /// Wrap a streaming response so it throws `AgentTurnDeadlineExceededError` if the WHOLE turn
+    /// (first token to completed action) runs past `seconds`. Elements pass through untouched
+    /// before the deadline; cancellation of the consumer tears down both inner tasks.
+    ///
+    /// The clock covers the entire turn rather than a per-chunk gap deliberately: a spiraling
+    /// reasoner streams steadily (no idle gap ever fires), it just never stops.
+    static func enforcing<Element: Sendable>(
+        seconds: TimeInterval,
+        on stream: AsyncThrowingStream<Element, Error>
+    ) -> AsyncThrowingStream<Element, Error> {
+        AsyncThrowingStream { continuation in
+            let relay = Task {
+                do {
+                    try await withThrowingTaskGroup(of: Void.self) { group in
+                        group.addTask {
+                            for try await element in stream {
+                                continuation.yield(element)
+                            }
+                        }
+                        group.addTask {
+                            try await Task.sleep(nanoseconds: UInt64(max(1, seconds) * 1_000_000_000))
+                            throw AgentTurnDeadlineExceededError(seconds: seconds)
+                        }
+                        // First child to finish decides: normal stream completion returns, the
+                        // deadline (or a stream error) throws. Either way the loser is cancelled.
+                        try await group.next()
+                        group.cancelAll()
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in relay.cancel() }
+        }
+    }
+
+    /// The bounded corrective nudge for a deadline overrun — the same recovery family as the
+    /// malformed-action correction: one user-role message, then a fresh sample.
+    static let correctionPrompt = """
+    You spent the whole turn reasoning without emitting an action. Stop planning. Base your next \
+    step ONLY on tool output you have actually received in this conversation — do not imagine \
+    files, data, or state you have not observed. Respond now with exactly one JSON action object \
+    (a tool call for the next concrete step, or a final "say" if the work is genuinely done).
+    """
+}

--- a/Sources/QuillCodeAgent/AgentUsageStreamActionRunner.swift
+++ b/Sources/QuillCodeAgent/AgentUsageStreamActionRunner.swift
@@ -10,11 +10,14 @@ extension AgentRunner {
         onProgress: AgentRunProgressHandler?
     ) async throws -> AgentAction {
         await publishStreamingNotice(in: &thread, onProgress: onProgress)
-        let stream = try await streamingLLM.actionEventStream(
+        var stream = try await streamingLLM.actionEventStream(
             thread: thread,
             userMessage: userMessage,
             tools: tools
         )
+        if let deadline = turnDeadlineSeconds {
+            stream = AgentTurnDeadline.enforcing(seconds: deadline, on: stream)
+        }
         do {
             return try await Self.collectStreamingAction(
                 from: stream,

--- a/Tests/QuillCodeAgentTests/AgentTurnDeadlineTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentTurnDeadlineTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// F20: a reasoner model can stream "thinking" indefinitely without ever completing an action —
+/// no terminal say, so the phrase guards never see it (live: 27k log lines classifying imaginary
+/// files on a 13-file folder sort, killed only by the 25-minute process timeout). The defense is a
+/// wall-clock turn deadline on the stream plus the bounded corrective re-prompt.
+final class AgentTurnDeadlineTests: XCTestCase {
+    // MARK: - Stream wrapper
+
+    func testElementsPassThroughBeforeDeadline() async throws {
+        let inner = AsyncThrowingStream<String, Error> { continuation in
+            continuation.yield("hello ")
+            continuation.yield("world")
+            continuation.finish()
+        }
+        let wrapped = AgentTurnDeadline.enforcing(seconds: 30, on: inner)
+        var collected = ""
+        for try await chunk in wrapped { collected += chunk }
+        XCTAssertEqual(collected, "hello world")
+    }
+
+    func testNeverEndingStreamHitsTheDeadline() async {
+        // A stream that yields one chunk and then hangs forever — the spiral shape.
+        let inner = AsyncThrowingStream<String, Error> { continuation in
+            continuation.yield("thinking…")
+            // never finishes
+        }
+        let wrapped = AgentTurnDeadline.enforcing(seconds: 0.2, on: inner)
+        do {
+            for try await _ in wrapped {}
+            XCTFail("expected the turn deadline to fire")
+        } catch let overrun as AgentTurnDeadlineExceededError {
+            XCTAssertEqual(Int(overrun.seconds * 10), 2)
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testStreamErrorsPropagateUnchangedBeforeDeadline() async {
+        struct Boom: Error {}
+        let inner = AsyncThrowingStream<String, Error> { continuation in
+            continuation.finish(throwing: Boom())
+        }
+        let wrapped = AgentTurnDeadline.enforcing(seconds: 30, on: inner)
+        do {
+            for try await _ in wrapped {}
+            XCTFail("expected the inner error")
+        } catch is Boom {
+            // expected
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    // MARK: - Resolver recovery
+
+    private actor ScriptedState {
+        var steps: [Result<AgentAction, Error>]
+        private(set) var calls: [[ChatMessage]] = []
+        init(_ steps: [Result<AgentAction, Error>]) { self.steps = steps }
+        func next(thread: ChatThread) throws -> AgentAction {
+            calls.append(thread.messages)
+            guard !steps.isEmpty else { return .say("out of steps") }
+            return try steps.removeFirst().get()
+        }
+        func recorded() -> [[ChatMessage]] { calls }
+    }
+
+    private struct ScriptedClient: LLMClient {
+        let state: ScriptedState
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            try await state.next(thread: thread)
+        }
+    }
+
+    func testDeadlineOverrunGetsOneCorrectiveAttemptAndRunSucceeds() async throws {
+        let state = ScriptedState([
+            .failure(AgentTurnDeadlineExceededError(seconds: 300)),
+            .success(.say("recovered and finished")),
+        ])
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+        let thread = ChatThread(title: "t")
+
+        let result = try await runner.send(
+            "summarize the current state of the repository",
+            in: thread,
+            workspaceRoot: FileManager.default.temporaryDirectory
+        )
+
+        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("recovered and finished") })
+        XCTAssertTrue(result.thread.events.contains {
+            $0.summary.contains("reasoned past the turn deadline")
+        })
+        // The corrective sample must carry the stop-planning nudge.
+        let calls = await state.recorded()
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertTrue(calls[1].contains {
+            $0.role == .user && $0.content.contains("Stop planning")
+        })
+    }
+
+    func testPersistentOverrunFailsAfterTheSharedBudget() async {
+        let state = ScriptedState([
+            .failure(AgentTurnDeadlineExceededError(seconds: 300)),
+            .failure(AgentTurnDeadlineExceededError(seconds: 300)),
+            .failure(AgentTurnDeadlineExceededError(seconds: 300)),
+        ])
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+        do {
+            _ = try await runner.send(
+                "summarize the current state of the repository",
+                in: ChatThread(title: "t"),
+                workspaceRoot: FileManager.default.temporaryDirectory
+            )
+            XCTFail("expected the overrun to surface after the correction budget")
+        } catch is AgentTurnDeadlineExceededError {
+            // expected: bounded, then honest failure
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    // MARK: - Configuration
+
+    func testRunnerDefaultsToTheLibraryDeadline() {
+        XCTAssertEqual(AgentRunner().turnDeadlineSeconds, AgentRunner.defaultTurnDeadlineSeconds)
+        XCTAssertEqual(AgentRunner.defaultTurnDeadlineSeconds, 300)
+    }
+
+    func testDeadlineCanBeDisabled() {
+        XCTAssertNil(AgentRunner(turnDeadlineSeconds: nil).turnDeadlineSeconds)
+    }
+}


### PR DESCRIPTION
## The 6th unattended-failure shape, fixed at the engine

Live (coworker row #32, dsv4-pro): two real tool calls, then **27k log lines of pure reasoning about files that don't exist**, no further action, killed only by the 25-minute process timeout. No terminal `.say` — the phrase-guard series (#1538/#1540) inspects terminal says and structurally cannot see this. The defense belongs on the stream clock.

## What this does

- **`AgentTurnDeadline.enforcing`** — generic stream wrapper; throws `AgentTurnDeadlineExceededError` when one whole turn (first token → completed action) exceeds the budget. Whole-turn deliberately: a spiraling reasoner streams *steadily*; per-chunk idle gaps never fire.
- **`AgentRunner.turnDeadlineSeconds`** — library default **300s**, `nil` disables. Both streaming runners (text + usage-event) wrap when set.
- **Resolver recovery arm** (malformed/interrupted family): bounded corrective re-prompt — *"Stop planning… base your next step ONLY on tool output you have actually received"* — sharing the existing 2-attempt budget, durable `Self-healing` notice, honest failure on exhaustion, user-stop honored first.

## Tests
Wrapper pass-through / deadline-fire / error-propagation; one-overrun recovery (nudge present in the corrective sample); persistent overrun stays fatal after the shared budget; config default + disable. 7 new; `QuillCodeAgentTests` **535/535**.

Completes the stall-shape series: 1-4 phrase guards (#1538/#1540), 5 open (premature sub-step completion), **6 this PR**. Findings F19 (#1542) and F21 (#1543) landed earlier today from the same live-driving program.