### PR TITLE
F29: citation-integrity gate — cited URLs must have grounded provenance

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -170,6 +170,9 @@ public struct AgentRunner: Sendable {
                 Self.mergedToolDefinitions(baseToolDefinitions, additionalToolDefinitions)
             )
             var runLoop = AgentRunLoopState()
+            // F29: URLs from the request and the thread's prior turns are grounded provenance —
+            // a follow-up send must not flag citations the previous send legitimately fetched.
+            runLoop.seedCitationProvenance(userMessage: userMessage, thread: next)
             var autoReviewCircuit = AutoReviewCircuitBreaker()
             let limit = max(1, maxToolSteps)
             let stateSignature = workspaceStateSignature ?? Self.defaultWorkspaceStateSignature
@@ -213,6 +216,21 @@ public struct AgentRunner: Sendable {
                         workspaceRoot: workspaceRoot
                     )
                 }
+                // F29: terminal citations must trace to grounded provenance. Deliberately NOT
+                // behind the hadDeniedStep guard — a denied write explains a missing file, never
+                // an ungrounded citation — and its failure mode is a bounded corrective plus an
+                // honest notice, so a denied-run false flag costs a note, not the run.
+                if runLoop.didFetchSuccessfully {
+                    resolvedAction = try await actionByRequiringCitationIntegrity(
+                        resolvedAction,
+                        thread: next,
+                        userMessage: userMessage,
+                        tools: tools,
+                        workspaceRoot: workspaceRoot,
+                        groundedURLs: runLoop.groundedURLs,
+                        writtenWorkspacePaths: runLoop.writtenWorkspacePaths
+                    )
+                }
                 try Task.checkCancellation()
                 switch resolvedAction {
                 case .say(let text):
@@ -241,6 +259,21 @@ public struct AgentRunner: Sendable {
                                 userMessage: userMessage,
                                 tools: tools,
                                 workspaceRoot: workspaceRoot
+                            )
+                        }
+                        // F29: the synthesized finalization answer is a terminal say and must
+                        // clear the citation gate like the model-say path (F25 lesson). The
+                        // grounded set includes the repeated fetch's own content, so a
+                        // finalization that quotes the fetched page never self-flags.
+                        if runLoop.didFetchSuccessfully {
+                            finalized = try await actionByRequiringCitationIntegrity(
+                                finalized,
+                                thread: next,
+                                userMessage: userMessage,
+                                tools: tools,
+                                workspaceRoot: workspaceRoot,
+                                groundedURLs: runLoop.groundedURLs,
+                                writtenWorkspacePaths: runLoop.writtenWorkspacePaths
                             )
                         }
                         switch finalized {

--- a/Sources/QuillCodeAgent/AgentCitationIntegrityGate.swift
+++ b/Sources/QuillCodeAgent/AgentCitationIntegrityGate.swift
@@ -1,0 +1,239 @@
+import Foundation
+import QuillCodeCore
+
+/// F29 — citation-integrity enforcement for research-shaped runs.
+///
+/// Live failures this closes: a speaker-brief run cited a URL lifted from search-result snippets
+/// that it never fetched (the fetch log shows a *different* path on the same host), and a re-drive
+/// on a second model leaked another unfetched pointer link — both under an explicit prompt rule
+/// forbidding exactly that. Prompts are insufficient for this class (same lesson as fabrication);
+/// the run loop must check the deliverable against the run's actual evidence.
+///
+/// The invariant is provenance, not "fetched exactly": a citation is legitimate when the URL is
+/// **grounded** — it appeared in the user's request, in prior turns of the thread, in a fetched
+/// page's own content, in a file the run read, or is itself a fetched URL (requested or
+/// post-redirect spelling). What the gate rejects is a URL whose only provenance is a search-result
+/// listing or model memory — precisely the observed leak. Accordingly the provenance harvest
+/// covers every successful tool result EXCEPT `host.web.search` output.
+///
+/// Scope is deliberately narrow to keep false positives inert:
+/// - Only markdown-linked `[text](http…)` URLs count as citations; image embeds `![…](…)`,
+///   fenced code blocks, and bare URLs in data files are never flagged.
+/// - Only the terminal say and task-named `.md` deliverables **this run itself wrote** are
+///   scanned — never user-supplied input files.
+/// - The gate only arms when the run performed at least one successful `host.web.fetch`.
+///
+/// Failure mode is honest surfacing, not a hard error: after the bounded corrective budget the
+/// run completes with a visible integrity notice naming the ungrounded links (mirroring the
+/// run-integrity verdict-in-transcript precedent), so a rare false positive degrades to a note
+/// instead of killing a finished task.
+enum AgentCitationIntegrityGate {
+    /// Normalizes a URL for grounded-vs-cited comparison: lowercases the scheme and host, drops
+    /// the fragment, and strips one trailing slash. Port, userinfo, path case, and query survive —
+    /// they distinguish origins and pages.
+    static func normalize(_ raw: String) -> String {
+        var value = raw
+        if let hash = value.firstIndex(of: "#") {
+            value = String(value[..<hash])
+        }
+        if value.hasSuffix("/") { value = String(value.dropLast()) }
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme,
+              let host = components.host
+        else {
+            return value
+        }
+        let user = components.user.map { "\($0)@" } ?? ""
+        let port = components.port.map { ":\($0)" } ?? ""
+        var path = components.percentEncodedPath
+        if path.hasSuffix("/") { path = String(path.dropLast()) }
+        let query = components.percentEncodedQuery.map { "?\($0)" } ?? ""
+        return "\(scheme.lowercased())://\(user)\(host.lowercased())\(port)\(path)\(query)"
+    }
+
+    /// Extracts the final URL from a successful `host.web.fetch` result. The executor's summary
+    /// line is `Fetched <finalURL> (HTTP …` — the URL after redirects, which is what a model
+    /// legitimately cites for a page it reached via a hop (notion.so → notion.com).
+    static func finalURL(fromFetchStdout stdout: String) -> String? {
+        guard stdout.hasPrefix("Fetched ") else { return nil }
+        let rest = stdout.dropFirst("Fetched ".count)
+        guard let end = rest.firstIndex(where: { $0 == " " || $0 == "\n" }) else { return nil }
+        let url = String(rest[..<end])
+        return url.hasPrefix("http") ? url : nil
+    }
+
+    /// Every http(s) URL appearing anywhere in the text, for building the grounded-provenance
+    /// set. Deliberately permissive — over-collecting provenance only ever *allows* citations.
+    static func allURLs(in text: String) -> [String] {
+        let pattern = #"https?://[^\s<>"'()\]]+(?:\([^\s()]*\)[^\s<>"'()\]]*)*"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard let r = Range(match.range, in: text) else { return nil }
+            return String(text[r]).trimmingCharacters(in: CharacterSet(charactersIn: ".,;:"))
+        }
+    }
+
+    /// Markdown-linked http(s) URLs in the text — the citations the gate audits.
+    ///
+    /// Handles the forms models actually emit: plain `[t](url)`, parenthesized URLs
+    /// (`…/Swift_(programming_language)`) via balanced-paren scanning, optional link titles
+    /// (`[t](url "title")`), and angle-bracket destinations (`[t](<url>)`). Image embeds
+    /// (`![alt](url)`) are skipped — an embed is not a citation — and fenced code blocks are
+    /// stripped first so documentation examples are never flagged.
+    static func markdownLinkedURLs(in text: String) -> [String] {
+        var urls: [String] = []
+        let stripped = withoutFencedCodeBlocks(text)
+        var index = stripped.startIndex
+        while let open = stripped[index...].firstIndex(of: "[") {
+            // `![` is an image embed, not a citation.
+            if open > stripped.startIndex, stripped[stripped.index(before: open)] == "!" {
+                index = stripped.index(after: open)
+                continue
+            }
+            guard let close = stripped[open...].firstIndex(of: "]"),
+                  stripped.index(after: close) < stripped.endIndex,
+                  stripped[stripped.index(after: close)] == "("
+            else {
+                index = stripped.index(after: open)
+                continue
+            }
+            let destinationStart = stripped.index(close, offsetBy: 2)
+            guard destinationStart < stripped.endIndex,
+                  let (rawDestination, afterDestination) = linkDestination(
+                    in: stripped, from: destinationStart
+                  )
+            else {
+                index = stripped.index(after: open)
+                continue
+            }
+            if rawDestination.hasPrefix("http://") || rawDestination.hasPrefix("https://") {
+                urls.append(rawDestination)
+            }
+            index = afterDestination
+        }
+        return urls
+    }
+
+    /// Reads one markdown link destination starting at `start` (just past `](`): either an
+    /// `<angle-bracketed>` destination, or a run of non-space characters with balanced
+    /// parentheses, optionally followed by a quoted title before the closing `)`.
+    private static func linkDestination(
+        in text: String,
+        from start: String.Index
+    ) -> (destination: String, after: String.Index)? {
+        var cursor = start
+        if text[cursor] == "<" {
+            let destinationStart = text.index(after: cursor)
+            guard let end = text[destinationStart...].firstIndex(of: ">") else { return nil }
+            return (String(text[destinationStart..<end]), text.index(after: end))
+        }
+        var depth = 0
+        var destinationEnd: String.Index?
+        while cursor < text.endIndex {
+            let character = text[cursor]
+            if character == "(" {
+                depth += 1
+            } else if character == ")" {
+                if depth == 0 { destinationEnd = cursor; break }
+                depth -= 1
+            } else if character == " " || character == "\n" {
+                // A space inside the parens starts an optional title; the destination ends here.
+                destinationEnd = cursor
+                break
+            }
+            cursor = text.index(after: cursor)
+        }
+        guard let end = destinationEnd else { return nil }
+        return (String(text[start..<end]), text.index(after: end))
+    }
+
+    private static func withoutFencedCodeBlocks(_ text: String) -> String {
+        var kept: [Substring] = []
+        var fenceMarker: Character?
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                let marker = trimmed.first
+                if fenceMarker == nil {
+                    fenceMarker = marker
+                    continue
+                }
+                if fenceMarker == marker {
+                    fenceMarker = nil
+                    continue
+                }
+            }
+            if fenceMarker == nil { kept.append(line) }
+        }
+        return kept.joined(separator: "\n")
+    }
+
+    /// The largest deliverable the gate will read. Citations live in prose files; anything
+    /// bigger is data and out of scope.
+    private static let maxScannedFileBytes = 512 * 1024
+
+    /// Returns the cited-but-ungrounded URLs (original spelling, deduplicated, in order) across
+    /// the terminal say and task-named `.md` deliverables this run wrote.
+    ///
+    /// - Parameters:
+    ///   - groundedURLs: normalized URLs with verifiable provenance this run — fetched URLs
+    ///     (requested + final), plus every URL appearing in successful non-search tool output,
+    ///     in the user message, or in the thread's prior messages.
+    ///   - writtenWorkspacePaths: workspace-relative paths this run wrote via file tools; only
+    ///     named deliverables among them are scanned, so user input files are never audited.
+    static func ungroundedCitations(
+        sayText: String,
+        userMessage: String,
+        workspaceRoot: URL,
+        groundedURLs: Set<String>,
+        writtenWorkspacePaths: Set<String>
+    ) -> [String] {
+        var scanned = sayText
+        for name in AgentDeliverableGate.requiredDeliverables(in: userMessage)
+        where name.lowercased().hasSuffix(".md") && wasWritten(name, in: writtenWorkspacePaths) {
+            let url = workspaceRoot.appendingPathComponent(name)
+            guard let data = try? Data(contentsOf: url), data.count <= maxScannedFileBytes,
+                  let text = String(data: data, encoding: .utf8)
+            else { continue }
+            scanned += "\n" + text
+        }
+        var seen = Set<String>()
+        var offenders: [String] = []
+        for cited in markdownLinkedURLs(in: scanned) {
+            let normalized = normalize(cited)
+            guard !groundedURLs.contains(normalized),
+                  seen.insert(normalized).inserted
+            else { continue }
+            offenders.append(cited)
+        }
+        return offenders
+    }
+
+    private static func wasWritten(_ deliverableName: String, in writtenPaths: Set<String>) -> Bool {
+        let name = deliverableName.hasPrefix("./") ? String(deliverableName.dropFirst(2)) : deliverableName
+        return writtenPaths.contains { written in
+            let path = written.hasPrefix("./") ? String(written.dropFirst(2)) : written
+            return path == name || path.hasSuffix("/" + name)
+        }
+    }
+
+    static func correctionPrompt(unfetched: [String]) -> String {
+        """
+        Citation-integrity check: your answer links URLs that have no verifiable source in this \
+        run: \(unfetched.joined(separator: ", ")). Each cited URL must come from a page you \
+        successfully fetched, a file you read, or the user's request — not from search-result \
+        snippets or memory. For each one, either fetch it now (host.web.fetch) and keep the link, \
+        or remove the link and mark the claim as 'unverified'. Update the deliverable file if it \
+        contains the link, then give your final answer. If something blocks you, write exactly \
+        what you did and what blocked you.
+        """
+    }
+
+    static func integrityNotice(unfetched: [String]) -> String {
+        """
+        ⚠ Citation integrity: \(unfetched.count) linked URL(s) have no verifiable source in this \
+        run and could not be verified: \(unfetched.joined(separator: ", "))
+        """
+    }
+}

--- a/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
@@ -103,6 +103,68 @@ extension AgentRunner {
         return candidate
     }
 
+    /// F29 — a terminal say may not cite markdown-linked URLs the run never successfully fetched.
+    /// The corrective loop gives the model a bounded chance to fetch or remove each link; a tool
+    /// action from the corrective sample flows back into the run loop like any other step.
+    /// Persistent refusal does NOT hard-fail the run: the say passes through with a visible
+    /// integrity notice appended, so a rare false positive degrades to a note, never a dead run.
+    func actionByRequiringCitationIntegrity(
+        _ action: AgentAction,
+        thread: ChatThread,
+        userMessage: String,
+        tools: [ToolDefinition],
+        workspaceRoot: URL,
+        groundedURLs: Set<String>,
+        writtenWorkspacePaths: Set<String>
+    ) async throws -> AgentAction {
+        var candidate = action
+        var retryThread = thread
+        func offenders(in text: String) -> [String] {
+            AgentCitationIntegrityGate.ungroundedCitations(
+                sayText: text,
+                userMessage: userMessage,
+                workspaceRoot: workspaceRoot,
+                groundedURLs: groundedURLs,
+                writtenWorkspacePaths: writtenWorkspacePaths
+            )
+        }
+        for _ in 0..<Self.promisedWorkCorrectionLimit {
+            guard case .say(let text) = candidate else { return candidate }
+            let ungrounded = offenders(in: text)
+            let correctionPrompt: String
+            if !ungrounded.isEmpty {
+                correctionPrompt = AgentCitationIntegrityGate.correctionPrompt(unfetched: ungrounded)
+            } else if let promise = AgentPromisedWorkGuard.correctionNeeded(for: text, tools: tools) {
+                // A corrective sample can dodge the gate with a link-free promise ("I'll fetch it
+                // now") — no offenders, so it would pass, and the promised-work guard upstream has
+                // already run. Re-screen promises here within the same budget (proven live by a
+                // review probe: the run ended on exactly that bare promise).
+                correctionPrompt = AgentPromisedWorkGuard.correctionPrompt(
+                    for: promise,
+                    assistantText: text,
+                    userMessage: userMessage
+                )
+            } else {
+                return candidate
+            }
+            retryThread.messages.append(.init(role: .assistant, content: text))
+            retryThread.messages.append(.init(role: .user, content: correctionPrompt))
+            retryThread.updatedAt = Date()
+            candidate = try await llm.nextAction(
+                thread: retryThread,
+                userMessage: correctionPrompt,
+                tools: tools
+            )
+        }
+        if case .say(let text) = candidate {
+            let ungrounded = offenders(in: text)
+            if !ungrounded.isEmpty {
+                return .say(text + "\n\n" + AgentCitationIntegrityGate.integrityNotice(unfetched: ungrounded))
+            }
+        }
+        return candidate
+    }
+
     private static func recoveredPromisedWorkAction(
         from text: String,
         tools: [ToolDefinition]

--- a/Sources/QuillCodeAgent/AgentRunLoopState.swift
+++ b/Sources/QuillCodeAgent/AgentRunLoopState.swift
@@ -8,6 +8,14 @@ struct AgentRunLoopState: Sendable {
     /// True once any tool action was DENIED this run. The deliverable gate (F23) skips
     /// enforcement then: a blocked write is a legitimate reason for a missing file.
     private(set) var hadDeniedStep = false
+    /// F29 grounded-provenance state. `groundedURLs` holds the normalized URL of every page this
+    /// run verifiably encountered: requested + final URLs of successful fetches, plus every URL
+    /// appearing in successful tool output EXCEPT `host.web.search` (search snippets are exactly
+    /// the ungrounded source the citation gate exists to reject). `didFetchSuccessfully` arms the
+    /// gate; `writtenWorkspacePaths` limits deliverable scanning to files this run itself wrote.
+    private(set) var groundedURLs: Set<String> = []
+    private(set) var didFetchSuccessfully = false
+    private(set) var writtenWorkspacePaths: Set<String> = []
 
     private var flailDetector = FlailDetector()
     private var previousWorkspaceState: String?
@@ -44,6 +52,7 @@ struct AgentRunLoopState: Sendable {
         toolResults.append(contentsOf: completion.toolResults)
         lastExecutedCall = completion.call
         lastCompletion = completion
+        recordCitationProvenance(completion)
 
         let workspaceState = stateSignature(workspaceRoot)
         let deltaSignature = workspaceState == previousWorkspaceState ? "" : workspaceState
@@ -59,6 +68,53 @@ struct AgentRunLoopState: Sendable {
                 completion.result.error ?? "",
             ].joined(separator: "\n"))
         ))
+    }
+
+    /// Seeds the grounded set from context that predates this run's tool steps: the user's
+    /// request and the thread's prior messages. Called once by the runner before the loop.
+    mutating func seedCitationProvenance(userMessage: String, thread: ChatThread) {
+        for url in AgentCitationIntegrityGate.allURLs(in: userMessage) {
+            groundedURLs.insert(AgentCitationIntegrityGate.normalize(url))
+        }
+        for message in thread.messages {
+            for url in AgentCitationIntegrityGate.allURLs(in: message.content) {
+                groundedURLs.insert(AgentCitationIntegrityGate.normalize(url))
+            }
+        }
+    }
+
+    private mutating func recordCitationProvenance(_ completion: AgentToolStepCompletion) {
+        guard completion.result.ok else { return }
+        let name = completion.call.name
+        // Scope: only host.file.write registers written paths (args.path + the executor's
+        // absolute artifact path). apply_patch reports no artifacts; a patch-authored deliverable
+        // is simply not scanned — under-enforcement, never a false positive on user files.
+        if name == "host.file.write" {
+            if let data = completion.call.argumentsJSON.data(using: .utf8),
+               let arguments = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let path = arguments["path"] as? String {
+                writtenWorkspacePaths.insert(path)
+            }
+            for artifact in completion.result.artifacts {
+                writtenWorkspacePaths.insert(artifact)
+            }
+        }
+        if name == "host.web.fetch" {
+            didFetchSuccessfully = true
+            if let data = completion.call.argumentsJSON.data(using: .utf8),
+               let arguments = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let requested = arguments["url"] as? String {
+                groundedURLs.insert(AgentCitationIntegrityGate.normalize(requested))
+            }
+        }
+        // Every URL visible in successful non-search output is grounded provenance: the final
+        // fetch URL in the summary line, links inside fetched page content, URLs in files the
+        // run read, addresses printed by shell commands. Search output stays ungrounded — a
+        // snippet listing is not a read page, and it is the observed leak source.
+        guard name != "host.web.search" else { return }
+        for url in AgentCitationIntegrityGate.allURLs(in: completion.result.stdout) {
+            groundedURLs.insert(AgentCitationIntegrityGate.normalize(url))
+        }
     }
 
     mutating func recordDeniedStep(_ completion: AgentToolStepCompletion) {

--- a/Tests/QuillCodeAgentTests/AgentCitationIntegrityGateTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentCitationIntegrityGateTests.swift
@@ -1,0 +1,369 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// F29 — citation-integrity enforcement. Live failures this closes: a speaker-brief run cited a
+/// search-snippet URL it never fetched (fetch log shows a different path on the same host), and a
+/// re-drive on a second model leaked an unfetched pointer link — both under an explicit prompt
+/// rule forbidding it. Prompts are insufficient for this class; the run loop must audit the
+/// terminal answer against the run's grounded provenance (fetched pages, their content, read
+/// files, the user's request, prior turns) — search snippets stay ungrounded on purpose.
+final class AgentCitationIntegrityGateTests: XCTestCase {
+    // MARK: - Normalization
+
+    func testNormalizeStripsFragmentAndTrailingSlashKeepsPortAndQuery() {
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.normalize("HTTPS://Example.COM/Path/#section"),
+            "https://example.com/Path"
+        )
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.normalize("https://example.com/"),
+            "https://example.com"
+        )
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.normalize("https://example.com:8443/a?b=1"),
+            "https://example.com:8443/a?b=1"
+        )
+    }
+
+    func testFinalURLParsedFromFetchSummaryLine() {
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.finalURL(
+                fromFetchStdout: "Fetched https://www.notion.com/pricing (HTTP 200, text/html, 1.2 MB fetched, converted to markdown).\n\n# Pricing"
+            ),
+            "https://www.notion.com/pricing"
+        )
+        XCTAssertNil(AgentCitationIntegrityGate.finalURL(fromFetchStdout: "some other output"))
+    }
+
+    // MARK: - Citation extraction (the audited side)
+
+    func testMarkdownLinksExtractedBareURLsIgnored() {
+        let text = """
+        See [the docs](https://example.com/docs) and also https://bare.example.com/ignored
+        plus [another](http://second.example.org/page).
+        """
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.markdownLinkedURLs(in: text),
+            ["https://example.com/docs", "http://second.example.org/page"]
+        )
+    }
+
+    func testParenthesizedURLsExtractIntact() {
+        // The Wikipedia shape that permanently false-positived under a lazy regex.
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.markdownLinkedURLs(
+                in: "[Swift](https://en.wikipedia.org/wiki/Swift_(programming_language)) is nice."
+            ),
+            ["https://en.wikipedia.org/wiki/Swift_(programming_language)"]
+        )
+    }
+
+    func testTitledAndAngleBracketLinksExtract() {
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.markdownLinkedURLs(
+                in: #"[docs](https://example.com/docs "Docs title") and [x](<https://example.com/angle>)"#
+            ),
+            ["https://example.com/docs", "https://example.com/angle"]
+        )
+    }
+
+    func testImageEmbedsAndCodeFencesAreNotCitations() {
+        let text = """
+        ![chart](https://example.com/chart.png)
+        ```
+        [example](https://example.com/in-code-fence)
+        ```
+        ~~~
+        [tilde](https://example.com/in-tilde-fence)
+        ~~~
+        [real](https://example.com/real)
+        """
+        XCTAssertEqual(
+            AgentCitationIntegrityGate.markdownLinkedURLs(in: text),
+            ["https://example.com/real"]
+        )
+    }
+
+    // MARK: - Provenance extraction (the allowing side)
+
+    func testAllURLsHarvestsBareAndParenthesizedSpellings() {
+        let text = """
+        Fetched https://en.wikipedia.org/wiki/Swift_(programming_language) (HTTP 200).
+        Body links: <a href="https://example.com/deep">deep</a>, trailing punctuation https://x.example.com/p.
+        """
+        let urls = AgentCitationIntegrityGate.allURLs(in: text)
+        XCTAssertTrue(urls.contains("https://en.wikipedia.org/wiki/Swift_(programming_language)"))
+        XCTAssertTrue(urls.contains("https://example.com/deep"))
+        XCTAssertTrue(urls.contains("https://x.example.com/p"))
+    }
+
+    // MARK: - ungroundedCitations
+
+    private func makeWorkspace() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("citation-gate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    func testUngroundedLinkFlaggedGroundedOneIsNot() throws {
+        let root = try makeWorkspace()
+        let offenders = AgentCitationIntegrityGate.ungroundedCitations(
+            sayText: "See [a](https://example.com/fetched/) and [b](https://example.com/guessed).",
+            userMessage: "Research the site.",
+            workspaceRoot: root,
+            groundedURLs: [AgentCitationIntegrityGate.normalize("https://example.com/fetched")],
+            writtenWorkspacePaths: []
+        )
+        XCTAssertEqual(offenders, ["https://example.com/guessed"])
+    }
+
+    func testLinkFoundInsideFetchedContentIsGrounded() throws {
+        // The wizardzines case: jvns.ca was fetched and its content links wizardzines.com. Citing
+        // that pointer is grounded provenance — the harvest side collects URLs from fetched output.
+        let root = try makeWorkspace()
+        let fetchedPage = "Fetched https://jvns.ca (HTTP 200).\n\nI make [Wizard Zines](https://wizardzines.com/)!"
+        var grounded = Set<String>()
+        for url in AgentCitationIntegrityGate.allURLs(in: fetchedPage) {
+            grounded.insert(AgentCitationIntegrityGate.normalize(url))
+        }
+        let offenders = AgentCitationIntegrityGate.ungroundedCitations(
+            sayText: "Creator of [Wizard Zines](https://wizardzines.com).",
+            userMessage: "Build a speaker brief.",
+            workspaceRoot: root,
+            groundedURLs: grounded,
+            writtenWorkspacePaths: []
+        )
+        XCTAssertTrue(offenders.isEmpty)
+    }
+
+    func testOnlyRunWrittenMarkdownDeliverablesAreScanned() throws {
+        let root = try makeWorkspace()
+        try """
+        Creator of [Wizard Zines](https://wizardzines.com), fetched [site](https://jvns.ca/).
+        """.write(to: root.appendingPathComponent("speaker-brief.md"), atomically: true, encoding: .utf8)
+        try "[user link](https://user-supplied.example.com/page)"
+            .write(to: root.appendingPathComponent("notes.md"), atomically: true, encoding: .utf8)
+        let grounded: Set<String> = [AgentCitationIntegrityGate.normalize("https://jvns.ca/")]
+        // notes.md exists and is named in the task, but the run never wrote it — user input files
+        // are never audited. speaker-brief.md WAS written by the run and is audited.
+        let offenders = AgentCitationIntegrityGate.ungroundedCitations(
+            sayText: "Done.",
+            userMessage: "Read notes.md, then build a brief and write speaker-brief.md",
+            workspaceRoot: root,
+            groundedURLs: grounded,
+            writtenWorkspacePaths: ["speaker-brief.md"]
+        )
+        XCTAssertEqual(offenders, ["https://wizardzines.com"])
+    }
+
+    // MARK: - Run-loop provenance recording
+
+    func testRunLoopHarvestsFetchAndReadOutputButNotSearch() {
+        var state = AgentRunLoopState()
+        let root = URL(fileURLWithPath: "/tmp")
+        let signature: (URL) -> String = { _ in "" }
+        func record(_ name: String, args: String, stdout: String, artifacts: [String] = []) {
+            _ = state.recordCompletedStep(
+                AgentToolStepCompletion(
+                    call: ToolCall(name: name, argumentsJSON: args),
+                    result: ToolResult(ok: true, stdout: stdout, artifacts: artifacts),
+                    followUpReviewResult: nil,
+                    toolResults: []
+                ),
+                workspaceRoot: root,
+                stateSignature: signature
+            )
+        }
+        record(
+            "host.web.fetch",
+            args: #"{"url":"https://www.notion.so/pricing"}"#,
+            stdout: "Fetched https://www.notion.com/pricing (HTTP 200).\n\nBody [link](https://example.com/inside)"
+        )
+        record(
+            "host.web.search",
+            args: #"{"query":"swift"}"#,
+            stdout: "1. https://snippet.example.com/unread — a search result"
+        )
+        record(
+            "host.file.write",
+            args: #"{"path":"brief.md","content":"x"}"#,
+            stdout: "Wrote /tmp/brief.md",
+            artifacts: ["/tmp/brief.md"]
+        )
+
+        XCTAssertTrue(state.didFetchSuccessfully)
+        XCTAssertTrue(state.groundedURLs.contains(AgentCitationIntegrityGate.normalize("https://www.notion.so/pricing")))
+        XCTAssertTrue(state.groundedURLs.contains(AgentCitationIntegrityGate.normalize("https://www.notion.com/pricing")))
+        XCTAssertTrue(state.groundedURLs.contains(AgentCitationIntegrityGate.normalize("https://example.com/inside")))
+        XCTAssertFalse(state.groundedURLs.contains(AgentCitationIntegrityGate.normalize("https://snippet.example.com/unread")))
+        XCTAssertTrue(state.writtenWorkspacePaths.contains("brief.md"))
+        XCTAssertTrue(state.writtenWorkspacePaths.contains("/tmp/brief.md"))
+    }
+
+    func testSeededProvenanceCoversUserMessageAndPriorTurns() {
+        var state = AgentRunLoopState()
+        var thread = ChatThread(title: "t")
+        thread.messages.append(.init(role: .assistant, content: "Earlier I cited [a](https://prior.example.com/page)."))
+        state.seedCitationProvenance(
+            userMessage: "Also include https://user.example.com/tracker in the summary.",
+            thread: thread
+        )
+        XCTAssertTrue(state.groundedURLs.contains(AgentCitationIntegrityGate.normalize("https://prior.example.com/page")))
+        XCTAssertTrue(state.groundedURLs.contains(AgentCitationIntegrityGate.normalize("https://user.example.com/tracker")))
+    }
+
+    // MARK: - End-to-end recovery through the runner
+
+    private actor ScriptedState {
+        var steps: [AgentAction]
+        init(_ steps: [AgentAction]) { self.steps = steps }
+        func next() -> AgentAction {
+            steps.isEmpty ? .say("out of steps") : steps.removeFirst()
+        }
+    }
+
+    private struct ScriptedClient: LLMClient {
+        let state: ScriptedState
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            await state.next()
+        }
+    }
+
+    private func fetchStubRunner(llm: ScriptedClient) -> AgentRunner {
+        var runner = AgentRunner(
+            llm: llm,
+            additionalToolDefinitions: [.webFetch]
+        )
+        runner.toolExecutionOverride = { call, _ in
+            guard call.name == "host.web.fetch" else { return nil }
+            return ToolResult(
+                ok: true,
+                stdout: "Fetched https://example.com/real (HTTP 200, text/html, 10 KB fetched, converted to markdown).\n\n# Real page"
+            )
+        }
+        return runner
+    }
+
+    func testUngroundedCitationIsCorrectedAndCleanAnswerPasses() async throws {
+        let root = try makeWorkspace()
+        let fetch = ToolCall(name: "host.web.fetch", argumentsJSON: #"{"url":"https://example.com/real"}"#)
+        let state = ScriptedState([
+            .tool(fetch),
+            .say("See [real](https://example.com/real) and [guessed](https://example.com/never-fetched)."),
+            .say("See [real](https://example.com/real); the other page is unverified."),
+        ])
+        let runner = fetchStubRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Research example.com and summarize.",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertTrue(final.contains("unverified"))
+        XCTAssertFalse(final.contains("never-fetched"))
+        XCTAssertFalse(final.contains("⚠ Citation integrity"))
+    }
+
+    func testPersistentRefusalSurfacesIntegrityNoticeInsteadOfFailing() async throws {
+        let root = try makeWorkspace()
+        let fetch = ToolCall(name: "host.web.fetch", argumentsJSON: #"{"url":"https://example.com/real"}"#)
+        let bad = AgentAction.say("See [guessed](https://example.com/never-fetched).")
+        let state = ScriptedState([.tool(fetch), bad, bad, bad])
+        let runner = fetchStubRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Research example.com and summarize.",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertTrue(final.contains("⚠ Citation integrity"))
+        XCTAssertTrue(final.contains("https://example.com/never-fetched"))
+    }
+
+    func testCitationCorrectiveCannotEndRunOnBarePromiseSay() async throws {
+        // Bypass proven by a review probe: the first corrective sample dodges the gate with a
+        // link-free promise ("I'll fetch it now") — zero offenders would have passed it. The gate
+        // must re-screen promises within its budget; here the second sample complies honestly.
+        let root = try makeWorkspace()
+        let fetch = ToolCall(name: "host.web.fetch", argumentsJSON: #"{"url":"https://example.com/real"}"#)
+        let promise = "I'll fetch https://example.com/never-fetched now and verify the link."
+        let state = ScriptedState([
+            .tool(fetch),
+            .say("See [guessed](https://example.com/never-fetched)."),
+            .say(promise),
+            .say("The claim is unverified; I could not confirm the page."),
+        ])
+        let runner = fetchStubRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Research example.com and summarize.",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertNotEqual(final, promise)
+        XCTAssertTrue(final.contains("unverified"))
+    }
+
+    func testRunWithoutFetchesEndsUntouched() async throws {
+        let root = try makeWorkspace()
+        let state = ScriptedState([.say("The answer links [docs](https://example.com/docs).")])
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+        let result = try await runner.send(
+            "What is the docs URL?",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertFalse(final.contains("⚠ Citation integrity"))
+    }
+
+    func testFollowUpTurnDoesNotFlagPriorTurnCitations() async throws {
+        // The multi-turn finding: turn 1 fetched five pages and wrote the brief; turn 2 fetches
+        // one new page. Turn-1 citations are grounded via the thread history seed.
+        let root = try makeWorkspace()
+        try "[t1](https://turn-one.example.com/page)".write(
+            to: root.appendingPathComponent("brief.md"), atomically: true, encoding: .utf8
+        )
+        var thread = ChatThread(title: "t")
+        thread.messages.append(.init(role: .user, content: "Build a brief and write brief.md"))
+        thread.messages.append(.init(
+            role: .assistant,
+            content: "Wrote brief.md citing [t1](https://turn-one.example.com/page)."
+        ))
+        let fetch = ToolCall(name: "host.web.fetch", argumentsJSON: #"{"url":"https://example.com/real"}"#)
+        let write = ToolCall(
+            name: "host.file.write",
+            argumentsJSON: try XCTUnwrap(String(
+                data: JSONSerialization.data(withJSONObject: [
+                    "path": "brief.md",
+                    "content": "[t1](https://turn-one.example.com/page) and [new](https://example.com/real)",
+                ]),
+                encoding: .utf8
+            ))
+        )
+        let state = ScriptedState([
+            .tool(fetch),
+            .tool(write),
+            .say("Updated brief.md with the new section."),
+        ])
+        let runner = fetchStubRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Add a section to the brief and write brief.md",
+            in: thread,
+            workspaceRoot: root
+        )
+
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertFalse(final.contains("⚠ Citation integrity"))
+    }
+}


### PR DESCRIPTION
Terminal answers in research-shaped runs may only cite markdown-linked URLs with **grounded provenance**: fetched pages (requested + final URL), URLs appearing in successful non-search tool output, the user's request, and prior turns. Search-snippet-only URLs — the observed live leak on two models — get a bounded corrective, then an honest ⚠ notice (never a dead run). Only files the run itself wrote are audited; user input files never are.

Round-1 adversarial review returned 15/15 confirmed findings against the first draft (notably: paren-URL truncation and the per-send fetch log vs multi-turn deliverables); this is the provenance rearchitecture that addresses all of them, plus a promise-say bypass proven by a review probe and now regression-tested.

Full suite 5272/5272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)