### PR TITLE
Gate download publication on exact-main CI

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -31,6 +31,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/validate-download-build-ref.sh
+      - name: Wait for successful exact-main CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/wait-for-successful-ci.sh
       - name: Plan download build
         id: plan
         env:

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildCIGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildCIGateTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+
+final class ParityDownloadBuildCIGateTests: QuillCodeParityTestCase {
+    private let commit = String(repeating: "a", count: 40)
+
+    func testWaitsForActiveExactRunAndAcceptsLaterSuccess() throws {
+        let successfulURL = "https://github.com/Lore-Hex/QuillCode/actions/runs/13"
+        let firstSnapshot = [
+            row(id: 10, status: "completed", conclusion: "success", branch: "feature"),
+            row(id: 11, status: "completed", conclusion: "success", event: "pull_request"),
+            row(id: 12, status: "in_progress", conclusion: ""),
+        ].joined(separator: "\n")
+        let result = try runGate(responses: [
+            firstSnapshot,
+            row(id: 13, status: "completed", conclusion: "success", url: successfulURL),
+        ])
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("1 matching CI run(s) are still active"), result.output)
+        XCTAssertTrue(result.output.contains("Validated successful exact-main CI"), result.output)
+        XCTAssertTrue(result.output.contains(successfulURL), result.output)
+        XCTAssertEqual(result.ghLog.components(separatedBy: "run list").count - 1, 2)
+        XCTAssertEqual(result.sleepLog.trimmingCharacters(in: .whitespacesAndNewlines), "1")
+    }
+
+    func testRejectsCompletedFailureAtBoundedDeadline() throws {
+        let result = try runGate(
+            responses: [row(id: 20, status: "completed", conclusion: "failure")],
+            waitSeconds: "0"
+        )
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("1 matching CI run(s) completed without success"),
+            result.output
+        )
+        XCTAssertTrue(result.output.contains("did not produce a successful exact-main CI run"))
+        XCTAssertTrue(result.sleepLog.isEmpty)
+    }
+
+    func testRetriesTransientGitHubQueryFailure() throws {
+        let result = try runGate(
+            responses: [
+                "",
+                row(id: 21, status: "completed", conclusion: "success"),
+            ],
+            failingCalls: [1]
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("GitHub CI query is temporarily unavailable"), result.output)
+        XCTAssertTrue(result.output.contains("Validated successful exact-main CI"), result.output)
+        XCTAssertEqual(result.ghLog.components(separatedBy: "run list").count - 1, 2)
+        XCTAssertEqual(result.sleepLog.trimmingCharacters(in: .whitespacesAndNewlines), "1")
+    }
+
+    func testRejectsPullRequestAndMismatchedRuns() throws {
+        let result = try runGate(responses: [[
+            row(id: 30, status: "completed", conclusion: "success", branch: "feature"),
+            row(id: 31, status: "completed", conclusion: "success", event: "pull_request"),
+            row(
+                id: 32,
+                status: "completed",
+                conclusion: "success",
+                sha: String(repeating: "b", count: 40)
+            ),
+        ].joined(separator: "\n")], waitSeconds: "0")
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(result.output.contains("no matching main-branch CI run exists yet"), result.output)
+    }
+
+    func testRejectsInvalidBoundsBeforeQueryingGitHub() throws {
+        let excessiveWait = try runGate(responses: [""], waitSeconds: "3601")
+        let zeroPoll = try runGate(responses: [""], waitSeconds: "0", pollSeconds: "0")
+
+        XCTAssertEqual(excessiveWait.exitCode, 2, excessiveWait.output)
+        XCTAssertTrue(excessiveWait.output.contains("must not exceed 3600"), excessiveWait.output)
+        XCTAssertTrue(excessiveWait.ghLog.isEmpty)
+        XCTAssertEqual(zeroPoll.exitCode, 2, zeroPoll.output)
+        XCTAssertTrue(zeroPoll.output.contains("must be a positive integer"), zeroPoll.output)
+        XCTAssertTrue(zeroPoll.ghLog.isEmpty)
+    }
+
+    private struct GateResult {
+        var exitCode: Int32
+        var output: String
+        var ghLog: String
+        var sleepLog: String
+    }
+
+    private func runGate(
+        responses: [String],
+        waitSeconds: String = "3",
+        pollSeconds: String = "1",
+        failingCalls: Set<Int> = []
+    ) throws -> GateResult {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-download-ci-gate-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let binDirectory = temporaryDirectory.appendingPathComponent("bin")
+        let responsesDirectory = temporaryDirectory.appendingPathComponent("responses")
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: responsesDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        for (index, response) in responses.enumerated() {
+            try response.write(
+                to: responsesDirectory.appendingPathComponent("\(index + 1).txt"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        for call in failingCalls {
+            try Data().write(to: responsesDirectory.appendingPathComponent("\(call).fail"))
+        }
+
+        let ghURL = binDirectory.appendingPathComponent("gh")
+        let sleepURL = binDirectory.appendingPathComponent("sleep")
+        let ghLogURL = temporaryDirectory.appendingPathComponent("gh.log")
+        let sleepLogURL = temporaryDirectory.appendingPathComponent("sleep.log")
+        let callCountURL = temporaryDirectory.appendingPathComponent("calls.txt")
+        try fakeGH.write(to: ghURL, atomically: true, encoding: .utf8)
+        try fakeSleep.write(to: sleepURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: ghURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sleepURL.path)
+
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts")
+                .appendingPathComponent("wait-for-successful-ci.sh")
+                .path
+        ]
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(binDirectory.path):\(environment["PATH"] ?? "")"
+        environment["GITHUB_REPOSITORY"] = "Lore-Hex/QuillCode"
+        environment["GITHUB_SHA"] = commit
+        environment["DOWNLOAD_BUILD_CI_WAIT_SECONDS"] = waitSeconds
+        environment["DOWNLOAD_BUILD_CI_POLL_SECONDS"] = pollSeconds
+        environment["CI_GATE_RESPONSES_DIR"] = responsesDirectory.path
+        environment["CI_GATE_RESPONSE_COUNT"] = String(responses.count)
+        environment["CI_GATE_CALL_COUNT_FILE"] = callCountURL.path
+        environment["CI_GATE_GH_LOG"] = ghLogURL.path
+        environment["CI_GATE_SLEEP_LOG"] = sleepLogURL.path
+        environment.removeValue(forKey: "GITHUB_OUTPUT")
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        return GateResult(
+            exitCode: process.terminationStatus,
+            output: String(
+                data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? "",
+            ghLog: (try? String(contentsOf: ghLogURL, encoding: .utf8)) ?? "",
+            sleepLog: (try? String(contentsOf: sleepLogURL, encoding: .utf8)) ?? ""
+        )
+    }
+
+    private func row(
+        id: Int,
+        status: String,
+        conclusion: String,
+        sha: String? = nil,
+        branch: String = "main",
+        event: String = "workflow_dispatch",
+        url: String? = nil
+    ) -> String {
+        [
+            String(id),
+            status,
+            conclusion,
+            sha ?? commit,
+            branch,
+            event,
+            url ?? "https://github.com/Lore-Hex/QuillCode/actions/runs/\(id)",
+        ].joined(separator: "\u{1F}")
+    }
+
+    private var fakeGH: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${CI_GATE_GH_LOG:?}"
+        if [[ "$1" != "run" || "$2" != "list" ]]; then
+          echo "unexpected gh invocation: $*" >&2
+          exit 9
+        fi
+        count=0
+        if [[ -f "${CI_GATE_CALL_COUNT_FILE:?}" ]]; then
+          read -r count < "$CI_GATE_CALL_COUNT_FILE"
+        fi
+        count=$((count + 1))
+        printf '%s\n' "$count" > "$CI_GATE_CALL_COUNT_FILE"
+        response_index="$count"
+        if (( response_index > CI_GATE_RESPONSE_COUNT )); then
+          response_index="$CI_GATE_RESPONSE_COUNT"
+        fi
+        if [[ -f "${CI_GATE_RESPONSES_DIR:?}/${response_index}.fail" ]]; then
+          exit 1
+        fi
+        cat "${CI_GATE_RESPONSES_DIR:?}/${response_index}.txt"
+        """
+    }
+
+    private var fakeSleep: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${CI_GATE_SLEEP_LOG:?}"
+        """
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -192,6 +192,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "contents: write",
             "release-policy:",
             "scripts/validate-download-build-ref.sh",
+            "Wait for successful exact-main CI",
+            "scripts/wait-for-successful-ci.sh",
             "scripts/plan-download-build.sh",
             "build-required: ${{ steps.plan.outputs.build-required }}",
             "if: needs.release-policy.outputs.build-required == 'true'",
@@ -231,6 +233,11 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             workflow.contains("permissions:\n  actions: read\n  contents: write"),
             "repository write permission must remain scoped to the publish job"
         )
+        let validationIndex = try XCTUnwrap(workflow.range(of: "scripts/validate-download-build-ref.sh"))
+        let ciGateIndex = try XCTUnwrap(workflow.range(of: "scripts/wait-for-successful-ci.sh"))
+        let planningIndex = try XCTUnwrap(workflow.range(of: "scripts/plan-download-build.sh"))
+        XCTAssertLessThan(validationIndex.lowerBound, ciGateIndex.lowerBound)
+        XCTAssertLessThan(ciGateIndex.lowerBound, planningIndex.lowerBound)
     }
 
     func testDownloadDocsExposeStableManifestLink() throws {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3419,3 +3419,18 @@
   `QuillCodeDesktopUpdateView`, and `QuillCodeDesktopUpdateControllerTests` cover repeated in-session
   checks, retry backoff, manual rescheduling, visible-state deferral, task deallocation, reentrant menu
   commands, and non-cancellable activation.
+
+## 2026-08-07: downloads wait for successful exact-main CI before packaging
+
+- **Decision:** The **Download Builds** release-policy job validates its ref, then waits up to 30
+  minutes for a successful `CI` workflow run with the exact requested commit, `main` as its head
+  branch, and a `push` or `workflow_dispatch` event before planning or packaging any release.
+- **Why:** Merge-train dispatches CI and downloads independently. Build 629 demonstrated that
+  packaging and publication could finish while exact-main CI was still running and temporarily red,
+  even though branch CI and the eventual rerun were green. Public updater state must never outrun the
+  authoritative main test result.
+- **Failure behavior:** Missing, active, failed, cancelled, or mismatched runs remain non-authorizing.
+  The bounded gate reports state changes without log spam and fails closed at timeout; a later green
+  CI result requires a new or rerun Download Builds attempt.
+- **Evidence:** `scripts/wait-for-successful-ci.sh`, `.github/workflows/download-builds.yml`,
+  `ParityDownloadBuildCIGateTests`, and `ParityDownloadBuildsGateTests`.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -34,6 +34,13 @@ The tester release is refreshed:
   names a publishing run that is unavailable, incomplete, failed, or mismatched
 - whenever a maintainer runs **Download Builds** manually from GitHub Actions
 
+Before packaging starts, **Download Builds** waits up to 30 minutes for a
+successful **CI** run whose commit and branch are exactly the requested `main`
+build. Pull-request CI, another branch, another commit, or a failed/cancelled run
+cannot authorize publication. The gate also covers merge-train, push, scheduled,
+manual, and stable-tag entrypoints, so a red or untested main commit cannot race
+ahead into the public updater feed.
+
 The nightly check skips packaging only when the live manifest publishes the
 current `main` commit and its exact **Download Builds** run completed successfully
 on that commit. This avoids no-op build-number updates and unnecessary updater

--- a/scripts/wait-for-successful-ci.sh
+++ b/scripts/wait-for-successful-ci.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+COMMIT="${GITHUB_SHA:?GITHUB_SHA is required}"
+BASE_BRANCH="main"
+WAIT_SECONDS="${DOWNLOAD_BUILD_CI_WAIT_SECONDS:-1800}"
+POLL_SECONDS="${DOWNLOAD_BUILD_CI_POLL_SECONDS:-15}"
+
+fail() {
+  echo "$*" >&2
+  exit 2
+}
+
+[[ "$REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+  fail "Invalid GitHub repository slug: $REPOSITORY"
+[[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "Exact-main CI requires a full lowercase commit SHA."
+[[ "$WAIT_SECONDS" =~ ^[0-9]+$ ]] ||
+  fail "DOWNLOAD_BUILD_CI_WAIT_SECONDS must be a non-negative integer."
+[[ "$POLL_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+  fail "DOWNLOAD_BUILD_CI_POLL_SECONDS must be a positive integer."
+WAIT_SECONDS=$((10#$WAIT_SECONDS))
+POLL_SECONDS=$((10#$POLL_SECONDS))
+(( WAIT_SECONDS <= 3600 )) ||
+  fail "DOWNLOAD_BUILD_CI_WAIT_SECONDS must not exceed 3600."
+(( POLL_SECONDS <= 300 )) ||
+  fail "DOWNLOAD_BUILD_CI_POLL_SECONDS must not exceed 300."
+
+deadline=$((SECONDS + WAIT_SECONDS))
+previous_state=""
+
+while true; do
+  query_succeeded=true
+  if ! run_rows="$(
+    gh run list \
+      --repo "$REPOSITORY" \
+      --workflow ci.yml \
+      --commit "$COMMIT" \
+      --branch "$BASE_BRANCH" \
+      --limit 20 \
+      --json databaseId,status,conclusion,headSha,headBranch,event,url \
+      --jq '
+        .[] |
+        [
+          (.databaseId | tostring),
+          .status,
+          (.conclusion // ""),
+          .headSha,
+          (.headBranch // ""),
+          .event,
+          .url
+        ] |
+        join("\u001f")
+      ' 2>/dev/null
+  )"; then
+    query_succeeded=false
+    run_rows=""
+  fi
+
+  matching_count=0
+  active_count=0
+  terminal_count=0
+  successful_url=""
+
+  while IFS=$'\x1f' read -r run_id status conclusion head_sha head_branch event url; do
+    [[ -n "$run_id" ]] || continue
+    [[ "$head_sha" == "$COMMIT" && "$head_branch" == "$BASE_BRANCH" ]] || continue
+    [[ "$event" == "push" || "$event" == "workflow_dispatch" ]] || continue
+
+    matching_count=$((matching_count + 1))
+    if [[ "$status" == "completed" && "$conclusion" == "success" ]]; then
+      successful_url="$url"
+      break
+    fi
+    if [[ "$status" == "completed" ]]; then
+      terminal_count=$((terminal_count + 1))
+    else
+      active_count=$((active_count + 1))
+    fi
+  done <<< "$run_rows"
+
+  if [[ -n "$successful_url" ]]; then
+    echo "Validated successful exact-main CI for $COMMIT: $successful_url"
+    exit 0
+  fi
+
+  if [[ "$query_succeeded" != "true" ]]; then
+    current_state="the GitHub CI query is temporarily unavailable"
+  elif (( matching_count == 0 )); then
+    current_state="no matching main-branch CI run exists yet"
+  elif (( active_count > 0 )); then
+    current_state="$active_count matching CI run(s) are still active"
+  else
+    current_state="$terminal_count matching CI run(s) completed without success"
+  fi
+  if [[ "$current_state" != "$previous_state" ]]; then
+    echo "Waiting for successful exact-main CI for $COMMIT: $current_state."
+    previous_state="$current_state"
+  fi
+
+  if (( SECONDS >= deadline )); then
+    fail "Commit $COMMIT did not produce a successful exact-main CI run within ${WAIT_SECONDS}s; $current_state."
+  fi
+
+  remaining=$((deadline - SECONDS))
+  sleep_seconds="$POLL_SECONDS"
+  if (( sleep_seconds > remaining )); then
+    sleep_seconds="$remaining"
+  fi
+  sleep "$sleep_seconds"
+done


### PR DESCRIPTION
## Summary
- hold Download Builds in release policy until an exact-SHA successful CI run exists on main
- reject pull-request, wrong-branch, wrong-commit, failed, cancelled, or missing CI as release authorization
- retry active/missing runs and transient GitHub API failures within a bounded 30-minute window, with state-change-only logging
- document the invariant and prove gate lifecycle plus workflow ordering deterministically

## Why
Build 629 showed that merge-train can dispatch CI and Download Builds concurrently: public publication completed while exact-main CI was still running and temporarily red. The release was valid and CI passed on rerun, but public updater state must never outrun authoritative main CI.

## Verification
- `swift test --disable-sandbox --filter ParityDownloadBuildCIGateTests` (5 tests, 0 failures)
- release-policy parity family (30 tests, 0 failures)
- full `QuillCodeParityTests` suite (322 tests, 0 failures)
- live GitHub probe resolved successful exact-main CI run 31188903915 for commit 8aaa285b
- `bash -n scripts/wait-for-successful-ci.sh`
- `git diff --check`
- code quality: waiter 100/A+, tests 100/A+