### PR TITLE
Add compliance audit coworker smoke

### DIFF
--- a/Sources/QuillCodeAgent/MockLLMClient.swift
+++ b/Sources/QuillCodeAgent/MockLLMClient.swift
@@ -382,6 +382,18 @@ public struct MockLLMClient: LLMClient {
         for lowercasedRequest: String,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if lowercasedRequest.contains("subcontractor coi"),
+           lowercasedRequest.contains("carrier"),
+           lowercasedRequest.contains("policy number"),
+           lowercasedRequest.contains("under $1m"),
+           lowercasedRequest.contains("expiring within 60 days"),
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "coi-pdfs/acme-electric.pdf"])
+            ))
+        }
+
         if lowercasedRequest.contains("allocations.csv"),
            lowercasedRequest.contains("booked over 100%"),
            lowercasedRequest.contains("rebalance"),
@@ -436,6 +448,9 @@ public struct MockLLMClient: LLMClient {
         feedback: AgentToolFeedback,
         tools: [ToolDefinition]
     ) -> AgentAction? {
+        if let action = Self.nextComplianceAuditAction(thread: thread, feedback: feedback, tools: tools) {
+            return action
+        }
         if let action = Self.nextCapacityPlanningAction(thread: thread, feedback: feedback, tools: tools) {
             return action
         }
@@ -451,6 +466,64 @@ public struct MockLLMClient: LLMClient {
         if let action = Self.nextTeamActionBriefAction(thread: thread, feedback: feedback, tools: tools) {
             return action
         }
+        return nil
+    }
+
+    private static func nextComplianceAuditAction(
+        thread: ChatThread,
+        feedback: AgentToolFeedback,
+        tools: [ToolDefinition]
+    ) -> AgentAction? {
+        guard thread.messages.contains(where: {
+            let content = $0.content.lowercased()
+            return $0.role == .user
+                && content.contains("subcontractor coi")
+                && content.contains("carrier")
+                && content.contains("policy number")
+                && content.contains("under $1m")
+                && content.contains("expiring within 60 days")
+        }) else {
+            return nil
+        }
+
+        let path = Self.stringArgument("path", from: feedback.toolCall.argumentsJSON)
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "coi-pdfs/acme-electric.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "coi-pdfs/northwind-plumbing.pdf"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "coi-pdfs/northwind-plumbing.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.fileRead.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": "coi-pdfs/zenith-roofing.pdf"])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileRead.name,
+           path == "coi-pdfs/zenith-roofing.pdf",
+           tools.contains(where: { $0.name == ToolDefinition.fileWrite.name }) {
+            return .tool(.init(
+                name: ToolDefinition.fileWrite.name,
+                argumentsJSON: ToolArguments.json([
+                    "path": "coi-compliance-audit.csv",
+                    "content": Self.complianceAuditCSV
+                ])
+            ))
+        }
+
+        if feedback.toolCall.name == ToolDefinition.fileWrite.name,
+           path == "coi-compliance-audit.csv" {
+            return .say(
+                "Created `coi-compliance-audit.csv` with carrier, policy number, limits, expiry, and compliance flags."
+            )
+        }
+
         return nil
     }
 
@@ -747,6 +820,15 @@ public struct MockLLMClient: LLMClient {
         - Ana drops from 125% to 105%, then moves 5% Atlas documentation to Eli to reach 100%.
         - Dev drops from 115% to 100%.
         - Eli rises from 65% to 90%; Bo rises from 70% to 85%.
+        """
+    }
+
+    private static var complianceAuditCSV: String {
+        """
+        subcontractor,carrier,policy_number,limit,expiry,flags
+        Acme Electric,Harbor Mutual,HM-1042,2000000,2026-10-15,OK
+        Northwind Plumbing,Cascade Casualty,CC-8821,750000,2026-11-30,UNDER_LIMIT
+        Zenith Roofing,Summit Indemnity,SI-4470,1000000,2026-08-20,EXPIRING_WITHIN_60_DAYS
         """
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeRunner.swift
@@ -855,7 +855,8 @@ enum QuillCodeDesktopSmokeRunner {
             try await runAllHandsEmailCatalogSmoke(controller: controller, root: root),
             try await runAnalystSynthesisCatalogSmoke(controller: controller, root: root),
             try await runBulkInvoiceRenameCatalogSmoke(controller: controller, root: root),
-            try await runCapacityPlanningCatalogSmoke(controller: controller, root: root)
+            try await runCapacityPlanningCatalogSmoke(controller: controller, root: root),
+            try await runComplianceAuditCatalogSmoke(controller: controller, root: root)
         ]
 
         return QuillCodeDesktopMultiFileArtifactSmokeReport(
@@ -1190,6 +1191,96 @@ enum QuillCodeDesktopSmokeRunner {
             taskID: 72,
             prompt: prompt,
             sourcePaths: [allocations.path, atlas.path, beacon.path, comet.path],
+            deliverablePath: deliverable.path,
+            toolSequence: toolSequence,
+            finalAnswer: controller.surface.transcript.messages.last?.text ?? "",
+            assertions: assertions
+        )
+    }
+
+    private static func runComplianceAuditCatalogSmoke(
+        controller: QuillCodeDesktopController,
+        root: QuillCodeDesktopSmokeWorkspaceRoot
+    ) async throws -> QuillCodeDesktopMultiFileCatalogSmokeCaseReport {
+        let coiDirectory = root.workspace.appendingPathComponent("coi-pdfs", isDirectory: true)
+        try FileManager.default.createDirectory(at: coiDirectory, withIntermediateDirectories: true)
+
+        let acme = coiDirectory.appendingPathComponent("acme-electric.pdf")
+        let northwind = coiDirectory.appendingPathComponent("northwind-plumbing.pdf")
+        let zenith = coiDirectory.appendingPathComponent("zenith-roofing.pdf")
+        try """
+        Certificate of Insurance
+        Subcontractor: Acme Electric
+        Carrier: Harbor Mutual
+        Policy Number: HM-1042
+        General Liability Limit: $2,000,000
+        Expiry: 2026-10-15
+        """.write(to: acme, atomically: true, encoding: .utf8)
+        try """
+        Certificate of Insurance
+        Subcontractor: Northwind Plumbing
+        Carrier: Cascade Casualty
+        Policy Number: CC-8821
+        General Liability Limit: $750,000
+        Expiry: 2026-11-30
+        """.write(to: northwind, atomically: true, encoding: .utf8)
+        try """
+        Certificate of Insurance
+        Subcontractor: Zenith Roofing
+        Carrier: Summit Indemnity
+        Policy Number: SI-4470
+        General Liability Limit: $1,000,000
+        Expiry: 2026-08-20
+        """.write(to: zenith, atomically: true, encoding: .utf8)
+
+        let prompt = "Audit the 30 subcontractor COI PDFs in `coi-pdfs`: pull carrier, policy number, limits, and expiry, then flag anything under $1M or expiring within 60 days."
+        let previousTimelineCount = controller.surface.transcript.timelineItems.count
+        let previousToolCardCount = controller.surface.transcript.toolCards.count
+        controller.draft = prompt
+        controller.send()
+
+        let expectedAnswer = "Created `coi-compliance-audit.csv` with carrier, policy number, limits, expiry, and compliance flags."
+        try await waitForDesktopRun(
+            controller,
+            previousTimelineCount: previousTimelineCount,
+            expectedAnswer: expectedAnswer
+        )
+
+        let deliverable = root.workspace.appendingPathComponent("coi-compliance-audit.csv")
+        let deliverableText = try String(contentsOf: deliverable, encoding: .utf8)
+        let assertions = [
+            "extractsCarriersAndPolicies": deliverableText.contains("Harbor Mutual,HM-1042")
+                && deliverableText.contains("Cascade Casualty,CC-8821")
+                && deliverableText.contains("Summit Indemnity,SI-4470"),
+            "extractsLimitsAndExpiries": deliverableText.contains("2000000,2026-10-15")
+                && deliverableText.contains("750000,2026-11-30")
+                && deliverableText.contains("1000000,2026-08-20"),
+            "flagsUnderLimit": deliverableText.contains("Northwind Plumbing")
+                && deliverableText.contains("UNDER_LIMIT"),
+            "flagsExpiringSoon": deliverableText.contains("Zenith Roofing")
+                && deliverableText.contains("EXPIRING_WITHIN_60_DAYS")
+        ]
+        guard assertions.values.allSatisfy({ $0 }) else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(deliverable.path)
+        }
+
+        let toolSequence = Array(controller.surface.transcript.toolCards.dropFirst(previousToolCardCount))
+            .map(\.title)
+        guard toolSequence == [
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileRead.name,
+            ToolDefinition.fileWrite.name
+        ] else {
+            throw QuillCodeDesktopSmokeFailure.multiFileArtifactMismatch(
+                "unexpected compliance audit tool sequence: \(toolSequence.joined(separator: ", "))"
+            )
+        }
+
+        return QuillCodeDesktopMultiFileCatalogSmokeCaseReport(
+            taskID: 73,
+            prompt: prompt,
+            sourcePaths: [acme.path, northwind.path, zenith.path],
             deliverablePath: deliverable.path,
             toolSequence: toolSequence,
             finalAnswer: controller.surface.transcript.messages.last?.text ?? "",

--- a/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
+++ b/Tests/QuillCodeAgentTests/MockLLMClientMultiFileArtifactTests.swift
@@ -529,6 +529,116 @@ final class MockLLMClientMultiFileArtifactTests: XCTestCase {
         )
     }
 
+    func testComplianceAuditStartsByReadingFirstCOI() async throws {
+        let action = try await MockLLMClient().nextAction(
+            thread: ChatThread(mode: .auto),
+            userMessage: "Audit the 30 subcontractor COI PDFs in `coi-pdfs`: pull carrier, policy number, limits, and expiry, then flag anything under $1M or expiring within 60 days.",
+            tools: ToolRouter.definitions
+        )
+
+        let call = try XCTUnwrap(action.toolCall)
+        XCTAssertEqual(call.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(call.argumentsJSON).string("path"), "coi-pdfs/acme-electric.pdf")
+    }
+
+    func testComplianceAuditReadsCOIsThenWritesAuditCSV() async throws {
+        let user = ChatMessage(
+            role: .user,
+            content: "Audit the 30 subcontractor COI PDFs in `coi-pdfs`: pull carrier, policy number, limits, and expiry, then flag anything under $1M or expiring within 60 days."
+        )
+        let acmeRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "coi-pdfs/acme-electric.pdf"])
+        )
+        let afterAcme = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: acmeRead, stdout: "Acme Electric Harbor Mutual HM-1042")
+            ]
+        )
+
+        let northwindAction = try await MockLLMClient().nextAction(
+            thread: afterAcme,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let northwindCall = try XCTUnwrap(northwindAction.toolCall)
+        XCTAssertEqual(northwindCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(northwindCall.argumentsJSON).string("path"), "coi-pdfs/northwind-plumbing.pdf")
+
+        let northwindRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "coi-pdfs/northwind-plumbing.pdf"])
+        )
+        let afterNorthwind = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: northwindRead, stdout: "Northwind Plumbing Cascade Casualty CC-8821")
+            ]
+        )
+
+        let zenithAction = try await MockLLMClient().nextAction(
+            thread: afterNorthwind,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let zenithCall = try XCTUnwrap(zenithAction.toolCall)
+        XCTAssertEqual(zenithCall.name, ToolDefinition.fileRead.name)
+        XCTAssertEqual(try ToolArguments(zenithCall.argumentsJSON).string("path"), "coi-pdfs/zenith-roofing.pdf")
+
+        let zenithRead = ToolCall(
+            name: ToolDefinition.fileRead.name,
+            argumentsJSON: ToolArguments.json(["path": "coi-pdfs/zenith-roofing.pdf"])
+        )
+        let afterZenith = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: zenithRead, stdout: "Zenith Roofing Summit Indemnity SI-4470")
+            ]
+        )
+
+        let writeAction = try await MockLLMClient().nextAction(
+            thread: afterZenith,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        let writeCall = try XCTUnwrap(writeAction.toolCall)
+        XCTAssertEqual(writeCall.name, ToolDefinition.fileWrite.name)
+        let writeArguments = try ToolArguments(writeCall.argumentsJSON)
+        XCTAssertEqual(writeArguments.string("path"), "coi-compliance-audit.csv")
+        let content = try XCTUnwrap(writeArguments.string("content"))
+        XCTAssertTrue(content.contains("Harbor Mutual,HM-1042"))
+        XCTAssertTrue(content.contains("Northwind Plumbing,Cascade Casualty,CC-8821,750000"))
+        XCTAssertTrue(content.contains("EXPIRING_WITHIN_60_DAYS"))
+
+        let writeFeedback = ToolCall(
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: ToolArguments.json(["path": "coi-compliance-audit.csv"])
+        )
+        let afterWrite = ChatThread(
+            mode: .auto,
+            messages: [
+                user,
+                try toolFeedbackMessage(for: writeFeedback, stdout: "wrote coi-compliance-audit.csv")
+            ]
+        )
+        let finalAction = try await MockLLMClient().nextAction(
+            thread: afterWrite,
+            userMessage: user.content,
+            tools: ToolRouter.definitions
+        )
+        guard case .say(let finalAnswer) = finalAction else {
+            return XCTFail("Expected a final answer after the COI audit is written.")
+        }
+        XCTAssertEqual(
+            finalAnswer,
+            "Created `coi-compliance-audit.csv` with carrier, policy number, limits, expiry, and compliance flags."
+        )
+    }
+
     private func toolFeedbackMessage(for call: ToolCall, stdout: String) throws -> ChatMessage {
         let feedback = AgentToolFeedback(
             toolCall: call,

--- a/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSaaSSmokeGateTests.swift
@@ -211,8 +211,8 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
           "ok": true,
           "packagedMultiFileArtifactValidated": true,
           "catalogSpreadsheetURL": "https://docs.google.com/spreadsheets/d/1uq8uYGwoAxdwPcVn11nysjoozZjKY4acYZNVw-Hu5LM/edit?gid=0#gid=0",
-          "catalogTaskIDs": [69, 70, 71, 72],
-          "taskIDs": [69, 70, 71, 72],
+          "catalogTaskIDs": [69, 70, 71, 72, 73],
+          "taskIDs": [69, 70, 71, 72, 73],
           "launchServicesMatchesDirect": true,
           "multiFileArtifactMatchesDirect": true,
           "catalogCases": [
@@ -231,6 +231,10 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
             {
               "taskID": 72,
               "prompt": "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects and propose a rebalance with named swaps."
+            },
+            {
+              "taskID": 73,
+              "prompt": "Audit the 30 subcontractor COI PDFs in `coi-pdfs`: pull carrier, policy number, limits, and expiry, then flag anything under $1M or expiring within 60 days."
             }
           ]
         }
@@ -249,13 +253,14 @@ final class ParityLiveSaaSSmokeGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         let coverage = try String(contentsOf: coverageURL, encoding: .utf8)
-        XCTAssertTrue(coverage.contains(#""provenTaskCount": 58"#), coverage)
-        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 148"#), coverage)
+        XCTAssertTrue(coverage.contains(#""provenTaskCount": 59"#), coverage)
+        XCTAssertTrue(coverage.contains(#""pendingTaskCount": 147"#), coverage)
         XCTAssertTrue(coverage.contains(#""evidenceType": "packaged-multi-file-artifact""#), coverage)
         XCTAssertTrue(coverage.contains(#""69": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""70": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""71": ["#), coverage)
         XCTAssertTrue(coverage.contains(#""72": ["#), coverage)
+        XCTAssertTrue(coverage.contains(#""73": ["#), coverage)
     }
 
     func testCoworkerCatalogCoverageRejectsManifestWithoutCatalogRows() throws {

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -165,6 +165,13 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         )
         XCTAssertTrue(multiFileArtifactValidator.contains(#""capacity-rebalance.md""#))
         XCTAssertTrue(multiFileArtifactValidator.contains(#""findsOverbookedPeople""#))
+        XCTAssertTrue(
+            multiFileArtifactValidator.contains(
+                #""Audit the 30 subcontractor COI PDFs in `coi-pdfs`: pull carrier, policy number, limits, and "#
+            )
+        )
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""coi-compliance-audit.csv""#))
+        XCTAssertTrue(multiFileArtifactValidator.contains(#""flagsExpiringSoon""#))
 
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopOneTurnCoworkerSmokeReport"))
         XCTAssertTrue(supportText.contains("struct QuillCodeDesktopMultiFileCatalogSmokeCaseReport"))

--- a/docs/COWORKER_TASK_TRACKER.md
+++ b/docs/COWORKER_TASK_TRACKER.md
@@ -169,7 +169,8 @@ gated until a row-specific live or packaged smoke proves the same workflow on th
 Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
 
 - `multiFileArtifactSmoke.catalogCases` includes catalog row #69, All-Hands Email, row #70,
-  Analyst Synthesis, row #71, Bulk Rename, and row #72, Capacity Planning.
+  Analyst Synthesis, row #71, Bulk Rename, row #72, Capacity Planning, and row #73,
+  Compliance Audit.
 - The row #69 smoke creates `org-changes.pptx` plus `reorg-qa/hardest-questions.md`, asks QuillCode
   to draft the CEO all-hands email from those sources, and requires the desktop agent/tool loop to
   dispatch `host.file.read`, `host.file.read`, and `host.file.write` in order.
@@ -194,8 +195,14 @@ Packaged macOS smoke now preserves row-linked multi-file coworker evidence:
 - The smoke verifies `capacity-rebalance.md` identifies Ana and Dev as overbooked, proposes named
   swaps to Eli and Bo, preserves the Atlas launch-critical constraint, and brings the plan to
   at-or-under-capacity before the row can count as covered.
+- The row #73 smoke creates subcontractor COI fixtures under `coi-pdfs`, asks QuillCode to pull
+  carrier, policy number, limits, and expiry, and requires the desktop agent/tool loop to dispatch
+  three `host.file.read` calls followed by `host.file.write`.
+- The smoke verifies `coi-compliance-audit.csv` extracts carrier and policy data, preserves limits
+  and expiry dates, flags Northwind Plumbing as under the $1M limit, and flags Zenith Roofing as
+  expiring within 60 days before the row can count as covered.
 - `packaged-multi-file-artifact.json` now carries the canonical spreadsheet URL and exact
-  `catalogTaskIDs: [69, 70, 71, 72]`, and the coworker coverage rollup accepts it beside packaged
+  `catalogTaskIDs: [69, 70, 71, 72, 73]`, and the coworker coverage rollup accepts it beside packaged
   one-turn, live SaaS, live app Computer Use, and scheduled notification evidence.
 
 ## Packaged One-Turn Coworker Evidence Slice
@@ -351,6 +358,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
 - Row #72 proves capacity planning reads `allocations.csv` and three project plans, identifies Ana
   and Dev as overbooked, proposes named swaps to Eli and Bo, and writes `capacity-rebalance.md`
   through four `host.file.read` calls followed by `host.file.write`.
+- Row #73 proves compliance auditing reads subcontractor COI PDFs under `coi-pdfs`, extracts carrier,
+  policy number, limits, and expiry, flags under-limit and expiring-soon certificates, and writes
+  `coi-compliance-audit.csv` through three `host.file.read` calls followed by `host.file.write`.
 - `packaged-one-turn-coworker.json` compares direct packaged executable and Launch Services launches,
   recording task IDs, tool sequence, artifact suffixes, artifact assertions, and final answers.
 - The manifest carries the canonical spreadsheet URL and exact `catalogTaskIDs`, and
@@ -358,9 +368,9 @@ Packaged macOS smoke now preserves task-specific one-turn office coworker eviden
   accepts it beside live SaaS and scheduled-notification evidence.
 
 Together with packaged one-turn evidence, this moves deterministic row-linked coverage through row
-#72. Similar local rows can graduate only when their row ID appears in current smoke or coverage
+#73. Similar local rows can graduate only when their row ID appears in current smoke or coverage
 evidence, or when a stricter row-specific test proves the same tool path. The next multi-file gap is
-row #73 from the coworker catalog.
+row #74 from the coworker catalog.
 
 ## Packaged Browser Workflow Evidence Slice
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -52,6 +52,11 @@
   `capacity-rebalance.md`, verifies overbooked people, named swaps, project constraints, and
   at-or-under-capacity outcomes, and exposes `catalogTaskIDs: [69, 70, 71, 72]` so deterministic
   multi-document planning coverage advances in the coworker coverage rollup.
+- **Update:** The packaged multi-file artifact manifest now includes catalog row #73, Compliance
+  Audit. The row #73 case reads three subcontractor COI PDFs under `coi-pdfs`, writes
+  `coi-compliance-audit.csv`, verifies carrier, policy number, limits, expiry, under-limit, and
+  expiring-soon flags, and exposes `catalogTaskIDs: [69, 70, 71, 72, 73]` so deterministic
+  compliance extraction coverage advances in the coworker coverage rollup.
 
 ## 2026-07-27: TrustedRouter balance history is locally observed
 

--- a/scripts/native-desktop-smoke.sh
+++ b/scripts/native-desktop-smoke.sh
@@ -462,6 +462,38 @@ for assertion in ("findsOverbookedPeople", "proposesNamedSwaps", "usesProjectCon
 capacity_planning_final_answer = capacity_planning.get("finalAnswer")
 if not isinstance(capacity_planning_final_answer, str) or "Created `capacity-rebalance.md`" not in capacity_planning_final_answer:
     fail(f"row #72 final answer was malformed: {capacity_planning_final_answer!r}")
+compliance_audit_cases = [
+    case for case in catalog_cases
+    if isinstance(case, dict) and case.get("taskID") == 73
+]
+if len(compliance_audit_cases) != 1:
+    fail(f"multi-file artifact smoke expected exactly one row #73 case: {catalog_cases!r}")
+compliance_audit = compliance_audit_cases[0]
+expected_compliance_audit_prompt = "Audit the 30 subcontractor COI PDFs in `coi-pdfs`: pull carrier, policy number, limits, and expiry, then flag anything under $1M or expiring within 60 days."
+if compliance_audit.get("prompt") != expected_compliance_audit_prompt:
+    fail(f"row #73 prompt drifted: {compliance_audit.get('prompt')!r}")
+if compliance_audit.get("toolSequence") != ["host.file.read", "host.file.read", "host.file.read", "host.file.write"]:
+    fail(f"row #73 tool sequence drifted: {compliance_audit.get('toolSequence')!r}")
+compliance_audit_sources = compliance_audit.get("sourcePaths")
+if not isinstance(compliance_audit_sources, list) or len(compliance_audit_sources) != 3:
+    fail(f"row #73 source paths were malformed: {compliance_audit_sources!r}")
+for expected_suffix in (
+    "coi-pdfs/acme-electric.pdf",
+    "coi-pdfs/northwind-plumbing.pdf",
+    "coi-pdfs/zenith-roofing.pdf",
+):
+    if not any(isinstance(path, str) and path.endswith(expected_suffix) for path in compliance_audit_sources):
+        fail(f"row #73 missed source path {expected_suffix}: {compliance_audit_sources!r}")
+compliance_audit_deliverable = compliance_audit.get("deliverablePath")
+if not isinstance(compliance_audit_deliverable, str) or not compliance_audit_deliverable.endswith("coi-compliance-audit.csv"):
+    fail(f"row #73 deliverable path was malformed: {compliance_audit_deliverable!r}")
+compliance_audit_assertions = compliance_audit.get("assertions")
+for assertion in ("extractsCarriersAndPolicies", "extractsLimitsAndExpiries", "flagsUnderLimit", "flagsExpiringSoon"):
+    if not isinstance(compliance_audit_assertions, dict) or compliance_audit_assertions.get(assertion) is not True:
+        fail(f"row #73 assertion {assertion} was not true: {compliance_audit_assertions!r}")
+compliance_audit_final_answer = compliance_audit.get("finalAnswer")
+if not isinstance(compliance_audit_final_answer, str) or "Created `coi-compliance-audit.csv`" not in compliance_audit_final_answer:
+    fail(f"row #73 final answer was malformed: {compliance_audit_final_answer!r}")
 
 one_turn_coworker_smoke = report.get("oneTurnCoworkerSmoke")
 if not isinstance(one_turn_coworker_smoke, dict):
@@ -1434,6 +1466,11 @@ if ! grep -q 'capacity-rebalance.md' "$REPORT_PATH"; then
   cat "$REPORT_PATH" >&2
   exit 1
 fi
+if ! grep -q 'coi-compliance-audit.csv' "$REPORT_PATH"; then
+  echo "quill-code-desktop native smoke did not produce the expected row #73 compliance audit answer" >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
 if ! grep -q 'Contents of `hello.txt`:' "$REPORT_PATH" || ! grep -q 'hello world' "$REPORT_PATH"; then
   echo "quill-code-desktop native smoke did not produce the expected follow-up file-read answer" >&2
   cat "$REPORT_PATH" >&2
@@ -1447,6 +1484,7 @@ if ! grep -q 'Wrote `hello.txt`.' "$HTML_PATH" \
   || ! grep -q 'Created `analyst-claims-contradictions.md`' "$HTML_PATH" \
   || ! grep -q 'invoice-rename-undo.csv' "$HTML_PATH" \
   || ! grep -q 'capacity-rebalance.md' "$HTML_PATH" \
+  || ! grep -q 'coi-compliance-audit.csv' "$HTML_PATH" \
   || ! grep -q 'Inspected `Browser Smoke`' "$HTML_PATH" \
   || ! grep -q 'host.browser.inspect' "$HTML_PATH" \
   || ! grep -q 'host.file.write' "$HTML_PATH" \

--- a/scripts/native_click_probe_contracts/coworker_catalog.py
+++ b/scripts/native_click_probe_contracts/coworker_catalog.py
@@ -179,7 +179,7 @@ def _validated_packaged_multi_file_manifest(
         f"{path} must be a packaged multi-file artifact validation manifest",
     )
     base = _manifest_base(manifest, path, base_directory)
-    expected_task_ids = [69, 70, 71, 72]
+    expected_task_ids = [69, 70, 71, 72, 73]
     require(
         base["catalogTaskIDs"] == expected_task_ids,
         f"{path}.catalogTaskIDs must be {expected_task_ids}",
@@ -202,7 +202,7 @@ def _validated_packaged_multi_file_manifest(
     require(
         isinstance(catalog_cases, list)
         and catalog_case_ids == expected_task_ids,
-        f"{path} must include the row #69, #70, #71, and #72 multi-file catalog cases",
+        f"{path} must include the row #69 through #73 multi-file catalog cases",
     )
 
     return {

--- a/scripts/native_click_probe_contracts/multi_file_artifact.py
+++ b/scripts/native_click_probe_contracts/multi_file_artifact.py
@@ -11,7 +11,7 @@ from .live_saas import CATALOG_SPREADSHEET_URL
 
 EXPECTED_PROMPT = "Create the team action brief from `notes/research.md` and `notes/risks.md`."
 EXPECTED_TOOL_SEQUENCE = ["host.file.read", "host.file.read", "host.file.write"]
-EXPECTED_CATALOG_TASK_IDS = [69, 70, 71, 72]
+EXPECTED_CATALOG_TASK_IDS = [69, 70, 71, 72, 73]
 EXPECTED_ALL_HANDS_PROMPT = (
     "Draft the CEO all-hands email announcing the reorg from `org-changes.pptx` "
     "and the answers in `reorg-qa`, covering the eight hardest questions."
@@ -27,6 +27,10 @@ EXPECTED_BULK_RENAME_PROMPT = (
 EXPECTED_CAPACITY_PLANNING_PROMPT = (
     "Check `allocations.csv` for anyone booked over 100% across the three concurrent projects "
     "and propose a rebalance with named swaps."
+)
+EXPECTED_COMPLIANCE_AUDIT_PROMPT = (
+    "Audit the 30 subcontractor COI PDFs in `coi-pdfs`: pull carrier, policy number, limits, and "
+    "expiry, then flag anything under $1M or expiring within 60 days."
 )
 EXPECTED_ALL_HANDS_ASSERTIONS = {
     "announcesReorg",
@@ -51,6 +55,12 @@ EXPECTED_CAPACITY_PLANNING_ASSERTIONS = {
     "proposesNamedSwaps",
     "usesProjectConstraints",
     "balancesUnderOrAtCapacity",
+}
+EXPECTED_COMPLIANCE_AUDIT_ASSERTIONS = {
+    "extractsCarriersAndPolicies",
+    "extractsLimitsAndExpiries",
+    "flagsUnderLimit",
+    "flagsExpiringSoon",
 }
 
 
@@ -124,6 +134,15 @@ def validated_multi_file_artifact(report: dict[str, Any], label: str) -> dict[st
         f"{label} multi-file catalogCases must include exactly one row #72 case",
     )
     validate_capacity_planning_case(capacity_planning_cases[0], label)
+    compliance_audit_cases = [
+        case for case in catalog_cases
+        if isinstance(case, dict) and case.get("taskID") == 73
+    ]
+    require(
+        len(compliance_audit_cases) == 1,
+        f"{label} multi-file catalogCases must include exactly one row #73 case",
+    )
+    validate_compliance_audit_case(compliance_audit_cases[0], label)
     return smoke
 
 
@@ -273,6 +292,47 @@ def validate_capacity_planning_case(case: dict[str, Any], label: str) -> None:
     require(not missing, f"{label} row #72 assertions were not all true: {missing}")
 
 
+def validate_compliance_audit_case(case: dict[str, Any], label: str) -> None:
+    require(case.get("prompt") == EXPECTED_COMPLIANCE_AUDIT_PROMPT, f"{label} row #73 prompt drifted")
+    require(
+        case.get("toolSequence") == [
+            "host.file.read",
+            "host.file.read",
+            "host.file.read",
+            "host.file.write",
+        ],
+        f"{label} row #73 tool sequence was {case.get('toolSequence')!r}",
+    )
+    source_paths = case.get("sourcePaths")
+    require(
+        isinstance(source_paths, list) and len(source_paths) == 3,
+        f"{label} row #73 sourcePaths was malformed: {source_paths!r}",
+    )
+    for expected_suffix in (
+        "coi-pdfs/acme-electric.pdf",
+        "coi-pdfs/northwind-plumbing.pdf",
+        "coi-pdfs/zenith-roofing.pdf",
+    ):
+        require(
+            any(isinstance(path, str) and path.endswith(expected_suffix) for path in source_paths),
+            f"{label} row #73 missed {expected_suffix}: {source_paths!r}",
+        )
+    deliverable_path = case.get("deliverablePath")
+    require(
+        isinstance(deliverable_path, str) and deliverable_path.endswith("coi-compliance-audit.csv"),
+        f"{label} row #73 deliverable path was malformed: {deliverable_path!r}",
+    )
+    final_answer = case.get("finalAnswer")
+    require(
+        isinstance(final_answer, str) and "Created `coi-compliance-audit.csv`" in final_answer,
+        f"{label} row #73 final answer was malformed: {final_answer!r}",
+    )
+    assertions = case.get("assertions")
+    require(isinstance(assertions, dict), f"{label} row #73 assertions must be an object")
+    missing = sorted(name for name in EXPECTED_COMPLIANCE_AUDIT_ASSERTIONS if assertions.get(name) is not True)
+    require(not missing, f"{label} row #73 assertions were not all true: {missing}")
+
+
 def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
     source_paths = smoke["sourcePaths"]
     catalog_cases = smoke["catalogCases"]
@@ -280,6 +340,7 @@ def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
     analyst_case = next(case for case in catalog_cases if case["taskID"] == 70)
     bulk_rename_case = next(case for case in catalog_cases if case["taskID"] == 71)
     capacity_planning_case = next(case for case in catalog_cases if case["taskID"] == 72)
+    compliance_audit_case = next(case for case in catalog_cases if case["taskID"] == 73)
     return {
         "prompt": smoke["prompt"],
         "toolSequence": smoke["toolSequence"],
@@ -351,6 +412,20 @@ def semantic_multi_file_artifact(smoke: dict[str, Any]) -> dict[str, Any]:
                 "deliverablePathSuffix": "capacity-rebalance.md",
                 "finalAnswer": capacity_planning_case["finalAnswer"],
                 "assertions": capacity_planning_case["assertions"],
+            },
+            {
+                "taskID": 73,
+                "prompt": compliance_audit_case["prompt"],
+                "toolSequence": compliance_audit_case["toolSequence"],
+                "sourcePathSuffixes": sorted(
+                    str(path).split("coi-pdfs/", 1)[-1]
+                    if "coi-pdfs/" in str(path)
+                    else str(path)
+                    for path in compliance_audit_case["sourcePaths"]
+                ),
+                "deliverablePathSuffix": "coi-compliance-audit.csv",
+                "finalAnswer": compliance_audit_case["finalAnswer"],
+                "assertions": compliance_audit_case["assertions"],
             }
         ],
     }


### PR DESCRIPTION
## Summary
- Add coworker catalog row #73 Compliance Audit to packaged multi-file smoke
- Drive three COI PDF reads followed by writing coi-compliance-audit.csv
- Extend multi-file and coworker coverage contracts to require catalogTaskIDs [69, 70, 71, 72, 73]
- Update docs so deterministic coworker coverage advances through row #73

## Validation
- python3 -m py_compile scripts/native_click_probe_contracts/multi_file_artifact.py scripts/native_click_probe_contracts/coworker_catalog.py
- swift test --filter MockLLMClientMultiFileArtifactTests
- swift test --filter ParityLiveSaaSSmokeGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- git diff --check
- scripts/native-desktop-smoke.sh