### PR TITLE
Modernize GitHub workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   swift:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Test
         run: swift test
       - name: Enforce no app-level Linux conditionals
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:6.2-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build CLI
         run: swift build --product quill-code
       - name: Smoke Linux Computer Use helpers
@@ -41,14 +41,14 @@ jobs:
   smoke:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Smoke
         env:
           QUILLCODE_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}/.quillcode-smoke-artifacts
         run: ./scripts/smoke.sh
       - name: Upload smoke UI artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quillcode-smoke-ui-${{ runner.os }}
           path: .quillcode-smoke-artifacts

--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -20,7 +20,7 @@ jobs:
   release-policy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Validate download build ref
@@ -32,7 +32,7 @@ jobs:
     needs: release-policy
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set build metadata
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
@@ -70,7 +70,7 @@ jobs:
             rm -f "$QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH"
           fi
       - name: Upload macOS downloads
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quillcode-macos-downloads
           path: ${{ runner.temp }}/quillcode-macos-downloads/assets/*
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:6.2-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set build metadata
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
@@ -98,7 +98,7 @@ jobs:
           QUILLCODE_DOWNLOAD_DIST_DIR: /tmp/quillcode-linux-downloads
         run: scripts/package-linux-downloads.sh
       - name: Upload Linux downloads
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quillcode-linux-downloads
           path: /tmp/quillcode-linux-downloads/assets/*
@@ -109,10 +109,10 @@ jobs:
     needs: [macos, linux]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/downloaded-artifacts
       - name: Prepare release assets

--- a/.github/workflows/live-trustedrouter-smoke.yml
+++ b/.github/workflows/live-trustedrouter-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       QUILLCODE_LIVE_MODEL: ${{ inputs.model || 'deepseekv4flash' }}
       QUILLCODE_LIVE_KEEP_ARTIFACTS: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Check live smoke secret
         run: |
           if [[ -z "${QUILLCODE_API_KEY:-}" ]]; then
@@ -37,7 +37,7 @@ jobs:
         run: ./scripts/live-tr-smoke.sh
       - name: Upload live smoke artifacts
         if: always() && env.QUILLCODE_API_KEY != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: live-trustedrouter-smoke
           path: /tmp/quillcode-live-smoke.*

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -30,7 +30,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'automerge')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run merge train
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/real-world-smoke.yml
+++ b/.github/workflows/real-world-smoke.yml
@@ -31,12 +31,12 @@ jobs:
       QUILLCODE_REQUIRE_LIVE_SMOKE: ${{ inputs.require_live && '1' || '0' }}
       QUILLCODE_REAL_WORLD_SMOKE_ARTIFACT_DIR: ${{ github.workspace }}/.quillcode-real-world-smoke
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run release-candidate real-world smoke
         run: ./scripts/real-world-smoke.sh
       - name: Upload real-world smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quillcode-real-world-smoke-${{ runner.os }}
           path: .quillcode-real-world-smoke

--- a/Tests/QuillCodeParityTests/ParityLiveSmokeScriptGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityLiveSmokeScriptGateTests.swift
@@ -129,7 +129,7 @@ final class ParityLiveSmokeScriptGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(workflow.contains("QUILLCODE_REQUIRE_LIVE_SMOKE: ${{ inputs.require_live && '1' || '0' }}"))
         XCTAssertTrue(workflow.contains("QUILLCODE_REAL_WORLD_SMOKE_ARTIFACT_DIR:"))
         XCTAssertTrue(workflow.contains("./scripts/real-world-smoke.sh"))
-        XCTAssertTrue(workflow.contains("actions/upload-artifact@v4"))
+        XCTAssertTrue(workflow.contains("actions/upload-artifact@v7"))
         XCTAssertTrue(workflow.contains("retention-days: 30"))
         XCTAssertFalse(
             workflow.contains("live-tr-smoke.sh"),

--- a/Tests/QuillCodeParityTests/ParityWorkflowActionVersionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkflowActionVersionGateTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+final class ParityWorkflowActionVersionGateTests: QuillCodeParityTestCase {
+    func testWorkflowsUseCurrentOfficialArtifactActionMajors() throws {
+        let expectations: [String: [String]] = [
+            "ci.yml": ["actions/checkout@v7", "actions/upload-artifact@v7"],
+            "download-builds.yml": [
+                "actions/checkout@v7",
+                "actions/upload-artifact@v7",
+                "actions/download-artifact@v8"
+            ],
+            "live-trustedrouter-smoke.yml": [
+                "actions/checkout@v7",
+                "actions/upload-artifact@v7"
+            ],
+            "merge-train.yml": ["actions/checkout@v7"],
+            "real-world-smoke.yml": [
+                "actions/checkout@v7",
+                "actions/upload-artifact@v7"
+            ]
+        ]
+
+        for (fileName, actionReferences) in expectations {
+            let workflow = try Self.workflowText(named: fileName)
+            for actionReference in actionReferences {
+                XCTAssertTrue(
+                    workflow.contains(actionReference),
+                    "\(fileName) must use \(actionReference)"
+                )
+            }
+        }
+    }
+
+    func testWorkflowsDoNotReintroduceNode20ActionMajors() throws {
+        let workflowDirectory = Self.packageRoot().appendingPathComponent(".github/workflows")
+        let workflowURLs = try FileManager.default.contentsOfDirectory(
+            at: workflowDirectory,
+            includingPropertiesForKeys: nil
+        )
+        .filter { $0.pathExtension == "yml" }
+
+        for workflowURL in workflowURLs {
+            let workflow = try String(contentsOf: workflowURL, encoding: .utf8)
+            XCTAssertFalse(
+                workflow.contains("actions/checkout@v4")
+                    || workflow.contains("actions/upload-artifact@v4")
+                    || workflow.contains("actions/download-artifact@v4"),
+                "\(workflowURL.lastPathComponent) reintroduced a Node 20 action major"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` to v7 across every workflow
- upgrade artifact upload/download actions to v7/v8
- add a parity gate preventing the deprecated Node 20 action majors from returning

`download-artifact@v8` also rejects digest mismatches by default.

## Verification
- all workflow YAML parsed locally
- `swift test --filter 'ParityWorkflowActionVersionGateTests|ParityLiveSmokeScriptGateTests|ParityDownload'` (18 passed)\n- `git diff --check`