### PR TITLE
Escalating corrective prompts (Cline learning #1)

### DIFF
--- a/Sources/QuillCodeAgent/AgentActionResolver.swift
+++ b/Sources/QuillCodeAgent/AgentActionResolver.swift
@@ -89,9 +89,17 @@ extension AgentRunner {
                     throw TrustedRouterAgentError.invalidActionJSON(text)
                 }
                 attempt += 1
-                let correctionPrompt = AgentMalformedActionGuard.correctionPrompt(
-                    malformedText: text,
-                    userMessage: userMessage
+                let correctionPrompt = AgentCorrectionEscalation.escalated(
+                    AgentMalformedActionGuard.correctionPrompt(
+                        malformedText: text,
+                        userMessage: userMessage
+                    ),
+                    attempt: attempt - 1,
+                    limit: Self.malformedActionCorrectionLimit,
+                    alternatives: [
+                        "respond with EXACTLY one JSON object — {\"type\":\"tool\",...} or {\"type\":\"say\",...} — and nothing else: no prose, no markdown, no code fences",
+                        "if you cannot produce the intended action, respond {\"type\":\"say\",\"text\":\"<what blocked you>\"}",
+                    ]
                 )
                 correctiveThread.messages.append(.init(
                     role: .assistant,

--- a/Sources/QuillCodeAgent/AgentCorrectionEscalation.swift
+++ b/Sources/QuillCodeAgent/AgentCorrectionEscalation.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Failure-count-aware escalation for corrective re-prompts (Cline learning #1,
+/// docs/CLINE_TOOL_LEARNINGS.md).
+///
+/// Every corrective loop in the runner used to send the SAME text on each attempt — a model that
+/// ignored the first correction saw nothing new and usually repeated itself. Cline's standout
+/// tool-feedback pattern escalates instead: early attempts diagnose and suggest; the final
+/// budgeted attempt switches to a directive form that forbids repeating the response and offers
+/// an explicit, numbered choice of ways out. The correction must teach an alternative, never
+/// just restate the rule.
+enum AgentCorrectionEscalation {
+    /// Wraps `base` with the final-attempt directive once the loop reaches its last budgeted
+    /// attempt. `attempt` is 0-based; earlier attempts pass `base` through unchanged so the
+    /// first correction stays diagnostic.
+    static func escalated(
+        _ base: String,
+        attempt: Int,
+        limit: Int,
+        alternatives: [String]
+    ) -> String {
+        guard limit > 1, attempt >= limit - 1 else { return base }
+        let numbered = alternatives.enumerated()
+            .map { "(\($0.offset + 1)) \($0.element)" }
+            .joined(separator: " ")
+        return """
+        FINAL ATTEMPT (\(attempt + 1) of \(limit)): your previous response ignored this same \
+        correction. Do NOT repeat that response. You must now do exactly ONE of the following: \
+        \(numbered)
+
+        \(base)
+        """
+    }
+}

--- a/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
@@ -10,7 +10,7 @@ extension AgentRunner {
     ) async throws -> AgentAction {
         var candidate = action
         var retryThread = thread
-        for _ in 0..<Self.promisedWorkCorrectionLimit {
+        for attempt in 0..<Self.promisedWorkCorrectionLimit {
             guard case .say(let text) = candidate,
                   let correction = AgentPromisedWorkGuard.correctionNeeded(for: text, tools: tools)
             else {
@@ -32,10 +32,19 @@ extension AgentRunner {
                 }
             }
 
-            let correctionPrompt = AgentPromisedWorkGuard.correctionPrompt(
-                for: correction,
-                assistantText: text,
-                userMessage: userMessage
+            let correctionPrompt = AgentCorrectionEscalation.escalated(
+                AgentPromisedWorkGuard.correctionPrompt(
+                    for: correction,
+                    assistantText: text,
+                    userMessage: userMessage
+                ),
+                attempt: attempt,
+                limit: Self.promisedWorkCorrectionLimit,
+                alternatives: [
+                    "emit the promised tool call as your next action, with no prose around it",
+                    "if the work is already complete, state the concrete result plainly in past tense",
+                    "if you are blocked, write exactly what you did and what blocked you",
+                ]
             )
             retryThread.messages.append(.init(role: .assistant, content: text))
             retryThread.messages.append(.init(role: .user, content: correctionPrompt))
@@ -74,14 +83,22 @@ extension AgentRunner {
         guard tools.contains(where: { $0.name == "host.file.write" }) else { return action }
         var candidate = action
         var retryThread = thread
-        for _ in 0..<Self.promisedWorkCorrectionLimit {
+        for attempt in 0..<Self.promisedWorkCorrectionLimit {
             guard case .say(let text) = candidate else { return candidate }
             let missing = AgentDeliverableGate.missingDeliverables(
                 in: userMessage,
                 workspaceRoot: workspaceRoot
             )
             guard !missing.isEmpty else { return candidate }
-            let correctionPrompt = AgentDeliverableGate.correctionPrompt(missing: missing)
+            let correctionPrompt = AgentCorrectionEscalation.escalated(
+                AgentDeliverableGate.correctionPrompt(missing: missing),
+                attempt: attempt,
+                limit: Self.promisedWorkCorrectionLimit,
+                alternatives: [
+                    "create the named file NOW with host.file.write (path + full content)",
+                    "if genuinely blocked, write exactly what you did and what blocked you — do not promise future work",
+                ]
+            )
             retryThread.messages.append(.init(role: .assistant, content: text))
             retryThread.messages.append(.init(role: .user, content: correctionPrompt))
             retryThread.updatedAt = Date()
@@ -128,12 +145,20 @@ extension AgentRunner {
                 writtenWorkspacePaths: writtenWorkspacePaths
             )
         }
-        for _ in 0..<Self.promisedWorkCorrectionLimit {
+        for attempt in 0..<Self.promisedWorkCorrectionLimit {
             guard case .say(let text) = candidate else { return candidate }
             let ungrounded = offenders(in: text)
             let correctionPrompt: String
             if !ungrounded.isEmpty {
-                correctionPrompt = AgentCitationIntegrityGate.correctionPrompt(unfetched: ungrounded)
+                correctionPrompt = AgentCorrectionEscalation.escalated(
+                    AgentCitationIntegrityGate.correctionPrompt(unfetched: ungrounded),
+                    attempt: attempt,
+                    limit: Self.promisedWorkCorrectionLimit,
+                    alternatives: [
+                        "call host.web.fetch on each listed URL now and keep only the ones that succeed",
+                        "remove the listed links and mark those claims 'unverified' in the deliverable file and your answer",
+                    ]
+                )
             } else if let promise = AgentPromisedWorkGuard.correctionNeeded(for: text, tools: tools) {
                 // A corrective sample can dodge the gate with a link-free promise ("I'll fetch it
                 // now") — no offenders, so it would pass, and the promised-work guard upstream has

--- a/Tests/QuillCodeAgentTests/AgentCorrectionEscalationTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentCorrectionEscalationTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// Cline learning #1 (docs/CLINE_TOOL_LEARNINGS.md): corrective re-prompts escalate with the
+/// failure count instead of repeating the same text. The final budgeted attempt switches to a
+/// directive form that forbids repeating the response and offers numbered ways out.
+final class AgentCorrectionEscalationTests: XCTestCase {
+    func testFirstAttemptPassesBaseThrough() {
+        let base = "Please write the file."
+        XCTAssertEqual(
+            AgentCorrectionEscalation.escalated(base, attempt: 0, limit: 2, alternatives: ["a"]),
+            base
+        )
+    }
+
+    func testFinalAttemptGetsDirectivePreambleWithNumberedAlternatives() {
+        let escalated = AgentCorrectionEscalation.escalated(
+            "Please write the file.",
+            attempt: 1,
+            limit: 2,
+            alternatives: ["write it now", "explain what blocked you"]
+        )
+        XCTAssertTrue(escalated.contains("FINAL ATTEMPT (2 of 2)"))
+        XCTAssertTrue(escalated.contains("Do NOT repeat that response"))
+        XCTAssertTrue(escalated.contains("(1) write it now"))
+        XCTAssertTrue(escalated.contains("(2) explain what blocked you"))
+        XCTAssertTrue(escalated.contains("Please write the file."))
+    }
+
+    func testSingleAttemptBudgetNeverEscalates() {
+        let base = "base"
+        XCTAssertEqual(
+            AgentCorrectionEscalation.escalated(base, attempt: 0, limit: 1, alternatives: ["a"]),
+            base
+        )
+    }
+
+    // MARK: - End-to-end: the deliverable gate's second corrective is escalated
+
+    private actor PromptRecorder {
+        var prompts: [String] = []
+        var steps: [AgentAction]
+        init(_ steps: [AgentAction]) { self.steps = steps }
+        func next(_ userMessage: String) -> AgentAction {
+            prompts.append(userMessage)
+            return steps.isEmpty ? .say("out of steps") : steps.removeFirst()
+        }
+        func recorded() -> [String] { prompts }
+    }
+
+    private struct RecordingClient: LLMClient {
+        let state: PromptRecorder
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            await state.next(userMessage)
+        }
+    }
+
+    func testDeliverableGateSecondCorrectiveIsDirective() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("escalation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        // Three bare "Done." says: initial + two corrective samples, then the hard failure.
+        let state = PromptRecorder([.say("Done."), .say("Done."), .say("Done.")])
+        let runner = AgentRunner(llm: RecordingClient(state: state))
+        do {
+            _ = try await runner.send(
+                "Search the folders and build index.md with a table.",
+                in: ChatThread(title: "t"),
+                workspaceRoot: root
+            )
+            XCTFail("expected missingNamedDeliverable")
+        } catch AgentError.missingNamedDeliverable {
+            // expected
+        }
+
+        let prompts = await state.recorded()
+        let correctives = prompts.filter { $0.contains("index.md") && $0 != prompts.first }
+        XCTAssertGreaterThanOrEqual(correctives.count, 2)
+        XCTAssertFalse(try XCTUnwrap(correctives.first).contains("FINAL ATTEMPT"))
+        XCTAssertTrue(try XCTUnwrap(correctives.last).contains("FINAL ATTEMPT"))
+        XCTAssertTrue(try XCTUnwrap(correctives.last).contains("host.file.write"))
+    }
+}

--- a/docs/CLINE_TOOL_LEARNINGS.md
+++ b/docs/CLINE_TOOL_LEARNINGS.md
@@ -1,0 +1,88 @@
+# Cline tool-excellence analysis → QuillCode plan
+
+Analyzed 2026-08-04 from a shallow clone of github.com/cline/cline (post-SDK restructure:
+`apps/vscode` extension + `sdk/packages/{core,shared,agents}`). Findings verified by reading the
+actual sources; file references below are to that tree.
+
+## Why Cline is "great at tools" — the real mechanics
+
+Cline's reputation does not come from exotic tools — its tool *set* is ordinary (read/write/
+replace_in_file/execute_command/browser/MCP). It comes from **feedback engineering**: what the
+model is told when a tool call goes wrong, and how that message changes as failures accumulate.
+
+### 1. Progressive, failure-count-aware error feedback (the standout)
+`apps/vscode/src/core/prompts/responses.ts` — `writeToFileMissingContentError(relPath,
+consecutiveFailures, contextUsagePercent)`:
+- **1st failure**: diagnosis + gentle suggestions (skeleton first; prefer replace_in_file).
+- **2nd failure**: "You must use a different strategy" + three enumerated alternatives.
+- **3rd+**: "CRITICAL: You have failed N times. Do NOT retry write_to_file for this file again.
+  Required action — choose ONE:" with concrete numbered strategies and size bounds
+  ("no more than 50-100 lines per replace_in_file call").
+- Blends in **context-window awareness**: past 50% usage it warns that output budget may be the
+  cause and mandates smaller-output strategies.
+
+The correction *teaches an alternative*, never just restates the rule. Every error message names
+the exact tool and parameter syntax to use next (`replaceInFileMissingDiffError` embeds a full
+SEARCH/REPLACE example; `executeCommandMissingCommandError` embeds a full XML example).
+
+### 2. Graded loop detection: soft warn, then hard stop
+`sdk/packages/core/src/runtime/safety/loop-detection.ts` — identical-call detection over a
+canonical **key-sorted JSON signature**, with two thresholds (default soft=3, hard=5). At soft
+the model gets "consider trying a different approach" and keeps going; at hard the run stops
+with a clear reason. Escalation is graduated, not binary.
+
+### 3. Session-level consecutive-mistake budget across categories
+`sdk/packages/core/src/runtime/safety/mistake-tracker.ts` — one counter spanning
+`api_error | invalid_tool_call | tool_execution_failed`; any successful step resets it. At the
+limit, a host callback can inject recovery guidance (and reset) or stop with a message that
+explicitly says **state was preserved and how to resume**. Per-step budgets alone can't see a
+run that alternates failure *kinds*.
+
+### 4. Context hygiene around tools
+- `duplicateFileReadNotice`: a repeated file read is *replaced in history* with a one-line
+  pointer to the latest read — precise dedup, cheaper than generic compaction.
+- `contextTruncationNotice` tells the model exactly what was dropped and what was kept.
+- `noToolsUsed()`: an automated, non-conversational retry message when a response contains no
+  tool call, with explicit next-step menu (attempt_completion / ask_followup_question / next
+  tool). Cline counts it as a mistake toward the budget.
+
+### 5. Honest denial/interruption semantics
+- Tool denied → the canonical string "The user denied this operation." — never euphemised.
+- `.clineignore` block → names the blocking mechanism and the two honest ways forward.
+- Interrupted tools are recorded in-history as "[tool] was interrupted and not executed" so the
+  model never believes a cancelled call ran.
+
+### 6. Conversation-boundary markers
+`sdk/packages/shared/src/prompt/format.ts` — mode switches (plan↔act) are marked *in the
+message stream* (`<mode_notice>`) at the exact boundary, with round-trip cancellation so a
+plan→act→plan toggle before sending never emits a stale notice.
+
+## What QuillCode already has (no action)
+- Tolerant fuzzy apply_patch (≈ Cline's multi-tier SEARCH/REPLACE matcher).
+- Flail detection on workspace deltas; repeated-call finalization; turn deadline (F20);
+  promised-work/deferral/readiness guards (#1538/#1540); deliverable gate (F23/F25); citation
+  gate (F29); model fallback (F22); async approval; auto-approval policy floors.
+- Mode-aware prompt guidance (read-only/review) — static per-mode, see gap 5.
+
+## Gaps → prioritized plan
+
+1. **Escalating corrective prompts** (Cline #1) — HIGH, low risk. QuillCode's corrective
+   re-prompts (malformed action, promised work, deliverable gate, citation gate) send the SAME
+   text on every attempt. Add attempt-indexed escalation: final budgeted attempt switches to a
+   directive form — "this is your Nth failed attempt; do NOT repeat the same response; choose
+   ONE of: …" with gate-specific concrete alternatives (the escape hatch made explicit).
+   → **Implemented in this PR** (`AgentCorrectionEscalation`).
+2. **Soft-warning tier before repeated-call finalization** (Cline #2) — MEDIUM-HIGH. Today the
+   second identical call finalizes immediately; a transient-failure retry is legitimate. Inject
+   one "you already ran exactly this; try a different approach or finish" notice first,
+   finalize on the next repeat. (Next PR.)
+3. **Cross-category consecutive-mistake budget** (Cline #3) — MEDIUM. Aggregate malformed +
+   denied + failed-tool streaks into one per-run counter with a preserved-state stop message.
+   maxToolSteps bounds runaway today, but spends the whole step budget doing it. (Next PR.)
+4. **Duplicate-file-read dedup** (Cline #4) — MEDIUM. On re-read of an unchanged file, replace
+   the older read's content in the thread with a pointer notice. Pairs with existing compaction.
+5. **Mode-switch notices** (Cline #6) — LOW-MED. Emit a one-line boundary notice into the next
+   user message after a plan/read-only/review mode change, with round-trip cancellation.
+6. **Context-usage-aware error guidance** (Cline #1's second axis) — LOW-MED. Thread current
+   context-usage % into write-failure corrections ("output budget likely insufficient — write a
+   skeleton, then extend in sections").


### PR DESCRIPTION
Analysis of cline/cline's tool layer (new [docs/CLINE_TOOL_LEARNINGS.md](https://github.com/Lore-Hex/QuillCode/blob/feat/escalating-correctives/docs/CLINE_TOOL_LEARNINGS.md)) shows its tool excellence is mostly **feedback engineering**: error messages that escalate with the consecutive-failure count and always teach an alternative. This PR adds `AgentCorrectionEscalation` and wires it into all four corrective loops (promised-work, deliverable gate, citation gate, malformed-action) — the final budgeted attempt becomes directive: 'FINAL ATTEMPT (2 of 2)… Do NOT repeat that response… do exactly ONE of: (1) … (2) …' with gate-specific concrete outs.

Stacked on #1551 (touches the same resolver); will retarget to main when it lands. Full suite 5276/5276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)