### PR TITLE
Recover interrupted updates and preserve shell environment

### DIFF
--- a/Sources/QuillCodeTools/ShellStreamingProcessRunner.swift
+++ b/Sources/QuillCodeTools/ShellStreamingProcessRunner.swift
@@ -90,13 +90,14 @@ final class ShellStreamingProcessRunner: @unchecked Sendable {
             return
         }
 
+        let environment = request.environment ?? ProcessInfo.processInfo.environment
         let launch: ShellProcessLaunch
         do {
             launch = try ShellProcessSandbox.launch(
                 executable: request.shellExecutableURL,
                 arguments: ["-lc", trimmed],
                 cwd: request.cwd,
-                environment: request.environment ?? ProcessInfo.processInfo.environment,
+                environment: environment,
                 policy: sandboxPolicy
             )
         } catch {
@@ -115,7 +116,7 @@ final class ShellStreamingProcessRunner: @unchecked Sendable {
         process.executableURL = launch.executable
         process.arguments = launch.arguments
         process.currentDirectoryURL = request.cwd
-        process.environment = request.environment
+        process.environment = environment
 
         let standardOutput = Pipe()
         let standardError = Pipe()

--- a/Sources/QuillCodeTools/ShellToolExecutor.swift
+++ b/Sources/QuillCodeTools/ShellToolExecutor.swift
@@ -220,7 +220,7 @@ public struct ShellToolExecutor: Sendable {
         process.executableURL = launch.executable
         process.arguments = launch.arguments
         process.currentDirectoryURL = request.cwd
-        process.environment = request.environment
+        process.environment = environment
 
         let stdout = Pipe()
         let stderr = Pipe()

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -42,6 +42,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     private let checker: any QuillCodeDesktopUpdateChecking
     private let preparer: any QuillCodeDesktopUpdatePreparing
     private let installer: any QuillCodeDesktopUpdateInstalling
+    private let recovery: any QuillCodeDesktopUpdateRecovering
     private let defaults: UserDefaults
     private let now: () -> Date
     private let automaticSchedule: QuillCodeDesktopUpdateSchedule
@@ -49,6 +50,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     private let terminateApplication: @MainActor () -> Void
     private var operationTask: Task<Void, Never>?
     private var automaticTask: Task<Void, Never>?
+    private var recoveryTask: Task<Void, Never>?
     private var generation = UUID()
     private var didStartAutomaticChecks = false
 
@@ -64,6 +66,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         checker: any QuillCodeDesktopUpdateChecking = QuillCodeDesktopUpdateChecker(),
         preparer: any QuillCodeDesktopUpdatePreparing = QuillCodeDesktopUpdatePreparer(),
         installer: any QuillCodeDesktopUpdateInstalling = QuillCodeDesktopUpdateInstaller(),
+        recovery: any QuillCodeDesktopUpdateRecovering = QuillCodeDesktopUpdateRecovery(),
         defaults: UserDefaults = .standard,
         now: @escaping () -> Date = Date.init,
         automaticSchedule: QuillCodeDesktopUpdateSchedule = .production,
@@ -75,6 +78,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         self.checker = checker
         self.preparer = preparer
         self.installer = installer
+        self.recovery = recovery
         self.defaults = defaults
         self.now = now
         self.automaticSchedule = automaticSchedule
@@ -85,6 +89,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     deinit {
         operationTask?.cancel()
         automaticTask?.cancel()
+        recoveryTask?.cancel()
     }
 
     func startAutomaticChecks() {
@@ -92,6 +97,11 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         didStartAutomaticChecks = true
         consumePreviousInstallResult()
         guard let configuration else { return }
+
+        let recovery = recovery
+        recoveryTask = Task {
+            await recovery.recoverInterruptedUpdate(configuration: configuration)
+        }
 
         let schedule = automaticSchedule
         let firstDelay = schedule.firstDelay(

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
@@ -35,54 +35,59 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
         configuration: QuillCodeDesktopUpdateConfiguration
     ) async throws -> QuillCodeDesktopPreparedUpdate {
         let workspaceURL = try await makeCleanWorkspace(for: release)
-        let archiveURL = workspaceURL.appendingPathComponent(release.asset.name, isDirectory: false)
-        try await downloader.download(
-            from: release.asset.url,
-            to: archiveURL,
-            maximumBytes: release.asset.sizeBytes
-        )
-        try Task.checkCancellation()
-
-        try await Task.detached(priority: .utility) {
-            try Self.verifyArchive(
-                at: archiveURL,
-                expectedSize: release.asset.sizeBytes,
-                expectedSHA256: release.asset.sha256
+        do {
+            let archiveURL = workspaceURL.appendingPathComponent(release.asset.name, isDirectory: false)
+            try await downloader.download(
+                from: release.asset.url,
+                to: archiveURL,
+                maximumBytes: release.asset.sizeBytes
             )
-        }.value
+            try Task.checkCancellation()
 
-        let extractedURL = workspaceURL.appendingPathComponent("Extracted", isDirectory: true)
-        try await Task.detached(priority: .utility) {
-            try FileManager.default.createDirectory(
-                at: extractedURL,
-                withIntermediateDirectories: false,
-                attributes: [.posixPermissions: 0o700]
-            )
-            let result = try QuillCodeDesktopUpdateProcessRunner.run(
-                executableURL: URL(fileURLWithPath: "/usr/bin/ditto"),
-                arguments: ["-x", "-k", archiveURL.path, extractedURL.path]
-            )
-            guard result.exitCode == 0 else {
-                throw QuillCodeDesktopUpdateError.invalidApplication(result.failureSummary)
-            }
-        }.value
+            try await Task.detached(priority: .utility) {
+                try Self.verifyArchive(
+                    at: archiveURL,
+                    expectedSize: release.asset.sizeBytes,
+                    expectedSHA256: release.asset.sha256
+                )
+            }.value
 
-        let applicationURL = try await Task.detached(priority: .utility) {
-            let appURL = try Self.singleApplication(in: extractedURL)
-            try Self.validateContainedLinks(in: extractedURL)
-            try QuillCodeDesktopDownloadedApplicationValidator.validate(
-                appURL,
+            let extractedURL = workspaceURL.appendingPathComponent("Extracted", isDirectory: true)
+            try await Task.detached(priority: .utility) {
+                try FileManager.default.createDirectory(
+                    at: extractedURL,
+                    withIntermediateDirectories: false,
+                    attributes: [.posixPermissions: 0o700]
+                )
+                let result = try QuillCodeDesktopUpdateProcessRunner.run(
+                    executableURL: URL(fileURLWithPath: "/usr/bin/ditto"),
+                    arguments: ["-x", "-k", archiveURL.path, extractedURL.path]
+                )
+                guard result.exitCode == 0 else {
+                    throw QuillCodeDesktopUpdateError.invalidApplication(result.failureSummary)
+                }
+            }.value
+
+            let applicationURL = try await Task.detached(priority: .utility) {
+                let appURL = try Self.singleApplication(in: extractedURL)
+                try Self.validateContainedLinks(in: extractedURL)
+                try QuillCodeDesktopDownloadedApplicationValidator.validate(
+                    appURL,
+                    release: release,
+                    configuration: configuration
+                )
+                return appURL
+            }.value
+
+            return QuillCodeDesktopPreparedUpdate(
                 release: release,
-                configuration: configuration
+                applicationURL: applicationURL,
+                workspaceURL: workspaceURL
             )
-            return appURL
-        }.value
-
-        return QuillCodeDesktopPreparedUpdate(
-            release: release,
-            applicationURL: applicationURL,
-            workspaceURL: workspaceURL
-        )
+        } catch {
+            await Self.removeFailedWorkspace(at: workspaceURL)
+            throw error
+        }
     }
 
     func makeCleanWorkspace(for release: QuillCodeDesktopUpdateRelease) async throws -> URL {
@@ -146,6 +151,12 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
         guard digest == expectedSHA256 else {
             throw QuillCodeDesktopUpdateError.checksumMismatch
         }
+    }
+
+    private static func removeFailedWorkspace(at workspaceURL: URL) async {
+        await Task.detached(priority: .utility) {
+            try? FileManager.default.removeItem(at: workspaceURL)
+        }.value
     }
 
     private static func singleApplication(in extractedURL: URL) throws -> URL {

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateRecovery.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateRecovery.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+protocol QuillCodeDesktopUpdateRecovering: Sendable {
+    func recoverInterruptedUpdate(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async
+}
+
+struct QuillCodeDesktopUpdateRecovery: QuillCodeDesktopUpdateRecovering, Sendable {
+    static let productionGracePeriod: TimeInterval = 2 * 60
+
+    private let gracePeriod: TimeInterval
+
+    init(gracePeriod: TimeInterval = productionGracePeriod) {
+        self.gracePeriod = gracePeriod.isFinite && gracePeriod >= 0
+            ? gracePeriod
+            : Self.productionGracePeriod
+    }
+
+    func recoverInterruptedUpdate(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async {
+        if gracePeriod > 0 {
+            do {
+                try await Task.sleep(for: .seconds(gracePeriod))
+            } catch {
+                return
+            }
+        }
+        guard !Task.isCancelled else { return }
+        let applicationURL = configuration.applicationURL
+        let bundleIdentifier = configuration.bundleIdentifier
+        _ = try? await Task.detached(priority: .utility) {
+            try Self.removeOrphanedStagingApplications(
+                beside: applicationURL,
+                bundleIdentifier: bundleIdentifier
+            )
+        }.value
+    }
+
+    @discardableResult
+    static func removeOrphanedStagingApplications(
+        beside applicationURL: URL,
+        bundleIdentifier: String
+    ) throws -> [URL] {
+        let applicationURL = applicationURL.standardizedFileURL
+        let values = try applicationURL.resourceValues(
+            forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+        )
+        guard applicationURL.pathExtension == "app",
+              values.isDirectory == true,
+              values.isSymbolicLink != true,
+              Bundle(url: applicationURL)?.bundleIdentifier == bundleIdentifier
+        else {
+            return []
+        }
+
+        let parentURL = applicationURL.deletingLastPathComponent()
+        let baseName = applicationURL.deletingPathExtension().lastPathComponent
+        let children = try FileManager.default.contentsOfDirectory(
+            at: parentURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: []
+        )
+        var removed: [URL] = []
+        for child in children where isOwnedStagingApplication(child, baseName: baseName) {
+            guard let childValues = try? child.resourceValues(
+                forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+            ),
+                  childValues.isDirectory == true,
+                  childValues.isSymbolicLink != true
+            else {
+                continue
+            }
+            do {
+                try FileManager.default.removeItem(at: child)
+                removed.append(child.standardizedFileURL)
+            } catch {
+                continue
+            }
+        }
+        return removed
+    }
+
+    private static func isOwnedStagingApplication(_ url: URL, baseName: String) -> Bool {
+        let prefix = ".\(baseName).update-"
+        let suffix = ".app"
+        let name = url.lastPathComponent
+        guard name.hasPrefix(prefix),
+              name.hasSuffix(suffix),
+              name.count > prefix.count + suffix.count
+        else {
+            return false
+        }
+        let identifierStart = name.index(name.startIndex, offsetBy: prefix.count)
+        let identifierEnd = name.index(name.endIndex, offsetBy: -suffix.count)
+        let identifier = String(name[identifierStart..<identifierEnd])
+        guard let uuid = UUID(uuidString: identifier) else { return false }
+        return uuid.uuidString.lowercased() == identifier
+    }
+}

--- a/Tests/QuillCodeCLITests/AppServerUserShellTests.swift
+++ b/Tests/QuillCodeCLITests/AppServerUserShellTests.swift
@@ -451,7 +451,7 @@ final class AppServerUserShellTests: XCTestCase {
         let output = UserShellOutputCollector()
         let session = try AppServerSession(
             request: CLIAppServerRequest(live: false, home: home),
-            environment: ["SHELL": "/bin/sh"],
+            environment: ["HOME": home.path, "SHELL": "/bin/sh"],
             currentDirectory: workspace,
             runnerFactory: { configuration in
                 AgentRunner(

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -55,6 +55,27 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         XCTAssertFalse(controller.isPresented)
     }
 
+    func testAutomaticStartupRunsInterruptedUpdateRecoveryOnlyOnce() async throws {
+        let recovery = UpdateRecoverySpy()
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: UpdateCheckerSpy(
+                result: .upToDate(latestVersion: "0.1.0", latestBuild: "42")
+            ),
+            recovery: recovery,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(initialDelay: 60),
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.startAutomaticChecks()
+        controller.startAutomaticChecks()
+
+        try await waitUntil { await recovery.callCount == 1 }
+        let recoveryCallCount = await recovery.callCount
+        XCTAssertEqual(recoveryCallCount, 1)
+    }
+
     func testBackgroundFailureStaysQuietButManualFailureIsVisible() async throws {
         let checker = UpdateCheckerSpy(error: .invalidResponse)
         let controller = QuillCodeDesktopUpdateController(
@@ -391,5 +412,13 @@ private actor UpdateInstallerSpy: QuillCodeDesktopUpdateInstalling {
         if let delay {
             try await Task.sleep(for: delay)
         }
+    }
+}
+
+private actor UpdateRecoverySpy: QuillCodeDesktopUpdateRecovering {
+    private(set) var callCount = 0
+
+    func recoverInterruptedUpdate(configuration: QuillCodeDesktopUpdateConfiguration) async {
+        callCount += 1
     }
 }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -131,6 +131,151 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         )
     }
 
+    func testRecoveryRemovesOnlyOwnedStagingApplicationDirectories() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let applicationURL = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        try makeFakeApplication(
+            at: applicationURL,
+            version: "0.1.0",
+            build: "42",
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+        let validIdentifier = UUID().uuidString.lowercased()
+        let stagingURL = root.appendingPathComponent(
+            ".Quill Cowork.update-\(validIdentifier).app",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: stagingURL, withIntermediateDirectories: false)
+        let malformedURL = root.appendingPathComponent(
+            ".Quill Cowork.update-not-a-uuid.app",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: malformedURL, withIntermediateDirectories: false)
+        let otherApplicationURL = root.appendingPathComponent(
+            ".Other App.update-\(UUID().uuidString.lowercased()).app",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: otherApplicationURL,
+            withIntermediateDirectories: false
+        )
+        let symlinkTargetURL = root.appendingPathComponent("symlink-target", isDirectory: true)
+        try FileManager.default.createDirectory(at: symlinkTargetURL, withIntermediateDirectories: false)
+        let symlinkURL = root.appendingPathComponent(
+            ".Quill Cowork.update-\(UUID().uuidString.lowercased()).app",
+            isDirectory: true
+        )
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: symlinkTargetURL)
+
+        let removed = try QuillCodeDesktopUpdateRecovery.removeOrphanedStagingApplications(
+            beside: applicationURL,
+            bundleIdentifier: "co.lorehex.QuillCowork"
+        )
+
+        XCTAssertEqual(removed.map(\.lastPathComponent), [stagingURL.lastPathComponent])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stagingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: malformedURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: otherApplicationURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: symlinkURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: symlinkTargetURL.path))
+    }
+
+    func testRecoveryRefusesToCleanBesideUnexpectedApplicationIdentity() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let applicationURL = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        try makeFakeApplication(
+            at: applicationURL,
+            version: "0.1.0",
+            build: "42",
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+        let stagingURL = root.appendingPathComponent(
+            ".Quill Cowork.update-\(UUID().uuidString.lowercased()).app",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: stagingURL, withIntermediateDirectories: false)
+
+        let removed = try QuillCodeDesktopUpdateRecovery.removeOrphanedStagingApplications(
+            beside: applicationURL,
+            bundleIdentifier: "com.example.NotQuillCowork"
+        )
+
+        XCTAssertEqual(removed, [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stagingURL.path))
+    }
+
+    func testRecoveryCancellationDuringGracePeriodLeavesStagingUntouched() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let applicationURL = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        try makeFakeApplication(
+            at: applicationURL,
+            version: "0.1.0",
+            build: "42",
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+        let stagingURL = root.appendingPathComponent(
+            ".Quill Cowork.update-\(UUID().uuidString.lowercased()).app",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: stagingURL, withIntermediateDirectories: false)
+        var configuration = makeConfiguration()
+        configuration.applicationURL = applicationURL
+        let recovery = QuillCodeDesktopUpdateRecovery(gracePeriod: 60)
+        let task = Task {
+            await recovery.recoverInterruptedUpdate(configuration: configuration)
+        }
+
+        task.cancel()
+        await task.value
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stagingURL.path))
+    }
+
+    func testPreparerRemovesWorkspaceAfterDownloadFailure() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let preparer = QuillCodeDesktopUpdatePreparer(
+            downloader: FailingUpdateDownloader(error: .invalidResponse),
+            cacheRoot: root
+        )
+
+        do {
+            _ = try await preparer.prepare(
+                release: makeRelease(build: "618"),
+                configuration: makeConfiguration()
+            )
+            XCTFail("Expected updater preparation to fail")
+        } catch {
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .invalidResponse)
+        }
+
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path), [])
+    }
+
+    func testPreparerRemovesWorkspaceAfterCancellation() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let preparer = QuillCodeDesktopUpdatePreparer(
+            downloader: CancellingUpdateDownloader(),
+            cacheRoot: root
+        )
+
+        do {
+            _ = try await preparer.prepare(
+                release: makeRelease(build: "619"),
+                configuration: makeConfiguration()
+            )
+            XCTFail("Expected updater preparation to be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path), [])
+    }
+
     func testHelperArgumentsRoundTripWithoutInterpretingPathsAsShell() throws {
         let root = URL(fileURLWithPath: "/tmp/Quill Cowork update; untouched")
         let request = QuillCodeDesktopUpdateHelperRequest(
@@ -413,6 +558,20 @@ private struct UpdateManifestLoaderStub: QuillCodeDesktopUpdateManifestLoading {
     func loadManifest(from url: URL, byteLimit: Int) async throws -> Data {
         guard data.count <= byteLimit else { throw QuillCodeDesktopUpdateError.manifestTooLarge }
         return data
+    }
+}
+
+private struct FailingUpdateDownloader: QuillCodeDesktopUpdateDownloading {
+    var error: QuillCodeDesktopUpdateError
+
+    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws {
+        throw error
+    }
+}
+
+private struct CancellingUpdateDownloader: QuillCodeDesktopUpdateDownloading {
+    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws {
+        throw CancellationError()
     }
 }
 

--- a/Tests/QuillCodeToolsTests/ShellToolExecutorTests.swift
+++ b/Tests/QuillCodeToolsTests/ShellToolExecutorTests.swift
@@ -33,6 +33,18 @@ final class ShellToolExecutorTests: XCTestCase {
         XCTAssertEqual(result.stdout, "from-shell-request")
     }
 
+    func testShellWithoutExplicitEnvironmentInheritsHome() throws {
+        let expectedHome = try XCTUnwrap(ProcessInfo.processInfo.environment["HOME"])
+
+        let result = ShellToolExecutor().run(.init(
+            command: "printf '%s' \"$HOME\"",
+            cwd: URL(fileURLWithPath: NSTemporaryDirectory())
+        ))
+
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertEqual(result.stdout, expectedHome)
+    }
+
     func testShellUsesSelectedExecutable() throws {
         let root = try makeTempDirectory()
         let argumentsFile = root.appendingPathComponent("shell-arguments.txt")
@@ -147,6 +159,23 @@ final class ShellToolExecutorTests: XCTestCase {
                 .map(String.init),
             ["-lc", "printf selected-stream-shell"]
         )
+    }
+
+    func testStreamingShellWithoutExplicitEnvironmentInheritsHome() async throws {
+        let expectedHome = try XCTUnwrap(ProcessInfo.processInfo.environment["HOME"])
+        let stream = ShellToolExecutor().runStreaming(.init(
+            command: "printf '%s' \"$HOME\"",
+            cwd: URL(fileURLWithPath: NSTemporaryDirectory())
+        ))
+        var finishedResult: ToolResult?
+
+        for await event in stream {
+            if case .finished(let result) = event { finishedResult = result }
+        }
+
+        let result = try XCTUnwrap(finishedResult)
+        XCTAssertTrue(result.ok, result.error ?? "")
+        XCTAssertEqual(result.stdout, expectedHome)
     }
 
     func testStreamingSessionSendsInputToRunningProcess() async throws {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,37 @@
 # QuillCode Decisions
 
+## 2026-08-07: shell subprocesses receive the environment used to plan their launch
+
+- **Decision:** Synchronous and streaming shell execution resolve one effective environment and pass
+  that same value to sandbox planning and `Process`. An omitted command-local environment inherits
+  the Quill Cowork process environment explicitly; an explicit environment remains authoritative.
+- **Why:** The launch paths previously computed the inherited environment for sandbox setup but
+  assigned the original optional override to `Process`. Under SwiftPM and some GUI launch contexts,
+  login shells could start without `HOME`, source the user's profile with broken absolute paths, and
+  contaminate command and SSH diagnostics. The mismatch also made full-suite results depend on the
+  developer machine's profile.
+- **Evidence:** `ShellToolExecutorTests` cover inherited `HOME` in synchronous and streaming paths.
+  `AppServerUserShellTests` uses an isolated temporary home, and `SSHRemoteProjectProbeTests` proves
+  that the intended remote failure remains the surfaced diagnostic.
+
+## 2026-08-07: interrupted updates clean up only updater-owned staging
+
+- **Decision:** Failed or cancelled preparation removes the workspace it created. On app startup,
+  `QuillCodeDesktopUpdateRecovery` waits two minutes and then removes only immediate hidden sibling
+  directories named `.Quill Cowork.update-<lowercase UUID>.app` beside a valid configured Quill
+  Cowork bundle.
+- **Safety boundary:** Recovery refuses symlinks, malformed identifiers, other app names, and an
+  unexpected destination bundle identity. The grace period exceeds the helper's parent-exit and
+  launch-handshake budgets so a second app instance cannot delete a legitimate in-flight staging
+  bundle. The successful preparation workspace remains intact for the detached helper.
+- **Why:** A process or machine stop can happen before activation, after the atomic swap, or during
+  rollback cleanup. Every window keeps a runnable destination bundle, but without reconciliation a
+  hidden full app copy could remain indefinitely. The bounded ownership contract recovers disk space
+  without broad deletion beside the user's installed application.
+- **Evidence:** `QuillCodeDesktopUpdateRecovery`, `QuillCodeDesktopUpdatePreparer`,
+  `QuillCodeDesktopUpdateControllerTests`, and `QuillCodeDesktopUpdateTests` cover exact ownership,
+  symlink/lookalike refusal, startup idempotence, cancellation, failure, swap, and rollback paths.
+
 ## 2026-08-06: macOS updates use a verified staged swap with rollback
 
 - **Decision:** Quill Cowork consumes its embedded GitHub release manifest directly. It checks on a

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -100,6 +100,11 @@ previous bundle. Background check failures stay quiet; user-initiated failures
 remain visible and retain direct retry and browser-download actions. Repeated
 menu checks cannot cancel an active download or the non-cancellable activation
 phase, and a background result never replaces update UI that is already visible.
+Failed or cancelled preparation removes its cache workspace immediately. After a
+two-minute active-helper grace period on launch, the app also removes only its
+exact hidden `.Quill Cowork.update-<lowercase UUID>.app` sibling directories left
+by an interrupted install; symlinks, lookalikes, and unexpected app identities are
+never treated as updater-owned staging.
 
 ## Tester Install Notes
 


### PR DESCRIPTION
## Summary
- clean failed or cancelled updater workspaces immediately
- recover only exact updater-owned orphan staging bundles after a guarded startup grace period
- preserve the effective inherited environment for synchronous and streaming shell subprocesses

## Verification
- `swift test --skip-build`: 5,361 tests, 5 skipped, 0 failures
- `scripts/packaged-macos-smoke.sh`
- focused updater and shell suites
- `git diff --check`
- deterministic code-quality grader: all changed Swift files A+