### PR TITLE
Publish a verified macOS disk image

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -203,7 +203,8 @@ jobs:
           Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 
           Downloads:
-          - \`Quill-Cowork-macOS-*.zip\`: macOS app bundle for testers.
+          - \`Quill-Cowork-macOS-*.dmg\`: recommended drag-to-Applications macOS installer.
+          - \`Quill-Cowork-macOS-*.zip\`: verified macOS auto-update archive and manual fallback.
           - \`Quill-Cowork-macOS-*-PERFORMANCE.json\`: measured launch and resident-memory release evidence.
           - \`quill-code-macOS-*.tar.gz\`: macOS CLI.
           - \`quill-code-linux-*.tar.gz\`: Linux CLI.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **A native macOS coding agent and AI coworker for real project work.**
 
-[Download for macOS (Apple silicon)](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip) · [Release notes and checksums](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest) · [CLI downloads](docs/DOWNLOADS.md)
+[Download for macOS (Apple silicon)](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg) · [Release notes and checksums](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest) · [CLI downloads](docs/DOWNLOADS.md)
 
 ![Quill Cowork desktop app showing TrustedRouter onboarding](docs/images/quill-cowork-desktop.png)
 
@@ -30,11 +30,14 @@ with automatic rollback.
 
 The current desktop build requires **macOS 14 or later** and an **Apple silicon Mac**.
 
-1. [Download the latest Quill Cowork zip](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip).
-2. Open the zip and move **Quill Cowork.app** into **Applications**.
+1. [Download the latest Quill Cowork disk image](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg).
+2. Open the disk image and drag **Quill Cowork.app** onto **Applications**, then eject it.
 3. For the current tester build, right-click the app and choose **Open** on first launch if macOS
    blocks it. Tester builds are ad-hoc code-signed but are not Apple-notarized yet.
 4. Sign in with TrustedRouter from the welcome screen, or add a developer key in **Settings**.
+
+The [ZIP app archive](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip)
+remains available as a manual fallback and as the verified auto-update payload.
 
 Quill Cowork checks for updates automatically and also provides **Check for Updates...** in the app
 menu. Downloads are size- and SHA-256-verified, the app identity and code signature are checked before
@@ -45,7 +48,7 @@ finish launching.
 
 | Platform | Artifact | Status |
 | --- | --- | --- |
-| macOS arm64 | [Quill Cowork app](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip) | Tester preview |
+| macOS arm64 | [Quill Cowork app](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg) | Tester preview |
 | macOS arm64 | [Quill Cowork CLI](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-macOS-arm64.tar.gz) | Tester preview |
 | Linux x86_64 | [Quill Cowork CLI](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-linux-x86_64.tar.gz) | Tester preview |
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationSampler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationSampler.swift
@@ -275,9 +275,7 @@ enum QuillCodeDesktopAccessibilityActivationSampler {
             expected: baseline,
             controller: controller
         )
-        // State changes can replace SwiftUI's backing AX elements. Let the accessibility
-        // hierarchy settle before the next contract resolves a fresh element snapshot.
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        await QuillCodeDesktopAccessibilityHierarchySettler.waitUntilStable(in: contentView)
         let resetIssue = didRestoreBaseline
             ? nil
             : "\(contract.contractID) could not restore its baseline state after AXPress"

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityHierarchySettler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityHierarchySettler.swift
@@ -1,0 +1,48 @@
+import AppKit
+import Foundation
+
+@MainActor
+enum QuillCodeDesktopAccessibilityHierarchySettler {
+    private static let sampleIntervalNanoseconds: UInt64 = 50_000_000
+    private static let requiredStableComparisons = 6
+    private static let maximumSamples = 30
+
+    static func waitUntilStable(in contentView: NSView) async {
+        var previousSignature: [String]?
+        var stableComparisonCount = 0
+
+        for _ in 0..<maximumSamples {
+            try? await Task.sleep(nanoseconds: sampleIntervalNanoseconds)
+            guard !Task.isCancelled else { return }
+            let currentSignature = signature(
+                for: QuillCodeDesktopAccessibilityTree(root: contentView).elements
+            )
+            if currentSignature == previousSignature {
+                stableComparisonCount += 1
+                if stableComparisonCount >= requiredStableComparisons {
+                    return
+                }
+            } else {
+                previousSignature = currentSignature
+                stableComparisonCount = 0
+            }
+        }
+    }
+
+    static func signature(
+        for elements: [QuillCodeDesktopAccessibilityElementSnapshot]
+    ) -> [String] {
+        elements.map { element in
+            let frame = element.frame.map {
+                [
+                    Int($0.minX.rounded()),
+                    Int($0.minY.rounded()),
+                    Int($0.width.rounded()),
+                    Int($0.height.rounded())
+                ].map(String.init).joined(separator: ",")
+            } ?? "none"
+            return [element.identifier, element.role, element.bestLabel, frame]
+                .joined(separator: "|")
+        }.sorted()
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Foundation
 import XCTest
 import QuillCodeApp
@@ -7,6 +8,49 @@ import QuillComputerUseKit
 
 @MainActor
 final class QuillCodeDesktopWindowReportTests: XCTestCase {
+    func testAccessibilityHierarchySignatureIsOrderIndependentAndFrameSensitive() {
+        let application = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
+        let first = QuillCodeDesktopAccessibilityElementSnapshot(
+            element: application,
+            identifier: "first",
+            role: "AXButton",
+            title: "First",
+            accessibilityLabel: "",
+            help: "",
+            value: "",
+            isFocused: false,
+            frame: CGRect(x: 10, y: 20, width: 100, height: 40),
+            ancestorIdentifiers: []
+        )
+        var moved = first
+        moved.frame = CGRect(x: 11, y: 20, width: 100, height: 40)
+        let second = QuillCodeDesktopAccessibilityElementSnapshot(
+            element: application,
+            identifier: "second",
+            role: "AXTextField",
+            title: "",
+            accessibilityLabel: "Search",
+            help: "",
+            value: "",
+            isFocused: true,
+            frame: CGRect(x: 20, y: 80, width: 200, height: 30),
+            ancestorIdentifiers: []
+        )
+
+        let forward = QuillCodeDesktopAccessibilityHierarchySettler.signature(
+            for: [first, second]
+        )
+        let reversed = QuillCodeDesktopAccessibilityHierarchySettler.signature(
+            for: [second, first]
+        )
+        let changed = QuillCodeDesktopAccessibilityHierarchySettler.signature(
+            for: [moved, second]
+        )
+
+        XCTAssertEqual(forward, reversed)
+        XCTAssertNotEqual(forward, changed)
+    }
+
     func testDesktopPerformanceSnapshotCapturesBoundedProcessResources() throws {
         let now = ProcessInfo.processInfo.systemUptime
         let snapshot = try QuillCodeDesktopPerformanceSnapshot.capture(

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -29,6 +29,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
                 encoding: .utf8
             )
         try Data("mac app".utf8).write(to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64.zip"))
+        try Data("mac installer".utf8).write(
+            to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64.dmg")
+        )
         try Data(#"{"withinBudget":true}"#.utf8).write(
             to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64-PERFORMANCE.json")
         )
@@ -94,7 +97,13 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertEqual(updaterAppAsset["name"] as? String, "Quill-Cowork-macOS-arm64.zip")
 
         let assets = try XCTUnwrap(manifest["assets"] as? [[String: Any]])
-        XCTAssertEqual(assets.count, 7)
+        XCTAssertEqual(assets.count, 8)
+
+        let installerAsset = try asset(named: "Quill-Cowork-macOS-arm64.dmg", in: assets)
+        XCTAssertEqual(installerAsset["kind"] as? String, "installer")
+        XCTAssertEqual(installerAsset["platform"] as? String, "macOS")
+        XCTAssertEqual(installerAsset["arch"] as? String, "arm64")
+        XCTAssertEqual(installerAsset["install"] as? String, "dmg-app")
 
         let appAsset = try asset(named: "Quill-Cowork-macOS-arm64.zip", in: assets)
         XCTAssertEqual(appAsset["kind"] as? String, "app")
@@ -221,6 +230,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "RELEASE_CHANNEL=\"tester\"",
             "RELEASE_CHANNEL=\"stable\"",
             "quillcode-macos-downloads/BUILD_INFO.txt",
+            "Quill-Cowork-macOS-*.dmg",
+            "recommended drag-to-Applications macOS installer",
             "\\`${MANIFEST_NAME}\\`: machine-readable build metadata",
             "updater feed metadata",
             "current-release-assets.txt",
@@ -293,6 +304,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             contentsOf: root.appendingPathComponent("scripts").appendingPathComponent("packaged-macos-smoke.sh"),
             encoding: .utf8
         )
+        let diskImageScript = try String(
+            contentsOf: root.appendingPathComponent("scripts").appendingPathComponent("create-macos-disk-image.sh"),
+            encoding: .utf8
+        )
 
         Self.assertSource(buildScript, containsAll: [
             "QUILLCODE_MACOS_UPDATE_CHANNEL",
@@ -312,10 +327,20 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "updateManifestURL=$UPDATE_MANIFEST_URL",
             "stableUpdateManifestURL=$STABLE_MANIFEST_URL",
             "testerUpdateManifestURL=$TESTER_MANIFEST_URL",
+            "installer=Quill-Cowork-macOS-$ARCH.dmg",
             "performance=Quill-Cowork-macOS-$ARCH-PERFORMANCE.json",
             "scripts/packaged-macos-performance-smoke.sh",
+            "scripts/create-macos-disk-image.sh",
             "signingTeamIdentifier=${SIGNING_TEAM_IDENTIFIER:-none}",
             "notarized=$NOTARIZED"
+        ])
+        Self.assertSource(diskImageScript, containsAll: [
+            "ditto \"$APP_BUNDLE\" \"$STAGING_DIR/$APP_NAME\"",
+            "ln -s /Applications \"$STAGING_DIR/Applications\"",
+            "hdiutil create",
+            "hdiutil verify",
+            "hdiutil attach",
+            "codesign --verify --deep --strict"
         ])
         Self.assertSource(smokeScript, containsAll: [
             "assert_plist_value QuillCodeUpdateChannel tester",

--- a/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
@@ -12,10 +12,12 @@ final class ParityPublicDistributionGateTests: QuillCodeParityTestCase {
         Self.assertSource(
             readme,
             containsAll: [
+                "releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg",
                 "releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip",
                 "docs/images/quill-cowork-desktop.png",
                 "macOS 14 or later",
                 "Apple silicon Mac",
+                "drag **Quill Cowork.app** onto **Applications**",
                 "checks for updates automatically",
                 "activation is atomic",
                 "not Apple-notarized yet"

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3533,3 +3533,17 @@
 - **Evidence:** `QuillCodeDesktopPerformanceSnapshot`, the window-smoke performance object,
   `scripts/native_click_probe_contracts/performance.py`, `scripts/packaged-macos-performance-smoke.sh`,
   packaged smoke artifacts, and the public architecture-specific `PERFORMANCE.json` release asset.
+
+## 2026-08-07: human installation uses a verified disk image
+
+- **Decision:** macOS releases publish a compressed read-only DMG containing the already signed
+  `Quill Cowork.app` and a standard `/Applications` shortcut. Packaging mounts the completed image,
+  validates both entries, and verifies the embedded app signature before upload.
+- **Updater boundary:** The DMG is the recommended human installation artifact. The ZIP remains the
+  updater's declared `macOSAppAsset`, preserving the existing bounded download, SHA-256, extraction,
+  staged-swap, launch-handshake, and rollback contract.
+- **Why:** A drag-to-Applications image gives testers the normal macOS install flow without coupling
+  installer presentation to the security-critical updater archive or weakening stable signing and
+  notarization requirements.
+- **Evidence:** `scripts/create-macos-disk-image.sh`, macOS download packaging, manifest
+  classification, public download docs, and `ParityDownloadBuildsGateTests`.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -10,7 +10,8 @@ Send testers this moving prerelease link:
 
 Direct asset links for the current tester channel:
 
-- [macOS app: `Quill-Cowork-macOS-arm64.zip`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip)
+- [macOS installer: `Quill-Cowork-macOS-arm64.dmg`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg)
+- [macOS updater archive: `Quill-Cowork-macOS-arm64.zip`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip)
 - [macOS performance evidence: `Quill-Cowork-macOS-arm64-PERFORMANCE.json`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64-PERFORMANCE.json)
 - [macOS CLI: `quill-code-macOS-arm64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-macOS-arm64.tar.gz)
 - [Linux CLI: `quill-code-linux-x86_64.tar.gz`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-linux-x86_64.tar.gz)
@@ -22,7 +23,9 @@ The build manifest is the app updater, website, and support script contract. It
 records the build channel, tag, commit, workflow run URL, version, build number,
 per-asset download URL, size, platform, architecture, and SHA-256 digest. It also
 includes an `updater` object with the feed URL, bundle identifier, minimum macOS
-version, signing/notarization status, and current macOS app asset.
+version, signing/notarization status, and current macOS updater asset. The DMG
+is the recommended human installation path; the ZIP remains the machine-verified
+updater payload so installation ergonomics cannot change update semantics.
 
 ## Build Cadence
 

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -54,6 +54,9 @@ def parse_build_info(asset_directory: Path) -> dict[str, str]:
 
 
 def classify_asset(name: str) -> dict[str, str]:
+    if name.startswith("Quill-Cowork-macOS-") and name.endswith(".dmg"):
+        arch = name.removeprefix("Quill-Cowork-macOS-").removesuffix(".dmg")
+        return {"kind": "installer", "platform": "macOS", "arch": arch, "install": "dmg-app"}
     if name.startswith("Quill-Cowork-macOS-") and name.endswith(".zip"):
         arch = name.removeprefix("Quill-Cowork-macOS-").removesuffix(".zip")
         return {"kind": "app", "platform": "macOS", "arch": arch, "install": "zip-app"}

--- a/scripts/create-macos-disk-image.sh
+++ b/scripts/create-macos-disk-image.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_BUNDLE=""
+OUTPUT_PATH=""
+VOLUME_NAME="Quill Cowork"
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/quill-cowork-disk-image.XXXXXX")"
+STAGING_DIR="$WORK_ROOT/staging"
+MOUNT_POINT="$WORK_ROOT/mounted"
+MOUNTED=false
+
+cleanup() {
+  set +e
+  if [[ "$MOUNTED" == true ]]; then
+    hdiutil detach -quiet "$MOUNT_POINT" || hdiutil detach -quiet -force "$MOUNT_POINT"
+  fi
+  rm -rf "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      APP_BUNDLE="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    --volume-name)
+      VOLUME_NAME="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "create-macos-disk-image.sh must run on macOS." >&2
+  exit 2
+fi
+if [[ ! -d "$APP_BUNDLE" || "$APP_BUNDLE" != *.app || -z "$OUTPUT_PATH" ]]; then
+  echo "Usage: create-macos-disk-image.sh --app APP_BUNDLE --output OUTPUT_DMG" >&2
+  exit 2
+fi
+
+APP_NAME="$(basename "$APP_BUNDLE")"
+APP_EXECUTABLE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP_BUNDLE/Contents/Info.plist")"
+if [[ ! -x "$APP_BUNDLE/Contents/MacOS/$APP_EXECUTABLE_NAME" ]]; then
+  echo "App executable is missing from $APP_BUNDLE" >&2
+  exit 1
+fi
+
+mkdir -p "$STAGING_DIR" "$MOUNT_POINT" "$(dirname "$OUTPUT_PATH")"
+ditto "$APP_BUNDLE" "$STAGING_DIR/$APP_NAME"
+ln -s /Applications "$STAGING_DIR/Applications"
+touch "$STAGING_DIR/.metadata_never_index"
+
+hdiutil create \
+  -quiet \
+  -ov \
+  -format UDZO \
+  -fs HFS+ \
+  -volname "$VOLUME_NAME" \
+  -srcfolder "$STAGING_DIR" \
+  "$OUTPUT_PATH"
+hdiutil verify -quiet "$OUTPUT_PATH"
+
+hdiutil attach -quiet -readonly -nobrowse -mountpoint "$MOUNT_POINT" "$OUTPUT_PATH"
+MOUNTED=true
+if [[ ! -d "$MOUNT_POINT/$APP_NAME" || ! -x "$MOUNT_POINT/$APP_NAME/Contents/MacOS/$APP_EXECUTABLE_NAME" ]]; then
+  echo "Mounted disk image does not contain an executable $APP_NAME bundle." >&2
+  exit 1
+fi
+if [[ ! -L "$MOUNT_POINT/Applications" || "$(readlink "$MOUNT_POINT/Applications")" != "/Applications" ]]; then
+  echo "Mounted disk image does not contain the /Applications install shortcut." >&2
+  exit 1
+fi
+codesign --verify --deep --strict "$MOUNT_POINT/$APP_NAME"
+hdiutil detach -quiet "$MOUNT_POINT"
+MOUNTED=false
+
+if [[ ! -s "$OUTPUT_PATH" ]]; then
+  echo "Disk image was not created: $OUTPUT_PATH" >&2
+  exit 1
+fi
+echo "$OUTPUT_PATH"

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -73,6 +73,7 @@ APP_BUNDLE="$(
 )"
 
 APP_ZIP="$ASSET_DIR/Quill-Cowork-macOS-$ARCH.zip"
+APP_DMG="$ASSET_DIR/Quill-Cowork-macOS-$ARCH.dmg"
 PERFORMANCE_MANIFEST="$ASSET_DIR/Quill-Cowork-macOS-$ARCH-PERFORMANCE.json"
 NOTARIZED=false
 CODESIGN_KIND="ad-hoc"
@@ -101,6 +102,9 @@ fi
 "$ROOT_DIR/scripts/packaged-macos-performance-smoke.sh" \
   --app "$APP_BUNDLE" \
   --manifest "$PERFORMANCE_MANIFEST"
+"$ROOT_DIR/scripts/create-macos-disk-image.sh" \
+  --app "$APP_BUNDLE" \
+  --output "$APP_DMG"
 ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$APP_ZIP"
 
 echo "==> Packaging quill-code macOS CLI ($ARCH)"
@@ -147,6 +151,7 @@ updateChannel=$UPDATE_CHANNEL
 updateManifestURL=$UPDATE_MANIFEST_URL
 stableUpdateManifestURL=$STABLE_MANIFEST_URL
 testerUpdateManifestURL=$TESTER_MANIFEST_URL
+installer=Quill-Cowork-macOS-$ARCH.dmg
 app=Quill-Cowork-macOS-$ARCH.zip
 performance=Quill-Cowork-macOS-$ARCH-PERFORMANCE.json
 cli=quill-code-macOS-$ARCH.tar.gz
@@ -157,7 +162,8 @@ INFO
 
 (
   cd "$ASSET_DIR"
-  shasum -a 256 Quill-Cowork-macOS-"$ARCH".zip \
+  shasum -a 256 Quill-Cowork-macOS-"$ARCH".dmg \
+    Quill-Cowork-macOS-"$ARCH".zip \
     Quill-Cowork-macOS-"$ARCH"-PERFORMANCE.json \
     quill-code-macOS-"$ARCH".tar.gz BUILD_INFO.txt \
     > "Quill-Cowork-macOS-$ARCH-SHASUMS256.txt"


### PR DESCRIPTION
## Summary
- publish a verified drag-to-Applications DMG as the recommended macOS installer
- preserve the ZIP app archive as the bounded, SHA-verified auto-update payload
- replace a fixed accessibility reset delay with bounded hierarchy-settling to eliminate an intermittent optimized-build focus race
- document and contract-test the human installer/updater boundary

## Verification
- `swift test -debug-info-format none`: 5,402 tests passed, 5 skipped
- packaged macOS smoke: direct executable, Launch Services, live-window accessibility/pixel checks passed
- packaged performance: 586 ms / 95.7 MiB; fresh release package 703 ms / 98.4 MiB
- fresh release package built DMG, ZIP, CLI, performance, build-info, and SHA-256 assets
- disk image creation, read-only mount, Applications shortcut, embedded executable, code signature, checksum, and updater manifest verified
- touched runtime/distribution files grade A+ with `scripts/grade-code-quality.py`