### PR TITLE
Recover visibly from unreadable saved chats

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeRuntimeSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeRuntimeSurface.swift
@@ -22,6 +22,7 @@ public enum RuntimeRecoveryReason: String, Codable, Sendable, Hashable {
     case emptyResponse = "empty-response"
     case malformedModelAction = "malformed-model-action"
     case runFailed = "run-failed"
+    case savedChatsUnreadable = "saved-chats-unreadable"
 }
 
 public struct RuntimeRecoveryTelemetry: Codable, Sendable, Hashable {

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -37,8 +37,9 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
         let projects = try projectStore.load()
         let childStore = SubagentThreadStore(directory: paths.subagentThreadsDirectory)
         let payloadStore = SubagentApprovalPayloadStore(directory: paths.subagentApprovalPayloadsDirectory)
+        let threadListing = threadStore.listing()
         let reconciliation = WorkspaceSubagentRelaunchReconciler.reconcile(
-            try threadStore.list(),
+            threadListing.threads,
             childStore: childStore,
             payloadStore: payloadStore
         )
@@ -81,6 +82,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             runner: runtime.runner,
             contextSummaryGenerator: runtime.contextSummaryGenerator,
             threadStore: threadStore,
+            threadLoadIssue: WorkspaceThreadLoadIssue(listing: threadListing),
             projectStore: projectStore,
             automationStore: automationStore,
             sidebarSavedSearchStore: sidebarSavedSearchStore,

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -36,6 +36,7 @@ public final class QuillCodeWorkspaceModel {
     public internal(set) var sidebarSelection: SidebarSelectionState
     public internal(set) var agentRuns: WorkspaceAgentRunRegistry
     public private(set) var lastError: String?
+    let threadLoadIssue: WorkspaceThreadLoadIssue?
 
     /// Set by the desktop layer to post a "come back and look" OS notification when an agent run
     /// finishes while the user is away — finished, errored, or blocked on an approval gate. The whole
@@ -150,6 +151,7 @@ public final class QuillCodeWorkspaceModel {
         runner: AgentRunner = AgentRunner(),
         contextSummaryGenerator: any WorkspaceContextSummaryGenerating = DeterministicWorkspaceContextSummaryGenerator(),
         threadStore: JSONThreadStore? = nil,
+        threadLoadIssue: WorkspaceThreadLoadIssue? = nil,
         projectStore: JSONProjectStore? = nil,
         automationStore: JSONAutomationStore? = nil,
         sidebarSavedSearchStore: JSONSidebarSavedSearchStore? = nil,
@@ -197,6 +199,7 @@ public final class QuillCodeWorkspaceModel {
         self.subagentSchedulerOverride = nil
         self.contextSummaryGenerator = contextSummaryGenerator
         self.threadPersistence = WorkspaceThreadPersistence(store: threadStore)
+        self.threadLoadIssue = threadLoadIssue
         self.projectStore = projectStore
         self.automationStore = automationStore
         self.sidebarSavedSearchStore = sidebarSavedSearchStore

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -296,7 +296,10 @@ public extension QuillCodeWorkspaceModel {
     }
 
     private func runtimeIssueSurface() -> RuntimeIssueSurface? {
-        WorkspaceRuntimeIssueBuilder(
+        if let threadLoadIssue {
+            return threadLoadIssue.runtimeIssue
+        }
+        return WorkspaceRuntimeIssueBuilder(
             config: root.config,
             hasStoredAPIKey: root.trustedRouterAPIKeyConfigured,
             modelID: root.topBar.model,

--- a/Sources/QuillCodeApp/WorkspaceThreadLoadIssue.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadLoadIssue.swift
@@ -1,0 +1,97 @@
+import Foundation
+import QuillCodePersistence
+
+public struct WorkspaceThreadLoadIssue: Sendable, Hashable {
+    private static let displayedThreadIDLimit = 3
+
+    private var loadedThreadCount: Int
+    private var fileIssues: [ThreadFileIssue]
+    private var directoryReadFailed: Bool
+
+    public init?(listing: ThreadListing) {
+        guard listing.directoryReadFailed || !listing.issues.isEmpty else { return nil }
+        self.loadedThreadCount = listing.threads.count
+        self.fileIssues = listing.issues
+        self.directoryReadFailed = listing.directoryReadFailed
+    }
+
+    var runtimeIssue: RuntimeIssueSurface {
+        RuntimeIssueSurface(
+            severity: .warning,
+            title: title,
+            message: message,
+            actionLabel: "Review diagnostics",
+            recovery: RuntimeRecoveryTelemetry(
+                route: .settings,
+                reason: .savedChatsUnreadable,
+                commandID: "settings"
+            ),
+            diagnostics: diagnostics
+        )
+    }
+
+    private var title: String {
+        if directoryReadFailed {
+            return "Saved chats could not be inspected"
+        }
+        return fileIssues.count == 1
+            ? "A saved chat could not be loaded"
+            : "Some saved chats could not be loaded"
+    }
+
+    private var message: String {
+        if directoryReadFailed {
+            return "Quill Cowork started without changing the chat directory. " +
+                "Review the storage diagnostics before continuing."
+        }
+        let count = fileIssues.count
+        let noun = count == 1 ? "chat" : "chats"
+        let healthy = loadedThreadCount == 0
+            ? ""
+            : " Your other \(loadedThreadCount) \(loadedThreadCount == 1 ? "chat is" : "chats are") still available."
+        return "\(count) saved \(noun) could not be loaded.\(healthy) " +
+            "The affected files were left unchanged so they can be recovered."
+    }
+
+    private var diagnostics: [RuntimeDiagnosticSurface] {
+        var rows = [
+            RuntimeDiagnosticSurface(label: "Loaded chats", value: String(loadedThreadCount)),
+            RuntimeDiagnosticSurface(label: "Affected files", value: String(fileIssues.count)),
+        ]
+        appendCount(.exceedsSizeLimit, label: "Oversized files", to: &rows)
+        appendCount(.symbolicLink, label: "Rejected links", to: &rows)
+        appendCount(.notRegularFile, label: "Non-file paths", to: &rows)
+        if directoryReadFailed {
+            rows.append(RuntimeDiagnosticSurface(label: "Directory scan", value: "Failed"))
+        }
+        if let threadIDs = displayedThreadIDs {
+            rows.append(RuntimeDiagnosticSurface(label: "Chat IDs", value: threadIDs))
+        }
+        rows.append(RuntimeDiagnosticSurface(
+            label: "Recovery",
+            value: "Back up ~/.quillcode/threads, then run quill-code doctor."
+        ))
+        return rows
+    }
+
+    private var displayedThreadIDs: String? {
+        let ids = fileIssues.compactMap { issue -> String? in
+            let stem = issue.fileURL.deletingPathExtension().lastPathComponent
+            return UUID(uuidString: stem)?.uuidString.lowercased()
+        }
+        guard !ids.isEmpty else { return nil }
+        let displayed = ids.prefix(Self.displayedThreadIDLimit)
+        let remainder = ids.count - displayed.count
+        return displayed.joined(separator: ", ") + (remainder > 0 ? " and \(remainder) more" : "")
+    }
+
+    private func appendCount(
+        _ reason: ThreadFileIssueReason,
+        label: String,
+        to rows: inout [RuntimeDiagnosticSurface]
+    ) {
+        let count = fileIssues.count { $0.reason == reason }
+        guard count > 0 else { return }
+        rows.append(RuntimeDiagnosticSurface(label: label, value: String(count)))
+    }
+}

--- a/Sources/QuillCodePersistence/ThreadStore.swift
+++ b/Sources/QuillCodePersistence/ThreadStore.swift
@@ -1,20 +1,77 @@
 import Foundation
 import QuillCodeCore
 
-/// Result of a best-effort thread listing: the healthy threads that decoded, plus the file URLs
-/// that could not be read (truncated, hand-edited, or schema-skewed) so callers can surface a
-/// self-healing notice instead of silently losing data.
+public enum ThreadFileIssueReason: String, Sendable, Hashable {
+    case unreadable
+    case notRegularFile = "not-regular-file"
+    case symbolicLink = "symbolic-link"
+    case exceedsSizeLimit = "exceeds-size-limit"
+}
+
+public struct ThreadFileIssue: Sendable, Hashable {
+    public var fileURL: URL
+    public var reason: ThreadFileIssueReason
+
+    public init(fileURL: URL, reason: ThreadFileIssueReason) {
+        self.fileURL = fileURL
+        self.reason = reason
+    }
+}
+
+/// Result of a best-effort thread listing: the healthy threads that decoded plus bounded,
+/// content-free diagnostics for files that were rejected. Callers can keep healthy chats visible
+/// and offer recovery guidance without loading hostile files or exposing their contents.
 public struct ThreadListing: Sendable {
     public var threads: [ChatThread]
     public var unreadable: [URL]
+    public var issues: [ThreadFileIssue]
+    public var directoryReadFailed: Bool
 
-    public init(threads: [ChatThread], unreadable: [URL]) {
+    public init(
+        threads: [ChatThread],
+        unreadable: [URL],
+        directoryReadFailed: Bool = false
+    ) {
         self.threads = threads
         self.unreadable = unreadable
+        self.issues = unreadable.map {
+            ThreadFileIssue(fileURL: $0, reason: .unreadable)
+        }
+        self.directoryReadFailed = directoryReadFailed
+    }
+
+    public init(
+        threads: [ChatThread],
+        issues: [ThreadFileIssue],
+        directoryReadFailed: Bool = false
+    ) {
+        self.threads = threads
+        self.unreadable = issues.map(\.fileURL)
+        self.issues = issues
+        self.directoryReadFailed = directoryReadFailed
+    }
+}
+
+public enum JSONThreadStoreError: LocalizedError, Equatable, Sendable {
+    case notRegularFile
+    case symbolicLink
+    case exceedsSizeLimit(maximumBytes: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notRegularFile:
+            "The saved chat path is not a regular file."
+        case .symbolicLink:
+            "The saved chat path is a symbolic link."
+        case .exceedsSizeLimit(let maximumBytes):
+            "The saved chat exceeds the \(maximumBytes)-byte loading limit."
+        }
     }
 }
 
 public struct JSONThreadStore: Sendable {
+    public static let maximumThreadFileBytes = 128 * 1_024 * 1_024
+
     public var directory: URL
 
     public init(directory: URL) {
@@ -27,13 +84,18 @@ public struct JSONThreadStore: Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(thread)
+        guard data.count <= Self.maximumThreadFileBytes else {
+            throw JSONThreadStoreError.exceedsSizeLimit(
+                maximumBytes: Self.maximumThreadFileBytes
+            )
+        }
         try data.write(to: fileURL(for: thread.id), options: .atomic)
     }
 
     public func load(_ id: UUID) throws -> ChatThread {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let data = try Data(contentsOf: fileURL(for: id))
+        let data = try Self.boundedData(contentsOf: fileURL(for: id))
         return try decoder.decode(ChatThread.self, from: data)
     }
 
@@ -53,28 +115,72 @@ public struct JSONThreadStore: Sendable {
     /// strict, so a direct open of a named corrupt thread still surfaces the decode error.
     public func listing() -> ThreadListing {
         guard FileManager.default.fileExists(atPath: directory.path) else {
-            return ThreadListing(threads: [], unreadable: [])
+            return ThreadListing(threads: [], issues: [])
         }
         guard let urls = try? FileManager.default.contentsOfDirectory(
             at: directory,
-            includingPropertiesForKeys: nil
-        ).filter({ $0.pathExtension == "json" }) else {
-            return ThreadListing(threads: [], unreadable: [])
+            includingPropertiesForKeys: [
+                .fileSizeKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+            ]
+        ).filter({ $0.pathExtension == "json" }).sorted(by: {
+            $0.lastPathComponent < $1.lastPathComponent
+        }) else {
+            return ThreadListing(threads: [], issues: [], directoryReadFailed: true)
         }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         var threads: [ChatThread] = []
-        var unreadable: [URL] = []
+        var issues: [ThreadFileIssue] = []
         for url in urls {
-            guard let data = try? Data(contentsOf: url),
-                  let thread = try? decoder.decode(ChatThread.self, from: data) else {
-                unreadable.append(url)
-                continue
+            do {
+                let data = try Self.boundedData(contentsOf: url)
+                threads.append(try decoder.decode(ChatThread.self, from: data))
+            } catch let error as JSONThreadStoreError {
+                issues.append(ThreadFileIssue(fileURL: url, reason: Self.issueReason(for: error)))
+            } catch {
+                issues.append(ThreadFileIssue(fileURL: url, reason: .unreadable))
             }
-            threads.append(thread)
         }
         threads.sort { $0.updatedAt > $1.updatedAt }
-        return ThreadListing(threads: threads, unreadable: unreadable)
+        return ThreadListing(threads: threads, issues: issues)
+    }
+
+    private static func boundedData(contentsOf url: URL) throws -> Data {
+        let values = try url.resourceValues(forKeys: [
+            .fileSizeKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+        ])
+        guard values.isSymbolicLink != true else {
+            throw JSONThreadStoreError.symbolicLink
+        }
+        guard values.isRegularFile == true else {
+            throw JSONThreadStoreError.notRegularFile
+        }
+        guard let fileSize = values.fileSize,
+              fileSize >= 0,
+              fileSize <= maximumThreadFileBytes
+        else {
+            throw JSONThreadStoreError.exceedsSizeLimit(maximumBytes: maximumThreadFileBytes)
+        }
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        guard data.count <= maximumThreadFileBytes else {
+            throw JSONThreadStoreError.exceedsSizeLimit(maximumBytes: maximumThreadFileBytes)
+        }
+        return data
+    }
+
+    private static func issueReason(for error: JSONThreadStoreError) -> ThreadFileIssueReason {
+        switch error {
+        case .notRegularFile:
+            .notRegularFile
+        case .symbolicLink:
+            .symbolicLink
+        case .exceedsSizeLimit:
+            .exceedsSizeLimit
+        }
     }
 
     private func fileURL(for id: UUID) -> URL {

--- a/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
@@ -175,13 +175,28 @@ final class WorkspaceConfigurationIntegrationTests: XCTestCase {
         let store = JSONThreadStore(directory: paths.threadsDirectory)
         try store.save(ChatThread(title: "Survivor A", updatedAt: Date(timeIntervalSince1970: 1)))
         try store.save(ChatThread(title: "Survivor B", updatedAt: Date(timeIntervalSince1970: 2)))
-        try Data("{ truncated mid-write".utf8)
-            .write(to: paths.threadsDirectory.appendingPathComponent("\(UUID().uuidString).json"))
+        let corruptID = UUID()
+        let corruptURL = paths.threadsDirectory.appendingPathComponent("\(corruptID.uuidString).json")
+        try Data("{ truncated mid-write".utf8).write(to: corruptURL)
 
         let model = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
 
         XCTAssertEqual(model.root.threads.map(\.title), ["Survivor B", "Survivor A"])
         XCTAssertEqual(model.root.selectedThreadID, model.root.threads.first?.id)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: corruptURL.path))
+        let issue = try XCTUnwrap(model.surface().runtimeIssue)
+        XCTAssertEqual(issue.severity, .warning)
+        XCTAssertEqual(issue.title, "A saved chat could not be loaded")
+        XCTAssertTrue(issue.message.contains("other 2 chats are still available"))
+        XCTAssertTrue(issue.message.contains("left unchanged"))
+        XCTAssertEqual(issue.actionLabel, "Review diagnostics")
+        XCTAssertEqual(issue.recovery?.route, .settings)
+        XCTAssertEqual(issue.recovery?.reason, .savedChatsUnreadable)
+        let diagnostics = Dictionary(uniqueKeysWithValues: issue.diagnostics.map { ($0.label, $0.value) })
+        XCTAssertEqual(diagnostics["Loaded chats"], "2")
+        XCTAssertEqual(diagnostics["Affected files"], "1")
+        XCTAssertEqual(diagnostics["Chat IDs"], corruptID.uuidString.lowercased())
+        XCTAssertEqual(model.surface().settings.runtimeIssue, issue)
     }
 
     func testBootstrapPersistsAndClearsTrustedRouterAPIKey() throws {

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueIntegrationTests.swift
@@ -1,10 +1,48 @@
 import XCTest
 import QuillCodeAgent
 import QuillCodeCore
+import QuillCodePersistence
 @testable import QuillCodeApp
 
 @MainActor
 final class WorkspaceRuntimeIssueIntegrationTests: XCTestCase {
+    func testSavedChatLoadIssueTakesPriorityAndRoutesToSettings() throws {
+        let privateFilename = "customer-acquisition-plan.json"
+        let listing = ThreadListing(
+            threads: [ChatThread(title: "Healthy")],
+            issues: [
+                ThreadFileIssue(
+                    fileURL: URL(fileURLWithPath: "/ignored/\(privateFilename)"),
+                    reason: .exceedsSizeLimit
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                topBar: TopBarState(agentStatus: QuillCodeRuntimeStatusLabel.signInWithTrustedRouter)
+            ),
+            threadLoadIssue: try XCTUnwrap(WorkspaceThreadLoadIssue(listing: listing))
+        )
+
+        let surface = model.surface()
+
+        XCTAssertEqual(surface.runtimeIssue?.title, "A saved chat could not be loaded")
+        XCTAssertEqual(surface.runtimeIssue?.recovery?.reason, .savedChatsUnreadable)
+        XCTAssertEqual(surface.topBar.runtimeIssueLabel, "A saved chat could not be loaded")
+        XCTAssertEqual(
+            surface.runtimeIssue?.diagnostics.first { $0.label == "Oversized files" }?.value,
+            "1"
+        )
+        XCTAssertFalse(
+            surface.runtimeIssue?.diagnostics.contains { $0.value.contains(privateFilename) } == true
+        )
+        let settings = try XCTUnwrap(surface.commands.first { $0.id == "settings" })
+        XCTAssertEqual(
+            RuntimeIssueRecoveryPlanner(commands: [settings]).action(for: surface.runtimeIssue),
+            .command(settings)
+        )
+    }
+
     func testApplyRuntimeRefreshesAgentStatus() {
         let model = QuillCodeWorkspaceModel()
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -9,6 +9,34 @@ import QuillCodeTools
 
 @MainActor
 final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
+    func testRenderedEmptyWorkspaceShowsSavedChatRecoveryIssue() throws {
+        let invalidID = UUID()
+        let listing = ThreadListing(
+            threads: [],
+            issues: [
+                ThreadFileIssue(
+                    fileURL: URL(fileURLWithPath: "/ignored/\(invalidID.uuidString).json"),
+                    reason: .unreadable
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(
+            threadLoadIssue: try XCTUnwrap(WorkspaceThreadLoadIssue(listing: listing))
+        )
+        let surface = model.surface()
+        XCTAssertEqual(surface.runtimeIssue?.title, "A saved chat could not be loaded")
+        XCTAssertTrue(surface.transcript.timelineItems.isEmpty)
+
+        let image = try renderWorkspace(surface)
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 1280)
+        XCTAssertEqual(stats.height, 900)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
+    }
+
     func testRenderedUpdaterShowsDeterminateDownloadProgressInsideSheet() async throws {
         let release = makeRelease(version: "0.2.0", build: "7")
         let controller = QuillCodeDesktopUpdateController(
@@ -238,7 +266,7 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         )
         .frame(width: 1280, height: 900)
 
-        return try render(
+        return try renderHostedView(
             view,
             width: 1280,
             height: 900,

--- a/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
@@ -150,6 +150,84 @@ final class JSONThreadStoreTests: PersistenceTestCase {
         // Compare by filename: contentsOfDirectory resolves the macOS /var -> /private/var symlink,
         // so raw URL equality is unreliable here.
         XCTAssertEqual(listing.unreadable.map(\.lastPathComponent), [corrupt.lastPathComponent])
+        XCTAssertEqual(listing.issues.map(\.reason), [.unreadable])
+        XCTAssertFalse(listing.directoryReadFailed)
+    }
+
+    func testListingRejectsSymlinkedThreadWithoutReadingItsTarget() throws {
+        let directory = try makeTempDirectory()
+        let outsideDirectory = try makeTempDirectory()
+        let outsideStore = JSONThreadStore(directory: outsideDirectory)
+        let outsideThread = ChatThread(title: "Outside")
+        try outsideStore.save(outsideThread)
+        let linkID = UUID()
+        let link = directory.appendingPathComponent("\(linkID.uuidString).json")
+        try FileManager.default.createSymbolicLink(
+            at: link,
+            withDestinationURL: outsideDirectory.appendingPathComponent(
+                "\(outsideThread.id.uuidString).json"
+            )
+        )
+        let store = JSONThreadStore(directory: directory)
+
+        let listing = store.listing()
+
+        XCTAssertTrue(listing.threads.isEmpty)
+        XCTAssertEqual(listing.issues.map(\.reason), [.symbolicLink])
+        XCTAssertThrowsError(try store.load(linkID)) { error in
+            XCTAssertEqual(error as? JSONThreadStoreError, .symbolicLink)
+        }
+    }
+
+    func testListingRejectsSparseOversizedThreadBeforeReadingIt() throws {
+        let directory = try makeTempDirectory()
+        let id = UUID()
+        let fileURL = directory.appendingPathComponent("\(id.uuidString).json")
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: fileURL)
+        try handle.truncate(atOffset: UInt64(JSONThreadStore.maximumThreadFileBytes + 1))
+        try handle.close()
+        let store = JSONThreadStore(directory: directory)
+
+        let listing = store.listing()
+
+        XCTAssertTrue(listing.threads.isEmpty)
+        XCTAssertEqual(listing.issues.map(\.reason), [.exceedsSizeLimit])
+        XCTAssertThrowsError(try store.load(id)) { error in
+            XCTAssertEqual(
+                error as? JSONThreadStoreError,
+                .exceedsSizeLimit(maximumBytes: JSONThreadStore.maximumThreadFileBytes)
+            )
+        }
+    }
+
+    func testListingRejectsNonFileThreadPath() throws {
+        let directory = try makeTempDirectory()
+        let id = UUID()
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent("\(id.uuidString).json"),
+            withIntermediateDirectories: false
+        )
+        let store = JSONThreadStore(directory: directory)
+
+        let listing = store.listing()
+
+        XCTAssertTrue(listing.threads.isEmpty)
+        XCTAssertEqual(listing.issues.map(\.reason), [.notRegularFile])
+        XCTAssertThrowsError(try store.load(id)) { error in
+            XCTAssertEqual(error as? JSONThreadStoreError, .notRegularFile)
+        }
+    }
+
+    func testListingReportsStorageRootThatIsNotADirectory() throws {
+        let rootFile = try makeTempDirectory().appendingPathComponent("threads")
+        try Data("not a directory".utf8).write(to: rootFile)
+
+        let listing = JSONThreadStore(directory: rootFile).listing()
+
+        XCTAssertTrue(listing.threads.isEmpty)
+        XCTAssertTrue(listing.issues.isEmpty)
+        XCTAssertTrue(listing.directoryReadFailed)
     }
 
     func testListToleratesSchemaIncompatibleFile() throws {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # QuillCode Decisions
 
+## 2026-08-07: damaged saved chats stay bounded, visible, and recoverable
+
+- **Decision:** Persisted chat files are inspected as regular non-symlink files before decoding,
+  rejected above 128 MiB, and loaded with mapped data. Startup continues with every healthy chat
+  when another file is truncated, schema-incompatible, oversized, or an unexpected filesystem type.
+- **Recovery boundary:** Rejected files remain unchanged. Bootstrap carries only bounded reason
+  counts and validated UUID chat IDs into a persistent warning; the transcript and Settings expose
+  recovery diagnostics without reading file contents, displaying absolute paths, or leaking decoder
+  errors. The warning takes priority over provider status until the storage problem is resolved.
+- **Why:** The persistence layer already skipped damaged files, but bootstrap discarded that evidence,
+  making chats disappear silently. Unbounded reads also let one malformed file create an avoidable
+  startup memory spike.
+- **Evidence:** `JSONThreadStoreTests` cover healthy preservation, strict direct loads, sparse
+  oversized files, and symlink refusal. `WorkspaceConfigurationIntegrationTests` covers bootstrap
+  diagnostics and source-file preservation, while `QuillCodeDesktopRenderedSmokeTests` verifies the
+  warning in an otherwise empty workspace.
+
 ## 2026-08-07: update downloads are bounded while bytes are in flight
 
 - **Decision:** The desktop updater streams each response directly into an updater-owned hidden


### PR DESCRIPTION
## Summary
- bound saved-chat reads at 128 MiB and reject symlink or non-file paths before decoding
- keep healthy chats available while surfacing a privacy-safe recovery warning and Settings diagnostics
- render the warning through a hosted desktop regression and document the persistence boundary

## Verification
- `swift test --disable-index-store -debug-info-format none` (5,396 tests, 5 skipped, 0 failures)
- `QUILLCODE_SWIFT_DEBUG_INFO_FORMAT=none scripts/packaged-macos-smoke.sh`
- `python3 scripts/grade-code-quality.py --root .` (all changed production files A+)
- `git diff --check`
- changed-diff long TrustedRouter-key scan