### PR TITLE
F30: word-budget gate — explicit N-word specs are checked mechanically

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -231,6 +231,16 @@ public struct AgentRunner: Sendable {
                         writtenWorkspacePaths: runLoop.writtenWorkspacePaths
                     )
                 }
+                // F30: explicit N-word specs are checked mechanically, like every other gate.
+                if !runLoop.hadDeniedStep {
+                    resolvedAction = try await actionByRequiringWordBudget(
+                        resolvedAction,
+                        thread: next,
+                        userMessage: userMessage,
+                        tools: tools,
+                        workspaceRoot: workspaceRoot
+                    )
+                }
                 try Task.checkCancellation()
                 switch resolvedAction {
                 case .say(let text):
@@ -274,6 +284,16 @@ public struct AgentRunner: Sendable {
                                 workspaceRoot: workspaceRoot,
                                 groundedURLs: runLoop.groundedURLs,
                                 writtenWorkspacePaths: runLoop.writtenWorkspacePaths
+                            )
+                        }
+                        // F30: the finalized say is a terminal say (F25 lesson) — same gates.
+                        if !runLoop.hadDeniedStep {
+                            finalized = try await actionByRequiringWordBudget(
+                                finalized,
+                                thread: next,
+                                userMessage: userMessage,
+                                tools: tools,
+                                workspaceRoot: workspaceRoot
                             )
                         }
                         switch finalized {

--- a/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
@@ -213,6 +213,61 @@ extension AgentRunner {
         AgentImmediateActionPlanner.action(for: userMessage, tools: tools)
     }
 
+
+    /// F30 — an explicit `N-word` phrase in the task is a mechanical spec, not a vibe. When a
+    /// terminal say arrives with a task-named `.md` deliverable outside ±25% of the requested
+    /// length, the model gets a bounded corrective (escalated on the final attempt) to rewrite
+    /// with substance; persistent shortfall appends an honest length notice — never a dead run.
+    func actionByRequiringWordBudget(
+        _ action: AgentAction,
+        thread: ChatThread,
+        userMessage: String,
+        tools: [ToolDefinition],
+        workspaceRoot: URL
+    ) async throws -> AgentAction {
+        guard AgentQuantitativeSpecGate.wordBudget(in: userMessage) != nil,
+              tools.contains(where: { $0.name == "host.file.write" })
+        else { return action }
+        var candidate = action
+        var retryThread = thread
+        for attempt in 0..<Self.promisedWorkCorrectionLimit {
+            guard case .say(let text) = candidate else { return candidate }
+            let violations = AgentQuantitativeSpecGate.violations(
+                userMessage: userMessage,
+                workspaceRoot: workspaceRoot
+            )
+            guard !violations.isEmpty else { return candidate }
+            let correctionPrompt = AgentCorrectionEscalation.escalated(
+                AgentQuantitativeSpecGate.correctionPrompt(violations: violations),
+                attempt: attempt,
+                limit: Self.promisedWorkCorrectionLimit,
+                alternatives: [
+                    "rewrite the deliverable to the requested length NOW with host.file.write (full revised content, substance not filler)",
+                    "if the source material cannot support the requested length, state exactly what is missing",
+                ]
+            )
+            retryThread.messages.append(.init(role: .assistant, content: text))
+            retryThread.messages.append(.init(role: .user, content: correctionPrompt))
+            retryThread.updatedAt = Date()
+            guard let sampled = try await correctiveSample(
+                thread: retryThread,
+                prompt: correctionPrompt,
+                tools: tools
+            ) else { continue }
+            candidate = sampled
+        }
+        if case .say(let text) = candidate {
+            let violations = AgentQuantitativeSpecGate.violations(
+                userMessage: userMessage,
+                workspaceRoot: workspaceRoot
+            )
+            if !violations.isEmpty {
+                return .say(text + "\n\n" + AgentQuantitativeSpecGate.lengthNotice(violations: violations))
+            }
+        }
+        return candidate
+    }
+
     /// F31: gate corrective samples call the raw LLM client, which throws on a malformed or
     /// empty response — with no recovery arm around these calls, ONE thinking-only sample killed
     /// an otherwise-finished research run (live: the deliverable gate's corrective after a

--- a/Sources/QuillCodeAgent/AgentQuantitativeSpecGate.swift
+++ b/Sources/QuillCodeAgent/AgentQuantitativeSpecGate.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// F30 — word-budget adherence for tasks that name an explicit length.
+///
+/// Live failure: "Turn my notes into a 300-word Monday exec update…" produced 222 words on one
+/// model and 185 on another — both content-complete, both treating the only quantitative spec in
+/// the task as a vibe. No guard checked it: the deliverable existed (F23 satisfied) and cited
+/// nothing (F29 silent). Same enforcement lesson as the other gates: an explicit number in the
+/// task needs a mechanical check, not prompt hope.
+///
+/// Scope is deliberately tight: only an explicit `N-word` / `N word(s)` phrase arms the gate,
+/// only task-named `.md` deliverables are measured, and compliance is a generous ±25% band —
+/// the gate exists to catch "asked for 300, delivered 185", not to nitpick 290.
+enum AgentQuantitativeSpecGate {
+    struct WordBudget: Equatable {
+        var words: Int
+        var minimum: Int { Int((Double(words) * 0.75).rounded(.down)) }
+        var maximum: Int { Int((Double(words) * 1.25).rounded(.up)) }
+    }
+
+    /// An explicit word-count phrase in the request ("300-word", "300 word", "300 words").
+    /// Bounded to 50–20000 so figures like "3 words" in prose or huge IDs never arm the gate.
+    static func wordBudget(in userMessage: String) -> WordBudget? {
+        let pattern = #"\b(\d{2,5})[-\s]words?\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+              let match = regex.firstMatch(
+                in: userMessage,
+                range: NSRange(userMessage.startIndex..., in: userMessage)
+              ),
+              let range = Range(match.range(at: 1), in: userMessage),
+              let words = Int(userMessage[range]),
+              (50...20_000).contains(words)
+        else { return nil }
+        return WordBudget(words: words)
+    }
+
+    static func wordCount(of text: String) -> Int {
+        text.split(whereSeparator: { $0.isWhitespace || $0.isNewline }).count
+    }
+
+    struct Violation: Equatable {
+        var deliverable: String
+        var actual: Int
+        var budget: WordBudget
+    }
+
+    /// Measures each existing task-named `.md` deliverable against the budget. Non-markdown
+    /// deliverables (CSV, PDF…) are data, not prose — never measured.
+    static func violations(
+        userMessage: String,
+        workspaceRoot: URL
+    ) -> [Violation] {
+        guard let budget = wordBudget(in: userMessage) else { return [] }
+        var found: [Violation] = []
+        for name in AgentDeliverableGate.requiredDeliverables(in: userMessage)
+        where name.lowercased().hasSuffix(".md") {
+            let url = workspaceRoot.appendingPathComponent(name)
+            guard let text = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            let actual = wordCount(of: text)
+            if actual < budget.minimum || actual > budget.maximum {
+                found.append(Violation(deliverable: name, actual: actual, budget: budget))
+            }
+        }
+        return found
+    }
+
+    static func correctionPrompt(violations: [Violation]) -> String {
+        let details = violations
+            .map { "\($0.deliverable) has \($0.actual) words but the task asks for about \($0.budget.words)" }
+            .joined(separator: "; ")
+        return """
+        Length check: \(details). Rewrite the deliverable to within 25% of the requested length \
+        (\(violations[0].budget.minimum)–\(violations[0].budget.maximum) words) using host.file.write \
+        with the full revised content — expand with substance from the source material (or tighten), \
+        never with filler. Then give your final answer. If the source material cannot support the \
+        requested length, write exactly what is missing.
+        """
+    }
+
+    static func lengthNotice(violations: [Violation]) -> String {
+        let details = violations
+            .map { "\($0.deliverable): \($0.actual) words vs ~\($0.budget.words) requested" }
+            .joined(separator: "; ")
+        return "⚠ Length: the deliverable does not meet the requested word count (\(details))."
+    }
+}

--- a/Tests/QuillCodeAgentTests/AgentQuantitativeSpecGateTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentQuantitativeSpecGateTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// F30 — word-budget adherence. Live failure: "a 300-word Monday exec update" produced 222 words
+/// on one model and 185 on another; the only quantitative spec in the task went unchecked.
+final class AgentQuantitativeSpecGateTests: XCTestCase {
+    // MARK: - Budget extraction
+
+    func testExtractsHyphenAndSpaceForms() {
+        XCTAssertEqual(AgentQuantitativeSpecGate.wordBudget(in: "write a 300-word update")?.words, 300)
+        XCTAssertEqual(AgentQuantitativeSpecGate.wordBudget(in: "a 1500 word essay")?.words, 1500)
+        XCTAssertEqual(AgentQuantitativeSpecGate.wordBudget(in: "about 250 words on X")?.words, 250)
+    }
+
+    func testUnboundedOrTinyFiguresDoNotArm() {
+        XCTAssertNil(AgentQuantitativeSpecGate.wordBudget(in: "summarize in your own words"))
+        XCTAssertNil(AgentQuantitativeSpecGate.wordBudget(in: "a 3 word answer"))
+        XCTAssertNil(AgentQuantitativeSpecGate.wordBudget(in: "no numbers here"))
+    }
+
+    func testToleranceBandIsTwentyFivePercent() {
+        let budget = try! XCTUnwrap(AgentQuantitativeSpecGate.wordBudget(in: "300-word memo"))
+        XCTAssertEqual(budget.minimum, 225)
+        XCTAssertEqual(budget.maximum, 375)
+    }
+
+    // MARK: - Violations
+
+    private func makeWorkspace() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wordbudget-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    func testShortDeliverableViolatesCompliantOnePasses() throws {
+        let root = try makeWorkspace()
+        let short = Array(repeating: "word", count: 185).joined(separator: " ")
+        try short.write(to: root.appendingPathComponent("exec-update.md"), atomically: true, encoding: .utf8)
+        let message = "Turn my notes into a 300-word exec update. Save it as exec-update.md."
+        let violations = AgentQuantitativeSpecGate.violations(userMessage: message, workspaceRoot: root)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first?.actual, 185)
+
+        let fine = Array(repeating: "word", count: 290).joined(separator: " ")
+        try fine.write(to: root.appendingPathComponent("exec-update.md"), atomically: true, encoding: .utf8)
+        XCTAssertTrue(AgentQuantitativeSpecGate.violations(userMessage: message, workspaceRoot: root).isEmpty)
+    }
+
+    func testNoBudgetOrNoMarkdownDeliverableNeverViolates() throws {
+        let root = try makeWorkspace()
+        try "a b c".write(to: root.appendingPathComponent("out.md"), atomically: true, encoding: .utf8)
+        XCTAssertTrue(AgentQuantitativeSpecGate.violations(
+            userMessage: "write out.md with the results",
+            workspaceRoot: root
+        ).isEmpty)
+        XCTAssertTrue(AgentQuantitativeSpecGate.violations(
+            userMessage: "build a 300-word summary into report.csv, save report.csv",
+            workspaceRoot: root
+        ).isEmpty)
+    }
+
+    // MARK: - End-to-end recovery
+
+    private actor ScriptedState {
+        var steps: [AgentAction]
+        let root: URL
+        init(_ steps: [AgentAction], root: URL) { self.steps = steps; self.root = root }
+        func next() -> AgentAction {
+            guard !steps.isEmpty else { return .say("out of steps") }
+            let step = steps.removeFirst()
+            if case .say(let text) = step, text == "REWRITE_THEN_DONE" {
+                let full = Array(repeating: "substance", count: 300).joined(separator: " ")
+                try? full.write(
+                    to: root.appendingPathComponent("exec-update.md"), atomically: true, encoding: .utf8
+                )
+                return .say("exec-update.md rewritten to the requested length.")
+            }
+            return step
+        }
+    }
+
+    private struct ScriptedClient: LLMClient {
+        let state: ScriptedState
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            await state.next()
+        }
+    }
+
+    func testShortDeliverableIsCorrectedAndRunSucceeds() async throws {
+        let root = try makeWorkspace()
+        let short = Array(repeating: "word", count: 185).joined(separator: " ")
+        try short.write(to: root.appendingPathComponent("exec-update.md"), atomically: true, encoding: .utf8)
+        let state = ScriptedState([.say("Done."), .say("REWRITE_THEN_DONE")], root: root)
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Turn my notes into a 300-word exec update. Save it as exec-update.md.",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertTrue(final.contains("rewritten"))
+        XCTAssertFalse(final.contains("⚠ Length"))
+        let text = try String(contentsOf: root.appendingPathComponent("exec-update.md"), encoding: .utf8)
+        XCTAssertGreaterThanOrEqual(AgentQuantitativeSpecGate.wordCount(of: text), 225)
+    }
+
+    func testPersistentShortfallSurfacesLengthNotice() async throws {
+        let root = try makeWorkspace()
+        let short = Array(repeating: "word", count: 100).joined(separator: " ")
+        try short.write(to: root.appendingPathComponent("exec-update.md"), atomically: true, encoding: .utf8)
+        let state = ScriptedState([.say("Done."), .say("Done."), .say("Done.")], root: root)
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "Turn my notes into a 300-word exec update. Save it as exec-update.md.",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertTrue(final.contains("⚠ Length"))
+        XCTAssertTrue(final.contains("100 words"))
+    }
+}


### PR DESCRIPTION
Two models under-delivered an explicit '300-word' spec (222w, 185w) in the coworker program — the task's only quantitative requirement went unchecked because the deliverable existed (F23 satisfied) and cited nothing (F29 silent). This adds `AgentQuantitativeSpecGate`: arms only on an explicit N-word phrase, measures task-named .md deliverables, ±25% tolerance, escalated correctives, honest ⚠ Length notice on persistent shortfall.

Full suite 5284/5284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)