### PR TITLE
F28: gate browser-tool prompt steering on the advertised surface

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterPromptBuilder.swift
@@ -139,6 +139,7 @@ public struct TrustedRouterPromptBuilder: Sendable {
             "- \(tool.name): \(tool.description). Parameters JSON schema: \(tool.parametersJSON)"
         }.joined(separator: "\n")
         let computerUseGuidance = computerUsePrompt(tools: tools)
+        let browserGuidance = browserPrompt(tools: tools)
         return """
         You are QuillCode, a native Swift coding agent.
 
@@ -174,9 +175,7 @@ public struct TrustedRouterPromptBuilder: Sendable {
         - If the user asks to download, save, or fetch a URL or domain, use host.shell.run immediately \
         with curl or wget, save into a relative workspace path such as downloads/example.com.html, create \
         parent directories first with mkdir -p when needed, and do not pipe remote content into a shell.
-        - If the user asks to open, inspect, check, view, or maintain a browser/SaaS page and gives a URL \
-        or domain, use host.browser.open immediately with "url"; then inspect or interact with the page \
-        using browser or Computer Use tools as needed.
+        \(browserGuidance)
         - If the user asks to fetch git refs or remote updates, use host.git.fetch instead of host.shell.run.
         - If the user asks to pull, sync, or update the current git branch from a remote, use \
         host.git.pull instead of host.shell.run. Omit "ffOnly" unless the user explicitly requests a \
@@ -564,6 +563,26 @@ public struct TrustedRouterPromptBuilder: Sendable {
             }
         }
         return parts
+    }
+
+    /// F28 — browser guidance must match the advertised surface. Headless exec never registers the
+    /// `host.browser.*` executors (they live in the app/desktop surfaces), so steering a model toward
+    /// `host.browser.open` there directs it at a tool that is not in its schema list; weak models burn
+    /// their correction budget emitting unknown-tool calls. With browser tools absent the guidance
+    /// flips to honest-limitation reporting, matching the webFetch description's conditional hint.
+    static func browserPrompt(tools: [ToolDefinition]) -> String {
+        guard tools.contains(where: { $0.name == ToolDefinition.browserOpen.name }) else {
+            return """
+            - Browser tools (host.browser.*) are NOT available in this run. For pages that require \
+            JavaScript or block plain fetches, report the limitation honestly in your answer instead of \
+            attempting browser actions or guessing at page content.
+            """
+        }
+        return """
+        - If the user asks to open, inspect, check, view, or maintain a browser/SaaS page and gives a URL \
+        or domain, use host.browser.open immediately with "url"; then inspect or interact with the page \
+        using browser or Computer Use tools as needed.
+        """
     }
 
     static func computerUsePrompt(tools: [ToolDefinition]) -> String {

--- a/Sources/QuillCodeTools/WebFetchToolDefinitions.swift
+++ b/Sources/QuillCodeTools/WebFetchToolDefinitions.swift
@@ -9,7 +9,9 @@ public extension ToolDefinition {
         links, lists, code blocks, tables); markdown and plain-text responses pass through; binary content \
         is refused. Responses are capped at 5 MB and long pages are truncated with a marker. Requests to \
         private, loopback, or link-local hosts are refused; redirects are re-checked against the same rules. \
-        For pages behind bot protection or requiring JavaScript, use host.browser.open instead.
+        For pages behind bot protection or requiring JavaScript, use host.browser.open instead when it \
+        is listed in your available tools; when it is not, report the page as unreachable honestly \
+        instead of guessing at its content.
         """,
         parametersJSON: """
         {"type":"object","properties":{"url":{"type":"string","description":"Absolute http or https URL to fetch."}},"required":["url"]}

--- a/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterPromptBuilderTests.swift
@@ -146,6 +146,20 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         XCTAssertTrue((image["url"] as? String)?.hasPrefix("data:image/png;base64,") == true)
     }
 
+    func testBrowserGuidanceMatchesAdvertisedSurface() {
+        // F28: with browser tools advertised (app/desktop surfaces), the prompt steers to
+        // host.browser.open; without them (headless exec), it must NOT — it flips to
+        // honest-limitation guidance so weak models don't emit unknown-tool calls.
+        let withBrowser = TrustedRouterPromptBuilder.systemPrompt(tools: [.shellRun, .browserOpen, .browserInspect])
+        XCTAssertTrue(withBrowser.contains("use host.browser.open immediately"))
+        XCTAssertFalse(withBrowser.contains("NOT available in this run"))
+
+        let headless = TrustedRouterPromptBuilder.systemPrompt(tools: [.shellRun, .webFetch])
+        XCTAssertFalse(headless.contains("use host.browser.open immediately"))
+        XCTAssertTrue(headless.contains("Browser tools (host.browser.*) are NOT available in this run"))
+        XCTAssertTrue(headless.contains("report the limitation honestly"))
+    }
+
     func testComputerUsePromptRequiresFreshScreenshotsAndTreatsPixelsAsUntrusted() {
         let prompt = TrustedRouterPromptBuilder.systemPrompt(tools: [
             .computerScreenshot,
@@ -196,8 +210,9 @@ final class TrustedRouterPromptBuilderTests: XCTestCase {
         XCTAssertTrue(prompt.contains("save into a relative workspace path"))
         XCTAssertTrue(prompt.contains("create parent directories first with mkdir -p"))
         XCTAssertTrue(prompt.contains("do not pipe remote content into a shell"))
-        XCTAssertTrue(prompt.contains("use host.browser.open immediately with \"url\""))
-        XCTAssertTrue(prompt.contains("browser/SaaS page"))
+        // F28: no browser tools in this list, so browser steering must be absent
+        // (testBrowserGuidanceMatchesAdvertisedSurface covers both sides).
+        XCTAssertFalse(prompt.contains("use host.browser.open immediately with \"url\""))
         XCTAssertTrue(prompt.contains("call host.skill.load immediately"))
         XCTAssertTrue(prompt.contains("with a non-empty \"name\" string"))
     }


### PR DESCRIPTION
Headless `quill-code exec` never registers `host.browser.*` executors, but the system prompt and the `host.web.fetch` description both unconditionally steered models toward `host.browser.open`. Strong models shrug it off (observed: coworker row122 honestly disclosed a grants.gov JS wall); weak models emit unknown-tool calls and burn the correction budget.

Fix mirrors the existing `computerUsePrompt(tools:)` pattern: `browserPrompt(tools:)` steers to browser tools only when advertised, and flips to honest-limitation guidance when not. `webFetch` description hint made conditional in prose.

Tests: `testBrowserGuidanceMatchesAdvertisedSurface` (both surfaces) + updated the stale always-on assertion in `testPromptRequiresNonEmptyShellCommand`. Full suite 5255/5255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)