### PR TITLE
CLI: privacy-pinned routes get no fallback model (F26)

### DIFF
--- a/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
+++ b/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
@@ -86,18 +86,30 @@ public enum CLIRuntimeFactory {
             // route-quality death observed ~1-in-6 runs on one provider), retry that step once on
             // a different model instead of killing the run. The alternate flips so the fallback is
             // never the same route that just failed.
-            let fallbackModel = model == "google/gemini-3.5-flash"
-                ? "deepseek/deepseek-v4-pro"
-                : "google/gemini-3.5-flash"
-            let fallbackLLM = TrustedRouterLLMClient(
-                promptBuilder: TrustedRouterPromptBuilder(
-                    imageAttachmentStore: configuration.imageAttachmentStore
-                ),
-                sessionStore: sessionStore,
-                apiKeyOverride: key,
-                model: fallbackModel,
-                baseURL: baseURL
-            )
+            //
+            // F26 (privacy boundary): NO fallback when the session model is a pinned privacy
+            // route — trustedrouter/e2e (confidential enclave) or trustedrouter/zdr (zero data
+            // retention). Falling back would silently move the user's sensitive content onto an
+            // ordinary route; observed live on an E2E-pinned pulse-survey run before this guard.
+            // A privacy-pinned run that cannot proceed fails honestly instead of downgrading.
+            let privacyPinnedRoutes: Set<String> = ["trustedrouter/e2e", "trustedrouter/zdr"]
+            let fallbackLLM: TrustedRouterLLMClient?
+            if privacyPinnedRoutes.contains(model) {
+                fallbackLLM = nil
+            } else {
+                let fallbackModel = model == "google/gemini-3.5-flash"
+                    ? "deepseek/deepseek-v4-pro"
+                    : "google/gemini-3.5-flash"
+                fallbackLLM = TrustedRouterLLMClient(
+                    promptBuilder: TrustedRouterPromptBuilder(
+                        imageAttachmentStore: configuration.imageAttachmentStore
+                    ),
+                    sessionStore: sessionStore,
+                    apiKeyOverride: key,
+                    model: fallbackModel,
+                    baseURL: baseURL
+                )
+            }
             runner = AgentRunner(
                 llm: llm,
                 safety: AutoSafetyReviewer(client: safety),

--- a/Tests/QuillCodeCLITests/CLIRuntimeFactoryTests.swift
+++ b/Tests/QuillCodeCLITests/CLIRuntimeFactoryTests.swift
@@ -116,4 +116,39 @@ final class CLIRuntimeFactoryTests: XCTestCase {
 
         XCTAssertNotNil(runner.compaction)
     }
+
+    func testPrivacyPinnedRoutesGetNoFallbackModel() throws {
+        // F26: an E2E/ZDR-pinned run must never silently fall back to an ordinary route —
+        // observed live: an E2E-pinned pulse-survey run hit the empty-response fallback and its
+        // sensitive content left the confidential enclave. Privacy-pinned runs fail honestly.
+        let workspace = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cli-privacy-\(UUID().uuidString)", isDirectory: true)
+        let paths = QuillCodePaths(home: workspace.appendingPathComponent("home"))
+        try paths.ensure()
+        defer { try? FileManager.default.removeItem(at: workspace) }
+
+        func runner(model: String) throws -> AgentRunner {
+            try CLIRuntimeFactory.make(CLIRuntimeConfiguration(
+                request: CLIRunRequest(
+                    style: .exec,
+                    prompt: "inspect",
+                    live: true,
+                    model: model,
+                    cwd: workspace,
+                    sandbox: .workspaceWrite
+                ),
+                appConfig: AppConfig(),
+                paths: paths,
+                imageAttachmentStore: ImageAttachmentStore(directory: paths.attachmentsDirectory),
+                environment: ["TRUSTEDROUTER_API_KEY": "sk-tr-test-key"]
+            ))
+        }
+
+        XCTAssertNil(try runner(model: "trustedrouter/e2e").fallbackLLM, "e2e must not fall back")
+        XCTAssertNil(try runner(model: "trustedrouter/zdr").fallbackLLM, "zdr must not fall back")
+        XCTAssertNotNil(
+            try runner(model: "deepseek/deepseek-v4-pro").fallbackLLM,
+            "ordinary routes keep the F22 fallback"
+        )
+    }
 }


### PR DESCRIPTION
## The resilience feature crossed a privacy boundary

Live (confidential-row drive): an exec run pinned to `trustedrouter/e2e` for a sensitive employee-survey task hit the F22 empty-response fallback — and its content **silently continued on gemini-3.5-flash**, off the confidential enclave. Caught the same hour, on fixture data.

## Fix

Privacy-pinned session models (`trustedrouter/e2e`, `trustedrouter/zdr`) get **no `fallbackLLM`**: a privacy-pinned run that cannot proceed fails honestly instead of downgrading. Ordinary routes keep the F22 fallback unchanged.

## Tests
e2e → nil · zdr → nil · ordinary → non-nil. **FULL suite 5254/5254.**

Fix series from the live-driving program: F18 #1541 · F19 #1542 · F20 #1544 · F21 #1543 · F22 #1545 · F23 #1546 · F25 #1547 · F24 (spawned session) · **F26 here**. Privacy lesson: resilience/fallback features must be audited against pinned-route intent.