### PR TITLE
Keep automatic updates scheduled in long-running sessions

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -44,12 +44,20 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     private let installer: any QuillCodeDesktopUpdateInstalling
     private let defaults: UserDefaults
     private let now: () -> Date
-    private let automaticCheckDelay: Duration
+    private let automaticSchedule: QuillCodeDesktopUpdateSchedule
     private let installResultURL: URL?
     private let terminateApplication: @MainActor () -> Void
-    private var task: Task<Void, Never>?
+    private var operationTask: Task<Void, Never>?
+    private var automaticTask: Task<Void, Never>?
     private var generation = UUID()
     private var didStartAutomaticChecks = false
+
+    private enum AutomaticCheckOutcome {
+        case success
+        case failure
+        case deferred
+        case rescheduled(TimeInterval)
+    }
 
     init(
         configuration: QuillCodeDesktopUpdateConfiguration? = .bundled(),
@@ -58,7 +66,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         installer: any QuillCodeDesktopUpdateInstalling = QuillCodeDesktopUpdateInstaller(),
         defaults: UserDefaults = .standard,
         now: @escaping () -> Date = Date.init,
-        automaticCheckDelay: Duration = .seconds(3),
+        automaticSchedule: QuillCodeDesktopUpdateSchedule = .production,
         installResultURL: URL? = try? QuillCodeDesktopUpdatePaths.installResultURL(),
         terminateApplication: @escaping @MainActor () -> Void =
             QuillCodeDesktopSystemApplication.terminateForUpdate
@@ -69,41 +77,69 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         self.installer = installer
         self.defaults = defaults
         self.now = now
-        self.automaticCheckDelay = automaticCheckDelay
+        self.automaticSchedule = automaticSchedule
         self.installResultURL = installResultURL
         self.terminateApplication = terminateApplication
     }
 
     deinit {
-        task?.cancel()
+        operationTask?.cancel()
+        automaticTask?.cancel()
     }
 
     func startAutomaticChecks() {
         guard !didStartAutomaticChecks else { return }
         didStartAutomaticChecks = true
         consumePreviousInstallResult()
-        guard let configuration, shouldAutomaticallyCheck(configuration: configuration) else { return }
+        guard let configuration else { return }
 
-        let generation = beginNewTask()
-        task = Task { [weak self] in
-            guard let self else { return }
-            try? await Task.sleep(for: self.automaticCheckDelay)
-            guard !Task.isCancelled else { return }
-            await self.performCheck(userInitiated: false, generation: generation)
+        let schedule = automaticSchedule
+        let firstDelay = schedule.firstDelay(
+            lastSuccessfulCheck: lastSuccessfulCheck(configuration: configuration),
+            now: now(),
+            channel: configuration.channel
+        )
+        automaticTask = Task { [weak self] in
+            var delay = firstDelay
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(delay))
+                } catch {
+                    return
+                }
+                guard let outcome = await self?.performAutomaticCheck(configuration: configuration) else {
+                    return
+                }
+                switch outcome {
+                case .success:
+                    delay = schedule.interval(for: configuration.channel)
+                case .failure:
+                    delay = schedule.failureRetryInterval
+                case .deferred:
+                    delay = schedule.busyRetryInterval
+                case .rescheduled(let remaining):
+                    delay = remaining
+                }
+            }
         }
     }
 
     func checkForUpdates() {
         isPresented = true
-        let generation = beginNewTask()
+        guard !state.isBusy else { return }
+        let generation = beginNewOperation()
         state = .checking
-        task = Task { [weak self] in
+        operationTask = Task { [weak self] in
             guard let self else { return }
-            await self.performCheck(userInitiated: true, generation: generation)
+            await self.performUserCheck(generation: generation)
         }
     }
 
     func updateAndRelaunch() {
+        guard !state.isBusy else {
+            isPresented = true
+            return
+        }
         guard let configuration,
               let release = state.release
         else {
@@ -113,10 +149,11 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             )
             return
         }
-        let generation = beginNewTask()
+        let generation = beginNewOperation()
         state = .downloading(release)
-        task = Task { [weak self] in
+        operationTask = Task { [weak self] in
             guard let self else { return }
+            defer { self.finishOperation(generation: generation) }
             do {
                 let prepared = try await preparer.prepare(
                     release: release,
@@ -143,8 +180,8 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     }
 
     func cancelCurrentOperation() {
-        guard let release = state.release else { return }
-        _ = beginNewTask()
+        guard case .downloading(let release) = state else { return }
+        _ = beginNewOperation()
         state = .updateAvailable(release)
     }
 
@@ -163,9 +200,10 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         NSWorkspace.shared.open(release.asset.url)
     }
 
-    private func performCheck(userInitiated: Bool, generation: UUID) async {
+    private func performUserCheck(generation: UUID) async {
+        defer { finishOperation(generation: generation) }
         guard let configuration else {
-            guard userInitiated, self.generation == generation else { return }
+            guard self.generation == generation else { return }
             state = .failed(
                 message: QuillCodeDesktopUpdateError.updatesUnavailable.localizedDescription,
                 release: nil
@@ -176,42 +214,76 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             let result = try await checker.check(configuration: configuration)
             try Task.checkCancellation()
             guard self.generation == generation else { return }
-            defaults.set(now(), forKey: lastCheckKey(configuration: configuration))
-            switch result {
-            case .updateAvailable(let release):
-                state = .updateAvailable(release)
-                isPresented = true
-            case .upToDate(let latestVersion, let latestBuild):
-                state = userInitiated
-                    ? .upToDate(latestVersion: latestVersion, latestBuild: latestBuild)
-                    : .idle
-            }
+            applySuccessfulCheck(result, userInitiated: true, configuration: configuration)
         } catch is CancellationError {
             return
         } catch {
             guard self.generation == generation else { return }
+            state = .failed(message: error.localizedDescription, release: nil)
+        }
+    }
+
+    private func performAutomaticCheck(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async -> AutomaticCheckOutcome {
+        let remaining = automaticSchedule.remainingDelay(
+            lastSuccessfulCheck: lastSuccessfulCheck(configuration: configuration),
+            now: now(),
+            channel: configuration.channel
+        )
+        guard remaining == 0 else { return .rescheduled(remaining) }
+        guard !state.isBusy, !isPresented else { return .deferred }
+        let startingGeneration = generation
+        do {
+            let result = try await checker.check(configuration: configuration)
+            try Task.checkCancellation()
+            guard generation == startingGeneration, !state.isBusy, !isPresented else {
+                return .deferred
+            }
+            applySuccessfulCheck(result, userInitiated: false, configuration: configuration)
+            return .success
+        } catch is CancellationError {
+            return .deferred
+        } catch {
+            return .failure
+        }
+    }
+
+    private func applySuccessfulCheck(
+        _ result: QuillCodeDesktopUpdateCheckResult,
+        userInitiated: Bool,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) {
+        defaults.set(now(), forKey: lastCheckKey(configuration: configuration))
+        switch result {
+        case .updateAvailable(let release):
+            state = .updateAvailable(release)
+            isPresented = true
+        case .upToDate(let latestVersion, let latestBuild):
             state = userInitiated
-                ? .failed(message: error.localizedDescription, release: nil)
+                ? .upToDate(latestVersion: latestVersion, latestBuild: latestBuild)
                 : .idle
         }
     }
 
-    private func beginNewTask() -> UUID {
-        task?.cancel()
+    private func beginNewOperation() -> UUID {
+        operationTask?.cancel()
+        operationTask = nil
         generation = UUID()
         return generation
     }
 
-    private func shouldAutomaticallyCheck(
+    private func finishOperation(generation: UUID) {
+        guard self.generation == generation else { return }
+        operationTask = nil
+    }
+
+    private func lastSuccessfulCheck(
         configuration: QuillCodeDesktopUpdateConfiguration
-    ) -> Bool {
-        guard let lastCheck = defaults.object(
+    ) -> Date? {
+        defaults.object(
             forKey: lastCheckKey(configuration: configuration)
-        ) as? Date else {
-            return true
-        }
-        let interval: TimeInterval = configuration.channel == .tester ? 6 * 60 * 60 : 24 * 60 * 60
-        return now().timeIntervalSince(lastCheck) >= interval
+        ) as? Date
     }
 
     private func lastCheckKey(configuration: QuillCodeDesktopUpdateConfiguration) -> String {

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateSchedule.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateSchedule.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct QuillCodeDesktopUpdateSchedule: Equatable, Sendable {
+    static let production = Self(
+        initialDelay: 3,
+        testerInterval: 6 * 60 * 60,
+        stableInterval: 24 * 60 * 60,
+        failureRetryInterval: 30 * 60,
+        busyRetryInterval: 5 * 60
+    )
+
+    var initialDelay: TimeInterval
+    var testerInterval: TimeInterval
+    var stableInterval: TimeInterval
+    var failureRetryInterval: TimeInterval
+    var busyRetryInterval: TimeInterval
+
+    init(
+        initialDelay: TimeInterval,
+        testerInterval: TimeInterval,
+        stableInterval: TimeInterval,
+        failureRetryInterval: TimeInterval,
+        busyRetryInterval: TimeInterval
+    ) {
+        self.initialDelay = Self.normalized(initialDelay, minimum: 0, fallback: 3)
+        self.testerInterval = Self.normalized(testerInterval, minimum: 0.01, fallback: 6 * 60 * 60)
+        self.stableInterval = Self.normalized(stableInterval, minimum: 0.01, fallback: 24 * 60 * 60)
+        self.failureRetryInterval = Self.normalized(
+            failureRetryInterval,
+            minimum: 0.01,
+            fallback: 30 * 60
+        )
+        self.busyRetryInterval = Self.normalized(
+            busyRetryInterval,
+            minimum: 0.01,
+            fallback: 5 * 60
+        )
+    }
+
+    func interval(for channel: QuillCodeDesktopUpdateChannel) -> TimeInterval {
+        channel == .tester ? testerInterval : stableInterval
+    }
+
+    func firstDelay(
+        lastSuccessfulCheck: Date?,
+        now: Date,
+        channel: QuillCodeDesktopUpdateChannel
+    ) -> TimeInterval {
+        let remaining = remainingDelay(
+            lastSuccessfulCheck: lastSuccessfulCheck,
+            now: now,
+            channel: channel
+        )
+        return remaining > 0 ? remaining : initialDelay
+    }
+
+    func remainingDelay(
+        lastSuccessfulCheck: Date?,
+        now: Date,
+        channel: QuillCodeDesktopUpdateChannel
+    ) -> TimeInterval {
+        guard let lastSuccessfulCheck else { return 0 }
+        let elapsed = now.timeIntervalSince(lastSuccessfulCheck)
+        guard elapsed.isFinite else { return 0 }
+        return max(0, interval(for: channel) - max(0, elapsed))
+    }
+
+    private static func normalized(
+        _ value: TimeInterval,
+        minimum: TimeInterval,
+        fallback: TimeInterval
+    ) -> TimeInterval {
+        value.isFinite && value >= minimum ? value : fallback
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
@@ -95,7 +95,8 @@ struct QuillCodeDesktopUpdateView: View {
                 icon: "exclamationmark.triangle.fill",
                 title: "Update couldn't be completed",
                 detail: message,
-                showsProgress: false
+                showsProgress: false,
+                scrollsDetail: true
             )
         }
     }
@@ -138,7 +139,8 @@ struct QuillCodeDesktopUpdateView: View {
         icon: String,
         title: String,
         detail: String,
-        showsProgress: Bool
+        showsProgress: Bool,
+        scrollsDetail: Bool = false
     ) -> some View {
         VStack(spacing: 14) {
             Image(systemName: icon)
@@ -148,11 +150,22 @@ struct QuillCodeDesktopUpdateView: View {
             Text(title)
                 .font(.headline)
                 .multilineTextAlignment(.center)
-            Text(detail)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
+            Group {
+                if scrollsDetail {
+                    ScrollView {
+                        Text(detail)
+                            .frame(maxWidth: .infinity)
+                            .padding(.horizontal, 4)
+                    }
+                    .frame(maxHeight: 84)
+                } else {
+                    Text(detail)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
             if showsProgress {
                 ProgressView()
                     .controlSize(.small)
@@ -189,14 +202,28 @@ struct QuillCodeDesktopUpdateView: View {
                     .foregroundStyle(.secondary)
             case .failed(_, let release):
                 if release != nil {
-                    Button("Download in Browser", action: controller.openDownloadInBrowser)
-                        .buttonStyle(QuillCodeActionButtonStyle())
-                        .quillCodeFormActionTarget()
+                    Button(action: controller.openDownloadInBrowser) {
+                        Label("Browser Download", systemImage: "safari")
+                    }
+                    .buttonStyle(QuillCodeActionButtonStyle())
+                    .quillCodeFormActionTarget()
                 }
                 Spacer()
-                Button("Check Again", action: controller.checkForUpdates)
+                if release != nil {
+                    Button(action: controller.updateAndRelaunch) {
+                        Label("Try Again", systemImage: "arrow.down.circle.fill")
+                    }
                     .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 110))
                     .quillCodeFormActionTarget(minWidth: 110)
+                    .accessibilityIdentifier("quillcode-update-retry")
+                } else {
+                    Button(action: controller.checkForUpdates) {
+                        Label("Check Again", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 110))
+                    .quillCodeFormActionTarget(minWidth: 110)
+                    .accessibilityIdentifier("quillcode-update-recheck")
+                }
             case .idle, .checking:
                 Spacer()
             case .upToDate:

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -9,6 +9,42 @@ import QuillCodeTools
 
 @MainActor
 final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
+    func testRenderedUpdaterFailureKeepsRecoveryActionsInsideSheet() async throws {
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: RenderedUpdateChecker(release: release),
+            preparer: RenderedFailingUpdatePreparer(),
+            defaults: UserDefaults(suiteName: "RenderedUpdaterFailure.\(UUID().uuidString)") ?? .standard,
+            automaticSchedule: .production,
+            installResultURL: nil
+        )
+        controller.checkForUpdates()
+        try await waitForUpdaterState(controller) { $0 == .updateAvailable(release) }
+        controller.updateAndRelaunch()
+        try await waitForUpdaterState(controller) {
+            if case .failed(_, let failedRelease) = $0 {
+                return failedRelease == release
+            }
+            return false
+        }
+
+        let image = try renderHostedView(
+            QuillCodeDesktopUpdateView(controller: controller),
+            width: 470,
+            height: 340,
+            debugPathEnvironmentKey: "QUILLCODE_RENDER_UPDATE_FAILURE_IMAGE_PATH"
+        )
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 470)
+        XCTAssertEqual(stats.height, 340)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.brightPixelRatio, 0.001)
+        XCTAssertGreaterThan(stats.blueAccentPixelRatio, 0.001)
+    }
+
     func testRenderedSSHConnectionDialogShowsConfiguredHostsAndActions() throws {
         let coordinator = QuillCodeSSHConnectionDialogCoordinator()
         coordinator.isPresented = true
@@ -291,6 +327,17 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTFail("Desktop send did not complete with expected answer: \(expectedAnswer)", file: file, line: line)
     }
 
+    private func waitForUpdaterState(
+        _ controller: QuillCodeDesktopUpdateController,
+        matches: @escaping (QuillCodeDesktopUpdateController.State) -> Bool
+    ) async throws {
+        for _ in 0..<200 {
+            if matches(controller.state) { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Updater did not reach the expected rendered state")
+    }
+
     private func makeTempDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("QuillCodeDesktopRenderTests-\(UUID().uuidString)", isDirectory: true)
@@ -299,6 +346,29 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
             try? FileManager.default.removeItem(at: url)
         }
         return url
+    }
+}
+
+private struct RenderedUpdateChecker: QuillCodeDesktopUpdateChecking {
+    var release: QuillCodeDesktopUpdateRelease
+
+    func check(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopUpdateCheckResult {
+        .updateAvailable(release)
+    }
+}
+
+private struct RenderedFailingUpdatePreparer: QuillCodeDesktopUpdatePreparing {
+    func prepare(
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopPreparedUpdate {
+        let detail = String(
+            repeating: "The downloaded bundle contains a component that could not be validated. ",
+            count: 8
+        )
+        throw QuillCodeDesktopUpdateError.invalidApplication(detail)
     }
 }
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -16,7 +16,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             preparer: preparer,
             installer: installer,
             defaults: defaults,
-            automaticCheckDelay: .zero,
+            automaticSchedule: makeAutomaticSchedule(),
             installResultURL: temporaryInstallResultURL(),
             terminateApplication: { terminationCount += 1 }
         )
@@ -42,7 +42,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             configuration: makeConfiguration(),
             checker: checker,
             defaults: defaults,
-            automaticCheckDelay: .zero,
+            automaticSchedule: makeAutomaticSchedule(),
             installResultURL: temporaryInstallResultURL()
         )
 
@@ -61,7 +61,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             configuration: makeConfiguration(),
             checker: checker,
             defaults: makeDefaults(),
-            automaticCheckDelay: .zero,
+            automaticSchedule: makeAutomaticSchedule(),
             installResultURL: temporaryInstallResultURL()
         )
 
@@ -88,7 +88,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         let controller = QuillCodeDesktopUpdateController(
             configuration: nil,
             defaults: makeDefaults(),
-            automaticCheckDelay: .zero,
+            automaticSchedule: makeAutomaticSchedule(),
             installResultURL: resultURL
         )
 
@@ -97,6 +97,184 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         XCTAssertEqual(controller.state, .idle)
         XCTAssertFalse(controller.isPresented)
         XCTAssertFalse(FileManager.default.fileExists(atPath: resultURL.path))
+    }
+
+    func testAutomaticChecksContinueWhileAppRemainsOpen() async throws {
+        let checker = UpdateCheckerSpy(
+            result: .upToDate(latestVersion: "0.1.0", latestBuild: "42")
+        )
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(testerInterval: 0.02),
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.startAutomaticChecks()
+
+        try await waitUntil { await checker.callCount >= 2 }
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.isPresented)
+    }
+
+    func testAutomaticFailureRetriesQuietly() async throws {
+        let checker = UpdateCheckerSpy(responses: [
+            .failure(.invalidResponse),
+            .success(.upToDate(latestVersion: "0.1.0", latestBuild: "42")),
+        ])
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(failureRetryInterval: 0.02),
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.startAutomaticChecks()
+
+        try await waitUntil { await checker.callCount >= 2 }
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.isPresented)
+    }
+
+    func testManualSuccessReschedulesPendingAutomaticCheck() async throws {
+        let checker = UpdateCheckerSpy(
+            result: .upToDate(latestVersion: "0.1.0", latestBuild: "42")
+        )
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(initialDelay: 0.05),
+            installResultURL: temporaryInstallResultURL()
+        )
+        controller.startAutomaticChecks()
+
+        controller.checkForUpdates()
+        try await waitUntil {
+            if case .upToDate = controller.state { return true }
+            return false
+        }
+        try await Task.sleep(for: .milliseconds(100))
+
+        let checkCallCount = await checker.callCount
+        XCTAssertEqual(checkCallCount, 1)
+    }
+
+    func testManualCheckDoesNotInterruptActiveDownload() async throws {
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let checker = UpdateCheckerSpy(result: .updateAvailable(release))
+        let preparer = UpdatePreparerSpy(release: release, delay: .milliseconds(100))
+        let installer = UpdateInstallerSpy()
+        var terminationCount = 0
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            preparer: preparer,
+            installer: installer,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(),
+            installResultURL: temporaryInstallResultURL(),
+            terminateApplication: { terminationCount += 1 }
+        )
+
+        controller.checkForUpdates()
+        try await waitUntil { controller.state == .updateAvailable(release) }
+        controller.updateAndRelaunch()
+        try await waitUntil {
+            if case .downloading = controller.state { return true }
+            return false
+        }
+
+        controller.checkForUpdates()
+
+        XCTAssertEqual(controller.state, .downloading(release))
+        let checkCallCount = await checker.callCount
+        XCTAssertEqual(checkCallCount, 1)
+        try await waitUntil { terminationCount == 1 }
+    }
+
+    func testCancelIsIgnoredAfterActivationStarts() async throws {
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let checker = UpdateCheckerSpy(result: .updateAvailable(release))
+        let installer = UpdateInstallerSpy(delay: .milliseconds(100))
+        var terminationCount = 0
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            preparer: UpdatePreparerSpy(release: release),
+            installer: installer,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(),
+            installResultURL: temporaryInstallResultURL(),
+            terminateApplication: { terminationCount += 1 }
+        )
+
+        controller.checkForUpdates()
+        try await waitUntil { controller.state == .updateAvailable(release) }
+        controller.updateAndRelaunch()
+        try await waitUntil {
+            if case .installing = controller.state { return true }
+            return false
+        }
+
+        controller.cancelCurrentOperation()
+
+        XCTAssertEqual(controller.state, .installing(release))
+        try await waitUntil { terminationCount == 1 }
+    }
+
+    func testVisibleInstallFailureDefersAutomaticNetworkWork() async throws {
+        let resultURL = temporaryInstallResultURL()
+        try FileManager.default.createDirectory(
+            at: resultURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let result = QuillCodeDesktopUpdateInstallResult.failure(message: "The previous build was restored.")
+        try JSONEncoder().encode(result).write(to: resultURL)
+        let checker = UpdateCheckerSpy(
+            result: .upToDate(latestVersion: "0.1.0", latestBuild: "42")
+        )
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(busyRetryInterval: 0.02),
+            installResultURL: resultURL
+        )
+
+        controller.startAutomaticChecks()
+        try await Task.sleep(for: .milliseconds(75))
+
+        XCTAssertEqual(
+            controller.state,
+            .failed(message: "The previous build was restored.", release: nil)
+        )
+        XCTAssertTrue(controller.isPresented)
+        let checkCallCount = await checker.callCount
+        XCTAssertEqual(checkCallCount, 0)
+    }
+
+    func testAutomaticSchedulerDoesNotRetainControllerBetweenChecks() async throws {
+        let checker = UpdateCheckerSpy(
+            result: .upToDate(latestVersion: "0.1.0", latestBuild: "42")
+        )
+        weak var weakController: QuillCodeDesktopUpdateController?
+        var controller: QuillCodeDesktopUpdateController? = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: checker,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(),
+            installResultURL: temporaryInstallResultURL()
+        )
+        weakController = controller
+        controller?.startAutomaticChecks()
+        try await waitUntil { await checker.callCount == 1 }
+
+        controller = nil
+
+        try await waitUntil { weakController == nil }
     }
 
     private func makeDefaults() -> UserDefaults {
@@ -110,6 +288,21 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
             .appendingPathComponent("UpdateResult.json")
+    }
+
+    private func makeAutomaticSchedule(
+        initialDelay: TimeInterval = 0,
+        testerInterval: TimeInterval = 60,
+        failureRetryInterval: TimeInterval = 60,
+        busyRetryInterval: TimeInterval = 60
+    ) -> QuillCodeDesktopUpdateSchedule {
+        QuillCodeDesktopUpdateSchedule(
+            initialDelay: initialDelay,
+            testerInterval: testerInterval,
+            stableInterval: 60,
+            failureRetryInterval: failureRetryInterval,
+            busyRetryInterval: busyRetryInterval
+        )
     }
 
     private func waitUntil(
@@ -127,35 +320,43 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
 }
 
 private actor UpdateCheckerSpy: QuillCodeDesktopUpdateChecking {
-    private let result: QuillCodeDesktopUpdateCheckResult?
-    private let error: QuillCodeDesktopUpdateError?
+    private var responses: [Result<QuillCodeDesktopUpdateCheckResult, QuillCodeDesktopUpdateError>]
     private(set) var callCount = 0
 
     init(result: QuillCodeDesktopUpdateCheckResult) {
-        self.result = result
-        self.error = nil
+        self.responses = [.success(result)]
     }
 
     init(error: QuillCodeDesktopUpdateError) {
-        self.result = nil
-        self.error = error
+        self.responses = [.failure(error)]
+    }
+
+    init(responses: [Result<QuillCodeDesktopUpdateCheckResult, QuillCodeDesktopUpdateError>]) {
+        self.responses = responses
     }
 
     func check(
         configuration: QuillCodeDesktopUpdateConfiguration
     ) async throws -> QuillCodeDesktopUpdateCheckResult {
         callCount += 1
-        if let error { throw error }
-        return result!
+        guard let response = responses.first else {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+        if responses.count > 1 {
+            responses.removeFirst()
+        }
+        return try response.get()
     }
 }
 
 private actor UpdatePreparerSpy: QuillCodeDesktopUpdatePreparing {
     private let release: QuillCodeDesktopUpdateRelease
+    private let delay: Duration?
     private(set) var callCount = 0
 
-    init(release: QuillCodeDesktopUpdateRelease) {
+    init(release: QuillCodeDesktopUpdateRelease, delay: Duration? = nil) {
         self.release = release
+        self.delay = delay
     }
 
     func prepare(
@@ -163,6 +364,9 @@ private actor UpdatePreparerSpy: QuillCodeDesktopUpdatePreparing {
         configuration: QuillCodeDesktopUpdateConfiguration
     ) async throws -> QuillCodeDesktopPreparedUpdate {
         callCount += 1
+        if let delay {
+            try await Task.sleep(for: delay)
+        }
         return QuillCodeDesktopPreparedUpdate(
             release: self.release,
             applicationURL: URL(fileURLWithPath: "/tmp/Quill Cowork.app"),
@@ -172,12 +376,20 @@ private actor UpdatePreparerSpy: QuillCodeDesktopUpdatePreparing {
 }
 
 private actor UpdateInstallerSpy: QuillCodeDesktopUpdateInstalling {
+    private let delay: Duration?
     private(set) var callCount = 0
+
+    init(delay: Duration? = nil) {
+        self.delay = delay
+    }
 
     func stageAndLaunch(
         preparedUpdate: QuillCodeDesktopPreparedUpdate,
         configuration: QuillCodeDesktopUpdateConfiguration
     ) async throws {
         callCount += 1
+        if let delay {
+            try await Task.sleep(for: delay)
+        }
     }
 }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3400,3 +3400,22 @@
   `scripts/plan-download-build.sh`, `.github/workflows/download-builds.yml`,
   `ParityPublishedReleaseVerificationGateTests`, `ParityDownloadBuildPlanGateTests`, and
   `ParityDownloadBuildsGateTests`.
+
+## 2026-08-07: automatic update scheduling survives long-running app sessions
+
+- **Decision:** The desktop updater owns one weakly captured automatic scheduler separately from its
+  foreground check/download/install task. The scheduler remains active for the app lifetime, checks
+  the persisted successful-check timestamp at every wake, and uses channel cadence plus bounded
+  failure and visible-UI deferrals. Foreground commands cannot cancel or overwrite an active update,
+  and activation is non-cancellable after the helper boundary.
+- **Why:** A one-shot launch check misses updates when Quill Cowork remains open for days. Sharing that
+  task with menu checks also allowed a repeated command to cancel a download or strand an activation
+  attempt. Re-reading the due time prevents a successful manual check from being followed by a
+  duplicate scheduled request.
+- **Memory and UX:** The sleeping task does not retain the controller between checks. Background
+  failures remain quiet, visible failures preserve bounded scrollable diagnostics, and failures tied
+  to a known release offer a direct retry without discarding the browser-download fallback.
+- **Evidence:** `QuillCodeDesktopUpdateSchedule`, `QuillCodeDesktopUpdateController`,
+  `QuillCodeDesktopUpdateView`, and `QuillCodeDesktopUpdateControllerTests` cover repeated in-session
+  checks, retry backoff, manual rescheduling, visible-state deferral, task deallocation, reentrant menu
+  commands, and non-cancellable activation.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -75,9 +75,12 @@ in the app: `tester-latest` for tester builds and `releases/latest` for stable
 builds. Manifest generation fails when `BUILD_INFO.txt` and this feed identity
 disagree, because the app intentionally rejects a manifest from any other URL.
 
-The macOS app checks this feed after launch, no more than every six hours on the
-tester channel or daily on stable. **Check for Updates...** in the app menu runs
-an immediate check. The updater compares `CFBundleShortVersionString` plus
+The macOS app starts checking this feed after launch and remains scheduled while
+the app stays open: every six hours on the tester channel or daily on stable.
+**Check for Updates...** in the app menu runs an immediate check and resets the
+next automatic due time when it succeeds. Quiet background failures retry after
+30 minutes; visible update UI or an active foreground update defers background
+work for five minutes. The updater compares `CFBundleShortVersionString` plus
 `CFBundleVersion`, requires the configured repository, product, channel, bundle
 identifier, architecture, and signing identity, downloads on demand, and verifies
 the exact size, SHA-256 digest, app identity, version, architecture, and macOS code
@@ -87,7 +90,9 @@ Installation stages the verified app beside the running bundle, then uses a
 detached helper for the final rename and relaunch. The new app must complete a
 launch handshake within 45 seconds. Otherwise the helper restores and reopens the
 previous bundle. Background check failures stay quiet; user-initiated failures
-remain visible and retain a direct browser-download fallback.
+remain visible and retain direct retry and browser-download actions. Repeated
+menu checks cannot cancel an active download or the non-cancellable activation
+phase, and a background result never replaces update UI that is already visible.
 
 ## Tester Install Notes
 


### PR DESCRIPTION
## Summary
- keep channel-aware automatic update checks scheduled for the full app session with bounded quiet retry and visible-UI deferral
- isolate automatic checks from foreground check/download/install operations, prevent reentrant cancellation, and avoid retaining the controller between sleeps
- add bounded failure diagnostics, direct retry and browser recovery actions, deterministic lifecycle coverage, rendered smoke coverage, and distribution docs

## Verification
- `swift test --disable-sandbox --filter QuillCodeDesktopUpdateControllerTests` (11 tests, 0 failures)
- updater-family tests (23 tests, 0 failures)
- rendered updater failure smoke test (1 test, 0 failures; image inspected at 470x340)
- release parity suite (317 tests, 0 failures)
- repository quality grader: A+ across implementation and tests
- `git diff --check`

## Local environment note
The exhaustive package run executed 5,348 tests twice. Four assertions in three unrelated login-shell tests are polluted by an existing `~/.profile` stderr line (`/.local/bin/env` is absent); updater tests remained green. Protected CI runs in a clean environment and is the authoritative full-suite result.