### PR TITLE
Graded repeat handling: nudge the first identical call before finalizing

### DIFF
--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -170,6 +170,8 @@ public struct AgentRunner: Sendable {
                 Self.mergedToolDefinitions(baseToolDefinitions, additionalToolDefinitions)
             )
             var runLoop = AgentRunLoopState()
+            /// One-shot corrective for the next sample only (Cline learning #2 repeat nudge).
+            var pendingRepeatNudge: String?
             // F29: URLs from the request and the thread's prior turns are grounded provenance —
             // a follow-up send must not flag citations the previous send legitimately fetched.
             runLoop.seedCitationProvenance(userMessage: userMessage, thread: next)
@@ -178,12 +180,15 @@ public struct AgentRunner: Sendable {
             let stateSignature = workspaceStateSignature ?? Self.defaultWorkspaceStateSignature
 
             for _ in 0..<limit {
+                let repeatNudge = pendingRepeatNudge
+                pendingRepeatNudge = nil
                 let action = try await nextActionCompactingOnOverflow(
                     thread: &next,
                     userMessage: userMessage,
                     tools: tools,
                     workspaceRoot: workspaceRoot,
-                    onProgress: onProgress
+                    onProgress: onProgress,
+                    injectedCorrection: repeatNudge
                 )
                 if let paused = await pauseIfSpendFuseRequiresApproval(
                     thread: &next,
@@ -249,29 +254,43 @@ public struct AgentRunner: Sendable {
                     return AgentRunResult(thread: next, toolResults: runLoop.toolResults)
                 case .tool(let call):
                     var activeCall = call
-                    if let lastCompletion = runLoop.repeatedCompletion(for: activeCall),
-                       runLoop.shouldSoftWarnOnRepeat(of: activeCall) {
+                    if let lastCompletion = runLoop.repeatedCompletion(for: activeCall) {
                         // Cline learning #2 (graded loop detection): finalizing on the FIRST repeat
                         // converts a recoverable moment into a terminal answer — the F25 incident
                         // was exactly that (an enrichment run repeated a search and "finished" with
-                        // raw search results instead of writing the required CSV). Nudge once with
-                        // the result the model already has, then let it act. A further repeat of the
-                        // same call falls through to finalization below, so this cannot loop.
-                        let notice = AgentRepeatedCallGuard.softWarning(
-                            call: activeCall,
-                            previousResult: lastCompletion.result
-                        )
-                        next.messages.append(.init(role: .user, content: notice))
-                        next.events.append(.init(
-                            kind: .notice,
-                            summary: "Self-healing: repeated the same \(activeCall.name) call; "
-                                + "asked for a different step before finalizing."
-                        ))
-                        next.updatedAt = Date()
-                        await onProgress?(next)
-                        continue
-                    }
-                    if let lastCompletion = runLoop.repeatedCompletion(for: activeCall) {
+                        // raw search results instead of writing the required CSV). Hand the model
+                        // the result it already has and let it take one more turn. The nudge rides
+                        // the resolver's corrective seam, so it never enters the durable transcript
+                        // and its action still passes every guard and gate.
+                        //
+                        // A preflight action is re-derived deterministically from the user's own
+                        // message each iteration — the MODEL never chose to repeat it, so nudging
+                        // it would spend a provider round-trip that direct commands are designed
+                        // never to need.
+                        let isPreflightRepeat: Bool = {
+                            guard enablesImmediateActionPreflight,
+                                  case .tool(let planned)? = AgentImmediateActionPlanner.action(
+                                    for: userMessage,
+                                    tools: tools
+                                  )
+                            else { return false }
+                            return planned.name == activeCall.name
+                                && planned.argumentsJSON == activeCall.argumentsJSON
+                        }()
+                        if !isPreflightRepeat, runLoop.shouldSoftWarnOnRepeat(of: activeCall) {
+                            pendingRepeatNudge = AgentRepeatedCallGuard.softWarning(
+                                call: activeCall,
+                                previousResult: lastCompletion.result
+                            )
+                            next.events.append(.init(
+                                kind: .notice,
+                                summary: "Self-healing: repeated the same \(activeCall.name) call; "
+                                    + "asked for a different step before finalizing."
+                            ))
+                            next.updatedAt = Date()
+                            await onProgress?(next)
+                            continue
+                        }
                         // F25: repeated-call finalization synthesizes an answer from the last tool
                         // result — it must not slip past the named-deliverable gate the ordinary
                         // terminal-say path enforces (live: an enrichment run repeated a search,

--- a/Sources/QuillCodeAgent/Agent.swift
+++ b/Sources/QuillCodeAgent/Agent.swift
@@ -249,6 +249,28 @@ public struct AgentRunner: Sendable {
                     return AgentRunResult(thread: next, toolResults: runLoop.toolResults)
                 case .tool(let call):
                     var activeCall = call
+                    if let lastCompletion = runLoop.repeatedCompletion(for: activeCall),
+                       runLoop.shouldSoftWarnOnRepeat(of: activeCall) {
+                        // Cline learning #2 (graded loop detection): finalizing on the FIRST repeat
+                        // converts a recoverable moment into a terminal answer — the F25 incident
+                        // was exactly that (an enrichment run repeated a search and "finished" with
+                        // raw search results instead of writing the required CSV). Nudge once with
+                        // the result the model already has, then let it act. A further repeat of the
+                        // same call falls through to finalization below, so this cannot loop.
+                        let notice = AgentRepeatedCallGuard.softWarning(
+                            call: activeCall,
+                            previousResult: lastCompletion.result
+                        )
+                        next.messages.append(.init(role: .user, content: notice))
+                        next.events.append(.init(
+                            kind: .notice,
+                            summary: "Self-healing: repeated the same \(activeCall.name) call; "
+                                + "asked for a different step before finalizing."
+                        ))
+                        next.updatedAt = Date()
+                        await onProgress?(next)
+                        continue
+                    }
                     if let lastCompletion = runLoop.repeatedCompletion(for: activeCall) {
                         // F25: repeated-call finalization synthesizes an answer from the last tool
                         // result — it must not slip past the named-deliverable gate the ordinary

--- a/Sources/QuillCodeAgent/AgentActionResolver.swift
+++ b/Sources/QuillCodeAgent/AgentActionResolver.swift
@@ -2,14 +2,22 @@ import Foundation
 import QuillCodeCore
 
 extension AgentRunner {
+    /// `injectedCorrection` seeds the resolver's existing corrective seam for ONE sample: the
+    /// prompt is delivered on the value-copy corrective thread (never the durable transcript) and
+    /// the resulting action flows back through the caller's whole pipeline — promised-work guard,
+    /// deliverable/citation/word-budget gates — exactly like any other action. The repeat nudge
+    /// (Cline learning #2) uses it; splicing a raw sample in at the call site instead bypassed the
+    /// streaming path, the promised-work guard, and put a user turn in the transcript.
     func nextAction(
         thread: inout ChatThread,
         userMessage: String,
         tools: [ToolDefinition],
         workspaceRoot: URL,
-        onProgress: AgentRunProgressHandler?
+        onProgress: AgentRunProgressHandler?,
+        injectedCorrection: String? = nil
     ) async throws -> AgentAction {
-        if enablesImmediateActionPreflight,
+        if injectedCorrection == nil,
+           enablesImmediateActionPreflight,
            let action = AgentImmediateActionPlanner.action(for: userMessage, tools: tools) {
             // The planner parsed this action from the user's own command. A user-authored file
             // write is not a model blind-overwrite, so record that target as known for this
@@ -28,7 +36,11 @@ extension AgentRunner {
         // AgentPromisedWorkResolver's retryThread) so malformed text never persists in the durable
         // transcript; the durable thread gets only a Self-healing notice per attempt.
         var correctiveThread = thread
-        var pendingCorrectionPrompt: String?
+        var pendingCorrectionPrompt: String? = injectedCorrection
+        if let injectedCorrection {
+            correctiveThread.messages.append(.init(role: .user, content: injectedCorrection))
+            correctiveThread.updatedAt = Date()
+        }
         var attempt = 0
         // F22: which client resolves this action. Flips to `fallbackLLM` (at most once) when the
         // primary exhausts the empty-response budget — a route-quality death an alternate model

--- a/Sources/QuillCodeAgent/AgentCompaction.swift
+++ b/Sources/QuillCodeAgent/AgentCompaction.swift
@@ -93,7 +93,8 @@ extension AgentRunner {
         userMessage: String,
         tools: [ToolDefinition],
         workspaceRoot: URL,
-        onProgress: AgentRunProgressHandler?
+        onProgress: AgentRunProgressHandler?,
+        injectedCorrection: String? = nil
     ) async throws -> AgentAction {
         guard let compaction else {
             return try await nextAction(
@@ -101,7 +102,8 @@ extension AgentRunner {
                 userMessage: userMessage,
                 tools: tools,
                 workspaceRoot: workspaceRoot,
-                onProgress: onProgress
+                onProgress: onProgress,
+                injectedCorrection: injectedCorrection
             )
         }
 
@@ -120,7 +122,8 @@ extension AgentRunner {
                     userMessage: userMessage,
                     tools: tools,
                     workspaceRoot: workspaceRoot,
-                    onProgress: onProgress
+                    onProgress: onProgress,
+                    injectedCorrection: injectedCorrection
                 )
             } catch {
                 // Only a recognized context overflow is compactable; everything else propagates

--- a/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
+++ b/Sources/QuillCodeAgent/AgentPromisedWorkResolver.swift
@@ -278,7 +278,7 @@ extension AgentRunner {
     /// loop re-prompts (escalated on the final attempt) or falls through to the gate's terminal
     /// behavior (hard fail / integrity notice / budget-spent tail). Transport and cancellation
     /// errors still propagate.
-    private func correctiveSample(
+    func correctiveSample(
         thread: ChatThread,
         prompt: String,
         tools: [ToolDefinition]

--- a/Sources/QuillCodeAgent/AgentRepeatedCallGuard.swift
+++ b/Sources/QuillCodeAgent/AgentRepeatedCallGuard.swift
@@ -1,0 +1,32 @@
+import Foundation
+import QuillCodeCore
+
+/// Cline learning #2 (docs/CLINE_TOOL_LEARNINGS.md): graded loop detection. Cline warns at three
+/// identical calls and stops at five; QuillCode used to finalize on the very first repeat, turning
+/// a recoverable moment into a terminal answer — the F25 incident was exactly that shape.
+///
+/// The nudge hands the model the result it already has, so a repeat caused by "I didn't see the
+/// output" resolves immediately, and names the two legitimate ways forward.
+enum AgentRepeatedCallGuard {
+    /// Keeps the echoed result small: the point is to remind, not to re-dump a large payload.
+    static let resultEchoLimit = 1024
+
+    static func softWarning(call: ToolCall, previousResult: ToolResult) -> String {
+        let output = [previousResult.stdout, previousResult.stderr, previousResult.error ?? ""]
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .joined(separator: "\n")
+        let echoed = output.count > resultEchoLimit
+            ? String(output.prefix(resultEchoLimit)) + "\n[truncated]"
+            : output
+        return """
+        You just requested \(call.name) with exactly the same arguments as the previous step. Here \
+        is the result you already have:
+
+        \(echoed.isEmpty ? "(the call produced no output)" : echoed)
+
+        Do not repeat that call. Either take a DIFFERENT next step that moves the task forward, or, \
+        if the task is complete, give your final answer now. If the previous call failed and you \
+        believe retrying will help, change something about it first and say what you changed.
+        """
+    }
+}

--- a/Sources/QuillCodeAgent/AgentRunLoopState.swift
+++ b/Sources/QuillCodeAgent/AgentRunLoopState.swift
@@ -17,6 +17,11 @@ struct AgentRunLoopState: Sendable {
     private(set) var didFetchSuccessfully = false
     private(set) var writtenWorkspacePaths: Set<String> = []
 
+    /// Call signatures that have already received the repeat SOFT WARNING (Cline learning #2).
+    /// One nudge per distinct call; a further repeat of the same call finalizes as before, so the
+    /// tier can never loop.
+    private var softWarnedCallSignatures: Set<String> = []
+
     private var flailDetector = FlailDetector()
     private var previousWorkspaceState: String?
     private var injectedFlailAssessment = false
@@ -141,6 +146,13 @@ struct AgentRunLoopState: Sendable {
 
     private func normalizedPath(_ path: String) -> String {
         path.hasPrefix("./") ? String(path.dropFirst(2)) : path
+    }
+
+    /// True the FIRST time a given call repeats: the caller should nudge the model instead of
+    /// finalizing. Returns false on any later repeat of the same call, restoring the old
+    /// finalize-immediately behavior so the run always terminates.
+    mutating func shouldSoftWarnOnRepeat(of call: ToolCall) -> Bool {
+        softWarnedCallSignatures.insert("\(call.name)\u{1}\(call.argumentsJSON)").inserted
     }
 
     mutating func recordDeniedStep(_ completion: AgentToolStepCompletion) {

--- a/Tests/QuillCodeAgentTests/AgentRepeatedCallGuardTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentRepeatedCallGuardTests.swift
@@ -86,8 +86,11 @@ final class AgentRepeatedCallGuardTests: XCTestCase {
 
         let final = try XCTUnwrap(result.thread.messages.last?.content)
         XCTAssertEqual(final, "The folder is empty.", "the nudged run must reach the model's own answer")
-        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("Do not repeat that call") })
-        XCTAssertTrue(result.thread.events.contains { ($0.summary ?? "").contains("repeated the same") })
+        XCTAssertTrue(result.thread.events.contains { $0.summary.contains("repeated the same") })
+        // The nudge itself lives only on a value copy: recording it durably would put a user turn
+        // in the transcript that the human never typed (caught by the MCP protocol smoke).
+        XCTAssertFalse(result.thread.messages.contains { $0.content.contains("Do not repeat that call") })
+        XCTAssertFalse(result.thread.messages.contains { $0.role == .user && $0.content.contains("already have") })
     }
 
     func testSecondRepeatStillFinalizes() async throws {

--- a/Tests/QuillCodeAgentTests/AgentRepeatedCallGuardTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentRepeatedCallGuardTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeAgent
+
+/// Cline learning #2 (graded loop detection): the FIRST repeat of an identical call gets a nudge
+/// carrying the result the model already has; only a further repeat finalizes. Finalizing on the
+/// first repeat is what turned the F25 incident terminal — an enrichment run repeated a search and
+/// "finished" with raw search results instead of writing the required CSV.
+final class AgentRepeatedCallGuardTests: XCTestCase {
+    func testSoftWarningEchoesThePreviousResultAndNamesBothWaysForward() {
+        let warning = AgentRepeatedCallGuard.softWarning(
+            call: ToolCall(name: "host.web.search", argumentsJSON: #"{"query":"stripe"}"#),
+            previousResult: ToolResult(ok: true, stdout: "1. Stripe — https://stripe.com")
+        )
+        XCTAssertTrue(warning.contains("host.web.search"))
+        XCTAssertTrue(warning.contains("https://stripe.com"))
+        XCTAssertTrue(warning.contains("Do not repeat that call"))
+        XCTAssertTrue(warning.contains("give your final answer"))
+    }
+
+    func testSoftWarningTruncatesLargeOutputAndHandlesEmpty() {
+        let large = String(repeating: "x", count: AgentRepeatedCallGuard.resultEchoLimit + 500)
+        let warning = AgentRepeatedCallGuard.softWarning(
+            call: ToolCall(name: "host.file.read", argumentsJSON: #"{"path":"a.txt"}"#),
+            previousResult: ToolResult(ok: true, stdout: large)
+        )
+        XCTAssertTrue(warning.contains("[truncated]"))
+        XCTAssertLessThan(warning.count, large.count)
+
+        let empty = AgentRepeatedCallGuard.softWarning(
+            call: ToolCall(name: "host.file.list", argumentsJSON: "{}"),
+            previousResult: ToolResult(ok: true, stdout: "")
+        )
+        XCTAssertTrue(empty.contains("produced no output"))
+    }
+
+    func testStateWarnsOncePerDistinctCall() {
+        var state = AgentRunLoopState()
+        let call = ToolCall(name: "host.file.list", argumentsJSON: #"{"path":"."}"#)
+        let other = ToolCall(name: "host.file.list", argumentsJSON: #"{"path":"src"}"#)
+        XCTAssertTrue(state.shouldSoftWarnOnRepeat(of: call))
+        XCTAssertFalse(state.shouldSoftWarnOnRepeat(of: call), "a second repeat must finalize")
+        XCTAssertTrue(state.shouldSoftWarnOnRepeat(of: other), "a different call gets its own nudge")
+    }
+
+    // MARK: - End to end
+
+    private actor ScriptedState {
+        var steps: [AgentAction]
+        var calls = 0
+        init(_ steps: [AgentAction]) { self.steps = steps }
+        func next() -> AgentAction {
+            calls += 1
+            return steps.isEmpty ? .say("out of steps") : steps.removeFirst()
+        }
+        func callCount() -> Int { calls }
+    }
+
+    private struct ScriptedClient: LLMClient {
+        let state: ScriptedState
+        func nextAction(thread: ChatThread, userMessage: String, tools: [ToolDefinition]) async throws -> AgentAction {
+            await state.next()
+        }
+    }
+
+    private func makeWorkspace() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repeat-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    func testFirstRepeatIsNudgedAndTheRunRecovers() async throws {
+        let root = try makeWorkspace()
+        let list = ToolCall(name: "host.file.list", argumentsJSON: #"{"path":"."}"#)
+        // list, list (repeat -> nudge, no finalize), then a real answer.
+        let state = ScriptedState([.tool(list), .tool(list), .say("The folder is empty.")])
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "What is in this folder?",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        let final = try XCTUnwrap(result.thread.messages.last?.content)
+        XCTAssertEqual(final, "The folder is empty.", "the nudged run must reach the model's own answer")
+        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("Do not repeat that call") })
+        XCTAssertTrue(result.thread.events.contains { ($0.summary ?? "").contains("repeated the same") })
+    }
+
+    func testSecondRepeatStillFinalizes() async throws {
+        let root = try makeWorkspace()
+        let list = ToolCall(name: "host.file.list", argumentsJSON: #"{"path":"."}"#)
+        // A model that ignores the nudge and repeats again must still terminate.
+        let state = ScriptedState([.tool(list), .tool(list), .tool(list)])
+        let runner = AgentRunner(llm: ScriptedClient(state: state))
+
+        let result = try await runner.send(
+            "What is in this folder?",
+            in: ChatThread(title: "t"),
+            workspaceRoot: root
+        )
+
+        XCTAssertNotNil(result.thread.messages.last?.content)
+        XCTAssertFalse(try XCTUnwrap(result.thread.messages.last?.content).isEmpty)
+    }
+}

--- a/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentStreamingTests.swift
@@ -123,7 +123,9 @@ final class AgentStreamingTests: XCTestCase {
         let eventKinds = await recorder.eventKinds()
         XCTAssertEqual(
             eventKinds,
-            [.message, .notice, .toolQueued, .toolRunning, .toolCompleted, .notice, .message]
+            // Two extra .notice events: the repeat NUDGE (Cline learning #2 — the first repeat is
+            // nudged rather than finalized) and the finalization notice after the model repeats again.
+            [.message, .notice, .toolQueued, .toolRunning, .toolCompleted, .notice, .notice, .notice, .message]
         )
         XCTAssertEqual(result.thread.events.map(\.kind), [
             .message,
@@ -132,9 +134,15 @@ final class AgentStreamingTests: XCTestCase {
             .toolRunning,
             .toolCompleted,
             .notice,
+            .notice,
+            .notice,
             .message
         ])
         XCTAssertEqual(result.thread.events[1].summary, AgentRunner.streamingNotice)
+        XCTAssertTrue(
+            result.thread.events.contains { $0.summary.contains("repeated the same") },
+            "the first repeat must be nudged before any finalization"
+        )
         XCTAssertTrue(result.thread.messages.last?.content.hasPrefix("You are `") == true)
     }
 

--- a/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
@@ -512,7 +512,11 @@ final class AgentToolLoopTests: XCTestCase {
         // answer. The nudge notice also names the tool, hence four matching events, not three.
         XCTAssertEqual(result.toolResults.count, 1)
         XCTAssertEqual(result.thread.events.filter { $0.summary.contains("host.shell.run") }.count, 4)
-        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("Do not repeat that call") })
+        XCTAssertTrue(result.thread.events.contains { $0.summary.contains("repeated the same") })
+        XCTAssertFalse(
+            result.thread.messages.contains { $0.content.contains("Do not repeat that call") },
+            "the nudge must not become a durable user turn"
+        )
         XCTAssertTrue(result.thread.messages.last?.content.hasPrefix("You are `") == true)
     }
 

--- a/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentToolLoopTests.swift
@@ -507,8 +507,12 @@ final class AgentToolLoopTests: XCTestCase {
             workspaceRoot: root
         )
 
+        // Two-tier repeat handling (Cline learning #2): the tool runs once; the first repeat is
+        // NUDGED with the result already in hand; only the next repeat synthesizes the final
+        // answer. The nudge notice also names the tool, hence four matching events, not three.
         XCTAssertEqual(result.toolResults.count, 1)
-        XCTAssertEqual(result.thread.events.filter { $0.summary.contains("host.shell.run") }.count, 3)
+        XCTAssertEqual(result.thread.events.filter { $0.summary.contains("host.shell.run") }.count, 4)
+        XCTAssertTrue(result.thread.messages.contains { $0.content.contains("Do not repeat that call") })
         XCTAssertTrue(result.thread.messages.last?.content.hasPrefix("You are `") == true)
     }
 
@@ -676,6 +680,9 @@ final class AgentToolLoopTests: XCTestCase {
             .toolQueued,
             .toolRunning,
             .toolCompleted,
+            // The scripted client repeats its last call; the first repeat is nudged
+            // (Cline learning #2) instead of finalizing immediately.
+            .notice,
             .message
         ])
         XCTAssertEqual(result.thread.events.filter { $0.summary.contains("host.git.diff") }.count, 3)

--- a/Tests/QuillCodeAppTests/WorkspaceMCPIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceMCPIntegrationTests.swift
@@ -178,11 +178,14 @@ final class WorkspaceMCPIntegrationTests: XCTestCase {
         let toolEventKinds = (model.selectedThread?.events ?? [])
             .filter { !RunIntegrityRecord.isRecord($0) }
             .map(\.kind)
+        // The scripted client repeats its MCP call, so the first repeat is NUDGED (Cline learning
+        // #2) before the run finalizes — one extra .notice between the tool completing and the
+        // final message.
         XCTAssertEqual(Array(toolEventKinds.suffix(5)), [
-            .message,
             .toolQueued,
             .toolRunning,
             .toolCompleted,
+            .notice,
             .message
         ])
         XCTAssertEqual(model.selectedThread?.messages.last?.content, "Output:\nhello from MCP")


### PR DESCRIPTION
Cline learning #2 (see [docs/CLINE_TOOL_LEARNINGS.md](https://github.com/Lore-Hex/QuillCode/blob/main/docs/CLINE_TOOL_LEARNINGS.md)): Cline warns at three identical calls and stops at five; QuillCode finalized on the **first** repeat, turning a recoverable moment terminal. The F25 incident was exactly that — an enrichment run repeated a search and "finished" with raw search results instead of writing the required CSV.

Now the first repeat gets a nudge carrying the result the model already has, plus a Self-healing notice; a further repeat of the same call finalizes as before. Bounded: at most one extra sample per distinct repeated call.

Four existing tests encoded the old contract and are updated to assert the **new** one explicitly (not loosened). The multi-call test is untouched — two different calls are not a repeat.

Full suite 5290/5290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)