### PR TITLE
Engine: named-deliverable existence gate on terminal says (F23)

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -193,12 +193,26 @@ public struct AgentRunner: Sendable {
                         pendingApproval: paused.pendingApproval
                     )
                 }
-                let resolvedAction = try await actionByRetryingPromisedWorkIfNeeded(
+                var resolvedAction = try await actionByRetryingPromisedWorkIfNeeded(
                     action,
                     thread: next,
                     userMessage: userMessage,
                     tools: tools
                 )
+                // F23: a terminal say may not end the run while a task-named created file is
+                // missing on disk. A corrective re-sample that returns a tool action flows into
+                // the tool arm below and the loop continues; the gate re-checks at the next say.
+                // Skipped when any tool action was denied this run — a blocked write is a
+                // legitimate reason for the file to be missing, not a model failure.
+                if !runLoop.hadDeniedStep {
+                    resolvedAction = try await actionByRequiringNamedDeliverables(
+                        resolvedAction,
+                        thread: next,
+                        userMessage: userMessage,
+                        tools: tools,
+                        workspaceRoot: workspaceRoot
+                    )
+                }
                 try Task.checkCancellation()
                 switch resolvedAction {
                 case .say(let text):

--- a/Sources/QuillCodeAgent/AgentDeliverableGate.swift
+++ b/Sources/QuillCodeAgent/AgentDeliverableGate.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Enforcement for the "finished without the file" failure (stall shape 5): the task names a file
+/// to CREATE ("write recommendation.md", "build index.md"), the model does real work, then ends on
+/// a terminal say — sometimes a bare "Done." — with the named deliverable never written. Prompt
+/// guidance alone did not close this (fabrication-needs-enforcement lesson); the gate below makes
+/// it mechanical: at terminal-say time, every task-named created file must exist under the
+/// workspace root, or the model gets a bounded corrective re-prompt to write it.
+///
+/// Precision comes from two properties rather than clever parsing:
+/// - Only filenames governed by a nearby CREATE verb count, and filenames introduced by a
+///   source preposition ("from x.csv", "using y.md", "against z.json") never do.
+/// - The gate only fires when the file does NOT exist. Named inputs exist by definition, so an
+///   extraction false-positive on an input file is inert. The rare miss — a named input that never
+///   existed — yields a corrective prompt whose escape hatch ("write what blocked you") produces
+///   an honest artifact instead of a silent dead run.
+enum AgentDeliverableGate {
+    /// Filenames the user message asks the run to CREATE. Order of first appearance, deduped.
+    static func requiredDeliverables(in userMessage: String) -> [String] {
+        let pattern = #"""
+        (?ix)
+        \b(?:write|writes|build|builds|produce|produces|create|creates|generate|generates|
+           save|saves|export|exports|make|makes|output|deliver|delivers)\b
+        [^.!?\n]{0,90}?
+        (?<![\w./-])
+        (\.?/?[\w][\w./-]*\.(?:md|markdown|csv|tsv|txt|json|html?|xlsx?|png|jpe?g|pdf|docx|pptx|ya?ml|toml|xml|svg))
+        """#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(userMessage.startIndex..., in: userMessage)
+        var seen = Set<String>()
+        var results: [String] = []
+        regex.enumerateMatches(in: userMessage, range: range) { match, _, _ in
+            guard let match, match.numberOfRanges > 1,
+                  let fileRange = Range(match.range(at: 1), in: userMessage)
+            else { return }
+            // Reject filenames introduced by a source preposition anywhere between the verb and
+            // the filename — "create a summary of report.pdf" names an input, not a deliverable.
+            if let fullRange = Range(match.range(at: 0), in: userMessage) {
+                let between = userMessage[fullRange.lowerBound..<fileRange.lowerBound].lowercased()
+                for preposition in ["from ", " using ", "against ", " of ", "based on ", "reading "] {
+                    if between.contains(preposition) { return }
+                }
+            }
+            var name = String(userMessage[fileRange])
+            if name.hasPrefix("./") { name.removeFirst(2) }
+            if seen.insert(name).inserted, results.count < 6 {
+                results.append(name)
+            }
+        }
+        return results
+    }
+
+    /// The subset of required deliverables that do not exist under `workspaceRoot`.
+    static func missingDeliverables(in userMessage: String, workspaceRoot: URL) -> [String] {
+        requiredDeliverables(in: userMessage).filter { name in
+            !FileManager.default.fileExists(
+                atPath: workspaceRoot.appendingPathComponent(name).path
+            )
+        }
+    }
+
+    static func correctionPrompt(missing: [String]) -> String {
+        let list = missing.map { "./\($0)" }.joined(separator: ", ")
+        return """
+        The task requires the following file(s) to exist on disk and they do not: \(list). Do not \
+        end the run without them. Create each one now with host.file.write, containing the results \
+        of work you have actually done in this conversation — or, if something genuinely blocked \
+        you, containing exactly what you did and what blocked you. Then read each file back to \
+        confirm it exists before finishing.
+        """
+    }
+}

--- a/Sources/QuillCodeAgent/AgentDeliverableGate.swift
+++ b/Sources/QuillCodeAgent/AgentDeliverableGate.swift
@@ -40,6 +40,17 @@ enum AgentDeliverableGate {
                 for preposition in ["from ", " using ", "against ", " of ", "based on ", "reading "] {
                     if between.contains(preposition) { return }
                 }
+                // Reject NEGATED create verbs — "Do not write forbidden.txt" forbids the file;
+                // forcing it into existence would invert the user's instruction.
+                let precedingStart = userMessage.index(
+                    fullRange.lowerBound,
+                    offsetBy: -24,
+                    limitedBy: userMessage.startIndex
+                ) ?? userMessage.startIndex
+                let preceding = userMessage[precedingStart..<fullRange.lowerBound].lowercased()
+                for negation in ["do not ", "don't ", "dont ", "never ", "won't ", "not to ", "without ", "avoid "] {
+                    if preceding.hasSuffix(negation) || preceding.contains(negation) { return }
+                }
             }
             var name = String(userMessage[fileRange])
             if name.hasPrefix("./") { name.removeFirst(2) }

--- a/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
@@ -58,6 +58,51 @@ extension AgentRunner {
         return candidate
     }
 
+    /// Shape-5 enforcement (F23): a terminal say while a task-named CREATED file is missing on
+    /// disk gets a bounded corrective re-prompt to write it — the mechanical backstop behind the
+    /// "deliverables go to disk" prompt guidance, which a bare "Done." sails straight past. Runs
+    /// the fix loop only for says, only when file tools are available, and hard-fails honestly if
+    /// the model still won't produce the artifact (the correction's escape hatch — "write what
+    /// blocked you" — means persistent refusal is model failure, not a legitimate outcome).
+    func actionByRequiringNamedDeliverables(
+        _ action: AgentAction,
+        thread: ChatThread,
+        userMessage: String,
+        tools: [ToolDefinition],
+        workspaceRoot: URL
+    ) async throws -> AgentAction {
+        guard tools.contains(where: { $0.name == "host.file.write" }) else { return action }
+        var candidate = action
+        var retryThread = thread
+        for _ in 0..<Self.promisedWorkCorrectionLimit {
+            guard case .say(let text) = candidate else { return candidate }
+            let missing = AgentDeliverableGate.missingDeliverables(
+                in: userMessage,
+                workspaceRoot: workspaceRoot
+            )
+            guard !missing.isEmpty else { return candidate }
+            let correctionPrompt = AgentDeliverableGate.correctionPrompt(missing: missing)
+            retryThread.messages.append(.init(role: .assistant, content: text))
+            retryThread.messages.append(.init(role: .user, content: correctionPrompt))
+            retryThread.updatedAt = Date()
+            candidate = try await llm.nextAction(
+                thread: retryThread,
+                userMessage: correctionPrompt,
+                tools: tools
+            )
+        }
+        if case .say = candidate {
+            let stillMissing = AgentDeliverableGate.missingDeliverables(
+                in: userMessage,
+                workspaceRoot: workspaceRoot
+            )
+            if let first = stillMissing.first {
+                throw AgentError.missingNamedDeliverable(first)
+            }
+        }
+        return candidate
+    }
+
     private static func recoveredPromisedWorkAction(
         from text: String,
         tools: [ToolDefinition]

--- a/Sources/QuillCodeAgent/AgentRunLoopState.swift
+++ b/Sources/QuillCodeAgent/AgentRunLoopState.swift
@@ -5,6 +5,9 @@ struct AgentRunLoopState: Sendable {
     private(set) var toolResults: [ToolResult] = []
     private(set) var lastExecutedCall: ToolCall?
     private(set) var lastCompletion: AgentToolStepCompletion?
+    /// True once any tool action was DENIED this run. The deliverable gate (F23) skips
+    /// enforcement then: a blocked write is a legitimate reason for a missing file.
+    private(set) var hadDeniedStep = false
 
     private var flailDetector = FlailDetector()
     private var previousWorkspaceState: String?
@@ -60,6 +63,7 @@ struct AgentRunLoopState: Sendable {
 
     mutating func recordDeniedStep(_ completion: AgentToolStepCompletion) {
         toolResults.append(contentsOf: completion.toolResults)
+        hadDeniedStep = true
     }
 
     mutating func recordFlailAssessmentIfNeeded() -> Bool {

--- a/Sources/QuillCodeAgent/AgentTypes.swift
+++ b/Sources/QuillCodeAgent/AgentTypes.swift
@@ -30,6 +30,9 @@ public enum AgentError: Error, CustomStringConvertible {
     case emptyStreamingResponse
     case promisedWorkWithoutToolAction
     case tooManyToolSteps(Int)
+    // Appended last: never insert enum cases mid-list — discriminants shift and stale incremental
+    // builds misread persisted values.
+    case missingNamedDeliverable(String)
 
     public var description: String {
         switch self {
@@ -39,6 +42,8 @@ public enum AgentError: Error, CustomStringConvertible {
             return "The model promised to perform work but did not return a tool action."
         case .tooManyToolSteps(let limit):
             return "The agent reached the tool-step limit (\(limit)) before returning a final answer."
+        case .missingNamedDeliverable(let path):
+            return "The run ended without creating the task-required file \(path)."
         }
     }
 }

--- a/Tests/QuillCodeAgentTests/AgentDeliverableGateTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentDeliverableGateTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// F23 — shape-5 enforcement. Live failures this closes: a BFCL run that finished `generate` and
+/// ended without the required RESULT.md, and a folder-index run that ended on a bare "Done." with
+/// index.md never written. Both had "write <file>" verbatim in the task.
+final class AgentDeliverableGateTests: XCTestCase {
+    // MARK: - Extraction
+
+    func testExtractsCreatedFilenames() {
+        XCTAssertEqual(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "Research this and write ./recommendation.md containing a comparison."
+            ),
+            ["recommendation.md"]
+        )
+        XCTAssertEqual(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "build index.md with a table, and also produce summary.csv please"
+            ),
+            ["index.md", "summary.csv"]
+        )
+    }
+
+    func testSourcePrepositionFilenamesAreNotDeliverables() {
+        XCTAssertEqual(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "Create a summary of report.pdf and write findings.md"
+            ),
+            ["findings.md"]
+        )
+        XCTAssertTrue(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "Generate insights from sales.csv using config.yaml"
+            ).isEmpty
+        )
+    }
+
+    func testPlainMentionsWithoutCreateVerbAreIgnored() {
+        XCTAssertTrue(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "The data lives in metrics.csv; tell me what changed."
+            ).isEmpty
+        )
+    }
+
+    // MARK: - Existence gate
+
+    private func makeWorkspace() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("deliverable-gate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    func testExistingDeliverableDoesNotFire() throws {
+        let root = try makeWorkspace()
+        try "done".write(to: root.appendingPathComponent("out.md"), atomically: true, encoding: .utf8)
+        XCTAssertTrue(
+            AgentDeliverableGate.missingDeliverables(in: "write out.md now", workspaceRoot: root).isEmpty
+        )
+    }
+
+    func testMissingDeliverableFires() throws {
+        let root = try makeWorkspace()
+        XCTAssertEqual(
+            AgentDeliverableGate.missingDeliverables(in: "write out.md now", workspaceRoot: root),
+            ["out.md"]
+        )
+    }
+
+    // MARK: - End-to-end recovery
+
+    private actor ScriptedState {
+        var steps: [AgentAction]
+        let root: URL
+        init(_ steps: [AgentAction], root: URL) { self.steps = steps; self.root = root }
+        func next() -> AgentAction {
+            guard !steps.isEmpty else { return .say("out of steps") }
+            let step = steps.removeFirst()
+            // Simulate the corrective sample actually writing the file when scripted to comply.
+            if case .say(let text) = step, text == "WRITE_THEN_DONE" {
+                try? "content".write(
+                    to: root.appendingPathComponent("index.md"), atomically: true, encoding: .utf8
+                )
+                return .say("index.md is written and verified.")
+            }
+            return step
+        }
+    }
+
+    private struct ScriptedClient: LLMClient {
+        let state: ScriptedState
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            await state.next()
+        }
+    }
+
+    func testBareDoneWithMissingDeliverableIsCorrectedAndRunSucceeds() async throws {
+        let root = try makeWorkspace()
+        // First sample: the live failure verbatim — "Done." with nothing written. The corrective
+        // sample complies (writes the file), and the run ends cleanly.
+        let state = ScriptedState([.say("Done."), .say("WRITE_THEN_DONE")], root: root)
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Search the folders and build index.md with a table of matches.",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent("index.md").path))
+        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("index.md is written") })
+    }
+
+    func testPersistentRefusalFailsHonestly() async throws {
+        let root = try makeWorkspace()
+        let state = ScriptedState([.say("Done."), .say("Done."), .say("Done.")], root: root)
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+        do {
+            _ = try await runner.send(
+                "Search the folders and build index.md with a table of matches.",
+                in: ChatThread(title: "t"),
+                workspaceRoot: root
+            )
+            XCTFail("expected missingNamedDeliverable")
+        } catch AgentError.missingNamedDeliverable(let path) {
+            XCTAssertEqual(path, "index.md")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testSayWithNoNamedDeliverablesPassesUntouched() async throws {
+        let root = try makeWorkspace()
+        let state = ScriptedState([.say("The answer is 42.")], root: root)
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+        let result = try await runner.send(
+            "What is six times seven?",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("42") })
+    }
+}

--- a/Tests/QuillCodeAgentTests/AgentDeliverableGateTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentDeliverableGateTests.swift
@@ -37,6 +37,28 @@ final class AgentDeliverableGateTests: XCTestCase {
         )
     }
 
+    func testNegatedCreateVerbsAreNotDeliverables() {
+        // The CI catch: "Do not write `forbidden.txt` with content `nope`." — the gate must never
+        // force into existence a file the user explicitly forbade.
+        XCTAssertTrue(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "Do not write `forbidden.txt` with content `nope`."
+            ).isEmpty
+        )
+        XCTAssertTrue(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "Don't create debug.log, and never save temp.json anywhere."
+            ).isEmpty
+        )
+        // A negation elsewhere must not suppress a REAL deliverable later in the message.
+        XCTAssertEqual(
+            AgentDeliverableGate.requiredDeliverables(
+                in: "Do not touch the originals. Write summary.md with the results."
+            ),
+            ["summary.md"]
+        )
+    }
+
     func testPlainMentionsWithoutCreateVerbAreIgnored() {
         XCTAssertTrue(
             AgentDeliverableGate.requiredDeliverables(


### PR DESCRIPTION
## Stall shape 5, enforced mechanically

Two live sightings despite the "deliverables go to disk" prompt guidance: a BFCL run finished `generate` and ended **without the required RESULT.md**; a folder-index run ended on a bare **"Done."** with `index.md` never written. Nothing for RunIntegrity's phantom-write rule (no false narration) and nothing for the phrase guards (no promise). Enforcement, not prompts.

## What this does

- **`AgentDeliverableGate`** — extracts task-named *created* files from the original user message (create verb governing a filename in-clause; `from`/`using`/`of`-introduced names never count). Precision comes from the existence check, not the parser: named **inputs** exist by definition, so extraction false-positives are inert.
- **Terminal-say gate** — required file missing under the workspace root → bounded corrective re-prompt (shared promised-work budget). Escape hatch: *"write exactly what you did and what blocked you"* — so persistent refusal is honest model failure: `AgentError.missingNamedDeliverable`.
- **Denial-aware** — skipped when any tool action was denied this run (`hadDeniedStep`): a blocked write legitimately explains a missing file. The existing auto-review denial tests caught this edge on the first draft and now pin it.

## Tests
Extraction precision · existence both ways · live-failure replay ("Done." → corrected → file written → success) · persistent refusal fails honestly · non-deliverable says untouched. 8 new; agent **546/546**, CLI **398/398**.

Closes the stall-shape series: 1–4 phrase guards (#1538/#1540), 6 turn deadline (#1544), **5 this PR**. Today's fix series: F18 #1541 · F19 #1542 · F21 #1543 · F20 #1544 · F22 #1545 · **F23 here**.