### PR TITLE
Harden stable release initiation

### DIFF
--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -181,6 +181,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "QuillCodeStableUpdateManifestURL",
             "QuillCodeTesterUpdateManifestURL",
             "canonical `vMAJOR.MINOR.PATCH` tag",
+            "scripts/start-stable-release.sh --check-only v0.1.0",
+            "creates one annotated tag and pushes it without force",
             "an existing stable release is never edited or clobbered automatically",
             "avoids no-op build-number updates and unnecessary",
             "channel is `tester`",

--- a/Tests/QuillCodeParityTests/ParityStableReleaseStartGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityStableReleaseStartGateTests.swift
@@ -1,0 +1,330 @@
+import XCTest
+
+final class ParityStableReleaseStartGateTests: QuillCodeParityTestCase {
+    func testCheckOnlyPassesWithoutCreatingATag() throws {
+        let result = try runStarter(arguments: ["--check-only", "v1.2.3"])
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Stable release preflight passed."))
+        XCTAssertTrue(result.output.contains("Apple distribution secret names: 7/7"))
+        XCTAssertFalse(result.gitLog.contains("tag -a"), result.gitLog)
+        XCTAssertFalse(result.gitLog.contains("push origin refs/tags/v1.2.3"), result.gitLog)
+        XCTAssertTrue(
+            result.ghLog.contains("run list --repo Lore-Hex/QuillCode --workflow ci.yml --commit \(Self.commitA)"),
+            result.ghLog
+        )
+        XCTAssertTrue(
+            result.ghLog.contains("secret list --repo Lore-Hex/QuillCode --app actions --json name"),
+            result.ghLog
+        )
+    }
+
+    func testPublishCreatesAndPushesOneAnnotatedExactCommitTag() throws {
+        let result = try runStarter(arguments: ["v1.2.3"])
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(
+            result.gitLog.contains(
+                "tag -a v1.2.3 -m Quill Cowork 1.2.3 \(Self.commitA)"
+            ),
+            result.gitLog
+        )
+        XCTAssertTrue(
+            result.gitLog.contains("push origin refs/tags/v1.2.3:refs/tags/v1.2.3"),
+            result.gitLog
+        )
+        XCTAssertFalse(result.gitLog.contains("--force"), result.gitLog)
+    }
+
+    func testPreflightRejectsDirtyStaleAndUntestedMainBeforeMutation() throws {
+        let dirty = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_DIRTY": "true"]
+        )
+        let stale = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_MAIN_COMMIT": Self.commitB]
+        )
+        let untested = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_TESTER_COMMIT": Self.commitB]
+        )
+
+        XCTAssertEqual(dirty.exitCode, 2, dirty.output)
+        XCTAssertTrue(dirty.output.contains("clean worktree"), dirty.output)
+        XCTAssertEqual(stale.exitCode, 2, stale.output)
+        XCTAssertTrue(stale.output.contains("not exact origin/main"), stale.output)
+        XCTAssertEqual(untested.exitCode, 2, untested.output)
+        XCTAssertTrue(untested.output.contains("tester-latest"), untested.output)
+        for result in [dirty, stale, untested] {
+            XCTAssertFalse(result.gitLog.contains("tag -a"), result.gitLog)
+        }
+    }
+
+    func testPreflightRejectsMissingCISecretAndWrongRemoteBeforeMutation() throws {
+        let missingCI = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_CI_URL": ""]
+        )
+        let missingSecret = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: [
+                "STABLE_RELEASE_SECRET_NAMES": Self.requiredSecrets
+                    .filter { $0 != "APPLE_TEAM_ID" }
+                    .joined(separator: "\n")
+            ]
+        )
+        let wrongRemote = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_REMOTE_URL": "git@github.com:Elsewhere/Other.git"]
+        )
+
+        XCTAssertEqual(missingCI.exitCode, 2, missingCI.output)
+        XCTAssertTrue(missingCI.output.contains("successful exact-commit CI"), missingCI.output)
+        XCTAssertEqual(missingSecret.exitCode, 2, missingSecret.output)
+        XCTAssertTrue(missingSecret.output.contains("APPLE_TEAM_ID"), missingSecret.output)
+        XCTAssertEqual(wrongRemote.exitCode, 2, wrongRemote.output)
+        XCTAssertTrue(wrongRemote.output.contains("does not point to"), wrongRemote.output)
+        for result in [missingCI, missingSecret, wrongRemote] {
+            XCTAssertFalse(result.gitLog.contains("tag -a"), result.gitLog)
+        }
+    }
+
+    func testPreflightRejectsMalformedNonMonotonicAndExistingReleases() throws {
+        let malformed = try runStarter(arguments: ["v1.2"])
+        let nonMonotonic = try runStarter(arguments: ["v1.2.1"])
+        let remoteTag = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: [
+                "STABLE_RELEASE_REMOTE_VERSION_TAGS":
+                    "\(Self.commitB)\trefs/tags/v1.2.3"
+            ]
+        )
+        let existingRelease = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: [
+                "STABLE_RELEASE_ROWS": "tester-latest\ttrue\nv1.2.3\tfalse"
+            ]
+        )
+
+        XCTAssertEqual(malformed.exitCode, 2, malformed.output)
+        XCTAssertTrue(malformed.output.contains("canonical vMAJOR.MINOR.PATCH"), malformed.output)
+        XCTAssertEqual(nonMonotonic.exitCode, 2, nonMonotonic.output)
+        XCTAssertTrue(nonMonotonic.output.contains("must be newer"), nonMonotonic.output)
+        XCTAssertEqual(remoteTag.exitCode, 2, remoteTag.output)
+        XCTAssertTrue(remoteTag.output.contains("will not be moved"), remoteTag.output)
+        XCTAssertEqual(existingRelease.exitCode, 2, existingRelease.output)
+        XCTAssertTrue(existingRelease.output.contains("already exists and is immutable"), existingRelease.output)
+    }
+
+    func testPreflightRejectsWrongBranchLocalTagPrivateRepoAndMissingTesterRelease() throws {
+        let wrongBranch = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_BRANCH": "feature"]
+        )
+        let localTag = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_LOCAL_TAG_EXISTS": "true"]
+        )
+        let privateRepository = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_VISIBILITY": "PRIVATE"]
+        )
+        let missingTesterRelease = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_ROWS": ""]
+        )
+
+        XCTAssertEqual(wrongBranch.exitCode, 2, wrongBranch.output)
+        XCTAssertTrue(wrongBranch.output.contains("must start from the main branch"), wrongBranch.output)
+        XCTAssertEqual(localTag.exitCode, 2, localTag.output)
+        XCTAssertTrue(localTag.output.contains("Local tag v1.2.3 already exists"), localTag.output)
+        XCTAssertEqual(privateRepository.exitCode, 2, privateRepository.output)
+        XCTAssertTrue(privateRepository.output.contains("repository to be public"), privateRepository.output)
+        XCTAssertEqual(missingTesterRelease.exitCode, 2, missingTesterRelease.output)
+        XCTAssertTrue(missingTesterRelease.output.contains("tester-latest prerelease is missing"), missingTesterRelease.output)
+        for result in [wrongBranch, localTag, privateRepository, missingTesterRelease] {
+            XCTAssertFalse(result.gitLog.contains("tag -a"), result.gitLog)
+        }
+    }
+
+    func testFailedPushRemovesOnlyTheNewLocalTag() throws {
+        let result = try runStarter(
+            arguments: ["v1.2.3"],
+            overrides: ["STABLE_RELEASE_PUSH_SUCCEEDS": "false"]
+        )
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(result.gitLog.contains("tag -a v1.2.3"), result.gitLog)
+        XCTAssertTrue(result.gitLog.contains("tag -d v1.2.3"), result.gitLog)
+        XCTAssertTrue(result.output.contains("newly created local tag was removed"), result.output)
+    }
+
+    private struct StarterResult {
+        var exitCode: Int32
+        var output: String
+        var gitLog: String
+        var ghLog: String
+    }
+
+    private func runStarter(
+        arguments: [String],
+        overrides: [String: String] = [:]
+    ) throws -> StarterResult {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-stable-release-start-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let binDirectory = temporaryDirectory.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let gitURL = binDirectory.appendingPathComponent("git")
+        let ghURL = binDirectory.appendingPathComponent("gh")
+        let gitLogURL = temporaryDirectory.appendingPathComponent("git.log")
+        let ghLogURL = temporaryDirectory.appendingPathComponent("gh.log")
+        try fakeGit.write(to: gitURL, atomically: true, encoding: .utf8)
+        try fakeGH.write(to: ghURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: gitURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: ghURL.path)
+
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts")
+                .appendingPathComponent("start-stable-release.sh")
+                .path
+        ] + arguments
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(binDirectory.path):\(environment["PATH"] ?? "")"
+        environment["STABLE_RELEASE_GIT_LOG"] = gitLogURL.path
+        environment["STABLE_RELEASE_GH_LOG"] = ghLogURL.path
+        environment["STABLE_RELEASE_BRANCH"] = "main"
+        environment["STABLE_RELEASE_DIRTY"] = "false"
+        environment["STABLE_RELEASE_HEAD_COMMIT"] = Self.commitA
+        environment["STABLE_RELEASE_MAIN_COMMIT"] = Self.commitA
+        environment["STABLE_RELEASE_TESTER_COMMIT"] = Self.commitA
+        environment["STABLE_RELEASE_REMOTE_URL"] = "git@github.com:Lore-Hex/QuillCode.git"
+        environment["STABLE_RELEASE_REMOTE_VERSION_TAGS"] =
+            "\(Self.commitB)\trefs/tags/v1.2.2"
+        environment["STABLE_RELEASE_LOCAL_TAG_EXISTS"] = "false"
+        environment["STABLE_RELEASE_VISIBILITY"] = "PUBLIC"
+        environment["STABLE_RELEASE_ROWS"] = "tester-latest\ttrue"
+        environment["STABLE_RELEASE_CI_URL"] =
+            "https://github.com/Lore-Hex/QuillCode/actions/runs/1"
+        environment["STABLE_RELEASE_SECRET_NAMES"] = Self.requiredSecrets.joined(separator: "\n")
+        environment["STABLE_RELEASE_PUSH_SUCCEEDS"] = "true"
+        for (key, value) in overrides {
+            environment[key] = value
+        }
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let gitLog = (try? String(contentsOf: gitLogURL, encoding: .utf8)) ?? ""
+        let ghLog = (try? String(contentsOf: ghLogURL, encoding: .utf8)) ?? ""
+        return StarterResult(
+            exitCode: process.terminationStatus,
+            output: output,
+            gitLog: gitLog,
+            ghLog: ghLog
+        )
+    }
+
+    private var fakeGit: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${STABLE_RELEASE_GIT_LOG:?}"
+        case "$1" in
+          remote)
+            [[ "$2" == "get-url" ]]
+            printf '%s\n' "${STABLE_RELEASE_REMOTE_URL:?}"
+            ;;
+          symbolic-ref)
+            printf '%s\n' "${STABLE_RELEASE_BRANCH:-}"
+            ;;
+          status)
+            if [[ "${STABLE_RELEASE_DIRTY:?}" == "true" ]]; then
+              printf '%s\n' ' M README.md'
+            fi
+            ;;
+          fetch)
+            ;;
+          rev-parse)
+            case "$3" in
+              HEAD*) printf '%s\n' "${STABLE_RELEASE_HEAD_COMMIT:?}" ;;
+              refs/remotes/*) printf '%s\n' "${STABLE_RELEASE_MAIN_COMMIT:?}" ;;
+              *) exit 9 ;;
+            esac
+            ;;
+          show-ref)
+            [[ "${STABLE_RELEASE_LOCAL_TAG_EXISTS:?}" == "true" ]]
+            ;;
+          ls-remote)
+            if [[ "$*" == *"refs/tags/tester-latest"* ]]; then
+              printf '%s\trefs/tags/tester-latest\n' "${STABLE_RELEASE_TESTER_COMMIT:?}"
+            else
+              printf '%s\n' "${STABLE_RELEASE_REMOTE_VERSION_TAGS:-}"
+            fi
+            ;;
+          tag)
+            ;;
+          push)
+            [[ "${STABLE_RELEASE_PUSH_SUCCEEDS:?}" == "true" ]]
+            ;;
+          *)
+            echo "unexpected git invocation: $*" >&2
+            exit 9
+            ;;
+        esac
+        """
+    }
+
+    private var fakeGH: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${STABLE_RELEASE_GH_LOG:?}"
+        if [[ "$1" == "repo" && "$2" == "view" ]]; then
+          printf '%s\n' "${STABLE_RELEASE_VISIBILITY:?}"
+          exit 0
+        fi
+        if [[ "$1" == "release" && "$2" == "list" ]]; then
+          printf '%s\n' "${STABLE_RELEASE_ROWS:-}"
+          exit 0
+        fi
+        if [[ "$1" == "run" && "$2" == "list" ]]; then
+          printf '%s\n' "${STABLE_RELEASE_CI_URL:-}"
+          exit 0
+        fi
+        if [[ "$1" == "secret" && "$2" == "list" ]]; then
+          printf '%s\n' "${STABLE_RELEASE_SECRET_NAMES:-}"
+          exit 0
+        fi
+        echo "unexpected gh invocation: $*" >&2
+        exit 9
+        """
+    }
+
+    private static let commitA = String(repeating: "a", count: 40)
+    private static let commitB = String(repeating: "b", count: 40)
+    private static let requiredSecrets = [
+        "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64",
+        "APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD",
+        "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY",
+        "APPLE_TEAM_ID",
+        "APPLE_NOTARY_KEY_ID",
+        "APPLE_NOTARY_ISSUER_ID",
+        "APPLE_NOTARY_PRIVATE_KEY_BASE64"
+    ]
+}

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -94,17 +94,22 @@ The app is still a tester build, so ask testers to include:
 ## Versioned Releases
 
 Stable releases are immutable and must use a canonical `vMAJOR.MINOR.PATCH` tag
-pointing to a commit on `main` with a successful **CI** run. Start from a clean,
-current `main`, verify that all Apple distribution secrets below are configured,
-then push the tag:
+pointing to a commit on `main` with a successful **CI** run. Use the fail-closed
+release starter instead of creating a tag by hand:
 
 ```bash
 git switch main
 git pull --ff-only origin main
-gh run list --workflow ci.yml --commit "$(git rev-parse HEAD)" --status success --limit 1
-git tag v0.1.0
-git push origin v0.1.0
+scripts/start-stable-release.sh --check-only v0.1.0
+scripts/start-stable-release.sh v0.1.0
 ```
+
+The preflight verifies the canonical and monotonically increasing version, exact
+clean `origin/main`, expected GitHub remote and public repository, successful
+exact-commit CI, a `tester-latest` tag and prerelease at the same commit, no
+existing local/remote tag or release, and all required Apple distribution secret
+names. The final command creates one annotated tag and pushes it without force.
+If that push fails, the command removes only the local tag it just created.
 
 The workflow rejects tags that are malformed, off `main`, missing successful CI,
 or already published. It creates the stable release as a draft, uploads every

--- a/scripts/start-stable-release.sh
+++ b/scripts/start-stable-release.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export LC_ALL=C
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPOSITORY="${GITHUB_REPOSITORY:-Lore-Hex/QuillCode}"
+REMOTE="${QUILLCODE_RELEASE_REMOTE:-origin}"
+BASE_BRANCH="${QUILLCODE_RELEASE_BASE_BRANCH:-main}"
+CHECK_ONLY=false
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/start-stable-release.sh [--check-only] vMAJOR.MINOR.PATCH
+
+Validates the exact public, tested main commit and Apple distribution secret names.
+Without --check-only, creates and pushes one annotated, immutable stable tag.
+USAGE
+}
+
+fail() {
+  echo "$*" >&2
+  exit 2
+}
+
+version_greater_than() {
+  local lhs="$1"
+  local rhs="$2"
+  local lhs_major lhs_minor lhs_patch rhs_major rhs_minor rhs_patch
+  IFS=. read -r lhs_major lhs_minor lhs_patch <<< "$lhs"
+  IFS=. read -r rhs_major rhs_minor rhs_patch <<< "$rhs"
+  local lhs_parts=("$lhs_major" "$lhs_minor" "$lhs_patch")
+  local rhs_parts=("$rhs_major" "$rhs_minor" "$rhs_patch")
+  local index lhs_part rhs_part
+
+  for index in 0 1 2; do
+    lhs_part="${lhs_parts[$index]}"
+    rhs_part="${rhs_parts[$index]}"
+    if (( ${#lhs_part} > ${#rhs_part} )); then
+      return 0
+    fi
+    if (( ${#lhs_part} < ${#rhs_part} )); then
+      return 1
+    fi
+    if [[ "$lhs_part" > "$rhs_part" ]]; then
+      return 0
+    fi
+    if [[ "$lhs_part" < "$rhs_part" ]]; then
+      return 1
+    fi
+  done
+  return 1
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+if [[ "${1:-}" == "--check-only" ]]; then
+  CHECK_ONLY=true
+  shift
+fi
+if [[ "$#" -ne 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+TAG="$1"
+if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  fail "Stable releases require a canonical vMAJOR.MINOR.PATCH tag."
+fi
+if [[ ! "$REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  fail "Invalid GitHub repository slug: $REPOSITORY"
+fi
+VERSION="${TAG#v}"
+
+for command in git gh; do
+  command -v "$command" >/dev/null 2>&1 || fail "Required command is unavailable: $command"
+done
+
+cd "$ROOT_DIR"
+
+REMOTE_URL="$(git remote get-url "$REMOTE")"
+NORMALIZED_REMOTE_URL="${REMOTE_URL%.git}"
+case "$NORMALIZED_REMOTE_URL" in
+  "https://github.com/$REPOSITORY"|"git@github.com:$REPOSITORY"|"ssh://git@github.com/$REPOSITORY") ;;
+  *) fail "Git remote $REMOTE does not point to https://github.com/$REPOSITORY." ;;
+esac
+
+CURRENT_BRANCH="$(git symbolic-ref --quiet --short HEAD || true)"
+if [[ "$CURRENT_BRANCH" != "$BASE_BRANCH" ]]; then
+  fail "Stable releases must start from the $BASE_BRANCH branch, not ${CURRENT_BRANCH:-detached HEAD}."
+fi
+if [[ -n "$(git status --porcelain=v1 --untracked-files=normal)" ]]; then
+  fail "Stable releases require a clean worktree, including no untracked files."
+fi
+
+git fetch --no-tags --prune "$REMOTE" \
+  "+refs/heads/$BASE_BRANCH:refs/remotes/$REMOTE/$BASE_BRANCH"
+
+HEAD_COMMIT="$(git rev-parse --verify 'HEAD^{commit}')"
+MAIN_COMMIT="$(git rev-parse --verify "refs/remotes/$REMOTE/$BASE_BRANCH^{commit}")"
+if [[ "$HEAD_COMMIT" != "$MAIN_COMMIT" ]]; then
+  fail "Local $BASE_BRANCH is not exact $REMOTE/$BASE_BRANCH ($MAIN_COMMIT)."
+fi
+if git show-ref --verify --quiet "refs/tags/$TAG"; then
+  fail "Local tag $TAG already exists."
+fi
+
+REMOTE_VERSION_TAGS="$(git ls-remote --tags --refs "$REMOTE" 'refs/tags/v*')"
+LATEST_VERSION=""
+while IFS=$'\t' read -r _ ref; do
+  [[ -z "$ref" ]] && continue
+  remote_tag="${ref#refs/tags/}"
+  if [[ "$remote_tag" == "$TAG" ]]; then
+    fail "Remote tag $TAG already exists and will not be moved."
+  fi
+  if [[ "$remote_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    remote_version="${remote_tag#v}"
+    if [[ -z "$LATEST_VERSION" ]] || version_greater_than "$remote_version" "$LATEST_VERSION"; then
+      LATEST_VERSION="$remote_version"
+    fi
+  fi
+done <<< "$REMOTE_VERSION_TAGS"
+if [[ -n "$LATEST_VERSION" ]] && ! version_greater_than "$VERSION" "$LATEST_VERSION"; then
+  fail "Stable version $VERSION must be newer than the latest tag, $LATEST_VERSION."
+fi
+
+TESTER_TAG_ROW="$(git ls-remote --refs "$REMOTE" refs/tags/tester-latest)"
+TESTER_COMMIT="$(awk 'NR == 1 { print $1 }' <<< "$TESTER_TAG_ROW")"
+if [[ "$TESTER_COMMIT" != "$HEAD_COMMIT" ]]; then
+  fail "Current main must already be published and exercised as tester-latest before a stable release."
+fi
+
+VISIBILITY="$(gh repo view "$REPOSITORY" --json visibility --jq '.visibility')"
+if [[ "$VISIBILITY" != "PUBLIC" ]]; then
+  fail "Stable releases require the GitHub repository to be public."
+fi
+
+RELEASE_ROWS="$(
+  gh release list \
+    --repo "$REPOSITORY" \
+    --limit 1000 \
+    --json tagName,isPrerelease \
+    --jq '.[] | [.tagName, .isPrerelease] | @tsv'
+)"
+TESTER_RELEASE_FOUND=false
+while IFS=$'\t' read -r release_tag is_prerelease; do
+  [[ -z "$release_tag" ]] && continue
+  if [[ "$release_tag" == "$TAG" ]]; then
+    fail "Stable release $TAG already exists and is immutable."
+  fi
+  if [[ "$release_tag" == "tester-latest" && "$is_prerelease" == "true" ]]; then
+    TESTER_RELEASE_FOUND=true
+  fi
+done <<< "$RELEASE_ROWS"
+if [[ "$TESTER_RELEASE_FOUND" != "true" ]]; then
+  fail "The public tester-latest prerelease is missing."
+fi
+
+CI_RUN_URL="$(
+  gh run list \
+    --repo "$REPOSITORY" \
+    --workflow ci.yml \
+    --commit "$HEAD_COMMIT" \
+    --status success \
+    --limit 1 \
+    --json url \
+    --jq '.[0].url // empty'
+)"
+if [[ -z "$CI_RUN_URL" ]]; then
+  fail "Commit $HEAD_COMMIT does not have a successful exact-commit CI run."
+fi
+
+REQUIRED_SECRETS=(
+  APPLE_DEVELOPER_ID_CERTIFICATE_BASE64
+  APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD
+  APPLE_DEVELOPER_ID_APPLICATION_IDENTITY
+  APPLE_TEAM_ID
+  APPLE_NOTARY_KEY_ID
+  APPLE_NOTARY_ISSUER_ID
+  APPLE_NOTARY_PRIVATE_KEY_BASE64
+)
+SECRET_NAMES="$(
+  gh secret list \
+    --repo "$REPOSITORY" \
+    --app actions \
+    --json name \
+    --jq '.[].name'
+)"
+for required_secret in "${REQUIRED_SECRETS[@]}"; do
+  if ! grep -Fxq "$required_secret" <<< "$SECRET_NAMES"; then
+    fail "Missing GitHub Actions secret: $required_secret"
+  fi
+done
+
+echo "Stable release preflight passed."
+echo "Repository: $REPOSITORY"
+echo "Tag: $TAG"
+echo "Commit: $HEAD_COMMIT"
+echo "Tester release: exact commit"
+echo "CI: $CI_RUN_URL"
+echo "Apple distribution secret names: ${#REQUIRED_SECRETS[@]}/${#REQUIRED_SECRETS[@]}"
+
+if [[ "$CHECK_ONLY" == "true" ]]; then
+  exit 0
+fi
+
+git tag -a "$TAG" -m "Quill Cowork $VERSION" "$HEAD_COMMIT"
+if ! git push "$REMOTE" "refs/tags/$TAG:refs/tags/$TAG"; then
+  git tag -d "$TAG" >/dev/null 2>&1 || true
+  fail "Failed to push $TAG; the newly created local tag was removed."
+fi
+
+echo "Stable release started: https://github.com/$REPOSITORY/actions/workflows/download-builds.yml"


### PR DESCRIPTION
## Summary
- add a single fail-closed stable-release starter with a read-only preflight mode
- require clean exact public main, matching tester publication, exact-commit CI, monotonic canonical versioning, no tag/release collision, and all Apple distribution secret names before mutation
- create one annotated non-force tag and remove only that local tag if the push fails
- replace the hand-written stable tag procedure in the distribution guide

## Verification
- `swift test --disable-sandbox --filter QuillCodeParityTests` (312 tests)
- live read-only repository visibility, release, exact-commit CI, and tester-tag queries
- `bash -n scripts/start-stable-release.sh`
- `git diff --check`