### PR TITLE
Measure packaged launch without harness delay

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -291,7 +291,6 @@ private enum QuillCodeDesktopWindowSmokeLaunch {
                     NotificationCenter.default.removeObserver(observer)
                     Self.observer = nil
                 }
-                try? await Task.sleep(nanoseconds: 300_000_000)
                 await QuillCodeDesktopWindowSmokeRunner.runAndExit(
                     request,
                     controller: controller,

--- a/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
@@ -21,6 +21,10 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
             #"static let measurement = "initial-live-window""#
         ])
         Self.assertSource(app, contains: "QuillCodeDesktopLaunchClock.appEntryUptime")
+        let smokeLaunchStart = try XCTUnwrap(
+            app.range(of: "private enum QuillCodeDesktopWindowSmokeLaunch")
+        ).lowerBound
+        Self.assertSource(String(app[smokeLaunchStart...]), excludes: "Task.sleep")
         Self.assertSource(runner, contains: "QuillCodeDesktopPerformanceSnapshot.capture(")
         let performanceIndex = try XCTUnwrap(runner.range(of: "let performance = try")).lowerBound
         let screenshotIndex = try XCTUnwrap(runner.range(of: "captureValidatedImageStats(")).lowerBound


### PR DESCRIPTION
## Summary
- remove the synthetic 300 ms post-launch sleep from the packaged live-window smoke
- rely on the existing bounded `waitForWindow` readiness polling
- contract-test that the smoke-launch path cannot add an artificial sleep
- keep the three-second launch and 256 MiB memory release budgets unchanged

## Evidence
- hosted release failure isolated to 3128.5 ms after the harness included its 300 ms delay
- corrected optimized launches: 271 ms, 229 ms, 240 ms
- corrected complete release package: 339 ms / 97.0 MiB
- focused performance contracts: 3 passed
- complete DMG, updater ZIP, CLI, checksums, signature, and mount verification passed
- both touched files grade A+ with `scripts/grade-code-quality.py`