### PR TITLE
Keep long transcript projection linear

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceTranscriptMessageIndex.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptMessageIndex.swift
@@ -1,0 +1,57 @@
+import Foundation
+import QuillCodeCore
+
+/// Matches persisted message events to their source messages without rescanning the transcript.
+/// Duplicate message text is consumed in source order, matching the historical first-unconsumed
+/// behavior of the transcript builder.
+struct WorkspaceTranscriptMessageIndex {
+    private struct Cursor {
+        let messageIndices: [Int]
+        var nextOffset = 0
+    }
+
+    private var cursorsByContent: [String: Cursor]
+    private let messageIDs: [UUID]
+    private var consumedMessageIDs: Set<UUID> = []
+
+    init(messages: [ChatMessage]) {
+        var indicesByContent: [String: [Int]] = [:]
+        indicesByContent.reserveCapacity(messages.count)
+        for index in messages.indices {
+            indicesByContent[messages[index].content, default: []].append(index)
+        }
+        cursorsByContent = indicesByContent.mapValues { Cursor(messageIndices: $0) }
+        messageIDs = messages.map(\.id)
+    }
+
+    mutating func consumeFirstIndex(matching content: String) -> Int? {
+        guard var cursor = cursorsByContent[content] else { return nil }
+
+        while cursor.messageIndices.indices.contains(cursor.nextOffset) {
+            let messageIndex = cursor.messageIndices[cursor.nextOffset]
+            cursor.nextOffset += 1
+            guard messageIDs.indices.contains(messageIndex),
+                  consumedMessageIDs.insert(messageIDs[messageIndex]).inserted
+            else {
+                continue
+            }
+            store(cursor, for: content)
+            return messageIndex
+        }
+
+        cursorsByContent.removeValue(forKey: content)
+        return nil
+    }
+
+    func isConsumed(_ messageID: UUID) -> Bool {
+        consumedMessageIDs.contains(messageID)
+    }
+
+    private mutating func store(_ cursor: Cursor, for content: String) {
+        if cursor.nextOffset == cursor.messageIndices.count {
+            cursorsByContent.removeValue(forKey: content)
+        } else {
+            cursorsByContent[content] = cursor
+        }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
@@ -44,23 +44,23 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         }
 
         let revertByMessageID = allowsRevert ? Self.revertByMessageID(for: thread) : [:]
-        var consumedMessageIDs = Set<UUID>()
+        var messageIndex: WorkspaceTranscriptMessageIndex?
         var reducer = WorkspaceToolCardEventReducer<[TranscriptTimelineItemSurface]>.timeline()
-
-        func appendMessage(matching summary: String) {
-            guard let message = thread.messages.first(where: {
-                !consumedMessageIDs.contains($0.id) && $0.content == summary
-            }) else {
-                return
-            }
-            consumedMessageIDs.insert(message.id)
-            reducer.state.append(.message(MessageSurface(message: message, revert: revertByMessageID[message.id])))
-        }
 
         for event in thread.events {
             switch event.kind {
             case .message:
-                appendMessage(matching: event.summary)
+                if messageIndex == nil {
+                    messageIndex = WorkspaceTranscriptMessageIndex(messages: thread.messages)
+                }
+                guard let index = messageIndex?.consumeFirstIndex(matching: event.summary) else {
+                    continue
+                }
+                let message = thread.messages[index]
+                reducer.state.append(.message(MessageSurface(
+                    message: message,
+                    revert: revertByMessageID[message.id]
+                )))
             case .messageFeedback, .reviewComment, .notice:
                 continue
             case .toolQueued, .toolRunning, .toolProgress, .toolCompleted, .toolFailed,
@@ -69,8 +69,13 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
             }
         }
 
-        for message in thread.messages
-        where Self.isVisibleTranscriptRole(message.role) && !consumedMessageIDs.contains(message.id) {
+        for index in thread.messages.indices {
+            let message = thread.messages[index]
+            guard Self.isVisibleTranscriptRole(message.role),
+                  messageIndex?.isConsumed(message.id) != true
+            else {
+                continue
+            }
             reducer.state.append(.message(MessageSurface(message: message, revert: revertByMessageID[message.id])))
         }
         return reducer.state

--- a/Sources/QuillCodeApp/WorkspaceTurnRevertPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceTurnRevertPlanner.swift
@@ -101,26 +101,37 @@ public enum WorkspaceTurnRevertPlanner {
     }
 
     public static func plans(for thread: ChatThread) -> [TurnRevertPlan] {
-        let userMessages = thread.messages
-            .filter { $0.role == .user }
-            .sorted { $0.createdAt < $1.createdAt }
+        // Most conversational turns do not edit files. Avoid sorting every user message while the
+        // transcript is rendering when no queued tool could possibly produce a revert plan.
+        guard thread.events.contains(where: { $0.kind == .toolQueued }) else { return [] }
+
+        let userMessages = thread.messages.enumerated()
+            .filter { $0.element.role == .user }
+            .sorted(by: chronologicalOrder)
         guard !userMessages.isEmpty else { return [] }
 
-        func turnID(at date: Date) -> UUID? {
-            userMessages.last(where: { $0.createdAt <= date })?.id
-        }
+        let queuedEvents = thread.events.enumerated()
+            .filter { $0.element.kind == .toolQueued }
+            .sorted(by: chronologicalOrder)
 
         var patchesByTurn: [UUID: [String]] = [:]
         var hasNonApplyByTurn: [UUID: Bool] = [:]
         var turnOrder: [UUID] = []
+        var nextUserIndex = userMessages.startIndex
+        var currentTurnID: UUID?
 
         // Sort by createdAt so the within-turn patch order matches the turn-attribution
-        // chronology (the executor reverse-applies newest-first, so order is load-bearing).
-        let queuedEvents = thread.events
-            .filter { $0.kind == .toolQueued }
-            .sorted { $0.createdAt < $1.createdAt }
-        for event in queuedEvents {
-            guard let turn = turnID(at: event.createdAt),
+        // chronology (the executor reverse-applies newest-first, so order is load-bearing). Source
+        // order breaks equal-time ties deterministically for decoded histories with coarse clocks.
+        for queuedEvent in queuedEvents {
+            let event = queuedEvent.element
+            while nextUserIndex < userMessages.endIndex,
+                  userMessages[nextUserIndex].element.createdAt <= event.createdAt {
+                currentTurnID = userMessages[nextUserIndex].element.id
+                userMessages.formIndex(after: &nextUserIndex)
+            }
+
+            guard let turn = currentTurnID,
                   let call = decodeCall(event.payloadJSON)
             else { continue }
 
@@ -143,6 +154,16 @@ public enum WorkspaceTurnRevertPlanner {
                 hasNonApplyPatchEdits: hasNonApplyByTurn[turn] ?? false
             )
         }
+    }
+
+    private static func chronologicalOrder<Element>(
+        _ lhs: EnumeratedSequence<[Element]>.Element,
+        _ rhs: EnumeratedSequence<[Element]>.Element
+    ) -> Bool where Element: ChronologicallyRecorded {
+        if lhs.element.createdAt != rhs.element.createdAt {
+            return lhs.element.createdAt < rhs.element.createdAt
+        }
+        return lhs.offset < rhs.offset
     }
 
     /// The revert plan for one turn (its starting user message), or nil when that turn made
@@ -191,3 +212,10 @@ public enum WorkspaceTurnRevertPlanner {
         (try? ToolArguments(call.argumentsJSON))?.string("patch")
     }
 }
+
+private protocol ChronologicallyRecorded {
+    var createdAt: Date { get }
+}
+
+extension ChatMessage: ChronologicallyRecorded {}
+extension ThreadEvent: ChronologicallyRecorded {}

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -227,6 +227,77 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(timeline[3].message?.text, unmatchedAssistant.content)
     }
 
+    func testTimelineConsumesDuplicateMessageTextInPersistedSourceOrder() {
+        let first = ChatMessage(role: .user, content: "same text")
+        let second = ChatMessage(role: .assistant, content: "same text")
+        let third = ChatMessage(role: .user, content: "same text")
+        let thread = ChatThread(
+            messages: [first, second, third],
+            events: [
+                ThreadEvent(kind: .message, summary: "same text"),
+                ThreadEvent(kind: .message, summary: "same text")
+            ]
+        )
+
+        let messages = WorkspaceTranscriptSurfaceBuilder(thread: thread)
+            .timelineItems()
+            .compactMap(\.message)
+
+        XCTAssertEqual(messages.map(\.id), [first.id, second.id, third.id])
+    }
+
+    func testTranscriptMessageIndexConsumesEachCandidateOnce() {
+        let messages = [
+            ChatMessage(role: .user, content: "repeated"),
+            ChatMessage(role: .assistant, content: "other"),
+            ChatMessage(role: .assistant, content: "repeated")
+        ]
+        var index = WorkspaceTranscriptMessageIndex(messages: messages)
+
+        XCTAssertEqual(index.consumeFirstIndex(matching: "repeated"), 0)
+        XCTAssertEqual(index.consumeFirstIndex(matching: "missing"), nil)
+        XCTAssertEqual(index.consumeFirstIndex(matching: "repeated"), 2)
+        XCTAssertEqual(index.consumeFirstIndex(matching: "repeated"), nil)
+        XCTAssertTrue(index.isConsumed(messages[0].id))
+        XCTAssertFalse(index.isConsumed(messages[1].id))
+        XCTAssertTrue(index.isConsumed(messages[2].id))
+    }
+
+    func testTranscriptMessageIndexPreservesDuplicateIDSuppression() {
+        let duplicateID = UUID()
+        let messages = [
+            ChatMessage(id: duplicateID, role: .user, content: "first"),
+            ChatMessage(id: duplicateID, role: .assistant, content: "second")
+        ]
+        var index = WorkspaceTranscriptMessageIndex(messages: messages)
+
+        XCTAssertEqual(index.consumeFirstIndex(matching: "first"), 0)
+        XCTAssertEqual(index.consumeFirstIndex(matching: "second"), nil)
+        XCTAssertTrue(index.isConsumed(duplicateID))
+    }
+
+    func testProjectsTenThousandMessageEventsWithoutLosingOrder() {
+        let count = 10_000
+        let messages = (0..<count).map { index in
+            ChatMessage(
+                role: index.isMultiple(of: 2) ? .user : .assistant,
+                content: "message-\(index)"
+            )
+        }
+        let events = messages.map { message in
+            ThreadEvent(kind: .message, summary: message.content)
+        }
+
+        let timeline = WorkspaceTranscriptSurfaceBuilder(
+            thread: ChatThread(messages: messages, events: events),
+            allowsRevert: false
+        ).timelineItems()
+
+        XCTAssertEqual(timeline.count, count)
+        XCTAssertEqual(timeline.first?.message?.id, messages.first?.id)
+        XCTAssertEqual(timeline.last?.message?.id, messages.last?.id)
+    }
+
     func testApprovalRequestTurnsActiveToolCardIntoActionableReview() throws {
         let call = ToolCall(
             id: "shell-approval-1",

--- a/Tests/QuillCodeAppTests/WorkspaceTurnRevertPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTurnRevertPlannerTests.swift
@@ -37,6 +37,57 @@ final class WorkspaceTurnRevertPlannerTests: XCTestCase {
         XCTAssertEqual(plans[1].patches, ["PATCH-C"])
     }
 
+    func testChronologicalAttributionUsesSourceOrderForEqualTimestamps() {
+        let first = userMessage("first", at: 100)
+        let second = userMessage("second", at: 100)
+        let thread = ChatThread(title: "T", messages: [first, second], events: [
+            applyPatchEvent("PATCH-A", at: 100),
+            applyPatchEvent("PATCH-B", at: 100)
+        ])
+
+        let plans = WorkspaceTurnRevertPlanner.plans(for: thread)
+
+        XCTAssertEqual(plans.map(\.turnMessageID), [second.id])
+        XCTAssertEqual(plans.first?.patches, ["PATCH-A", "PATCH-B"])
+    }
+
+    func testChronologicalAttributionHandlesOutOfOrderPersistedCollections() {
+        let first = userMessage("first", at: 100)
+        let second = userMessage("second", at: 300)
+        let thread = ChatThread(title: "T", messages: [second, first], events: [
+            applyPatchEvent("PATCH-C", at: 350),
+            applyPatchEvent("PATCH-A", at: 150),
+            applyPatchEvent("PATCH-B", at: 160)
+        ])
+
+        let plans = WorkspaceTurnRevertPlanner.plans(for: thread)
+
+        XCTAssertEqual(plans.map(\.turnMessageID), [first.id, second.id])
+        XCTAssertEqual(plans.map(\.patches), [["PATCH-A", "PATCH-B"], ["PATCH-C"]])
+    }
+
+    func testAttributesThousandsOfEditingTurnsWithoutLosingBoundaries() {
+        let count = 2_500
+        let messages = (0..<count).map { index in
+            userMessage("turn-\(index)", at: TimeInterval(index * 2))
+        }
+        let events = (0..<count).map { index in
+            applyPatchEvent("PATCH-\(index)", at: TimeInterval(index * 2 + 1))
+        }
+
+        let plans = WorkspaceTurnRevertPlanner.plans(for: ChatThread(
+            title: "Large history",
+            messages: messages,
+            events: events
+        ))
+
+        XCTAssertEqual(plans.count, count)
+        XCTAssertEqual(plans.first?.turnMessageID, messages.first?.id)
+        XCTAssertEqual(plans.first?.patches, ["PATCH-0"])
+        XCTAssertEqual(plans.last?.turnMessageID, messages.last?.id)
+        XCTAssertEqual(plans.last?.patches, ["PATCH-\(count - 1)"])
+    }
+
     func testTurnWithoutApplyPatchYieldsNoPlan() {
         let u1 = userMessage("only shell", at: 100)
         let thread = ChatThread(title: "T", messages: [u1], events: [

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,23 @@
 # QuillCode Decisions
 
+## 2026-08-07: transcript projection stays linear in long-session history
+
+- **Decision:** Message events use an on-demand content index that consumes duplicate text in
+  persisted source order, and revert planning advances one chronological user-turn cursor across
+  queued tool events. Equal timestamps use persisted source order as the deterministic tie-breaker.
+- **Why:** The native transcript uses lazy view construction, but its model projection still matched
+  every message event by rescanning all messages and attributed every queued tool by searching all
+  prior user turns. Rebuilding a long daily-driving transcript could therefore take quadratic work
+  before SwiftUI displayed any row. Message-only chats also sorted every user turn for revert plans
+  even when no queued tool existed.
+- **Safety boundary:** The message index remains lazy until a message event needs it, unmatched visible
+  messages still append in source order, duplicate IDs retain their historical suppression behavior,
+  and out-of-order persisted collections are sorted without changing within-timestamp source order.
+- **Evidence:** `WorkspaceTranscriptSurfaceBuilderTests` cover duplicate text, duplicate IDs, and
+  unmatched messages, including a 10,000-message projection fixture.
+  `WorkspaceTurnRevertPlannerTests` cover chronological grouping, out-of-order persistence,
+  equal-time attribution, and a 2,500-editing-turn fixture.
+
 ## 2026-08-07: shell subprocesses receive the environment used to plan their launch
 
 - **Decision:** Synchronous and streaming shell execution resolve one effective environment and pass


### PR DESCRIPTION
## Summary
- replace quadratic event-to-message scans with an on-demand source-order index
- attribute queued tools to user turns with one chronological cursor
- skip revert planning work entirely for message-only chats and make equal-time ordering deterministic

## Performance evidence
- 10,000 message events projected in 24 ms on the development Mac
- 2,500 editing turns attributed in 43 ms on the development Mac

## Verification
- focused transcript/revert/parity: 33 tests, 0 failures
- full suite: 5,368 tests, 5 skipped, 0 failures
- `scripts/packaged-macos-smoke.sh`
- `git diff --check`
- all changed production Swift files: 100/A+