### PR TITLE
Skip redundant scheduled download builds

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -8,9 +8,7 @@ on:
   schedule:
     - cron: "17 10 * * *"
 
-permissions:
-  actions: read
-  contents: write
+permissions: {}
 
 concurrency:
   group: download-builds-${{ github.ref }}
@@ -19,20 +17,36 @@ concurrency:
 jobs:
   release-policy:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      build-required: ${{ steps.plan.outputs.build-required }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Validate download build ref
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/validate-download-build-ref.sh
+      - name: Plan download build
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/plan-download-build.sh
 
   macos:
     needs: release-policy
+    if: needs.release-policy.outputs.build-required == 'true'
     runs-on: macos-15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Set build metadata
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
@@ -79,10 +93,15 @@ jobs:
 
   linux:
     needs: release-policy
+    if: needs.release-policy.outputs.build-required == 'true'
     runs-on: ubuntu-latest
     container: swift:6.2-noble
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Set build metadata
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
@@ -108,6 +127,9 @@ jobs:
   publish:
     needs: [macos, linux]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -180,7 +202,7 @@ jobs:
           - \`Quill-Cowork-macOS-*.zip\`: macOS app bundle for testers.
           - \`quill-code-macOS-*.tar.gz\`: macOS CLI.
           - \`quill-code-linux-*.tar.gz\`: Linux CLI.
-          - \`SHASUMS256.txt\`: checksum manifest for every asset.
+          - \`SHASUMS256.txt\`: checksums for package and build-info assets.
           - \`${MANIFEST_NAME}\`: machine-readable build metadata, updater feed metadata, download URLs, sizes, and SHA-256 digests.
 
           macOS distribution note: ${MACOS_DISTRIBUTION_NOTE} Computer Use still requires normal macOS Screen Recording and Accessibility permissions.

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildPlanGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildPlanGateTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+
+final class ParityDownloadBuildPlanGateTests: QuillCodeParityTestCase {
+    func testNonScheduledAndTaggedRunsAlwaysBuildWithoutReleaseLookup() throws {
+        let cases = [
+            (event: "workflow_dispatch", refType: "branch"),
+            (event: "push", refType: "branch"),
+            (event: "schedule", refType: "tag")
+        ]
+
+        for testCase in cases {
+            let result = try runPlanner(eventName: testCase.event, refType: testCase.refType)
+            XCTAssertEqual(result.exitCode, 0, result.output)
+            XCTAssertEqual(result.buildRequired, "true")
+            XCTAssertTrue(result.ghLog.isEmpty)
+        }
+    }
+
+    func testScheduledRunSkipsAnAlreadyPublishedCommit() throws {
+        let commit = String(repeating: "a", count: 40)
+        let result = try runPlanner(commit: commit, publishedCommit: commit)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertEqual(result.buildRequired, "false")
+        XCTAssertTrue(result.output.contains("already publishes commit \(commit)"))
+        XCTAssertTrue(result.ghLog.contains("release download tester-latest"))
+    }
+
+    func testScheduledRunBuildsWhenPublishedCommitIsStale() throws {
+        let result = try runPlanner(publishedCommit: String(repeating: "b", count: 40))
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertEqual(result.buildRequired, "true")
+        XCTAssertTrue(result.output.contains("instead of"))
+    }
+
+    func testScheduledRunRepairsMissingOrMalformedManifest() throws {
+        let missing = try runPlanner(manifestAvailable: false)
+        let malformed = try runPlanner(manifestMalformed: true)
+
+        XCTAssertEqual(missing.exitCode, 0, missing.output)
+        XCTAssertEqual(missing.buildRequired, "true")
+        XCTAssertTrue(missing.output.contains("manifest is unavailable"))
+        XCTAssertEqual(malformed.exitCode, 0, malformed.output)
+        XCTAssertEqual(malformed.buildRequired, "true")
+        XCTAssertTrue(malformed.output.contains("manifest is malformed"))
+    }
+
+    private struct PlannerResult {
+        var exitCode: Int32
+        var output: String
+        var buildRequired: String?
+        var ghLog: String
+    }
+
+    private func runPlanner(
+        eventName: String = "schedule",
+        refType: String = "branch",
+        commit: String = String(repeating: "a", count: 40),
+        publishedCommit: String = String(repeating: "a", count: 40),
+        manifestAvailable: Bool = true,
+        manifestMalformed: Bool = false
+    ) throws -> PlannerResult {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-download-plan-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let binDirectory = temporaryDirectory.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let ghURL = binDirectory.appendingPathComponent("gh")
+        let ghLogURL = temporaryDirectory.appendingPathComponent("gh.log")
+        let githubOutputURL = temporaryDirectory.appendingPathComponent("github-output")
+        try fakeGH.write(to: ghURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: ghURL.path)
+
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts")
+                .appendingPathComponent("plan-download-build.sh")
+                .path
+        ]
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(binDirectory.path):\(environment["PATH"] ?? "")"
+        environment["GITHUB_EVENT_NAME"] = eventName
+        environment["GITHUB_REF_TYPE"] = refType
+        environment["GITHUB_SHA"] = commit
+        environment["GITHUB_REPOSITORY"] = "Lore-Hex/QuillCode"
+        environment["GITHUB_OUTPUT"] = githubOutputURL.path
+        environment["DOWNLOAD_PLAN_MANIFEST_AVAILABLE"] = manifestAvailable ? "true" : "false"
+        environment["DOWNLOAD_PLAN_MANIFEST_MALFORMED"] = manifestMalformed ? "true" : "false"
+        environment["DOWNLOAD_PLAN_PUBLISHED_COMMIT"] = publishedCommit
+        environment["DOWNLOAD_PLAN_GH_LOG"] = ghLogURL.path
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let githubOutput = (try? String(contentsOf: githubOutputURL, encoding: .utf8)) ?? ""
+        let buildRequired = githubOutput
+            .split(separator: "\n")
+            .first { $0.hasPrefix("build-required=") }
+            .map { String($0.dropFirst("build-required=".count)) }
+        let ghLog = (try? String(contentsOf: ghLogURL, encoding: .utf8)) ?? ""
+        return PlannerResult(
+            exitCode: process.terminationStatus,
+            output: output,
+            buildRequired: buildRequired,
+            ghLog: ghLog
+        )
+    }
+
+    private var fakeGH: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${DOWNLOAD_PLAN_GH_LOG:?}"
+        if [[ "$1" == "release" && "$2" == "download" ]]; then
+          [[ "${DOWNLOAD_PLAN_MANIFEST_AVAILABLE:?}" == "true" ]] || exit 1
+          output_directory="${!#}"
+          if [[ "${DOWNLOAD_PLAN_MANIFEST_MALFORMED:?}" == "true" ]]; then
+            printf '%s\n' '{not-json' > "$output_directory/latest-tester-build.json"
+          else
+            printf '{"commit":"%s"}\n' "${DOWNLOAD_PLAN_PUBLISHED_COMMIT:?}" \
+              > "$output_directory/latest-tester-build.json"
+          fi
+          exit 0
+        fi
+        echo "unexpected gh invocation: $*" >&2
+        exit 9
+        """
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -125,9 +125,16 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         let workflow = try Self.workflowText(named: "download-builds.yml")
 
         Self.assertSource(workflow, containsAll: [
+            "permissions: {}",
             "actions: read",
+            "contents: read",
+            "contents: write",
             "release-policy:",
             "scripts/validate-download-build-ref.sh",
+            "scripts/plan-download-build.sh",
+            "build-required: ${{ steps.plan.outputs.build-required }}",
+            "if: needs.release-policy.outputs.build-required == 'true'",
+            "persist-credentials: false",
             "needs: release-policy",
             "group: download-builds-${{ github.ref }}",
             "cancel-in-progress: false",
@@ -154,6 +161,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             workflow.contains("cancel-in-progress: true"),
             "a scheduled build must not cancel another run while it is publishing release assets"
         )
+        XCTAssertFalse(
+            workflow.contains("permissions:\n  actions: read\n  contents: write"),
+            "repository write permission must remain scoped to the publish job"
+        )
     }
 
     func testDownloadDocsExposeStableManifestLink() throws {
@@ -171,6 +182,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "QuillCodeTesterUpdateManifestURL",
             "canonical `vMAJOR.MINOR.PATCH` tag",
             "an existing stable release is never edited or clobbered automatically",
+            "avoids no-op build-number updates and unnecessary",
             "channel is `tester`",
             "channel is `stable`"
         ])

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -29,11 +29,15 @@ The tester release is refreshed:
 
 - after every successful push to `main`
 - after merge-train PR merges, which explicitly dispatch **Download Builds**
-- every night from the scheduled **Download Builds** workflow
+- from the nightly **Download Builds** recovery check when the published tester
+  manifest is missing, malformed, stale, or points to another `main` commit
 - whenever a maintainer runs **Download Builds** manually from GitHub Actions
 
-The workflow updates the stable `tester-latest` tag and replaces release assets
-in place, so the links above do not change as new builds are published.
+The nightly check skips packaging when the live manifest already publishes the
+current `main` commit. This avoids no-op build-number updates and unnecessary
+updater prompts. When a build is required, the workflow updates the stable
+`tester-latest` tag and replaces release assets in place, so the links above do
+not change as new builds are published.
 
 ## Auto-Update Contract
 

--- a/scripts/plan-download-build.sh
+++ b/scripts/plan-download-build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT_NAME="${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
+REF_TYPE="${GITHUB_REF_TYPE:?GITHUB_REF_TYPE is required}"
+COMMIT="${GITHUB_SHA:?GITHUB_SHA is required}"
+REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+OUTPUT_FILE="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+build_required=true
+reason="${EVENT_NAME} runs always produce a fresh build"
+
+if [[ "$EVENT_NAME" == "schedule" && "$REF_TYPE" == "branch" ]]; then
+  download_directory="$(mktemp -d)"
+  trap 'rm -rf "$download_directory"' EXIT
+  manifest_path="$download_directory/latest-tester-build.json"
+
+  if gh release download tester-latest \
+    --repo "$REPOSITORY" \
+    --pattern latest-tester-build.json \
+    --dir "$download_directory" >/dev/null 2>&1; then
+    if published_commit="$(python3 - "$manifest_path" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        manifest = json.load(handle)
+except (OSError, ValueError):
+    raise SystemExit(1)
+
+commit = manifest.get("commit")
+if not isinstance(commit, str) or not commit:
+    raise SystemExit(1)
+print(commit)
+PY
+    )"; then
+      if [[ "$published_commit" == "$COMMIT" ]]; then
+        build_required=false
+        reason="tester manifest already publishes commit $COMMIT"
+      else
+        reason="tester manifest publishes $published_commit instead of $COMMIT"
+      fi
+    else
+      reason="tester manifest is malformed; rebuilding to repair it"
+    fi
+  else
+    reason="tester manifest is unavailable; rebuilding to restore it"
+  fi
+fi
+
+printf 'build-required=%s\n' "$build_required" >> "$OUTPUT_FILE"
+printf 'Download build required: %s (%s).\n' "$build_required" "$reason"


### PR DESCRIPTION
## Summary
- skip nightly packaging when the live tester manifest already publishes the exact current main commit
- rebuild on missing, malformed, stale, or mismatched release state so scheduled runs remain self-healing
- scope repository write access to the publish job while packaging jobs remain read-only without persisted checkout credentials

## Verification
- `swift test --filter ParityDownload` (14 tests)
- workflow YAML parse, `bash -n`, and `git diff --check`
- live planner check against the current tester manifest (`false`) and a deliberately stale commit (`true`)