### PR TITLE
F31: gate corrective samples tolerate malformed model output

### DIFF
--- a/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
@@ -49,11 +49,12 @@ extension AgentRunner {
             retryThread.messages.append(.init(role: .assistant, content: text))
             retryThread.messages.append(.init(role: .user, content: correctionPrompt))
             retryThread.updatedAt = Date()
-            candidate = try await llm.nextAction(
+            guard let sampled = try await correctiveSample(
                 thread: retryThread,
-                userMessage: correctionPrompt,
+                prompt: correctionPrompt,
                 tools: tools
-            )
+            ) else { continue }
+            candidate = sampled
         }
 
         // Budget spent. Only unmet promised work is a hard failure — a model that keeps ASKING
@@ -102,11 +103,12 @@ extension AgentRunner {
             retryThread.messages.append(.init(role: .assistant, content: text))
             retryThread.messages.append(.init(role: .user, content: correctionPrompt))
             retryThread.updatedAt = Date()
-            candidate = try await llm.nextAction(
+            guard let sampled = try await correctiveSample(
                 thread: retryThread,
-                userMessage: correctionPrompt,
+                prompt: correctionPrompt,
                 tools: tools
-            )
+            ) else { continue }
+            candidate = sampled
         }
         if case .say = candidate {
             let stillMissing = AgentDeliverableGate.missingDeliverables(
@@ -175,11 +177,12 @@ extension AgentRunner {
             retryThread.messages.append(.init(role: .assistant, content: text))
             retryThread.messages.append(.init(role: .user, content: correctionPrompt))
             retryThread.updatedAt = Date()
-            candidate = try await llm.nextAction(
+            guard let sampled = try await correctiveSample(
                 thread: retryThread,
-                userMessage: correctionPrompt,
+                prompt: correctionPrompt,
                 tools: tools
-            )
+            ) else { continue }
+            candidate = sampled
         }
         if case .say(let text) = candidate {
             let ungrounded = offenders(in: text)
@@ -209,4 +212,28 @@ extension AgentRunner {
     ) -> AgentAction? {
         AgentImmediateActionPlanner.action(for: userMessage, tools: tools)
     }
+
+    /// F31: gate corrective samples call the raw LLM client, which throws on a malformed or
+    /// empty response — with no recovery arm around these calls, ONE thinking-only sample killed
+    /// an otherwise-finished research run (live: the deliverable gate's corrective after a
+    /// misnamed deliverable; TrustedRouterAgentError.invalidActionJSON propagated straight out of
+    /// send()). The main resolver's malformed-recovery loop does not cover these paths — the
+    /// F25 lesson applied to sampling: every model-sampling path needs bounded tolerance, not
+    /// just the main action loop. A bad sample returns nil, consuming the attempt; the caller's
+    /// loop re-prompts (escalated on the final attempt) or falls through to the gate's terminal
+    /// behavior (hard fail / integrity notice / budget-spent tail). Transport and cancellation
+    /// errors still propagate.
+    private func correctiveSample(
+        thread: ChatThread,
+        prompt: String,
+        tools: [ToolDefinition]
+    ) async throws -> AgentAction? {
+        do {
+            return try await llm.nextAction(thread: thread, userMessage: prompt, tools: tools)
+        } catch TrustedRouterAgentError.invalidActionJSON, TrustedRouterAgentError.emptyResponse,
+                TrustedRouterAgentError.emptyToolArguments {
+            return nil
+        }
+    }
+
 }

--- a/Tests/QuillCodeAgentTests/AgentCorrectionEscalationTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentCorrectionEscalationTests.swift
@@ -56,6 +56,53 @@ final class AgentCorrectionEscalationTests: XCTestCase {
         }
     }
 
+    // MARK: - F31: a malformed corrective sample must not kill the run
+
+    private actor ThrowingState {
+        var steps: [Result<AgentAction, Error>]
+        init(_ steps: [Result<AgentAction, Error>]) { self.steps = steps }
+        func next() throws -> AgentAction {
+            guard !steps.isEmpty else { return .say("out of steps") }
+            return try steps.removeFirst().get()
+        }
+    }
+
+    private struct ThrowingClient: LLMClient {
+        let state: ThrowingState
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            try await state.next()
+        }
+    }
+
+    func testMalformedCorrectiveSampleConsumesAttemptInsteadOfKillingRun() async throws {
+        // Live F31: terminal say with the named deliverable missing → gate corrective sample
+        // returns thinking-only garbage (invalidActionJSON). The run must NOT die on it; the
+        // attempt is consumed and the gate reaches its honest terminal behavior.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("f31-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let state = ThrowingState([
+            .success(.say("Done.")),
+            .failure(TrustedRouterAgentError.invalidActionJSON("thinking-only garbage")),
+            .failure(TrustedRouterAgentError.invalidActionJSON("more garbage")),
+        ])
+        let runner = AgentRunner(llm: ThrowingClient(state: state))
+        do {
+            _ = try await runner.send(
+                "Search the folders and build index.md with a table.",
+                in: ChatThread(title: "t"),
+                workspaceRoot: root
+            )
+            XCTFail("expected missingNamedDeliverable")
+        } catch AgentError.missingNamedDeliverable(let path) {
+            XCTAssertEqual(path, "index.md")
+        } catch {
+            XCTFail("run died on the malformed sample instead of the gate's honest failure: \(error)")
+        }
+    }
+
     func testDeliverableGateSecondCorrectiveIsDirective() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("escalation-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
The three gate corrective loops (promised-work, deliverable F23, citation F29) sample the model via the raw LLM client — no recovery arm, so ONE thinking-only response threw `invalidActionJSON` straight out of `send()`. Found live by the coworker loop: two consecutive run deaths on a research row, each after 20+ successful tool steps, dying in the deliverable gate's corrective. This is the F25 lesson applied to sampling: every model-sampling path needs bounded tolerance, not just the main action loop.

`correctiveSample` wraps those calls: malformed/empty samples consume the attempt (re-prompt, escalated on final) instead of killing the run; budget exhaustion reaches each gate's honest terminal behavior. Transport errors and cancellation still propagate.

(Was pushed to #1553's branch seconds after the train merged it — this is the same commit, cherry-picked onto main.) Full suite 5277/5277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)