### PR TITLE
Preserve updater cleanup path across helper launch

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
@@ -167,6 +167,7 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
             "--failed-app", failedApplicationURL.path,
             "--handshake", handshakeURL.path,
             "--result", resultURL.path,
+            "--log", logURL.path,
             "--bundle-id", expectedBundleIdentifier,
             "--version", expectedVersion,
             "--build", expectedBuild
@@ -195,6 +196,7 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
               let failed = values["--failed-app"],
               let handshake = values["--handshake"],
               let result = values["--result"],
+              let log = values["--log"],
               let bundleIdentifier = values["--bundle-id"],
               let version = values["--version"],
               let build = values["--build"]
@@ -210,7 +212,7 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
             failedApplicationURL: URL(fileURLWithPath: failed).standardizedFileURL,
             handshakeURL: URL(fileURLWithPath: handshake).standardizedFileURL,
             resultURL: URL(fileURLWithPath: result).standardizedFileURL,
-            logURL: URL(fileURLWithPath: "/dev/null"),
+            logURL: URL(fileURLWithPath: log).standardizedFileURL,
             expectedBundleIdentifier: bundleIdentifier,
             expectedVersion: version,
             expectedBuild: build

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -160,6 +160,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         XCTAssertEqual(parsed.failedApplicationURL, request.failedApplicationURL)
         XCTAssertEqual(parsed.handshakeURL, request.handshakeURL)
         XCTAssertEqual(parsed.resultURL, request.resultURL)
+        XCTAssertEqual(parsed.logURL, request.logURL)
         XCTAssertEqual(parsed.expectedVersion, request.expectedVersion)
         XCTAssertEqual(parsed.expectedBuild, request.expectedBuild)
     }
@@ -211,7 +212,12 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             launchHandshakeTimeout: 2
         )
 
-        XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 0)
+        let parsedRequest = try XCTUnwrap(QuillCodeDesktopUpdateHelperRequest.parse(
+            arguments: [request.helperURL.path] + request.arguments,
+            executableURL: request.helperURL
+        ))
+
+        XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(parsedRequest, environment: environment), 0)
         XCTAssertEqual(try bundleBuild(at: destination), "2")
         XCTAssertFalse(FileManager.default.fileExists(atPath: incoming.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: request.backupApplicationURL.path))


### PR DESCRIPTION
## Summary
- serialize the validated updater log path into the launched helper request
- preserve that path while parsing the cross-process request
- run the successful cleanup test through request serialization and parsing

## Real-world finding
A live build-1 to build-618 update pruned old workspaces but retained the current successful workspace because the parsed helper used /dev/null for its log path and correctly failed its cleanup safety guard.

## Verification
- swift test --filter QuillCodeDesktopUpdate (15 passed)
- git diff --check