### PR TITLE
Verify published download releases

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -247,3 +247,30 @@ jobs:
 
             gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/* --clobber
           fi
+
+  verify-published:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Verify public release downloads
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            RELEASE_TAG="${GITHUB_REF_NAME}"
+            RELEASE_CHANNEL="stable"
+          else
+            RELEASE_TAG="tester-latest"
+            RELEASE_CHANNEL="tester"
+          fi
+          scripts/verify-published-release.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --channel "$RELEASE_CHANNEL" \
+            --commit "$GITHUB_SHA" \
+            --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildPlanGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildPlanGateTests.swift
@@ -22,8 +22,9 @@ final class ParityDownloadBuildPlanGateTests: QuillCodeParityTestCase {
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         XCTAssertEqual(result.buildRequired, "false")
-        XCTAssertTrue(result.output.contains("already publishes commit \(commit)"))
+        XCTAssertTrue(result.output.contains("already publishes verified commit \(commit)"))
         XCTAssertTrue(result.ghLog.contains("release download tester-latest"))
+        XCTAssertTrue(result.ghLog.contains("run view 12345"))
     }
 
     func testScheduledRunBuildsWhenPublishedCommitIsStale() throws {
@@ -46,6 +47,23 @@ final class ParityDownloadBuildPlanGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(malformed.output.contains("manifest is malformed"))
     }
 
+    func testScheduledRunRebuildsWhenPublishingRunIsNotSuccessfulAndExact() throws {
+        let cases = [
+            try runPlanner(runStatus: "in_progress", runConclusion: ""),
+            try runPlanner(runConclusion: "failure"),
+            try runPlanner(runCommit: String(repeating: "b", count: 40)),
+            try runPlanner(runURL: "https://github.com/Lore-Hex/QuillCode/actions/runs/999"),
+            try runPlanner(runName: "CI"),
+            try runPlanner(runAvailable: false)
+        ]
+
+        for result in cases {
+            XCTAssertEqual(result.exitCode, 0, result.output)
+            XCTAssertEqual(result.buildRequired, "true")
+            XCTAssertTrue(result.output.contains("run is unavailable, incomplete, failed, or mismatched"))
+        }
+    }
+
     private struct PlannerResult {
         var exitCode: Int32
         var output: String
@@ -59,7 +77,13 @@ final class ParityDownloadBuildPlanGateTests: QuillCodeParityTestCase {
         commit: String = String(repeating: "a", count: 40),
         publishedCommit: String = String(repeating: "a", count: 40),
         manifestAvailable: Bool = true,
-        manifestMalformed: Bool = false
+        manifestMalformed: Bool = false,
+        runAvailable: Bool = true,
+        runStatus: String = "completed",
+        runConclusion: String = "success",
+        runCommit: String = String(repeating: "a", count: 40),
+        runURL: String = "https://github.com/Lore-Hex/QuillCode/actions/runs/12345",
+        runName: String = "Download Builds"
     ) throws -> PlannerResult {
         let temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("quillcode-download-plan-tests")
@@ -96,6 +120,12 @@ final class ParityDownloadBuildPlanGateTests: QuillCodeParityTestCase {
         environment["DOWNLOAD_PLAN_MANIFEST_AVAILABLE"] = manifestAvailable ? "true" : "false"
         environment["DOWNLOAD_PLAN_MANIFEST_MALFORMED"] = manifestMalformed ? "true" : "false"
         environment["DOWNLOAD_PLAN_PUBLISHED_COMMIT"] = publishedCommit
+        environment["DOWNLOAD_PLAN_RUN_AVAILABLE"] = runAvailable ? "true" : "false"
+        environment["DOWNLOAD_PLAN_RUN_STATUS"] = runStatus
+        environment["DOWNLOAD_PLAN_RUN_CONCLUSION"] = runConclusion
+        environment["DOWNLOAD_PLAN_RUN_COMMIT"] = runCommit
+        environment["DOWNLOAD_PLAN_RUN_URL"] = runURL
+        environment["DOWNLOAD_PLAN_RUN_NAME"] = runName
         environment["DOWNLOAD_PLAN_GH_LOG"] = ghLogURL.path
         process.environment = environment
 
@@ -131,9 +161,25 @@ final class ParityDownloadBuildPlanGateTests: QuillCodeParityTestCase {
           if [[ "${DOWNLOAD_PLAN_MANIFEST_MALFORMED:?}" == "true" ]]; then
             printf '%s\n' '{not-json' > "$output_directory/latest-tester-build.json"
           else
-            printf '{"commit":"%s"}\n' "${DOWNLOAD_PLAN_PUBLISHED_COMMIT:?}" \
-              > "$output_directory/latest-tester-build.json"
+            {
+              printf '%s' '{"schemaVersion":1,"product":"Quill Cowork","channel":"tester",'
+              printf '%s' '"tag":"tester-latest","commit":"'
+              printf '%s' "${DOWNLOAD_PLAN_PUBLISHED_COMMIT:?}"
+              printf '%s' '","workflowRunURL":"https://github.com/Lore-Hex/QuillCode/actions/runs/12345",'
+              printf '%s' '"updater":{"channel":"tester","manifestURL":"https://github.com/'
+              printf '%s\n' 'Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"}}'
+            } > "$output_directory/latest-tester-build.json"
           fi
+          exit 0
+        fi
+        if [[ "$1" == "run" && "$2" == "view" ]]; then
+          [[ "${DOWNLOAD_PLAN_RUN_AVAILABLE:?}" == "true" ]] || exit 1
+          printf '%s\t%s\t%s\t%s\t%s\n' \
+            "${DOWNLOAD_PLAN_RUN_STATUS-}" \
+            "${DOWNLOAD_PLAN_RUN_CONCLUSION-}" \
+            "${DOWNLOAD_PLAN_RUN_COMMIT:?}" \
+            "${DOWNLOAD_PLAN_RUN_URL:?}" \
+            "${DOWNLOAD_PLAN_RUN_NAME:?}"
           exit 0
         fi
         echo "unexpected gh invocation: $*" >&2

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -121,6 +121,67 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertEqual(checksumAsset["kind"] as? String, "checksum")
     }
 
+    func testStableManifestUsesTheMovingFeedEmbeddedInTheStableApp() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-stable-manifest-tests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let stableFeed = "https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json"
+        let testerFeed = "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/" +
+            "latest-tester-build.json"
+        let buildInfoURL = temporaryDirectory.appendingPathComponent("BUILD_INFO.txt")
+        try """
+        product=Quill Cowork
+        platform=macOS
+        arch=arm64
+        version=1.2.3
+        build=456
+        bundleIdentifier=co.lorehex.QuillCowork
+        minimumSystemVersion=14.0
+        updateChannel=stable
+        updateManifestURL=\(stableFeed)
+        stableUpdateManifestURL=\(stableFeed)
+        testerUpdateManifestURL=\(testerFeed)
+        """.write(to: buildInfoURL, atomically: true, encoding: .utf8)
+        try Data("stable app".utf8).write(
+            to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64.zip")
+        )
+
+        let manifestURL = temporaryDirectory.appendingPathComponent("latest-stable-build.json")
+        let script = Self.packageRoot()
+            .appendingPathComponent("scripts")
+            .appendingPathComponent("build-download-manifest.py")
+        let arguments = [
+            "--assets-dir", temporaryDirectory.path,
+            "--repo", "Lore-Hex/QuillCode",
+            "--tag", "v1.2.3",
+            "--channel", "stable",
+            "--commit", String(repeating: "a", count: 40),
+            "--workflow-run-url", "https://github.com/Lore-Hex/QuillCode/actions/runs/456",
+            "--generated-at", "2026-08-07T00:00:00Z",
+            "--output", manifestURL.path
+        ]
+        let result = try Self.runPython(script, arguments: arguments)
+        XCTAssertEqual(result.exitCode, 0, result.output)
+
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let updater = try XCTUnwrap(manifest["updater"] as? [String: Any])
+        XCTAssertEqual(updater["channel"] as? String, "stable")
+        XCTAssertEqual(updater["manifestURL"] as? String, stableFeed)
+        XCTAssertEqual(updater["stableManifestURL"] as? String, stableFeed)
+        XCTAssertEqual(updater["testerManifestURL"] as? String, testerFeed)
+
+        let mismatchedBuildInfo = try String(contentsOf: buildInfoURL, encoding: .utf8)
+            .replacingOccurrences(of: stableFeed, with: "https://example.com/stable.json", options: [], range: nil)
+        try mismatchedBuildInfo.write(to: buildInfoURL, atomically: true, encoding: .utf8)
+        let mismatch = try Self.runPython(script, arguments: arguments)
+        XCTAssertNotEqual(mismatch.exitCode, 0)
+        XCTAssertTrue(mismatch.output.contains("BUILD_INFO updateManifestURL must be"), mismatch.output)
+    }
+
     func testDownloadBuildWorkflowPublishesManifestWithReleaseAssets() throws {
         let workflow = try Self.workflowText(named: "download-builds.yml")
 
@@ -155,7 +216,12 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "--draft",
             "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/*",
             "gh release edit \"$RELEASE_TAG\" --draft=false --latest",
-            "Stable release $RELEASE_TAG already exists and is immutable."
+            "Stable release $RELEASE_TAG already exists and is immutable.",
+            "verify-published:",
+            "needs: publish",
+            "Verify public release downloads",
+            "scripts/verify-published-release.py",
+            "--workflow-run-url \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\""
         ])
         XCTAssertFalse(
             workflow.contains("cancel-in-progress: true"),
@@ -182,6 +248,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "QuillCodeTesterUpdateManifestURL",
             "canonical `vMAJOR.MINOR.PATCH` tag",
             "scripts/start-stable-release.sh --check-only v0.1.0",
+            "scripts/verify-published-release.py",
+            "same moving channel feed embedded",
+            "publication is not green until this consumer check passes",
             "creates one annotated tag and pushes it without force",
             "an existing stable release is never edited or clobbered automatically",
             "avoids no-op build-number updates and unnecessary",

--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -1,0 +1,303 @@
+import CryptoKit
+import Foundation
+import XCTest
+
+final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase {
+    private let repository = "Lore-Hex/QuillCode"
+    private let tag = "tester-latest"
+    private let commit = String(repeating: "a", count: 40)
+    private let workflowRunURL = "https://github.com/Lore-Hex/QuillCode/actions/runs/12345"
+
+    func testVerifierAcceptsAnExactPublishedReleaseSnapshot() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Verified public Quill Cowork tester release tester-latest"))
+    }
+
+    func testVerifierRejectsFeedDriftAndPayloadCorruption() throws {
+        let feedFixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: feedFixture.root) }
+        try mutateManifest(feedFixture) { manifest in
+            var updater = try XCTUnwrap(manifest["updater"] as? [String: Any])
+            updater["manifestURL"] = stableManifestURL
+            manifest["updater"] = updater
+        }
+        let feedResult = try runVerifier(feedFixture)
+        XCTAssertEqual(feedResult.exitCode, 2, feedResult.output)
+        XCTAssertTrue(feedResult.output.contains("updater manifestURL"), feedResult.output)
+
+        let payloadFixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: payloadFixture.root) }
+        let appURL = payloadFixture.assets.appendingPathComponent("Quill-Cowork-macOS-arm64.zip")
+        var appData = try Data(contentsOf: appURL)
+        appData.append(Data("tampered".utf8))
+        try appData.write(to: appURL)
+        let payloadResult = try runVerifier(payloadFixture)
+        XCTAssertEqual(payloadResult.exitCode, 2, payloadResult.output)
+        XCTAssertTrue(payloadResult.output.contains("exceeds its declared size"), payloadResult.output)
+    }
+
+    func testVerifierRejectsStaleReleaseAssetsAndTagDrift() throws {
+        let inventoryFixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: inventoryFixture.root) }
+        var release = try jsonObject(at: inventoryFixture.releaseJSON)
+        var assets = try XCTUnwrap(release["assets"] as? [[String: Any]])
+        assets.append([
+            "name": "stale.zip",
+            "state": "uploaded",
+            "size": 1,
+            "digest": "sha256:\(String(repeating: "0", count: 64))",
+            "browser_download_url": releaseDownloadURL(named: "stale.zip")
+        ])
+        release["assets"] = assets
+        try writeJSON(release, to: inventoryFixture.releaseJSON)
+        let inventoryResult = try runVerifier(inventoryFixture)
+        XCTAssertEqual(inventoryResult.exitCode, 2, inventoryResult.output)
+        XCTAssertTrue(inventoryResult.output.contains("inventory does not exactly match"), inventoryResult.output)
+
+        let tagFixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: tagFixture.root) }
+        let tagResult = try runVerifier(tagFixture, tagCommit: String(repeating: "b", count: 40))
+        XCTAssertEqual(tagResult.exitCode, 2, tagResult.output)
+        XCTAssertTrue(tagResult.output.contains("release tag resolves to"), tagResult.output)
+    }
+
+    private struct Fixture {
+        var root: URL
+        var assets: URL
+        var manifest: URL
+        var releaseJSON: URL
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-cowork-release-verifier-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let assetsURL = root.appendingPathComponent("assets", isDirectory: true)
+        try FileManager.default.createDirectory(at: assetsURL, withIntermediateDirectories: true)
+
+        let appName = "Quill-Cowork-macOS-arm64.zip"
+        let cliName = "quill-code-macOS-arm64.tar.gz"
+        let buildInfoName = "BUILD_INFO.txt"
+        let checksumsName = "SHASUMS256.txt"
+        try Data("verified app payload".utf8).write(to: assetsURL.appendingPathComponent(appName))
+        try Data("verified cli payload".utf8).write(to: assetsURL.appendingPathComponent(cliName))
+        try """
+        product=Quill Cowork
+        platform=macOS
+        arch=arm64
+        version=0.2.0
+        build=123
+        commit=\(commit)
+        createdAt=2026-08-07T00:00:00Z
+        configuration=release
+        bundleIdentifier=co.lorehex.QuillCowork
+        minimumSystemVersion=14.0
+        updateChannel=tester
+        updateManifestURL=\(testerManifestURL)
+        stableUpdateManifestURL=\(stableManifestURL)
+        testerUpdateManifestURL=\(testerManifestURL)
+        app=\(appName)
+        cli=\(cliName)
+        codesign=ad-hoc
+        signingTeamIdentifier=none
+        notarized=false
+        """.write(
+            to: assetsURL.appendingPathComponent(buildInfoName),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let checksummedNames = [buildInfoName, appName, cliName].sorted()
+        let checksumText = try checksummedNames.map { name in
+            let digest = try sha256(at: assetsURL.appendingPathComponent(name))
+            return "\(digest)  \(name)"
+        }.joined(separator: "\n") + "\n"
+        try checksumText.write(
+            to: assetsURL.appendingPathComponent(checksumsName),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let appAsset = try manifestAsset(
+            named: appName,
+            kind: "app",
+            platform: "macOS",
+            arch: "arm64",
+            install: "zip-app",
+            assetsURL: assetsURL
+        )
+        let manifestAssets = try [
+            manifestAsset(
+                named: buildInfoName,
+                kind: "metadata",
+                platform: "macOS",
+                arch: "any",
+                install: "text",
+                assetsURL: assetsURL
+            ),
+            appAsset,
+            manifestAsset(
+                named: checksumsName,
+                kind: "checksum",
+                platform: "any",
+                arch: "any",
+                install: "text",
+                assetsURL: assetsURL
+            ),
+            manifestAsset(
+                named: cliName,
+                kind: "cli",
+                platform: "macOS",
+                arch: "arm64",
+                install: "tarball",
+                assetsURL: assetsURL
+            )
+        ]
+        let manifest: [String: Any] = [
+            "schemaVersion": 1,
+            "product": "Quill Cowork",
+            "channel": "tester",
+            "tag": tag,
+            "releaseURL": "https://github.com/\(repository)/releases/tag/\(tag)",
+            "commit": commit,
+            "version": "0.2.0",
+            "build": "123",
+            "generatedAt": "2026-08-07T00:00:01Z",
+            "workflowRunURL": workflowRunURL,
+            "updater": [
+                "schemaVersion": 1,
+                "format": "github-release-manifest",
+                "channel": "tester",
+                "manifestURL": testerManifestURL,
+                "stableManifestURL": stableManifestURL,
+                "testerManifestURL": testerManifestURL,
+                "bundleIdentifier": "co.lorehex.QuillCowork",
+                "minimumSystemVersion": "14.0",
+                "codesign": "ad-hoc",
+                "signingTeamIdentifier": NSNull(),
+                "notarized": false,
+                "macOSAppAsset": appAsset
+            ],
+            "assets": manifestAssets
+        ]
+        let manifestURL = root.appendingPathComponent("latest-tester-build.json")
+        try writeJSON(manifest, to: manifestURL)
+
+        var releaseAssets = try manifestAssets.map { asset -> [String: Any] in
+            let name = try XCTUnwrap(asset["name"] as? String)
+            return [
+                "name": name,
+                "state": "uploaded",
+                "size": try XCTUnwrap(asset["sizeBytes"] as? Int),
+                "digest": "sha256:\(try XCTUnwrap(asset["sha256"] as? String))",
+                "browser_download_url": releaseDownloadURL(named: name)
+            ]
+        }
+        releaseAssets.append([
+            "name": manifestURL.lastPathComponent,
+            "state": "uploaded",
+            "size": try Data(contentsOf: manifestURL).count,
+            "digest": "sha256:\(try sha256(at: manifestURL))",
+            "browser_download_url": releaseDownloadURL(named: manifestURL.lastPathComponent)
+        ])
+        let release: [String: Any] = [
+            "tag_name": tag,
+            "draft": false,
+            "prerelease": true,
+            "assets": releaseAssets
+        ]
+        let releaseJSONURL = root.appendingPathComponent("release.json")
+        try writeJSON(release, to: releaseJSONURL)
+        return Fixture(root: root, assets: assetsURL, manifest: manifestURL, releaseJSON: releaseJSONURL)
+    }
+
+    private func manifestAsset(
+        named name: String,
+        kind: String,
+        platform: String,
+        arch: String,
+        install: String,
+        assetsURL: URL
+    ) throws -> [String: Any] {
+        let url = assetsURL.appendingPathComponent(name)
+        return [
+            "name": name,
+            "kind": kind,
+            "platform": platform,
+            "arch": arch,
+            "install": install,
+            "sizeBytes": try Data(contentsOf: url).count,
+            "sha256": try sha256(at: url),
+            "url": releaseDownloadURL(named: name)
+        ]
+    }
+
+    private func runVerifier(
+        _ fixture: Fixture,
+        tagCommit: String? = nil
+    ) throws -> ScriptResult {
+        let script = Self.packageRoot()
+            .appendingPathComponent("scripts")
+            .appendingPathComponent("verify-published-release.py")
+        return try Self.runPython(script, arguments: [
+            "--repo", repository,
+            "--tag", tag,
+            "--channel", "tester",
+            "--commit", commit,
+            "--workflow-run-url", workflowRunURL,
+            "--release-json", fixture.releaseJSON.path,
+            "--tag-commit", tagCommit ?? commit,
+            "--manifest", fixture.manifest.path,
+            "--assets-dir", fixture.assets.path
+        ])
+    }
+
+    private func mutateManifest(
+        _ fixture: Fixture,
+        mutation: (inout [String: Any]) throws -> Void
+    ) throws {
+        var manifest = try jsonObject(at: fixture.manifest)
+        try mutation(&manifest)
+        try writeJSON(manifest, to: fixture.manifest)
+
+        var release = try jsonObject(at: fixture.releaseJSON)
+        var assets = try XCTUnwrap(release["assets"] as? [[String: Any]])
+        let index = try XCTUnwrap(assets.firstIndex { $0["name"] as? String == fixture.manifest.lastPathComponent })
+        assets[index]["size"] = try Data(contentsOf: fixture.manifest).count
+        assets[index]["digest"] = "sha256:\(try sha256(at: fixture.manifest))"
+        release["assets"] = assets
+        try writeJSON(release, to: fixture.releaseJSON)
+    }
+
+    private func jsonObject(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func writeJSON(_ value: [String: Any], to url: URL) throws {
+        let data = try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .sortedKeys])
+        try (data + Data("\n".utf8)).write(to: url)
+    }
+
+    private func sha256(at url: URL) throws -> String {
+        let digest = SHA256.hash(data: try Data(contentsOf: url))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func releaseDownloadURL(named name: String) -> String {
+        "https://github.com/\(repository)/releases/download/\(tag)/\(name)"
+    }
+
+    private var testerManifestURL: String {
+        releaseDownloadURL(named: "latest-tester-build.json")
+    }
+
+    private var stableManifestURL: String {
+        "https://github.com/\(repository)/releases/latest/download/latest-stable-build.json"
+    }
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3381,3 +3381,22 @@
   `scripts/native_click_probe_contracts/live_app_computer_use_template.py`,
   `scripts/live-app-computer-use-smoke.sh`, `scripts/live-app-computer-use-template.sh`, and
   `ParityLiveAppComputerUseSmokeGateTests`.
+
+## 2026-08-07: published downloads are verified as a public consumer
+
+- **Decision:** Every non-skipped **Download Builds** run has a read-only post-publish job that
+  resolves the release tag, validates the release/manifest/updater contract, downloads every public
+  asset with strict aggregate and per-file bounds, and checks GitHub API digests, manifest digests,
+  `SHASUMS256.txt`, and `BUILD_INFO.txt`. Stable manifests identify the same moving
+  `releases/latest` feed embedded in stable apps; tester manifests identify `tester-latest`.
+- **Why:** Pre-upload package checks cannot prove that GitHub serves a coherent public release. The
+  previous stable manifest also reported its immutable tag URL while the app embedded the moving
+  stable URL, causing the updater's exact-feed defense to reject a legitimate stable manifest.
+- **Recovery:** Scheduled deduplication skips only when the tester manifest is structurally valid and
+  its exact **Download Builds** run completed successfully on the same commit. Failed, partial, or
+  mismatched publications are rebuilt instead of becoming a permanently skipped state.
+- **Evidence:** `scripts/verify-published-release.py`, `scripts/release_verification_contract.py`,
+  `scripts/release_verification_files.py`, `scripts/build-download-manifest.py`,
+  `scripts/plan-download-build.sh`, `.github/workflows/download-builds.yml`,
+  `ParityPublishedReleaseVerificationGateTests`, `ParityDownloadBuildPlanGateTests`, and
+  `ParityDownloadBuildsGateTests`.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -30,14 +30,24 @@ The tester release is refreshed:
 - after every successful push to `main`
 - after merge-train PR merges, which explicitly dispatch **Download Builds**
 - from the nightly **Download Builds** recovery check when the published tester
-  manifest is missing, malformed, stale, or points to another `main` commit
+  manifest is missing, malformed, stale, points to another `main` commit, or
+  names a publishing run that is unavailable, incomplete, failed, or mismatched
 - whenever a maintainer runs **Download Builds** manually from GitHub Actions
 
-The nightly check skips packaging when the live manifest already publishes the
-current `main` commit. This avoids no-op build-number updates and unnecessary
-updater prompts. When a build is required, the workflow updates the stable
-`tester-latest` tag and replaces release assets in place, so the links above do
-not change as new builds are published.
+The nightly check skips packaging only when the live manifest publishes the
+current `main` commit and its exact **Download Builds** run completed successfully
+on that commit. This avoids no-op build-number updates and unnecessary updater
+prompts without treating a partial publication as healthy.
+When a build is required, the workflow updates the stable `tester-latest` tag
+and replaces release assets in place, so the links above do not change as new
+builds are published.
+
+After publishing, a separate read-only job consumes the release through the
+same public GitHub API and download URLs users receive. It resolves the release
+tag to the expected commit, checks the exact release inventory and updater feed
+contract, then downloads every declared asset with bounded streaming and
+verifies GitHub's digest, manifest size/SHA-256, `SHASUMS256.txt`, and
+`BUILD_INFO.txt`. A publication is not green until this consumer check passes.
 
 ## Auto-Update Contract
 
@@ -59,6 +69,11 @@ The stable feed is:
 ```text
 https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json
 ```
+
+The manifest's `updater.manifestURL` is the same moving channel feed embedded
+in the app: `tester-latest` for tester builds and `releases/latest` for stable
+builds. Manifest generation fails when `BUILD_INFO.txt` and this feed identity
+disagree, because the app intentionally rejects a manifest from any other URL.
 
 The macOS app checks this feed after launch, no more than every six hours on the
 tester channel or daily on stable. **Check for Updates...** in the app menu runs
@@ -158,6 +173,17 @@ The workflow publishes the same manifest schema for manual, scheduled, `main`,
 and `v*` tag builds. For `v*` tags, the channel is `stable` and the asset is
 `latest-stable-build.json`; for `tester-latest`, the channel is `tester` and the
 asset is `latest-tester-build.json`.
+
+To re-run the public consumer verification for a known publication:
+
+```bash
+scripts/verify-published-release.py \
+  --repo Lore-Hex/QuillCode \
+  --tag tester-latest \
+  --channel tester \
+  --commit "$COMMIT" \
+  --workflow-run-url "$WORKFLOW_RUN_URL"
+```
 
 ## Local Packaging
 

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -24,7 +24,12 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--tag", required=True, help="Release tag used in download URLs.")
     parser.add_argument("--commit", required=True, help="Git commit SHA for this build.")
     parser.add_argument("--workflow-run-url", required=True, help="GitHub Actions run URL.")
-    parser.add_argument("--channel", default="tester", help="Release channel label.")
+    parser.add_argument(
+        "--channel",
+        choices=("stable", "tester"),
+        default="tester",
+        help="Release channel label.",
+    )
     parser.add_argument("--generated-at", help="UTC ISO timestamp override for tests.")
     parser.add_argument("--output", required=True, help="Manifest JSON output path.")
     return parser.parse_args()
@@ -84,9 +89,7 @@ def latest_release_download_url(repo: str, asset_name: str) -> str:
 def build_updater_metadata(
     *,
     repo: str,
-    tag: str,
     channel: str,
-    output_path: Path,
     build_info: dict[str, str],
     assets: list[dict[str, object]],
 ) -> dict[str, object]:
@@ -97,13 +100,32 @@ def build_updater_metadata(
     signing_team = build_info.get("signingTeamIdentifier")
     if not signing_team or signing_team == "none":
         signing_team = None
+    stable_manifest_url = latest_release_download_url(repo, "latest-stable-build.json")
+    tester_manifest_url = release_download_url(
+        repo,
+        "tester-latest",
+        "latest-tester-build.json",
+    )
+    manifest_url = stable_manifest_url if channel == "stable" else tester_manifest_url
+    expected_build_info = {
+        "updateChannel": channel,
+        "updateManifestURL": manifest_url,
+        "stableUpdateManifestURL": stable_manifest_url,
+        "testerUpdateManifestURL": tester_manifest_url,
+    }
+    for key, expected in expected_build_info.items():
+        actual = build_info.get(key)
+        if actual != expected:
+            raise SystemExit(
+                f"BUILD_INFO {key} must be {expected!r}, found {actual!r}"
+            )
     return {
         "schemaVersion": 1,
         "format": "github-release-manifest",
         "channel": channel,
-        "manifestURL": release_download_url(repo, tag, output_path.name),
-        "stableManifestURL": latest_release_download_url(repo, "latest-stable-build.json"),
-        "testerManifestURL": release_download_url(repo, "tester-latest", "latest-tester-build.json"),
+        "manifestURL": manifest_url,
+        "stableManifestURL": stable_manifest_url,
+        "testerManifestURL": tester_manifest_url,
         "bundleIdentifier": build_info.get("bundleIdentifier", "co.lorehex.QuillCowork"),
         "minimumSystemVersion": build_info.get("minimumSystemVersion", "14.0"),
         "codesign": build_info.get("codesign", "unknown"),
@@ -146,9 +168,7 @@ def build_manifest(arguments: argparse.Namespace) -> dict[str, object]:
 
     updater = build_updater_metadata(
         repo=arguments.repo,
-        tag=arguments.tag,
         channel=arguments.channel,
-        output_path=output_path,
         build_info=build_info,
         assets=assets,
     )

--- a/scripts/plan-download-build.sh
+++ b/scripts/plan-download-build.sh
@@ -19,8 +19,9 @@ if [[ "$EVENT_NAME" == "schedule" && "$REF_TYPE" == "branch" ]]; then
     --repo "$REPOSITORY" \
     --pattern latest-tester-build.json \
     --dir "$download_directory" >/dev/null 2>&1; then
-    if published_commit="$(python3 - "$manifest_path" <<'PY'
+    if published_metadata="$(python3 - "$manifest_path" "$REPOSITORY" <<'PY'
 import json
+import re
 import sys
 
 try:
@@ -29,15 +30,52 @@ try:
 except (OSError, ValueError):
     raise SystemExit(1)
 
+repository = sys.argv[2]
 commit = manifest.get("commit")
-if not isinstance(commit, str) or not commit:
+workflow_run_url = manifest.get("workflowRunURL")
+expected_manifest_url = (
+    f"https://github.com/{repository}/releases/download/"
+    "tester-latest/latest-tester-build.json"
+)
+updater = manifest.get("updater")
+if (
+    manifest.get("schemaVersion") != 1
+    or manifest.get("product") != "Quill Cowork"
+    or manifest.get("channel") != "tester"
+    or manifest.get("tag") != "tester-latest"
+    or not isinstance(commit, str)
+    or re.fullmatch(r"[0-9a-f]{40}", commit) is None
+    or not isinstance(workflow_run_url, str)
+    or re.fullmatch(
+        rf"https://github\.com/{re.escape(repository)}/actions/runs/([0-9]+)",
+        workflow_run_url,
+    ) is None
+    or not isinstance(updater, dict)
+    or updater.get("channel") != "tester"
+    or updater.get("manifestURL") != expected_manifest_url
+):
     raise SystemExit(1)
-print(commit)
+run_id = workflow_run_url.rsplit("/", 1)[1]
+print(f"{commit}\t{run_id}\t{workflow_run_url}")
 PY
     )"; then
+      IFS=$'\t' read -r published_commit published_run_id published_run_url <<< "$published_metadata"
       if [[ "$published_commit" == "$COMMIT" ]]; then
-        build_required=false
-        reason="tester manifest already publishes commit $COMMIT"
+        published_run="$(gh run view "$published_run_id" \
+          --repo "$REPOSITORY" \
+          --json status,conclusion,headSha,url,name \
+          --jq '[.status, .conclusion, .headSha, .url, .name] | @tsv' 2>/dev/null || true)"
+        IFS=$'\t' read -r run_status run_conclusion run_commit run_url run_name <<< "$published_run"
+        if [[ "$run_status" == "completed" &&
+              "$run_conclusion" == "success" &&
+              "$run_commit" == "$COMMIT" &&
+              "$run_url" == "$published_run_url" &&
+              "$run_name" == "Download Builds" ]]; then
+          build_required=false
+          reason="tester manifest already publishes verified commit $COMMIT"
+        else
+          reason="tester manifest run is unavailable, incomplete, failed, or mismatched; rebuilding"
+        fi
       else
         reason="tester manifest publishes $published_commit instead of $COMMIT"
       fi

--- a/scripts/release_verification_contract.py
+++ b/scripts/release_verification_contract.py
@@ -1,0 +1,276 @@
+"""Structural contract validation for published Quill Cowork releases."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+PRODUCT = "Quill Cowork"
+BUNDLE_IDENTIFIER = "co.lorehex.QuillCowork"
+MANIFEST_BYTE_LIMIT = 256 * 1024
+API_BYTE_LIMIT = 4 * 1024 * 1024
+MAXIMUM_ASSET_BYTES = 2 * 1024 * 1024 * 1024
+MAXIMUM_RELEASE_BYTES = 4 * 1024 * 1024 * 1024
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
+VERSION_PATTERN = re.compile(
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+)
+BUILD_PATTERN = re.compile(r"0|[1-9][0-9]*")
+REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+class VerificationError(RuntimeError):
+    """A public release violated the distribution contract."""
+
+
+def expected_urls(repo: str, tag: str, channel: str) -> dict[str, str]:
+    encoded_tag = quote(tag, safe="")
+    manifest_name = f"latest-{channel}-build.json"
+    return {
+        "manifest_name": manifest_name,
+        "manifest": (
+            f"https://github.com/{repo}/releases/download/{encoded_tag}/"
+            f"{quote(manifest_name, safe='')}"
+        ),
+        "release": f"https://github.com/{repo}/releases/tag/{encoded_tag}",
+        "stable": (
+            f"https://github.com/{repo}/releases/latest/download/"
+            "latest-stable-build.json"
+        ),
+        "tester": (
+            f"https://github.com/{repo}/releases/download/tester-latest/"
+            "latest-tester-build.json"
+        ),
+    }
+
+
+def load_json_bytes(data: bytes, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise VerificationError(f"{label} is not valid UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise VerificationError(f"{label} must be a JSON object")
+    return value
+
+
+def required_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise VerificationError(f"{label} must be a nonempty string")
+    return value
+
+
+def required_integer(value: Any, label: str) -> int:
+    if type(value) is not int:
+        raise VerificationError(f"{label} must be an integer")
+    return value
+
+
+def api_asset_map(release: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw_assets = release.get("assets")
+    if not isinstance(raw_assets, list):
+        raise VerificationError("release assets must be an array")
+    assets: dict[str, dict[str, Any]] = {}
+    for index, raw_asset in enumerate(raw_assets):
+        if not isinstance(raw_asset, dict):
+            raise VerificationError(f"release asset {index} must be an object")
+        name = required_string(raw_asset.get("name"), f"release asset {index} name")
+        if name in assets:
+            raise VerificationError(f"release contains duplicate asset {name!r}")
+        assets[name] = raw_asset
+    return assets
+
+
+def validate_api_asset(
+    api_asset: dict[str, Any],
+    *,
+    name: str,
+    size: int,
+    digest: str,
+    url: str,
+) -> None:
+    if api_asset.get("state") != "uploaded":
+        raise VerificationError(f"release asset {name!r} is not uploaded")
+    if required_integer(api_asset.get("size"), f"release asset {name} size") != size:
+        raise VerificationError(
+            f"release asset {name!r} size disagrees with the manifest"
+        )
+    if api_asset.get("digest") != f"sha256:{digest}":
+        raise VerificationError(
+            f"release asset {name!r} digest disagrees with the manifest"
+        )
+    if api_asset.get("browser_download_url") != url:
+        raise VerificationError(
+            f"release asset {name!r} URL disagrees with the manifest"
+        )
+
+
+def validate_manifest(
+    manifest: dict[str, Any],
+    manifest_bytes: bytes,
+    release: dict[str, Any],
+    tag_commit: str,
+    *,
+    repo: str,
+    tag: str,
+    channel: str,
+    commit: str,
+    workflow_run_url: str,
+) -> list[dict[str, Any]]:
+    urls = expected_urls(repo, tag, channel)
+    expected_prerelease = channel == "tester"
+    if release.get("tag_name") != tag:
+        raise VerificationError("GitHub release tag does not match the requested tag")
+    if release.get("draft") is not False:
+        raise VerificationError("GitHub release is still a draft")
+    if release.get("prerelease") is not expected_prerelease:
+        raise VerificationError(
+            "GitHub release prerelease state does not match its channel"
+        )
+    if tag_commit != commit:
+        raise VerificationError(f"release tag resolves to {tag_commit}, expected {commit}")
+
+    expected_top_level = {
+        "schemaVersion": 1,
+        "product": PRODUCT,
+        "channel": channel,
+        "tag": tag,
+        "releaseURL": urls["release"],
+        "commit": commit,
+        "workflowRunURL": workflow_run_url,
+    }
+    for key, expected in expected_top_level.items():
+        if manifest.get(key) != expected:
+            raise VerificationError(
+                f"manifest {key} does not match the published release"
+            )
+    version = required_string(manifest.get("version"), "manifest version")
+    build = required_string(manifest.get("build"), "manifest build")
+    if not VERSION_PATTERN.fullmatch(version) or not BUILD_PATTERN.fullmatch(build):
+        raise VerificationError("manifest version/build metadata is not canonical")
+    if channel == "stable" and tag != f"v{version}":
+        raise VerificationError("stable release tag does not match the manifest version")
+    generated_at = required_string(manifest.get("generatedAt"), "manifest generatedAt")
+    timestamp_pattern = r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
+    if not re.fullmatch(timestamp_pattern, generated_at):
+        raise VerificationError("manifest generatedAt is not a UTC timestamp")
+
+    updater = manifest.get("updater")
+    if not isinstance(updater, dict):
+        raise VerificationError("manifest updater must be an object")
+    expected_feed = urls["stable"] if channel == "stable" else urls["tester"]
+    expected_updater = {
+        "schemaVersion": 1,
+        "format": "github-release-manifest",
+        "channel": channel,
+        "manifestURL": expected_feed,
+        "stableManifestURL": urls["stable"],
+        "testerManifestURL": urls["tester"],
+        "bundleIdentifier": BUNDLE_IDENTIFIER,
+    }
+    for key, expected in expected_updater.items():
+        if updater.get(key) != expected:
+            raise VerificationError(
+                f"manifest updater {key} does not match the app feed contract"
+            )
+    required_string(updater.get("minimumSystemVersion"), "updater minimumSystemVersion")
+    if channel == "stable":
+        if updater.get("codesign") != "developer-id":
+            raise VerificationError("stable updater metadata is not Developer ID signed")
+        required_string(
+            updater.get("signingTeamIdentifier"),
+            "updater signingTeamIdentifier",
+        )
+        if updater.get("notarized") is not True:
+            raise VerificationError("stable updater metadata is not notarized")
+
+    raw_assets = manifest.get("assets")
+    if not isinstance(raw_assets, list) or not raw_assets:
+        raise VerificationError("manifest assets must be a nonempty array")
+    api_assets = api_asset_map(release)
+    assets: list[dict[str, Any]] = []
+    names: set[str] = set()
+    total_size = 0
+    for index, raw_asset in enumerate(raw_assets):
+        if not isinstance(raw_asset, dict):
+            raise VerificationError(f"manifest asset {index} must be an object")
+        name = required_string(raw_asset.get("name"), f"manifest asset {index} name")
+        if (
+            name in names
+            or name != Path(name).name
+            or name in (".", "..")
+            or ".." in name
+            or "/" in name
+            or "\\" in name
+            or len(name) > 180
+        ):
+            raise VerificationError(
+                f"manifest asset name {name!r} is unsafe or duplicated"
+            )
+        names.add(name)
+        for field in ("kind", "platform", "arch", "install"):
+            required_string(raw_asset.get(field), f"manifest asset {name} {field}")
+        size = required_integer(
+            raw_asset.get("sizeBytes"),
+            f"manifest asset {name} sizeBytes",
+        )
+        digest = required_string(
+            raw_asset.get("sha256"),
+            f"manifest asset {name} sha256",
+        )
+        if size <= 0 or size > MAXIMUM_ASSET_BYTES:
+            raise VerificationError(f"manifest asset {name!r} has an invalid size")
+        if not DIGEST_PATTERN.fullmatch(digest):
+            raise VerificationError(f"manifest asset {name!r} has an invalid SHA-256")
+        expected_url = (
+            f"https://github.com/{repo}/releases/download/"
+            f"{quote(tag, safe='')}/{quote(name, safe='')}"
+        )
+        if raw_asset.get("url") != expected_url:
+            raise VerificationError(f"manifest asset {name!r} has an unexpected URL")
+        api_asset = api_assets.get(name)
+        if api_asset is None:
+            raise VerificationError(f"GitHub release is missing manifest asset {name!r}")
+        validate_api_asset(
+            api_asset,
+            name=name,
+            size=size,
+            digest=digest,
+            url=expected_url,
+        )
+        total_size += size
+        if total_size > MAXIMUM_RELEASE_BYTES:
+            raise VerificationError("manifest release size exceeds its aggregate limit")
+        assets.append(raw_asset)
+
+    manifest_name = urls["manifest_name"]
+    expected_names = names | {manifest_name}
+    if set(api_assets) != expected_names:
+        raise VerificationError(
+            "GitHub release asset inventory does not exactly match the manifest"
+        )
+    manifest_digest = hashlib.sha256(manifest_bytes).hexdigest()
+    validate_api_asset(
+        api_assets[manifest_name],
+        name=manifest_name,
+        size=len(manifest_bytes),
+        digest=manifest_digest,
+        url=urls["manifest"],
+    )
+
+    app_assets = [
+        asset
+        for asset in assets
+        if asset["kind"] == "app"
+        and asset["platform"] == "macOS"
+        and asset["install"] == "zip-app"
+    ]
+    if len(app_assets) != 1 or updater.get("macOSAppAsset") != app_assets[0]:
+        raise VerificationError("updater macOS app asset is missing or ambiguous")
+    return assets

--- a/scripts/release_verification_files.py
+++ b/scripts/release_verification_files.py
@@ -1,0 +1,169 @@
+"""Bounded on-disk artifact validation for Quill Cowork releases."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any
+
+from release_verification_contract import (
+    BUNDLE_IDENTIFIER,
+    PRODUCT,
+    VerificationError,
+)
+
+
+def read_bounded(path: Path, byte_limit: int, label: str) -> bytes:
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise VerificationError(f"{label} must be a regular file")
+        size = path.stat().st_size
+        if size > byte_limit:
+            raise VerificationError(f"{label} exceeds its {byte_limit}-byte limit")
+        return path.read_bytes()
+    except OSError as error:
+        raise VerificationError(f"{label} could not be read") from error
+
+
+def sha256_path(path: Path, expected_size: int, label: str) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise VerificationError(f"{label} must be a regular file")
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                size += len(chunk)
+                if size > expected_size:
+                    raise VerificationError(f"{label} exceeds its declared size")
+                digest.update(chunk)
+    except OSError as error:
+        raise VerificationError(f"{label} could not be read") from error
+    if size != expected_size:
+        raise VerificationError(
+            f"{label} size mismatch: expected {expected_size}, downloaded {size}"
+        )
+    return digest.hexdigest()
+
+
+def parse_key_value_file(path: Path, label: str) -> dict[str, str]:
+    data = read_bounded(path, 256 * 1024, label)
+    try:
+        lines = data.decode("utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise VerificationError(f"{label} is not UTF-8") from error
+    values: dict[str, str] = {}
+    for line in lines:
+        key, separator, value = line.partition("=")
+        if not separator or not key or key in values:
+            raise VerificationError(
+                f"{label} contains malformed or duplicate metadata"
+            )
+        values[key] = value
+    return values
+
+
+def verify_build_info(
+    asset_directory: Path,
+    assets: list[dict[str, Any]],
+    manifest: dict[str, Any],
+    *,
+    channel: str,
+    commit: str,
+) -> None:
+    updater = manifest["updater"]
+    app_asset = updater["macOSAppAsset"]
+    build_info = parse_key_value_file(
+        asset_directory / "BUILD_INFO.txt",
+        "BUILD_INFO.txt",
+    )
+    signing_team = updater.get("signingTeamIdentifier") or "none"
+    expected = {
+        "product": PRODUCT,
+        "platform": "macOS",
+        "arch": app_asset["arch"],
+        "version": manifest["version"],
+        "build": manifest["build"],
+        "commit": commit,
+        "bundleIdentifier": BUNDLE_IDENTIFIER,
+        "minimumSystemVersion": updater["minimumSystemVersion"],
+        "updateChannel": channel,
+        "updateManifestURL": updater["manifestURL"],
+        "stableUpdateManifestURL": updater["stableManifestURL"],
+        "testerUpdateManifestURL": updater["testerManifestURL"],
+        "app": app_asset["name"],
+        "codesign": updater.get("codesign") or "unknown",
+        "signingTeamIdentifier": signing_team,
+        "notarized": "true" if updater.get("notarized") is True else "false",
+    }
+    for key, expected_value in expected.items():
+        if build_info.get(key) != expected_value:
+            raise VerificationError(
+                f"BUILD_INFO.txt {key} disagrees with the manifest"
+            )
+    asset_names = {asset["name"] for asset in assets}
+    if build_info.get("cli") not in asset_names:
+        raise VerificationError("BUILD_INFO.txt names a missing macOS CLI asset")
+
+
+def verify_primary_checksums(
+    asset_directory: Path,
+    assets: list[dict[str, Any]],
+) -> None:
+    checksum_path = asset_directory / "SHASUMS256.txt"
+    data = read_bounded(checksum_path, 1024 * 1024, "SHASUMS256.txt")
+    try:
+        lines = data.decode("utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise VerificationError("SHASUMS256.txt is not UTF-8") from error
+    checksums: dict[str, str] = {}
+    for line in lines:
+        match = re.fullmatch(r"([0-9a-f]{64})  ([^/\\]+)", line)
+        if not match or match.group(2) in checksums:
+            raise VerificationError(
+                "SHASUMS256.txt contains malformed or duplicate entries"
+            )
+        checksums[match.group(2)] = match.group(1)
+    expected = {
+        asset["name"]: asset["sha256"]
+        for asset in assets
+        if asset["name"] != "SHASUMS256.txt"
+    }
+    if checksums != expected:
+        raise VerificationError(
+            "SHASUMS256.txt does not exactly cover the release assets"
+        )
+
+
+def verify_asset_files(
+    asset_directory: Path,
+    assets: list[dict[str, Any]],
+    manifest: dict[str, Any],
+    *,
+    channel: str,
+    commit: str,
+) -> None:
+    if asset_directory.is_symlink() or not asset_directory.is_dir():
+        raise VerificationError("asset directory must be a real directory")
+    expected_names = {asset["name"] for asset in assets}
+    actual_names = {path.name for path in asset_directory.iterdir()}
+    if actual_names != expected_names:
+        raise VerificationError(
+            "downloaded asset directory does not exactly match the manifest"
+        )
+    for asset in assets:
+        path = asset_directory / asset["name"]
+        digest = sha256_path(path, asset["sizeBytes"], asset["name"])
+        if digest != asset["sha256"]:
+            raise VerificationError(
+                f"downloaded asset {asset['name']!r} failed SHA-256 verification"
+            )
+    verify_primary_checksums(asset_directory, assets)
+    verify_build_info(
+        asset_directory,
+        assets,
+        manifest,
+        channel=channel,
+        commit=commit,
+    )

--- a/scripts/verify-published-release.py
+++ b/scripts/verify-published-release.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Verify a published Quill Cowork release through its public download contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+from urllib.parse import quote
+
+from release_verification_contract import (
+    API_BYTE_LIMIT,
+    MANIFEST_BYTE_LIMIT,
+    REPOSITORY_PATTERN,
+    SHA_PATTERN,
+    VerificationError,
+    expected_urls,
+    load_json_bytes,
+    validate_manifest,
+)
+from release_verification_files import read_bounded, verify_asset_files
+
+
+Result = TypeVar("Result")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download and verify a published Quill Cowork GitHub release."
+    )
+    parser.add_argument("--repo", required=True, help="GitHub owner/repository slug.")
+    parser.add_argument("--tag", required=True, help="Published release tag.")
+    parser.add_argument("--channel", required=True, choices=("stable", "tester"))
+    parser.add_argument("--commit", required=True, help="Expected 40-character commit SHA.")
+    parser.add_argument(
+        "--workflow-run-url",
+        required=True,
+        help="Expected publishing run URL.",
+    )
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=6,
+        help="Public snapshot retry count.",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=float,
+        default=5,
+        help="Seconds between retries.",
+    )
+    parser.add_argument("--release-json", type=Path, help="Offline release API fixture.")
+    parser.add_argument("--tag-commit", help="Offline resolved tag commit.")
+    parser.add_argument("--manifest", type=Path, help="Offline manifest fixture.")
+    parser.add_argument(
+        "--assets-dir",
+        type=Path,
+        help="Offline directory containing release assets.",
+    )
+    arguments = parser.parse_args()
+    if not REPOSITORY_PATTERN.fullmatch(arguments.repo):
+        parser.error("--repo must be an owner/repository slug")
+    if not SHA_PATTERN.fullmatch(arguments.commit):
+        parser.error("--commit must be a lowercase 40-character SHA")
+    if arguments.attempts < 1 or arguments.attempts > 20:
+        parser.error("--attempts must be between 1 and 20")
+    if arguments.retry_delay < 0 or arguments.retry_delay > 60:
+        parser.error("--retry-delay must be between 0 and 60 seconds")
+    offline_values = (
+        arguments.release_json,
+        arguments.tag_commit,
+        arguments.manifest,
+        arguments.assets_dir,
+    )
+    if any(value is not None for value in offline_values) and not all(
+        value is not None for value in offline_values
+    ):
+        parser.error(
+            "offline verification requires --release-json, --tag-commit, "
+            "--manifest, and --assets-dir"
+        )
+    return arguments
+
+
+def fetch_bytes(
+    url: str,
+    byte_limit: int,
+    *,
+    token: str | None = None,
+    accept: str = "application/octet-stream",
+) -> bytes:
+    headers = {
+        "Accept": accept,
+        "User-Agent": "Quill-Cowork-Release-Verifier/1",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            if response.status != 200:
+                raise VerificationError(f"GET {url} returned HTTP {response.status}")
+            length = response.headers.get("Content-Length")
+            if length and int(length) > byte_limit:
+                raise VerificationError(
+                    f"GET {url} exceeds its {byte_limit}-byte limit"
+                )
+            data = response.read(byte_limit + 1)
+    except VerificationError:
+        raise
+    except urllib.error.HTTPError as error:
+        raise VerificationError(f"GET {url} returned HTTP {error.code}") from error
+    except urllib.error.URLError as error:
+        raise VerificationError(f"GET {url} failed: {error.reason}") from error
+    except (OSError, ValueError) as error:
+        raise VerificationError(f"GET {url} failed: {error}") from error
+    if len(data) > byte_limit:
+        raise VerificationError(f"GET {url} exceeds its {byte_limit}-byte limit")
+    return data
+
+
+def api_json(repo: str, path: str, token: str | None) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{repo}/{path}"
+    return load_json_bytes(
+        fetch_bytes(
+            url,
+            API_BYTE_LIMIT,
+            token=token,
+            accept="application/vnd.github+json",
+        ),
+        url,
+    )
+
+
+def resolve_tag_commit(repo: str, tag: str, token: str | None) -> str:
+    reference = api_json(repo, f"git/ref/tags/{quote(tag, safe='')}", token)
+    target = reference.get("object")
+    for _ in range(5):
+        if not isinstance(target, dict):
+            break
+        target_type = target.get("type")
+        sha = target.get("sha")
+        if not isinstance(sha, str) or not SHA_PATTERN.fullmatch(sha):
+            break
+        if target_type == "commit":
+            return sha
+        if target_type != "tag":
+            break
+        tag_object = api_json(repo, f"git/tags/{sha}", token)
+        target = tag_object.get("object")
+    raise VerificationError(f"release tag {tag!r} does not resolve to a commit")
+
+
+def download_asset(url: str, destination: Path, size: int, digest: str) -> None:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "User-Agent": "Quill-Cowork-Release-Verifier/1",
+        },
+    )
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response, temporary.open(
+            "xb"
+        ) as output:
+            if response.status != 200 or not response.geturl().lower().startswith(
+                "https://"
+            ):
+                raise VerificationError(
+                    f"download for {destination.name!r} returned an invalid response"
+                )
+            response_length = response.headers.get("Content-Length")
+            if response_length and int(response_length) != size:
+                raise VerificationError(
+                    f"download for {destination.name!r} reported the wrong size"
+                )
+            hasher = hashlib.sha256()
+            downloaded = 0
+            while chunk := response.read(1024 * 1024):
+                downloaded += len(chunk)
+                if downloaded > size:
+                    raise VerificationError(
+                        f"download for {destination.name!r} exceeded its size"
+                    )
+                output.write(chunk)
+                hasher.update(chunk)
+        if downloaded != size or hasher.hexdigest() != digest:
+            raise VerificationError(
+                f"download for {destination.name!r} failed integrity verification"
+            )
+        temporary.replace(destination)
+    except VerificationError:
+        temporary.unlink(missing_ok=True)
+        raise
+    except urllib.error.HTTPError as error:
+        temporary.unlink(missing_ok=True)
+        raise VerificationError(
+            f"download for {destination.name!r} returned HTTP {error.code}"
+        ) from error
+    except urllib.error.URLError as error:
+        temporary.unlink(missing_ok=True)
+        raise VerificationError(
+            f"download for {destination.name!r} failed: {error.reason}"
+        ) from error
+    except (OSError, ValueError) as error:
+        temporary.unlink(missing_ok=True)
+        raise VerificationError(
+            f"download for {destination.name!r} failed: {error}"
+        ) from error
+
+
+def retry(
+    operation: Callable[[], Result],
+    *,
+    attempts: int,
+    delay: float,
+    label: str,
+) -> Result:
+    last_error: VerificationError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except VerificationError as error:
+            last_error = error
+            if attempt < attempts:
+                print(
+                    f"{label} attempt {attempt} failed: {error}; retrying",
+                    flush=True,
+                )
+                time.sleep(delay)
+    if last_error is None:
+        raise VerificationError(f"{label} did not run")
+    raise last_error
+
+
+def validate_snapshot(
+    release: dict[str, Any],
+    manifest_bytes: bytes,
+    tag_commit: str,
+    arguments: argparse.Namespace,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    manifest = load_json_bytes(manifest_bytes, "manifest")
+    assets = validate_manifest(
+        manifest,
+        manifest_bytes,
+        release,
+        tag_commit,
+        repo=arguments.repo,
+        tag=arguments.tag,
+        channel=arguments.channel,
+        commit=arguments.commit,
+        workflow_run_url=arguments.workflow_run_url,
+    )
+    return manifest, assets
+
+
+def verify_offline(arguments: argparse.Namespace) -> None:
+    if (
+        arguments.release_json is None
+        or arguments.tag_commit is None
+        or arguments.manifest is None
+        or arguments.assets_dir is None
+    ):
+        raise VerificationError("offline verifier arguments are incomplete")
+    release = load_json_bytes(
+        read_bounded(arguments.release_json, API_BYTE_LIMIT, "release JSON"),
+        "release JSON",
+    )
+    manifest_bytes = read_bounded(
+        arguments.manifest,
+        MANIFEST_BYTE_LIMIT,
+        "manifest",
+    )
+    manifest, assets = validate_snapshot(
+        release,
+        manifest_bytes,
+        arguments.tag_commit,
+        arguments,
+    )
+    verify_asset_files(
+        arguments.assets_dir,
+        assets,
+        manifest,
+        channel=arguments.channel,
+        commit=arguments.commit,
+    )
+
+
+def verify_public(arguments: argparse.Namespace) -> None:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    urls = expected_urls(arguments.repo, arguments.tag, arguments.channel)
+
+    def fetch_snapshot() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        release = api_json(
+            arguments.repo,
+            f"releases/tags/{quote(arguments.tag, safe='')}",
+            token,
+        )
+        tag_commit = resolve_tag_commit(arguments.repo, arguments.tag, token)
+        manifest_bytes = fetch_bytes(urls["manifest"], MANIFEST_BYTE_LIMIT)
+        return validate_snapshot(release, manifest_bytes, tag_commit, arguments)
+
+    manifest, assets = retry(
+        fetch_snapshot,
+        attempts=arguments.attempts,
+        delay=arguments.retry_delay,
+        label="public release snapshot",
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="quill-cowork-release-verify-"
+    ) as directory:
+        asset_directory = Path(directory)
+        for asset in assets:
+            destination = asset_directory / asset["name"]
+            retry(
+                lambda asset=asset, destination=destination: download_asset(
+                    asset["url"],
+                    destination,
+                    asset["sizeBytes"],
+                    asset["sha256"],
+                ),
+                attempts=3,
+                delay=arguments.retry_delay,
+                label=f"asset {asset['name']}",
+            )
+        verify_asset_files(
+            asset_directory,
+            assets,
+            manifest,
+            channel=arguments.channel,
+            commit=arguments.commit,
+        )
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        if arguments.release_json is not None:
+            verify_offline(arguments)
+        else:
+            verify_public(arguments)
+    except VerificationError as error:
+        print(f"Published release verification failed: {error}", file=os.sys.stderr)
+        return 2
+    print(
+        f"Verified public Quill Cowork {arguments.channel} release {arguments.tag} "
+        f"at {arguments.commit}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- fix stable manifests to identify the same moving releases/latest feed embedded in stable apps
- verify every published release from the public GitHub API and download surface, including tag provenance, exact inventory, bounded payloads, digests, checksums, and build metadata
- rebuild scheduled tester downloads when the originating publishing run is unavailable, incomplete, failed, or mismatched
- keep verifier contract, file validation, and network orchestration in separately graded A+ modules

## Verification
- 14 focused release-contract tests
- 317 QuillCodeParityTests
- live public verification of tester build 627 and every release asset
- live scheduled planner check against the successful build 627 workflow
- git diff --check
- all changed code and test files grade A+