### PR TITLE
Add resilient macOS auto updates

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -30,10 +30,32 @@ jobs:
             echo "QUILLCODE_UPDATE_CHANNEL=tester" >> "$GITHUB_ENV"
           fi
           echo "QUILLCODE_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+      - name: Configure Apple distribution signing
+        env:
+          APPLE_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+        run: scripts/configure-macos-distribution-signing.sh
       - name: Package macOS app and CLI
         env:
           QUILLCODE_DOWNLOAD_DIST_DIR: ${{ runner.temp }}/quillcode-macos-downloads
         run: scripts/package-macos-downloads.sh
+      - name: Remove temporary Apple signing material
+        if: always()
+        run: |
+          if [[ -n "${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}" && -f "$QUILLCODE_MACOS_SIGNING_KEYCHAIN" ]]; then
+            security delete-keychain "$QUILLCODE_MACOS_SIGNING_KEYCHAIN" || true
+          fi
+          if [[ -n "${QUILLCODE_MACOS_NOTARY_KEY_PATH:-}" && -f "$QUILLCODE_MACOS_NOTARY_KEY_PATH" ]]; then
+            rm -f "$QUILLCODE_MACOS_NOTARY_KEY_PATH"
+          fi
+          if [[ -n "${QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH:-}" && -f "$QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH" ]]; then
+            rm -f "$QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH"
+          fi
       - name: Upload macOS downloads
         uses: actions/upload-artifact@v4
         with:
@@ -82,7 +104,9 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p "$RUNNER_TEMP/release-assets"
-          find "$RUNNER_TEMP/downloaded-artifacts" -maxdepth 3 -type f -print -exec cp {} "$RUNNER_TEMP/release-assets/" \;
+          find "$RUNNER_TEMP/downloaded-artifacts" -maxdepth 3 -type f ! -name BUILD_INFO.txt -print -exec cp {} "$RUNNER_TEMP/release-assets/" \;
+          cp "$RUNNER_TEMP/downloaded-artifacts/quillcode-macos-downloads/BUILD_INFO.txt" \
+            "$RUNNER_TEMP/release-assets/BUILD_INFO.txt"
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
             RELEASE_TAG="${GITHUB_REF_NAME}"
             RELEASE_CHANNEL="stable"
@@ -129,6 +153,13 @@ jobs:
           fi
           MANIFEST_NAME="latest-${RELEASE_CHANNEL}-build.json"
 
+          if grep -Fxq 'codesign=developer-id' "$RUNNER_TEMP/release-assets/BUILD_INFO.txt" &&
+             grep -Fxq 'notarized=true' "$RUNNER_TEMP/release-assets/BUILD_INFO.txt"; then
+            MACOS_DISTRIBUTION_NOTE="The macOS app is Developer ID signed, hardened, notarized by Apple, and stapled for normal first launch."
+          else
+            MACOS_DISTRIBUTION_NOTE="This tester build is ad-hoc signed and not notarized. If Gatekeeper blocks first launch, use right-click > Open."
+          fi
+
           cat > "$RUNNER_TEMP/release-notes.md" <<NOTES
           Automated Quill Cowork ${RELEASE_CHANNEL} build.
 
@@ -142,7 +173,7 @@ jobs:
           - \`SHASUMS256.txt\`: checksum manifest for every asset.
           - \`${MANIFEST_NAME}\`: machine-readable build metadata, updater feed metadata, download URLs, sizes, and SHA-256 digests.
 
-          macOS distribution note: this build is ad-hoc signed but not notarized yet. If Gatekeeper blocks first launch, use right-click > Open. Computer Use still requires normal macOS Screen Recording and Accessibility permissions.
+          macOS distribution note: ${MACOS_DISTRIBUTION_NOTE} Computer Use still requires normal macOS Screen Recording and Accessibility permissions.
           NOTES
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Download the latest automated tester build from
 [Quill Cowork Tester Build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest).
 The tester release is refreshed after every successful `main` push and nightly;
 see [Downloadable Builds](docs/DOWNLOADS.md) for direct app/CLI links, the
-machine-readable build manifest, and tester notes.
+machine-readable build manifest, tester notes, and the in-app verified update and
+rollback flow.
 
 ```bash
 swift test

--- a/Sources/quill-code-desktop/DesktopCommands.swift
+++ b/Sources/quill-code-desktop/DesktopCommands.swift
@@ -6,12 +6,18 @@ struct QuillCodeDesktopCommands: Commands {
     var commands: [WorkspaceCommandSurface]
     var shortcutProfile: WorkspaceShortcutProfile
     var onCommand: (String) -> Void
+    var onCheckForUpdates: () -> Void
 
     private var commandsByID: [String: WorkspaceCommandSurface] {
         Dictionary(uniqueKeysWithValues: commands.map { ($0.id, $0) })
     }
 
     var body: some Commands {
+        CommandGroup(after: .appInfo) {
+            Button("Check for Updates...", action: onCheckForUpdates)
+                .accessibilityIdentifier("quillcode-menu-check-for-updates")
+        }
+
         CommandMenu(QuillCodeProduct.displayName) {
             command("New Chat", id: "new-chat")
             command("New Confidential Chat", id: "new-confidential-chat")

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -32,10 +32,16 @@ struct QuillCodeDesktopApp: App {
             return
         }
 
-        let controller = QuillCodeDesktopController()
+        let smokeRequest = QuillCodeDesktopSmokeRequest(arguments: CommandLine.arguments)
+        let controller = QuillCodeDesktopController(
+            updateController: smokeRequest == nil ? nil : QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            )
+        )
         _controller = StateObject(wrappedValue: controller)
 
-        guard let request = QuillCodeDesktopSmokeRequest(arguments: CommandLine.arguments) else {
+        guard let request = smokeRequest else {
             QuillCodeDesktopMainWindowPresenter.shared.scheduleLaunch(controller: controller)
             return
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import SwiftUI
 import UniformTypeIdentifiers
 import QuillCodeApp
@@ -8,6 +9,10 @@ struct QuillCodeDesktopApp: App {
     @StateObject private var controller: QuillCodeDesktopController
 
     init() {
+        if let updateRequest = QuillCodeDesktopUpdateHelperRequest.parse(arguments: CommandLine.arguments) {
+            Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
+        }
+
         // Quill Cowork is a dark-themed appliance: pin the whole app (every window, sheet, popover, and
         // system-drawn control) to the dark aqua appearance. Without this, system chrome — .roundedBorder
         // text fields, sheet/popover backgrounds, menu text — follows the user's macOS appearance, so on a
@@ -51,7 +56,8 @@ struct QuillCodeDesktopApp: App {
                 shortcutProfile: WorkspaceShortcutRegistry.profile(
                     preferences: controller.surface.settings.keyboardShortcuts
                 ),
-                onCommand: { controller.runCommand(commandID: $0) }
+                onCommand: { controller.runCommand(commandID: $0) },
+                onCheckForUpdates: controller.checkForUpdates
             )
         }
         MenuBarExtra {
@@ -71,6 +77,7 @@ struct QuillCodeDesktopApp: App {
                 onStopAll: controller.stopAll,
                 onDisconnectAll: controller.disconnectAll,
                 onComputerUseSetup: controller.openSettings,
+                onCheckForUpdates: controller.checkForUpdates,
                 onQuit: {
                     NSApplication.shared.terminate(nil)
                 }
@@ -89,6 +96,7 @@ struct QuillCodeDesktopRootView: View {
         workspaceContent
             .preferredColorScheme(.dark)
             .quillCodeDesktopCommandBindings(controller: controller)
+            .modifier(QuillCodeDesktopUpdatePresentation(controller: controller.updateController))
             .fileImporter(
                 isPresented: $controller.isProjectImporterPresented,
                 allowedContentTypes: [.folder],
@@ -107,6 +115,8 @@ struct QuillCodeDesktopRootView: View {
                     }
             }
             .task {
+                QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()
+                controller.updateController.startAutomaticChecks()
                 await controller.refreshModelCatalog()
             }
     }
@@ -189,6 +199,16 @@ struct QuillCodeDesktopRootView: View {
             onLoadSubagentTranscript: controller.loadSubagentTranscript,
             onCommand: controller.runCommand
         )
+    }
+}
+
+private struct QuillCodeDesktopUpdatePresentation: ViewModifier {
+    @ObservedObject var controller: QuillCodeDesktopUpdateController
+
+    func body(content: Content) -> some View {
+        content.sheet(isPresented: $controller.isPresented) {
+            QuillCodeDesktopUpdateView(controller: controller)
+        }
     }
 }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Commands.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Commands.swift
@@ -43,6 +43,10 @@ extension QuillCodeDesktopController {
         isSettingsPresented = true
     }
 
+    func checkForUpdates() {
+        updateController.checkForUpdates()
+    }
+
     func stopAll() {
         activeWorkCoordinator.stopAll(
             draft: &draft,

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -47,6 +47,7 @@ final class QuillCodeDesktopController: ObservableObject {
     let transcriptExportCoordinator: QuillCodeDesktopTranscriptExportCoordinator
     let worktreeCoordinator: QuillCodeDesktopWorktreeCoordinator
     let workflowRecordingCoordinator: QuillCodeDesktopWorkflowRecordingCoordinator
+    let updateController: QuillCodeDesktopUpdateController
     let tasks = QuillCodeDesktopTaskCoordinator()
     // Retained here because UNUserNotificationCenter.delegate is weak; nil until the window installs it.
     private var approvalNotificationDelegate: QuillCodeApprovalNotificationDelegate?
@@ -61,6 +62,7 @@ final class QuillCodeDesktopController: ObservableObject {
         sshRemoteProjectProbe: SSHRemoteProjectProbe = SSHRemoteProjectProbe(),
         transcriptExportCoordinator: QuillCodeDesktopTranscriptExportCoordinator =
             QuillCodeDesktopTranscriptExportCoordinator(),
+        updateController: QuillCodeDesktopUpdateController? = nil,
         workspaceRoot: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
     ) {
         self.bootstrap = bootstrap
@@ -91,6 +93,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.transcriptExportCoordinator = transcriptExportCoordinator
         self.worktreeCoordinator = QuillCodeDesktopWorktreeCoordinator()
         self.workflowRecordingCoordinator = QuillCodeDesktopWorkflowRecordingCoordinator()
+        self.updateController = updateController ?? QuillCodeDesktopUpdateController()
         do {
             self.model = try bootstrap.makeModel()
         } catch {

--- a/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+enum QuillCodeDesktopDownloadedApplicationValidator {
+    static func validate(
+        _ applicationURL: URL,
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) throws {
+        guard applicationURL.pathExtension == "app",
+              let bundle = Bundle(url: applicationURL),
+              bundle.bundleIdentifier == configuration.bundleIdentifier,
+              bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String == release.version,
+              bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String == release.build,
+              let executableURL = bundle.executableURL,
+              FileManager.default.isExecutableFile(atPath: executableURL.path)
+        else {
+            throw QuillCodeDesktopUpdateError.invalidApplication("its identity or version does not match")
+        }
+
+        let signature = try QuillCodeDesktopUpdateProcessRunner.run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+            arguments: ["--verify", "--deep", "--strict", "--verbose=2", applicationURL.path]
+        )
+        guard signature.exitCode == 0 else {
+            throw QuillCodeDesktopUpdateError.invalidApplication("its code signature is invalid")
+        }
+
+        if let expectedTeam = configuration.expectedSigningTeamIdentifier {
+            let details = try QuillCodeDesktopUpdateProcessRunner.run(
+                executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+                arguments: ["--display", "--verbose=4", applicationURL.path]
+            )
+            guard details.exitCode == 0,
+                  details.combinedOutput.contains("TeamIdentifier=\(expectedTeam)")
+            else {
+                throw QuillCodeDesktopUpdateError.invalidApplication("its signing identity does not match")
+            }
+        }
+
+        let architectures = try QuillCodeDesktopUpdateProcessRunner.run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/lipo"),
+            arguments: ["-archs", executableURL.path]
+        )
+        let availableArchitectures = Set(
+            architectures.standardOutput.split(whereSeparator: \.isWhitespace).map(String.init)
+        )
+        guard architectures.exitCode == 0,
+              availableArchitectures.contains(configuration.architecture)
+        else {
+            throw QuillCodeDesktopUpdateError.invalidApplication("it does not support this Mac")
+        }
+    }
+}
+
+struct QuillCodeDesktopUpdateProcessResult: Sendable {
+    var exitCode: Int32
+    var standardOutput: String
+    var standardError: String
+
+    var combinedOutput: String {
+        [standardOutput, standardError].filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+
+    var failureSummary: String {
+        let value = combinedOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? "the system extraction tool failed" : String(value.prefix(500))
+    }
+}
+
+enum QuillCodeDesktopUpdateProcessRunner {
+    private static let outputByteLimit = 64 * 1_024
+
+    static func run(executableURL: URL, arguments: [String]) throws -> QuillCodeDesktopUpdateProcessResult {
+        let captureRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "quill-cowork-process-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let outputURL = captureRoot.appendingPathComponent("stdout")
+        let errorURL = captureRoot.appendingPathComponent("stderr")
+        try FileManager.default.createDirectory(at: captureRoot, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: captureRoot) }
+        guard FileManager.default.createFile(atPath: outputURL.path, contents: nil),
+              FileManager.default.createFile(atPath: errorURL.path, contents: nil)
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed("system-tool output could not be captured")
+        }
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        let errorHandle = try FileHandle(forWritingTo: errorURL)
+        defer {
+            try? outputHandle.close()
+            try? errorHandle.close()
+        }
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardOutput = outputHandle
+        process.standardError = errorHandle
+        do {
+            try process.run()
+        } catch {
+            throw QuillCodeDesktopUpdateError.installationFailed("a required system tool could not start")
+        }
+        process.waitUntilExit()
+        try outputHandle.close()
+        try errorHandle.close()
+        return QuillCodeDesktopUpdateProcessResult(
+            exitCode: process.terminationStatus,
+            standardOutput: try capturedText(at: outputURL),
+            standardError: try capturedText(at: errorURL)
+        )
+    }
+
+    private static func capturedText(at url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: outputByteLimit) ?? Data()
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopSemanticVersion.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSemanticVersion.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct QuillCodeDesktopSemanticVersion: Comparable, Equatable, Sendable {
+    private var components: [UInt64]
+    private var prerelease: [Identifier]?
+
+    init?(_ value: String) {
+        guard value == value.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        let withoutBuild = value.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false)[0]
+        let versionParts = withoutBuild.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+        let numberParts = versionParts[0].split(separator: ".", omittingEmptySubsequences: false)
+        let parsed = numberParts.compactMap { UInt64($0) }
+        guard !numberParts.isEmpty,
+              numberParts.count <= 4,
+              numberParts.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }),
+              numberParts.allSatisfy({ $0.count == 1 || $0.first != "0" }),
+              parsed.count == numberParts.count
+        else {
+            return nil
+        }
+        var normalizedComponents = parsed
+        while normalizedComponents.count > 1 && normalizedComponents.last == 0 {
+            normalizedComponents.removeLast()
+        }
+        components = normalizedComponents
+
+        if versionParts.count == 2 {
+            let identifiers = versionParts[1].split(separator: ".", omittingEmptySubsequences: false)
+            guard !identifiers.isEmpty,
+                  identifiers.allSatisfy({ !$0.isEmpty && $0.allSatisfy(Self.isIdentifierCharacter) })
+            else {
+                return nil
+            }
+            prerelease = identifiers.map(Identifier.init)
+        } else {
+            prerelease = nil
+        }
+    }
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+        for index in 0..<count {
+            let left = index < lhs.components.count ? lhs.components[index] : 0
+            let right = index < rhs.components.count ? rhs.components[index] : 0
+            if left != right { return left < right }
+        }
+        switch (lhs.prerelease, rhs.prerelease) {
+        case (nil, nil):
+            return false
+        case (nil, _?):
+            return false
+        case (_?, nil):
+            return true
+        case (let left?, let right?):
+            for (leftID, rightID) in zip(left, right) where leftID != rightID {
+                return leftID < rightID
+            }
+            return left.count < right.count
+        }
+    }
+
+    private static func isIdentifierCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "-"
+    }
+
+    private enum Identifier: Equatable, Comparable, Sendable {
+        case numeric(UInt64)
+        case text(String)
+
+        init(_ value: Substring) {
+            if let number = UInt64(value), value.count == 1 || value.first != "0" {
+                self = .numeric(number)
+            } else {
+                self = .text(String(value))
+            }
+        }
+
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.numeric(let left), .numeric(let right)):
+                return left < right
+            case (.numeric, .text):
+                return true
+            case (.text, .numeric):
+                return false
+            case (.text(let left), .text(let right)):
+                return left < right
+            }
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -85,6 +85,10 @@ struct QuillCodeDesktopWindowSmokeWorkspaceRoot: Sendable, Hashable {
         return QuillCodeDesktopController(
             bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
             browserLiveDOMCapturer: nil,
+            updateController: QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            ),
             workspaceRoot: workspace
         )
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopSystemApplication.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSystemApplication.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 
 @MainActor
 enum QuillCodeDesktopSystemApplication {
@@ -8,5 +9,15 @@ enum QuillCodeDesktopSystemApplication {
 
     static func startDictation() {
         NSApp.sendAction(Selector(("startDictation:")), to: nil, from: nil)
+    }
+
+    static func terminateForUpdate() {
+        // SwiftUI can defer or decline a normal termination while a sheet-driven async action still
+        // owns the scene. The detached updater helper cannot proceed until this process is gone, so
+        // retain a short, bounded fallback after first allowing normal app shutdown to complete.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            Darwin.exit(EXIT_SUCCESS)
+        }
+        NSApplication.shared.terminate(nil)
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateChecker.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateChecker.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+protocol QuillCodeDesktopUpdateChecking: Sendable {
+    func check(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopUpdateCheckResult
+}
+
+protocol QuillCodeDesktopUpdateManifestLoading: Sendable {
+    func loadManifest(from url: URL, byteLimit: Int) async throws -> Data
+}
+
+struct QuillCodeDesktopUpdateChecker: QuillCodeDesktopUpdateChecking, Sendable {
+    static let manifestByteLimit = 256 * 1_024
+
+    private let loader: any QuillCodeDesktopUpdateManifestLoading
+
+    init(loader: any QuillCodeDesktopUpdateManifestLoading = QuillCodeDesktopUpdateManifestLoader()) {
+        self.loader = loader
+    }
+
+    func check(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopUpdateCheckResult {
+        guard GitHubReleaseRepositoryScope(manifestURL: configuration.manifestURL) != nil else {
+            throw QuillCodeDesktopUpdateError.unexpectedFeed
+        }
+        let data = try await loader.loadManifest(
+            from: configuration.manifestURL,
+            byteLimit: Self.manifestByteLimit
+        )
+        let manifest: QuillCodeDesktopUpdateManifest
+        do {
+            manifest = try JSONDecoder().decode(QuillCodeDesktopUpdateManifest.self, from: data)
+        } catch {
+            throw QuillCodeDesktopUpdateError.unsupportedManifest
+        }
+        return try QuillCodeDesktopUpdateManifestValidator.validate(
+            manifest,
+            configuration: configuration
+        )
+    }
+}
+
+struct QuillCodeDesktopUpdateManifestLoader: QuillCodeDesktopUpdateManifestLoading, @unchecked Sendable {
+    private let session: URLSession
+
+    init(session: URLSession? = nil) {
+        self.session = session ?? Self.makeSession()
+    }
+
+    func loadManifest(from url: URL, byteLimit: Int) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Quill-Cowork-Updater/1", forHTTPHeaderField: "User-Agent")
+
+        let bytes: URLSession.AsyncBytes
+        let response: URLResponse
+        do {
+            (bytes, response) = try await session.bytes(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+        guard let response = response as? HTTPURLResponse,
+              response.statusCode == 200
+        else {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+        guard response.expectedContentLength <= 0 || response.expectedContentLength <= byteLimit else {
+            throw QuillCodeDesktopUpdateError.manifestTooLarge
+        }
+
+        var data = Data()
+        data.reserveCapacity(min(byteLimit, 16 * 1_024))
+        do {
+            for try await byte in bytes {
+                guard data.count < byteLimit else {
+                    throw QuillCodeDesktopUpdateError.manifestTooLarge
+                }
+                data.append(byte)
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as QuillCodeDesktopUpdateError {
+            throw error
+        } catch {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+        return data
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForResource = 30
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.waitsForConnectivity = true
+        return URLSession(configuration: configuration)
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -1,0 +1,245 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class QuillCodeDesktopUpdateController: ObservableObject {
+    private static let installResultByteLimit = 64 * 1_024
+
+    enum State: Equatable {
+        case idle
+        case checking
+        case updateAvailable(QuillCodeDesktopUpdateRelease)
+        case downloading(QuillCodeDesktopUpdateRelease)
+        case installing(QuillCodeDesktopUpdateRelease)
+        case upToDate(latestVersion: String, latestBuild: String)
+        case failed(message: String, release: QuillCodeDesktopUpdateRelease?)
+
+        var release: QuillCodeDesktopUpdateRelease? {
+            switch self {
+            case .updateAvailable(let release), .downloading(let release), .installing(let release):
+                return release
+            case .failed(_, let release):
+                return release
+            case .idle, .checking, .upToDate:
+                return nil
+            }
+        }
+
+        var isBusy: Bool {
+            switch self {
+            case .checking, .downloading, .installing:
+                return true
+            case .idle, .updateAvailable, .upToDate, .failed:
+                return false
+            }
+        }
+    }
+
+    @Published private(set) var state: State = .idle
+    @Published var isPresented = false
+
+    let configuration: QuillCodeDesktopUpdateConfiguration?
+    private let checker: any QuillCodeDesktopUpdateChecking
+    private let preparer: any QuillCodeDesktopUpdatePreparing
+    private let installer: any QuillCodeDesktopUpdateInstalling
+    private let defaults: UserDefaults
+    private let now: () -> Date
+    private let automaticCheckDelay: Duration
+    private let installResultURL: URL?
+    private let terminateApplication: @MainActor () -> Void
+    private var task: Task<Void, Never>?
+    private var generation = UUID()
+    private var didStartAutomaticChecks = false
+
+    init(
+        configuration: QuillCodeDesktopUpdateConfiguration? = .bundled(),
+        checker: any QuillCodeDesktopUpdateChecking = QuillCodeDesktopUpdateChecker(),
+        preparer: any QuillCodeDesktopUpdatePreparing = QuillCodeDesktopUpdatePreparer(),
+        installer: any QuillCodeDesktopUpdateInstalling = QuillCodeDesktopUpdateInstaller(),
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init,
+        automaticCheckDelay: Duration = .seconds(3),
+        installResultURL: URL? = try? QuillCodeDesktopUpdatePaths.installResultURL(),
+        terminateApplication: @escaping @MainActor () -> Void =
+            QuillCodeDesktopSystemApplication.terminateForUpdate
+    ) {
+        self.configuration = configuration
+        self.checker = checker
+        self.preparer = preparer
+        self.installer = installer
+        self.defaults = defaults
+        self.now = now
+        self.automaticCheckDelay = automaticCheckDelay
+        self.installResultURL = installResultURL
+        self.terminateApplication = terminateApplication
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    func startAutomaticChecks() {
+        guard !didStartAutomaticChecks else { return }
+        didStartAutomaticChecks = true
+        consumePreviousInstallResult()
+        guard let configuration, shouldAutomaticallyCheck(configuration: configuration) else { return }
+
+        let generation = beginNewTask()
+        task = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: self.automaticCheckDelay)
+            guard !Task.isCancelled else { return }
+            await self.performCheck(userInitiated: false, generation: generation)
+        }
+    }
+
+    func checkForUpdates() {
+        isPresented = true
+        let generation = beginNewTask()
+        state = .checking
+        task = Task { [weak self] in
+            guard let self else { return }
+            await self.performCheck(userInitiated: true, generation: generation)
+        }
+    }
+
+    func updateAndRelaunch() {
+        guard let configuration,
+              let release = state.release
+        else {
+            state = .failed(
+                message: QuillCodeDesktopUpdateError.updatesUnavailable.localizedDescription,
+                release: nil
+            )
+            return
+        }
+        let generation = beginNewTask()
+        state = .downloading(release)
+        task = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let prepared = try await preparer.prepare(
+                    release: release,
+                    configuration: configuration
+                )
+                try Task.checkCancellation()
+                guard self.generation == generation else { return }
+                self.state = .installing(release)
+                try await installer.stageAndLaunch(
+                    preparedUpdate: prepared,
+                    configuration: configuration
+                )
+                try Task.checkCancellation()
+                guard self.generation == generation else { return }
+                self.terminateApplication()
+            } catch is CancellationError {
+                guard self.generation == generation else { return }
+                self.state = .updateAvailable(release)
+            } catch {
+                guard self.generation == generation else { return }
+                self.state = .failed(message: error.localizedDescription, release: release)
+            }
+        }
+    }
+
+    func cancelCurrentOperation() {
+        guard let release = state.release else { return }
+        _ = beginNewTask()
+        state = .updateAvailable(release)
+    }
+
+    func dismiss() {
+        guard !state.isBusy else { return }
+        isPresented = false
+    }
+
+    func openReleasePage() {
+        guard let release = state.release else { return }
+        NSWorkspace.shared.open(release.releaseURL)
+    }
+
+    func openDownloadInBrowser() {
+        guard let release = state.release else { return }
+        NSWorkspace.shared.open(release.asset.url)
+    }
+
+    private func performCheck(userInitiated: Bool, generation: UUID) async {
+        guard let configuration else {
+            guard userInitiated, self.generation == generation else { return }
+            state = .failed(
+                message: QuillCodeDesktopUpdateError.updatesUnavailable.localizedDescription,
+                release: nil
+            )
+            return
+        }
+        do {
+            let result = try await checker.check(configuration: configuration)
+            try Task.checkCancellation()
+            guard self.generation == generation else { return }
+            defaults.set(now(), forKey: lastCheckKey(configuration: configuration))
+            switch result {
+            case .updateAvailable(let release):
+                state = .updateAvailable(release)
+                isPresented = true
+            case .upToDate(let latestVersion, let latestBuild):
+                state = userInitiated
+                    ? .upToDate(latestVersion: latestVersion, latestBuild: latestBuild)
+                    : .idle
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard self.generation == generation else { return }
+            state = userInitiated
+                ? .failed(message: error.localizedDescription, release: nil)
+                : .idle
+        }
+    }
+
+    private func beginNewTask() -> UUID {
+        task?.cancel()
+        generation = UUID()
+        return generation
+    }
+
+    private func shouldAutomaticallyCheck(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> Bool {
+        guard let lastCheck = defaults.object(
+            forKey: lastCheckKey(configuration: configuration)
+        ) as? Date else {
+            return true
+        }
+        let interval: TimeInterval = configuration.channel == .tester ? 6 * 60 * 60 : 24 * 60 * 60
+        return now().timeIntervalSince(lastCheck) >= interval
+    }
+
+    private func lastCheckKey(configuration: QuillCodeDesktopUpdateConfiguration) -> String {
+        "QuillCodeUpdater.lastSuccessfulCheck.\(configuration.channel.rawValue)"
+    }
+
+    private func consumePreviousInstallResult() {
+        guard let installResultURL,
+              FileManager.default.fileExists(atPath: installResultURL.path)
+        else {
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: installResultURL) }
+
+        guard let values = try? installResultURL.resourceValues(
+            forKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey]
+        ),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              let fileSize = values.fileSize,
+              fileSize <= Self.installResultByteLimit,
+              let data = try? Data(contentsOf: installResultURL, options: .mappedIfSafe),
+              let result = try? JSONDecoder().decode(QuillCodeDesktopUpdateInstallResult.self, from: data)
+        else {
+            return
+        }
+        guard result.status == .failure else { return }
+        state = .failed(message: result.message, release: nil)
+        isPresented = true
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
@@ -1,0 +1,270 @@
+import Darwin
+import Foundation
+
+enum QuillCodeDesktopUpdateHelper {
+    static func run(_ request: QuillCodeDesktopUpdateHelperRequest) -> Int32 {
+        guard let environment = try? QuillCodeDesktopUpdateHelperEnvironment.production() else {
+            fputs("Quill Cowork update failed: updater paths are unavailable\n", stderr)
+            return 1
+        }
+        return run(request, environment: environment)
+    }
+
+    static func run(
+        _ request: QuillCodeDesktopUpdateHelperRequest,
+        environment: QuillCodeDesktopUpdateHelperEnvironment
+    ) -> Int32 {
+        var didValidate = false
+        do {
+            try validate(request, environment: environment)
+            didValidate = true
+            guard waitForProcessToExit(
+                request.parentProcessID,
+                timeout: environment.parentExitTimeout
+            ) else {
+                throw QuillCodeDesktopUpdateError.installationFailed("the running app did not exit")
+            }
+            try install(request, environment: environment)
+            return 0
+        } catch {
+            if didValidate {
+                removeUnactivatedStagingIfSafe(request)
+            }
+            writeResult(
+                .failure(message: error.localizedDescription),
+                to: request.resultURL,
+                allowedResultURL: environment.resultURL
+            )
+            fputs("Quill Cowork update failed: \(error.localizedDescription)\n", stderr)
+            return 1
+        }
+    }
+
+    private static func removeUnactivatedStagingIfSafe(_ request: QuillCodeDesktopUpdateHelperRequest) {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: request.destinationApplicationURL.path),
+              fileManager.fileExists(atPath: request.incomingApplicationURL.path),
+              !fileManager.fileExists(atPath: request.backupApplicationURL.path)
+        else {
+            return
+        }
+        try? fileManager.removeItem(at: request.incomingApplicationURL)
+    }
+
+    private static func validate(
+        _ request: QuillCodeDesktopUpdateHelperRequest,
+        environment: QuillCodeDesktopUpdateHelperEnvironment
+    ) throws {
+        let fileManager = FileManager.default
+        let parent = request.destinationApplicationURL.deletingLastPathComponent().standardizedFileURL
+        let siblingURLs = [
+            request.incomingApplicationURL,
+            request.backupApplicationURL,
+            request.failedApplicationURL
+        ]
+        guard siblingURLs.allSatisfy({ $0.deletingLastPathComponent().standardizedFileURL == parent }),
+              request.destinationApplicationURL.pathExtension == "app",
+              request.incomingApplicationURL.pathExtension == "app",
+              request.backupApplicationURL.pathExtension == "app",
+              request.failedApplicationURL.pathExtension == "app",
+              request.incomingApplicationURL.lastPathComponent.contains(".update-"),
+              request.backupApplicationURL.lastPathComponent.contains(".backup-"),
+              request.failedApplicationURL.lastPathComponent.contains(".failed-"),
+              fileManager.fileExists(atPath: request.destinationApplicationURL.path),
+              fileManager.fileExists(atPath: request.incomingApplicationURL.path),
+              !fileManager.fileExists(atPath: request.backupApplicationURL.path),
+              !fileManager.fileExists(atPath: request.failedApplicationURL.path),
+              bundleMatches(
+                request.destinationApplicationURL,
+                identifier: request.expectedBundleIdentifier,
+                version: nil,
+                build: nil
+              ),
+              bundleMatches(
+                request.incomingApplicationURL,
+                identifier: request.expectedBundleIdentifier,
+                version: request.expectedVersion,
+                build: request.expectedBuild
+              ),
+              QuillCodeDesktopUpdateLaunchHandshake.isAllowed(
+                request.handshakeURL,
+                cacheRoot: environment.cacheRootURL
+              ),
+              request.resultURL.standardizedFileURL == environment.resultURL.standardizedFileURL
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed("the staged update request is invalid")
+        }
+    }
+
+    private static func install(
+        _ request: QuillCodeDesktopUpdateHelperRequest,
+        environment: QuillCodeDesktopUpdateHelperEnvironment
+    ) throws {
+        let fileManager = FileManager.default
+        try fileManager.moveItem(
+            at: request.destinationApplicationURL,
+            to: request.backupApplicationURL
+        )
+        do {
+            try fileManager.moveItem(
+                at: request.incomingApplicationURL,
+                to: request.destinationApplicationURL
+            )
+        } catch {
+            try? fileManager.moveItem(
+                at: request.backupApplicationURL,
+                to: request.destinationApplicationURL
+            )
+            throw QuillCodeDesktopUpdateError.installationFailed("the staged app could not be activated")
+        }
+
+        let launchedProcessID = try launch(
+            request.destinationApplicationURL,
+            handshakeURL: request.handshakeURL
+        )
+        guard waitForFile(
+            request.handshakeURL,
+            timeout: environment.launchHandshakeTimeout
+        ) else {
+            terminateProcess(launchedProcessID)
+            try rollback(request)
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the new build did not finish launching; the previous build was restored"
+            )
+        }
+
+        try? fileManager.removeItem(at: request.backupApplicationURL)
+        try? fileManager.removeItem(at: request.handshakeURL)
+        writeResult(
+            .success(version: request.expectedVersion, build: request.expectedBuild),
+            to: request.resultURL,
+            allowedResultURL: environment.resultURL
+        )
+    }
+
+    private static func rollback(_ request: QuillCodeDesktopUpdateHelperRequest) throws {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: request.destinationApplicationURL.path),
+              fileManager.fileExists(atPath: request.backupApplicationURL.path)
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed("the previous app backup is missing")
+        }
+        try fileManager.moveItem(
+            at: request.destinationApplicationURL,
+            to: request.failedApplicationURL
+        )
+        do {
+            try fileManager.moveItem(
+                at: request.backupApplicationURL,
+                to: request.destinationApplicationURL
+            )
+        } catch {
+            try? fileManager.moveItem(
+                at: request.failedApplicationURL,
+                to: request.destinationApplicationURL
+            )
+            throw QuillCodeDesktopUpdateError.installationFailed("the previous app could not be restored")
+        }
+        _ = try launch(request.destinationApplicationURL, handshakeURL: nil)
+        try? fileManager.removeItem(at: request.failedApplicationURL)
+        try? fileManager.removeItem(at: request.handshakeURL)
+    }
+
+    private static func launch(
+        _ applicationURL: URL,
+        handshakeURL: URL?
+    ) throws -> Int32 {
+        guard let bundle = Bundle(url: applicationURL),
+              let executableURL = bundle.executableURL,
+              FileManager.default.isExecutableFile(atPath: executableURL.path)
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed("the app executable is missing")
+        }
+        var arguments: [String] = []
+        if let handshakeURL {
+            arguments = [QuillCodeDesktopUpdateLaunchHandshake.argument, handshakeURL.path]
+        }
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        do {
+            try process.run()
+        } catch {
+            throw QuillCodeDesktopUpdateError.installationFailed("the updated app could not be launched")
+        }
+        return process.processIdentifier
+    }
+
+    private static func bundleMatches(
+        _ url: URL,
+        identifier: String,
+        version: String?,
+        build: String?
+    ) -> Bool {
+        guard let bundle = Bundle(url: url), bundle.bundleIdentifier == identifier else { return false }
+        if let version,
+           bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String != version {
+            return false
+        }
+        if let build,
+           bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String != build {
+            return false
+        }
+        return true
+    }
+
+    private static func waitForProcessToExit(_ processID: Int32, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if kill(processID, 0) == -1 && errno == ESRCH { return true }
+            usleep(100_000)
+        }
+        return kill(processID, 0) == -1 && errno == ESRCH
+    }
+
+    private static func waitForFile(_ url: URL, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            usleep(100_000)
+        }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    private static func terminateProcess(_ processID: Int32) {
+        guard processID > 1 else { return }
+        _ = kill(processID, SIGTERM)
+        guard !waitForProcessToExit(processID, timeout: 3) else { return }
+        _ = kill(processID, SIGKILL)
+        _ = waitForProcessToExit(processID, timeout: 2)
+    }
+
+    private static func writeResult(
+        _ result: QuillCodeDesktopUpdateInstallResult,
+        to url: URL,
+        allowedResultURL: URL
+    ) {
+        guard url.standardizedFileURL == allowedResultURL.standardizedFileURL,
+              let data = try? JSONEncoder().encode(result)
+        else {
+            return
+        }
+        try? data.write(to: url, options: [.atomic, .completeFileProtection])
+    }
+}
+
+struct QuillCodeDesktopUpdateHelperEnvironment: Sendable {
+    var cacheRootURL: URL
+    var resultURL: URL
+    var parentExitTimeout: TimeInterval
+    var launchHandshakeTimeout: TimeInterval
+
+    static func production() throws -> Self {
+        Self(
+            cacheRootURL: try QuillCodeDesktopUpdatePaths.cacheRoot(),
+            resultURL: try QuillCodeDesktopUpdatePaths.installResultURL(),
+            parentExitTimeout: 30,
+            launchHandshakeTimeout: 45
+        )
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+protocol QuillCodeDesktopUpdateInstalling: Sendable {
+    func stageAndLaunch(
+        preparedUpdate: QuillCodeDesktopPreparedUpdate,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws
+}
+
+struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendable {
+    private let runningExecutableURL: URL?
+
+    init(runningExecutableURL: URL? = Bundle.main.executableURL) {
+        self.runningExecutableURL = runningExecutableURL
+    }
+
+    func stageAndLaunch(
+        preparedUpdate: QuillCodeDesktopPreparedUpdate,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws {
+        guard configuration.applicationURL.pathExtension == "app",
+              let runningExecutableURL,
+              FileManager.default.isExecutableFile(atPath: runningExecutableURL.path)
+        else {
+            throw QuillCodeDesktopUpdateError.installationUnavailable
+        }
+
+        let request = try await Task.detached(priority: .utility) {
+            try Self.stage(
+                preparedUpdate: preparedUpdate,
+                configuration: configuration,
+                runningExecutableURL: runningExecutableURL
+            )
+        }.value
+        try Task.checkCancellation()
+        try Self.launchHelper(request)
+    }
+
+    private static func stage(
+        preparedUpdate: QuillCodeDesktopPreparedUpdate,
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        runningExecutableURL: URL
+    ) throws -> QuillCodeDesktopUpdateHelperRequest {
+        let fileManager = FileManager.default
+        let destinationURL = configuration.applicationURL.standardizedFileURL
+        let destinationParent = destinationURL.deletingLastPathComponent()
+        guard fileManager.fileExists(atPath: destinationURL.path),
+              fileManager.isWritableFile(atPath: destinationParent.path)
+        else {
+            throw QuillCodeDesktopUpdateError.installationUnavailable
+        }
+
+        let identifier = UUID().uuidString.lowercased()
+        let baseName = destinationURL.deletingPathExtension().lastPathComponent
+        let incomingURL = destinationParent.appendingPathComponent(
+            ".\(baseName).update-\(identifier).app",
+            isDirectory: true
+        )
+        let backupURL = destinationParent.appendingPathComponent(
+            ".\(baseName).backup-\(identifier).app",
+            isDirectory: true
+        )
+        let failedURL = destinationParent.appendingPathComponent(
+            ".\(baseName).failed-\(identifier).app",
+            isDirectory: true
+        )
+        let handshakeURL = preparedUpdate.workspaceURL.appendingPathComponent(
+            "launch-\(identifier).ack",
+            isDirectory: false
+        )
+        let helperURL = preparedUpdate.workspaceURL.appendingPathComponent(
+            "QuillCoworkUpdateHelper-\(identifier)",
+            isDirectory: false
+        )
+        let logURL = preparedUpdate.workspaceURL.appendingPathComponent(
+            "install-\(identifier).log",
+            isDirectory: false
+        )
+        let resultURL = try QuillCodeDesktopUpdatePaths.installResultURL()
+
+        guard !fileManager.fileExists(atPath: incomingURL.path),
+              !fileManager.fileExists(atPath: backupURL.path),
+              !fileManager.fileExists(atPath: failedURL.path)
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed("a staging path already exists")
+        }
+
+        do {
+            try fileManager.copyItem(at: preparedUpdate.applicationURL, to: incomingURL)
+            try QuillCodeDesktopDownloadedApplicationValidator.validate(
+                incomingURL,
+                release: preparedUpdate.release,
+                configuration: configuration
+            )
+            try fileManager.copyItem(at: runningExecutableURL, to: helperURL)
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: helperURL.path)
+            try fileManager.createDirectory(
+                at: resultURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } catch {
+            try? fileManager.removeItem(at: incomingURL)
+            try? fileManager.removeItem(at: helperURL)
+            if let updateError = error as? QuillCodeDesktopUpdateError {
+                throw updateError
+            }
+            throw QuillCodeDesktopUpdateError.installationFailed("the verified app could not be staged")
+        }
+
+        return QuillCodeDesktopUpdateHelperRequest(
+            parentProcessID: ProcessInfo.processInfo.processIdentifier,
+            helperURL: helperURL,
+            incomingApplicationURL: incomingURL,
+            destinationApplicationURL: destinationURL,
+            backupApplicationURL: backupURL,
+            failedApplicationURL: failedURL,
+            handshakeURL: handshakeURL,
+            resultURL: resultURL,
+            logURL: logURL,
+            expectedBundleIdentifier: configuration.bundleIdentifier,
+            expectedVersion: preparedUpdate.release.version,
+            expectedBuild: preparedUpdate.release.build
+        )
+    }
+
+    private static func launchHelper(_ request: QuillCodeDesktopUpdateHelperRequest) throws {
+        FileManager.default.createFile(atPath: request.logURL.path, contents: nil)
+        let logHandle = try FileHandle(forWritingTo: request.logURL)
+        let process = Process()
+        process.executableURL = request.helperURL
+        process.arguments = request.arguments
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        do {
+            try process.run()
+        } catch {
+            try? logHandle.close()
+            throw QuillCodeDesktopUpdateError.installationFailed("the update helper could not start")
+        }
+    }
+}
+
+struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
+    static let modeArgument = "--quillcode-apply-update"
+
+    var parentProcessID: Int32
+    var helperURL: URL
+    var incomingApplicationURL: URL
+    var destinationApplicationURL: URL
+    var backupApplicationURL: URL
+    var failedApplicationURL: URL
+    var handshakeURL: URL
+    var resultURL: URL
+    var logURL: URL
+    var expectedBundleIdentifier: String
+    var expectedVersion: String
+    var expectedBuild: String
+
+    var arguments: [String] {
+        [
+            Self.modeArgument,
+            "--parent-pid", String(parentProcessID),
+            "--incoming-app", incomingApplicationURL.path,
+            "--destination-app", destinationApplicationURL.path,
+            "--backup-app", backupApplicationURL.path,
+            "--failed-app", failedApplicationURL.path,
+            "--handshake", handshakeURL.path,
+            "--result", resultURL.path,
+            "--bundle-id", expectedBundleIdentifier,
+            "--version", expectedVersion,
+            "--build", expectedBuild
+        ]
+    }
+
+    static func parse(arguments: [String], executableURL: URL? = Bundle.main.executableURL) -> Self? {
+        guard let modeIndex = arguments.firstIndex(of: modeArgument), let executableURL else { return nil }
+        var values: [String: String] = [:]
+        var index = modeIndex + 1
+        while index + 1 < arguments.count {
+            let key = arguments[index]
+            if key.hasPrefix("--") {
+                values[key] = arguments[index + 1]
+                index += 2
+            } else {
+                index += 1
+            }
+        }
+        guard let parentValue = values["--parent-pid"],
+              let parentProcessID = Int32(parentValue),
+              parentProcessID > 1,
+              let incoming = values["--incoming-app"],
+              let destination = values["--destination-app"],
+              let backup = values["--backup-app"],
+              let failed = values["--failed-app"],
+              let handshake = values["--handshake"],
+              let result = values["--result"],
+              let bundleIdentifier = values["--bundle-id"],
+              let version = values["--version"],
+              let build = values["--build"]
+        else {
+            return nil
+        }
+        return Self(
+            parentProcessID: parentProcessID,
+            helperURL: executableURL.standardizedFileURL,
+            incomingApplicationURL: URL(fileURLWithPath: incoming).standardizedFileURL,
+            destinationApplicationURL: URL(fileURLWithPath: destination).standardizedFileURL,
+            backupApplicationURL: URL(fileURLWithPath: backup).standardizedFileURL,
+            failedApplicationURL: URL(fileURLWithPath: failed).standardizedFileURL,
+            handshakeURL: URL(fileURLWithPath: handshake).standardizedFileURL,
+            resultURL: URL(fileURLWithPath: result).standardizedFileURL,
+            logURL: URL(fileURLWithPath: "/dev/null"),
+            expectedBundleIdentifier: bundleIdentifier,
+            expectedVersion: version,
+            expectedBuild: build
+        )
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateManifestValidator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateManifestValidator.swift
@@ -1,0 +1,188 @@
+import Foundation
+import QuillCodeApp
+
+enum QuillCodeDesktopUpdateManifestValidator {
+    static let maximumAssetBytes: Int64 = 2 * 1_024 * 1_024 * 1_024
+
+    static func validate(
+        _ manifest: QuillCodeDesktopUpdateManifest,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) throws -> QuillCodeDesktopUpdateCheckResult {
+        guard manifest.schemaVersion == 1,
+              manifest.updater.schemaVersion == 1,
+              manifest.updater.format == "github-release-manifest"
+        else {
+            throw QuillCodeDesktopUpdateError.unsupportedManifest
+        }
+        guard manifest.product == QuillCodeProduct.displayName,
+              manifest.channel == configuration.channel,
+              manifest.updater.channel == configuration.channel,
+              manifest.updater.bundleIdentifier == configuration.bundleIdentifier
+        else {
+            throw QuillCodeDesktopUpdateError.wrongProductOrChannel
+        }
+        try validateSigning(manifest.updater, configuration: configuration)
+        guard manifest.updater.manifestURL == configuration.manifestURL,
+              manifest.updater.stableManifestURL == configuration.stableManifestURL,
+              manifest.updater.testerManifestURL == configuration.testerManifestURL
+        else {
+            throw QuillCodeDesktopUpdateError.unexpectedFeed
+        }
+        guard isHex(manifest.commit, length: 40),
+              let releaseVersion = QuillCodeDesktopSemanticVersion(manifest.version),
+              let releaseBuild = UInt64(manifest.build),
+              let currentVersion = QuillCodeDesktopSemanticVersion(configuration.currentVersion),
+              let currentBuild = UInt64(configuration.currentBuild),
+              QuillCodeDesktopSemanticVersion(manifest.updater.minimumSystemVersion) != nil
+        else {
+            throw QuillCodeDesktopUpdateError.invalidVersionMetadata
+        }
+
+        let repositoryScope = try repositoryScope(for: configuration)
+        guard repositoryScope.containsReleasePage(manifest.releaseURL, tag: manifest.tag),
+              repositoryScope.containsManifestURL(manifest.updater.manifestURL),
+              repositoryScope.containsManifestURL(manifest.updater.stableManifestURL),
+              repositoryScope.containsManifestURL(manifest.updater.testerManifestURL)
+        else {
+            throw QuillCodeDesktopUpdateError.unexpectedFeed
+        }
+        let asset = try compatibleAsset(in: manifest, configuration: configuration, scope: repositoryScope)
+        guard releaseVersion > currentVersion || (
+            releaseVersion == currentVersion && releaseBuild > currentBuild
+        ) else {
+            return .upToDate(latestVersion: manifest.version, latestBuild: manifest.build)
+        }
+        return .updateAvailable(QuillCodeDesktopUpdateRelease(
+            channel: manifest.channel,
+            tag: manifest.tag,
+            releaseURL: manifest.releaseURL,
+            commit: manifest.commit,
+            version: manifest.version,
+            build: manifest.build,
+            asset: asset
+        ))
+    }
+
+    private static func validateSigning(
+        _ updater: QuillCodeDesktopUpdateManifest.Updater,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) throws {
+        if let expectedTeam = configuration.expectedSigningTeamIdentifier {
+            guard updater.codesign == "developer-id",
+                  updater.signingTeamIdentifier == expectedTeam
+            else {
+                throw QuillCodeDesktopUpdateError.wrongSigningIdentity
+            }
+        }
+        if configuration.channel == .stable {
+            guard configuration.expectedSigningTeamIdentifier != nil,
+                  updater.notarized == true
+            else {
+                throw QuillCodeDesktopUpdateError.unsignedStableUpdate
+            }
+        }
+    }
+
+    private static func compatibleAsset(
+        in manifest: QuillCodeDesktopUpdateManifest,
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        scope: GitHubReleaseRepositoryScope
+    ) throws -> QuillCodeDesktopUpdateManifest.Asset {
+        guard let updaterAsset = manifest.updater.macOSAppAsset,
+              let asset = manifest.assets.first(where: { $0.name == updaterAsset.name }),
+              asset == updaterAsset,
+              asset.kind == "app",
+              asset.platform == "macOS",
+              asset.arch == configuration.architecture,
+              asset.install == "zip-app",
+              asset.sizeBytes > 0,
+              asset.sizeBytes <= maximumAssetBytes,
+              isSafeAssetName(asset.name),
+              isHex(asset.sha256, length: 64),
+              scope.containsDownloadURL(asset.url, tag: manifest.tag)
+        else {
+            throw QuillCodeDesktopUpdateError.noCompatibleApplication
+        }
+        return asset
+    }
+
+    private static func repositoryScope(
+        for configuration: QuillCodeDesktopUpdateConfiguration
+    ) throws -> GitHubReleaseRepositoryScope {
+        guard let scope = GitHubReleaseRepositoryScope(manifestURL: configuration.manifestURL),
+              scope == GitHubReleaseRepositoryScope(manifestURL: configuration.stableManifestURL),
+              scope == GitHubReleaseRepositoryScope(manifestURL: configuration.testerManifestURL)
+        else {
+            throw QuillCodeDesktopUpdateError.unexpectedFeed
+        }
+        return scope
+    }
+
+    private static func isSafeAssetName(_ name: String) -> Bool {
+        !name.isEmpty &&
+            name.count <= 180 &&
+            name == (name as NSString).lastPathComponent &&
+            !name.contains("..")
+    }
+
+    private static func isHex(_ value: String, length: Int) -> Bool {
+        value.count == length && value.unicodeScalars.allSatisfy { scalar in
+            ("0"..."9").contains(Character(scalar)) || ("a"..."f").contains(Character(scalar))
+        }
+    }
+}
+
+struct GitHubReleaseRepositoryScope: Equatable, Sendable {
+    private var owner: String
+    private var repository: String
+
+    init?(manifestURL: URL) {
+        guard manifestURL.scheme?.lowercased() == "https",
+              manifestURL.host?.lowercased() == "github.com"
+        else {
+            return nil
+        }
+        let components = manifestURL.pathComponents.filter { $0 != "/" }
+        guard components.count >= 4,
+              components[2] == "releases",
+              !components[0].isEmpty,
+              !components[1].isEmpty
+        else {
+            return nil
+        }
+        owner = components[0]
+        repository = components[1]
+    }
+
+    func containsManifestURL(_ url: URL) -> Bool {
+        containsRepositoryURL(url) && url.pathExtension == "json"
+    }
+
+    func containsDownloadURL(_ url: URL, tag: String) -> Bool {
+        guard containsRepositoryURL(url) else { return false }
+        let components = url.pathComponents.filter { $0 != "/" }
+        return components.count >= 6 &&
+            components[2] == "releases" &&
+            components[3] == "download" &&
+            components[4] == tag
+    }
+
+    func containsReleasePage(_ url: URL, tag: String) -> Bool {
+        guard containsRepositoryURL(url) else { return false }
+        let components = url.pathComponents.filter { $0 != "/" }
+        return components.count == 5 &&
+            components[2] == "releases" &&
+            components[3] == "tag" &&
+            components[4] == tag
+    }
+
+    private func containsRepositoryURL(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "https",
+              url.host?.lowercased() == "github.com"
+        else {
+            return false
+        }
+        let components = url.pathComponents.filter { $0 != "/" }
+        return components.count >= 2 && components[0] == owner && components[1] == repository
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
@@ -1,0 +1,202 @@
+import Foundation
+import QuillCodeApp
+
+enum QuillCodeDesktopUpdateChannel: String, Codable, Sendable {
+    case stable
+    case tester
+}
+
+struct QuillCodeDesktopUpdateConfiguration: Equatable, Sendable {
+    static let manifestInfoKey = "QuillCodeUpdateManifestURL"
+    static let channelInfoKey = "QuillCodeUpdateChannel"
+    static let stableManifestInfoKey = "QuillCodeStableUpdateManifestURL"
+    static let testerManifestInfoKey = "QuillCodeTesterUpdateManifestURL"
+    static let signingTeamInfoKey = "QuillCodeSigningTeamIdentifier"
+
+    var channel: QuillCodeDesktopUpdateChannel
+    var manifestURL: URL
+    var stableManifestURL: URL
+    var testerManifestURL: URL
+    var currentVersion: String
+    var currentBuild: String
+    var bundleIdentifier: String
+    var architecture: String
+    var applicationURL: URL
+    var expectedSigningTeamIdentifier: String?
+
+    static func bundled(
+        bundle: Bundle = .main,
+        architecture: String = QuillCodeDesktopArchitecture.current
+    ) -> Self? {
+        guard let channelValue = bundle.object(forInfoDictionaryKey: channelInfoKey) as? String,
+              let channel = QuillCodeDesktopUpdateChannel(rawValue: channelValue),
+              let manifestURL = infoURL(manifestInfoKey, bundle: bundle),
+              let stableManifestURL = infoURL(stableManifestInfoKey, bundle: bundle),
+              let testerManifestURL = infoURL(testerManifestInfoKey, bundle: bundle),
+              let currentVersion = nonemptyInfoString("CFBundleShortVersionString", bundle: bundle),
+              let currentBuild = nonemptyInfoString("CFBundleVersion", bundle: bundle),
+              let bundleIdentifier = bundle.bundleIdentifier,
+              bundleIdentifier == QuillCodeProduct.bundleIdentifier,
+              QuillCodeDesktopSemanticVersion(currentVersion) != nil,
+              UInt64(currentBuild) != nil,
+              GitHubReleaseRepositoryScope(manifestURL: manifestURL) != nil,
+              GitHubReleaseRepositoryScope(manifestURL: stableManifestURL) != nil,
+              GitHubReleaseRepositoryScope(manifestURL: testerManifestURL) != nil
+        else {
+            return nil
+        }
+        return Self(
+            channel: channel,
+            manifestURL: manifestURL,
+            stableManifestURL: stableManifestURL,
+            testerManifestURL: testerManifestURL,
+            currentVersion: currentVersion,
+            currentBuild: currentBuild,
+            bundleIdentifier: bundleIdentifier,
+            architecture: architecture,
+            applicationURL: bundle.bundleURL.standardizedFileURL,
+            expectedSigningTeamIdentifier: nonemptyInfoString(signingTeamInfoKey, bundle: bundle)
+        )
+    }
+
+    private static func infoURL(_ key: String, bundle: Bundle) -> URL? {
+        guard let value = nonemptyInfoString(key, bundle: bundle),
+              let url = URL(string: value),
+              url.scheme?.lowercased() == "https"
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func nonemptyInfoString(_ key: String, bundle: Bundle) -> String? {
+        guard let value = bundle.object(forInfoDictionaryKey: key) as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+enum QuillCodeDesktopArchitecture {
+    static var current: String {
+        #if arch(arm64)
+        "arm64"
+        #elseif arch(x86_64)
+        "x86_64"
+        #else
+        "unknown"
+        #endif
+    }
+}
+
+struct QuillCodeDesktopUpdateManifest: Codable, Equatable, Sendable {
+    var schemaVersion: Int
+    var product: String
+    var channel: QuillCodeDesktopUpdateChannel
+    var tag: String
+    var releaseURL: URL
+    var commit: String
+    var version: String
+    var build: String
+    var generatedAt: String
+    var workflowRunURL: URL
+    var updater: Updater
+    var assets: [Asset]
+
+    struct Updater: Codable, Equatable, Sendable {
+        var schemaVersion: Int
+        var format: String
+        var channel: QuillCodeDesktopUpdateChannel
+        var manifestURL: URL
+        var stableManifestURL: URL
+        var testerManifestURL: URL
+        var bundleIdentifier: String
+        var minimumSystemVersion: String
+        var codesign: String?
+        var signingTeamIdentifier: String?
+        var notarized: Bool?
+        var macOSAppAsset: Asset?
+    }
+
+    struct Asset: Codable, Equatable, Sendable {
+        var name: String
+        var kind: String
+        var platform: String
+        var arch: String
+        var install: String
+        var sizeBytes: Int64
+        var sha256: String
+        var url: URL
+    }
+}
+
+struct QuillCodeDesktopUpdateRelease: Equatable, Sendable {
+    var channel: QuillCodeDesktopUpdateChannel
+    var tag: String
+    var releaseURL: URL
+    var commit: String
+    var version: String
+    var build: String
+    var asset: QuillCodeDesktopUpdateManifest.Asset
+
+    var displayVersion: String {
+        "\(version) (\(build))"
+    }
+}
+
+enum QuillCodeDesktopUpdateCheckResult: Equatable, Sendable {
+    case updateAvailable(QuillCodeDesktopUpdateRelease)
+    case upToDate(latestVersion: String, latestBuild: String)
+}
+
+enum QuillCodeDesktopUpdateError: LocalizedError, Equatable, Sendable {
+    case updatesUnavailable
+    case invalidResponse
+    case manifestTooLarge
+    case unsupportedManifest
+    case wrongProductOrChannel
+    case unexpectedFeed
+    case invalidVersionMetadata
+    case noCompatibleApplication
+    case wrongSigningIdentity
+    case unsignedStableUpdate
+    case downloadSizeMismatch
+    case checksumMismatch
+    case invalidApplication(String)
+    case installationUnavailable
+    case installationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .updatesUnavailable:
+            "Updates are unavailable in this development build."
+        case .invalidResponse:
+            "The update server returned an invalid response."
+        case .manifestTooLarge:
+            "The update metadata exceeded its size limit."
+        case .unsupportedManifest:
+            "This build cannot read the update metadata format."
+        case .wrongProductOrChannel:
+            "The update does not match this app or release channel."
+        case .unexpectedFeed:
+            "The update metadata points outside the configured GitHub release feed."
+        case .invalidVersionMetadata:
+            "The update has invalid version metadata."
+        case .noCompatibleApplication:
+            "No compatible macOS app is available for this Mac."
+        case .wrongSigningIdentity:
+            "The update was not signed by Quill Cowork's configured distribution identity."
+        case .unsignedStableUpdate:
+            "The stable update is not marked as signed and notarized."
+        case .downloadSizeMismatch:
+            "The downloaded update size did not match the release metadata."
+        case .checksumMismatch:
+            "The downloaded update failed its SHA-256 integrity check."
+        case .invalidApplication(let reason):
+            "The downloaded app could not be verified: \(reason)"
+        case .installationUnavailable:
+            "Quill Cowork cannot replace itself from its current location."
+        case .installationFailed(let reason):
+            "The update could not be installed: \(reason)"
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
@@ -1,0 +1,236 @@
+import CryptoKit
+import Foundation
+
+struct QuillCodeDesktopPreparedUpdate: Equatable, Sendable {
+    var release: QuillCodeDesktopUpdateRelease
+    var applicationURL: URL
+    var workspaceURL: URL
+}
+
+protocol QuillCodeDesktopUpdatePreparing: Sendable {
+    func prepare(
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopPreparedUpdate
+}
+
+protocol QuillCodeDesktopUpdateDownloading: Sendable {
+    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws
+}
+
+struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable {
+    private let downloader: any QuillCodeDesktopUpdateDownloading
+    private let cacheRoot: URL?
+
+    init(
+        downloader: any QuillCodeDesktopUpdateDownloading = QuillCodeDesktopUpdateDownloader(),
+        cacheRoot: URL? = nil
+    ) {
+        self.downloader = downloader
+        self.cacheRoot = cacheRoot
+    }
+
+    func prepare(
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopPreparedUpdate {
+        let workspaceURL = try await makeCleanWorkspace(for: release)
+        let archiveURL = workspaceURL.appendingPathComponent(release.asset.name, isDirectory: false)
+        try await downloader.download(
+            from: release.asset.url,
+            to: archiveURL,
+            maximumBytes: release.asset.sizeBytes
+        )
+        try Task.checkCancellation()
+
+        try await Task.detached(priority: .utility) {
+            try Self.verifyArchive(
+                at: archiveURL,
+                expectedSize: release.asset.sizeBytes,
+                expectedSHA256: release.asset.sha256
+            )
+        }.value
+
+        let extractedURL = workspaceURL.appendingPathComponent("Extracted", isDirectory: true)
+        try await Task.detached(priority: .utility) {
+            try FileManager.default.createDirectory(
+                at: extractedURL,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let result = try QuillCodeDesktopUpdateProcessRunner.run(
+                executableURL: URL(fileURLWithPath: "/usr/bin/ditto"),
+                arguments: ["-x", "-k", archiveURL.path, extractedURL.path]
+            )
+            guard result.exitCode == 0 else {
+                throw QuillCodeDesktopUpdateError.invalidApplication(result.failureSummary)
+            }
+        }.value
+
+        let applicationURL = try await Task.detached(priority: .utility) {
+            let appURL = try Self.singleApplication(in: extractedURL)
+            try Self.validateContainedLinks(in: extractedURL)
+            try QuillCodeDesktopDownloadedApplicationValidator.validate(
+                appURL,
+                release: release,
+                configuration: configuration
+            )
+            return appURL
+        }.value
+
+        return QuillCodeDesktopPreparedUpdate(
+            release: release,
+            applicationURL: applicationURL,
+            workspaceURL: workspaceURL
+        )
+    }
+
+    private func makeCleanWorkspace(for release: QuillCodeDesktopUpdateRelease) async throws -> URL {
+        let configuredCacheRoot = cacheRoot
+        return try await Task.detached(priority: .utility) {
+            let root = try configuredCacheRoot ?? Self.defaultCacheRoot()
+            try FileManager.default.createDirectory(
+                at: root,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let workspace = root.appendingPathComponent(
+                "\(release.commit.prefix(12))-\(release.build)",
+                isDirectory: true
+            )
+            if FileManager.default.fileExists(atPath: workspace.path) {
+                try FileManager.default.removeItem(at: workspace)
+            }
+            try FileManager.default.createDirectory(
+                at: workspace,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+            return workspace
+        }.value
+    }
+
+    private static func defaultCacheRoot() throws -> URL {
+        try QuillCodeDesktopUpdatePaths.cacheRoot()
+    }
+
+    static func verifyArchive(
+        at archiveURL: URL,
+        expectedSize: Int64,
+        expectedSHA256: String
+    ) throws {
+        let values = try archiveURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+        guard values.isRegularFile == true,
+              Int64(values.fileSize ?? -1) == expectedSize
+        else {
+            throw QuillCodeDesktopUpdateError.downloadSizeMismatch
+        }
+
+        let handle = try FileHandle(forReadingFrom: archiveURL)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while true {
+            let data = try handle.read(upToCount: 1_024 * 1_024) ?? Data()
+            if data.isEmpty { break }
+            hasher.update(data: data)
+        }
+        let digest = hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        guard digest == expectedSHA256 else {
+            throw QuillCodeDesktopUpdateError.checksumMismatch
+        }
+    }
+
+    private static func singleApplication(in extractedURL: URL) throws -> URL {
+        let children = try FileManager.default.contentsOfDirectory(
+            at: extractedURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let applications = children.filter { child in
+            child.pathExtension == "app" &&
+                (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        }
+        guard applications.count == 1 else {
+            throw QuillCodeDesktopUpdateError.invalidApplication(
+                "the archive must contain exactly one app bundle"
+            )
+        }
+        return applications[0]
+    }
+
+    private static func validateContainedLinks(in rootURL: URL) throws {
+        let canonicalRoot = rootURL.resolvingSymlinksInPath().standardizedFileURL.path + "/"
+        guard let enumerator = FileManager.default.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isSymbolicLinkKey],
+            options: [],
+            errorHandler: { _, _ in false }
+        ) else {
+            throw QuillCodeDesktopUpdateError.invalidApplication("the app archive could not be inspected")
+        }
+
+        for case let itemURL as URL in enumerator {
+            let values = try itemURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+            guard values.isSymbolicLink == true else { continue }
+            let resolvedPath = itemURL.resolvingSymlinksInPath().standardizedFileURL.path
+            guard resolvedPath == rootURL.standardizedFileURL.path || resolvedPath.hasPrefix(canonicalRoot) else {
+                throw QuillCodeDesktopUpdateError.invalidApplication(
+                    "the app archive contains a link outside its bundle"
+                )
+            }
+        }
+    }
+}
+
+struct QuillCodeDesktopUpdateDownloader: QuillCodeDesktopUpdateDownloading, @unchecked Sendable {
+    private let session: URLSession
+
+    init(session: URLSession? = nil) {
+        self.session = session ?? Self.makeSession()
+    }
+
+    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        request.setValue("application/zip", forHTTPHeaderField: "Accept")
+        request.setValue("Quill-Cowork-Updater/1", forHTTPHeaderField: "User-Agent")
+
+        let temporaryURL: URL
+        let response: URLResponse
+        do {
+            (temporaryURL, response) = try await session.download(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+        guard let response = response as? HTTPURLResponse,
+              response.statusCode == 200,
+              response.expectedContentLength <= 0 || response.expectedContentLength <= maximumBytes
+        else {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+        let values = try temporaryURL.resourceValues(forKeys: [.fileSizeKey])
+        guard Int64(values.fileSize ?? -1) <= maximumBytes else {
+            throw QuillCodeDesktopUpdateError.downloadSizeMismatch
+        }
+        do {
+            try FileManager.default.moveItem(at: temporaryURL, to: destinationURL)
+        } catch {
+            throw QuillCodeDesktopUpdateError.installationFailed("the download could not be staged")
+        }
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 30 * 60
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.waitsForConnectivity = true
+        return URLSession(configuration: configuration)
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+enum QuillCodeDesktopUpdateLaunchHandshake {
+    static let argument = "--quillcode-update-handshake"
+
+    static func acknowledgeIfRequested(arguments: [String] = CommandLine.arguments) {
+        guard let index = arguments.firstIndex(of: argument),
+              arguments.indices.contains(index + 1)
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: arguments[index + 1]).standardizedFileURL
+        guard isAllowed(url) else { return }
+        try? Data("ready\n".utf8).write(to: url, options: [.atomic, .completeFileProtection])
+    }
+
+    static func isAllowed(_ url: URL) -> Bool {
+        guard let cacheRoot = try? QuillCodeDesktopUpdatePaths.cacheRoot() else { return false }
+        return isAllowed(url, cacheRoot: cacheRoot)
+    }
+
+    static func isAllowed(_ url: URL, cacheRoot: URL) -> Bool {
+        let rootPath = cacheRoot.standardizedFileURL.path + "/"
+        return url.standardizedFileURL.path.hasPrefix(rootPath) &&
+            url.pathExtension == "ack" &&
+            url.lastPathComponent.hasPrefix("launch-")
+    }
+}
+
+struct QuillCodeDesktopUpdateInstallResult: Codable, Equatable, Sendable {
+    enum Status: String, Codable, Sendable {
+        case success
+        case failure
+    }
+
+    var status: Status
+    var message: String
+    var version: String?
+    var build: String?
+    var recordedAt: Date
+
+    static func success(version: String, build: String) -> Self {
+        Self(
+            status: .success,
+            message: "Quill Cowork was updated successfully.",
+            version: version,
+            build: build,
+            recordedAt: Date()
+        )
+    }
+
+    static func failure(message: String) -> Self {
+        Self(status: .failure, message: message, version: nil, build: nil, recordedAt: Date())
+    }
+}
+
+enum QuillCodeDesktopUpdatePaths {
+    static func cacheRoot() throws -> URL {
+        guard let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            throw QuillCodeDesktopUpdateError.installationUnavailable
+        }
+        return caches
+            .appendingPathComponent("co.lorehex.QuillCowork", isDirectory: true)
+            .appendingPathComponent("Updates", isDirectory: true)
+    }
+
+    static func installResultURL() throws -> URL {
+        guard let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            throw QuillCodeDesktopUpdateError.installationUnavailable
+        }
+        return applicationSupport
+            .appendingPathComponent("co.lorehex.QuillCowork", isDirectory: true)
+            .appendingPathComponent("UpdateResult.json", isDirectory: false)
+    }
+
+    static func isAllowedInstallResultURL(_ url: URL) -> Bool {
+        guard let expected = try? installResultURL() else { return false }
+        return url.standardizedFileURL == expected.standardizedFileURL
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+import QuillCodeApp
+
+struct QuillCodeDesktopUpdateView: View {
+    @ObservedObject var controller: QuillCodeDesktopUpdateController
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 20)
+                .padding(.top, 18)
+                .padding(.bottom, 14)
+
+            Divider().opacity(0.55)
+
+            content
+                .padding(24)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            Divider().opacity(0.55)
+            footer
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+        }
+        .frame(width: 470, height: 340)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .interactiveDismissDisabled(controller.state.isBusy)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "arrow.triangle.2.circlepath.circle.fill")
+                .font(.system(size: 28, weight: .medium))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Color.accentColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Quill Cowork Update")
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("quillcode-update-title")
+                if let configuration = controller.configuration {
+                    Text("Current version \(configuration.currentVersion) (\(configuration.currentBuild))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Button(action: controller.dismiss) {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.bold))
+                    .quillCodeIconButtonTarget(size: 36, radius: 9)
+            }
+            .buttonStyle(QuillCodePressableButtonStyle())
+            .disabled(controller.state.isBusy)
+            .help("Close")
+            .accessibilityLabel("Close update")
+            .accessibilityIdentifier("quillcode-update-close")
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch controller.state {
+        case .idle, .checking:
+            statusContent(
+                icon: "arrow.triangle.2.circlepath",
+                title: "Checking for updates...",
+                detail: "Contacting the GitHub release feed.",
+                showsProgress: true
+            )
+        case .updateAvailable(let release):
+            updateContent(release)
+        case .downloading(let release):
+            statusContent(
+                icon: "arrow.down.circle",
+                title: "Downloading \(release.displayVersion)",
+                detail: ByteCountFormatter.string(fromByteCount: release.asset.sizeBytes, countStyle: .file),
+                showsProgress: true
+            )
+        case .installing(let release):
+            statusContent(
+                icon: "shippingbox",
+                title: "Preparing \(release.displayVersion)",
+                detail: "Quill Cowork will relaunch when the verified update is ready.",
+                showsProgress: true
+            )
+        case .upToDate(let version, let build):
+            statusContent(
+                icon: "checkmark.circle.fill",
+                title: "You're up to date",
+                detail: "Quill Cowork \(version) (\(build)) is the latest version.",
+                showsProgress: false
+            )
+        case .failed(let message, _):
+            statusContent(
+                icon: "exclamationmark.triangle.fill",
+                title: "Update couldn't be completed",
+                detail: message,
+                showsProgress: false
+            )
+        }
+    }
+
+    private func updateContent(_ release: QuillCodeDesktopUpdateRelease) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: "arrow.down.app.fill")
+                    .font(.system(size: 34, weight: .medium))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(Color.accentColor)
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Version \(release.displayVersion) is ready")
+                        .font(.headline)
+                    Text("\(release.channel.rawValue.capitalized) channel")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(ByteCountFormatter.string(fromByteCount: release.asset.sizeBytes, countStyle: .file))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Label("SHA-256 integrity verified before install", systemImage: "checkmark.shield")
+                Label("Automatic rollback if the new build cannot launch", systemImage: "arrow.uturn.backward.circle")
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+
+            Button("View release on GitHub", action: controller.openReleasePage)
+                .buttonStyle(.link)
+                .quillCodeLinkTarget(minWidth: nil, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func statusContent(
+        icon: String,
+        title: String,
+        detail: String,
+        showsProgress: Bool
+    ) -> some View {
+        VStack(spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 38, weight: .medium))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Color.accentColor)
+            Text(title)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Text(detail)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            if showsProgress {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel(title)
+            }
+        }
+        .frame(maxWidth: 380)
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        HStack(spacing: 8) {
+            switch controller.state {
+            case .updateAvailable:
+                Button("Later", action: controller.dismiss)
+                    .buttonStyle(QuillCodeActionButtonStyle())
+                    .quillCodeFormActionTarget()
+                Spacer()
+                Button(action: controller.updateAndRelaunch) {
+                    Label("Update and Relaunch", systemImage: "arrow.down.circle.fill")
+                }
+                .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 168))
+                .quillCodeFormActionTarget(minWidth: 168)
+                .accessibilityIdentifier("quillcode-update-install")
+            case .downloading:
+                Spacer()
+                Button("Cancel", action: controller.cancelCurrentOperation)
+                    .buttonStyle(QuillCodeActionButtonStyle())
+                    .quillCodeFormActionTarget()
+            case .installing:
+                Spacer()
+                Text("Keep Quill Cowork open")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .failed(_, let release):
+                if release != nil {
+                    Button("Download in Browser", action: controller.openDownloadInBrowser)
+                        .buttonStyle(QuillCodeActionButtonStyle())
+                        .quillCodeFormActionTarget()
+                }
+                Spacer()
+                Button("Check Again", action: controller.checkForUpdates)
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 110))
+                    .quillCodeFormActionTarget(minWidth: 110)
+            case .idle, .checking:
+                Spacer()
+            case .upToDate:
+                Spacer()
+                Button("Done", action: controller.dismiss)
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary))
+                    .quillCodeFormActionTarget()
+            }
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeMenuBarView.swift
+++ b/Sources/quill-code-desktop/QuillCodeMenuBarView.swift
@@ -17,6 +17,7 @@ struct QuillCodeMenuBarView: View {
     var onStopAll: () -> Void
     var onDisconnectAll: () -> Void
     var onComputerUseSetup: () -> Void
+    var onCheckForUpdates: () -> Void
     var onQuit: () -> Void
 
     var body: some View {
@@ -57,6 +58,7 @@ struct QuillCodeMenuBarView: View {
             menuActionButton("Computer Use Setup", action: onComputerUseSetup)
         }
         menuActionButton("Settings...", action: onSettings)
+        menuActionButton("Check for Updates...", action: onCheckForUpdates)
         Divider()
         menuActionButton("Stop All", isDisabled: stopAllCommand?.isEnabled != true, action: onStopAll)
         menuActionButton(

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
+    func testManualCheckShowsAvailableUpdateThenInstallsAndTerminates() async throws {
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let checker = UpdateCheckerSpy(result: .updateAvailable(release))
+        let preparer = UpdatePreparerSpy(release: release)
+        let installer = UpdateInstallerSpy()
+        let defaults = makeDefaults()
+        var terminationCount = 0
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            preparer: preparer,
+            installer: installer,
+            defaults: defaults,
+            automaticCheckDelay: .zero,
+            installResultURL: temporaryInstallResultURL(),
+            terminateApplication: { terminationCount += 1 }
+        )
+
+        controller.checkForUpdates()
+        try await waitUntil { controller.state == .updateAvailable(release) }
+        XCTAssertTrue(controller.isPresented)
+
+        controller.updateAndRelaunch()
+        try await waitUntil { terminationCount == 1 }
+
+        let prepareCallCount = await preparer.callCount
+        let installCallCount = await installer.callCount
+        XCTAssertEqual(prepareCallCount, 1)
+        XCTAssertEqual(installCallCount, 1)
+    }
+
+    func testRecentSuccessfulAutomaticCheckSuppressesNetworkWork() async throws {
+        let defaults = makeDefaults()
+        defaults.set(Date(), forKey: "QuillCodeUpdater.lastSuccessfulCheck.tester")
+        let checker = UpdateCheckerSpy(result: .upToDate(latestVersion: "0.1.0", latestBuild: "42"))
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            defaults: defaults,
+            automaticCheckDelay: .zero,
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.startAutomaticChecks()
+        try await Task.sleep(for: .milliseconds(50))
+
+        let checkCallCount = await checker.callCount
+        XCTAssertEqual(checkCallCount, 0)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.isPresented)
+    }
+
+    func testBackgroundFailureStaysQuietButManualFailureIsVisible() async throws {
+        let checker = UpdateCheckerSpy(error: .invalidResponse)
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            defaults: makeDefaults(),
+            automaticCheckDelay: .zero,
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.startAutomaticChecks()
+        try await waitUntil { await checker.callCount == 1 }
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.isPresented)
+
+        controller.checkForUpdates()
+        try await waitUntil {
+            if case .failed = controller.state { return true }
+            return false
+        }
+        XCTAssertTrue(controller.isPresented)
+    }
+
+    func testOversizedInstallResultIsDiscardedWithoutPresenting() throws {
+        let resultURL = temporaryInstallResultURL()
+        try FileManager.default.createDirectory(
+            at: resultURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(repeating: 0x41, count: 64 * 1_024 + 1).write(to: resultURL)
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: nil,
+            defaults: makeDefaults(),
+            automaticCheckDelay: .zero,
+            installResultURL: resultURL
+        )
+
+        controller.startAutomaticChecks()
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.isPresented)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: resultURL.path))
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "QuillCodeDesktopUpdateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func temporaryInstallResultURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("UpdateResult.json")
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @escaping @MainActor () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for updater state")
+    }
+}
+
+private actor UpdateCheckerSpy: QuillCodeDesktopUpdateChecking {
+    private let result: QuillCodeDesktopUpdateCheckResult?
+    private let error: QuillCodeDesktopUpdateError?
+    private(set) var callCount = 0
+
+    init(result: QuillCodeDesktopUpdateCheckResult) {
+        self.result = result
+        self.error = nil
+    }
+
+    init(error: QuillCodeDesktopUpdateError) {
+        self.result = nil
+        self.error = error
+    }
+
+    func check(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopUpdateCheckResult {
+        callCount += 1
+        if let error { throw error }
+        return result!
+    }
+}
+
+private actor UpdatePreparerSpy: QuillCodeDesktopUpdatePreparing {
+    private let release: QuillCodeDesktopUpdateRelease
+    private(set) var callCount = 0
+
+    init(release: QuillCodeDesktopUpdateRelease) {
+        self.release = release
+    }
+
+    func prepare(
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopPreparedUpdate {
+        callCount += 1
+        return QuillCodeDesktopPreparedUpdate(
+            release: self.release,
+            applicationURL: URL(fileURLWithPath: "/tmp/Quill Cowork.app"),
+            workspaceURL: URL(fileURLWithPath: "/tmp/quill-cowork-update")
+        )
+    }
+}
+
+private actor UpdateInstallerSpy: QuillCodeDesktopUpdateInstalling {
+    private(set) var callCount = 0
+
+    func stageAndLaunch(
+        preparedUpdate: QuillCodeDesktopPreparedUpdate,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws {
+        callCount += 1
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -1,0 +1,477 @@
+import CryptoKit
+import Darwin
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopUpdateModelTests: XCTestCase {
+    func testReleaseDisplayVersionUsesStandardVersionAndBuildFormatting() {
+        XCTAssertEqual(makeRelease(version: "0.2.0", build: "7").displayVersion, "0.2.0 (7)")
+    }
+
+    func testSemanticVersionOrderingHandlesBuildMetadataAndPrereleases() throws {
+        XCTAssertLessThan(try version("0.9.9"), try version("1.0.0-alpha.1"))
+        XCTAssertLessThan(try version("1.0.0-alpha.1"), try version("1.0.0-alpha.beta"))
+        XCTAssertLessThan(try version("1.0.0-alpha.beta"), try version("1.0.0-beta"))
+        XCTAssertLessThan(try version("1.0.0-beta.2"), try version("1.0.0-beta.11"))
+        XCTAssertLessThan(try version("1.0.0-rc.1"), try version("1.0.0"))
+        XCTAssertEqual(try version("1.0"), try version("1.0.0+build.7"))
+        XCTAssertNil(QuillCodeDesktopSemanticVersion("1..0"))
+        XCTAssertNil(QuillCodeDesktopSemanticVersion("01.0.0"))
+    }
+
+    func testValidatorSelectsOnlyANewerMatchingApplication() throws {
+        let configuration = makeConfiguration(currentVersion: "0.1.0", currentBuild: "41")
+
+        XCTAssertEqual(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                makeManifest(version: "0.1.0", build: "42"),
+                configuration: configuration
+            ),
+            .updateAvailable(makeRelease(version: "0.1.0", build: "42"))
+        )
+        XCTAssertEqual(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                makeManifest(version: "0.1.0", build: "41"),
+                configuration: configuration
+            ),
+            .upToDate(latestVersion: "0.1.0", latestBuild: "41")
+        )
+        XCTAssertEqual(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                makeManifest(version: "0.0.9", build: "999"),
+                configuration: configuration
+            ),
+            .upToDate(latestVersion: "0.0.9", latestBuild: "999")
+        )
+    }
+
+    func testValidatorRejectsWrongArchitectureAndRepository() throws {
+        let configuration = makeConfiguration()
+        var wrongArchitecture = makeManifest()
+        wrongArchitecture.updater.macOSAppAsset?.arch = "x86_64"
+        wrongArchitecture.assets[0].arch = "x86_64"
+
+        XCTAssertThrowsError(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                wrongArchitecture,
+                configuration: configuration
+            )
+        ) { error in
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .noCompatibleApplication)
+        }
+
+        var wrongRepository = makeManifest()
+        let hostileURL = try XCTUnwrap(URL(
+            string: "https://github.com/Elsewhere/Other/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip"
+        ))
+        wrongRepository.updater.macOSAppAsset?.url = hostileURL
+        wrongRepository.assets[0].url = hostileURL
+
+        XCTAssertThrowsError(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                wrongRepository,
+                configuration: configuration
+            )
+        ) { error in
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .noCompatibleApplication)
+        }
+    }
+
+    func testCheckerDecodesAndValidatesManifestData() async throws {
+        let data = try JSONEncoder().encode(makeManifest(version: "0.2.0", build: "1"))
+        let checker = QuillCodeDesktopUpdateChecker(loader: UpdateManifestLoaderStub(data: data))
+
+        let result = try await checker.check(configuration: makeConfiguration())
+
+        XCTAssertEqual(result, .updateAvailable(makeRelease(version: "0.2.0", build: "1")))
+    }
+
+    func testArchiveVerificationRejectsTampering() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let archive = root.appendingPathComponent("update.zip")
+        try Data("payload".utf8).write(to: archive)
+
+        try QuillCodeDesktopUpdatePreparer.verifyArchive(
+            at: archive,
+            expectedSize: 7,
+            expectedSHA256: "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5"
+        )
+        XCTAssertThrowsError(
+            try QuillCodeDesktopUpdatePreparer.verifyArchive(
+                at: archive,
+                expectedSize: 7,
+                expectedSHA256: String(repeating: "0", count: 64)
+            )
+        ) { error in
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .checksumMismatch)
+        }
+    }
+
+    func testHelperArgumentsRoundTripWithoutInterpretingPathsAsShell() throws {
+        let root = URL(fileURLWithPath: "/tmp/Quill Cowork update; untouched")
+        let request = QuillCodeDesktopUpdateHelperRequest(
+            parentProcessID: 123,
+            helperURL: root.appendingPathComponent("helper"),
+            incomingApplicationURL: root.appendingPathComponent(".Quill Cowork.update-id.app"),
+            destinationApplicationURL: root.appendingPathComponent("Quill Cowork.app"),
+            backupApplicationURL: root.appendingPathComponent(".Quill Cowork.backup-id.app"),
+            failedApplicationURL: root.appendingPathComponent(".Quill Cowork.failed-id.app"),
+            handshakeURL: root.appendingPathComponent("launch-id.ack"),
+            resultURL: root.appendingPathComponent("UpdateResult.json"),
+            logURL: root.appendingPathComponent("install.log"),
+            expectedBundleIdentifier: "co.lorehex.QuillCowork",
+            expectedVersion: "0.2.0",
+            expectedBuild: "99"
+        )
+
+        let parsed = try XCTUnwrap(QuillCodeDesktopUpdateHelperRequest.parse(
+            arguments: ["helper"] + request.arguments,
+            executableURL: request.helperURL
+        ))
+
+        XCTAssertEqual(parsed.parentProcessID, request.parentProcessID)
+        XCTAssertEqual(parsed.incomingApplicationURL, request.incomingApplicationURL)
+        XCTAssertEqual(parsed.destinationApplicationURL, request.destinationApplicationURL)
+        XCTAssertEqual(parsed.backupApplicationURL, request.backupApplicationURL)
+        XCTAssertEqual(parsed.failedApplicationURL, request.failedApplicationURL)
+        XCTAssertEqual(parsed.handshakeURL, request.handshakeURL)
+        XCTAssertEqual(parsed.resultURL, request.resultURL)
+        XCTAssertEqual(parsed.expectedVersion, request.expectedVersion)
+        XCTAssertEqual(parsed.expectedBuild, request.expectedBuild)
+    }
+
+    func testHelperCompletesVerifiedSwapAfterLaunchHandshake() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cacheRoot = root.appendingPathComponent("cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+        let destination = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        let incoming = root.appendingPathComponent(".Quill Cowork.update-success.app", isDirectory: true)
+        try makeFakeApplication(
+            at: destination,
+            version: "0.1.0",
+            build: "1",
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+        try makeFakeApplication(
+            at: incoming,
+            version: "0.2.0",
+            build: "2",
+            executableScript: """
+            #!/bin/sh
+            if [ "$1" = "--quillcode-update-handshake" ] && [ -n "$2" ]; then
+              printf 'ready\n' > "$2"
+            fi
+            exit 0
+            """
+        )
+        let resultURL = root.appendingPathComponent("UpdateResult.json")
+        let request = makeHelperRequest(
+            root: root,
+            cacheRoot: cacheRoot,
+            destination: destination,
+            incoming: incoming,
+            resultURL: resultURL,
+            expectedVersion: "0.2.0",
+            expectedBuild: "2",
+            suffix: "success"
+        )
+        let environment = QuillCodeDesktopUpdateHelperEnvironment(
+            cacheRootURL: cacheRoot,
+            resultURL: resultURL,
+            parentExitTimeout: 0.1,
+            launchHandshakeTimeout: 2
+        )
+
+        XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 0)
+        XCTAssertEqual(try bundleBuild(at: destination), "2")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: incoming.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.backupApplicationURL.path))
+        let result = try JSONDecoder().decode(
+            QuillCodeDesktopUpdateInstallResult.self,
+            from: Data(contentsOf: resultURL)
+        )
+        XCTAssertEqual(result.status, .success)
+        XCTAssertEqual(result.version, "0.2.0")
+        XCTAssertEqual(result.build, "2")
+    }
+
+    func testHelperTerminatesFailedChildAndRollsBack() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cacheRoot = root.appendingPathComponent("cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+        let destination = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        let incoming = root.appendingPathComponent(".Quill Cowork.update-rollback.app", isDirectory: true)
+        let childPIDURL = root.appendingPathComponent("failed-child.pid")
+        let rollbackLaunchedURL = root.appendingPathComponent("rollback-launched")
+        try makeFakeApplication(
+            at: destination,
+            version: "0.1.0",
+            build: "1",
+            executableScript: "#!/bin/sh\nprintf 'ready' > '\(rollbackLaunchedURL.path)'\nexit 0\n"
+        )
+        try makeFakeApplication(
+            at: incoming,
+            version: "0.2.0",
+            build: "2",
+            executableScript: "#!/bin/sh\nprintf '%s' \"$$\" > '\(childPIDURL.path)'\nsleep 30\n"
+        )
+        let resultURL = root.appendingPathComponent("UpdateResult.json")
+        let request = makeHelperRequest(
+            root: root,
+            cacheRoot: cacheRoot,
+            destination: destination,
+            incoming: incoming,
+            resultURL: resultURL,
+            expectedVersion: "0.2.0",
+            expectedBuild: "2",
+            suffix: "rollback"
+        )
+        let environment = QuillCodeDesktopUpdateHelperEnvironment(
+            cacheRootURL: cacheRoot,
+            resultURL: resultURL,
+            parentExitTimeout: 0.1,
+            launchHandshakeTimeout: 1
+        )
+
+        XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 1)
+        XCTAssertEqual(try bundleBuild(at: destination), "1")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.backupApplicationURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.failedApplicationURL.path))
+        let childPID = try XCTUnwrap(Int32(String(contentsOf: childPIDURL, encoding: .utf8)))
+        XCTAssertEqual(kill(childPID, 0), -1)
+        XCTAssertEqual(errno, ESRCH)
+        let result = try JSONDecoder().decode(
+            QuillCodeDesktopUpdateInstallResult.self,
+            from: Data(contentsOf: resultURL)
+        )
+        XCTAssertEqual(result.status, .failure)
+        XCTAssertTrue(result.message.contains("previous build was restored"))
+        let rollbackDeadline = Date().addingTimeInterval(1)
+        while !FileManager.default.fileExists(atPath: rollbackLaunchedURL.path),
+              Date() < rollbackDeadline {
+            usleep(10_000)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rollbackLaunchedURL.path))
+    }
+
+    func testBundledConfigurationReadsEveryReleaseFeedKey() throws {
+        let bundle = try makeApplicationBundle()
+
+        let configuration = try XCTUnwrap(
+            QuillCodeDesktopUpdateConfiguration.bundled(bundle: bundle, architecture: "arm64")
+        )
+
+        XCTAssertEqual(configuration.channel, .tester)
+        XCTAssertEqual(configuration.currentVersion, "0.1.0")
+        XCTAssertEqual(configuration.currentBuild, "42")
+        XCTAssertEqual(configuration.bundleIdentifier, "co.lorehex.QuillCowork")
+        XCTAssertEqual(configuration.architecture, "arm64")
+        XCTAssertEqual(configuration.expectedSigningTeamIdentifier, "ABCD123456")
+    }
+
+    private func version(_ value: String) throws -> QuillCodeDesktopSemanticVersion {
+        try XCTUnwrap(QuillCodeDesktopSemanticVersion(value))
+    }
+
+    private func makeHelperRequest(
+        root: URL,
+        cacheRoot: URL,
+        destination: URL,
+        incoming: URL,
+        resultURL: URL,
+        expectedVersion: String,
+        expectedBuild: String,
+        suffix: String
+    ) -> QuillCodeDesktopUpdateHelperRequest {
+        QuillCodeDesktopUpdateHelperRequest(
+            parentProcessID: Int32.max,
+            helperURL: root.appendingPathComponent("helper"),
+            incomingApplicationURL: incoming,
+            destinationApplicationURL: destination,
+            backupApplicationURL: root.appendingPathComponent(".Quill Cowork.backup-\(suffix).app"),
+            failedApplicationURL: root.appendingPathComponent(".Quill Cowork.failed-\(suffix).app"),
+            handshakeURL: cacheRoot.appendingPathComponent("launch-\(suffix).ack"),
+            resultURL: resultURL,
+            logURL: root.appendingPathComponent("install.log"),
+            expectedBundleIdentifier: "co.lorehex.QuillCowork",
+            expectedVersion: expectedVersion,
+            expectedBuild: expectedBuild
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func bundleBuild(at applicationURL: URL) throws -> String {
+        let infoURL = applicationURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        let data = try Data(contentsOf: infoURL)
+        let values = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+        return try XCTUnwrap(values["CFBundleVersion"] as? String)
+    }
+}
+
+private struct UpdateManifestLoaderStub: QuillCodeDesktopUpdateManifestLoading {
+    var data: Data
+
+    func loadManifest(from url: URL, byteLimit: Int) async throws -> Data {
+        guard data.count <= byteLimit else { throw QuillCodeDesktopUpdateError.manifestTooLarge }
+        return data
+    }
+}
+
+func makeConfiguration(
+    currentVersion: String = "0.1.0",
+    currentBuild: String = "42"
+) -> QuillCodeDesktopUpdateConfiguration {
+    QuillCodeDesktopUpdateConfiguration(
+        channel: .tester,
+        manifestURL: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"
+        )!,
+        stableManifestURL: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json"
+        )!,
+        testerManifestURL: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"
+        )!,
+        currentVersion: currentVersion,
+        currentBuild: currentBuild,
+        bundleIdentifier: "co.lorehex.QuillCowork",
+        architecture: "arm64",
+        applicationURL: URL(fileURLWithPath: "/Applications/Quill Cowork.app"),
+        expectedSigningTeamIdentifier: nil
+    )
+}
+
+private func makeManifest(
+    version: String = "0.1.0",
+    build: String = "43"
+) -> QuillCodeDesktopUpdateManifest {
+    let asset = makeAsset()
+    return QuillCodeDesktopUpdateManifest(
+        schemaVersion: 1,
+        product: "Quill Cowork",
+        channel: .tester,
+        tag: "tester-latest",
+        releaseURL: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest")!,
+        commit: String(repeating: "a", count: 40),
+        version: version,
+        build: build,
+        generatedAt: "2026-08-06T00:00:00Z",
+        workflowRunURL: URL(string: "https://github.com/Lore-Hex/QuillCode/actions/runs/1")!,
+        updater: .init(
+            schemaVersion: 1,
+            format: "github-release-manifest",
+            channel: .tester,
+            manifestURL: URL(
+                string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"
+            )!,
+            stableManifestURL: URL(
+                string: "https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json"
+            )!,
+            testerManifestURL: URL(
+                string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"
+            )!,
+            bundleIdentifier: "co.lorehex.QuillCowork",
+            minimumSystemVersion: "14.0",
+            codesign: "ad-hoc",
+            signingTeamIdentifier: nil,
+            notarized: false,
+            macOSAppAsset: asset
+        ),
+        assets: [asset]
+    )
+}
+
+func makeRelease(
+    version: String = "0.1.0",
+    build: String = "43"
+) -> QuillCodeDesktopUpdateRelease {
+    QuillCodeDesktopUpdateRelease(
+        channel: .tester,
+        tag: "tester-latest",
+        releaseURL: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest")!,
+        commit: String(repeating: "a", count: 40),
+        version: version,
+        build: build,
+        asset: makeAsset()
+    )
+}
+
+private func makeAsset() -> QuillCodeDesktopUpdateManifest.Asset {
+    QuillCodeDesktopUpdateManifest.Asset(
+        name: "Quill-Cowork-macOS-arm64.zip",
+        kind: "app",
+        platform: "macOS",
+        arch: "arm64",
+        install: "zip-app",
+        sizeBytes: 10_000,
+        sha256: String(repeating: "b", count: 64),
+        url: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip"
+        )!
+    )
+}
+
+private func makeApplicationBundle() throws -> Bundle {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        .appendingPathComponent("Quill Cowork.app", isDirectory: true)
+    let contents = root.appendingPathComponent("Contents", isDirectory: true)
+    let executableDirectory = contents.appendingPathComponent("MacOS", isDirectory: true)
+    try FileManager.default.createDirectory(at: executableDirectory, withIntermediateDirectories: true)
+    let executable = executableDirectory.appendingPathComponent("Quill Cowork")
+    try Data("#!/bin/sh\nexit 0\n".utf8).write(to: executable)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+    let plist: [String: Any] = [
+        "CFBundleExecutable": "Quill Cowork",
+        "CFBundleIdentifier": "co.lorehex.QuillCowork",
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": "0.1.0",
+        "CFBundleVersion": "42",
+        "QuillCodeUpdateChannel": "tester",
+        "QuillCodeUpdateManifestURL": "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json",
+        "QuillCodeStableUpdateManifestURL": "https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json",
+        "QuillCodeTesterUpdateManifestURL": "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json",
+        "QuillCodeSigningTeamIdentifier": "ABCD123456"
+    ]
+    let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+    try data.write(to: contents.appendingPathComponent("Info.plist"))
+    return try XCTUnwrap(Bundle(url: root))
+}
+
+private func makeFakeApplication(
+    at root: URL,
+    version: String,
+    build: String,
+    executableScript: String
+) throws {
+    let contents = root.appendingPathComponent("Contents", isDirectory: true)
+    let executableDirectory = contents.appendingPathComponent("MacOS", isDirectory: true)
+    try FileManager.default.createDirectory(at: executableDirectory, withIntermediateDirectories: true)
+    let executable = executableDirectory.appendingPathComponent("Quill Cowork")
+    try Data(executableScript.utf8).write(to: executable)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+    let plist: [String: Any] = [
+        "CFBundleExecutable": "Quill Cowork",
+        "CFBundleIdentifier": "co.lorehex.QuillCowork",
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": version,
+        "CFBundleVersion": build
+    ]
+    let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+    try data.write(to: contents.appendingPathComponent("Info.plist"))
+}

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -84,6 +84,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         )
         XCTAssertEqual(updater["bundleIdentifier"] as? String, "co.lorehex.QuillCowork")
         XCTAssertEqual(updater["minimumSystemVersion"] as? String, "14.0")
+        XCTAssertEqual(updater["codesign"] as? String, "unknown")
+        XCTAssertEqual(updater["notarized"] as? Bool, false)
+        XCTAssertNil(updater["signingTeamIdentifier"] as? String)
         let updaterAppAsset = try XCTUnwrap(updater["macOSAppAsset"] as? [String: Any])
         XCTAssertEqual(updaterAppAsset["name"] as? String, "Quill-Cowork-macOS-arm64.zip")
 
@@ -131,6 +134,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "--output \"$RUNNER_TEMP/release-assets/$MANIFEST_NAME\"",
             "RELEASE_CHANNEL=\"tester\"",
             "RELEASE_CHANNEL=\"stable\"",
+            "quillcode-macos-downloads/BUILD_INFO.txt",
             "\\`${MANIFEST_NAME}\\`: machine-readable build metadata",
             "updater feed metadata",
             "current-release-assets.txt",
@@ -185,7 +189,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "<key>QuillCodeUpdateChannel</key>",
             "<key>QuillCodeUpdateManifestURL</key>",
             "<key>QuillCodeStableUpdateManifestURL</key>",
-            "<key>QuillCodeTesterUpdateManifestURL</key>"
+            "<key>QuillCodeTesterUpdateManifestURL</key>",
+            "QuillCodeSigningTeamIdentifier"
         ])
         Self.assertSource(packageScript, containsAll: [
             "bundleIdentifier=$BUNDLE_ID",
@@ -193,7 +198,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "updateChannel=$UPDATE_CHANNEL",
             "updateManifestURL=$UPDATE_MANIFEST_URL",
             "stableUpdateManifestURL=$STABLE_MANIFEST_URL",
-            "testerUpdateManifestURL=$TESTER_MANIFEST_URL"
+            "testerUpdateManifestURL=$TESTER_MANIFEST_URL",
+            "signingTeamIdentifier=${SIGNING_TEAM_IDENTIFIER:-none}",
+            "notarized=$NOTARIZED"
         ])
         Self.assertSource(smokeScript, containsAll: [
             "assert_plist_value QuillCodeUpdateChannel tester",

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,25 @@
 # QuillCode Decisions
 
+## 2026-08-06: macOS updates use a verified staged swap with rollback
+
+- **Decision:** Quill Cowork consumes its embedded GitHub release manifest directly. It checks on a
+  channel-specific cadence and through a manual app-menu command, then validates repository, channel,
+  architecture, version/build, asset size, SHA-256, app identity, code signature, and configured
+  signing team before offering Update and Relaunch.
+- **Crash boundary:** The running app copies the verified bundle to a hidden sibling and launches a
+  copied helper. The helper waits for the parent to exit, keeps the old bundle as a backup, activates
+  the staged bundle, and requires a launch-handshake file from the new app. A missing handshake rolls
+  back and reopens the prior bundle instead of leaving a broken installation.
+- **Distribution boundary:** Tester builds may remain ad-hoc signed for rapid iteration. Stable tags
+  fail closed unless CI has a Developer ID Application certificate, signing team, and App Store
+  Connect API key; configured builds use the hardened runtime, `notarytool`, and a stapled ticket.
+- **Why:** An update feed without an in-app consumer does not make the product updateable, while a
+  blind self-replacement can strand users. The staged handshake keeps updates user-visible and
+  recoverable while preserving a direct browser fallback for read-only or protected locations.
+- **Evidence:** `QuillCodeDesktopUpdateController`, `QuillCodeDesktopUpdatePreparer`,
+  `QuillCodeDesktopUpdateHelper`, `scripts/package-macos-downloads.sh`, and
+  `QuillCodeDesktopUpdateTests`.
+
 ## 2026-07-27: Office Coworker Catalog Drives QuillCode Parity Tracking
 
 - **Decision:** Treat the office coworker task spreadsheet as the canonical QuillCode coverage
@@ -891,8 +911,8 @@
   and explicitly not notarized until Apple signing/notarization credentials are configured.
 - Tester releases also publish `latest-tester-build.json` as a machine-readable download manifest. The manifest records
   channel, tag, commit, workflow run, version/build metadata, and per-asset URL/size/platform/arch/SHA-256 fields so the
-  website, support scripts, and future in-app updater experiments can consume the same stable tester channel without
-  scraping GitHub release HTML.
+  website, support scripts, and in-app updater consume the same stable tester channel without scraping GitHub release
+  HTML.
 - QuillCode keeps TrustedRouter model-advisor guidance as a compact skill-backed pointer in the base prompt instead of
   carrying the full Lore-Hex/LLM-advisor playbook on every request. The prompt names the live-data-first behavior,
   concise 2-5 option recommendations, key privacy filters, and secret-handling guardrails; detailed model-selection

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -21,7 +21,7 @@ The build manifest is the app updater, website, and support script contract. It
 records the build channel, tag, commit, workflow run URL, version, build number,
 per-asset download URL, size, platform, architecture, and SHA-256 digest. It also
 includes an `updater` object with the feed URL, bundle identifier, minimum macOS
-version, and current macOS app asset.
+version, signing/notarization status, and current macOS app asset.
 
 ## Build Cadence
 
@@ -56,20 +56,29 @@ The stable feed is:
 https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json
 ```
 
-Updater clients should fetch the configured manifest, compare
-`CFBundleShortVersionString` plus `CFBundleVersion` against the manifest
-`version` plus `build`, select the `assets` entry where `kind` is `app`,
-`platform` is `macOS`, and `arch` matches the machine, verify the SHA-256 digest,
-then download and install that zip. Current tester builds are ad-hoc signed and
-not notarized, so silent in-place replacement should stay behind a signed and
-notarized stable release path. Tester updates can safely present the verified
-download and installation handoff.
+The macOS app checks this feed after launch, no more than every six hours on the
+tester channel or daily on stable. **Check for Updates...** in the app menu runs
+an immediate check. The updater compares `CFBundleShortVersionString` plus
+`CFBundleVersion`, requires the configured repository, product, channel, bundle
+identifier, architecture, and signing identity, downloads on demand, and verifies
+the exact size, SHA-256 digest, app identity, version, architecture, and macOS code
+signature before installation.
+
+Installation stages the verified app beside the running bundle, then uses a
+detached helper for the final rename and relaunch. The new app must complete a
+launch handshake within 45 seconds. Otherwise the helper restores and reopens the
+previous bundle. Background check failures stay quiet; user-initiated failures
+remain visible and retain a direct browser-download fallback.
 
 ## Tester Install Notes
 
 The macOS tester app is ad-hoc signed but not notarized yet. Testers may need to
 right-click **Open** the first time. Computer Use still requires normal macOS
 Screen Recording and Accessibility permissions.
+
+Tester builds support the same user-initiated update and rollback flow. A stable
+tag cannot publish a macOS app unless Developer ID signing and Apple notarization
+are configured.
 
 The app is still a tester build, so ask testers to include:
 
@@ -89,6 +98,26 @@ git push origin v0.1.0
 
 Use versioned releases for public announcements. Use `tester-latest` for quick
 iteration with early testers.
+
+## Apple Distribution Credentials
+
+The **Download Builds** workflow uses these repository secrets when present:
+
+- `APPLE_DEVELOPER_ID_CERTIFICATE_BASE64`
+- `APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD`
+- `APPLE_DEVELOPER_ID_APPLICATION_IDENTITY`
+- `APPLE_TEAM_ID`
+- `APPLE_NOTARY_KEY_ID`
+- `APPLE_NOTARY_ISSUER_ID`
+- `APPLE_NOTARY_PRIVATE_KEY_BASE64`
+
+The certificate secret is a base64-encoded Developer ID Application `.p12`. The
+notary key secret is a base64-encoded App Store Connect API `.p8`. The workflow
+imports both into a temporary runner-only signing area, enables the hardened
+runtime, submits the zipped app to `notarytool`, staples and validates the ticket,
+and deletes temporary credential files. Partial secret configuration fails the
+macOS job. Missing secrets still permit ad-hoc tester builds, but stable `v*` tags
+fail before packaging.
 
 ## Manual Build Refresh
 

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -94,6 +94,9 @@ def build_updater_metadata(
         asset for asset in assets
         if asset.get("kind") == "app" and asset.get("platform") == "macOS"
     ]
+    signing_team = build_info.get("signingTeamIdentifier")
+    if not signing_team or signing_team == "none":
+        signing_team = None
     return {
         "schemaVersion": 1,
         "format": "github-release-manifest",
@@ -103,6 +106,9 @@ def build_updater_metadata(
         "testerManifestURL": release_download_url(repo, "tester-latest", "latest-tester-build.json"),
         "bundleIdentifier": build_info.get("bundleIdentifier", "co.lorehex.QuillCowork"),
         "minimumSystemVersion": build_info.get("minimumSystemVersion", "14.0"),
+        "codesign": build_info.get("codesign", "unknown"),
+        "signingTeamIdentifier": signing_team,
+        "notarized": build_info.get("notarized", "false").lower() == "true",
         "macOSAppAsset": app_assets[0] if app_assets else None,
     }
 

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -13,6 +13,9 @@ UPDATE_CHANNEL="${QUILLCODE_MACOS_UPDATE_CHANNEL:-tester}"
 UPDATE_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json}"
 UPDATE_STABLE_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_STABLE_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json}"
 UPDATE_TESTER_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_TESTER_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json}"
+SIGNING_IDENTITY="${QUILLCODE_MACOS_SIGNING_IDENTITY:-}"
+SIGNING_TEAM_IDENTIFIER="${QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER:-}"
+SIGNING_KEYCHAIN="${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -115,10 +118,32 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
 </plist>
 PLIST
 
+if [[ -n "$SIGNING_TEAM_IDENTIFIER" ]]; then
+  /usr/libexec/PlistBuddy -c \
+    "Add :QuillCodeSigningTeamIdentifier string $SIGNING_TEAM_IDENTIFIER" \
+    "$CONTENTS_DIR/Info.plist"
+fi
+
 printf 'APPL????' > "$CONTENTS_DIR/PkgInfo"
 plutil -lint "$CONTENTS_DIR/Info.plist" >&2
 
-if [[ "${QUILLCODE_MACOS_ADHOC_CODESIGN:-0}" == "1" ]]; then
+if [[ -n "$SIGNING_IDENTITY" ]]; then
+  if [[ -z "$SIGNING_TEAM_IDENTIFIER" ]]; then
+    echo "QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER is required for Developer ID signing." >&2
+    exit 2
+  fi
+  CODESIGN_ARGUMENTS=(
+    --force
+    --options runtime
+    --timestamp
+    --sign "$SIGNING_IDENTITY"
+  )
+  if [[ -n "$SIGNING_KEYCHAIN" ]]; then
+    CODESIGN_ARGUMENTS+=(--keychain "$SIGNING_KEYCHAIN")
+  fi
+  codesign "${CODESIGN_ARGUMENTS[@]}" "$APP_BUNDLE" >&2
+  codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE" >&2
+elif [[ "${QUILLCODE_MACOS_ADHOC_CODESIGN:-0}" == "1" ]]; then
   codesign --force --deep --sign - "$APP_BUNDLE" >&2
 fi
 

--- a/scripts/configure-macos-distribution-signing.sh
+++ b/scripts/configure-macos-distribution-signing.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CERTIFICATE_BASE64="${APPLE_DEVELOPER_ID_CERTIFICATE_BASE64:-}"
+CERTIFICATE_PASSWORD="${APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD:-}"
+SIGNING_IDENTITY="${APPLE_DEVELOPER_ID_APPLICATION_IDENTITY:-}"
+SIGNING_TEAM_IDENTIFIER="${APPLE_TEAM_ID:-}"
+NOTARY_KEY_ID="${APPLE_NOTARY_KEY_ID:-}"
+NOTARY_ISSUER_ID="${APPLE_NOTARY_ISSUER_ID:-}"
+NOTARY_KEY_BASE64="${APPLE_NOTARY_PRIVATE_KEY_BASE64:-}"
+
+VALUES=(
+  "$CERTIFICATE_BASE64"
+  "$CERTIFICATE_PASSWORD"
+  "$SIGNING_IDENTITY"
+  "$SIGNING_TEAM_IDENTIFIER"
+  "$NOTARY_KEY_ID"
+  "$NOTARY_ISSUER_ID"
+  "$NOTARY_KEY_BASE64"
+)
+CONFIGURED_VALUES=0
+for value in "${VALUES[@]}"; do
+  if [[ -n "$value" ]]; then
+    CONFIGURED_VALUES=$((CONFIGURED_VALUES + 1))
+  fi
+done
+
+if [[ "$CONFIGURED_VALUES" == 0 ]]; then
+  echo "Apple distribution signing is not configured; tester builds will use ad-hoc signing."
+  exit 0
+fi
+if [[ "$CONFIGURED_VALUES" != "${#VALUES[@]}" ]]; then
+  echo "Apple distribution signing secrets are only partially configured." >&2
+  exit 2
+fi
+if [[ -z "${RUNNER_TEMP:-}" || -z "${GITHUB_ENV:-}" ]]; then
+  echo "RUNNER_TEMP and GITHUB_ENV are required on the signing runner." >&2
+  exit 2
+fi
+
+SIGNING_ROOT="$RUNNER_TEMP/quill-cowork-signing"
+CERTIFICATE_PATH="$SIGNING_ROOT/developer-id.p12"
+NOTARY_KEY_PATH="$SIGNING_ROOT/AuthKey_${NOTARY_KEY_ID}.p8"
+KEYCHAIN_PATH="$SIGNING_ROOT/build.keychain-db"
+KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+
+mkdir -p "$SIGNING_ROOT"
+chmod 700 "$SIGNING_ROOT"
+printf '%s' "$CERTIFICATE_BASE64" | openssl base64 -d -A > "$CERTIFICATE_PATH"
+printf '%s' "$NOTARY_KEY_BASE64" | openssl base64 -d -A > "$NOTARY_KEY_PATH"
+chmod 600 "$CERTIFICATE_PATH" "$NOTARY_KEY_PATH"
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security import "$CERTIFICATE_PATH" \
+  -k "$KEYCHAIN_PATH" \
+  -P "$CERTIFICATE_PASSWORD" \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: \
+  -s \
+  -k "$KEYCHAIN_PASSWORD" \
+  "$KEYCHAIN_PATH"
+security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -F "$SIGNING_IDENTITY" >/dev/null
+
+{
+  echo "QUILLCODE_MACOS_SIGNING_IDENTITY=$SIGNING_IDENTITY"
+  echo "QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER=$SIGNING_TEAM_IDENTIFIER"
+  echo "QUILLCODE_MACOS_SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
+  echo "QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH=$CERTIFICATE_PATH"
+  echo "QUILLCODE_MACOS_NOTARY_KEY_ID=$NOTARY_KEY_ID"
+  echo "QUILLCODE_MACOS_NOTARY_ISSUER_ID=$NOTARY_ISSUER_ID"
+  echo "QUILLCODE_MACOS_NOTARY_KEY_PATH=$NOTARY_KEY_PATH"
+} >> "$GITHUB_ENV"
+
+echo "Configured Developer ID signing and App Store Connect notarization credentials."

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -12,6 +12,12 @@ BUNDLE_ID="${QUILLCODE_MACOS_BUNDLE_ID:-co.lorehex.QuillCowork}"
 MINIMUM_SYSTEM_VERSION="${QUILLCODE_MACOS_MINIMUM_SYSTEM_VERSION:-14.0}"
 REPO="${GITHUB_REPOSITORY:-Lore-Hex/QuillCode}"
 UPDATE_CHANNEL="${QUILLCODE_UPDATE_CHANNEL:-tester}"
+SIGNING_IDENTITY="${QUILLCODE_MACOS_SIGNING_IDENTITY:-}"
+SIGNING_TEAM_IDENTIFIER="${QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER:-}"
+SIGNING_KEYCHAIN="${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}"
+NOTARY_KEY_ID="${QUILLCODE_MACOS_NOTARY_KEY_ID:-}"
+NOTARY_ISSUER_ID="${QUILLCODE_MACOS_NOTARY_ISSUER_ID:-}"
+NOTARY_KEY_PATH="${QUILLCODE_MACOS_NOTARY_KEY_PATH:-}"
 TESTER_MANIFEST_URL="${QUILLCODE_TESTER_UPDATE_MANIFEST_URL:-https://github.com/$REPO/releases/download/tester-latest/latest-tester-build.json}"
 STABLE_MANIFEST_URL="${QUILLCODE_STABLE_UPDATE_MANIFEST_URL:-https://github.com/$REPO/releases/latest/download/latest-stable-build.json}"
 ASSET_DIR="$DIST_DIR/assets"
@@ -31,6 +37,17 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 2
 fi
 
+if [[ "$UPDATE_CHANNEL" == "stable" ]]; then
+  if [[ -z "$SIGNING_IDENTITY" || -z "$SIGNING_TEAM_IDENTIFIER" ]]; then
+    echo "Stable macOS builds require a Developer ID signing identity and team identifier." >&2
+    exit 2
+  fi
+  if [[ -z "$NOTARY_KEY_ID" || -z "$NOTARY_ISSUER_ID" || -z "$NOTARY_KEY_PATH" ]]; then
+    echo "Stable macOS builds require App Store Connect notarization credentials." >&2
+    exit 2
+  fi
+fi
+
 cd "$ROOT_DIR"
 rm -rf "$DIST_DIR"
 mkdir -p "$ASSET_DIR" "$CLI_DIR"
@@ -45,6 +62,9 @@ APP_BUNDLE="$(
   QUILLCODE_MACOS_UPDATE_MANIFEST_URL="$UPDATE_MANIFEST_URL" \
   QUILLCODE_MACOS_UPDATE_STABLE_MANIFEST_URL="$STABLE_MANIFEST_URL" \
   QUILLCODE_MACOS_UPDATE_TESTER_MANIFEST_URL="$TESTER_MANIFEST_URL" \
+  QUILLCODE_MACOS_SIGNING_IDENTITY="$SIGNING_IDENTITY" \
+  QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER="$SIGNING_TEAM_IDENTIFIER" \
+  QUILLCODE_MACOS_SIGNING_KEYCHAIN="$SIGNING_KEYCHAIN" \
   QUILLCODE_MACOS_ADHOC_CODESIGN="${QUILLCODE_MACOS_ADHOC_CODESIGN:-1}" \
     "$ROOT_DIR/scripts/build-macos-app.sh" \
       --configuration "$CONFIGURATION" \
@@ -52,6 +72,30 @@ APP_BUNDLE="$(
 )"
 
 APP_ZIP="$ASSET_DIR/Quill-Cowork-macOS-$ARCH.zip"
+NOTARIZED=false
+CODESIGN_KIND="ad-hoc"
+if [[ -n "$SIGNING_IDENTITY" ]]; then
+  CODESIGN_KIND="developer-id"
+  if [[ -n "$NOTARY_KEY_ID" && -n "$NOTARY_ISSUER_ID" && -n "$NOTARY_KEY_PATH" ]]; then
+    if [[ ! -f "$NOTARY_KEY_PATH" ]]; then
+      echo "Notarization private key does not exist: $NOTARY_KEY_PATH" >&2
+      exit 2
+    fi
+    NOTARY_ARCHIVE="$DIST_DIR/notarization-submission.zip"
+    ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$NOTARY_ARCHIVE"
+    xcrun notarytool submit "$NOTARY_ARCHIVE" \
+      --key "$NOTARY_KEY_PATH" \
+      --key-id "$NOTARY_KEY_ID" \
+      --issuer "$NOTARY_ISSUER_ID" \
+      --wait
+    xcrun stapler staple "$APP_BUNDLE"
+    xcrun stapler validate "$APP_BUNDLE"
+    codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+    spctl --assess --type execute --verbose=2 "$APP_BUNDLE"
+    NOTARIZED=true
+    rm -f "$NOTARY_ARCHIVE"
+  fi
+fi
 ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$APP_ZIP"
 
 echo "==> Packaging quill-code macOS CLI ($ARCH)"
@@ -89,8 +133,9 @@ stableUpdateManifestURL=$STABLE_MANIFEST_URL
 testerUpdateManifestURL=$TESTER_MANIFEST_URL
 app=Quill-Cowork-macOS-$ARCH.zip
 cli=quill-code-macOS-$ARCH.tar.gz
-codesign=ad-hoc
-notarized=false
+codesign=$CODESIGN_KIND
+signingTeamIdentifier=${SIGNING_TEAM_IDENTIFIER:-none}
+notarized=$NOTARIZED
 INFO
 
 (


### PR DESCRIPTION
## Summary
- add a native Quill Cowork updater with trusted GitHub feed validation, bounded disk-backed downloads, SHA-256/code-signature/architecture checks, and semantic version selection
- add a staged helper install with launch handshake, exact-process ownership, automatic rollback, and one-shot bounded result reporting
- add polished manual and automatic update UX in the app/menu bar, with quiet throttled background checks and browser fallback
- add Developer ID signing and Apple notarization support to Download Builds; stable publication fails closed without complete credentials
- publish signing/notarization metadata in update manifests and document the release setup

## Validation
- `swift test --filter 'QuillCodeDesktopUpdate|ParityDownloadBuildsGateTests|QuillCodeNativeHitTargetSourceAuditTests'` (26 passed)
- `swift build --configuration release --product quill-code-desktop`
- `scripts/packaged-macos-smoke.sh` (direct launch, Launch Services, AX/click contracts, live window)
- release-mode tester packaging, code-sign verification, checksum verification, and manifest generation
- stable packaging verified to exit before build when Developer ID/notary credentials are absent
- real packaged updater exercised against the public tester feed, including failed-launch rollback and cleanup
- full suite exercised (5,311 tests); after fixing the updater hit-target audit, the only local failures are three unrelated shell tests whose expected output is polluted by an existing `~/.profile` error: `/.local/bin/env: No such file or directory`

## Distribution note
The stable signing/notarization path is implemented and fail-closed, but requires the documented Apple repository secrets before a notarized stable tag can publish.
