### PR TITLE
F32: a read-back of the run's own deliverable must not ground its citations

### DIFF
--- a/Sources/QuillCodeAgent/AgentRunLoopState.swift
+++ b/Sources/QuillCodeAgent/AgentRunLoopState.swift
@@ -112,9 +112,35 @@ struct AgentRunLoopState: Sendable {
         // run read, addresses printed by shell commands. Search output stays ungrounded — a
         // snippet listing is not a read page, and it is the observed leak source.
         guard name != "host.web.search" else { return }
+        // Self-confirmation guard: the system prompt MANDATES reading a written artifact back
+        // ("read the artifact back (host.file.read / host.file.list) to confirm it exists"), so
+        // harvesting that read's output would launder the model's own text into provenance — write
+        // a fabricated URL, read the file back, and the citation gate blesses it. A read of a file
+        // this run wrote proves nothing about the world. (Residual: `cat`-style shell echoes of an
+        // own-written file are not detectable here; the mandated path is host.file.read.)
+        guard !isReadOfOwnOutput(completion) else { return }
         for url in AgentCitationIntegrityGate.allURLs(in: completion.result.stdout) {
             groundedURLs.insert(AgentCitationIntegrityGate.normalize(url))
         }
+    }
+
+    private func isReadOfOwnOutput(_ completion: AgentToolStepCompletion) -> Bool {
+        guard completion.call.name == "host.file.read",
+              let data = completion.call.argumentsJSON.data(using: .utf8),
+              let arguments = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let path = arguments["path"] as? String
+        else { return false }
+        let read = normalizedPath(path)
+        return writtenWorkspacePaths.contains { written in
+            let candidate = normalizedPath(written)
+            return candidate == read
+                || candidate.hasSuffix("/" + read)
+                || read.hasSuffix("/" + candidate)
+        }
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        path.hasPrefix("./") ? String(path.dropFirst(2)) : path
     }
 
     mutating func recordDeniedStep(_ completion: AgentToolStepCompletion) {

--- a/Tests/QuillCodeAgentTests/AgentCitationIntegrityGateTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentCitationIntegrityGateTests.swift
@@ -203,6 +203,49 @@ final class AgentCitationIntegrityGateTests: XCTestCase {
         XCTAssertTrue(state.writtenWorkspacePaths.contains("/tmp/brief.md"))
     }
 
+    func testReadingBackOwnDeliverableDoesNotGroundItsCitations() throws {
+        // The prompt MANDATES reading a written artifact back ("read the artifact back
+        // (host.file.read / host.file.list) to confirm it exists"). Harvesting that read's stdout
+        // as provenance lets a model launder a fabricated URL: write it, read it back, cite it.
+        var state = AgentRunLoopState()
+        let root = URL(fileURLWithPath: "/tmp")
+        func record(_ name: String, args: String, stdout: String, artifacts: [String] = []) {
+            _ = state.recordCompletedStep(
+                AgentToolStepCompletion(
+                    call: ToolCall(name: name, argumentsJSON: args),
+                    result: ToolResult(ok: true, stdout: stdout, artifacts: artifacts),
+                    followUpReviewResult: nil,
+                    toolResults: []
+                ),
+                workspaceRoot: root,
+                stateSignature: { _ in "" }
+            )
+        }
+        let fabricated = "https://fabricated.example.com/never-fetched"
+        record(
+            "host.file.write",
+            args: #"{"path":"brief.md","content":"see [x](https://fabricated.example.com/never-fetched)"}"#,
+            stdout: "Wrote /tmp/brief.md",
+            artifacts: ["/tmp/brief.md"]
+        )
+        record(
+            "host.file.read",
+            args: #"{"path":"brief.md"}"#,
+            stdout: "1\tsee [x](https://fabricated.example.com/never-fetched)"
+        )
+
+        XCTAssertFalse(
+            state.groundedURLs.contains(AgentCitationIntegrityGate.normalize(fabricated)),
+            "a read-back of the run's own deliverable must not ground its citations"
+        )
+
+        // A read of a genuine SOURCE file the run did not write still grounds normally.
+        record("host.file.read", args: #"{"path":"sources/notes.md"}"#, stdout: "1\tsee https://real.example.com/page")
+        XCTAssertTrue(
+            state.groundedURLs.contains(AgentCitationIntegrityGate.normalize("https://real.example.com/page"))
+        )
+    }
+
     func testSeededProvenanceCoversUserMessageAndPriorTurns() {
         var state = AgentRunLoopState()
         var thread = ChatThread(title: "t")

--- a/docs/CLINE_TOOL_LEARNINGS.md
+++ b/docs/CLINE_TOOL_LEARNINGS.md
@@ -86,3 +86,48 @@ plan→act→plan toggle before sending never emits a stale notice.
 6. **Context-usage-aware error guidance** (Cline #1's second axis) — LOW-MED. Thread current
    context-usage % into write-failure corrections ("output budget likely insufficient — write a
    skeleton, then extend in sections").
+
+---
+
+## Appendix: F21 (merge/extraction data-loss gate) — attempted twice, NOT shipped
+
+The live failure is real: a twelve-month merge silently dropped months 5–12 (reported total
+84,206.52 against a true 120,805.90), and a re-drive produced the right rows with a completely
+empty amount column. The prompt rule shipped in #1543 reduced but did not close it. Two mechanical
+gate designs were built, adversarially reviewed, and **both were rejected on their premise**.
+
+**Draft 1 — "an empty column in an extraction output is lost data."** Review (18 agents, 3 lenses;
+8/9 findings verified by compiling and executing the real source) killed it:
+- The premise is false for ordinary output. No vendor gave a discount → the `discount` column is
+  correctly empty; no source lists middle names → `middle` is correctly empty. Both were flagged.
+- The escalated correction then told the model to *delete a column the user had asked for*.
+- A path bug (absolute artifact path collapsed to a basename) made a subdirectory deliverable
+  resolve to a same-named file at the workspace root — auditing, and offering to **overwrite**, a
+  user's source file the run never wrote.
+
+**Draft 2 — "an empty column whose header words appear in what the run READ is lost data."**
+Provenance narrowing, harvesting a bounded vocabulary from read/shell/fetch output. Review round 2
+(19 agents) killed it too:
+- **Self-confirmation.** The system prompt *mandates* reading a written artifact back
+  ("read the artifact back … to confirm it exists"). That read injects the deliverable's own header
+  words into the vocabulary, so provenance collapses back to "any empty column" — the exact premise
+  round 1 rejected. Reproduced end-to-end through the real `AgentRunner`.
+- `host.file.search` echoes the model's own query into stdout, so grepping for a field name makes
+  that field "source-backed" even with zero matches.
+- Harness JSON envelope keys (`name`, `path`, `kind`, `query`, `matches`, `preview`) enter the
+  vocabulary as if they were source text.
+- For generic single-word headers (`date`, `total`, `notes`, `amount`) the requirement is close to
+  vacuous anyway — and the correction then asserts a falsehood ("those field names DO appear in the
+  source material"), pressuring the model to **fabricate values**. In a data-integrity gate that is
+  the worst possible failure mode: it manufactures exactly the wrong numbers the program exists to
+  prevent.
+
+**Decision: do not ship.** Numeric reconciliation needs task semantics the runner does not have
+(is an output row a source row, an aggregate, or a filtered subset?), and every cheap proxy tried
+here fails worse than the defect. The prompt rule (#1543) stands; verification of merges stays with
+the human or an explicit per-task check.
+
+**Transferable lesson (already applied, see F32 below):** any invariant derived from the run's own
+tool output can be poisoned by the run's own writing, because the product's prompt requires the
+model to read its artifacts back. A gate's evidence must come from somewhere the model cannot
+author.


### PR DESCRIPTION
**Shipped-code bypass of the F29 citation gate (#1551).** The gate grounds URLs seen in any successful non-search tool output — and the system prompt *mandates* reading a written artifact back to confirm it exists. So: write `brief.md` with a fabricated URL → read it back as instructed → the URL is now "grounded" → the gate passes the fabricated citation. The added test fails against `main` before this change.

Fix: provenance skips `host.file.read` of a path this run wrote. Reads of genuine source files still ground normally.

Also documents why the F21 merge/extraction data-loss gate was built twice and shipped **neither** time (two adversarial review rounds, 37 agents; each killed the premise — the second by this very self-confirmation mechanism, and that draft's correction would have pressured the model to fabricate values). That appendix is where this fix came from.

Full suite 5285/5285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)