### PR TITLE
Fix: "save it as report.csv" must not fire a fabricated download

### DIFF
--- a/Sources/QuillCodeAgent/AgentDownloadRequestParser.swift
+++ b/Sources/QuillCodeAgent/AgentDownloadRequestParser.swift
@@ -26,8 +26,14 @@ enum AgentDownloadRequestParser {
 
     private static func extractDownloadTarget(from request: String) -> String? {
         let tokens = downloadTokens(in: request)
+        // The file the user asked us to WRITE is never the thing to fetch. "Save it as
+        // transactions.csv" used to yield `curl https://transactions.csv` as the run's first
+        // action (live: seen as the opening step of an office task in the desktop app).
+        let destination = extractRequestedDownloadPath(from: request)?.lowercased()
 
-        if let token = tokens.first(where: looksLikeDownloadSource) {
+        if let token = tokens.first(where: {
+            looksLikeDownloadSource($0) && $0.lowercased() != destination
+        }) {
             return token
         }
         if let quoted = AgentRequestTextScanner.backtickQuotedValues(in: request).first(where: looksLikeDownloadSource) {
@@ -71,8 +77,24 @@ enum AgentDownloadRequestParser {
             return false
         }
         let firstPathComponent = lower.split(separator: "/", maxSplits: 1).first ?? ""
-        return firstPathComponent.contains(".")
+        guard firstPathComponent.contains(".") else { return false }
+        // A bare local filename is not a host. `report.md`, `transactions.csv`, `deck.pptx` all
+        // "contain a dot", but their final component is a FILE EXTENSION, not a TLD — treating
+        // them as download sources fabricates `https://<filename>` and fires a doomed curl.
+        // A real bare-host source ("example.com/data.csv") keeps its host in the first component.
+        let suffix = firstPathComponent.split(separator: ".").last.map(String.init) ?? ""
+        return !localFileExtensions.contains(suffix)
     }
+
+    /// Extensions that mark a token as a local artifact rather than a hostname. Deliberately the
+    /// document/data/media types office tasks name as OUTPUTS; unknown suffixes still pass so a
+    /// genuine `example.io/report` style source is unaffected.
+    private static let localFileExtensions: Set<String> = [
+        "csv", "tsv", "md", "markdown", "txt", "text", "log", "json", "yaml", "yml", "xml",
+        "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "rtf", "odt", "ods",
+        "png", "jpg", "jpeg", "gif", "svg", "webp", "heic", "mp3", "mp4", "mov", "wav",
+        "zip", "tar", "gz", "sql", "db", "sqlite", "ics", "vcf",
+    ]
 
     private static func extractRequestedDownloadPath(from request: String) -> String? {
         if let quotedPath = AgentRequestTextScanner.backtickQuotedValues(in: request)

--- a/Tests/QuillCodeAgentTests/AgentDownloadRequestParserTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentDownloadRequestParserTests.swift
@@ -32,3 +32,30 @@ final class AgentDownloadRequestParserTests: XCTestCase {
         XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "Open https://example.com in the browser"))
     }
 }
+
+extension AgentDownloadRequestParserTests {
+    /// Live desktop failure: "Pull the transaction tables … Save it as transactions.csv" opened the
+    /// run with `curl -L --fail … --output 'transactions.csv' 'https://transactions.csv'`, which
+    /// died on "Could not resolve host". A bare local filename is an OUTPUT, never a fetch source.
+    func testSaveAsLocalFilenameIsNotADownload() {
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(
+            from: "Pull the transaction tables out of these three bank statement PDFs into one clean CSV with date, description, and amount. Save it as transactions.csv"
+        ))
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "Save it as report.md"))
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "save the summary as deck.pptx"))
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "fetch the numbers and save them as q3.xlsx"))
+    }
+
+    /// The real download paths must keep working.
+    func testGenuineDownloadsStillParse() {
+        let bareHost = AgentDownloadRequestParser.shellCommand(from: "download example.com/data.csv")
+        XCTAssertNotNil(bareHost)
+        XCTAssertEqual(bareHost?.contains("https://example.com/data.csv"), true)
+
+        let explicit = AgentDownloadRequestParser.shellCommand(
+            from: "save https://example.com/report.pdf as downloads/report.pdf"
+        )
+        XCTAssertNotNil(explicit)
+        XCTAssertEqual(explicit?.contains("https://example.com/report.pdf"), true)
+    }
+}


### PR DESCRIPTION
**Found by driving a real office-coworker task through the desktop app** (not the CLI — this never reproduces headlessly the same way).

Task: *"Pull the transaction tables out of these three bank statement PDFs … Save it as transactions.csv"*. The run's **first action** was:

```
mkdir -p '.' && curl -L --fail --silent --show-error --output 'transactions.csv' 'https://transactions.csv'
→ curl: (6) Could not resolve host: transactions.csv
```

`AgentDownloadRequestParser` arms on the word `save `, and `looksLikeDownloadSource` accepted any token whose first path component contains a dot — so the **output filename** became the **fetch source**, normalized to `https://<filename>`. Any office task phrased "…save it as <file>" opens with a doomed network call and a red Failed card.

Two guards: the requested destination is never a candidate source, and a bare token ending in a document/data/media extension is a local artifact rather than a host. Genuine `example.com/data.csv` and explicit URLs are unaffected (covered by tests).

Full suite 5292/5292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)