### PR TITLE
Test: realistic MCP wait budget; record two evidence-based Cline rejections

### DIFF
--- a/Tests/QuillCodeCLITests/MCPServerSessionTests.swift
+++ b/Tests/QuillCodeCLITests/MCPServerSessionTests.swift
@@ -651,12 +651,22 @@ private struct MCPServerTestFixture {
         await session.receive(try MCPServerWireTestCodec.responseData(id: id, result: result))
     }
 
+    /// Wall-clock budget for an EXPECTED message to arrive. Generous on purpose: the smoke job
+    /// runs this alongside the full 5290-test suite, and the cancellation case has to spawn a
+    /// sandboxed shell and tear it down. At 3s it produced a false red on a correct change (CI
+    /// reported 15s wall for a 3s budget — the polling loop itself was starved), which costs a
+    /// whole review cycle to disprove. Raising it cannot mask a real failure: a message that never
+    /// arrives still fails, just later.
+    static let messageWaitBudget = Duration.seconds(30)
+    private static let messagePollInterval = Duration.milliseconds(10)
+
     func waitForMessage(
         _ predicate: @escaping ([String: CLIJSONValue]) -> Bool
     ) async throws -> [String: CLIJSONValue] {
-        for _ in 0..<300 {
+        let deadline = ContinuousClock.now.advanced(by: Self.messageWaitBudget)
+        while ContinuousClock.now < deadline {
             if let message = await sink.snapshot().first(where: predicate) { return message }
-            try await Task.sleep(for: .milliseconds(10))
+            try await Task.sleep(for: Self.messagePollInterval)
         }
         throw MCPServerTestError.timeout
     }

--- a/docs/CLINE_TOOL_LEARNINGS.md
+++ b/docs/CLINE_TOOL_LEARNINGS.md
@@ -131,3 +131,41 @@ the human or an explicit per-task check.
 tool output can be poisoned by the run's own writing, because the product's prompt requires the
 model to read its artifacts back. A gate's evidence must come from somewhere the model cannot
 author.
+
+---
+
+## Appendix 2: two more Cline learnings, rejected on evidence (2026-08-05)
+
+Before building either, the coworker corpus (120 most recent persisted runs in `~/.quillcode/threads`)
+was measured. Both premises turned out to be false **for this codebase**, so neither shipped.
+
+### Cross-category consecutive-mistake budget — REJECTED
+Cline's `MistakeTracker` aggregates `api_error | invalid_tool_call | tool_execution_failed` into one
+per-session counter, because a run alternating failure *kinds* never trips any single per-kind
+budget. QuillCode has no such counter (only `promisedWorkCorrectionLimit` = 2,
+`malformedActionCorrectionLimit` = 2, and `maxToolSteps`).
+
+Measured: 11 of 120 runs mixed multiple failure categories, with exactly the predicted alternating
+shape — `MEMMMM`, `EMMME`, `EEEMM` (M = malformed, E = empty response, D = denied).
+
+But **every one of those runs succeeded**: a real final answer, the deliverable verified on disk, no
+step ceiling, no flail stop. The existing per-category self-healing (F13 empty-response retry, F22
+model fallback, F31 malformed-sample tolerance) already absorbs the churn. A Cline-style budget of
+~3 consecutive mistakes would have **killed** runs that currently work — e.g. `MEMMMM` (23 tool
+steps → a complete speaker brief) and `EEEEE` (23 steps → same). The mechanism's only effect here
+would be premature stops on healthy runs.
+
+### Duplicate-file-read dedup — REJECTED
+Cline replaces a repeated file read in history with a one-line pointer to save context.
+
+Measured: only **2 of 120 runs** (1%) re-read the same path at all, and both were a second read-back
+of the run's *own* output (`contacts_clean.csv`, `speaker-brief.md`) — the artifact confirmation the
+system prompt mandates. There is no context bloat to reclaim.
+
+### Still unevaluated
+Mode-switch notices and context-usage-aware write-failure guidance are interactive/desktop concerns;
+the headless corpus contains no mode switches and no size-driven write failures, so there is no
+evidence either way. They need interactive telemetry before they are worth building.
+
+**Method note:** measuring first cost one thread scan. The F21 gate cost two full build-and-review
+rounds to reach the same kind of "premise is false" verdict. Measure the corpus before building.


### PR DESCRIPTION
**The flake.** `MCPServerSessionTests.waitForMessage` polled 3s for an expected message. The smoke job runs it alongside the full 5290-test suite, and the cancellation case spawns and tears down a sandboxed shell — CI reported **15s wall for a 3s budget**, i.e. the polling loop was starved. That produced a false red on #1557 (a correct change): the same commit passed on rerun, and the test passes 3/3 locally. Now 30s on a monotonic clock. This cannot mask a real failure — a message that never arrives still fails, just later.

**Two Cline learnings measured and rejected before building** (appendix 2 in the doc), using the 120 most recent persisted runs:

- *Cross-category mistake budget*: 11/120 runs really do mix failure kinds in the predicted alternating shape (`MEMMMM`, `EMMME`) — but **every one succeeded**, deliverable verified, no ceiling, no flail. Existing per-category self-healing (F13/F22/F31) absorbs it. A ~3-mistake budget would have killed runs that currently work.
- *Duplicate-file-read dedup*: only 2/120 runs (1%) re-read a path, and both were the prompt-mandated read-back of their own output. No bloat to reclaim.

Measuring the corpus cost one scan; the F21 gate cost two full build-and-review rounds to reach the same kind of verdict.

Full suite 5290/5290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)