### PR TITLE
Harden download release publishing policy

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -9,6 +9,7 @@ on:
     - cron: "17 10 * * *"
 
 permissions:
+  actions: read
   contents: write
 
 concurrency:
@@ -16,7 +17,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate download build ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/validate-download-build-ref.sh
+
   macos:
+    needs: release-policy
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +78,7 @@ jobs:
           retention-days: 14
 
   linux:
+    needs: release-policy
     runs-on: ubuntu-latest
     container: swift:6.2-noble
     steps:
@@ -138,14 +152,10 @@ jobs:
             RELEASE_TAG="${GITHUB_REF_NAME}"
             RELEASE_TITLE="Quill Cowork ${GITHUB_REF_NAME}"
             RELEASE_CHANNEL="stable"
-            PRERELEASE_FLAG=()
-            LATEST_FLAG=(--latest)
           else
             RELEASE_TAG="tester-latest"
             RELEASE_TITLE="Quill Cowork Tester Build"
             RELEASE_CHANNEL="tester"
-            PRERELEASE_FLAG=(--prerelease)
-            LATEST_FLAG=(--latest=false)
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git tag -f "$RELEASE_TAG" "$GITHUB_SHA"
@@ -176,27 +186,42 @@ jobs:
           macOS distribution note: ${MACOS_DISTRIBUTION_NOTE} Computer Use still requires normal macOS Screen Recording and Accessibility permissions.
           NOTES
 
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release edit "$RELEASE_TAG" \
-              --title "$RELEASE_TITLE" \
-              --notes-file "$RUNNER_TEMP/release-notes.md" \
-              --target "$GITHUB_SHA" \
-              "${PRERELEASE_FLAG[@]}"
-          else
+          if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              echo "Stable release $RELEASE_TAG already exists and is immutable." >&2
+              exit 2
+            fi
             gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --draft \
               --title "$RELEASE_TITLE" \
               --notes-file "$RUNNER_TEMP/release-notes.md" \
-              --target "$GITHUB_SHA" \
-              "${PRERELEASE_FLAG[@]}" \
-              "${LATEST_FLAG[@]}"
+              --target "$GITHUB_SHA"
+            gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/*
+            gh release edit "$RELEASE_TAG" --draft=false --latest
+          else
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release edit "$RELEASE_TAG" \
+                --title "$RELEASE_TITLE" \
+                --notes-file "$RUNNER_TEMP/release-notes.md" \
+                --target "$GITHUB_SHA" \
+                --prerelease
+            else
+              gh release create "$RELEASE_TAG" \
+                --title "$RELEASE_TITLE" \
+                --notes-file "$RUNNER_TEMP/release-notes.md" \
+                --target "$GITHUB_SHA" \
+                --prerelease \
+                --latest=false
+            fi
+
+            find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -printf '%f\n' | sort > "$RUNNER_TEMP/current-release-assets.txt"
+            gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' |
+              while IFS= read -r asset_name; do
+                if [[ -n "$asset_name" ]] && ! grep -Fxq "$asset_name" "$RUNNER_TEMP/current-release-assets.txt"; then
+                  gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
+                fi
+              done
+
+            gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/* --clobber
           fi
-
-          find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -printf '%f\n' | sort > "$RUNNER_TEMP/current-release-assets.txt"
-          gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' |
-            while IFS= read -r asset_name; do
-              if [[ -n "$asset_name" ]] && ! grep -Fxq "$asset_name" "$RUNNER_TEMP/current-release-assets.txt"; then
-                gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
-              fi
-            done
-
-          gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/* --clobber

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -125,6 +125,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         let workflow = try Self.workflowText(named: "download-builds.yml")
 
         Self.assertSource(workflow, containsAll: [
+            "actions: read",
+            "release-policy:",
+            "scripts/validate-download-build-ref.sh",
+            "needs: release-policy",
             "group: download-builds-${{ github.ref }}",
             "cancel-in-progress: false",
             "QUILLCODE_UPDATE_CHANNEL=stable",
@@ -139,7 +143,12 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "updater feed metadata",
             "current-release-assets.txt",
             "gh release delete-asset \"$RELEASE_TAG\" \"$asset_name\" --yes",
-            "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/* --clobber"
+            "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/* --clobber",
+            "--verify-tag",
+            "--draft",
+            "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/*",
+            "gh release edit \"$RELEASE_TAG\" --draft=false --latest",
+            "Stable release $RELEASE_TAG already exists and is immutable."
         ])
         XCTAssertFalse(
             workflow.contains("cancel-in-progress: true"),
@@ -160,6 +169,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "QuillCodeUpdateManifestURL",
             "QuillCodeStableUpdateManifestURL",
             "QuillCodeTesterUpdateManifestURL",
+            "canonical `vMAJOR.MINOR.PATCH` tag",
+            "an existing stable release is never edited or clobbered automatically",
             "channel is `tester`",
             "channel is `stable`"
         ])

--- a/Tests/QuillCodeParityTests/ParityDownloadReleasePolicyGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadReleasePolicyGateTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+
+final class ParityDownloadReleasePolicyGateTests: QuillCodeParityTestCase {
+    func testCurrentMainTesterBuildPasses() throws {
+        let result = try runPolicy(refType: "branch", refName: "main")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Validated tester download build at current main commit"))
+        XCTAssertTrue(result.ghLog.isEmpty)
+    }
+
+    func testTesterBuildRejectsFeatureAndStaleMainRefs() throws {
+        let feature = try runPolicy(refType: "branch", refName: "feature")
+        let stale = try runPolicy(
+            refType: "branch",
+            refName: "main",
+            mainCommit: String(repeating: "b", count: 40)
+        )
+
+        XCTAssertEqual(feature.exitCode, 2, feature.output)
+        XCTAssertTrue(feature.output.contains("only be published from main"))
+        XCTAssertEqual(stale.exitCode, 2, stale.output)
+        XCTAssertTrue(stale.output.contains("Refusing to publish a stale tester build"))
+    }
+
+    func testStableBuildRequiresCanonicalTagOnMain() throws {
+        let malformed = try runPolicy(refType: "tag", refName: "v1.2")
+        let offMain = try runPolicy(refType: "tag", refName: "v1.2.3", isMainAncestor: false)
+
+        XCTAssertEqual(malformed.exitCode, 2, malformed.output)
+        XCTAssertTrue(malformed.output.contains("canonical vMAJOR.MINOR.PATCH"))
+        XCTAssertEqual(offMain.exitCode, 2, offMain.output)
+        XCTAssertTrue(offMain.output.contains("must point to a commit on main"))
+    }
+
+    func testStableBuildRequiresSuccessfulCIAndNewRelease() throws {
+        let missingCI = try runPolicy(refType: "tag", refName: "v1.2.3", successfulCIRuns: 0)
+        let existingRelease = try runPolicy(refType: "tag", refName: "v1.2.3", releaseExists: true)
+
+        XCTAssertEqual(missingCI.exitCode, 2, missingCI.output)
+        XCTAssertTrue(missingCI.output.contains("requires a successful CI run"))
+        XCTAssertEqual(existingRelease.exitCode, 2, existingRelease.output)
+        XCTAssertTrue(existingRelease.output.contains("already exists and is immutable"))
+    }
+
+    func testValidatedStableBuildPassesWithCIAndNoExistingRelease() throws {
+        let result = try runPolicy(refType: "tag", refName: "v1.2.3")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Validated immutable stable release v1.2.3"))
+        XCTAssertTrue(result.ghLog.contains("run list --repo Lore-Hex/QuillCode --workflow ci.yml"))
+        XCTAssertTrue(result.ghLog.contains("release view v1.2.3 --repo Lore-Hex/QuillCode"))
+    }
+
+    private struct PolicyResult {
+        var exitCode: Int32
+        var output: String
+        var ghLog: String
+    }
+
+    private func runPolicy(
+        refType: String,
+        refName: String,
+        commit: String = String(repeating: "a", count: 40),
+        mainCommit: String? = nil,
+        tagCommit: String? = nil,
+        isMainAncestor: Bool = true,
+        successfulCIRuns: Int = 1,
+        releaseExists: Bool = false
+    ) throws -> PolicyResult {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-release-policy-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let binDirectory = temporaryDirectory.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let gitURL = binDirectory.appendingPathComponent("git")
+        let ghURL = binDirectory.appendingPathComponent("gh")
+        let ghLogURL = temporaryDirectory.appendingPathComponent("gh.log")
+        try fakeGit.write(to: gitURL, atomically: true, encoding: .utf8)
+        try fakeGH.write(to: ghURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: gitURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: ghURL.path)
+
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts")
+                .appendingPathComponent("validate-download-build-ref.sh")
+                .path
+        ]
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(binDirectory.path):\(environment["PATH"] ?? "")"
+        environment["GITHUB_REF_TYPE"] = refType
+        environment["GITHUB_REF_NAME"] = refName
+        environment["GITHUB_SHA"] = commit
+        environment["GITHUB_REPOSITORY"] = "Lore-Hex/QuillCode"
+        environment["RELEASE_POLICY_MAIN_COMMIT"] = mainCommit ?? commit
+        environment["RELEASE_POLICY_TAG_COMMIT"] = tagCommit ?? commit
+        environment["RELEASE_POLICY_IS_MAIN_ANCESTOR"] = isMainAncestor ? "true" : "false"
+        environment["RELEASE_POLICY_SUCCESSFUL_CI_RUNS"] = String(successfulCIRuns)
+        environment["RELEASE_POLICY_RELEASE_EXISTS"] = releaseExists ? "true" : "false"
+        environment["RELEASE_POLICY_GH_LOG"] = ghLogURL.path
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let ghLog = (try? String(contentsOf: ghLogURL, encoding: .utf8)) ?? ""
+        return PolicyResult(exitCode: process.terminationStatus, output: output, ghLog: ghLog)
+    }
+
+    private var fakeGit: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [[ "$1" == "fetch" ]]; then
+          exit 0
+        fi
+        if [[ "$1" == "rev-parse" && "$2" == "--verify" ]]; then
+          case "$3" in
+            refs/remotes/origin/main*) printf '%s\n' "${RELEASE_POLICY_MAIN_COMMIT:?}" ;;
+            refs/tags/*) printf '%s\n' "${RELEASE_POLICY_TAG_COMMIT:?}" ;;
+            *) printf '%s\n' "${GITHUB_SHA:?}" ;;
+          esac
+          exit 0
+        fi
+        if [[ "$1" == "merge-base" && "$2" == "--is-ancestor" ]]; then
+          [[ "${RELEASE_POLICY_IS_MAIN_ANCESTOR:?}" == "true" ]]
+          exit
+        fi
+        echo "unexpected git invocation: $*" >&2
+        exit 9
+        """
+    }
+
+    private var fakeGH: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${RELEASE_POLICY_GH_LOG:?}"
+        if [[ "$1" == "run" && "$2" == "list" ]]; then
+          printf '%s\n' "${RELEASE_POLICY_SUCCESSFUL_CI_RUNS:?}"
+          exit 0
+        fi
+        if [[ "$1" == "release" && "$2" == "view" ]]; then
+          [[ "${RELEASE_POLICY_RELEASE_EXISTS:?}" == "true" ]]
+          exit
+        fi
+        echo "unexpected gh invocation: $*" >&2
+        exit 9
+        """
+    }
+}

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -89,12 +89,24 @@ The app is still a tester build, so ask testers to include:
 
 ## Versioned Releases
 
-Push a tag such as `v0.1.0` to create a versioned release with the same assets:
+Stable releases are immutable and must use a canonical `vMAJOR.MINOR.PATCH` tag
+pointing to a commit on `main` with a successful **CI** run. Start from a clean,
+current `main`, verify that all Apple distribution secrets below are configured,
+then push the tag:
 
 ```bash
+git switch main
+git pull --ff-only origin main
+gh run list --workflow ci.yml --commit "$(git rev-parse HEAD)" --status success --limit 1
 git tag v0.1.0
 git push origin v0.1.0
 ```
+
+The workflow rejects tags that are malformed, off `main`, missing successful CI,
+or already published. It creates the stable release as a draft, uploads every
+asset, and only then publishes it as the latest release. If a stable publish
+fails after creating its draft, inspect and delete that draft before retrying;
+an existing stable release is never edited or clobbered automatically.
 
 Use versioned releases for public announcements. Use `tester-latest` for quick
 iteration with early testers.

--- a/scripts/validate-download-build-ref.sh
+++ b/scripts/validate-download-build-ref.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REF_TYPE="${GITHUB_REF_TYPE:?GITHUB_REF_TYPE is required}"
+REF_NAME="${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
+COMMIT="${GITHUB_SHA:?GITHUB_SHA is required}"
+REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+git fetch --no-tags --prune origin \
+  +refs/heads/main:refs/remotes/origin/main
+
+MAIN_COMMIT="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')"
+CHECKED_OUT_COMMIT="$(git rev-parse --verify "${COMMIT}^{commit}")"
+if [[ "$CHECKED_OUT_COMMIT" != "$COMMIT" ]]; then
+  echo "Download build commit did not resolve exactly: $COMMIT" >&2
+  exit 2
+fi
+
+if [[ "$REF_TYPE" == "branch" ]]; then
+  if [[ "$REF_NAME" != "main" ]]; then
+    echo "Tester downloads may only be published from main, not $REF_NAME." >&2
+    exit 2
+  fi
+  if [[ "$COMMIT" != "$MAIN_COMMIT" ]]; then
+    echo "Refusing to publish a stale tester build; origin/main is $MAIN_COMMIT." >&2
+    exit 2
+  fi
+  echo "Validated tester download build at current main commit $COMMIT."
+  exit 0
+fi
+
+if [[ "$REF_TYPE" != "tag" ]]; then
+  echo "Download builds require the main branch or a stable version tag." >&2
+  exit 2
+fi
+if [[ ! "$REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Stable release tags must use canonical vMAJOR.MINOR.PATCH form." >&2
+  exit 2
+fi
+
+TAG_COMMIT="$(git rev-parse --verify "refs/tags/${REF_NAME}^{commit}")"
+if [[ "$TAG_COMMIT" != "$COMMIT" ]]; then
+  echo "Stable tag $REF_NAME does not resolve to workflow commit $COMMIT." >&2
+  exit 2
+fi
+if ! git merge-base --is-ancestor "$COMMIT" refs/remotes/origin/main; then
+  echo "Stable tag $REF_NAME must point to a commit on main." >&2
+  exit 2
+fi
+
+SUCCESSFUL_CI_RUNS="$(
+  gh run list \
+    --repo "$REPOSITORY" \
+    --workflow ci.yml \
+    --commit "$COMMIT" \
+    --status success \
+    --limit 1 \
+    --json databaseId \
+    --jq 'length'
+)"
+if [[ ! "$SUCCESSFUL_CI_RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Stable tag $REF_NAME requires a successful CI run for commit $COMMIT." >&2
+  exit 2
+fi
+if gh release view "$REF_NAME" --repo "$REPOSITORY" >/dev/null 2>&1; then
+  echo "Stable release $REF_NAME already exists and is immutable." >&2
+  exit 2
+fi
+
+echo "Validated immutable stable release $REF_NAME at main commit $COMMIT."


### PR DESCRIPTION
## Summary
- validate tester builds are the current `main` commit
- require canonical stable tags on CI-green `main` commits
- make stable releases immutable and publish them draft-first after every asset uploads
- document and functionally test the stable release runbook

## Verification
- `swift test --filter ParityDownload` (10 passed)
- real repository dry run against current `origin/main`
- workflow YAML parse, `bash -n`, and `git diff --check`
- full suite: 5,318 tests executed; four unrelated assertions are contaminated by the local `~/.profile` startup error and will be rerun by clean GitHub CI