### PR TITLE
Desktop auto mode: stop stalling on benign steps

### DIFF
--- a/Sources/QuillCodeAgent/AgentDownloadRequestParser.swift
+++ b/Sources/QuillCodeAgent/AgentDownloadRequestParser.swift
@@ -26,8 +26,14 @@ enum AgentDownloadRequestParser {
 
     private static func extractDownloadTarget(from request: String) -> String? {
         let tokens = downloadTokens(in: request)
+        // The file the user asked us to WRITE is never the thing to fetch. "Save it as
+        // transactions.csv" used to yield `curl https://transactions.csv` as the run's first
+        // action (live: seen as the opening step of an office task in the desktop app).
+        let destination = extractRequestedDownloadPath(from: request)?.lowercased()
 
-        if let token = tokens.first(where: looksLikeDownloadSource) {
+        if let token = tokens.first(where: {
+            looksLikeDownloadSource($0) && $0.lowercased() != destination
+        }) {
             return token
         }
         if let quoted = AgentRequestTextScanner.backtickQuotedValues(in: request).first(where: looksLikeDownloadSource) {
@@ -71,8 +77,24 @@ enum AgentDownloadRequestParser {
             return false
         }
         let firstPathComponent = lower.split(separator: "/", maxSplits: 1).first ?? ""
-        return firstPathComponent.contains(".")
+        guard firstPathComponent.contains(".") else { return false }
+        // A bare local filename is not a host. `report.md`, `transactions.csv`, `deck.pptx` all
+        // "contain a dot", but their final component is a FILE EXTENSION, not a TLD — treating
+        // them as download sources fabricates `https://<filename>` and fires a doomed curl.
+        // A real bare-host source ("example.com/data.csv") keeps its host in the first component.
+        let suffix = firstPathComponent.split(separator: ".").last.map(String.init) ?? ""
+        return !localFileExtensions.contains(suffix)
     }
+
+    /// Extensions that mark a token as a local artifact rather than a hostname. Deliberately the
+    /// document/data/media types office tasks name as OUTPUTS; unknown suffixes still pass so a
+    /// genuine `example.io/report` style source is unaffected.
+    private static let localFileExtensions: Set<String> = [
+        "csv", "tsv", "md", "markdown", "txt", "text", "log", "json", "yaml", "yml", "xml",
+        "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "rtf", "odt", "ods",
+        "png", "jpg", "jpeg", "gif", "svg", "webp", "heic", "mp3", "mp4", "mov", "wav",
+        "zip", "tar", "gz", "sql", "db", "sqlite", "ics", "vcf",
+    ]
 
     private static func extractRequestedDownloadPath(from request: String) -> String? {
         if let quotedPath = AgentRequestTextScanner.backtickQuotedValues(in: request)

--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -135,7 +135,23 @@ public struct QuillCodeRuntimeFactory: Sendable {
         return QuillCodeRuntime(
             runner: AgentRunner(
                 llm: llm,
-                safety: AutoSafetyReviewer(client: safetyClient),
+                // Auto mode is the DAILY-DRIVER mode: the human picked "just do it". The static
+                // policy still falls through to `.clarify` whenever a tool's effect is not
+                // lexically implied by the user's own words, which in office work means a plain
+                // `python3 --version`, a `pdftotext` probe, or any setup step stops the task dead
+                // behind an approval whose stated reason ("does not clearly match the latest user
+                // message") means nothing to the person reading it. Observed live in the desktop
+                // on the very first coworker task.
+                //
+                // Headless runs already resolve this with AutonomousApprovalSafetyReviewer;
+                // applying it here gives the desktop the same permissiveness. What it does NOT
+                // relax: `.deny` verdicts pass through untouched (the hard floors — destructive
+                // commands, credential exfiltration — still block), and shell commands touching
+                // paths OUTSIDE the workspace are still denied (F24). Containment stays with the
+                // hard-deny floors and the filesystem sandbox, not with lexical intent-matching.
+                safety: AutonomousApprovalSafetyReviewer(
+                    base: AutoSafetyReviewer(client: safetyClient)
+                ),
                 webSearch: webSearch,
                 webSearchLivenessChecker: WebFetchURLLivenessChecker(),
                 maxToolSteps: config.maxToolSteps,

--- a/Sources/QuillCodeApp/WorkspaceAgentRunContextBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentRunContextBuilder.swift
@@ -96,7 +96,11 @@ struct WorkspaceAgentRunContextBuilder: Sendable {
         let requiresE2EOnlyTraffic = threadIsConfidential
             || TrustedRouterDefaults.isE2EEligible(modelID ?? "", catalog: modelCatalog)
         if requiresE2EOnlyTraffic {
-            activeRunner.safety = AutoSafetyReviewer()
+            // Same daily-driver permissiveness as the non-confidential path (see RuntimeFactory):
+            // the model reviewer is dropped for E2E threads, so the static policy's `.clarify`
+            // fallthrough would stall confidential runs even more often. Hard denies and the
+            // out-of-workspace shell guard still apply.
+            activeRunner.safety = AutonomousApprovalSafetyReviewer(base: AutoSafetyReviewer())
             if var compaction = activeRunner.compaction {
                 compaction.compactor.summarizer = DeterministicThreadCompactionSummarizer()
                 activeRunner.compaction = compaction

--- a/Tests/QuillCodeAgentTests/AgentDownloadRequestParserTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentDownloadRequestParserTests.swift
@@ -32,3 +32,30 @@ final class AgentDownloadRequestParserTests: XCTestCase {
         XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "Open https://example.com in the browser"))
     }
 }
+
+extension AgentDownloadRequestParserTests {
+    /// Live desktop failure: "Pull the transaction tables … Save it as transactions.csv" opened the
+    /// run with `curl -L --fail … --output 'transactions.csv' 'https://transactions.csv'`, which
+    /// died on "Could not resolve host". A bare local filename is an OUTPUT, never a fetch source.
+    func testSaveAsLocalFilenameIsNotADownload() {
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(
+            from: "Pull the transaction tables out of these three bank statement PDFs into one clean CSV with date, description, and amount. Save it as transactions.csv"
+        ))
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "Save it as report.md"))
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "save the summary as deck.pptx"))
+        XCTAssertNil(AgentDownloadRequestParser.shellCommand(from: "fetch the numbers and save them as q3.xlsx"))
+    }
+
+    /// The real download paths must keep working.
+    func testGenuineDownloadsStillParse() {
+        let bareHost = AgentDownloadRequestParser.shellCommand(from: "download example.com/data.csv")
+        XCTAssertNotNil(bareHost)
+        XCTAssertEqual(bareHost?.contains("https://example.com/data.csv"), true)
+
+        let explicit = AgentDownloadRequestParser.shellCommand(
+            from: "save https://example.com/report.pdf as downloads/report.pdf"
+        )
+        XCTAssertNotNil(explicit)
+        XCTAssertEqual(explicit?.contains("https://example.com/report.pdf"), true)
+    }
+}

--- a/Tests/QuillCodeAppTests/DesktopAutoModePermissivenessTests.swift
+++ b/Tests/QuillCodeAppTests/DesktopAutoModePermissivenessTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import QuillCodeCore
+import QuillCodeSafety
+import QuillCodeTools
+@testable import QuillCodeApp
+
+/// The desktop's daily-driver contract: in auto mode a benign setup step must NOT stop the task
+/// behind an approval, while the hard floors and the out-of-workspace shell guard still hold.
+///
+/// Live failure this encodes: an office task ("pull the transaction tables out of these PDFs …")
+/// stalled on `python3 -c "import sys; print(sys.version)"` with the rationale "The requested tool
+/// action does not clearly match the latest user message."
+final class DesktopAutoModePermissivenessTests: XCTestCase {
+    private func context(cmd: String, userMessage: String) -> SafetyContext {
+        SafetyContext(
+            mode: .auto,
+            userMessage: userMessage,
+            toolCall: ToolCall(
+                name: ToolDefinition.shellRun.name,
+                argumentsJSON: ToolArguments.json(["cmd": cmd])
+            ),
+            toolDefinition: .shellRun,
+            recentMessages: [],
+            workspaceRoot: URL(fileURLWithPath: "/tmp/ws")
+        )
+    }
+
+    private let officeTask = "Pull the transaction tables out of these three bank statement PDFs into one clean CSV with date, description, and amount. Save it as transactions.csv"
+
+    func testStaticPolicyAloneWouldStallABenignSetupStep() async {
+        let review = await AutoSafetyReviewer().review(
+            context(cmd: "python3 -c \"import sys; print(sys.version)\"", userMessage: officeTask)
+        )
+        XCTAssertEqual(review.verdict, .clarify, "baseline: this is the stall the desktop showed")
+    }
+
+    func testDesktopWrapperApprovesBenignSetupSteps() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: AutoSafetyReviewer())
+        for cmd in [
+            "python3 -c \"import sys; print(sys.version)\"",
+            "command -v pdftotext",
+            "pdftotext -layout statement-2026-04.pdf -",
+            "python3 -m venv .venv && .venv/bin/pip install pypdf",
+        ] {
+            let review = await reviewer.review(context(cmd: cmd, userMessage: officeTask))
+            XCTAssertEqual(review.verdict, .approve, "auto mode must not stall on: \(cmd)")
+        }
+    }
+
+    func testOutsideWorkspaceShellIsStillBlocked() async {
+        let reviewer = AutonomousApprovalSafetyReviewer(base: AutoSafetyReviewer())
+        let review = await reviewer.review(
+            context(cmd: "grep -r secret ~/Documents", userMessage: officeTask)
+        )
+        XCTAssertEqual(review.verdict, .deny, "F24: out-of-workspace reads still require a human")
+    }
+}


### PR DESCRIPTION
**Found by driving a real office task through the desktop app.** It stopped dead on `python3 -c "import sys; print(sys.version)"` behind an approval reading *"The requested tool action does not clearly match the latest user message"* — meaningless to a human, for a version probe.

The static policy's `.auto` branch approves only read-risk tools, workspace-bounded mutations, or tools whose effect is **lexically implied by the user's words**. Office work needs shell for setup (`command -v pdftotext`, `python3 -m venv`, `pdftotext …`), none of which is implied by "pull the transaction tables out of these PDFs" — so every setup step became an interruption. Headless never showed this because it already wraps the reviewer in `AutonomousApprovalSafetyReviewer`; the desktop didn't.

Auto mode is the daily-driver mode — the human already said "just do it" — so it now gets the same wrapper at both desktop sites (normal + the E2E/confidential path, which drops the model reviewer and would stall even more).

**Not relaxed:** `.deny` passes through untouched, so hard floors (destructive commands, credential exfiltration) still block; out-of-workspace shell paths are still denied (F24). Containment stays with the hard-deny floors and the filesystem sandbox rather than lexical intent-matching. Review and Plan modes are untouched.

Tests assert all three: the baseline stall, benign steps now approving, and out-of-workspace shell still denied. Full suite 5295/5295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)