### PR TITLE
Harden visible browser navigation lifecycle

### DIFF
--- a/Sources/quill-code-desktop/DesktopBrowserNavigationWaitRegistry.swift
+++ b/Sources/quill-code-desktop/DesktopBrowserNavigationWaitRegistry.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Owns the single in-flight visible-browser navigation for each tab.
+///
+/// WebKit can deliver an old navigation callback after a newer load has started. Correlating the
+/// callback with the navigation object prevents that stale event from releasing the newer waiter.
+/// Every exit path removes the continuation and cancels its timeout task before resuming it.
+@MainActor
+final class DesktopBrowserNavigationWaitRegistry {
+    private struct Waiter {
+        let requestID: UUID
+        let continuation: CheckedContinuation<Void, any Error>
+        let timeoutTask: Task<Void, Never>
+        var navigationID: ObjectIdentifier?
+    }
+
+    private let timeoutNanoseconds: UInt64
+    private var waitersByTabID: [UUID: Waiter] = [:]
+
+    init(timeoutNanoseconds: UInt64) {
+        self.timeoutNanoseconds = timeoutNanoseconds
+    }
+
+    var activeCount: Int {
+        waitersByTabID.count
+    }
+
+    func wait(for tabID: UUID, start: () -> AnyObject?) async throws {
+        let requestID = UUID()
+
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+
+                finish(
+                    tabID: tabID,
+                    error: DesktopBrowserSessionScriptError.navigationSuperseded
+                )
+
+                let timeoutTask = Task { @MainActor [weak self] in
+                    do {
+                        try await Task.sleep(nanoseconds: self?.timeoutNanoseconds ?? 0)
+                    } catch {
+                        return
+                    }
+                    self?.finish(tabID: tabID, requestID: requestID, error: nil)
+                }
+                waitersByTabID[tabID] = Waiter(
+                    requestID: requestID,
+                    continuation: continuation,
+                    timeoutTask: timeoutTask,
+                    navigationID: nil
+                )
+
+                let navigationID = start().map(ObjectIdentifier.init)
+                guard var waiter = waitersByTabID[tabID], waiter.requestID == requestID else {
+                    return
+                }
+                waiter.navigationID = navigationID
+                waitersByTabID[tabID] = waiter
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.finish(
+                    tabID: tabID,
+                    requestID: requestID,
+                    error: CancellationError()
+                )
+            }
+        }
+    }
+
+    /// Resolves only the waiter associated with `navigation`. A callback from an older WebKit load
+    /// is ignored when a newer request owns the tab.
+    @discardableResult
+    func resolve(for tabID: UUID, navigation: AnyObject?, error: (any Error)?) -> Bool {
+        guard let waiter = waitersByTabID[tabID] else { return false }
+        if let expectedNavigationID = waiter.navigationID {
+            guard let navigationID = navigation.map(ObjectIdentifier.init),
+                  expectedNavigationID == navigationID
+            else {
+                return false
+            }
+        }
+        return finish(tabID: tabID, requestID: waiter.requestID, error: error)
+    }
+
+    @discardableResult
+    func finish(tabID: UUID, error: (any Error)?) -> Bool {
+        guard let waiter = waitersByTabID[tabID] else { return false }
+        return finish(tabID: tabID, requestID: waiter.requestID, error: error)
+    }
+
+    func finishAll(error: any Error) {
+        for tabID in Array(waitersByTabID.keys) {
+            finish(tabID: tabID, error: error)
+        }
+    }
+
+    @discardableResult
+    private func finish(tabID: UUID, requestID: UUID, error: (any Error)?) -> Bool {
+        guard let waiter = waitersByTabID[tabID], waiter.requestID == requestID else {
+            return false
+        }
+
+        waitersByTabID.removeValue(forKey: tabID)
+        waiter.timeoutTask.cancel()
+        if let error {
+            waiter.continuation.resume(throwing: error)
+        } else {
+            waiter.continuation.resume()
+        }
+        return true
+    }
+}

--- a/Sources/quill-code-desktop/DesktopBrowserSessionContracts.swift
+++ b/Sources/quill-code-desktop/DesktopBrowserSessionContracts.swift
@@ -31,6 +31,8 @@ enum DesktopBrowserSessionScriptError: Error, Sendable, Equatable {
     case noOpenSession
     case noSelectedTab
     case emptySource
+    /// A newer open replaced an in-flight navigation for the same visible tab.
+    case navigationSuperseded
     /// The page failed to load (DNS, connection refused, TLS, blocked). Carries the platform
     /// message so the model is told what actually went wrong instead of getting a blank DOM.
     case navigationFailed(String)

--- a/Sources/quill-code-desktop/DesktopBrowserSessionWindowController.swift
+++ b/Sources/quill-code-desktop/DesktopBrowserSessionWindowController.swift
@@ -15,6 +15,7 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
         var snapshot: BrowserSessionTabSnapshot
         var item: NSTabViewItem
         var webView: WKWebView
+        var activeNavigation: WKNavigation?
     }
 
     var onClose: (() -> Void)?
@@ -22,12 +23,13 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
 
     private let tabView: NSTabView
     private var tabs: [UUID: SessionTab] = [:]
-    /// Continuations parked by `navigateSelectedTab`, keyed by tab, resumed exactly once by
-    /// `didFinish` / a load failure / the navigation timeout — whichever lands first.
-    private var navigationWaiters: [UUID: [CheckedContinuation<Void, Error>]] = [:]
+    private let navigationWaiters: DesktopBrowserNavigationWaitRegistry
 
     init(snapshot: BrowserSessionSyncSnapshot) {
         self.tabView = NSTabView()
+        self.navigationWaiters = DesktopBrowserNavigationWaitRegistry(
+            timeoutNanoseconds: UInt64(Self.navigationTimeoutSeconds * 1_000_000_000)
+        )
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1120, height: 760),
@@ -52,8 +54,15 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
     }
 
     func windowWillClose(_ notification: Notification) {
-        tabs.values.forEach { $0.webView.navigationDelegate = nil }
+        navigationWaiters.finishAll(error: DesktopBrowserSessionScriptError.noOpenSession)
+        tabs.values.forEach {
+            $0.webView.stopLoading()
+            $0.webView.navigationDelegate = nil
+        }
+        tabs.removeAll(keepingCapacity: false)
+        onSessionUpdate = nil
         onClose?()
+        onClose = nil
     }
 
     func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
@@ -61,10 +70,27 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
         emitSessionUpdate()
     }
 
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation?) {
+        guard let id = tabID(for: webView), let navigation else { return }
+        if let activeNavigation = tabs[id]?.activeNavigation,
+           activeNavigation !== navigation {
+            navigationWaiters.finish(
+                tabID: id,
+                error: DesktopBrowserSessionScriptError.navigationSuperseded
+            )
+        }
+        storeActiveNavigation(navigation, for: id, webView: webView)
+    }
+
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: Error) {
-        guard let id = tabID(for: webView) else { return }
-        resumeNavigationWaiters(
+        guard let id = tabID(for: webView),
+              finishActiveNavigation(for: id, navigation: navigation)
+        else {
+            return
+        }
+        navigationWaiters.resolve(
             for: id,
+            navigation: navigation,
             error: DesktopBrowserSessionScriptError.navigationFailed(error.localizedDescription)
         )
     }
@@ -74,22 +100,26 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
         didFailProvisionalNavigation navigation: WKNavigation?,
         withError error: Error
     ) {
-        guard let id = tabID(for: webView) else { return }
-        resumeNavigationWaiters(
+        guard let id = tabID(for: webView),
+              finishActiveNavigation(for: id, navigation: navigation)
+        else {
+            return
+        }
+        navigationWaiters.resolve(
             for: id,
+            navigation: navigation,
             error: DesktopBrowserSessionScriptError.navigationFailed(error.localizedDescription)
         )
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
-        if let id = tabID(for: webView) {
-            resumeNavigationWaiters(for: id, error: nil)
-        }
         guard let id = tabID(for: webView),
+              finishActiveNavigation(for: id, navigation: navigation),
               var tab = tabs[id]
         else {
             return
         }
+        navigationWaiters.resolve(for: id, navigation: navigation, error: nil)
         let title = nonEmpty(webView.title) ?? tab.snapshot.title
         if let url = webView.url {
             tab.snapshot = BrowserSessionTabSnapshot(
@@ -129,7 +159,7 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
         else {
             return
         }
-        tab.webView.reload()
+        beginUserNavigation(tab.webView.reload(), for: selectedID, webView: tab.webView)
     }
 
     func goBackSelectedTab(fallback snapshot: BrowserSessionSyncSnapshot) {
@@ -142,7 +172,7 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
             sync(snapshot)
             return
         }
-        tab.webView.goBack()
+        beginUserNavigation(tab.webView.goBack(), for: selectedID, webView: tab.webView)
     }
 
     func goForwardSelectedTab(fallback snapshot: BrowserSessionSyncSnapshot) {
@@ -155,7 +185,7 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
             sync(snapshot)
             return
         }
-        tab.webView.goForward()
+        beginUserNavigation(tab.webView.goForward(), for: selectedID, webView: tab.webView)
     }
 
     func evaluateJavaScriptInSelectedTab(_ source: String) async throws -> DesktopBrowserSessionScriptResult {
@@ -191,51 +221,38 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
         // Already on this exact URL: the page is loaded, so capture it rather than forcing a
         // reload (a reload would also lose any state the user or a prior step established).
         if tab.webView.url?.absoluteString != url.absoluteString {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                // Register BEFORE navigating. Everything here is @MainActor-serialized, so the
-                // waiter cannot miss a `didFinish` that lands between these two statements.
-                navigationWaiters[selectedID, default: []].append(continuation)
-                navigate(tab.webView, to: url)
-                Task { @MainActor [weak self] in
-                    try? await Task.sleep(
-                        nanoseconds: UInt64(Self.navigationTimeoutSeconds * 1_000_000_000)
-                    )
-                    // Timeout resolves SUCCESSFULLY: capture the partial page instead of failing.
-                    self?.resumeNavigationWaiters(for: selectedID, error: nil)
-                }
+            try await navigationWaiters.wait(for: selectedID) {
+                let navigation = navigate(tab.webView, to: url)
+                storeActiveNavigation(navigation, for: selectedID, webView: tab.webView)
+                return navigation
+            }
+        } else if tab.webView.isLoading {
+            try await navigationWaiters.wait(for: selectedID) {
+                tab.activeNavigation
             }
         }
 
-        return try await captureLiveDOMSnapshotInSelectedTab()
-    }
-
-    /// Resume and CLEAR every waiter for a tab. Clearing first is what makes a double-resume
-    /// (didFinish racing the timeout, or didFail racing didFinish) impossible — resuming a
-    /// continuation twice is a hard crash in Swift.
-    private func resumeNavigationWaiters(for id: UUID, error: Error?) {
-        guard let waiters = navigationWaiters.removeValue(forKey: id), !waiters.isEmpty else {
-            return
-        }
-        for waiter in waiters {
-            if let error {
-                waiter.resume(throwing: error)
-            } else {
-                waiter.resume()
-            }
-        }
+        return try await captureLiveDOMSnapshot(in: selectedID)
     }
 
     func captureLiveDOMSnapshotInSelectedTab() async throws -> BrowserLiveDOMSnapshot {
-        guard let selectedID = selectedTabID(),
-              let tab = tabs[selectedID]
-        else {
+        guard let selectedID = selectedTabID() else {
             throw DesktopBrowserSessionScriptError.noSelectedTab
         }
+        return try await captureLiveDOMSnapshot(in: selectedID)
+    }
+
+    private func captureLiveDOMSnapshot(in tabID: UUID) async throws -> BrowserLiveDOMSnapshot {
+        guard let tab = tabs[tabID] else { throw DesktopBrowserSessionScriptError.noSelectedTab }
+        let webView = tab.webView
         let snapshot = try await DesktopBrowserLiveDOMSnapshotExtractor.snapshot(
-            from: tab.webView,
+            from: webView,
             fallbackURL: tab.snapshot.url
         )
-        emitSessionUpdate(liveDOMSnapshots: [selectedID: snapshot])
+        guard let currentTab = tabs[tabID], currentTab.webView === webView else {
+            throw DesktopBrowserSessionScriptError.noSelectedTab
+        }
+        emitSessionUpdate(liveDOMSnapshots: [tabID: snapshot])
         return snapshot
     }
 
@@ -285,7 +302,13 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
         if var tab = tabs[snapshot.id] {
             tab.snapshot = snapshot
             tab.item.label = snapshot.title
-            navigate(tab.webView, to: snapshot.url)
+            if let navigation = navigate(tab.webView, to: snapshot.url) {
+                navigationWaiters.finish(
+                    tabID: snapshot.id,
+                    error: DesktopBrowserSessionScriptError.navigationSuperseded
+                )
+                tab.activeNavigation = navigation
+            }
             tabs[snapshot.id] = tab
             return
         }
@@ -296,25 +319,61 @@ final class DesktopBrowserSessionWindowController: NSWindowController,
         item.label = snapshot.title
         item.view = webView
         tabView.addTabViewItem(item)
-        tabs[snapshot.id] = SessionTab(snapshot: snapshot, item: item, webView: webView)
-        navigate(webView, to: snapshot.url)
+        tabs[snapshot.id] = SessionTab(
+            snapshot: snapshot,
+            item: item,
+            webView: webView,
+            activeNavigation: navigate(webView, to: snapshot.url)
+        )
     }
 
-    private func navigate(_ webView: WKWebView, to url: URL) {
-        guard webView.url?.absoluteString != url.absoluteString else { return }
+    private func navigate(_ webView: WKWebView, to url: URL) -> WKNavigation? {
+        guard webView.url?.absoluteString != url.absoluteString else { return nil }
         if url.isFileURL {
-            webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            return webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
         } else {
-            webView.load(URLRequest(url: url))
+            return webView.load(URLRequest(url: url))
         }
     }
 
     private func removeTabs(excluding retainedIDs: Set<UUID>) {
         for id in tabs.keys where !retainedIDs.contains(id) {
             guard let tab = tabs.removeValue(forKey: id) else { continue }
+            navigationWaiters.finish(tabID: id, error: DesktopBrowserSessionScriptError.noSelectedTab)
+            tab.webView.stopLoading()
             tab.webView.navigationDelegate = nil
             tabView.removeTabViewItem(tab.item)
         }
+    }
+
+    private func storeActiveNavigation(_ navigation: WKNavigation?, for id: UUID, webView: WKWebView) {
+        guard var tab = tabs[id], tab.webView === webView else { return }
+        tab.activeNavigation = navigation
+        tabs[id] = tab
+    }
+
+    private func beginUserNavigation(_ navigation: WKNavigation?, for id: UUID, webView: WKWebView) {
+        guard let navigation else { return }
+        navigationWaiters.finish(
+            tabID: id,
+            error: DesktopBrowserSessionScriptError.navigationSuperseded
+        )
+        storeActiveNavigation(navigation, for: id, webView: webView)
+    }
+
+    /// Returns false for a stale callback from a load that an active newer navigation replaced.
+    private func finishActiveNavigation(for id: UUID, navigation: WKNavigation?) -> Bool {
+        guard var tab = tabs[id] else { return false }
+        if let navigation {
+            guard let activeNavigation = tab.activeNavigation,
+                  activeNavigation === navigation
+            else {
+                return false
+            }
+        }
+        tab.activeNavigation = nil
+        tabs[id] = tab
+        return true
     }
 
     private func reorderTabs(_ orderedIDs: [UUID]) {

--- a/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
@@ -133,6 +133,11 @@ struct QuillCodeDesktopBrowserCoordinator {
                 ok: false,
                 error: "Could not load \(url.absoluteString): \(message)"
             )
+        } catch DesktopBrowserSessionScriptError.navigationSuperseded {
+            return ToolResult(
+                ok: false,
+                error: "A newer browser navigation replaced the request for \(url.absoluteString)."
+            )
         } catch {
             return nil
         }

--- a/Tests/QuillCodeDesktopTests/DesktopBrowserNavigationWaitRegistryTests.swift
+++ b/Tests/QuillCodeDesktopTests/DesktopBrowserNavigationWaitRegistryTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import quill_code_desktop
+
+@MainActor
+final class DesktopBrowserNavigationWaitRegistryTests: XCTestCase {
+    private final class NavigationToken {}
+
+    func testMatchingNavigationCompletesAndReleasesWaiter() async throws {
+        let registry = DesktopBrowserNavigationWaitRegistry(timeoutNanoseconds: 5_000_000_000)
+        let tabID = UUID()
+        let navigation = NavigationToken()
+
+        let task = Task { @MainActor in
+            try await registry.wait(for: tabID) { navigation }
+        }
+        await Task.yield()
+
+        XCTAssertEqual(registry.activeCount, 1)
+        XCTAssertTrue(registry.resolve(for: tabID, navigation: navigation, error: nil))
+        try await task.value
+        XCTAssertEqual(registry.activeCount, 0)
+        XCTAssertFalse(registry.resolve(for: tabID, navigation: navigation, error: nil))
+    }
+
+    func testNewNavigationSupersedesOldAndIgnoresItsLateCallback() async throws {
+        let registry = DesktopBrowserNavigationWaitRegistry(timeoutNanoseconds: 5_000_000_000)
+        let tabID = UUID()
+        let oldNavigation = NavigationToken()
+        let newNavigation = NavigationToken()
+
+        let oldTask = Task { @MainActor in
+            try await registry.wait(for: tabID) { oldNavigation }
+        }
+        await Task.yield()
+        let newTask = Task { @MainActor in
+            try await registry.wait(for: tabID) { newNavigation }
+        }
+        await Task.yield()
+
+        await assertThrows(.navigationSuperseded, from: oldTask)
+        XCTAssertEqual(registry.activeCount, 1)
+        XCTAssertFalse(registry.resolve(for: tabID, navigation: oldNavigation, error: nil))
+        XCTAssertFalse(registry.resolve(for: tabID, navigation: nil, error: nil))
+        XCTAssertEqual(registry.activeCount, 1)
+        XCTAssertTrue(registry.resolve(for: tabID, navigation: newNavigation, error: nil))
+        try await newTask.value
+        XCTAssertEqual(registry.activeCount, 0)
+    }
+
+    func testCancellationPromptlyReleasesWaiterWithoutTouchingReplacement() async throws {
+        let registry = DesktopBrowserNavigationWaitRegistry(timeoutNanoseconds: 5_000_000_000)
+        let tabID = UUID()
+        let cancelledNavigation = NavigationToken()
+
+        let cancelledTask = Task { @MainActor in
+            try await registry.wait(for: tabID) { cancelledNavigation }
+        }
+        await Task.yield()
+        cancelledTask.cancel()
+
+        do {
+            try await cancelledTask.value
+            XCTFail("Expected navigation cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(registry.activeCount, 0)
+
+        let replacementNavigation = NavigationToken()
+        let replacementTask = Task { @MainActor in
+            try await registry.wait(for: tabID) { replacementNavigation }
+        }
+        await Task.yield()
+        XCTAssertFalse(registry.resolve(for: tabID, navigation: cancelledNavigation, error: nil))
+        XCTAssertTrue(registry.resolve(for: tabID, navigation: replacementNavigation, error: nil))
+        try await replacementTask.value
+    }
+
+    func testTimeoutCapturesPartialPageAndReleasesWaiter() async throws {
+        let registry = DesktopBrowserNavigationWaitRegistry(timeoutNanoseconds: 1_000_000)
+        let tabID = UUID()
+
+        try await registry.wait(for: tabID) { NavigationToken() }
+
+        XCTAssertEqual(registry.activeCount, 0)
+    }
+
+    func testTabAndWindowClosureFailAllAffectedWaiters() async {
+        let registry = DesktopBrowserNavigationWaitRegistry(timeoutNanoseconds: 5_000_000_000)
+        let firstTabID = UUID()
+        let secondTabID = UUID()
+        let firstTask = Task { @MainActor in
+            try await registry.wait(for: firstTabID) { NavigationToken() }
+        }
+        let secondTask = Task { @MainActor in
+            try await registry.wait(for: secondTabID) { NavigationToken() }
+        }
+        await Task.yield()
+
+        XCTAssertTrue(registry.finish(tabID: firstTabID, error: DesktopBrowserSessionScriptError.noSelectedTab))
+        await assertThrows(.noSelectedTab, from: firstTask)
+        XCTAssertEqual(registry.activeCount, 1)
+
+        registry.finishAll(error: DesktopBrowserSessionScriptError.noOpenSession)
+        await assertThrows(.noOpenSession, from: secondTask)
+        XCTAssertEqual(registry.activeCount, 0)
+    }
+
+    func testRapidReplacementKeepsOnlyOneWaiterAndOneWinningNavigation() async throws {
+        let registry = DesktopBrowserNavigationWaitRegistry(timeoutNanoseconds: 5_000_000_000)
+        let tabID = UUID()
+        var tasks: [Task<Void, any Error>] = []
+        var winningNavigation: NavigationToken?
+
+        for _ in 0..<1_000 {
+            let navigation = NavigationToken()
+            winningNavigation = navigation
+            tasks.append(Task { @MainActor in
+                try await registry.wait(for: tabID) { navigation }
+            })
+            await Task.yield()
+            XCTAssertLessThanOrEqual(registry.activeCount, 1)
+        }
+
+        for task in tasks.dropLast() {
+            await assertThrows(.navigationSuperseded, from: task)
+        }
+        let winner = try XCTUnwrap(winningNavigation)
+        XCTAssertTrue(registry.resolve(for: tabID, navigation: winner, error: nil))
+        try await tasks.last?.value
+        XCTAssertEqual(registry.activeCount, 0)
+    }
+
+    private func assertThrows(
+        _ expected: DesktopBrowserSessionScriptError,
+        from task: Task<Void, any Error>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            try await task.value
+            XCTFail("Expected \(expected)", file: file, line: line)
+        } catch let error as DesktopBrowserSessionScriptError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/Tests/QuillCodeDesktopTests/DesktopBrowserOpenNavigationTests.swift
+++ b/Tests/QuillCodeDesktopTests/DesktopBrowserOpenNavigationTests.swift
@@ -87,6 +87,26 @@ final class DesktopBrowserOpenNavigationTests: XCTestCase {
         )
     }
 
+    func testSupersededNavigationReportsTheReplacementInsteadOfFallingBack() async throws {
+        let presenter = NavigationRecordingPresenter()
+        presenter.navigationError = .navigationSuperseded
+        let controller = try makeController(presenter: presenter)
+
+        let result = await controller.browserCoordinator.openSessionAndCaptureLiveDOM(
+            model: controller.model,
+            addressDraft: "https://example.com/old-request",
+            workspaceRoot: try makeTempDirectory(),
+            refresh: {}
+        )
+
+        let unwrapped = try XCTUnwrap(result)
+        XCTAssertFalse(unwrapped.ok)
+        XCTAssertEqual(
+            unwrapped.error,
+            "A newer browser navigation replaced the request for https://example.com/old-request."
+        )
+    }
+
     /// With no live browser surface (headless runs, the Noop presenter), the coordinator returns nil
     /// so the caller falls back to the legacy metadata path — this feature can only ADD capability.
     func testNoLiveSessionFallsBackRatherThanFailing() async throws {
@@ -143,6 +163,7 @@ private final class NavigationRecordingPresenter: DesktopBrowserSessionPresentin
     var onSessionUpdate: (@MainActor (BrowserSessionUpdate) -> Void)?
     private(set) var navigatedURLs: [URL] = []
     var navigationFailureMessage: String?
+    var navigationError: DesktopBrowserSessionScriptError?
     private var hasOpenSession = false
 
     func presentSession(_ snapshot: BrowserSessionSyncSnapshot) { hasOpenSession = true }
@@ -150,6 +171,9 @@ private final class NavigationRecordingPresenter: DesktopBrowserSessionPresentin
 
     func navigateSelectedTab(to url: URL) async throws -> BrowserLiveDOMSnapshot {
         guard hasOpenSession else { throw DesktopBrowserSessionScriptError.noOpenSession }
+        if let navigationError {
+            throw navigationError
+        }
         if let navigationFailureMessage {
             throw DesktopBrowserSessionScriptError.navigationFailed(navigationFailureMessage)
         }

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -16,6 +16,7 @@ UPDATE_TESTER_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_TESTER_MANIFEST_URL:-https:
 SIGNING_IDENTITY="${QUILLCODE_MACOS_SIGNING_IDENTITY:-}"
 SIGNING_TEAM_IDENTIFIER="${QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER:-}"
 SIGNING_KEYCHAIN="${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}"
+SWIFT_DEBUG_INFO_FORMAT="${QUILLCODE_SWIFT_DEBUG_INFO_FORMAT:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -41,9 +42,21 @@ fi
 
 cd "$ROOT_DIR"
 
+SWIFT_BUILD_ARGUMENTS=(--configuration "$CONFIGURATION" --product quill-code-desktop)
+if [[ -n "$SWIFT_DEBUG_INFO_FORMAT" ]]; then
+  case "$SWIFT_DEBUG_INFO_FORMAT" in
+    dwarf|codeview|none) ;;
+    *)
+      echo "Unsupported QUILLCODE_SWIFT_DEBUG_INFO_FORMAT: $SWIFT_DEBUG_INFO_FORMAT" >&2
+      exit 2
+      ;;
+  esac
+  SWIFT_BUILD_ARGUMENTS+=(-debug-info-format "$SWIFT_DEBUG_INFO_FORMAT")
+fi
+
 echo "==> Building quill-code-desktop ($CONFIGURATION)" >&2
-swift build --configuration "$CONFIGURATION" --product quill-code-desktop >&2
-BIN_DIR="$(swift build --configuration "$CONFIGURATION" --product quill-code-desktop --show-bin-path)"
+swift build "${SWIFT_BUILD_ARGUMENTS[@]}" >&2
+BIN_DIR="$(swift build "${SWIFT_BUILD_ARGUMENTS[@]}" --show-bin-path)"
 SOURCE_EXECUTABLE="$BIN_DIR/quill-code-desktop"
 
 if [[ ! -x "$SOURCE_EXECUTABLE" ]]; then


### PR DESCRIPTION
## Summary
- bound visible-browser navigation state to one cancellation-aware waiter per tab
- correlate WebKit callbacks to the originating navigation and release state on tab or window closure
- keep DOM capture attached to the original tab across user tab switches
- add a validated debug-info override for reliable local macOS smoke builds

## Testing
- full Swift suite: 5,383 tests, 5 skipped, 0 failures
- QuillCodeDesktopTests: 139 tests, 0 failures
- focused navigation lifecycle and browser-open tests: 11 tests, 0 failures
- packaged macOS app smoke: direct render, Launch Services render, and live-window proof passed
- parity packaged macOS smoke gate passed
- code-quality grades: all production modules A+