### PR TITLE
Make desktop update activation atomic

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
@@ -44,7 +44,12 @@ enum QuillCodeDesktopUpdateHelper {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: request.destinationApplicationURL.path),
               fileManager.fileExists(atPath: request.incomingApplicationURL.path),
-              !fileManager.fileExists(atPath: request.backupApplicationURL.path)
+              bundleMatches(
+                request.incomingApplicationURL,
+                identifier: request.expectedBundleIdentifier,
+                version: request.expectedVersion,
+                build: request.expectedBuild
+              )
         else {
             return
         }
@@ -57,23 +62,12 @@ enum QuillCodeDesktopUpdateHelper {
     ) throws {
         let fileManager = FileManager.default
         let parent = request.destinationApplicationURL.deletingLastPathComponent().standardizedFileURL
-        let siblingURLs = [
-            request.incomingApplicationURL,
-            request.backupApplicationURL,
-            request.failedApplicationURL
-        ]
-        guard siblingURLs.allSatisfy({ $0.deletingLastPathComponent().standardizedFileURL == parent }),
+        guard request.incomingApplicationURL.deletingLastPathComponent().standardizedFileURL == parent,
               request.destinationApplicationURL.pathExtension == "app",
               request.incomingApplicationURL.pathExtension == "app",
-              request.backupApplicationURL.pathExtension == "app",
-              request.failedApplicationURL.pathExtension == "app",
               request.incomingApplicationURL.lastPathComponent.contains(".update-"),
-              request.backupApplicationURL.lastPathComponent.contains(".backup-"),
-              request.failedApplicationURL.lastPathComponent.contains(".failed-"),
               fileManager.fileExists(atPath: request.destinationApplicationURL.path),
               fileManager.fileExists(atPath: request.incomingApplicationURL.path),
-              !fileManager.fileExists(atPath: request.backupApplicationURL.path),
-              !fileManager.fileExists(atPath: request.failedApplicationURL.path),
               bundleMatches(
                 request.destinationApplicationURL,
                 identifier: request.expectedBundleIdentifier,
@@ -101,27 +95,24 @@ enum QuillCodeDesktopUpdateHelper {
         environment: QuillCodeDesktopUpdateHelperEnvironment
     ) throws {
         let fileManager = FileManager.default
-        try fileManager.moveItem(
-            at: request.destinationApplicationURL,
-            to: request.backupApplicationURL
+        try swapApplications(
+            request.destinationApplicationURL,
+            request.incomingApplicationURL
         )
+
+        let launchedProcessID: Int32
         do {
-            try fileManager.moveItem(
-                at: request.incomingApplicationURL,
-                to: request.destinationApplicationURL
+            launchedProcessID = try launch(
+                request.destinationApplicationURL,
+                handshakeURL: request.handshakeURL
             )
         } catch {
-            try? fileManager.moveItem(
-                at: request.backupApplicationURL,
-                to: request.destinationApplicationURL
+            try rollback(request)
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the new build could not be launched; the previous build was restored"
             )
-            throw QuillCodeDesktopUpdateError.installationFailed("the staged app could not be activated")
         }
 
-        let launchedProcessID = try launch(
-            request.destinationApplicationURL,
-            handshakeURL: request.handshakeURL
-        )
         guard waitForFile(
             request.handshakeURL,
             timeout: environment.launchHandshakeTimeout
@@ -133,7 +124,7 @@ enum QuillCodeDesktopUpdateHelper {
             )
         }
 
-        try? fileManager.removeItem(at: request.backupApplicationURL)
+        try? fileManager.removeItem(at: request.incomingApplicationURL)
         try? fileManager.removeItem(at: request.handshakeURL)
         writeResult(
             .success(version: request.expectedVersion, build: request.expectedBuild),
@@ -162,29 +153,38 @@ enum QuillCodeDesktopUpdateHelper {
     private static func rollback(_ request: QuillCodeDesktopUpdateHelperRequest) throws {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: request.destinationApplicationURL.path),
-              fileManager.fileExists(atPath: request.backupApplicationURL.path)
+              fileManager.fileExists(atPath: request.incomingApplicationURL.path)
         else {
             throw QuillCodeDesktopUpdateError.installationFailed("the previous app backup is missing")
         }
-        try fileManager.moveItem(
-            at: request.destinationApplicationURL,
-            to: request.failedApplicationURL
+        try swapApplications(
+            request.destinationApplicationURL,
+            request.incomingApplicationURL
         )
-        do {
-            try fileManager.moveItem(
-                at: request.backupApplicationURL,
-                to: request.destinationApplicationURL
-            )
-        } catch {
-            try? fileManager.moveItem(
-                at: request.failedApplicationURL,
-                to: request.destinationApplicationURL
-            )
-            throw QuillCodeDesktopUpdateError.installationFailed("the previous app could not be restored")
-        }
         _ = try launch(request.destinationApplicationURL, handshakeURL: nil)
-        try? fileManager.removeItem(at: request.failedApplicationURL)
+        try? fileManager.removeItem(at: request.incomingApplicationURL)
         try? fileManager.removeItem(at: request.handshakeURL)
+    }
+
+    private static func swapApplications(_ firstURL: URL, _ secondURL: URL) throws {
+        // Keep the destination bundle present if the helper or machine stops during activation.
+        let result = firstURL.withUnsafeFileSystemRepresentation { firstPath in
+            secondURL.withUnsafeFileSystemRepresentation { secondPath in
+                guard let firstPath, let secondPath else { return Int32(-1) }
+                return renameatx_np(
+                    AT_FDCWD,
+                    firstPath,
+                    AT_FDCWD,
+                    secondPath,
+                    UInt32(RENAME_SWAP)
+                )
+            }
+        }
+        guard result == 0 else {
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the app bundles could not be swapped atomically"
+            )
+        }
     }
 
     private static func launch(

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
@@ -56,14 +56,6 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             ".\(baseName).update-\(identifier).app",
             isDirectory: true
         )
-        let backupURL = destinationParent.appendingPathComponent(
-            ".\(baseName).backup-\(identifier).app",
-            isDirectory: true
-        )
-        let failedURL = destinationParent.appendingPathComponent(
-            ".\(baseName).failed-\(identifier).app",
-            isDirectory: true
-        )
         let handshakeURL = preparedUpdate.workspaceURL.appendingPathComponent(
             "launch-\(identifier).ack",
             isDirectory: false
@@ -78,10 +70,7 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
         )
         let resultURL = try QuillCodeDesktopUpdatePaths.installResultURL()
 
-        guard !fileManager.fileExists(atPath: incomingURL.path),
-              !fileManager.fileExists(atPath: backupURL.path),
-              !fileManager.fileExists(atPath: failedURL.path)
-        else {
+        guard !fileManager.fileExists(atPath: incomingURL.path) else {
             throw QuillCodeDesktopUpdateError.installationFailed("a staging path already exists")
         }
 
@@ -113,8 +102,6 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             helperURL: helperURL,
             incomingApplicationURL: incomingURL,
             destinationApplicationURL: destinationURL,
-            backupApplicationURL: backupURL,
-            failedApplicationURL: failedURL,
             handshakeURL: handshakeURL,
             resultURL: resultURL,
             logURL: logURL,
@@ -148,8 +135,6 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
     var helperURL: URL
     var incomingApplicationURL: URL
     var destinationApplicationURL: URL
-    var backupApplicationURL: URL
-    var failedApplicationURL: URL
     var handshakeURL: URL
     var resultURL: URL
     var logURL: URL
@@ -163,8 +148,6 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
             "--parent-pid", String(parentProcessID),
             "--incoming-app", incomingApplicationURL.path,
             "--destination-app", destinationApplicationURL.path,
-            "--backup-app", backupApplicationURL.path,
-            "--failed-app", failedApplicationURL.path,
             "--handshake", handshakeURL.path,
             "--result", resultURL.path,
             "--log", logURL.path,
@@ -192,8 +175,6 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
               parentProcessID > 1,
               let incoming = values["--incoming-app"],
               let destination = values["--destination-app"],
-              let backup = values["--backup-app"],
-              let failed = values["--failed-app"],
               let handshake = values["--handshake"],
               let result = values["--result"],
               let log = values["--log"],
@@ -208,8 +189,6 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
             helperURL: executableURL.standardizedFileURL,
             incomingApplicationURL: URL(fileURLWithPath: incoming).standardizedFileURL,
             destinationApplicationURL: URL(fileURLWithPath: destination).standardizedFileURL,
-            backupApplicationURL: URL(fileURLWithPath: backup).standardizedFileURL,
-            failedApplicationURL: URL(fileURLWithPath: failed).standardizedFileURL,
             handshakeURL: URL(fileURLWithPath: handshake).standardizedFileURL,
             resultURL: URL(fileURLWithPath: result).standardizedFileURL,
             logURL: URL(fileURLWithPath: log).standardizedFileURL,

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -138,8 +138,6 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             helperURL: root.appendingPathComponent("helper"),
             incomingApplicationURL: root.appendingPathComponent(".Quill Cowork.update-id.app"),
             destinationApplicationURL: root.appendingPathComponent("Quill Cowork.app"),
-            backupApplicationURL: root.appendingPathComponent(".Quill Cowork.backup-id.app"),
-            failedApplicationURL: root.appendingPathComponent(".Quill Cowork.failed-id.app"),
             handshakeURL: root.appendingPathComponent("launch-id.ack"),
             resultURL: root.appendingPathComponent("UpdateResult.json"),
             logURL: root.appendingPathComponent("install.log"),
@@ -156,8 +154,6 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         XCTAssertEqual(parsed.parentProcessID, request.parentProcessID)
         XCTAssertEqual(parsed.incomingApplicationURL, request.incomingApplicationURL)
         XCTAssertEqual(parsed.destinationApplicationURL, request.destinationApplicationURL)
-        XCTAssertEqual(parsed.backupApplicationURL, request.backupApplicationURL)
-        XCTAssertEqual(parsed.failedApplicationURL, request.failedApplicationURL)
         XCTAssertEqual(parsed.handshakeURL, request.handshakeURL)
         XCTAssertEqual(parsed.resultURL, request.resultURL)
         XCTAssertEqual(parsed.logURL, request.logURL)
@@ -195,7 +191,6 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         )
         let resultURL = root.appendingPathComponent("UpdateResult.json")
         let request = makeHelperRequest(
-            root: root,
             cacheRoot: cacheRoot,
             destination: destination,
             incoming: incoming,
@@ -220,7 +215,6 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(parsedRequest, environment: environment), 0)
         XCTAssertEqual(try bundleBuild(at: destination), "2")
         XCTAssertFalse(FileManager.default.fileExists(atPath: incoming.path))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: request.backupApplicationURL.path))
         let result = try JSONDecoder().decode(
             QuillCodeDesktopUpdateInstallResult.self,
             from: Data(contentsOf: resultURL)
@@ -256,7 +250,6 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         )
         let resultURL = root.appendingPathComponent("UpdateResult.json")
         let request = makeHelperRequest(
-            root: root,
             cacheRoot: cacheRoot,
             destination: destination,
             incoming: incoming,
@@ -275,8 +268,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
 
         XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 1)
         XCTAssertEqual(try bundleBuild(at: destination), "1")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: request.backupApplicationURL.path))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: request.failedApplicationURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: incoming.path))
         let childPID = try XCTUnwrap(Int32(String(contentsOf: childPIDURL, encoding: .utf8)))
         XCTAssertEqual(kill(childPID, 0), -1)
         XCTAssertEqual(errno, ESRCH)
@@ -293,6 +285,63 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         }
         XCTAssertTrue(FileManager.default.fileExists(atPath: rollbackLaunchedURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: workspace.path))
+    }
+
+    func testHelperRollsBackWhenUpdatedExecutableCannotLaunch() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cacheRoot = root.appendingPathComponent("cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+        let workspace = cacheRoot.appendingPathComponent("launch-failure-workspace", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: false)
+        let destination = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        let incoming = root.appendingPathComponent(".Quill Cowork.update-launch-failure.app", isDirectory: true)
+        let rollbackLaunchedURL = root.appendingPathComponent("rollback-launched")
+        try makeFakeApplication(
+            at: destination,
+            version: "0.1.0",
+            build: "1",
+            executableScript: "#!/bin/sh\nprintf 'ready' > '\(rollbackLaunchedURL.path)'\nexit 0\n"
+        )
+        try makeFakeApplication(
+            at: incoming,
+            version: "0.2.0",
+            build: "2",
+            executableScript: "#!/definitely/missing/interpreter\n"
+        )
+        let resultURL = root.appendingPathComponent("UpdateResult.json")
+        let request = makeHelperRequest(
+            cacheRoot: cacheRoot,
+            destination: destination,
+            incoming: incoming,
+            resultURL: resultURL,
+            expectedVersion: "0.2.0",
+            expectedBuild: "2",
+            suffix: "launch-failure",
+            workspace: workspace
+        )
+        let environment = QuillCodeDesktopUpdateHelperEnvironment(
+            cacheRootURL: cacheRoot,
+            resultURL: resultURL,
+            parentExitTimeout: 0.1,
+            launchHandshakeTimeout: 0.1
+        )
+
+        XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 1)
+        XCTAssertEqual(try bundleBuild(at: destination), "1")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: incoming.path))
+        let result = try JSONDecoder().decode(
+            QuillCodeDesktopUpdateInstallResult.self,
+            from: Data(contentsOf: resultURL)
+        )
+        XCTAssertEqual(result.status, .failure)
+        XCTAssertTrue(result.message.contains("previous build was restored"))
+        let rollbackDeadline = Date().addingTimeInterval(1)
+        while !FileManager.default.fileExists(atPath: rollbackLaunchedURL.path),
+              Date() < rollbackDeadline {
+            usleep(10_000)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rollbackLaunchedURL.path))
     }
 
     func testBundledConfigurationReadsEveryReleaseFeedKey() throws {
@@ -315,7 +364,6 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
     }
 
     private func makeHelperRequest(
-        root: URL,
         cacheRoot: URL,
         destination: URL,
         incoming: URL,
@@ -331,8 +379,6 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             helperURL: workspace.appendingPathComponent("helper"),
             incomingApplicationURL: incoming,
             destinationApplicationURL: destination,
-            backupApplicationURL: root.appendingPathComponent(".Quill Cowork.backup-\(suffix).app"),
-            failedApplicationURL: root.appendingPathComponent(".Quill Cowork.failed-\(suffix).app"),
             handshakeURL: workspace.appendingPathComponent("launch-\(suffix).ack"),
             resultURL: resultURL,
             logURL: workspace.appendingPathComponent("install.log"),


### PR DESCRIPTION
## Summary
- atomically swap the installed and staged app bundles so the destination path never disappears mid-update
- use the same atomic swap for rollback and remove obsolete backup/failed helper paths
- restore the previous build when the updated executable cannot launch, not only when its startup handshake times out

## Verification
- `swift test --disable-sandbox --filter QuillCodeDesktopUpdate` (16 tests)
- `swift test --disable-sandbox --filter QuillCodeDesktopTests` (118 tests)
- `git diff --check`