### PR TITLE
Stream bounded updater progress

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -36,6 +36,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     }
 
     @Published private(set) var state: State = .idle
+    @Published private(set) var preparationProgress: QuillCodeDesktopUpdatePreparationProgress?
     @Published var isPresented = false
 
     let configuration: QuillCodeDesktopUpdateConfiguration?
@@ -161,16 +162,19 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         }
         let generation = beginNewOperation()
         state = .downloading(release)
+        preparationProgress = .downloading(receivedBytes: 0, totalBytes: release.asset.sizeBytes)
         operationTask = Task { [weak self] in
             guard let self else { return }
             defer { self.finishOperation(generation: generation) }
             do {
-                let prepared = try await preparer.prepare(
+                let prepared = try await self.prepareUpdate(
                     release: release,
-                    configuration: configuration
+                    configuration: configuration,
+                    generation: generation
                 )
                 try Task.checkCancellation()
                 guard self.generation == generation else { return }
+                self.preparationProgress = nil
                 self.state = .installing(release)
                 try await installer.stageAndLaunch(
                     preparedUpdate: prepared,
@@ -181,9 +185,11 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
                 self.terminateApplication()
             } catch is CancellationError {
                 guard self.generation == generation else { return }
+                self.preparationProgress = nil
                 self.state = .updateAvailable(release)
             } catch {
                 guard self.generation == generation else { return }
+                self.preparationProgress = nil
                 self.state = .failed(message: error.localizedDescription, release: release)
             }
         }
@@ -279,8 +285,40 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     private func beginNewOperation() -> UUID {
         operationTask?.cancel()
         operationTask = nil
+        preparationProgress = nil
         generation = UUID()
         return generation
+    }
+
+    private func prepareUpdate(
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        generation: UUID
+    ) async throws -> QuillCodeDesktopPreparedUpdate {
+        let (progressStream, progressContinuation) = AsyncStream.makeStream(
+            of: QuillCodeDesktopUpdatePreparationProgress.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        let progressTask = Task { @MainActor [weak self] in
+            for await progress in progressStream {
+                guard let self,
+                      self.generation == generation,
+                      case .downloading = self.state
+                else {
+                    return
+                }
+                self.preparationProgress = progress
+            }
+        }
+        defer {
+            progressContinuation.finish()
+            progressTask.cancel()
+        }
+        return try await preparer.prepare(
+            release: release,
+            configuration: configuration,
+            progress: { progressContinuation.yield($0) }
+        )
     }
 
     private func finishOperation(generation: UUID) {

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateDownloader.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateDownloader.swift
@@ -1,0 +1,255 @@
+import Foundation
+
+protocol QuillCodeDesktopUpdateDownloading: Sendable {
+    func download(
+        from url: URL,
+        to destinationURL: URL,
+        maximumBytes: Int64,
+        progress: @escaping @Sendable (_ receivedBytes: Int64) -> Void
+    ) async throws
+}
+
+struct QuillCodeDesktopUpdateDownloader: QuillCodeDesktopUpdateDownloading, @unchecked Sendable {
+    private let sessionConfiguration: URLSessionConfiguration
+
+    init(session: URLSession? = nil) {
+        self.sessionConfiguration = session?.configuration ?? Self.makeSessionConfiguration()
+    }
+
+    func download(
+        from url: URL,
+        to destinationURL: URL,
+        maximumBytes: Int64,
+        progress: @escaping @Sendable (_ receivedBytes: Int64) -> Void
+    ) async throws {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        request.setValue("application/zip", forHTTPHeaderField: "Accept")
+        request.setValue("Quill-Cowork-Updater/1", forHTTPHeaderField: "User-Agent")
+
+        let delegate = try QuillCodeDesktopUpdateDataDelegate(
+            destinationURL: destinationURL,
+            maximumBytes: maximumBytes,
+            progress: progress
+        )
+        let delegateQueue = OperationQueue()
+        delegateQueue.name = "co.lorehex.QuillCowork.update-download"
+        delegateQueue.qualityOfService = .utility
+        delegateQueue.maxConcurrentOperationCount = 1
+        let session = URLSession(
+            configuration: sessionConfiguration,
+            delegate: delegate,
+            delegateQueue: delegateQueue
+        )
+        defer { session.invalidateAndCancel() }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                let task = session.dataTask(with: request)
+                if delegate.start(task: task, continuation: continuation) {
+                    task.resume()
+                }
+            }
+        } onCancel: {
+            delegate.cancel()
+        }
+    }
+
+    private static func makeSessionConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 30 * 60
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.waitsForConnectivity = true
+        return configuration
+    }
+}
+
+private final class QuillCodeDesktopUpdateDataDelegate: NSObject,
+    URLSessionDataDelegate,
+    @unchecked Sendable
+{
+    private let destinationURL: URL
+    private let temporaryURL: URL
+    private let maximumBytes: Int64
+    private let reportIntervalBytes: Int64
+    private let progress: @Sendable (Int64) -> Void
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, any Error>?
+    private var task: URLSessionDataTask?
+    private var outputHandle: FileHandle?
+    private var receivedBytes: Int64 = 0
+    private var lastReportedBytes: Int64 = 0
+    private var cancelRequested = false
+    private var isComplete = false
+
+    init(
+        destinationURL: URL,
+        maximumBytes: Int64,
+        progress: @escaping @Sendable (Int64) -> Void
+    ) throws {
+        self.destinationURL = destinationURL
+        self.temporaryURL = destinationURL.deletingLastPathComponent().appendingPathComponent(
+            ".\(destinationURL.lastPathComponent).\(UUID().uuidString.lowercased()).download",
+            isDirectory: false
+        )
+        self.maximumBytes = maximumBytes
+        self.reportIntervalBytes = max(64 * 1_024, min(maximumBytes / 100, 1_024 * 1_024))
+        self.progress = progress
+        guard maximumBytes > 0,
+              FileManager.default.createFile(atPath: temporaryURL.path, contents: nil)
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the download workspace could not be created"
+            )
+        }
+        self.outputHandle = try FileHandle(forWritingTo: temporaryURL)
+    }
+
+    deinit {
+        try? outputHandle?.close()
+        try? FileManager.default.removeItem(at: temporaryURL)
+    }
+
+    func start(
+        task: URLSessionDataTask,
+        continuation: CheckedContinuation<Void, any Error>
+    ) -> Bool {
+        lock.lock()
+        self.task = task
+        self.continuation = continuation
+        let shouldCancel = cancelRequested
+        lock.unlock()
+        if shouldCancel {
+            task.cancel()
+            complete(.failure(CancellationError()))
+            return false
+        }
+        return true
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelRequested = true
+        let task = task
+        let hasContinuation = continuation != nil
+        lock.unlock()
+        task?.cancel()
+        if hasContinuation {
+            complete(.failure(CancellationError()))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let response = response as? HTTPURLResponse,
+              response.statusCode == 200
+        else {
+            completionHandler(.cancel)
+            complete(.failure(QuillCodeDesktopUpdateError.invalidResponse))
+            return
+        }
+        guard response.expectedContentLength <= 0 || response.expectedContentLength <= maximumBytes else {
+            completionHandler(.cancel)
+            complete(.failure(QuillCodeDesktopUpdateError.downloadSizeMismatch))
+            return
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        lock.lock()
+        guard !isComplete, let outputHandle else {
+            lock.unlock()
+            return
+        }
+        let incomingByteCount = Int64(data.count)
+        guard incomingByteCount <= maximumBytes - receivedBytes else {
+            lock.unlock()
+            dataTask.cancel()
+            complete(.failure(QuillCodeDesktopUpdateError.downloadSizeMismatch))
+            return
+        }
+        let nextByteCount = receivedBytes + incomingByteCount
+        do {
+            try outputHandle.write(contentsOf: data)
+        } catch {
+            lock.unlock()
+            dataTask.cancel()
+            complete(.failure(QuillCodeDesktopUpdateError.installationFailed(
+                "the download could not be staged"
+            )))
+            return
+        }
+        receivedBytes = nextByteCount
+        let shouldReport = receivedBytes == maximumBytes ||
+            receivedBytes - lastReportedBytes >= reportIntervalBytes
+        if shouldReport {
+            lastReportedBytes = receivedBytes
+        }
+        let reportedBytes = receivedBytes
+        lock.unlock()
+        if shouldReport { progress(reportedBytes) }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if error != nil {
+            complete(.failure(QuillCodeDesktopUpdateError.invalidResponse))
+        } else {
+            completeSuccessfulTransfer()
+        }
+    }
+
+    private func completeSuccessfulTransfer() {
+        lock.lock()
+        let byteCount = receivedBytes
+        lock.unlock()
+        guard byteCount == maximumBytes else {
+            complete(.failure(QuillCodeDesktopUpdateError.downloadSizeMismatch))
+            return
+        }
+        complete(.success(()))
+    }
+
+    private func complete(_ result: Result<Void, any Error>) {
+        lock.lock()
+        guard !isComplete, let continuation else {
+            lock.unlock()
+            return
+        }
+        isComplete = true
+        self.continuation = nil
+        task = nil
+        let outputHandle = outputHandle
+        self.outputHandle = nil
+        lock.unlock()
+
+        try? outputHandle?.close()
+        let finalResult: Result<Void, any Error>
+        switch result {
+        case .success:
+            do {
+                try FileManager.default.moveItem(at: temporaryURL, to: destinationURL)
+                finalResult = .success(())
+            } catch {
+                try? FileManager.default.removeItem(at: temporaryURL)
+                finalResult = .failure(QuillCodeDesktopUpdateError.installationFailed(
+                    "the download could not be staged"
+                ))
+            }
+        case .failure(let error):
+            try? FileManager.default.removeItem(at: temporaryURL)
+            finalResult = .failure(error)
+        }
+        continuation.resume(with: finalResult)
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
@@ -148,6 +148,22 @@ enum QuillCodeDesktopUpdateCheckResult: Equatable, Sendable {
     case upToDate(latestVersion: String, latestBuild: String)
 }
 
+enum QuillCodeDesktopUpdatePreparationProgress: Equatable, Sendable {
+    case downloading(receivedBytes: Int64, totalBytes: Int64)
+    case verifying
+    case extracting
+    case validatingApplication
+
+    var downloadFraction: Double? {
+        guard case .downloading(let receivedBytes, let totalBytes) = self,
+              totalBytes > 0
+        else {
+            return nil
+        }
+        return min(max(Double(receivedBytes) / Double(totalBytes), 0), 1)
+    }
+}
+
 enum QuillCodeDesktopUpdateError: LocalizedError, Equatable, Sendable {
     case updatesUnavailable
     case invalidResponse

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
@@ -10,12 +10,18 @@ struct QuillCodeDesktopPreparedUpdate: Equatable, Sendable {
 protocol QuillCodeDesktopUpdatePreparing: Sendable {
     func prepare(
         release: QuillCodeDesktopUpdateRelease,
-        configuration: QuillCodeDesktopUpdateConfiguration
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        progress: @escaping @Sendable (QuillCodeDesktopUpdatePreparationProgress) -> Void
     ) async throws -> QuillCodeDesktopPreparedUpdate
 }
 
-protocol QuillCodeDesktopUpdateDownloading: Sendable {
-    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws
+extension QuillCodeDesktopUpdatePreparing {
+    func prepare(
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopPreparedUpdate {
+        try await prepare(release: release, configuration: configuration, progress: { _ in })
+    }
 }
 
 struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable {
@@ -32,18 +38,27 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
 
     func prepare(
         release: QuillCodeDesktopUpdateRelease,
-        configuration: QuillCodeDesktopUpdateConfiguration
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        progress: @escaping @Sendable (QuillCodeDesktopUpdatePreparationProgress) -> Void
     ) async throws -> QuillCodeDesktopPreparedUpdate {
         let workspaceURL = try await makeCleanWorkspace(for: release)
         do {
             let archiveURL = workspaceURL.appendingPathComponent(release.asset.name, isDirectory: false)
+            progress(.downloading(receivedBytes: 0, totalBytes: release.asset.sizeBytes))
             try await downloader.download(
                 from: release.asset.url,
                 to: archiveURL,
-                maximumBytes: release.asset.sizeBytes
+                maximumBytes: release.asset.sizeBytes,
+                progress: { receivedBytes in
+                    progress(.downloading(
+                        receivedBytes: receivedBytes,
+                        totalBytes: release.asset.sizeBytes
+                    ))
+                }
             )
             try Task.checkCancellation()
 
+            progress(.verifying)
             try await Task.detached(priority: .utility) {
                 try Self.verifyArchive(
                     at: archiveURL,
@@ -53,6 +68,7 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
             }.value
 
             let extractedURL = workspaceURL.appendingPathComponent("Extracted", isDirectory: true)
+            progress(.extracting)
             try await Task.detached(priority: .utility) {
                 try FileManager.default.createDirectory(
                     at: extractedURL,
@@ -68,6 +84,7 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
                 }
             }.value
 
+            progress(.validatingApplication)
             let applicationURL = try await Task.detached(priority: .utility) {
                 let appURL = try Self.singleApplication(in: extractedURL)
                 try Self.validateContainedLinks(in: extractedURL)
@@ -198,58 +215,5 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
                 )
             }
         }
-    }
-}
-
-struct QuillCodeDesktopUpdateDownloader: QuillCodeDesktopUpdateDownloading, @unchecked Sendable {
-    private let session: URLSession
-
-    init(session: URLSession? = nil) {
-        self.session = session ?? Self.makeSession()
-    }
-
-    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws {
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 30
-        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        request.setValue("application/zip", forHTTPHeaderField: "Accept")
-        request.setValue("Quill-Cowork-Updater/1", forHTTPHeaderField: "User-Agent")
-
-        let temporaryURL: URL
-        let response: URLResponse
-        do {
-            (temporaryURL, response) = try await session.download(for: request)
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            throw QuillCodeDesktopUpdateError.invalidResponse
-        }
-        guard let response = response as? HTTPURLResponse,
-              response.statusCode == 200,
-              response.expectedContentLength <= 0 || response.expectedContentLength <= maximumBytes
-        else {
-            throw QuillCodeDesktopUpdateError.invalidResponse
-        }
-        let values = try temporaryURL.resourceValues(forKeys: [.fileSizeKey])
-        guard Int64(values.fileSize ?? -1) <= maximumBytes else {
-            throw QuillCodeDesktopUpdateError.downloadSizeMismatch
-        }
-        do {
-            try FileManager.default.moveItem(at: temporaryURL, to: destinationURL)
-        } catch {
-            throw QuillCodeDesktopUpdateError.installationFailed("the download could not be staged")
-        }
-    }
-
-    private static func makeSession() -> URLSession {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = 30
-        configuration.timeoutIntervalForResource = 30 * 60
-        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        configuration.urlCache = nil
-        configuration.httpShouldSetCookies = false
-        configuration.httpCookieAcceptPolicy = .never
-        configuration.waitsForConnectivity = true
-        return URLSession(configuration: configuration)
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
@@ -70,12 +70,7 @@ struct QuillCodeDesktopUpdateView: View {
         case .updateAvailable(let release):
             updateContent(release)
         case .downloading(let release):
-            statusContent(
-                icon: "arrow.down.circle",
-                title: "Downloading \(release.displayVersion)",
-                detail: ByteCountFormatter.string(fromByteCount: release.asset.sizeBytes, countStyle: .file),
-                showsProgress: true
-            )
+            preparationStatusContent(release)
         case .installing(let release):
             statusContent(
                 icon: "shippingbox",
@@ -97,6 +92,48 @@ struct QuillCodeDesktopUpdateView: View {
                 detail: message,
                 showsProgress: false,
                 scrollsDetail: true
+            )
+        }
+    }
+
+    private func preparationStatusContent(_ release: QuillCodeDesktopUpdateRelease) -> some View {
+        let progress = controller.preparationProgress
+        switch progress {
+        case .downloading(let receivedBytes, let totalBytes):
+            return statusContent(
+                icon: "arrow.down.circle",
+                title: "Downloading \(release.displayVersion)",
+                detail: "\(fileSize(receivedBytes)) of \(fileSize(totalBytes))",
+                showsProgress: true,
+                progressValue: progress?.downloadFraction
+            )
+        case .verifying:
+            return statusContent(
+                icon: "checkmark.shield",
+                title: "Verifying update",
+                detail: "Checking the download size and SHA-256 digest.",
+                showsProgress: true
+            )
+        case .extracting:
+            return statusContent(
+                icon: "shippingbox",
+                title: "Unpacking update",
+                detail: "Preparing the verified app bundle.",
+                showsProgress: true
+            )
+        case .validatingApplication:
+            return statusContent(
+                icon: "checkmark.seal",
+                title: "Validating app",
+                detail: "Checking its identity, version, architecture, and code signature.",
+                showsProgress: true
+            )
+        case nil:
+            return statusContent(
+                icon: "arrow.down.circle",
+                title: "Downloading \(release.displayVersion)",
+                detail: fileSize(release.asset.sizeBytes),
+                showsProgress: true
             )
         }
     }
@@ -140,6 +177,7 @@ struct QuillCodeDesktopUpdateView: View {
         title: String,
         detail: String,
         showsProgress: Bool,
+        progressValue: Double? = nil,
         scrollsDetail: Bool = false
     ) -> some View {
         VStack(spacing: 14) {
@@ -167,9 +205,16 @@ struct QuillCodeDesktopUpdateView: View {
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
             if showsProgress {
-                ProgressView()
-                    .controlSize(.small)
-                    .accessibilityLabel(title)
+                if let progressValue {
+                    ProgressView(value: progressValue)
+                        .frame(width: 220)
+                        .accessibilityLabel(title)
+                        .accessibilityValue(Text("\(Int(progressValue * 100)) percent"))
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel(title)
+                }
             }
         }
         .frame(maxWidth: 380)
@@ -233,5 +278,9 @@ struct QuillCodeDesktopUpdateView: View {
                     .quillCodeFormActionTarget()
             }
         }
+    }
+
+    private func fileSize(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: max(bytes, 0), countStyle: .file)
     }
 }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -9,6 +9,46 @@ import QuillCodeTools
 
 @MainActor
 final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
+    func testRenderedUpdaterShowsDeterminateDownloadProgressInsideSheet() async throws {
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: RenderedUpdateChecker(release: release),
+            preparer: RenderedProgressUpdatePreparer(),
+            defaults: UserDefaults(suiteName: "RenderedUpdaterProgress.\(UUID().uuidString)") ?? .standard,
+            automaticSchedule: .production,
+            installResultURL: nil
+        )
+        controller.checkForUpdates()
+        try await waitForUpdaterState(controller) { $0 == .updateAvailable(release) }
+        controller.updateAndRelaunch()
+        for _ in 0..<200 {
+            if controller.preparationProgress == .downloading(
+                receivedBytes: 5_000,
+                totalBytes: 10_000
+            ) {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(controller.preparationProgress?.downloadFraction, 0.5)
+        defer { controller.cancelCurrentOperation() }
+
+        let image = try renderHostedView(
+            QuillCodeDesktopUpdateView(controller: controller),
+            width: 470,
+            height: 340,
+            debugPathEnvironmentKey: "QUILLCODE_RENDER_UPDATE_PROGRESS_IMAGE_PATH"
+        )
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 470)
+        XCTAssertEqual(stats.height, 340)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.blueAccentPixelRatio, 0.001)
+    }
+
     func testRenderedUpdaterFailureKeepsRecoveryActionsInsideSheet() async throws {
         let release = makeRelease(version: "0.2.0", build: "7")
         let controller = QuillCodeDesktopUpdateController(
@@ -362,13 +402,26 @@ private struct RenderedUpdateChecker: QuillCodeDesktopUpdateChecking {
 private struct RenderedFailingUpdatePreparer: QuillCodeDesktopUpdatePreparing {
     func prepare(
         release: QuillCodeDesktopUpdateRelease,
-        configuration: QuillCodeDesktopUpdateConfiguration
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        progress: @escaping @Sendable (QuillCodeDesktopUpdatePreparationProgress) -> Void
     ) async throws -> QuillCodeDesktopPreparedUpdate {
         let detail = String(
             repeating: "The downloaded bundle contains a component that could not be validated. ",
             count: 8
         )
         throw QuillCodeDesktopUpdateError.invalidApplication(detail)
+    }
+}
+
+private struct RenderedProgressUpdatePreparer: QuillCodeDesktopUpdatePreparing {
+    func prepare(
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        progress: @escaping @Sendable (QuillCodeDesktopUpdatePreparationProgress) -> Void
+    ) async throws -> QuillCodeDesktopPreparedUpdate {
+        progress(.downloading(receivedBytes: 5_000, totalBytes: 10_000))
+        try await Task.sleep(for: .seconds(10))
+        throw CancellationError()
     }
 }
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -246,6 +246,52 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         try await waitUntil { terminationCount == 1 }
     }
 
+    func testPreparationProgressAdvancesAndClearsBeforeActivation() async throws {
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let progressUpdates: [QuillCodeDesktopUpdatePreparationProgress] = [
+            .downloading(receivedBytes: 5_000, totalBytes: 10_000),
+            .verifying,
+            .extracting,
+            .validatingApplication,
+        ]
+        let preparer = UpdatePreparerSpy(
+            release: release,
+            progressUpdates: progressUpdates,
+            progressDelay: .milliseconds(30)
+        )
+        let installer = UpdateInstallerSpy(delay: .milliseconds(100))
+        var terminationCount = 0
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: UpdateCheckerSpy(result: .updateAvailable(release)),
+            preparer: preparer,
+            installer: installer,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(),
+            installResultURL: temporaryInstallResultURL(),
+            terminateApplication: { terminationCount += 1 }
+        )
+
+        controller.checkForUpdates()
+        try await waitUntil { controller.state == .updateAvailable(release) }
+        controller.updateAndRelaunch()
+
+        try await waitUntil {
+            controller.preparationProgress == .downloading(
+                receivedBytes: 5_000,
+                totalBytes: 10_000
+            )
+        }
+        XCTAssertEqual(controller.preparationProgress?.downloadFraction, 0.5)
+        try await waitUntil { controller.preparationProgress == .validatingApplication }
+        try await waitUntil {
+            if case .installing = controller.state { return true }
+            return false
+        }
+        XCTAssertNil(controller.preparationProgress)
+        try await waitUntil { terminationCount == 1 }
+    }
+
     func testVisibleInstallFailureDefersAutomaticNetworkWork() async throws {
         let resultURL = temporaryInstallResultURL()
         try FileManager.default.createDirectory(
@@ -373,18 +419,34 @@ private actor UpdateCheckerSpy: QuillCodeDesktopUpdateChecking {
 private actor UpdatePreparerSpy: QuillCodeDesktopUpdatePreparing {
     private let release: QuillCodeDesktopUpdateRelease
     private let delay: Duration?
+    private let progressUpdates: [QuillCodeDesktopUpdatePreparationProgress]
+    private let progressDelay: Duration?
     private(set) var callCount = 0
 
-    init(release: QuillCodeDesktopUpdateRelease, delay: Duration? = nil) {
+    init(
+        release: QuillCodeDesktopUpdateRelease,
+        delay: Duration? = nil,
+        progressUpdates: [QuillCodeDesktopUpdatePreparationProgress] = [],
+        progressDelay: Duration? = nil
+    ) {
         self.release = release
         self.delay = delay
+        self.progressUpdates = progressUpdates
+        self.progressDelay = progressDelay
     }
 
     func prepare(
         release: QuillCodeDesktopUpdateRelease,
-        configuration: QuillCodeDesktopUpdateConfiguration
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        progress: @escaping @Sendable (QuillCodeDesktopUpdatePreparationProgress) -> Void
     ) async throws -> QuillCodeDesktopPreparedUpdate {
         callCount += 1
+        for update in progressUpdates {
+            progress(update)
+            if let progressDelay {
+                try await Task.sleep(for: progressDelay)
+            }
+        }
         if let delay {
             try await Task.sleep(for: delay)
         }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -86,6 +86,162 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         XCTAssertEqual(result, .updateAvailable(makeRelease(version: "0.2.0", build: "1")))
     }
 
+    func testPreparationDownloadFractionClampsAndOnlyAppliesToDownloads() {
+        XCTAssertEqual(
+            QuillCodeDesktopUpdatePreparationProgress.downloading(
+                receivedBytes: -1,
+                totalBytes: 10
+            ).downloadFraction,
+            0
+        )
+        XCTAssertEqual(
+            QuillCodeDesktopUpdatePreparationProgress.downloading(
+                receivedBytes: 11,
+                totalBytes: 10
+            ).downloadFraction,
+            1
+        )
+        XCTAssertNil(QuillCodeDesktopUpdatePreparationProgress.verifying.downloadFraction)
+    }
+
+    func testDownloaderStreamsIncreasingBoundedProgressAndStagesExactPayload() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let payload = Data(repeating: 0x5a, count: 512 * 1_024)
+        UpdateDownloadURLProtocol.state.configure(payload: payload, chunkBytes: 16 * 1_024)
+        let session = UpdateDownloadURLProtocol.session()
+        defer {
+            session.invalidateAndCancel()
+            UpdateDownloadURLProtocol.state.reset()
+        }
+        let destination = root.appendingPathComponent("Quill-Cowork.zip")
+        let progress = UpdateDownloadProgressRecorder()
+        let downloader = QuillCodeDesktopUpdateDownloader(session: session)
+
+        try await downloader.download(
+            from: try XCTUnwrap(URL(string: "https://github.com/Lore-Hex/QuillCode/update.zip")),
+            to: destination,
+            maximumBytes: Int64(payload.count),
+            progress: { progress.append($0) }
+        )
+
+        XCTAssertEqual(try Data(contentsOf: destination), payload)
+        let values = progress.values
+        XCTAssertEqual(values.last, Int64(payload.count))
+        XCTAssertEqual(values, values.sorted())
+        XCTAssertEqual(Set(values).count, values.count)
+        XCTAssertLessThanOrEqual(values.count, 100)
+    }
+
+    func testDownloaderCancelsChunkedTransferAsSoonAsItExceedsByteLimit() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let payload = Data(repeating: 0x41, count: 2 * 1_024 * 1_024)
+        let maximumBytes: Int64 = 128 * 1_024
+        UpdateDownloadURLProtocol.state.configure(payload: payload, chunkBytes: 16 * 1_024)
+        let session = UpdateDownloadURLProtocol.session()
+        defer {
+            session.invalidateAndCancel()
+            UpdateDownloadURLProtocol.state.reset()
+        }
+        let destination = root.appendingPathComponent("oversized.zip")
+        let downloader = QuillCodeDesktopUpdateDownloader(session: session)
+
+        do {
+            try await downloader.download(
+                from: try XCTUnwrap(URL(string: "https://github.com/Lore-Hex/QuillCode/oversized.zip")),
+                to: destination,
+                maximumBytes: maximumBytes,
+                progress: { _ in }
+            )
+            XCTFail("Expected oversized update transfer to be cancelled")
+        } catch let error as QuillCodeDesktopUpdateError {
+            XCTAssertEqual(error, .downloadSizeMismatch)
+        }
+
+        for _ in 0..<100 where !UpdateDownloadURLProtocol.state.wasStopped {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTAssertTrue(UpdateDownloadURLProtocol.state.wasStopped)
+        XCTAssertLessThan(UpdateDownloadURLProtocol.state.deliveredBytes, payload.count)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    func testDownloaderRejectsDeclaredOversizeBeforeStaging() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let maximumBytes: Int64 = 128 * 1_024
+        UpdateDownloadURLProtocol.state.configure(
+            payload: Data(repeating: 0x41, count: 16 * 1_024),
+            chunkBytes: 16 * 1_024,
+            declaredContentLength: Int(maximumBytes + 1)
+        )
+        let session = UpdateDownloadURLProtocol.session()
+        defer {
+            session.invalidateAndCancel()
+            UpdateDownloadURLProtocol.state.reset()
+        }
+        let destination = root.appendingPathComponent("declared-oversized.zip")
+        let downloader = QuillCodeDesktopUpdateDownloader(session: session)
+
+        do {
+            try await downloader.download(
+                from: try XCTUnwrap(URL(
+                    string: "https://github.com/Lore-Hex/QuillCode/declared-oversized.zip"
+                )),
+                to: destination,
+                maximumBytes: maximumBytes,
+                progress: { _ in }
+            )
+            XCTFail("Expected declared oversized update transfer to be rejected")
+        } catch let error as QuillCodeDesktopUpdateError {
+            XCTAssertEqual(error, .downloadSizeMismatch)
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    func testDownloaderCancellationStopsTransportAndRemovesPartialFile() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let payload = Data(repeating: 0x42, count: 2 * 1_024 * 1_024)
+        UpdateDownloadURLProtocol.state.configure(payload: payload, chunkBytes: 16 * 1_024)
+        let session = UpdateDownloadURLProtocol.session()
+        defer {
+            session.invalidateAndCancel()
+            UpdateDownloadURLProtocol.state.reset()
+        }
+        let destination = root.appendingPathComponent("cancelled.zip")
+        let downloader = QuillCodeDesktopUpdateDownloader(session: session)
+        let task = Task {
+            try await downloader.download(
+                from: try XCTUnwrap(URL(string: "https://github.com/Lore-Hex/QuillCode/cancelled.zip")),
+                to: destination,
+                maximumBytes: Int64(payload.count),
+                progress: { _ in }
+            )
+        }
+
+        for _ in 0..<100 where UpdateDownloadURLProtocol.state.deliveredBytes == 0 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        task.cancel()
+        do {
+            try await task.value
+            XCTFail("Expected update transfer cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+        for _ in 0..<100 where !UpdateDownloadURLProtocol.state.wasStopped {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        XCTAssertTrue(UpdateDownloadURLProtocol.state.wasStopped)
+        XCTAssertLessThan(UpdateDownloadURLProtocol.state.deliveredBytes, payload.count)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: root.path), [])
+    }
+
     func testArchiveVerificationRejectsTampering() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -564,14 +720,175 @@ private struct UpdateManifestLoaderStub: QuillCodeDesktopUpdateManifestLoading {
 private struct FailingUpdateDownloader: QuillCodeDesktopUpdateDownloading {
     var error: QuillCodeDesktopUpdateError
 
-    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws {
+    func download(
+        from url: URL,
+        to destinationURL: URL,
+        maximumBytes: Int64,
+        progress: @escaping @Sendable (Int64) -> Void
+    ) async throws {
         throw error
     }
 }
 
 private struct CancellingUpdateDownloader: QuillCodeDesktopUpdateDownloading {
-    func download(from url: URL, to destinationURL: URL, maximumBytes: Int64) async throws {
+    func download(
+        from url: URL,
+        to destinationURL: URL,
+        maximumBytes: Int64,
+        progress: @escaping @Sendable (Int64) -> Void
+    ) async throws {
         throw CancellationError()
+    }
+}
+
+private final class UpdateDownloadProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Int64] = []
+
+    var values: [Int64] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func append(_ value: Int64) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+}
+
+private final class UpdateDownloadURLProtocolState: @unchecked Sendable {
+    struct Configuration: Sendable {
+        var payload: Data
+        var chunkBytes: Int
+        var declaredContentLength: Int?
+    }
+
+    private let lock = NSLock()
+    private var configuration: Configuration?
+    private var stopped = false
+    private var delivered = 0
+
+    var wasStopped: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+
+    var deliveredBytes: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return delivered
+    }
+
+    func configure(
+        payload: Data,
+        chunkBytes: Int,
+        declaredContentLength: Int? = nil
+    ) {
+        lock.lock()
+        configuration = Configuration(
+            payload: payload,
+            chunkBytes: chunkBytes,
+            declaredContentLength: declaredContentLength
+        )
+        stopped = false
+        delivered = 0
+        lock.unlock()
+    }
+
+    func snapshot() -> Configuration? {
+        lock.lock()
+        defer { lock.unlock() }
+        return configuration
+    }
+
+    func recordDelivery(_ byteCount: Int) {
+        lock.lock()
+        delivered += byteCount
+        lock.unlock()
+    }
+
+    func recordStop() {
+        lock.lock()
+        stopped = true
+        lock.unlock()
+    }
+
+    func reset() {
+        lock.lock()
+        configuration = nil
+        stopped = false
+        delivered = 0
+        lock.unlock()
+    }
+}
+
+private final class UpdateDownloadURLProtocol: URLProtocol, @unchecked Sendable {
+    static let state = UpdateDownloadURLProtocolState()
+
+    private let lock = NSLock()
+    private var isStopped = false
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [UpdateDownloadURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let configuration = Self.state.snapshot(),
+              let url = request.url
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        var headers = ["Content-Type": "application/zip"]
+        if let declaredContentLength = configuration.declaredContentLength {
+            headers["Content-Length"] = String(declaredContentLength)
+        }
+        guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: headers
+              )
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        deliver(configuration, offset: 0)
+    }
+
+    override func stopLoading() {
+        lock.lock()
+        isStopped = true
+        lock.unlock()
+        Self.state.recordStop()
+    }
+
+    private func deliver(_ configuration: UpdateDownloadURLProtocolState.Configuration, offset: Int) {
+        lock.lock()
+        let stopped = isStopped
+        lock.unlock()
+        guard !stopped else { return }
+        guard offset < configuration.payload.count else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        let end = min(offset + configuration.chunkBytes, configuration.payload.count)
+        let chunk = configuration.payload.subdata(in: offset..<end)
+        Self.state.recordDelivery(chunk.count)
+        client?.urlProtocol(self, didLoad: chunk)
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + .milliseconds(2)) { [weak self] in
+            self?.deliver(configuration, offset: end)
+        }
     }
 }
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,21 @@
 # QuillCode Decisions
 
+## 2026-08-07: update downloads are bounded while bytes are in flight
+
+- **Decision:** The desktop updater streams each response directly into an updater-owned hidden
+  partial file. It rejects a declared oversized response before accepting it, cancels at the first
+  chunk that would exceed the manifest size, and requires the completed transfer to match that size
+  exactly before moving it into the preparation workspace.
+- **Resource boundary:** Response bytes do not accumulate in memory. Progress reporting is throttled,
+  the controller keeps only the newest pending update, and every failure or cancellation closes and
+  removes the partial file before returning.
+- **User experience:** The update sheet shows determinate bytes and percentage while downloading,
+  followed by distinct verifying, unpacking, and app-validation phases. Operation generations prevent
+  late progress from a cancelled or replaced transfer from changing visible state.
+- **Evidence:** `QuillCodeDesktopUpdateTests` exercise exact streaming, declared and runtime oversize
+  rejection, cancellation, and partial-file cleanup. `QuillCodeDesktopUpdateControllerTests` covers
+  progress lifetime, and `QuillCodeDesktopRenderedSmokeTests` verifies the fixed-size sheet at 50%.
+
 ## 2026-08-07: transcript projection stays linear in long-session history
 
 - **Decision:** Message events use an on-demand content index that consumes duplicate text in

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -93,6 +93,13 @@ identifier, architecture, and signing identity, downloads on demand, and verifie
 the exact size, SHA-256 digest, app identity, version, architecture, and macOS code
 signature before installation.
 
+Archive bytes stream directly to an updater-owned partial file instead of being
+buffered in memory. A declared oversized response is rejected immediately; a
+chunked response is cancelled at the first chunk that would exceed the manifest
+size. Cancellation and failure remove the partial file. The update sheet reports
+bounded determinate byte progress, then identifies the verification, unpacking,
+and app-validation phases separately.
+
 Installation stages the verified app beside the running bundle, then uses a
 detached helper for the final rename and relaunch. The new app must complete a
 launch handshake within 45 seconds. Otherwise the helper restores and reopens the


### PR DESCRIPTION
## Summary
- stream desktop update archives directly to disk with strict in-flight byte limits and partial-file cleanup
- show determinate byte progress plus verification, extraction, and app-validation phases
- isolate downloader ownership and cover cancellation, oversize responses, progress lifetime, and rendered layout

## Verification
- swift test --disable-index-store -debug-info-format none (5,390 tests, 5 skipped, 0 failures)
- QUILLCODE_SWIFT_DEBUG_INFO_FORMAT=none scripts/packaged-macos-smoke.sh
- scripts/grade-code-quality.py (all affected production updater files A+)
- git diff --check