### PR TITLE
Bound ephemeral spend accounting memory

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceEphemeralSpendLedger.swift
+++ b/Sources/QuillCodeApp/WorkspaceEphemeralSpendLedger.swift
@@ -1,0 +1,136 @@
+import Foundation
+import QuillCodeCore
+
+/// Session-only, content-free accounting for destroyed confidential and side conversations.
+/// Usage is compacted by local day and model, bounding retained events to the active month plus
+/// any prior-month days in the active week while preserving exact spend and provider-call counts.
+struct WorkspaceEphemeralSpendLedger: Sendable, Hashable {
+    private var receiptThreadID = UUID()
+    private var retainedSince: Date?
+    private var buckets: [Bucket: Aggregate] = [:]
+    private var cachedReceiptThread: ChatThread?
+
+    var isEmpty: Bool { buckets.isEmpty }
+    var bucketCount: Int { buckets.count }
+
+    mutating func retain(
+        _ thread: ChatThread,
+        calendar: Calendar = .current,
+        now: Date = Date()
+    ) {
+        guard thread.runtimeContext.isEphemeral else { return }
+        let retentionStart = prepareRetentionWindow(calendar: calendar, now: now)
+        var didChange = false
+
+        for event in thread.events {
+            guard event.createdAt >= retentionStart,
+                  event.createdAt <= now,
+                  let record = ModelTokenUsageEvent.record(from: event)
+            else {
+                continue
+            }
+            let modelID = record.modelID ?? thread.model
+            let bucket = Bucket(
+                dayStart: calendar.startOfDay(for: event.createdAt),
+                modelID: TrustedRouterDefaults.canonicalModelID(modelID)
+            )
+            if var aggregate = buckets[bucket] {
+                aggregate.usage = Self.adding(aggregate.usage, record.usage)
+                aggregate.callCount = Self.saturatingAdd(aggregate.callCount, record.callCount)
+                aggregate.latestCreatedAt = max(aggregate.latestCreatedAt, event.createdAt)
+                buckets[bucket] = aggregate
+            } else {
+                buckets[bucket] = Aggregate(
+                    eventID: event.id,
+                    usage: record.usage,
+                    callCount: record.callCount,
+                    latestCreatedAt: event.createdAt
+                )
+            }
+            didChange = true
+        }
+        if didChange {
+            cachedReceiptThread = nil
+        }
+    }
+
+    mutating func periodThreads(
+        calendar: Calendar = .current,
+        now: Date = Date()
+    ) -> [ChatThread] {
+        _ = prepareRetentionWindow(calendar: calendar, now: now)
+        if let cachedReceiptThread {
+            return [cachedReceiptThread]
+        }
+        let events = buckets
+            .sorted { lhs, rhs in
+                if lhs.key.dayStart != rhs.key.dayStart {
+                    return lhs.key.dayStart < rhs.key.dayStart
+                }
+                return lhs.key.modelID < rhs.key.modelID
+            }
+            .map { bucket, aggregate -> ThreadEvent in
+                var event = ModelTokenUsageEvent.event(
+                    usage: aggregate.usage,
+                    modelID: bucket.modelID,
+                    callCount: aggregate.callCount
+                )
+                event.id = aggregate.eventID
+                event.createdAt = aggregate.latestCreatedAt
+                return event
+            }
+        guard let first = events.first, let last = events.last else { return [] }
+
+        let thread = ChatThread(
+            id: receiptThreadID,
+            title: "Ephemeral spend receipts",
+            events: events,
+            createdAt: first.createdAt,
+            updatedAt: last.createdAt
+        )
+        cachedReceiptThread = thread
+        return [thread]
+    }
+
+    @discardableResult
+    private mutating func prepareRetentionWindow(calendar: Calendar, now: Date) -> Date {
+        let today = calendar.startOfDay(for: now)
+        let monthStart = calendar.dateInterval(of: .month, for: now)?.start ?? today
+        let weekStart = calendar.dateInterval(of: .weekOfYear, for: now)?.start ?? today
+        let currentStart = min(monthStart, weekStart)
+        if let retainedSince, currentStart > retainedSince {
+            let oldCount = buckets.count
+            buckets = buckets.filter { $0.value.latestCreatedAt >= currentStart }
+            if buckets.count != oldCount {
+                cachedReceiptThread = nil
+            }
+        }
+        retainedSince = currentStart
+        return currentStart
+    }
+
+    private static func adding(_ lhs: ModelTokenUsage, _ rhs: ModelTokenUsage) -> ModelTokenUsage {
+        ModelTokenUsage(
+            promptTokens: saturatingAdd(lhs.promptTokens, rhs.promptTokens),
+            completionTokens: saturatingAdd(lhs.completionTokens, rhs.completionTokens),
+            totalTokens: saturatingAdd(lhs.totalTokens, rhs.totalTokens)
+        )
+    }
+
+    private static func saturatingAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Int.max : sum
+    }
+
+    private struct Bucket: Sendable, Hashable {
+        var dayStart: Date
+        var modelID: String
+    }
+
+    private struct Aggregate: Sendable, Hashable {
+        var eventID: UUID
+        var usage: ModelTokenUsage
+        var callCount: Int
+        var latestCreatedAt: Date
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -47,12 +47,10 @@ public final class QuillCodeWorkspaceModel {
     /// only — without this hook the provider/tool work would keep executing after the UI promised
     /// the session was destroyed. nil in tests / the CLI.
     public var onEphemeralThreadDiscarded: (@MainActor (UUID) -> Void)?
-    /// Content-free spend receipts distilled from destroyed confidential threads (usage events only —
-    /// token counts, model id, timestamps; no messages). The run-spend period ledger is built from
-    /// `root.threads`, so without these a destroyed confidential session's spend would vanish from the
-    /// daily/weekly/monthly accounting and repeated confidential use could exceed configured limits.
-    /// Session-only by design: it must never be persisted with the rest of the workspace.
-    var discardedEphemeralSpendThreads: [ChatThread] = []
+    /// Content-free spend accounting distilled from destroyed confidential threads. It aggregates
+    /// usage by day/model, prunes once receipts leave every active period, and is session-only so
+    /// private content never enters persistence while daily/weekly/monthly limits remain accurate.
+    var discardedEphemeralSpendLedger = WorkspaceEphemeralSpendLedger()
     /// Optional platform hook for browser tools that need a live native browser surface. Desktop installs
     /// this for visible WebKit sessions; nil keeps the pure app-core snapshot executor behavior.
     public var visibleBrowserToolOverride: AgentToolExecutionOverride?

--- a/Sources/QuillCodeApp/WorkspaceModelAgentSession.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelAgentSession.swift
@@ -63,14 +63,15 @@ extension QuillCodeWorkspaceModel {
         workspaceRoot: URL,
         runProject: ProjectRef?
     ) -> WorkspaceAgentSendSessionFactory {
-        WorkspaceAgentSendSessionFactory(
+        let ephemeralSpendThreads = discardedEphemeralSpendLedger.periodThreads()
+        return WorkspaceAgentSendSessionFactory(
             baseRunner: runner,
             selectedProject: runProject,
             config: root.config,
             modelCatalog: root.modelCatalog,
-            // Include receipts from destroyed confidential sessions so the period ledger keeps counting
-            // spend the threads themselves no longer exist to report.
-            spendPeriodThreads: root.threads + discardedEphemeralSpendThreads,
+            // Include compact receipts from destroyed ephemeral sessions so the period ledger keeps
+            // counting spend the threads themselves no longer exist to report.
+            spendPeriodThreads: root.threads + ephemeralSpendThreads,
             browser: browser,
             browserToolOverride: WorkspaceBrowserAgentToolOverride.make { [weak self] call, workspaceRoot in
                 guard let self else { return nil }

--- a/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
@@ -22,24 +22,7 @@ extension QuillCodeWorkspaceModel {
     /// destroyed (discard-on-exit, but also typed /clear and /delete which bypass the exit helper) —
     /// so cycling confidential sessions can never launder spend past the configured period limits.
     func retainEphemeralSpendReceipt(for thread: ChatThread) {
-        guard thread.runtimeContext.isEphemeral,
-              let receipt = Self.spendReceiptStub(from: thread)
-        else { return }
-        discardedEphemeralSpendThreads.append(receipt)
-    }
-
-    /// Distills a destroyed ephemeral thread's provider-usage events (token counts, model id,
-    /// timestamps — never message content) into a stub the spend-period ledger can keep counting.
-    private static func spendReceiptStub(from thread: ChatThread) -> ChatThread? {
-        let usageEvents = thread.events.filter { ModelTokenUsageEvent.usage(from: $0) != nil }
-        guard !usageEvents.isEmpty else { return nil }
-        return ChatThread(
-            title: "Confidential spend receipt",
-            model: thread.model,
-            events: usageEvents,
-            createdAt: thread.createdAt,
-            updatedAt: thread.updatedAt
-        )
+        discardedEphemeralSpendLedger.retain(thread)
     }
 
     @discardableResult

--- a/Sources/QuillCodeApp/WorkspaceRunReceiptSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceRunReceiptSurfaceBuilder.swift
@@ -39,6 +39,7 @@ struct WorkspaceRunReceiptSurfaceBuilder: Sendable, Hashable {
     private static func receiptDetail(_ receipt: RunSpendReceipt) -> String {
         [
             receipt.modelID,
+            receipt.callCount > 1 ? "\(receipt.callCount) model calls" : nil,
             WorkspaceTokenUsageLabelBuilder.label(for: receipt.usage),
             receipt.price?.detailLabel
         ]

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -142,6 +142,7 @@ public extension QuillCodeWorkspaceModel {
             agentRuns: agentRuns,
             attentionCursorID: attentionCursorID
         ).surface()
+        let spendPeriodThreads = root.threads + discardedEphemeralSpendLedger.periodThreads()
         let topBar = WorkspaceTopBarSurfaceBuilder(
             topBarState: topBarState,
             thread: thread,
@@ -153,6 +154,7 @@ public extension QuillCodeWorkspaceModel {
             defaultModelID: root.config.defaultModel,
             favoriteModelIDs: root.config.favoriteModels,
             recentThreads: root.threads,
+            spendPeriodThreads: spendPeriodThreads,
             runtimeIssue: runtimeIssue,
             trustedRouterCredits: root.trustedRouterCredits,
             hasTrustedRouterCredential: root.trustedRouterAPIKeyConfigured,

--- a/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
@@ -12,6 +12,7 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
     var defaultModelID: String
     var favoriteModelIDs: [String]
     var recentThreads: [ChatThread]
+    var spendPeriodThreads: [ChatThread]? = nil
     var runtimeIssue: RuntimeIssueSurface?
     var trustedRouterCredits: TrustedRouterCreditsState = .unavailable
     var hasTrustedRouterCredential: Bool = false
@@ -188,7 +189,7 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
     private func quotaLimitSurfaces() -> [TokenQuotaLimitSurface] {
         WorkspaceQuotaLimitSurfaceBuilder(runtimeIssue: runtimeIssue).quotaLimits()
             + WorkspaceSpendHistoryQuotaBuilder(
-                threads: recentThreads,
+                threads: spendPeriodThreads ?? recentThreads,
                 modelCatalog: modelCatalog,
                 periodLimits: runSpendPeriodLimits
             ).quotaLimits()

--- a/Sources/QuillCodeCore/ModelTokenUsage.swift
+++ b/Sources/QuillCodeCore/ModelTokenUsage.swift
@@ -44,23 +44,38 @@ public struct ModelTokenUsage: Codable, Sendable, Hashable {
 public struct ModelTokenUsageRecord: Codable, Sendable, Hashable {
     public var usage: ModelTokenUsage
     public var modelID: String?
+    /// Number of provider calls represented by this record. Ordinary usage events represent one
+    /// call; compact period ledgers can merge equivalent receipts without falsifying call counts.
+    public var callCount: Int
 
-    public init(usage: ModelTokenUsage, modelID: String? = nil) {
+    public init(usage: ModelTokenUsage, modelID: String? = nil, callCount: Int = 1) {
         self.usage = usage
         self.modelID = Self.normalizedModelID(modelID)
+        self.callCount = max(1, callCount)
     }
 
     private enum CodingKeys: String, CodingKey {
         case usage
         case modelID
+        case callCount
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(
             usage: try container.decode(ModelTokenUsage.self, forKey: .usage),
-            modelID: try container.decodeIfPresent(String.self, forKey: .modelID)
+            modelID: try container.decodeIfPresent(String.self, forKey: .modelID),
+            callCount: try container.decodeIfPresent(Int.self, forKey: .callCount) ?? 1
         )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(usage, forKey: .usage)
+        try container.encodeIfPresent(modelID, forKey: .modelID)
+        if callCount > 1 {
+            try container.encode(callCount, forKey: .callCount)
+        }
     }
 
     private static func normalizedModelID(_ value: String?) -> String? {
@@ -72,11 +87,19 @@ public struct ModelTokenUsageRecord: Codable, Sendable, Hashable {
 public enum ModelTokenUsageEvent {
     public static let summary = "Model token usage"
 
-    public static func event(usage: ModelTokenUsage, modelID: String? = nil) -> ThreadEvent {
+    public static func event(
+        usage: ModelTokenUsage,
+        modelID: String? = nil,
+        callCount: Int = 1
+    ) -> ThreadEvent {
         ThreadEvent(
             kind: .notice,
             summary: summary,
-            payloadJSON: try? JSONHelpers.encodePretty(ModelTokenUsageRecord(usage: usage, modelID: modelID))
+            payloadJSON: try? JSONHelpers.encodePretty(ModelTokenUsageRecord(
+                usage: usage,
+                modelID: modelID,
+                callCount: callCount
+            ))
         )
     }
 

--- a/Sources/QuillCodeCore/RunSpendLedger.swift
+++ b/Sources/QuillCodeCore/RunSpendLedger.swift
@@ -19,6 +19,7 @@ public struct RunSpendLedger: Sendable, Hashable {
                 usage: record.usage,
                 modelID: modelID,
                 modelName: model?.displayName,
+                callCount: record.callCount,
                 price: RunSpendReceiptPrice.price(usage: record.usage, model: model)
             )
         }
@@ -34,11 +35,15 @@ public struct RunSpendLedger: Sendable, Hashable {
     }
 
     public var pricedCallCount: Int {
-        receipts.count - unpricedCallCount
+        receipts.reduce(0) { count, receipt in
+            Self.saturatingAdd(count, receipt.price == nil ? 0 : receipt.callCount)
+        }
     }
 
     public var unpricedCallCount: Int {
-        receipts.filter { $0.price == nil }.count
+        receipts.reduce(0) { count, receipt in
+            Self.saturatingAdd(count, receipt.price == nil ? receipt.callCount : 0)
+        }
     }
 
     public var blocksNextRun: Bool {
@@ -65,9 +70,10 @@ public struct RunSpendLedger: Sendable, Hashable {
     }
 
     public var summaryDetail: String {
-        let totalLabel = unpricedCallCount == receipts.count ? "Unpriced" : Self.costLabel(totalUSD)
+        let totalLabel = pricedCallCount == 0 ? "Unpriced" : Self.costLabel(totalUSD)
+        let totalCallCount = Self.saturatingAdd(pricedCallCount, unpricedCallCount)
         var parts = [
-            "\(totalLabel) across \(Self.count(receipts.count, singular: "model call"))"
+            "\(totalLabel) across \(Self.count(totalCallCount, singular: "model call"))"
         ]
         if unpricedCallCount > 0 {
             parts.append("\(unpricedCallCount) unpriced")
@@ -97,6 +103,11 @@ public struct RunSpendLedger: Sendable, Hashable {
         "\(value) \(singular)\(value == 1 ? "" : "s")"
     }
 
+    private static func saturatingAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Int.max : sum
+    }
+
     /// Tolerance for the "spend has reached the fuse" float comparison. Shared with
     /// `RunSpendFusePolicy` so the ledger's `blocksNextRun` and the policy's bucket math never drift.
     static let spendComparisonEpsilon = 0.000_000_001
@@ -107,6 +118,7 @@ public struct RunSpendReceipt: Sendable, Hashable {
     public var usage: ModelTokenUsage
     public var modelID: String
     public var modelName: String?
+    public var callCount: Int
     public var price: RunSpendReceiptPrice?
 
     public init(
@@ -114,12 +126,14 @@ public struct RunSpendReceipt: Sendable, Hashable {
         usage: ModelTokenUsage,
         modelID: String,
         modelName: String?,
+        callCount: Int = 1,
         price: RunSpendReceiptPrice?
     ) {
         self.id = id
         self.usage = usage
         self.modelID = modelID
         self.modelName = modelName
+        self.callCount = max(1, callCount)
         self.price = price
     }
 }

--- a/Sources/QuillCodeCore/RunSpendPeriodLedger.swift
+++ b/Sources/QuillCodeCore/RunSpendPeriodLedger.swift
@@ -28,8 +28,8 @@ public struct RunSpendPeriodLedger: Sendable, Hashable {
             ).summary
             return RunSpendFuseSummary(
                 totalUSD: total.totalUSD + summary.totalUSD,
-                pricedCallCount: total.pricedCallCount + summary.pricedCallCount,
-                unpricedCallCount: total.unpricedCallCount + summary.unpricedCallCount
+                pricedCallCount: Self.saturatingAdd(total.pricedCallCount, summary.pricedCallCount),
+                unpricedCallCount: Self.saturatingAdd(total.unpricedCallCount, summary.unpricedCallCount)
             )
         }
     }
@@ -62,5 +62,10 @@ public struct RunSpendPeriodLedger: Sendable, Hashable {
             composerAttachments: thread.composerAttachments,
             followUpQueue: thread.followUpQueue
         )
+    }
+
+    private static func saturatingAdd(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Int.max : sum
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceConfidentialModeTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfidentialModeTests.swift
@@ -449,7 +449,7 @@ final class WorkspaceConfidentialModeTests: XCTestCase {
 
         _ = model.newChat()
 
-        let receipt = try XCTUnwrap(model.discardedEphemeralSpendThreads.first)
+        let receipt = try XCTUnwrap(model.discardedEphemeralSpendLedger.periodThreads().first)
         XCTAssertTrue(receipt.messages.isEmpty, "receipts carry usage only — never conversation content")
         XCTAssertEqual(receipt.events.count, 1)
         XCTAssertEqual(
@@ -465,7 +465,7 @@ final class WorkspaceConfidentialModeTests: XCTestCase {
 
         _ = model.newChat()
 
-        XCTAssertTrue(model.discardedEphemeralSpendThreads.isEmpty)
+        XCTAssertTrue(model.discardedEphemeralSpendLedger.isEmpty)
     }
 
     func testArchivingAConfidentialThreadIsRefused() throws {
@@ -714,7 +714,10 @@ final class WorkspaceConfidentialModeTests: XCTestCase {
                 _ = model.deleteThread(confidentialID)
             }
 
-            let receipt = try XCTUnwrap(model.discardedEphemeralSpendThreads.first, "\(destroy) must retain spend")
+            let receipt = try XCTUnwrap(
+                model.discardedEphemeralSpendLedger.periodThreads().first,
+                "\(destroy) must retain spend"
+            )
             XCTAssertTrue(receipt.messages.isEmpty)
             XCTAssertEqual(
                 ModelTokenUsageEvent.usage(from: try XCTUnwrap(receipt.events.first))?.contextTokens,
@@ -854,7 +857,7 @@ final class WorkspaceConfidentialModeTests: XCTestCase {
         XCTAssertTrue(model.returnFromSideConversation())
 
         let receipt = try XCTUnwrap(
-            model.discardedEphemeralSpendThreads.first,
+            model.discardedEphemeralSpendLedger.periodThreads().first,
             "a destroyed side conversation's spend must still count against period limits"
         )
         XCTAssertTrue(receipt.messages.isEmpty, "receipts carry usage only — never conversation content")

--- a/Tests/QuillCodeAppTests/WorkspaceEphemeralSpendLedgerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceEphemeralSpendLedgerTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceEphemeralSpendLedgerTests: XCTestCase {
+    func testTenThousandDestroyedSessionsCompactToOneDayModelReceipt() throws {
+        let calendar = utcCalendar()
+        let now = date(2026, 8, 7, hour: 12, calendar: calendar)
+        var ledger = WorkspaceEphemeralSpendLedger()
+
+        for _ in 0..<10_000 {
+            let thread = ephemeralThread(
+                modelID: "acme/agent",
+                usage: ModelTokenUsage(promptTokens: 1, completionTokens: 2),
+                createdAt: now,
+                secret: "must never survive"
+            )
+            ledger.retain(thread, calendar: calendar, now: now)
+        }
+
+        let receiptThread = try XCTUnwrap(ledger.periodThreads(calendar: calendar, now: now).first)
+        let record = try XCTUnwrap(receiptThread.events.first.flatMap(ModelTokenUsageEvent.record(from:)))
+        XCTAssertEqual(ledger.bucketCount, 1)
+        XCTAssertEqual(receiptThread.events.count, 1)
+        XCTAssertTrue(receiptThread.messages.isEmpty)
+        XCTAssertEqual(record.callCount, 10_000)
+        XCTAssertEqual(record.usage.promptTokens, 10_000)
+        XCTAssertEqual(record.usage.completionTokens, 20_000)
+        XCTAssertEqual(record.usage.totalTokens, 30_000)
+    }
+
+    func testCompactionPreservesDailyModelBucketsSpendAndCallCounts() throws {
+        let calendar = utcCalendar()
+        let yesterday = date(2026, 8, 6, hour: 18, calendar: calendar)
+        let now = date(2026, 8, 7, hour: 12, calendar: calendar)
+        var ledger = WorkspaceEphemeralSpendLedger()
+
+        ledger.retain(ephemeralThread(
+            modelID: "acme/agent",
+            usage: ModelTokenUsage(promptTokens: 1_000, completionTokens: 500),
+            createdAt: yesterday
+        ), calendar: calendar, now: now)
+        for modelID in ["acme/agent", "acme/agent", "acme/other"] {
+            ledger.retain(ephemeralThread(
+                modelID: modelID,
+                usage: ModelTokenUsage(promptTokens: 1_000, completionTokens: 500),
+                createdAt: now
+            ), calendar: calendar, now: now)
+        }
+
+        let threads = ledger.periodThreads(calendar: calendar, now: now)
+        let summary = RunSpendPeriodLedger(
+            threads: threads,
+            modelCatalog: pricedModels(),
+            now: now
+        ).summary(since: calendar.startOfDay(for: now))
+
+        XCTAssertEqual(ledger.bucketCount, 3)
+        XCTAssertEqual(threads.first?.events.count, 3)
+        XCTAssertEqual(summary.pricedCallCount, 3)
+        XCTAssertEqual(summary.unpricedCallCount, 0)
+        XCTAssertEqual(summary.totalUSD, 0.015, accuracy: 0.000_001)
+    }
+
+    func testMonthRolloverKeepsTheOverlappingWeekThenReleasesIt() throws {
+        var calendar = utcCalendar()
+        calendar.firstWeekday = 2
+        let january = date(2026, 1, 31, hour: 23, calendar: calendar)
+        let february = date(2026, 2, 1, hour: 1, calendar: calendar)
+        let nextWeek = date(2026, 2, 2, hour: 1, calendar: calendar)
+        var ledger = WorkspaceEphemeralSpendLedger()
+        ledger.retain(ephemeralThread(
+            modelID: "acme/agent",
+            usage: ModelTokenUsage(promptTokens: 1_000),
+            createdAt: january
+        ), calendar: calendar, now: january)
+
+        XCTAssertEqual(ledger.bucketCount, 1)
+        let overlappingWeek = ledger.periodThreads(calendar: calendar, now: february)
+        let weeklySummary = RunSpendPeriodLedger(
+            threads: overlappingWeek,
+            modelCatalog: pricedModels(),
+            now: february
+        ).summary(since: try XCTUnwrap(calendar.dateInterval(of: .weekOfYear, for: february)?.start))
+        XCTAssertEqual(weeklySummary.pricedCallCount, 1)
+        XCTAssertEqual(ledger.bucketCount, 1)
+
+        XCTAssertTrue(ledger.periodThreads(calendar: calendar, now: nextWeek).isEmpty)
+        XCTAssertEqual(ledger.bucketCount, 0)
+    }
+
+    func testIgnoresDurableThreadsAndNonUsageEvents() {
+        let calendar = utcCalendar()
+        let now = date(2026, 8, 7, hour: 12, calendar: calendar)
+        var durable = ChatThread(
+            title: "Durable",
+            messages: [.init(role: .user, content: "ordinary transcript")],
+            events: [ModelTokenUsageEvent.event(usage: ModelTokenUsage(promptTokens: 500))]
+        )
+        durable.events[0].createdAt = now
+        var ephemeral = ChatThread(
+            title: "Side",
+            events: [ThreadEvent(kind: .notice, createdAt: now, summary: "No usage")],
+            runtimeContext: .sideConversation(parentThreadID: durable.id)
+        )
+        ephemeral.messages = [.init(role: .user, content: "private transcript")]
+        var ledger = WorkspaceEphemeralSpendLedger()
+
+        ledger.retain(durable, calendar: calendar, now: now)
+        ledger.retain(ephemeral, calendar: calendar, now: now)
+
+        XCTAssertTrue(ledger.isEmpty)
+        XCTAssertTrue(ledger.periodThreads(calendar: calendar, now: now).isEmpty)
+    }
+
+    private func ephemeralThread(
+        modelID: String,
+        usage: ModelTokenUsage,
+        createdAt: Date,
+        secret: String = ""
+    ) -> ChatThread {
+        var event = ModelTokenUsageEvent.event(usage: usage, modelID: modelID)
+        event.createdAt = createdAt
+        return ChatThread(
+            title: "Side",
+            model: modelID,
+            messages: secret.isEmpty ? [] : [.init(role: .user, content: secret)],
+            events: [event],
+            runtimeContext: .sideConversation(parentThreadID: UUID())
+        )
+    }
+
+    private func pricedModels() -> [ModelInfo] {
+        ["acme/agent", "acme/other"].map { modelID in
+            ModelInfo(
+                id: modelID,
+                provider: "acme",
+                displayName: modelID,
+                category: "Custom",
+                capabilities: ModelCapabilities(
+                    inputPricePerMillionTokens: 2,
+                    outputPricePerMillionTokens: 6
+                )
+            )
+        }
+    }
+
+    private func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        hour: Int,
+        calendar: Calendar
+    ) -> Date {
+        calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour
+        ))!
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageIntegrationTests.swift
@@ -313,6 +313,31 @@ final class WorkspaceTokenUsageIntegrationTests: XCTestCase {
         )
     }
 
+    func testTopBarSpendHistoryIncludesDestroyedEphemeralSessions() throws {
+        let current = ChatThread(title: "Durable", model: "acme/agent")
+        var ephemeral = ChatThread(
+            title: "Side",
+            model: "acme/agent",
+            messages: [.init(role: .user, content: "private")],
+            events: [usageEvent(prompt: 1_000, completion: 500, modelID: "acme/agent")],
+            runtimeContext: .sideConversation(parentThreadID: current.id)
+        )
+        ephemeral.updatedAt = Date()
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                threads: [current],
+                selectedThreadID: current.id,
+                modelCatalog: pricedModelCatalog()
+            )
+        )
+        model.discardedEphemeralSpendLedger.retain(ephemeral)
+
+        let quotaRows = try XCTUnwrap(model.surface().topBar.tokenBudget?.visibleQuotaLimits)
+
+        XCTAssertEqual(quotaRows.map(\.periodLabel), ["Today", "Week", "Month"])
+        XCTAssertEqual(quotaRows.map(\.usageLabel), ["$0.0050", "$0.0050", "$0.0050"])
+    }
+
     func testActivityRunReceiptsKeepLegacyUnpricedUsageAuditable() throws {
         let legacyUsage = ModelTokenUsage(promptTokens: 100, completionTokens: 25)
         let legacyEvent = ThreadEvent(

--- a/Tests/QuillCodeCoreTests/ModelTokenUsageTests.swift
+++ b/Tests/QuillCodeCoreTests/ModelTokenUsageTests.swift
@@ -38,12 +38,13 @@ final class ModelTokenUsageTests: XCTestCase {
 
     func testUsageEventRoundTripsThroughThreadEventPayload() throws {
         let usage = ModelTokenUsage(promptTokens: 10, completionTokens: 2, totalTokens: 12)
-        let event = ModelTokenUsageEvent.event(usage: usage, modelID: " /prometheus ")
+        let event = ModelTokenUsageEvent.event(usage: usage, modelID: " /prometheus ", callCount: 7)
 
         XCTAssertEqual(event.kind, .notice)
         XCTAssertEqual(event.summary, ModelTokenUsageEvent.summary)
         XCTAssertEqual(ModelTokenUsageEvent.usage(from: event), usage)
         XCTAssertEqual(ModelTokenUsageEvent.record(from: event)?.modelID, TrustedRouterDefaults.prometheusModel)
+        XCTAssertEqual(ModelTokenUsageEvent.record(from: event)?.callCount, 7)
     }
 
     func testUsageEventReadsLegacyUsagePayload() throws {
@@ -57,5 +58,18 @@ final class ModelTokenUsageTests: XCTestCase {
         XCTAssertEqual(ModelTokenUsageEvent.usage(from: event), usage)
         XCTAssertEqual(ModelTokenUsageEvent.record(from: event)?.usage, usage)
         XCTAssertNil(ModelTokenUsageEvent.record(from: event)?.modelID)
+        XCTAssertEqual(ModelTokenUsageEvent.record(from: event)?.callCount, 1)
+    }
+
+    func testStructuredRecordDefaultsLegacyCallCountAndOmitsOrdinaryCountWhenEncoding() throws {
+        let legacyData = #"{"usage":{"promptTokens":10,"completionTokens":2,"totalTokens":12},"modelID":"acme/agent"}"#
+            .data(using: .utf8)!
+
+        let record = try JSONDecoder().decode(ModelTokenUsageRecord.self, from: legacyData)
+        let encoded = try JSONEncoder().encode(record)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        XCTAssertEqual(record.callCount, 1)
+        XCTAssertNil(object["callCount"], "ordinary usage receipts should not grow on disk")
     }
 }

--- a/Tests/QuillCodeCoreTests/RunSpendFusePolicyTests.swift
+++ b/Tests/QuillCodeCoreTests/RunSpendFusePolicyTests.swift
@@ -2,6 +2,53 @@ import XCTest
 @testable import QuillCodeCore
 
 final class RunSpendFusePolicyTests: XCTestCase {
+    func testAggregatedUsagePreservesProviderCallCounts() {
+        let thread = ChatThread(
+            title: "Compacted cost",
+            model: "acme/agent",
+            events: [
+                ModelTokenUsageEvent.event(
+                    usage: ModelTokenUsage(promptTokens: 10_000, completionTokens: 5_000),
+                    modelID: "acme/agent",
+                    callCount: 37
+                ),
+                ModelTokenUsageEvent.event(
+                    usage: ModelTokenUsage(promptTokens: 500, completionTokens: 100),
+                    modelID: "unknown/agent",
+                    callCount: 4
+                )
+            ]
+        )
+
+        let ledger = RunSpendLedger(thread: thread, modelCatalog: [pricedModel()], fuseUSD: nil)
+
+        XCTAssertEqual(ledger.receipts.count, 2)
+        XCTAssertEqual(ledger.pricedCallCount, 37)
+        XCTAssertEqual(ledger.unpricedCallCount, 4)
+        XCTAssertEqual(ledger.summaryDetail, "$0.05 across 41 model calls · 4 unpriced · fuse off")
+    }
+
+    func testAggregatedCallCountsSaturateInsteadOfOverflowing() {
+        let events = (0..<2).map { _ in
+            ModelTokenUsageEvent.event(
+                usage: ModelTokenUsage(promptTokens: 1),
+                modelID: "acme/agent",
+                callCount: Int.max
+            )
+        } + [ModelTokenUsageEvent.event(
+            usage: ModelTokenUsage(promptTokens: 1),
+            modelID: "unknown/agent",
+            callCount: Int.max
+        )]
+        let thread = ChatThread(title: "Malformed aggregate", model: "acme/agent", events: events)
+
+        let ledger = RunSpendLedger(thread: thread, modelCatalog: [pricedModel()], fuseUSD: nil)
+
+        XCTAssertEqual(ledger.pricedCallCount, Int.max)
+        XCTAssertEqual(ledger.unpricedCallCount, Int.max)
+        XCTAssertTrue(ledger.summaryDetail.contains("across \(Int.max) model calls"))
+    }
+
     func testRequestsApprovalWhenPricedThreadSpendCrossesFuse() throws {
         let thread = ChatThread(
             title: "Cost",


### PR DESCRIPTION
## Summary
- replace app-lifetime synthetic confidential/side-chat thread accumulation with a content-free day/model spend ledger
- retain only receipts needed by active daily, weekly, or monthly periods and cache the materialized period thread
- preserve exact priced/unpriced call counts with backward-compatible compact usage records
- include destroyed ephemeral spend in the visible top-bar quota history

## Verification
- focused accounting/confidential/UI suites: 81 tests, 0 failures before final assertion strengthening
- stress fixture: 10,000 destroyed sessions compact to one event in about 0.15s
- full Swift suite: 5,376 tests, 5 skipped, 0 failures in 223s
- packaged macOS direct, Launch Services, and live-window smoke passed
- production source modules remain A+ in the code-quality grader