### PR TITLE
Gate macOS releases on native performance

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -204,6 +204,7 @@ jobs:
 
           Downloads:
           - \`Quill-Cowork-macOS-*.zip\`: macOS app bundle for testers.
+          - \`Quill-Cowork-macOS-*-PERFORMANCE.json\`: measured launch and resident-memory release evidence.
           - \`quill-code-macOS-*.tar.gz\`: macOS CLI.
           - \`quill-code-linux-*.tar.gz\`: Linux CLI.
           - \`SHASUMS256.txt\`: checksums for package and build-info assets.

--- a/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
+++ b/Sources/QuillCodeApp/QuillCodeSearchAndShortcutDialogs.swift
@@ -280,7 +280,9 @@ struct QuillCodeSearchView: View {
         .background(QuillCodePalette.background)
         .onAppear {
             selection.reconcile(with: results, preferredID: sidebar.selectedThreadID)
-            focusSearchField()
+        }
+        .task {
+            await focusSearchField()
         }
         .onChange(of: localQuery) { _, newValue in
             if query != newValue {
@@ -324,11 +326,12 @@ struct QuillCodeSearchView: View {
         onSelectThread(id)
     }
 
-    private func focusSearchField() {
-        DispatchQueue.main.async {
-            isSearchFocused = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+    @MainActor
+    private func focusSearchField() async {
+        isSearchFocused = true
+        for delay in [50_000_000, 200_000_000] as [UInt64] {
+            try? await Task.sleep(nanoseconds: delay)
+            guard !Task.isCancelled else { return }
             isSearchFocused = true
         }
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -9,6 +9,7 @@ struct QuillCodeDesktopApp: App {
     @StateObject private var controller: QuillCodeDesktopController
 
     init() {
+        _ = QuillCodeDesktopLaunchClock.appEntryUptime
         if let updateRequest = QuillCodeDesktopUpdateHelperRequest.parse(arguments: CommandLine.arguments) {
             Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopPerformanceSnapshot.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopPerformanceSnapshot.swift
@@ -1,0 +1,64 @@
+import Darwin
+import Foundation
+
+enum QuillCodeDesktopLaunchClock {
+    static let appEntryUptime = ProcessInfo.processInfo.systemUptime
+}
+
+struct QuillCodeDesktopPerformanceSnapshot: Equatable, Sendable {
+    static let schemaVersion = 1
+    static let measurement = "initial-live-window"
+
+    var launchReadyMilliseconds: Double
+    var residentMemoryBytes: Int64
+    var threadCount: Int
+
+    static func capture(
+        launchStartedAtUptime: TimeInterval,
+        nowUptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) throws -> Self {
+        var taskInfo = proc_taskinfo()
+        let expectedSize = Int32(MemoryLayout<proc_taskinfo>.stride)
+        let capturedSize = withUnsafeMutablePointer(to: &taskInfo) { pointer in
+            proc_pidinfo(
+                getpid(),
+                PROC_PIDTASKINFO,
+                0,
+                pointer,
+                expectedSize
+            )
+        }
+        guard capturedSize == expectedSize,
+              taskInfo.pti_resident_size > 0,
+              taskInfo.pti_threadnum > 0
+        else {
+            throw QuillCodeDesktopSmokeFailure.performanceSnapshotUnavailable
+        }
+
+        let elapsed = nowUptime - launchStartedAtUptime
+        guard elapsed.isFinite, elapsed >= 0 else {
+            throw QuillCodeDesktopSmokeFailure.performanceSnapshotUnavailable
+        }
+        let milliseconds = (elapsed * 100_000).rounded() / 100
+
+        return Self(
+            launchReadyMilliseconds: milliseconds,
+            residentMemoryBytes: clampedInt64(taskInfo.pti_resident_size),
+            threadCount: Int(taskInfo.pti_threadnum)
+        )
+    }
+
+    var dictionary: [String: Any] {
+        [
+            "schemaVersion": Self.schemaVersion,
+            "measurement": Self.measurement,
+            "launchReadyMilliseconds": launchReadyMilliseconds,
+            "residentMemoryBytes": residentMemoryBytes,
+            "threadCount": threadCount
+        ]
+    }
+
+    private static func clampedInt64(_ value: UInt64) -> Int64 {
+        Int64(min(value, UInt64(Int64.max)))
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -504,6 +504,7 @@ struct QuillCodeDesktopWindowSmokeReport {
     var stateRootPath: String
     var appStatePath: String
     var workspacePath: String
+    var performance: QuillCodeDesktopPerformanceSnapshot
     var image: QuillCodeDesktopSmokePixelReport
     var nativeHitTargets: QuillCodeNativeHitTargetAuditReport
     var accessibilityFrameSamples: QuillCodeDesktopAccessibilityFrameSampleReport
@@ -531,6 +532,7 @@ struct QuillCodeDesktopWindowSmokeReport {
                 "stateRootPath": stateRootPath,
                 "appStatePath": appStatePath,
                 "workspacePath": workspacePath,
+                "performance": performance.dictionary,
                 "image": image.dictionary,
                 "nativeHitTargets": nativeHitTargets.dictionary,
                 "accessibilityFrameSamples": accessibilityFrameSamples.dictionary,
@@ -687,6 +689,7 @@ enum QuillCodeDesktopSmokeFailure: Error {
     case computerUseActionMismatch(String)
     case multiFileArtifactMismatch(String)
     case oneTurnCoworkerMismatch(String)
+    case performanceSnapshotUnavailable
     case nativeAccessibilityActivationFailed([String])
     case nativeAccessibilityFrameSamplingFailed([String])
     case nativeHitTargetAuditFailed([String])

--- a/Sources/quill-code-desktop/QuillCodeDesktopWindowSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWindowSmokeRunner.swift
@@ -54,6 +54,9 @@ enum QuillCodeDesktopWindowSmokeRunner {
         guard bounds.width >= 900, bounds.height >= 620 else {
             throw QuillCodeDesktopSmokeFailure.windowContentTooSmall(bounds.width, bounds.height)
         }
+        let performance = try QuillCodeDesktopPerformanceSnapshot.capture(
+            launchStartedAtUptime: QuillCodeDesktopLaunchClock.appEntryUptime
+        )
 
         let screenshotURL = screenshotURL(request: request)
         let stats = try await captureValidatedImageStats(
@@ -90,6 +93,7 @@ enum QuillCodeDesktopWindowSmokeRunner {
             stateRootPath: workspaceRoot.root.path,
             appStatePath: workspaceRoot.appState.path,
             workspacePath: workspaceRoot.workspace.path,
+            performance: performance,
             image: stats.report,
             nativeHitTargets: nativeHitTargets,
             accessibilityFrameSamples: accessibilityFrameSamples,

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
@@ -7,6 +7,31 @@ import QuillComputerUseKit
 
 @MainActor
 final class QuillCodeDesktopWindowReportTests: XCTestCase {
+    func testDesktopPerformanceSnapshotCapturesBoundedProcessResources() throws {
+        let now = ProcessInfo.processInfo.systemUptime
+        let snapshot = try QuillCodeDesktopPerformanceSnapshot.capture(
+            launchStartedAtUptime: now - 1.25,
+            nowUptime: now
+        )
+
+        XCTAssertEqual(snapshot.launchReadyMilliseconds, 1_250, accuracy: 0.01)
+        XCTAssertGreaterThan(snapshot.residentMemoryBytes, 0)
+        XCTAssertGreaterThan(snapshot.threadCount, 0)
+        XCTAssertEqual(
+            snapshot.dictionary["measurement"] as? String,
+            "initial-live-window"
+        )
+    }
+
+    func testDesktopPerformanceSnapshotRejectsInvalidLaunchTiming() {
+        XCTAssertThrowsError(
+            try QuillCodeDesktopPerformanceSnapshot.capture(
+                launchStartedAtUptime: 2,
+                nowUptime: 1
+            )
+        )
+    }
+
     func testDesktopSmokePixelValidationAcceptsConfiguredMinimumColorBuckets() throws {
         let stats = QuillCodeDesktopSmokePixelStats(
             report: QuillCodeDesktopSmokePixelReport(
@@ -206,6 +231,11 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
             stateRootPath: "/tmp/quillcode-window-state",
             appStatePath: "/tmp/quillcode-window-state/app-state",
             workspacePath: "/tmp/quillcode-window-state/workspace",
+            performance: QuillCodeDesktopPerformanceSnapshot(
+                launchReadyMilliseconds: 742.5,
+                residentMemoryBytes: 96 * 1_024 * 1_024,
+                threadCount: 18
+            ),
             image: QuillCodeDesktopSmokePixelReport(
                 width: 2560,
                 height: 1800,
@@ -241,9 +271,14 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
         XCTAssertTrue(json.contains(#""allowsTextSelection" : false"#))
         XCTAssertTrue(json.contains(#""surface""#))
         XCTAssertTrue(json.contains(#""composerCanSend" : false"#))
+        XCTAssertTrue(json.contains(#""measurement" : "initial-live-window""#))
         XCTAssertEqual(jsonObject["stateRootPath"] as? String, "/tmp/quillcode-window-state")
         XCTAssertEqual(jsonObject["appStatePath"] as? String, "/tmp/quillcode-window-state/app-state")
         XCTAssertEqual(jsonObject["workspacePath"] as? String, "/tmp/quillcode-window-state/workspace")
+        XCTAssertEqual(
+            (jsonObject["performance"] as? [String: Any])?["residentMemoryBytes"] as? Int,
+            96 * 1_024 * 1_024
+        )
     }
 
     func testComputerUseCoordinatorRefreshesForegroundApplication() async throws {

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -29,6 +29,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
                 encoding: .utf8
             )
         try Data("mac app".utf8).write(to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64.zip"))
+        try Data(#"{"withinBudget":true}"#.utf8).write(
+            to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64-PERFORMANCE.json")
+        )
         try Data("mac cli".utf8).write(to: temporaryDirectory.appendingPathComponent("quill-code-macOS-arm64.tar.gz"))
         try Data("linux cli".utf8).write(to: temporaryDirectory.appendingPathComponent("quill-code-linux-x86_64.tar.gz"))
         try "placeholder checksums\n"
@@ -91,7 +94,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertEqual(updaterAppAsset["name"] as? String, "Quill-Cowork-macOS-arm64.zip")
 
         let assets = try XCTUnwrap(manifest["assets"] as? [[String: Any]])
-        XCTAssertEqual(assets.count, 6)
+        XCTAssertEqual(assets.count, 7)
 
         let appAsset = try asset(named: "Quill-Cowork-macOS-arm64.zip", in: assets)
         XCTAssertEqual(appAsset["kind"] as? String, "app")
@@ -101,6 +104,15 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertEqual(appAsset["url"] as? String, "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip")
         XCTAssertEqual(appAsset["sizeBytes"] as? Int, 7)
         XCTAssertEqual((appAsset["sha256"] as? String)?.count, 64)
+
+        let performanceAsset = try asset(
+            named: "Quill-Cowork-macOS-arm64-PERFORMANCE.json",
+            in: assets
+        )
+        XCTAssertEqual(performanceAsset["kind"] as? String, "performance")
+        XCTAssertEqual(performanceAsset["platform"] as? String, "macOS")
+        XCTAssertEqual(performanceAsset["arch"] as? String, "arm64")
+        XCTAssertEqual(performanceAsset["install"] as? String, "json")
 
         let linuxAsset = try asset(named: "quill-code-linux-x86_64.tar.gz", in: assets)
         XCTAssertEqual(linuxAsset["kind"] as? String, "cli")
@@ -300,6 +312,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "updateManifestURL=$UPDATE_MANIFEST_URL",
             "stableUpdateManifestURL=$STABLE_MANIFEST_URL",
             "testerUpdateManifestURL=$TESTER_MANIFEST_URL",
+            "performance=Quill-Cowork-macOS-$ARCH-PERFORMANCE.json",
+            "scripts/packaged-macos-performance-smoke.sh",
             "signingTeamIdentifier=${SIGNING_TEAM_IDENTIFIER:-none}",
             "notarized=$NOTARIZED"
         ])

--- a/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import XCTest
+
+final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
+    func testPackagedPerformanceEvidenceStaysOnReleaseBoundary() throws {
+        let snapshot = try Self.desktopSourceText(named: "QuillCodeDesktopPerformanceSnapshot.swift")
+        let app = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let runner = try Self.desktopSourceText(named: "QuillCodeDesktopWindowSmokeRunner.swift")
+        let support = try Self.desktopSourceText(named: "QuillCodeDesktopSmokeSupport.swift")
+        let packagedSmoke = try Self.scriptText(named: "packaged-macos-smoke.sh")
+        let performanceSmoke = try Self.scriptText(named: "packaged-macos-performance-smoke.sh")
+        let packageDownloads = try Self.scriptText(named: "package-macos-downloads.sh")
+        let workflow = try Self.workflowText(named: "download-builds.yml")
+        let downloads = try Self.docsText(named: "DOWNLOADS.md")
+
+        Self.assertSource(snapshot, containsAll: [
+            "proc_pidinfo(",
+            "PROC_PIDTASKINFO",
+            "pti_resident_size",
+            "pti_threadnum",
+            #"static let measurement = "initial-live-window""#
+        ])
+        Self.assertSource(app, contains: "QuillCodeDesktopLaunchClock.appEntryUptime")
+        Self.assertSource(runner, contains: "QuillCodeDesktopPerformanceSnapshot.capture(")
+        let performanceIndex = try XCTUnwrap(runner.range(of: "let performance = try")).lowerBound
+        let screenshotIndex = try XCTUnwrap(runner.range(of: "captureValidatedImageStats(")).lowerBound
+        XCTAssertLessThan(performanceIndex, screenshotIndex)
+        Self.assertSource(support, contains: #""performance": performance.dictionary"#)
+
+        Self.assertSource(packagedSmoke, containsAll: [
+            "packaged-performance.json",
+            "native-click-probe-contracts.py\" performance",
+            "performance_manifest=packaged-performance.json"
+        ])
+        Self.assertSource(performanceSmoke, containsAll: [
+            "--native-window-smoke",
+            "--max-launch-ready-milliseconds",
+            "--max-resident-memory-bytes",
+            "QUILLCODE_MAX_LAUNCH_READY_MILLISECONDS",
+            "QUILLCODE_MAX_RESIDENT_MEMORY_BYTES"
+        ])
+        Self.assertSource(packageDownloads, containsAll: [
+            "Quill-Cowork-macOS-$ARCH-PERFORMANCE.json",
+            "scripts/packaged-macos-performance-smoke.sh",
+            "performance=Quill-Cowork-macOS-$ARCH-PERFORMANCE.json",
+            #"SWIFT_BUILD_ARGUMENTS+=(-debug-info-format "$SWIFT_DEBUG_INFO_FORMAT")"#
+        ])
+        Self.assertSource(workflow, contains: "measured launch and resident-memory release evidence")
+        Self.assertSource(downloads, containsAll: [
+            "within three",
+            "256 MiB",
+            "PERFORMANCE.json"
+        ])
+    }
+
+    func testPerformanceValidatorWritesBoundedEvidenceManifest() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runValidator(
+            report: fixture.report,
+            manifest: fixture.manifest,
+            maximumLaunchMilliseconds: 1_000,
+            maximumResidentBytes: 128 * 1_024 * 1_024
+        )
+        XCTAssertEqual(result.exitCode, 0, result.output)
+
+        let data = try Data(contentsOf: fixture.manifest)
+        let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(manifest["ok"] as? Bool, true)
+        XCTAssertEqual(manifest["withinBudget"] as? Bool, true)
+        XCTAssertEqual(manifest["measurement"] as? String, "initial-live-window")
+        XCTAssertEqual(manifest["launchReadyMilliseconds"] as? Double, 750)
+        XCTAssertEqual(manifest["residentMemoryBytes"] as? Int, 96 * 1_024 * 1_024)
+        let budgets = try XCTUnwrap(manifest["budgets"] as? [String: Any])
+        XCTAssertEqual(budgets["maximumLaunchReadyMilliseconds"] as? Double, 1_000)
+        XCTAssertEqual(budgets["maximumResidentMemoryBytes"] as? Int, 128 * 1_024 * 1_024)
+    }
+
+    func testPerformanceValidatorFailsClosedAboveEitherBudget() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let slow = try runValidator(
+            report: fixture.report,
+            manifest: fixture.manifest,
+            maximumLaunchMilliseconds: 500,
+            maximumResidentBytes: 128 * 1_024 * 1_024
+        )
+        XCTAssertNotEqual(slow.exitCode, 0)
+        XCTAssertTrue(slow.output.contains("exceeds 500.00ms budget"), slow.output)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.manifest.path))
+
+        let large = try runValidator(
+            report: fixture.report,
+            manifest: fixture.manifest,
+            maximumLaunchMilliseconds: 1_000,
+            maximumResidentBytes: 64 * 1_024 * 1_024
+        )
+        XCTAssertNotEqual(large.exitCode, 0)
+        XCTAssertTrue(large.output.contains("exceeds 67108864 byte budget"), large.output)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.manifest.path))
+    }
+
+    private func makeFixture() throws -> (root: URL, report: URL, manifest: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-performance-gate-(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let report = root.appendingPathComponent("window-report.json")
+        let manifest = root.appendingPathComponent("performance.json")
+        let payload: [String: Any] = [
+            "ok": true,
+            "appName": "Quill Cowork",
+            "performance": [
+                "schemaVersion": 1,
+                "measurement": "initial-live-window",
+                "launchReadyMilliseconds": 750.0,
+                "residentMemoryBytes": 96 * 1_024 * 1_024,
+                "threadCount": 18
+            ]
+        ]
+        try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
+            .write(to: report, options: .atomic)
+        return (root, report, manifest)
+    }
+
+    private func runValidator(
+        report: URL,
+        manifest: URL,
+        maximumLaunchMilliseconds: Int,
+        maximumResidentBytes: Int
+    ) throws -> ScriptResult {
+        try Self.runPython(
+            Self.packageRoot().appendingPathComponent("scripts/native-click-probe-contracts.py"),
+            arguments: [
+                "performance",
+                report.path,
+                "--manifest", manifest.path,
+                "--max-launch-ready-milliseconds", String(maximumLaunchMilliseconds),
+                "--max-resident-memory-bytes", String(maximumResidentBytes)
+            ]
+        )
+    }
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3517,3 +3517,19 @@
   CI result requires a new or rerun Download Builds attempt.
 - **Evidence:** `scripts/wait-for-successful-ci.sh`, `.github/workflows/download-builds.yml`,
   `ParityDownloadBuildCIGateTests`, and `ParityDownloadBuildsGateTests`.
+
+## 2026-08-07: published macOS builds carry native performance evidence
+
+- **Decision:** The packaged live-window smoke captures app-entry-to-window-ready time, resident
+  memory, and thread count directly from the native process before screenshot and
+  Accessibility sampling. Default release budgets are three seconds and 256 MiB resident memory.
+- **Why:** Functional smoke alone cannot protect Quill Cowork's native speed and memory advantage.
+  Measuring the release-configured `.app` makes large startup or footprint regressions fail before
+  publication and gives future optimization work a durable baseline rather than anecdotes.
+- **Boundary:** This is an initial empty-workspace measurement, not a claim about long-running peak
+  memory or arbitrary project sizes. The first budgets retain broad headroom across GitHub macOS
+  runners; daily-driving and workload evidence should tighten them without making CI hardware noise
+  the product metric.
+- **Evidence:** `QuillCodeDesktopPerformanceSnapshot`, the window-smoke performance object,
+  `scripts/native_click_probe_contracts/performance.py`, `scripts/packaged-macos-performance-smoke.sh`,
+  packaged smoke artifacts, and the public architecture-specific `PERFORMANCE.json` release asset.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -11,6 +11,7 @@ Send testers this moving prerelease link:
 Direct asset links for the current tester channel:
 
 - [macOS app: `Quill-Cowork-macOS-arm64.zip`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip)
+- [macOS performance evidence: `Quill-Cowork-macOS-arm64-PERFORMANCE.json`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64-PERFORMANCE.json)
 - [macOS CLI: `quill-code-macOS-arm64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-macOS-arm64.tar.gz)
 - [Linux CLI: `quill-code-linux-x86_64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-linux-x86_64.tar.gz)
 - [Checksums: `SHASUMS256.txt`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/SHASUMS256.txt)
@@ -55,6 +56,13 @@ tag to the expected commit, checks the exact release inventory and updater feed
 contract, then downloads every declared asset with bounded streaming and
 verifies GitHub's digest, manifest size/SHA-256, `SHASUMS256.txt`, and
 `BUILD_INFO.txt`. A publication is not green until this consumer check passes.
+
+The release-configured macOS app must also open a real native window within three
+seconds and remain below 256 MiB of resident memory at that initial-window
+boundary. The measured values, thread count, and enforced budgets
+ship as the architecture-specific `PERFORMANCE.json` asset. These intentionally
+conservative first budgets catch major regressions while repeated tester evidence
+establishes tighter native baselines.
 
 ## Auto-Update Contract
 

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -63,6 +63,9 @@ def classify_asset(name: str) -> dict[str, str]:
     if name.startswith("quill-code-linux-") and name.endswith(".tar.gz"):
         arch = name.removeprefix("quill-code-linux-").removesuffix(".tar.gz")
         return {"kind": "cli", "platform": "Linux", "arch": arch, "install": "tarball"}
+    if name.startswith("Quill-Cowork-macOS-") and name.endswith("-PERFORMANCE.json"):
+        arch = name.removeprefix("Quill-Cowork-macOS-").removesuffix("-PERFORMANCE.json")
+        return {"kind": "performance", "platform": "macOS", "arch": arch, "install": "json"}
     if name == "BUILD_INFO.txt":
         return {"kind": "metadata", "platform": "macOS", "arch": "any", "install": "text"}
     if name.startswith("BUILD_INFO-linux-") and name.endswith(".txt"):

--- a/scripts/native_click_probe_contracts/cli.py
+++ b/scripts/native_click_probe_contracts/cli.py
@@ -21,6 +21,11 @@ from .packaged_window import (
     write_accessibility_readiness_manifest,
     write_comparison_manifest,
 )
+from .performance import (
+    DEFAULT_MAX_LAUNCH_READY_MILLISECONDS,
+    DEFAULT_MAX_RESIDENT_MEMORY_BYTES,
+    write_performance_manifest,
+)
 from .probe_contracts import validate_report
 from .scheduled_coworker import write_scheduled_coworker_manifest
 from .scheduled_notification_observation import write_scheduled_notification_observation_manifest
@@ -89,6 +94,23 @@ def main() -> None:
     frames_parser.add_argument("screenshot", type=Path)
     frames_parser.add_argument("--click-probe-manifest", type=Path)
     frames_parser.add_argument("--manifest", required=True, type=Path)
+
+    performance_parser = subparsers.add_parser(
+        "performance",
+        help="validate packaged native launch and resident-memory evidence",
+    )
+    performance_parser.add_argument("report", type=Path)
+    performance_parser.add_argument("--manifest", required=True, type=Path)
+    performance_parser.add_argument(
+        "--max-launch-ready-milliseconds",
+        type=float,
+        default=DEFAULT_MAX_LAUNCH_READY_MILLISECONDS,
+    )
+    performance_parser.add_argument(
+        "--max-resident-memory-bytes",
+        type=int,
+        default=DEFAULT_MAX_RESIDENT_MEMORY_BYTES,
+    )
 
     computer_use_parser = subparsers.add_parser(
         "computer-use",
@@ -218,6 +240,13 @@ def main() -> None:
             args.screenshot,
             args.click_probe_manifest,
             args.manifest,
+        )
+    elif args.command == "performance":
+        write_performance_manifest(
+            args.report,
+            args.manifest,
+            max_launch_ready_milliseconds=args.max_launch_ready_milliseconds,
+            max_resident_memory_bytes=args.max_resident_memory_bytes,
         )
     elif args.command == "computer-use":
         write_computer_use_manifest(

--- a/scripts/native_click_probe_contracts/performance.py
+++ b/scripts/native_click_probe_contracts/performance.py
@@ -1,0 +1,108 @@
+"""Validate packaged native launch and resident-memory evidence."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from .json_io import load_report, require
+
+
+DEFAULT_MAX_LAUNCH_READY_MILLISECONDS = 3_000.0
+DEFAULT_MAX_RESIDENT_MEMORY_BYTES = 256 * 1024 * 1024
+
+
+def _finite_number(value: Any, label: str) -> float:
+    require(
+        not isinstance(value, bool) and isinstance(value, (int, float)),
+        f"{label} is not numeric: {value!r}",
+    )
+    number = float(value)
+    require(math.isfinite(number), f"{label} is not finite: {value!r}")
+    return number
+
+
+def _positive_integer(value: Any, label: str) -> int:
+    require(
+        not isinstance(value, bool) and isinstance(value, int) and value > 0,
+        f"{label} is not a positive integer: {value!r}",
+    )
+    return value
+
+
+def write_performance_manifest(
+    report_path: Path,
+    manifest_path: Path,
+    *,
+    max_launch_ready_milliseconds: float = DEFAULT_MAX_LAUNCH_READY_MILLISECONDS,
+    max_resident_memory_bytes: int = DEFAULT_MAX_RESIDENT_MEMORY_BYTES,
+) -> None:
+    max_launch = _finite_number(
+        max_launch_ready_milliseconds,
+        "maximum launch-ready milliseconds",
+    )
+    max_resident = _positive_integer(
+        max_resident_memory_bytes,
+        "maximum resident-memory bytes",
+    )
+    require(max_launch > 0, "maximum launch-ready milliseconds must be positive")
+
+    report = load_report(report_path)
+    require(report.get("ok") is True, f"{report_path} does not report ok=true")
+    require(report.get("appName") == "Quill Cowork", f"{report_path} has the wrong app identity")
+    performance = report.get("performance")
+    require(isinstance(performance, dict), f"{report_path} is missing performance evidence")
+    require(performance.get("schemaVersion") == 1, "unsupported performance evidence schema")
+    require(
+        performance.get("measurement") == "initial-live-window",
+        "unexpected performance measurement boundary",
+    )
+
+    launch_ready = _finite_number(
+        performance.get("launchReadyMilliseconds"),
+        "performance.launchReadyMilliseconds",
+    )
+    resident = _positive_integer(
+        performance.get("residentMemoryBytes"),
+        "performance.residentMemoryBytes",
+    )
+    thread_count = _positive_integer(
+        performance.get("threadCount"),
+        "performance.threadCount",
+    )
+    require(launch_ready >= 0, "performance.launchReadyMilliseconds cannot be negative")
+    require(
+        launch_ready <= max_launch,
+        f"packaged launch-ready time {launch_ready:.2f}ms exceeds {max_launch:.2f}ms budget",
+    )
+    require(
+        resident <= max_resident,
+        f"packaged resident memory {resident} bytes exceeds {max_resident} byte budget",
+    )
+
+    manifest = {
+        "schemaVersion": 1,
+        "ok": True,
+        "product": "Quill Cowork",
+        "measurement": "initial-live-window",
+        "launchReadyMilliseconds": launch_ready,
+        "residentMemoryBytes": resident,
+        "residentMemoryMiB": round(resident / (1024 * 1024), 2),
+        "threadCount": thread_count,
+        "budgets": {
+            "maximumLaunchReadyMilliseconds": max_launch,
+            "maximumResidentMemoryBytes": max_resident,
+        },
+        "withinBudget": True,
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with manifest_path.open("w", encoding="utf-8") as manifest_file:
+        json.dump(manifest, manifest_file, indent=2, sort_keys=True)
+        manifest_file.write("\n")
+
+    print(
+        "Quill Cowork packaged performance passed: "
+        f"{launch_ready:.2f}ms launch-ready, {manifest['residentMemoryMiB']:.2f} MiB resident."
+    )

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -15,6 +15,7 @@ UPDATE_CHANNEL="${QUILLCODE_UPDATE_CHANNEL:-tester}"
 SIGNING_IDENTITY="${QUILLCODE_MACOS_SIGNING_IDENTITY:-}"
 SIGNING_TEAM_IDENTIFIER="${QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER:-}"
 SIGNING_KEYCHAIN="${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}"
+SWIFT_DEBUG_INFO_FORMAT="${QUILLCODE_SWIFT_DEBUG_INFO_FORMAT:-}"
 NOTARY_KEY_ID="${QUILLCODE_MACOS_NOTARY_KEY_ID:-}"
 NOTARY_ISSUER_ID="${QUILLCODE_MACOS_NOTARY_ISSUER_ID:-}"
 NOTARY_KEY_PATH="${QUILLCODE_MACOS_NOTARY_KEY_PATH:-}"
@@ -72,6 +73,7 @@ APP_BUNDLE="$(
 )"
 
 APP_ZIP="$ASSET_DIR/Quill-Cowork-macOS-$ARCH.zip"
+PERFORMANCE_MANIFEST="$ASSET_DIR/Quill-Cowork-macOS-$ARCH-PERFORMANCE.json"
 NOTARIZED=false
 CODESIGN_KIND="ad-hoc"
 if [[ -n "$SIGNING_IDENTITY" ]]; then
@@ -96,11 +98,25 @@ if [[ -n "$SIGNING_IDENTITY" ]]; then
     rm -f "$NOTARY_ARCHIVE"
   fi
 fi
+"$ROOT_DIR/scripts/packaged-macos-performance-smoke.sh" \
+  --app "$APP_BUNDLE" \
+  --manifest "$PERFORMANCE_MANIFEST"
 ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$APP_ZIP"
 
 echo "==> Packaging quill-code macOS CLI ($ARCH)"
-swift build --configuration "$CONFIGURATION" --product quill-code >&2
-BIN_DIR="$(swift build --configuration "$CONFIGURATION" --product quill-code --show-bin-path)"
+SWIFT_BUILD_ARGUMENTS=(--configuration "$CONFIGURATION" --product quill-code)
+if [[ -n "$SWIFT_DEBUG_INFO_FORMAT" ]]; then
+  case "$SWIFT_DEBUG_INFO_FORMAT" in
+    dwarf|codeview|none) ;;
+    *)
+      echo "Unsupported QUILLCODE_SWIFT_DEBUG_INFO_FORMAT: $SWIFT_DEBUG_INFO_FORMAT" >&2
+      exit 2
+      ;;
+  esac
+  SWIFT_BUILD_ARGUMENTS+=(-debug-info-format "$SWIFT_DEBUG_INFO_FORMAT")
+fi
+swift build "${SWIFT_BUILD_ARGUMENTS[@]}" >&2
+BIN_DIR="$(swift build "${SWIFT_BUILD_ARGUMENTS[@]}" --show-bin-path)"
 cp "$BIN_DIR/quill-code" "$CLI_DIR/quill-code"
 chmod 755 "$CLI_DIR/quill-code"
 cat > "$CLI_DIR/README.txt" <<README
@@ -132,6 +148,7 @@ updateManifestURL=$UPDATE_MANIFEST_URL
 stableUpdateManifestURL=$STABLE_MANIFEST_URL
 testerUpdateManifestURL=$TESTER_MANIFEST_URL
 app=Quill-Cowork-macOS-$ARCH.zip
+performance=Quill-Cowork-macOS-$ARCH-PERFORMANCE.json
 cli=quill-code-macOS-$ARCH.tar.gz
 codesign=$CODESIGN_KIND
 signingTeamIdentifier=${SIGNING_TEAM_IDENTIFIER:-none}
@@ -140,7 +157,9 @@ INFO
 
 (
   cd "$ASSET_DIR"
-  shasum -a 256 Quill-Cowork-macOS-"$ARCH".zip quill-code-macOS-"$ARCH".tar.gz BUILD_INFO.txt \
+  shasum -a 256 Quill-Cowork-macOS-"$ARCH".zip \
+    Quill-Cowork-macOS-"$ARCH"-PERFORMANCE.json \
+    quill-code-macOS-"$ARCH".tar.gz BUILD_INFO.txt \
     > "Quill-Cowork-macOS-$ARCH-SHASUMS256.txt"
 )
 

--- a/scripts/packaged-macos-performance-smoke.sh
+++ b/scripts/packaged-macos-performance-smoke.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_BUNDLE=""
+MANIFEST_PATH=""
+MAX_LAUNCH_READY_MILLISECONDS="${QUILLCODE_MAX_LAUNCH_READY_MILLISECONDS:-3000}"
+MAX_RESIDENT_MEMORY_BYTES="${QUILLCODE_MAX_RESIDENT_MEMORY_BYTES:-268435456}"
+SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/quillcode-packaged-performance.XXXXXX")"
+REPORT_PATH="$SMOKE_ROOT/window-report.json"
+SCREENSHOT_PATH="$SMOKE_ROOT/window.png"
+STATE_ROOT="$SMOKE_ROOT/window-state"
+
+cleanup() {
+  rm -rf "$SMOKE_ROOT"
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      APP_BUNDLE="$2"
+      shift 2
+      ;;
+    --manifest)
+      MANIFEST_PATH="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "packaged-macos-performance-smoke.sh must run on macOS." >&2
+  exit 2
+fi
+if [[ ! -d "$APP_BUNDLE" || -z "$MANIFEST_PATH" ]]; then
+  echo "Usage: packaged-macos-performance-smoke.sh --app APP_BUNDLE --manifest OUTPUT_JSON" >&2
+  exit 2
+fi
+
+INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
+EXECUTABLE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST")"
+APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/$EXECUTABLE_NAME"
+if [[ ! -x "$APP_EXECUTABLE" ]]; then
+  echo "Packaged app executable is missing: $APP_EXECUTABLE" >&2
+  exit 1
+fi
+
+echo "==> Measuring packaged Quill Cowork launch and resident memory"
+"$APP_EXECUTABLE" \
+  --native-window-smoke \
+  --window-smoke-report "$REPORT_PATH" \
+  --window-smoke-screenshot "$SCREENSHOT_PATH" \
+  --window-smoke-state-root "$STATE_ROOT" \
+  >/dev/null &
+SMOKE_PID="$!"
+
+elapsed=0
+while kill -0 "$SMOKE_PID" 2>/dev/null; do
+  if [[ "$elapsed" -ge 60 ]]; then
+    echo "Packaged performance smoke timed out after 60s." >&2
+    kill "$SMOKE_PID" 2>/dev/null || true
+    wait "$SMOKE_PID" 2>/dev/null || true
+    exit 124
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+done
+wait "$SMOKE_PID"
+
+"$ROOT_DIR/scripts/native-click-probe-contracts.py" performance \
+  "$REPORT_PATH" \
+  --manifest "$MANIFEST_PATH" \
+  --max-launch-ready-milliseconds "$MAX_LAUNCH_READY_MILLISECONDS" \
+  --max-resident-memory-bytes "$MAX_RESIDENT_MEMORY_BYTES"

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -15,6 +15,7 @@ ONE_TURN_COWORKER_MANIFEST="$SMOKE_ROOT/packaged-one-turn-coworker.json"
 BROWSER_WORKFLOW_MANIFEST="$SMOKE_ROOT/packaged-browser-workflow.json"
 COMPUTER_USE_MANIFEST="$SMOKE_ROOT/packaged-computer-use.json"
 COMPUTER_USE_ACTION_MANIFEST="$SMOKE_ROOT/packaged-computer-use-action.json"
+PERFORMANCE_MANIFEST="$SMOKE_ROOT/packaged-performance.json"
 WINDOW_REPORT_PATH="$SMOKE_ROOT/window-report.json"
 WINDOW_SCREENSHOT_PATH="$SMOKE_ROOT/window.png"
 WINDOW_STATE_ROOT="$SMOKE_ROOT/window-state"
@@ -64,6 +65,9 @@ cleanup() {
     if [[ -e "$COMPUTER_USE_ACTION_MANIFEST" ]]; then
       cp "$COMPUTER_USE_ACTION_MANIFEST" "$ARTIFACT_DIR/packaged-computer-use-action.json"
     fi
+    if [[ -e "$PERFORMANCE_MANIFEST" ]]; then
+      cp "$PERFORMANCE_MANIFEST" "$ARTIFACT_DIR/packaged-performance.json"
+    fi
     if [[ -e "$WINDOW_REPORT_PATH" ]]; then
       cp "$WINDOW_REPORT_PATH" "$ARTIFACT_DIR/window-report.json"
     fi
@@ -88,6 +92,7 @@ cleanup() {
       printf 'browser_workflow_manifest=packaged-browser-workflow.json\n'
       printf 'computer_use_manifest=packaged-computer-use.json\n'
       printf 'computer_use_action_manifest=packaged-computer-use-action.json\n'
+      printf 'performance_manifest=packaged-performance.json\n'
       printf 'window_smoke=window-report.json\n'
       printf 'window_screenshot=window.png\n'
     } > "$ARTIFACT_DIR/manifest.txt"
@@ -232,6 +237,10 @@ fi
   "$WINDOW_SCREENSHOT_PATH" \
   --click-probe-manifest "$CLICK_PROBE_MANIFEST" \
   --manifest "$ACCESSIBILITY_FRAMES_MANIFEST"
+
+"$ROOT_DIR/scripts/native-click-probe-contracts.py" performance \
+  "$WINDOW_REPORT_PATH" \
+  --manifest "$PERFORMANCE_MANIFEST"
 
 "$ROOT_DIR/scripts/native-click-probe-contracts.py" computer-use \
   "$DIRECT_SMOKE_ARTIFACT_DIR/report.json" \


### PR DESCRIPTION
## Summary
- capture app-entry-to-live-window latency, resident memory, and thread count from the packaged native app
- fail macOS publication above a 3 second / 256 MiB budget and publish architecture-specific PERFORMANCE.json evidence
- make Search focus recovery cancellable and reliable across optimized transient-surface transitions
- let the CLI packager honor the existing Swift debug-info override

## Verification
- full Swift suite: 5,401 tests, 5 skipped, 0 failures
- focused performance/download/window contracts: 21 tests, 0 failures
- packaged direct executable + Launch Services + live-window smoke: passed
- final release package: 672.05 ms launch-ready, 99.84 MiB resident, 7 threads
- package checksums, shell syntax, Python compile, diff/secret scan: passed
- changed-file quality grader: A+