### PR TITLE
Harden downloadable build update feeds

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -24,8 +24,10 @@ jobs:
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
             echo "QUILLCODE_BUILD_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+            echo "QUILLCODE_UPDATE_CHANNEL=stable" >> "$GITHUB_ENV"
           else
             echo "QUILLCODE_BUILD_VERSION=0.1.0" >> "$GITHUB_ENV"
+            echo "QUILLCODE_UPDATE_CHANNEL=tester" >> "$GITHUB_ENV"
           fi
           echo "QUILLCODE_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
       - name: Package macOS app and CLI
@@ -49,8 +51,10 @@ jobs:
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
             echo "QUILLCODE_BUILD_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+            echo "QUILLCODE_UPDATE_CHANNEL=stable" >> "$GITHUB_ENV"
           else
             echo "QUILLCODE_BUILD_VERSION=0.1.0" >> "$GITHUB_ENV"
+            echo "QUILLCODE_UPDATE_CHANNEL=tester" >> "$GITHUB_ENV"
           fi
           echo "QUILLCODE_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
       - name: Package Linux CLI
@@ -86,6 +90,7 @@ jobs:
             RELEASE_TAG="tester-latest"
             RELEASE_CHANNEL="tester"
           fi
+          MANIFEST_NAME="latest-${RELEASE_CHANNEL}-build.json"
           (
             cd "$RUNNER_TEMP/release-assets"
             find . -maxdepth 1 -type f ! -name SHASUMS256.txt -printf '%P\0' | sort -z | xargs -0 sha256sum > SHASUMS256.txt
@@ -97,7 +102,7 @@ jobs:
             --channel "$RELEASE_CHANNEL" \
             --commit "$GITHUB_SHA" \
             --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            --output "$RUNNER_TEMP/release-assets/latest-tester-build.json"
+            --output "$RUNNER_TEMP/release-assets/$MANIFEST_NAME"
           find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -print | sort
       - name: Publish tester or tagged release
         env:
@@ -108,11 +113,13 @@ jobs:
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
             RELEASE_TAG="${GITHUB_REF_NAME}"
             RELEASE_TITLE="Quill Cowork ${GITHUB_REF_NAME}"
+            RELEASE_CHANNEL="stable"
             PRERELEASE_FLAG=()
             LATEST_FLAG=(--latest)
           else
             RELEASE_TAG="tester-latest"
             RELEASE_TITLE="Quill Cowork Tester Build"
+            RELEASE_CHANNEL="tester"
             PRERELEASE_FLAG=(--prerelease)
             LATEST_FLAG=(--latest=false)
             git config user.name "github-actions[bot]"
@@ -120,9 +127,10 @@ jobs:
             git tag -f "$RELEASE_TAG" "$GITHUB_SHA"
             git push origin "refs/tags/$RELEASE_TAG" --force
           fi
+          MANIFEST_NAME="latest-${RELEASE_CHANNEL}-build.json"
 
           cat > "$RUNNER_TEMP/release-notes.md" <<NOTES
-          Automated Quill Cowork tester build.
+          Automated Quill Cowork ${RELEASE_CHANNEL} build.
 
           Commit: \`${GITHUB_SHA}\`
           Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
@@ -132,9 +140,9 @@ jobs:
           - \`quill-code-macOS-*.tar.gz\`: macOS CLI.
           - \`quill-code-linux-*.tar.gz\`: Linux CLI.
           - \`SHASUMS256.txt\`: checksum manifest for every asset.
-          - \`latest-tester-build.json\`: machine-readable build metadata, download URLs, sizes, and SHA-256 digests.
+          - \`${MANIFEST_NAME}\`: machine-readable build metadata, updater feed metadata, download URLs, sizes, and SHA-256 digests.
 
-          macOS tester note: this build is ad-hoc signed but not notarized yet. If Gatekeeper blocks first launch, use right-click > Open. Computer Use still requires normal macOS Screen Recording and Accessibility permissions.
+          macOS distribution note: this build is ad-hoc signed but not notarized yet. If Gatekeeper blocks first launch, use right-click > Open. Computer Use still requires normal macOS Screen Recording and Accessibility permissions.
           NOTES
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -151,5 +159,13 @@ jobs:
               "${PRERELEASE_FLAG[@]}" \
               "${LATEST_FLAG[@]}"
           fi
+
+          find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -printf '%f\n' | sort > "$RUNNER_TEMP/current-release-assets.txt"
+          gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' |
+            while IFS= read -r asset_name; do
+              if [[ -n "$asset_name" ]] && ! grep -Fxq "$asset_name" "$RUNNER_TEMP/current-release-assets.txt"; then
+                gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
+              fi
+            done
 
           gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/* --clobber

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -8,7 +8,19 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
-        try "product=Quill Cowork\nplatform=macOS\narch=arm64\nversion=0.2.0\nbuild=123\n"
+        try """
+        product=Quill Cowork
+        platform=macOS
+        arch=arm64
+        version=0.2.0
+        build=123
+        bundleIdentifier=co.lorehex.QuillCowork
+        minimumSystemVersion=14.0
+        updateChannel=tester
+        updateManifestURL=https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
+        stableUpdateManifestURL=https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json
+        testerUpdateManifestURL=https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
+        """
             .write(to: temporaryDirectory.appendingPathComponent("BUILD_INFO.txt"), atomically: true, encoding: .utf8)
         try "product=Quill Cowork\nplatform=Linux\narch=x86_64\nversion=0.2.0\nbuild=123\n"
             .write(
@@ -54,6 +66,27 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "https://github.com/Lore-Hex/QuillCode/actions/runs/1"
         )
 
+        let updater = try XCTUnwrap(manifest["updater"] as? [String: Any])
+        XCTAssertEqual(updater["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(updater["format"] as? String, "github-release-manifest")
+        XCTAssertEqual(updater["channel"] as? String, "tester")
+        XCTAssertEqual(
+            updater["manifestURL"] as? String,
+            "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"
+        )
+        XCTAssertEqual(
+            updater["stableManifestURL"] as? String,
+            "https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json"
+        )
+        XCTAssertEqual(
+            updater["testerManifestURL"] as? String,
+            "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"
+        )
+        XCTAssertEqual(updater["bundleIdentifier"] as? String, "co.lorehex.QuillCowork")
+        XCTAssertEqual(updater["minimumSystemVersion"] as? String, "14.0")
+        let updaterAppAsset = try XCTUnwrap(updater["macOSAppAsset"] as? [String: Any])
+        XCTAssertEqual(updaterAppAsset["name"] as? String, "Quill-Cowork-macOS-arm64.zip")
+
         let assets = try XCTUnwrap(manifest["assets"] as? [[String: Any]])
         XCTAssertEqual(assets.count, 6)
 
@@ -91,11 +124,17 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         Self.assertSource(workflow, containsAll: [
             "group: download-builds-${{ github.ref }}",
             "cancel-in-progress: false",
+            "QUILLCODE_UPDATE_CHANNEL=stable",
+            "QUILLCODE_UPDATE_CHANNEL=tester",
             "scripts/build-download-manifest.py",
-            "--output \"$RUNNER_TEMP/release-assets/latest-tester-build.json\"",
+            "MANIFEST_NAME=\"latest-${RELEASE_CHANNEL}-build.json\"",
+            "--output \"$RUNNER_TEMP/release-assets/$MANIFEST_NAME\"",
             "RELEASE_CHANNEL=\"tester\"",
             "RELEASE_CHANNEL=\"stable\"",
-            "\\`latest-tester-build.json\\`: machine-readable build metadata",
+            "\\`${MANIFEST_NAME}\\`: machine-readable build metadata",
+            "updater feed metadata",
+            "current-release-assets.txt",
+            "gh release delete-asset \"$RELEASE_TAG\" \"$asset_name\" --yes",
             "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/* --clobber"
         ])
         XCTAssertFalse(
@@ -110,11 +149,58 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
 
         Self.assertSource(downloads, containsAll: [
             "latest-tester-build.json",
-            "Build manifest",
+            "latest-stable-build.json",
+            "app updater, website, and support script contract",
+            "Auto-Update Contract",
+            "QuillCodeUpdateChannel",
+            "QuillCodeUpdateManifestURL",
+            "QuillCodeStableUpdateManifestURL",
+            "QuillCodeTesterUpdateManifestURL",
             "channel is `tester`",
             "channel is `stable`"
         ])
         Self.assertSource(readme, contains: "machine-readable build manifest")
+    }
+
+    func testMacOSDownloadPackagingEmbedsUpdaterMetadata() throws {
+        let root = Self.packageRoot()
+        let buildScript = try String(
+            contentsOf: root.appendingPathComponent("scripts").appendingPathComponent("build-macos-app.sh"),
+            encoding: .utf8
+        )
+        let packageScript = try String(
+            contentsOf: root.appendingPathComponent("scripts").appendingPathComponent("package-macos-downloads.sh"),
+            encoding: .utf8
+        )
+        let smokeScript = try String(
+            contentsOf: root.appendingPathComponent("scripts").appendingPathComponent("packaged-macos-smoke.sh"),
+            encoding: .utf8
+        )
+
+        Self.assertSource(buildScript, containsAll: [
+            "QUILLCODE_MACOS_UPDATE_CHANNEL",
+            "QUILLCODE_MACOS_UPDATE_MANIFEST_URL",
+            "QUILLCODE_MACOS_UPDATE_STABLE_MANIFEST_URL",
+            "QUILLCODE_MACOS_UPDATE_TESTER_MANIFEST_URL",
+            "<key>QuillCodeUpdateChannel</key>",
+            "<key>QuillCodeUpdateManifestURL</key>",
+            "<key>QuillCodeStableUpdateManifestURL</key>",
+            "<key>QuillCodeTesterUpdateManifestURL</key>"
+        ])
+        Self.assertSource(packageScript, containsAll: [
+            "bundleIdentifier=$BUNDLE_ID",
+            "minimumSystemVersion=$MINIMUM_SYSTEM_VERSION",
+            "updateChannel=$UPDATE_CHANNEL",
+            "updateManifestURL=$UPDATE_MANIFEST_URL",
+            "stableUpdateManifestURL=$STABLE_MANIFEST_URL",
+            "testerUpdateManifestURL=$TESTER_MANIFEST_URL"
+        ])
+        Self.assertSource(smokeScript, containsAll: [
+            "assert_plist_value QuillCodeUpdateChannel tester",
+            "assert_plist_value QuillCodeUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json",
+            "assert_plist_value QuillCodeStableUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json",
+            "assert_plist_value QuillCodeTesterUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"
+        ])
     }
 
     func testMergeTrainRefreshesTesterDownloadsAfterMerges() throws {

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -14,12 +14,14 @@ Direct asset links for the current tester channel:
 - [macOS CLI: `quill-code-macOS-arm64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-macOS-arm64.tar.gz)
 - [Linux CLI: `quill-code-linux-x86_64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-linux-x86_64.tar.gz)
 - [Checksums: `SHASUMS256.txt`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/SHASUMS256.txt)
-- [Build manifest: `latest-tester-build.json`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json)
+- [Tester manifest: `latest-tester-build.json`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json)
+- [Stable manifest: `latest-stable-build.json`](https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json)
 
-The build manifest is intended for the website, updater experiments, and support
-scripts. It records the build channel, tag, commit, workflow run URL, version,
-build number, and per-asset download URL, size, platform, architecture, and
-SHA-256 digest.
+The build manifest is the app updater, website, and support script contract. It
+records the build channel, tag, commit, workflow run URL, version, build number,
+per-asset download URL, size, platform, architecture, and SHA-256 digest. It also
+includes an `updater` object with the feed URL, bundle identifier, minimum macOS
+version, and current macOS app asset.
 
 ## Build Cadence
 
@@ -32,6 +34,36 @@ The tester release is refreshed:
 
 The workflow updates the stable `tester-latest` tag and replaces release assets
 in place, so the links above do not change as new builds are published.
+
+## Auto-Update Contract
+
+The packaged macOS app embeds update metadata in `Info.plist`:
+
+- `QuillCodeUpdateChannel`
+- `QuillCodeUpdateManifestURL`
+- `QuillCodeStableUpdateManifestURL`
+- `QuillCodeTesterUpdateManifestURL`
+
+The tester feed is:
+
+```text
+https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
+```
+
+The stable feed is:
+
+```text
+https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json
+```
+
+Updater clients should fetch the configured manifest, compare
+`CFBundleShortVersionString` plus `CFBundleVersion` against the manifest
+`version` plus `build`, select the `assets` entry where `kind` is `app`,
+`platform` is `macOS`, and `arch` matches the machine, verify the SHA-256 digest,
+then download and install that zip. Current tester builds are ad-hoc signed and
+not notarized, so silent in-place replacement should stay behind a signed and
+notarized stable release path. Tester updates can safely present the verified
+download and installation handoff.
 
 ## Tester Install Notes
 
@@ -72,9 +104,10 @@ Then watch it:
 gh run list --repo Lore-Hex/QuillCode --workflow download-builds.yml --limit 1
 ```
 
-The workflow publishes the same `latest-tester-build.json` schema for manual,
-scheduled, `main`, and `v*` tag builds. For `v*` tags, the channel is `stable`;
-for `tester-latest`, the channel is `tester`.
+The workflow publishes the same manifest schema for manual, scheduled, `main`,
+and `v*` tag builds. For `v*` tags, the channel is `stable` and the asset is
+`latest-stable-build.json`; for `tester-latest`, the channel is `tester` and the
+asset is `latest-tester-build.json`.
 
 ## Local Packaging
 

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -17,7 +17,7 @@ PRODUCT = "Quill Cowork"
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Write latest-tester-build.json for Quill Cowork release assets."
+        description="Write a channel download manifest for Quill Cowork release assets."
     )
     parser.add_argument("--assets-dir", required=True, help="Directory containing release assets.")
     parser.add_argument("--repo", required=True, help="GitHub repository, for example Lore-Hex/QuillCode.")
@@ -76,6 +76,37 @@ def release_download_url(repo: str, tag: str, asset_name: str) -> str:
     return f"https://github.com/{repo}/releases/download/{encoded_tag}/{encoded_name}"
 
 
+def latest_release_download_url(repo: str, asset_name: str) -> str:
+    encoded_name = quote(asset_name, safe="")
+    return f"https://github.com/{repo}/releases/latest/download/{encoded_name}"
+
+
+def build_updater_metadata(
+    *,
+    repo: str,
+    tag: str,
+    channel: str,
+    output_path: Path,
+    build_info: dict[str, str],
+    assets: list[dict[str, object]],
+) -> dict[str, object]:
+    app_assets = [
+        asset for asset in assets
+        if asset.get("kind") == "app" and asset.get("platform") == "macOS"
+    ]
+    return {
+        "schemaVersion": 1,
+        "format": "github-release-manifest",
+        "channel": channel,
+        "manifestURL": release_download_url(repo, tag, output_path.name),
+        "stableManifestURL": latest_release_download_url(repo, "latest-stable-build.json"),
+        "testerManifestURL": release_download_url(repo, "tester-latest", "latest-tester-build.json"),
+        "bundleIdentifier": build_info.get("bundleIdentifier", "co.lorehex.QuillCowork"),
+        "minimumSystemVersion": build_info.get("minimumSystemVersion", "14.0"),
+        "macOSAppAsset": app_assets[0] if app_assets else None,
+    }
+
+
 def build_manifest(arguments: argparse.Namespace) -> dict[str, object]:
     asset_directory = Path(arguments.assets_dir)
     output_path = Path(arguments.output)
@@ -107,6 +138,15 @@ def build_manifest(arguments: argparse.Namespace) -> dict[str, object]:
     if not assets:
         raise SystemExit(f"no release assets found in {asset_directory}")
 
+    updater = build_updater_metadata(
+        repo=arguments.repo,
+        tag=arguments.tag,
+        channel=arguments.channel,
+        output_path=output_path,
+        build_info=build_info,
+        assets=assets,
+    )
+
     return {
         "schemaVersion": SCHEMA_VERSION,
         "product": PRODUCT,
@@ -118,6 +158,7 @@ def build_manifest(arguments: argparse.Namespace) -> dict[str, object]:
         "build": build_info.get("build", "unknown"),
         "generatedAt": generated_at,
         "workflowRunURL": arguments.workflow_run_url,
+        "updater": updater,
         "assets": assets,
     }
 

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -9,6 +9,10 @@ BUNDLE_ID="${QUILLCODE_MACOS_BUNDLE_ID:-co.lorehex.QuillCowork}"
 MINIMUM_SYSTEM_VERSION="${QUILLCODE_MACOS_MINIMUM_SYSTEM_VERSION:-14.0}"
 VERSION="${QUILLCODE_MACOS_APP_VERSION:-0.1.0}"
 BUILD_NUMBER="${QUILLCODE_MACOS_BUILD_NUMBER:-1}"
+UPDATE_CHANNEL="${QUILLCODE_MACOS_UPDATE_CHANNEL:-tester}"
+UPDATE_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json}"
+UPDATE_STABLE_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_STABLE_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json}"
+UPDATE_TESTER_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_TESTER_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -99,6 +103,14 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
   <true/>
   <key>NSSupportsSuddenTermination</key>
   <true/>
+  <key>QuillCodeUpdateChannel</key>
+  <string>$UPDATE_CHANNEL</string>
+  <key>QuillCodeUpdateManifestURL</key>
+  <string>$UPDATE_MANIFEST_URL</string>
+  <key>QuillCodeStableUpdateManifestURL</key>
+  <string>$UPDATE_STABLE_MANIFEST_URL</string>
+  <key>QuillCodeTesterUpdateManifestURL</key>
+  <string>$UPDATE_TESTER_MANIFEST_URL</string>
 </dict>
 </plist>
 PLIST

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -8,10 +8,23 @@ VERSION="${QUILLCODE_BUILD_VERSION:-0.1.0}"
 BUILD_NUMBER="${QUILLCODE_BUILD_NUMBER:-0}"
 ARCH="$(uname -m)"
 COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+BUNDLE_ID="${QUILLCODE_MACOS_BUNDLE_ID:-co.lorehex.QuillCowork}"
+MINIMUM_SYSTEM_VERSION="${QUILLCODE_MACOS_MINIMUM_SYSTEM_VERSION:-14.0}"
+REPO="${GITHUB_REPOSITORY:-Lore-Hex/QuillCode}"
+UPDATE_CHANNEL="${QUILLCODE_UPDATE_CHANNEL:-tester}"
+TESTER_MANIFEST_URL="${QUILLCODE_TESTER_UPDATE_MANIFEST_URL:-https://github.com/$REPO/releases/download/tester-latest/latest-tester-build.json}"
+STABLE_MANIFEST_URL="${QUILLCODE_STABLE_UPDATE_MANIFEST_URL:-https://github.com/$REPO/releases/latest/download/latest-stable-build.json}"
 ASSET_DIR="$DIST_DIR/assets"
 APP_OUTPUT_DIR="$DIST_DIR/app"
 CLI_ROOT="$DIST_DIR/cli"
 CLI_DIR="$CLI_ROOT/quill-code-macOS-$ARCH"
+
+if [[ "$UPDATE_CHANNEL" == "stable" ]]; then
+  DEFAULT_UPDATE_MANIFEST_URL="$STABLE_MANIFEST_URL"
+else
+  DEFAULT_UPDATE_MANIFEST_URL="$TESTER_MANIFEST_URL"
+fi
+UPDATE_MANIFEST_URL="${QUILLCODE_UPDATE_MANIFEST_URL:-$DEFAULT_UPDATE_MANIFEST_URL}"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "package-macos-downloads.sh must run on macOS." >&2
@@ -26,6 +39,12 @@ echo "==> Packaging Quill Cowork macOS app ($ARCH, version $VERSION build $BUILD
 APP_BUNDLE="$(
   QUILLCODE_MACOS_APP_VERSION="$VERSION" \
   QUILLCODE_MACOS_BUILD_NUMBER="$BUILD_NUMBER" \
+  QUILLCODE_MACOS_BUNDLE_ID="$BUNDLE_ID" \
+  QUILLCODE_MACOS_MINIMUM_SYSTEM_VERSION="$MINIMUM_SYSTEM_VERSION" \
+  QUILLCODE_MACOS_UPDATE_CHANNEL="$UPDATE_CHANNEL" \
+  QUILLCODE_MACOS_UPDATE_MANIFEST_URL="$UPDATE_MANIFEST_URL" \
+  QUILLCODE_MACOS_UPDATE_STABLE_MANIFEST_URL="$STABLE_MANIFEST_URL" \
+  QUILLCODE_MACOS_UPDATE_TESTER_MANIFEST_URL="$TESTER_MANIFEST_URL" \
   QUILLCODE_MACOS_ADHOC_CODESIGN="${QUILLCODE_MACOS_ADHOC_CODESIGN:-1}" \
     "$ROOT_DIR/scripts/build-macos-app.sh" \
       --configuration "$CONFIGURATION" \
@@ -62,6 +81,12 @@ build=$BUILD_NUMBER
 commit=$COMMIT
 createdAt=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 configuration=$CONFIGURATION
+bundleIdentifier=$BUNDLE_ID
+minimumSystemVersion=$MINIMUM_SYSTEM_VERSION
+updateChannel=$UPDATE_CHANNEL
+updateManifestURL=$UPDATE_MANIFEST_URL
+stableUpdateManifestURL=$STABLE_MANIFEST_URL
+testerUpdateManifestURL=$TESTER_MANIFEST_URL
 app=Quill-Cowork-macOS-$ARCH.zip
 cli=quill-code-macOS-$ARCH.tar.gz
 codesign=ad-hoc

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -159,6 +159,10 @@ assert_plist_value CFBundleIdentifier co.lorehex.QuillCowork
 assert_plist_value CFBundlePackageType APPL
 assert_plist_value LSApplicationCategoryType public.app-category.developer-tools
 assert_plist_value NSPrincipalClass NSApplication
+assert_plist_value QuillCodeUpdateChannel tester
+assert_plist_value QuillCodeUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
+assert_plist_value QuillCodeStableUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json
+assert_plist_value QuillCodeTesterUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
 
 QUILLCODE_DESKTOP_EXECUTABLE="$APP_EXECUTABLE" \
 QUILLCODE_NATIVE_DESKTOP_SMOKE_LABEL="packaged macOS app" \


### PR DESCRIPTION
## Summary
- publish channel-specific download manifests for tester and stable builds
- embed updater feed metadata into the packaged macOS app and BUILD_INFO assets
- prune stale release assets before uploading the current asset set
- document and test the updater/download contract

## Verification
- swift test --filter ParityDownloadBuildsGateTests
- swift test --filter ParityPackagedMacOSSmokeGateTests
- git diff --check
- PYTHONPYCACHEPREFIX=/private/tmp/quillcode-pyc python3 -m py_compile scripts/build-download-manifest.py
- zsh -n scripts/build-macos-app.sh
- zsh -n scripts/package-macos-downloads.sh
- zsh -n scripts/packaged-macos-smoke.sh