### PR TITLE
Safety: outside-workspace shell paths require human approval in auto mode (F24)

### DIFF
--- a/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
+++ b/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
@@ -143,9 +143,18 @@ public enum CLIRuntimeFactory {
         // `uv venv` during setup). This converts `.clarify` -> `.approve` while leaving hard-deny
         // floors and the filesystem sandbox fully in force. Interactive runs are untouched: the
         // human at the keyboard still gets the approval prompt.
+        //
+        // F24 exception: under workspace-write, a shell command referencing paths outside the
+        // workspace root is honestly DENIED instead of waived (the sandbox does not clamp
+        // host.shell.run reads, and the live incident grepped the real ~/Documents). Only
+        // --sandbox danger-full-access — an explicit opt-in to full filesystem reach — keeps the
+        // waive for out-of-workspace paths.
         if request.style == .exec,
            request.sandbox == .workspaceWrite || request.sandbox == .dangerFullAccess {
-            runner.safety = AutonomousApprovalSafetyReviewer(base: runner.safety)
+            runner.safety = AutonomousApprovalSafetyReviewer(
+                base: runner.safety,
+                waivesOutsideWorkspacePaths: request.sandbox == .dangerFullAccess
+            )
         }
         return runner
     }

--- a/Sources/QuillCodeCore/ApprovalModels.swift
+++ b/Sources/QuillCodeCore/ApprovalModels.swift
@@ -139,6 +139,10 @@ public enum ApprovalReviewFallbackReason: String, Codable, Sendable, Hashable {
     case permissionRuleAllowed = "permission_rule_allowed"
     case permissionRuleAsked = "permission_rule_asked"
     case explicitApprovalRequired = "explicit_approval_required"
+    /// F24: the shell command references a path outside the workspace root in Auto mode. Surfaced
+    /// to the human (interactive) or honestly denied (headless exec) — never silently approved by
+    /// the model reviewer or the autonomous override.
+    case outsideWorkspacePath = "outside_workspace_path"
 }
 
 public struct ApprovalReviewTelemetry: Codable, Sendable, Hashable {

--- a/Sources/QuillCodeSafety/AutonomousApprovalSafetyReviewer.swift
+++ b/Sources/QuillCodeSafety/AutonomousApprovalSafetyReviewer.swift
@@ -18,16 +18,45 @@ import QuillCodeCore
 ///
 /// Applied ONLY to headless/exec runs whose sandbox is workspace-write or danger-full-access.
 /// Interactive runs keep their `.clarify` so the human at the keyboard can decide.
+///
+/// F24 carve-out: a `.clarify` for a shell command that references paths OUTSIDE the workspace
+/// root is not "unrecognized but safe" — it is the one question that must not be answered with a
+/// silent yes (live incident: `grep` over the real ~/Documents echoed personal filenames into run
+/// output). Under workspace-write, that clarify becomes an honest `.deny` with a clear message
+/// instead of an approve. `--sandbox danger-full-access` sets `waivesOutsideWorkspacePaths`: the
+/// user explicitly opted into full filesystem reach, so the original waive behavior applies.
 public struct AutonomousApprovalSafetyReviewer: SafetyReviewer {
     private let base: any SafetyReviewer
+    private let waivesOutsideWorkspacePaths: Bool
 
-    public init(base: any SafetyReviewer) {
+    public init(base: any SafetyReviewer, waivesOutsideWorkspacePaths: Bool = false) {
         self.base = base
+        self.waivesOutsideWorkspacePaths = waivesOutsideWorkspacePaths
     }
 
     public func review(_ context: SafetyContext) async -> SafetyReview {
         let review = await base.review(context)
         guard review.verdict == .clarify else { return review }
+
+        if !waivesOutsideWorkspacePaths,
+           let violation = StaticSafetyOutsideWorkspaceShellPolicy.violation(context) {
+            let listed = violation.offendingPaths.prefix(4).joined(separator: ", ")
+            return SafetyReview(
+                verdict: .deny,
+                rationale: "Blocked: this shell command references paths outside the workspace "
+                    + "(\(listed)). A headless autonomous run has no human to approve "
+                    + "out-of-workspace access, and the model reviewer may not waive it. Name the "
+                    + "exact path in the task message to authorize it, or run interactively to "
+                    + "approve it.",
+                reviewerModel: review.reviewerModel,
+                userIntentMatched: review.userIntentMatched,
+                riskLevel: review.riskLevel,
+                userAuthorization: review.userAuthorization
+            ).withReviewTelemetry(.init(
+                source: .autonomousOverride,
+                fallbackReason: .outsideWorkspacePath
+            ))
+        }
 
         return SafetyReview(
             verdict: .approve,

--- a/Sources/QuillCodeSafety/Safety.swift
+++ b/Sources/QuillCodeSafety/Safety.swift
@@ -122,6 +122,21 @@ public struct StaticSafetyReviewer: SafetyReviewer {
         if let explicitReview = ExplicitApprovalPolicy.review(for: context) {
             return explicitReview
         }
+        // F24: a shell command reaching outside the workspace root must surface to a human — it
+        // must never ride in on an intent rule or a static approve. Hard-deny floors stay senior
+        // (an out-of-workspace command that ALSO trips a floor stays `.deny`, it does not soften
+        // to an approvable `.clarify`), which is why the floor is consulted first here.
+        if context.mode == .auto,
+           hardDenyReason(context) == nil,
+           let violation = StaticSafetyOutsideWorkspaceShellPolicy.violation(context) {
+            return SafetyReview(
+                verdict: .clarify,
+                rationale: violation.rationale
+            ).withReviewTelemetry(.init(
+                source: .staticPolicy,
+                fallbackReason: .outsideWorkspacePath
+            ))
+        }
         let review: SafetyReview = switch context.mode {
         case .readOnly:
             if context.toolDefinition?.risk == .read {
@@ -225,6 +240,18 @@ public struct AutoSafetyReviewer: SafetyReviewer {
             return baseline.withReviewTelemetry(.init(
                 source: .staticPolicy,
                 fallbackReason: .staticDenied
+            ))
+        }
+        // F24: never hand an outside-workspace shell command to the model reviewer — the live
+        // incident's `grep` over ~/Documents was exactly a model-reviewer approval. The verbatim
+        // user-named-path exception is inside `violation`; hard-denies returned above.
+        if let violation = StaticSafetyOutsideWorkspaceShellPolicy.violation(context) {
+            return SafetyReview(
+                verdict: .clarify,
+                rationale: violation.rationale
+            ).withReviewTelemetry(.init(
+                source: .staticPolicy,
+                fallbackReason: .outsideWorkspacePath
             ))
         }
         guard let client else {

--- a/Sources/QuillCodeSafety/StaticSafetyOutsideWorkspaceShellPolicy.swift
+++ b/Sources/QuillCodeSafety/StaticSafetyOutsideWorkspaceShellPolicy.swift
@@ -1,0 +1,289 @@
+import Foundation
+import QuillCodeCore
+
+/// F24 — the outside-workspace shell gate.
+///
+/// Live incident (2026-07-30, coworker row #104): a `quill-code exec --sandbox workspace-write`
+/// run in Auto mode executed
+///
+///     find ~/Documents ~/Desktop -type f -exec grep -H "Project Northstar" {} \; 2>/dev/null || true
+///
+/// over the REAL home Documents/Desktop folders and echoed personal filenames into the run output.
+/// The file tools are clamped to the workspace (`hostToolAccessScope = workspaceOnly`), but
+/// `host.shell.run` escapes that clamp. The static shell policies correctly did NOT approve
+/// (`StaticSafetyShellCommandSafety.isSafeArgument` rejects `~`/absolute arguments) — but "not
+/// statically approved" only routed the call to the MODEL reviewer, which approved it; and in
+/// headless exec the autonomous override would have converted a `.clarify` to `.approve` anyway.
+/// Nothing in the pipeline treated "shell reaches outside the workspace" as something only a HUMAN
+/// (or the user's own words) may authorize.
+///
+/// This policy is that treatment. A shell command that references a path outside the workspace root
+/// (`~` paths, `$HOME`/`${HOME}` expansions, absolute paths not under the workspace, or `..`
+/// traversal that escapes it) is never silently approvable in Auto mode:
+///   - the static reviewer surfaces `.clarify` (interactive runs show approval_required to the human),
+///   - `AutoSafetyReviewer` returns that `.clarify` WITHOUT consulting the model reviewer,
+///   - `AutonomousApprovalSafetyReviewer` (headless workspace-write) denies it honestly instead of
+///     waiving the clarify.
+///
+/// One exception, mirroring the F10 user-typed-URL rule: the user's message naming the exact path
+/// verbatim authorizes it — they named the target, they own the reach. Hard-deny floors always run
+/// first and are never weakened: `cat ~/.ssh/id_rsa` stays DENY, it does not soften to clarify.
+enum StaticSafetyOutsideWorkspaceShellPolicy {
+    struct Violation: Equatable, Sendable {
+        /// The offending path references as written in the command, first-seen order, de-duplicated.
+        var offendingPaths: [String]
+        /// Approval-surface message for the interactive `.clarify`.
+        var rationale: String
+    }
+
+    /// Write-only/interactive device endpoints every shell pipeline uses (`2>/dev/null`); they
+    /// carry no personal data, so they are not treated as an escape.
+    private static let harmlessDevicePaths: Set<String> = [
+        "/dev/null", "/dev/stdin", "/dev/stdout", "/dev/stderr", "/dev/tty",
+    ]
+
+    /// Standard system executable directories. `/usr/bin/python3 x.py` reaches nothing that bare
+    /// `python3 x.py` (via PATH) cannot, so an absolute path DIRECTLY inside one of these is not an
+    /// escape. Only the binary's own directory qualifies — `/usr/bin/../../etc/passwd` has a `..`
+    /// segment and never matches.
+    private static let systemExecutableDirectories: Set<String> = [
+        "/usr/bin", "/bin", "/usr/sbin", "/sbin", "/usr/local/bin", "/opt/homebrew/bin",
+    ]
+
+    /// Executables whose path arguments name a target WITHOUT exposing its contents or listing:
+    /// `df -h /` reports mount-point statistics and cannot read a byte of any file. Their segments
+    /// skip the gate (the long-standing "How much hd?" diagnostic approval). Deliberately tiny —
+    /// `du`/`ls`/`stat` reveal names, sizes, or per-entry metadata and stay gated. The exemption is
+    /// void when the command contains substitution (`$(`/backtick), which can smuggle any read.
+    private static let contentBlindExecutables: Set<String> = ["df"]
+
+    /// The violation for this tool call, or nil when the gate does not apply: not a shell command,
+    /// no out-of-workspace path reference, or every offending path is named verbatim in the user's
+    /// message. Purely syntactic — never touches the filesystem (`homeDirectoryPath` is injectable
+    /// for tests).
+    static func violation(
+        _ context: SafetyContext,
+        homeDirectoryPath: String = NSHomeDirectory()
+    ) -> Violation? {
+        guard context.toolCall.name.contains("shell.run"),
+              let command = try? ToolArguments(context.toolCall.argumentsJSON).requiredString("cmd")
+        else {
+            return nil
+        }
+        let home = normalizedDirectoryPath(homeDirectoryPath)
+        let workspaceRoot = context.workspaceRoot.map { normalizedDirectoryPath($0.path) }
+
+        var offending: [String] = []
+        let folded = StaticSafetyPolicy.collapseWhitespace(command, foldNewlines: true)
+        let substitutionFree = !folded.contains("$(") && !folded.contains("`")
+        // Segments are split on any run of `;`/`&`/`|` so a content-blind head only ever vouches
+        // for its OWN arguments — `df -h / && cat /etc/passwd` still gates the `cat` segment.
+        for segment in folded.split(whereSeparator: { $0 == ";" || $0 == "&" || $0 == "|" }) {
+            let tokens = segment.split(separator: " ").map { cleaned(String($0)) }.filter { !$0.isEmpty }
+            if substitutionFree,
+               let head = tokens.first,
+               contentBlindExecutables.contains(StaticSafetyShellCommandSafety.basename(head)) {
+                continue
+            }
+            for token in tokens {
+                for candidate in pathCandidates(in: token) {
+                    guard let escape = escapingPath(
+                        candidate,
+                        home: home,
+                        workspaceRoot: workspaceRoot
+                    ) else { continue }
+                    if isNamedVerbatim(
+                        written: candidate,
+                        expanded: escape,
+                        home: home,
+                        in: context.userMessage
+                    ) { continue }
+                    if !offending.contains(candidate) {
+                        offending.append(candidate)
+                    }
+                }
+            }
+        }
+        guard !offending.isEmpty else { return nil }
+
+        let listed = offending.prefix(4).joined(separator: ", ")
+        return Violation(
+            offendingPaths: offending,
+            rationale: "This shell command references paths outside the workspace (\(listed)). "
+                + "Auto mode requires explicit approval for out-of-workspace paths: approve it here, "
+                + "or ask again naming the exact path (e.g. \"\(offending[0])\") to authorize it."
+        )
+    }
+
+    // MARK: - Token cleanup
+
+    /// Strips the shell syntax wrapped around a path spelling: quotes anywhere in the token
+    /// (`"~/My"` and `"$HOME"/x` both unwrap), a redirection prefix (`2>/dev/null`, `&>/tmp/x`),
+    /// a leading `(` or `$( `, and trailing sentence/subshell punctuation.
+    private static func cleaned(_ rawToken: String) -> String {
+        var token = rawToken
+        token.removeAll { $0 == "\"" || $0 == "'" }
+        token = strippingRedirectPrefix(token)
+        while let first = token.first, first == "(" {
+            token.removeFirst()
+        }
+        while let last = token.last, ");,:!?".contains(last) {
+            token.removeLast()
+        }
+        return token
+    }
+
+    /// `2>/dev/null` → `/dev/null`, `&>>~/log` → `~/log`; a token with no redirect operator is
+    /// returned unchanged (so `2fast` keeps its digit).
+    private static func strippingRedirectPrefix(_ token: String) -> String {
+        var index = token.startIndex
+        while index < token.endIndex, token[index].isNumber {
+            index = token.index(after: index)
+        }
+        var sawRedirect = false
+        while index < token.endIndex, token[index] == ">" || token[index] == "<" || token[index] == "&" {
+            sawRedirect = true
+            index = token.index(after: index)
+        }
+        return sawRedirect ? String(token[index...]) : token
+    }
+
+    /// The path spellings a token can carry: the token itself, and — for `--flag=/path` /
+    /// `VAR=~/path` forms — the value after the first `=`.
+    private static func pathCandidates(in token: String) -> [String] {
+        var candidates: [String] = []
+        if isPathSpelling(token) {
+            candidates.append(token)
+        } else if let equals = token.firstIndex(of: "=") {
+            let value = String(token[token.index(after: equals)...])
+            if isPathSpelling(value) {
+                candidates.append(value)
+            }
+        }
+        return candidates
+    }
+
+    private static func isPathSpelling(_ token: String) -> Bool {
+        token.hasPrefix("~") || token.hasPrefix("/") || hasHomeVariablePrefix(token)
+            || hasEscapingTraversalSegment(token)
+    }
+
+    /// `$HOME` / `${HOME}` followed by `/` or end-of-token. The boundary check keeps
+    /// `$HOMEBREW_PREFIX/bin` from false-positiving.
+    private static func hasHomeVariablePrefix(_ token: String) -> Bool {
+        for prefix in ["$HOME", "${HOME}"] where token.hasPrefix(prefix) {
+            let rest = token.dropFirst(prefix.count)
+            if rest.isEmpty || rest.hasPrefix("/") { return true }
+        }
+        return false
+    }
+
+    /// A relative spelling with a `..` path SEGMENT (`../x`, `a/../b`) — the same segment rule as
+    /// `StaticSafetyShellCommandSafety.isSafeArgument`, so `go test ./...` and `git log a..b` pass.
+    private static func hasEscapingTraversalSegment(_ token: String) -> Bool {
+        token.split(separator: "/", omittingEmptySubsequences: false).contains("..")
+    }
+
+    // MARK: - Escape resolution
+
+    /// The lexically-resolved absolute path when `candidate` reaches outside the workspace root,
+    /// nil when it stays inside (or is a harmless device / system-binary reference). Unknowable
+    /// targets (another user's `~name`, a `..` spelling with no workspace root) resolve to the
+    /// spelling itself: conservatively outside.
+    private static func escapingPath(
+        _ candidate: String,
+        home: String,
+        workspaceRoot: String?
+    ) -> String? {
+        let expanded: String
+        if candidate == "~" {
+            expanded = home
+        } else if candidate.hasPrefix("~/") {
+            expanded = home + candidate.dropFirst(1)
+        } else if candidate.hasPrefix("~") {
+            // `~otheruser/...` — no portable expansion; treat as outside.
+            return candidate
+        } else if hasHomeVariablePrefix(candidate) {
+            let suffix = candidate.hasPrefix("${HOME}")
+                ? candidate.dropFirst("${HOME}".count)
+                : candidate.dropFirst("$HOME".count)
+            expanded = home + suffix
+        } else if candidate.hasPrefix("/") {
+            expanded = candidate
+        } else {
+            // Relative `..` traversal: resolve against the workspace root when known.
+            guard let workspaceRoot else { return candidate }
+            expanded = workspaceRoot + "/" + candidate
+        }
+
+        let resolved = URL(fileURLWithPath: expanded).standardized.path
+        if harmlessDevicePaths.contains(resolved) { return nil }
+        if !hasEscapingTraversalSegment(candidate),
+           systemExecutableDirectories.contains(parentDirectory(of: resolved)) {
+            return nil
+        }
+        if let workspaceRoot, isWithin(resolved, root: workspaceRoot) { return nil }
+        return resolved
+    }
+
+    private static func parentDirectory(of path: String) -> String {
+        URL(fileURLWithPath: path).deletingLastPathComponent().path
+    }
+
+    private static func normalizedDirectoryPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardized.path
+    }
+
+    private static func isWithin(_ path: String, root: String) -> Bool {
+        path == root || path.hasPrefix(root + "/")
+    }
+
+    // MARK: - The verbatim-path exception (mirrors the F10 user-typed-URL rule)
+
+    /// Whether the user's message names this exact path — any equivalent spelling: as written in
+    /// the command (`~/Documents`), fully expanded (`/Users/x/Documents`), or the `~` spelling of
+    /// the expanded path when it sits under home. Compared case-insensitively with whitespace
+    /// collapsed, and the occurrence must END at a path boundary: "back up ~/Documents" vouches
+    /// for `~/Documents`, but "~/Documents/old" does NOT — naming a deeper path never authorizes
+    /// reading its parent. Single-character spellings other than `~` (notably `/`) are too weak to
+    /// vouch.
+    private static func isNamedVerbatim(
+        written: String,
+        expanded: String,
+        home: String,
+        in userMessage: String
+    ) -> Bool {
+        let haystack = StaticSafetyPolicy
+            .collapseWhitespace(userMessage, foldNewlines: true)
+            .lowercased()
+        var needles = [written.lowercased(), expanded.lowercased()]
+        if expanded == home {
+            needles.append("~")
+        } else if expanded.hasPrefix(home + "/") {
+            needles.append("~" + expanded.dropFirst(home.count).lowercased())
+        }
+        for needle in Set(needles) {
+            guard needle.count >= 2 || needle == "~" else { continue }
+            guard !needle.allSatisfy({ $0 == "/" }) else { continue }
+            if containsPathBounded(haystack, needle: needle) { return true }
+        }
+        return false
+    }
+
+    private static func containsPathBounded(_ haystack: String, needle: String) -> Bool {
+        var searchRange = haystack.startIndex..<haystack.endIndex
+        while let range = haystack.range(of: needle, range: searchRange) {
+            if range.upperBound == haystack.endIndex {
+                return true
+            }
+            let next = haystack[range.upperBound]
+            let continuesPath = next == "/" || next == "." || next == "_" || next == "-"
+                || next.isLetter || next.isNumber
+            if !continuesPath {
+                return true
+            }
+            searchRange = range.upperBound..<haystack.endIndex
+        }
+        return false
+    }
+}

--- a/Tests/QuillCodeSafetyTests/OutsideWorkspaceShellPolicyTests.swift
+++ b/Tests/QuillCodeSafetyTests/OutsideWorkspaceShellPolicyTests.swift
@@ -1,0 +1,420 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeSafety
+
+/// F24 — the outside-workspace shell gate. The live incident (2026-07-30, coworker row #104): in a
+/// headless `--sandbox workspace-write` Auto run, the model reviewer approved a `find`/`grep` over
+/// the REAL `~/Documents` and `~/Desktop`, echoing personal filenames into run output — file tools
+/// are workspace-clamped, but `host.shell.run` is not. These tests pin the closed pipeline:
+/// the exact live command can never be silently approved (static, model, or autonomous override),
+/// legitimate workspace commands are unaffected, the verbatim user-named-path exception works, and
+/// hard-deny floors still win over the gate.
+final class OutsideWorkspaceShellPolicyTests: SafetyPolicyTestCase {
+    /// The exact command from the live incident thread (915E9531 / BED35E6F, 2026-07-31T04:06Z).
+    private let liveIncidentCommand =
+        #"find ~/Documents ~/Desktop -type f -exec grep -H "Project Northstar" {} \; 2>/dev/null || true"#
+    /// The row-#104-shaped task prompt: "Documents and Desktop" appear as bare words, so nothing in
+    /// the message names `~/Documents` / `~/Desktop` verbatim.
+    private let liveIncidentMessage = "You are working fully autonomously. TASK: Find every file "
+        + "under Documents and Desktop that mentions \"Project Northstar\" and write an index of "
+        + "matches to ./index.md."
+
+    private let workspaceRoot = URL(fileURLWithPath: "/Users/dev/workspace")
+    private let home = "/Users/dev"
+
+    private func context(
+        command: String,
+        userMessage: String,
+        mode: AgentMode = .auto,
+        workspaceRoot: URL? = URL(fileURLWithPath: "/Users/dev/workspace")
+    ) -> SafetyContext {
+        SafetyContext(
+            mode: mode,
+            userMessage: userMessage,
+            toolCall: ToolCall(name: shellRun.name, argumentsJSON: shellArgumentsJSON(command)),
+            toolDefinition: shellRun,
+            recentMessages: [.init(role: .user, content: userMessage)],
+            workspaceRoot: workspaceRoot
+        )
+    }
+
+    private func violation(
+        command: String,
+        userMessage: String,
+        workspaceRoot: URL? = URL(fileURLWithPath: "/Users/dev/workspace")
+    ) -> StaticSafetyOutsideWorkspaceShellPolicy.Violation? {
+        StaticSafetyOutsideWorkspaceShellPolicy.violation(
+            context(command: command, userMessage: userMessage, workspaceRoot: workspaceRoot),
+            homeDirectoryPath: home
+        )
+    }
+
+    // MARK: - Policy unit: the incident and its spellings are violations
+
+    func testLiveIncidentGrepIsAViolation() {
+        let violation = violation(command: liveIncidentCommand, userMessage: liveIncidentMessage)
+        XCTAssertNotNil(violation)
+        XCTAssertEqual(violation?.offendingPaths, ["~/Documents", "~/Desktop"])
+    }
+
+    func testHomeSpellingVariantsAreViolations() {
+        for cmd in [
+            "grep -r Northstar $HOME/Documents",
+            "grep -r Northstar ${HOME}/Desktop",
+            #"ls "$HOME"/Documents"#,
+            #"cat "~/Documents/notes.txt""#,
+            "ls ~",
+            "du -sh ~/",
+            "find /Users/dev/Documents -type f",
+            "cat /etc/passwd",
+            "cp report.pdf ~backup/stash",
+        ] {
+            XCTAssertNotNil(
+                violation(command: cmd, userMessage: "index the project files"),
+                "\(cmd) reaches outside the workspace and must be gated"
+            )
+        }
+    }
+
+    func testFlagValueAndRedirectSpellingsAreViolations() {
+        for cmd in [
+            "tar -cf backup.tar --directory=/Users/dev/Documents .",
+            "python3 script.py --out=~/Desktop/result.txt",
+            "echo done >>~/Desktop/log.txt",
+            "cat report.md > /Users/dev/Documents/copy.md",
+        ] {
+            XCTAssertNotNil(
+                violation(command: cmd, userMessage: "process the report"),
+                "\(cmd) must be gated"
+            )
+        }
+    }
+
+    func testTraversalEscapingWorkspaceIsAViolation() {
+        XCTAssertNotNil(violation(command: "cat ../outside.txt", userMessage: "read the file"))
+        XCTAssertNotNil(violation(
+            command: "grep -r x ../../Documents",
+            userMessage: "search the docs"
+        ))
+        // No workspace root known → traversal cannot be proven inside → gated.
+        XCTAssertNotNil(violation(
+            command: "cat ../outside.txt",
+            userMessage: "read the file",
+            workspaceRoot: nil
+        ))
+    }
+
+    // MARK: - Policy unit: legitimate workspace commands are unaffected
+
+    func testWorkspaceCommandsAreNotViolations() {
+        for cmd in [
+            "grep -r TODO src",
+            "find . -name '*.log'",
+            "swift test 2>/dev/null",
+            "go test ./...",
+            "git log main..feature",
+            "git diff HEAD~1",
+            "make build && ./bin/app < input.txt",
+            "grep Northstar ./Documents/notes.txt",
+            "/Users/dev/workspace/scripts/lint.sh",
+            "cat /Users/dev/workspace/README.md",
+            "/usr/bin/python3 script.py",
+            "/bin/sh -c 'echo hi'",
+            "awk 'NR>2 {print}' data.csv",
+        ] {
+            XCTAssertNil(
+                violation(command: cmd, userMessage: "index the project files"),
+                "\(cmd) stays inside the workspace and must not be gated"
+            )
+        }
+    }
+
+    func testHomePathResolvingInsideWorkspaceIsNotAViolation() {
+        XCTAssertNil(violation(command: "cat ~/workspace/README.md", userMessage: "read the readme"))
+        XCTAssertNil(violation(command: "cat $HOME/workspace/README.md", userMessage: "read it"))
+        // …but the same spelling escaping the workspace is gated.
+        XCTAssertNotNil(violation(command: "cat ~/other/README.md", userMessage: "read it"))
+    }
+
+    func testSystemBinaryHeadIsExemptButItsArgumentsAreNot() {
+        XCTAssertNil(violation(command: "/usr/bin/env python3 x.py", userMessage: "run it"))
+        XCTAssertNotNil(
+            violation(command: "/usr/bin/python3 ~/Documents/x.py", userMessage: "run it"),
+            "a system interpreter must not smuggle an out-of-workspace argument"
+        )
+        XCTAssertNotNil(
+            violation(command: "cat /usr/bin/../../etc/passwd", userMessage: "run it"),
+            "a `..` spelling never qualifies for the system-binary exemption"
+        )
+    }
+
+    /// `df` reports mount-point statistics and cannot read file contents or names — its segments
+    /// keep the long-standing diagnostic approval. The exemption never leaks past its own segment
+    /// and is void under command substitution.
+    func testContentBlindDiagnosticsAreExemptPerSegment() {
+        XCTAssertNil(violation(
+            command: "df -h / /Quill 2>/dev/null || df -h /",
+            userMessage: "How much hd?"
+        ))
+        XCTAssertEqual(
+            violation(command: "df -h / && cat /etc/passwd", userMessage: "check disk")?
+                .offendingPaths,
+            ["/etc/passwd"],
+            "the df exemption must not vouch for a chained cat"
+        )
+        XCTAssertNotNil(
+            violation(command: "df -h $(cat /etc/secret)", userMessage: "check disk"),
+            "command substitution voids the content-blind exemption"
+        )
+        XCTAssertNotNil(
+            violation(command: "du -sh ~/Documents", userMessage: "check disk"),
+            "du reveals per-directory names and sizes and stays gated"
+        )
+    }
+
+    func testNonShellToolsAreOutOfScope() {
+        let ctx = SafetyContext(
+            mode: .auto,
+            userMessage: "read my docs",
+            toolCall: ToolCall(name: "host.file.read", argumentsJSON: #"{"path":"~/Documents/x"}"#),
+            toolDefinition: nil,
+            recentMessages: [],
+            workspaceRoot: workspaceRoot
+        )
+        XCTAssertNil(
+            StaticSafetyOutsideWorkspaceShellPolicy.violation(ctx, homeDirectoryPath: home),
+            "file tools are already clamped by hostToolAccessScope; the gate guards shell only"
+        )
+    }
+
+    // MARK: - Policy unit: the verbatim user-named-path exception (F10-style)
+
+    func testUserNamingThePathVerbatimLiftsTheGate() {
+        XCTAssertNil(violation(
+            command: "grep -r Northstar ~/Documents",
+            userMessage: "search ~/Documents for Northstar"
+        ))
+        // The expanded spelling vouches for the tilde spelling and vice versa.
+        XCTAssertNil(violation(
+            command: "grep -r Northstar ~/Documents",
+            userMessage: "search /Users/dev/Documents for Northstar"
+        ))
+        XCTAssertNil(violation(
+            command: "grep -r Northstar /Users/dev/Documents",
+            userMessage: "search ~/Documents for Northstar"
+        ))
+    }
+
+    func testExceptionIsPerPathNotPerCommand() {
+        let violation = violation(
+            command: "grep -r Northstar ~/Documents ~/Desktop",
+            userMessage: "search ~/Documents for Northstar"
+        )
+        XCTAssertEqual(
+            violation?.offendingPaths, ["~/Desktop"],
+            "naming ~/Documents must not also authorize ~/Desktop"
+        )
+    }
+
+    func testNamingADeeperPathDoesNotAuthorizeItsParent() {
+        XCTAssertNotNil(
+            violation(
+                command: "grep -r Northstar ~/Documents",
+                userMessage: "search ~/Documents/old for Northstar"
+            ),
+            "naming ~/Documents/old must not authorize all of ~/Documents"
+        )
+    }
+
+    func testBareFolderWordsDoNotVouch() {
+        XCTAssertNotNil(
+            violation(command: liveIncidentCommand, userMessage: liveIncidentMessage),
+            "the incident prompt's bare 'Documents and Desktop' names no exact path"
+        )
+        XCTAssertNotNil(
+            violation(
+                command: "ls /",
+                userMessage: "check https://example.com/docs please"
+            ),
+            "a '/' inside an unrelated URL must never vouch for the filesystem root"
+        )
+    }
+
+    // MARK: - Static reviewer: gate beats intent rules, hard-denies beat the gate
+
+    /// "disk" is a diagnostic intent trigger that historically blanket-approved shell.run — the
+    /// gate must outrank it.
+    func testGateOutranksDiagnosticIntentApproval() async {
+        let review = await StaticSafetyReviewer().review(context(
+            command: "du -sh ~/Documents",
+            userMessage: "how much disk space is used?"
+        ))
+        XCTAssertEqual(review.verdict, .clarify)
+        XCTAssertEqual(review.reviewTelemetry?.fallbackReason, .outsideWorkspacePath)
+    }
+
+    func testLiveIncidentClarifiesAtTheStaticLayer() async {
+        let review = await StaticSafetyReviewer().review(context(
+            command: liveIncidentCommand,
+            userMessage: liveIncidentMessage
+        ))
+        XCTAssertEqual(review.verdict, .clarify)
+        XCTAssertEqual(review.reviewTelemetry?.fallbackReason, .outsideWorkspacePath)
+    }
+
+    /// Hard-deny floors are senior: an out-of-workspace command that also trips a floor stays
+    /// `.deny` — the gate must not soften it into an approvable `.clarify`.
+    func testHardDenyStillWinsOverTheGate() async {
+        for cmd in ["cat ~/.ssh/id_rsa", "rm -rf / ~/Documents"] {
+            let review = await StaticSafetyReviewer().review(context(
+                command: cmd,
+                userMessage: "run \(cmd)"
+            ))
+            XCTAssertEqual(review.verdict, .deny, "\(cmd) must stay hard-denied")
+        }
+    }
+
+    func testWorkspaceCommandsKeepTheirStaticApproval() async {
+        let review = await StaticSafetyReviewer().review(context(
+            command: "grep -r TODO src",
+            userMessage: "run a grep for TODO"
+        ))
+        XCTAssertEqual(review.verdict, .approve)
+    }
+
+    // MARK: - Auto reviewer: the model is never consulted for an out-of-workspace command
+
+    func testModelReviewerCannotApproveTheLiveIncident() async {
+        let client = ApprovingSafetyModelClient()
+        let reviewer = AutoSafetyReviewer(client: client, primaryModel: "m1", fallbackModel: "m2")
+        let review = await reviewer.review(context(
+            command: liveIncidentCommand,
+            userMessage: liveIncidentMessage
+        ))
+        XCTAssertEqual(review.verdict, .clarify)
+        XCTAssertEqual(review.reviewTelemetry?.fallbackReason, .outsideWorkspacePath)
+        let calls = await client.callCount()
+        XCTAssertEqual(calls, 0, "the model reviewer must not even be asked (it approved the live incident)")
+    }
+
+    func testVerbatimNamedPathStillReachesTheModelReviewer() async {
+        let client = ApprovingSafetyModelClient()
+        let reviewer = AutoSafetyReviewer(client: client, primaryModel: "m1", fallbackModel: "m2")
+        let review = await reviewer.review(context(
+            command: "grep -r Northstar ~/Documents",
+            userMessage: "search ~/Documents for Northstar"
+        ))
+        XCTAssertEqual(review.verdict, .approve, "the user named the exact path — normal flow applies")
+        let calls = await client.callCount()
+        XCTAssertEqual(calls, 1)
+    }
+
+    // MARK: - Autonomous (headless exec) layer: honest deny, not a silent yes
+
+    /// The full exec stack as CLIRuntimeFactory wires it under workspace-write: the exact live
+    /// incident must dead-end in a clear DENY, not an autonomous approve.
+    func testLiveIncidentIsDeniedByTheFullAutonomousStack() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(
+            base: AutoSafetyReviewer(
+                client: ApprovingSafetyModelClient(),
+                primaryModel: "m1",
+                fallbackModel: "m2"
+            )
+        )
+        let review = await reviewer.review(context(
+            command: liveIncidentCommand,
+            userMessage: liveIncidentMessage
+        ))
+        XCTAssertEqual(review.verdict, .deny)
+        XCTAssertTrue(review.rationale.contains("~/Documents"), review.rationale)
+        XCTAssertTrue(review.rationale.contains("outside the workspace"), review.rationale)
+        XCTAssertEqual(review.reviewTelemetry?.source, .autonomousOverride)
+        XCTAssertEqual(review.reviewTelemetry?.fallbackReason, .outsideWorkspacePath)
+    }
+
+    /// Any base `.clarify` on an out-of-workspace command is denied — even one produced for an
+    /// unrelated reason — so no reviewer composition can waive the gate headlessly.
+    func testAutonomousOverrideDeniesOutsideWorkspaceClarify() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: FixedClarifyReviewer())
+        let review = await reviewer.review(context(
+            command: "grep -r Northstar ~/Desktop",
+            userMessage: liveIncidentMessage
+        ))
+        XCTAssertEqual(review.verdict, .deny)
+    }
+
+    func testAutonomousOverrideStillWaivesWorkspaceScopedClarify() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: FixedClarifyReviewer())
+        let review = await reviewer.review(context(
+            command: "git clone https://github.com/x/y",
+            userMessage: "set up the tool"
+        ))
+        XCTAssertEqual(review.verdict, .approve, "the F22-era waive for workspace-safe setup must survive")
+        XCTAssertEqual(review.reviewTelemetry?.source, .autonomousOverride)
+    }
+
+    func testAutonomousOverrideHonorsVerbatimNamedPath() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: FixedClarifyReviewer())
+        let review = await reviewer.review(context(
+            command: "grep -r Northstar ~/Documents",
+            userMessage: "search ~/Documents for Northstar"
+        ))
+        XCTAssertEqual(review.verdict, .approve, "the user named the path — the waive applies as before")
+    }
+
+    /// `--sandbox danger-full-access` is an explicit opt-in to full filesystem reach: the waive is
+    /// preserved there (CLIRuntimeFactory passes waivesOutsideWorkspacePaths: true).
+    func testDangerFullAccessKeepsTheWaive() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(
+            base: FixedClarifyReviewer(),
+            waivesOutsideWorkspacePaths: true
+        )
+        let review = await reviewer.review(context(
+            command: liveIncidentCommand,
+            userMessage: liveIncidentMessage
+        ))
+        XCTAssertEqual(review.verdict, .approve)
+    }
+
+    /// Hard-denies pass through the autonomous wrapper untouched — the gate adds a floor, it never
+    /// replaces one.
+    func testHardDenyStaysDeniedThroughTheFullStack() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(
+            base: AutoSafetyReviewer(
+                client: ApprovingSafetyModelClient(),
+                primaryModel: "m1",
+                fallbackModel: "m2"
+            )
+        )
+        let review = await reviewer.review(context(
+            command: "cat ~/.ssh/id_rsa",
+            userMessage: "cat ~/.ssh/id_rsa"
+        ))
+        XCTAssertEqual(review.verdict, .deny)
+        XCTAssertNotEqual(
+            review.reviewTelemetry?.fallbackReason, .outsideWorkspacePath,
+            "a credential read is the hard-deny floor's verdict, not the workspace gate's"
+        )
+    }
+}
+
+/// A model reviewer that approves everything it is asked about — the live-incident behavior. The
+/// gate's job is to ensure it is never asked.
+private actor ApprovingSafetyModelClient: SafetyModelClient {
+    private var calls = 0
+
+    func review(prompt: String, model: String) async throws -> String {
+        calls += 1
+        return #"{"verdict":"approve","rationale":"looks fine","userIntentMatched":true}"#
+    }
+
+    func callCount() -> Int {
+        calls
+    }
+}
+
+private struct FixedClarifyReviewer: SafetyReviewer {
+    func review(_ context: SafetyContext) async -> SafetyReview {
+        SafetyReview(verdict: .clarify, rationale: "base: clarify")
+    }
+}


### PR DESCRIPTION
## F24 — the outside-workspace shell gate

**Live incident (2026-07-30, coworker program F24, row #104):** a `quill-code exec --sandbox workspace-write` auto run executed

```
find ~/Documents ~/Desktop -type f -exec grep -H "Project Northstar" {} \; 2>/dev/null || true
```

over the **real** `~/Documents` and `~/Desktop` and echoed personal filenames into run output (persisted threads `915E9531`/`BED35E6F`; the pinned re-drive is `22EC299B`). File tools are workspace-clamped by `hostToolAccessScope=workspaceOnly`, but `host.shell.run` escapes that clamp.

**Confirmed approval path:** the static shell policies correctly did NOT approve (`StaticSafetyShellCommandSafety.isSafeArgument` rejects `~`/absolute args) — but "not statically approved" merely routed the call to the **model reviewer, which approved it**; and in headless exec `AutonomousApprovalSafetyReviewer` converts any surviving `.clarify` to `.approve`. Nothing treated "shell reaches outside the workspace" as a question only a human (or the user's own words) may answer.

## The gate

New `StaticSafetyOutsideWorkspaceShellPolicy`: in auto mode, a shell command referencing a path outside the workspace root (`~` paths, `$HOME`/`${HOME}` expansions, absolute paths not under the workspace, escaping `..` traversal) is never silently approvable:

- **Interactive:** `StaticSafetyReviewer` returns `.clarify` (surfaces `approval_required` to the human) instead of any intent-rule/static approve — e.g. the `"disk"` diagnostic trigger can no longer bless `du -sh ~/Documents`.
- **Model bypass:** `AutoSafetyReviewer` returns that `.clarify` **without consulting the model reviewer** — the reviewer that approved the live incident is never asked.
- **Headless exec (`workspace-write`):** `AutonomousApprovalSafetyReviewer` now **denies honestly** with a clear, actionable message instead of waiving the clarify. `--sandbox danger-full-access` keeps the waive — it is an explicit opt-in to full filesystem reach (`CLIRuntimeFactory` passes `waivesOutsideWorkspacePaths`).

**Exception (mirrors the F10 user-typed-URL rule):** the user's message naming the exact path verbatim authorizes it — any equivalent spelling (written `~/Documents`, expanded `/Users/x/Documents`, or the `~`-form of an absolute path), boundary-checked so naming `~/Documents/old` never vouches for all of `~/Documents`, and per-path (naming `~/Documents` does not authorize `~/Desktop` in the same command).

**Hard-deny floors unchanged and senior:** the floor is consulted before the gate, so `cat ~/.ssh/id_rsa` stays `.deny` — it never softens into an approvable `.clarify`. No existing floor was touched.

**Usability carve-outs (each pinned by tests):** `/dev` sinks (`2>/dev/null`), absolute binaries directly inside system bin dirs (`/usr/bin/python3` adds nothing over PATH), and per-segment content-blind diagnostics (`df` — mount statistics, cannot read file bytes; void under command substitution; keeps the existing "How much hd?" calibration fixtures green).

`ApprovalReviewFallbackReason` gains `outside_workspace_path`, appended in last position (append-only discriminant rule).

## Tests

`Tests/QuillCodeSafetyTests/OutsideWorkspaceShellPolicyTests.swift` (mirrors `RunIntentShellPolicyTests` style), covering the required matrix:

- **The exact live grep cannot ride through** at any layer: policy unit → static reviewer (`.clarify`, `outside_workspace_path` telemetry) → `AutoSafetyReviewer` with an always-approving model client (clarify, **0 model calls**) → full exec stack (`.deny` naming the offending paths).
- **Legit workspace commands unaffected:** relative paths, `go test ./...`, `git log a..b`, absolute paths under the workspace, `~` expansions resolving inside the workspace, `df` diagnostics, system interpreters; plus `git clone` keeps the F22-era autonomous waive.
- **Verbatim-path exception works** end-to-end (interactive and headless), per-path, cross-spelling, and parent/child-boundary-checked.
- **Hard-denies still win** through the full stack, with telemetry proving it is the floor's verdict, not the gate's.

Full suite: **5253/5253** (6 pre-existing diagnostics fixtures initially caught the gate over-blocking `df -h /` — fixed via the content-blind carve-out, not by weakening the fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)