### PR TITLE
Engine: fallback model rescues empty-response route deaths (F22)

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -84,6 +84,13 @@ public struct AgentRunner: Sendable {
     /// action" correction (F20: a reasoner can stream thinking tokens indefinitely without ever
     /// acting; no terminal say means the phrase guards never see it). nil disables the deadline.
     public var turnDeadlineSeconds: TimeInterval?
+    /// Last-resort model for a step the primary cannot produce at all (F22): when the primary
+    /// exhausts the empty-response correction budget — a route-quality failure observed at ~1-in-6
+    /// runs on one provider while an alternate model completed the same step first try — the
+    /// resolver retries the SAME step once on this client instead of killing the run. All prior
+    /// tool work is preserved (same thread); the switch is recorded as a Self-healing notice.
+    /// nil (the default) keeps today's behavior: exhaustion is terminal.
+    public var fallbackLLM: LLMClient?
 
     public init(
         llm: LLMClient = MockLLMClient(),
@@ -109,7 +116,8 @@ public struct AgentRunner: Sendable {
         compaction: AgentCompactionPolicy? = nil,
         lsp: LSPCoordinator? = nil,
         runSpendFusePolicy: RunSpendFusePolicy? = nil,
-        turnDeadlineSeconds: TimeInterval? = AgentRunner.defaultTurnDeadlineSeconds
+        turnDeadlineSeconds: TimeInterval? = AgentRunner.defaultTurnDeadlineSeconds,
+        fallbackLLM: LLMClient? = nil
     ) {
         self.llm = llm
         self.safety = safety
@@ -135,6 +143,7 @@ public struct AgentRunner: Sendable {
         self.lsp = lsp
         self.runSpendFusePolicy = runSpendFusePolicy
         self.turnDeadlineSeconds = turnDeadlineSeconds
+        self.fallbackLLM = fallbackLLM
     }
 
     public func send(

--- a/Sources/QuillCodeAgent/AgentActionResolver.swift
+++ b/Sources/QuillCodeAgent/AgentActionResolver.swift
@@ -30,6 +30,11 @@ extension AgentRunner {
         var correctiveThread = thread
         var pendingCorrectionPrompt: String?
         var attempt = 0
+        // F22: which client resolves this action. Flips to `fallbackLLM` (at most once) when the
+        // primary exhausts the empty-response budget — a route-quality death an alternate model
+        // reliably survives. Scoped per-action: the next action starts back on the primary.
+        var activeLLM: LLMClient = llm
+        var usedFallback = false
         while true {
             do {
                 if let correctionPrompt = pendingCorrectionPrompt {
@@ -38,14 +43,16 @@ extension AgentRunner {
                         correctionPrompt: correctionPrompt,
                         tools: tools,
                         thread: &thread,
-                        onProgress: onProgress
+                        onProgress: onProgress,
+                        via: activeLLM
                     )
                 }
                 return try await dispatchNextAction(
                     thread: &thread,
                     userMessage: userMessage,
                     tools: tools,
-                    onProgress: onProgress
+                    onProgress: onProgress,
+                    via: activeLLM
                 )
             } catch TrustedRouterAgentError.emptyToolArguments(let toolName) {
                 if let action = AgentImmediateActionPlanner.action(for: userMessage, tools: tools) {
@@ -146,6 +153,22 @@ extension AgentRunner {
                 // which the transport classifier already deems "worth one more try".
                 try Task.checkCancellation()
                 guard attempt < Self.malformedActionCorrectionLimit else {
+                    // F22: the primary cannot produce this step at all. Try the fallback model —
+                    // once — with a fresh correction budget before declaring the run dead.
+                    if let fallback = fallbackLLM, !usedFallback {
+                        usedFallback = true
+                        activeLLM = fallback
+                        attempt = 0
+                        pendingCorrectionPrompt = nil
+                        thread.events.append(.init(
+                            kind: .notice,
+                            summary: "Self-healing: the model kept returning empty responses; "
+                                + "switching to the fallback model for this step."
+                        ))
+                        thread.updatedAt = Date()
+                        await onProgress?(thread)
+                        continue
+                    }
                     throw AgentError.emptyStreamingResponse
                 }
                 attempt += 1
@@ -172,7 +195,8 @@ extension AgentRunner {
         correctionPrompt: String,
         tools: [ToolDefinition],
         thread: inout ChatThread,
-        onProgress: AgentRunProgressHandler?
+        onProgress: AgentRunProgressHandler?,
+        via llm: LLMClient
     ) async throws -> AgentAction {
         var correctiveRun = correctiveThread
         let priorEventCount = correctiveRun.events.count
@@ -180,7 +204,8 @@ extension AgentRunner {
             thread: &correctiveRun,
             userMessage: correctionPrompt,
             tools: tools,
-            onProgress: nil
+            onProgress: nil,
+            via: llm
         )
         if correctiveRun.events.count > priorEventCount {
             thread.events.append(contentsOf: correctiveRun.events[priorEventCount...])
@@ -195,7 +220,8 @@ extension AgentRunner {
         thread: inout ChatThread,
         userMessage: String,
         tools: [ToolDefinition],
-        onProgress: AgentRunProgressHandler?
+        onProgress: AgentRunProgressHandler?,
+        via llm: LLMClient
     ) async throws -> AgentAction {
         if let usageStreamingLLM = llm as? any UsageStreamingLLMClient {
             return try await nextUsageStreamingAction(

--- a/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
+++ b/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
@@ -82,6 +82,22 @@ public enum CLIRuntimeFactory {
                     baseURL: baseURL
                 )
             )
+            // F22: when the session model exhausts the empty-response budget on a step (a
+            // route-quality death observed ~1-in-6 runs on one provider), retry that step once on
+            // a different model instead of killing the run. The alternate flips so the fallback is
+            // never the same route that just failed.
+            let fallbackModel = model == "google/gemini-3.5-flash"
+                ? "deepseek/deepseek-v4-pro"
+                : "google/gemini-3.5-flash"
+            let fallbackLLM = TrustedRouterLLMClient(
+                promptBuilder: TrustedRouterPromptBuilder(
+                    imageAttachmentStore: configuration.imageAttachmentStore
+                ),
+                sessionStore: sessionStore,
+                apiKeyOverride: key,
+                model: fallbackModel,
+                baseURL: baseURL
+            )
             runner = AgentRunner(
                 llm: llm,
                 safety: AutoSafetyReviewer(client: safety),
@@ -93,7 +109,8 @@ public enum CLIRuntimeFactory {
                     llm: llm,
                     catalog: [],
                     sessionModelID: model
-                ))
+                )),
+                fallbackLLM: fallbackLLM
             )
         } else {
             runner = AgentRunner(

--- a/Tests/QuillCodeAgentTests/AgentFallbackLLMTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentFallbackLLMTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// F22: when the primary model exhausts the empty-response correction budget on a step (a
+/// route-quality death observed at ~1-in-6 runs on one provider while an alternate model completed
+/// the same step first try), the resolver retries that step once on the fallback client instead of
+/// killing the run — preserving all prior tool work in the same thread.
+final class AgentFallbackLLMTests: XCTestCase {
+    private actor ScriptedState {
+        var steps: [Result<AgentAction, Error>]
+        private(set) var callCount = 0
+        init(_ steps: [Result<AgentAction, Error>]) { self.steps = steps }
+        func next() throws -> AgentAction {
+            callCount += 1
+            guard !steps.isEmpty else { return .say("out of steps") }
+            return try steps.removeFirst().get()
+        }
+        func calls() -> Int { callCount }
+    }
+
+    private struct ScriptedClient: LLMClient {
+        let state: ScriptedState
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            try await state.next()
+        }
+    }
+
+    private static let alwaysEmpty: [Result<AgentAction, Error>] = [
+        .failure(AgentError.emptyStreamingResponse),
+        .failure(AgentError.emptyStreamingResponse),
+        .failure(AgentError.emptyStreamingResponse),
+    ]
+
+    func testExhaustedEmptyResponsesSwitchToFallbackAndRunSucceeds() async throws {
+        let primary = ScriptedState(Self.alwaysEmpty)
+        let fallback = ScriptedState([.success(.say("fallback finished the step"))])
+        let runner = AgentRunner(
+            llm: ScriptedClient(state: primary),
+            fallbackLLM: ScriptedClient(state: fallback)
+        )
+
+        let result = try await runner.send(
+            "summarize the current state of the repository",
+            in: ChatThread(title: "t"),
+            workspaceRoot: FileManager.default.temporaryDirectory
+        )
+
+        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("fallback finished the step") })
+        XCTAssertTrue(result.thread.events.contains { $0.summary.contains("switching to the fallback model") })
+        let primaryCalls = await primary.calls()
+        let fallbackCalls = await fallback.calls()
+        XCTAssertEqual(primaryCalls, 3, "primary gets its full budget first")
+        XCTAssertEqual(fallbackCalls, 1)
+    }
+
+    func testFallbackAlsoFailingStaysFatalAndBounded() async {
+        let primary = ScriptedState(Self.alwaysEmpty)
+        let fallback = ScriptedState(Self.alwaysEmpty + Self.alwaysEmpty)
+        let runner = AgentRunner(
+            llm: ScriptedClient(state: primary),
+            fallbackLLM: ScriptedClient(state: fallback)
+        )
+        do {
+            _ = try await runner.send(
+                "summarize the current state of the repository",
+                in: ChatThread(title: "t"),
+                workspaceRoot: FileManager.default.temporaryDirectory
+            )
+            XCTFail("expected the exhaustion to stay fatal")
+        } catch AgentError.emptyStreamingResponse {
+            // expected
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+        let fallbackCalls = await fallback.calls()
+        XCTAssertEqual(fallbackCalls, 3, "fallback gets ONE fresh budget, never loops")
+    }
+
+    func testNoFallbackConfiguredKeepsTodaysFatalBehavior() async {
+        let primary = ScriptedState(Self.alwaysEmpty)
+        let runner = AgentRunner(llm: ScriptedClient(state: primary))
+        do {
+            _ = try await runner.send(
+                "summarize the current state of the repository",
+                in: ChatThread(title: "t"),
+                workspaceRoot: FileManager.default.temporaryDirectory
+            )
+            XCTFail("expected fatal exhaustion")
+        } catch AgentError.emptyStreamingResponse {
+            // expected — nil fallback preserves existing behavior exactly
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## The F13 death, fixed at the engine

Three coworker-catalog runs died today the same way: dsv4-pro's TR route returns empty responses → 2-attempt budget exhausted → `AgentError error 1` → dead unattended run. Each time, gemini-3.5-flash completed the same step **first try**. ~1-in-6 dsv4-pro runs. A route-quality blip one model-switch away from success should not kill a run.

## What this does

- **`AgentRunner.fallbackLLM`** (default `nil` = exactly today's behavior): on exhausted empty-response budget for a step, switch to the fallback client **once** with a fresh budget — same thread, all prior tool work preserved — with a durable `Self-healing` notice. Per-action scope: the next step starts back on the primary.
- Dispatch + corrective paths parameterized on the active client.
- **CLI live runs wire it automatically**: fallback = `google/gemini-3.5-flash`, flipping to `deepseek/deepseek-v4-pro` when the session model *is* gemini — the fallback is never the route that just failed.

## Tests
Switch-and-succeed (primary exhausts its full budget first; fallback called once) · fallback-also-fails stays fatal and bounded (one fresh budget, no loop) · nil keeps current behavior. Agent **538/538**, CLI **398/398**.

Engine series today: F20 turn deadline (#1544) → **F22 this PR**. Prompt series: F19 (#1542), F21 (#1543).