### PR TITLE
Engine: repeated-call finalization passes through the deliverable gate (F25)

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -220,14 +220,37 @@ public struct AgentRunner: Sendable {
                     await onProgress?(next)
                     return AgentRunResult(thread: next, toolResults: runLoop.toolResults)
                 case .tool(let call):
-                    if let lastCompletion = runLoop.repeatedCompletion(for: call) {
-                        appendAssistantMessage(Self.finalAnswer(
+                    var activeCall = call
+                    if let lastCompletion = runLoop.repeatedCompletion(for: activeCall) {
+                        // F25: repeated-call finalization synthesizes an answer from the last tool
+                        // result — it must not slip past the named-deliverable gate the ordinary
+                        // terminal-say path enforces (live: an enrichment run repeated a search,
+                        // "finalized" with raw search results, and exited with the required CSV
+                        // never written). Route the synthesized say through the same gate; if the
+                        // corrective sample answers with a fresh tool action (e.g. the missing
+                        // file's write), execute it below like any tool step.
+                        var finalized: AgentAction = .say(Self.finalAnswer(
                             for: lastCompletion.call,
                             result: lastCompletion.result,
                             followUpReviewResult: lastCompletion.followUpReviewResult
-                        ), to: &next)
-                        await onProgress?(next)
-                        return AgentRunResult(thread: next, toolResults: runLoop.toolResults)
+                        ))
+                        if !runLoop.hadDeniedStep {
+                            finalized = try await actionByRequiringNamedDeliverables(
+                                finalized,
+                                thread: next,
+                                userMessage: userMessage,
+                                tools: tools,
+                                workspaceRoot: workspaceRoot
+                            )
+                        }
+                        switch finalized {
+                        case .say(let text):
+                            appendAssistantMessage(text, to: &next)
+                            await onProgress?(next)
+                            return AgentRunResult(thread: next, toolResults: runLoop.toolResults)
+                        case .tool(let recoveredCall):
+                            activeCall = recoveredCall
+                        }
                     }
 
                     // Baseline the workspace state before the first tool step, so that step's own
@@ -237,7 +260,7 @@ public struct AgentRunner: Sendable {
                         stateSignature: stateSignature
                     )
                     let step = try await runToolStep(
-                        call,
+                        activeCall,
                         userMessage: userMessage,
                         thread: &next,
                         workspaceRoot: workspaceRoot,

--- a/Tests/QuillCodeAgentTests/AgentDeliverableGateTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentDeliverableGateTests.swift
@@ -155,6 +155,40 @@ final class AgentDeliverableGateTests: XCTestCase {
         }
     }
 
+    func testRepeatedCallFinalizationAlsoPassesThroughTheGate() async throws {
+        // F25 live failure: an enrichment run repeated a search, the repeated-call path
+        // "finalized" with raw search results, and exited with the required CSV never written —
+        // bypassing the gate entirely. The finalized say must be gated like any terminal say;
+        // the corrective sample here writes the file via a real tool action.
+        let root = try makeWorkspace()
+        let search = ToolCall(name: "host.file.list", argumentsJSON: #"{"path":"."}"#)
+        let write = ToolCall(
+            name: "host.file.write",
+            argumentsJSON: try XCTUnwrap(String(
+                data: JSONSerialization.data(withJSONObject: [
+                    "path": "./leads.csv", "content": "company\nStripe\n",
+                ]),
+                encoding: .utf8
+            ))
+        )
+        let state = ScriptedState([
+            .tool(search),
+            .tool(search),        // repeat → finalization path
+            .tool(write),         // corrective sample: write the missing deliverable
+            .say("leads.csv written."),
+        ], root: root)
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Search the folder and build leads.csv from what you find.",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent("leads.csv").path))
+        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("leads.csv written") })
+    }
+
     func testSayWithNoNamedDeliverablesPassesUntouched() async throws {
         let root = try makeWorkspace()
         let state = ScriptedState([.say("The answer is 42.")], root: root)


### PR DESCRIPTION
## The gate had a bypass

Live (coworker lead-enrichment drive): model repeats a search → repeated-call finalization synthesizes **raw search results as the final answer** → returns directly → run exits "finished" with the required `leads_enriched.csv` never written. The F23 gate (#1546) never saw it — that path returned before the gate.

## Fix

The synthesized say now routes through `actionByRequiringNamedDeliverables` exactly like an ordinary terminal say (still skipped after denied steps). A corrective sample that answers with a tool action (the missing file's write) executes through the normal tool-step path (`activeCall`).

## Tests
Live-shape replay: search → repeated search → gate fires → corrective write executes → file exists → honest final say. 10/10 gate tests; **FULL suite 5228/5228** locally.

Completes F23 (#1546); found by the same live-driving program (F18 #1541 · F19 #1542 · F20 #1544 · F21 #1543 · F22 #1545 · F23 #1546 · **F25 here**).