### PR TITLE
Verify packaged source provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ remains available as a manual fallback and as the verified auto-update payload.
 
 Quill Cowork checks for updates automatically and also provides **Check for Updates...** in the app
 menu. Downloads are size- and SHA-256-verified, the app identity and code signature are checked before
-installation, activation is atomic, and the previous build is restored if the new build cannot
-finish launching.
+installation, the packaged source commit must match the public manifest, activation is atomic, and
+the previous build is restored if the new build cannot finish launching. Use **Report an Issue...**
+in the app menu to open a prefilled GitHub report with bounded build and system information; it does
+not attach project paths, transcripts, or credentials.
 
 ## Downloads
 

--- a/Sources/quill-code-desktop/DesktopCommands.swift
+++ b/Sources/quill-code-desktop/DesktopCommands.swift
@@ -7,6 +7,7 @@ struct QuillCodeDesktopCommands: Commands {
     var shortcutProfile: WorkspaceShortcutProfile
     var onCommand: (String) -> Void
     var onCheckForUpdates: () -> Void
+    var onReportIssue: () -> Void
 
     private var commandsByID: [String: WorkspaceCommandSurface] {
         Dictionary(uniqueKeysWithValues: commands.map { ($0.id, $0) })
@@ -16,6 +17,8 @@ struct QuillCodeDesktopCommands: Commands {
         CommandGroup(after: .appInfo) {
             Button("Check for Updates...", action: onCheckForUpdates)
                 .accessibilityIdentifier("quillcode-menu-check-for-updates")
+            Button("Report an Issue...", action: onReportIssue)
+                .accessibilityIdentifier("quillcode-menu-report-issue")
         }
 
         CommandMenu(QuillCodeProduct.displayName) {

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -64,7 +64,8 @@ struct QuillCodeDesktopApp: App {
                     preferences: controller.surface.settings.keyboardShortcuts
                 ),
                 onCommand: { controller.runCommand(commandID: $0) },
-                onCheckForUpdates: controller.checkForUpdates
+                onCheckForUpdates: controller.checkForUpdates,
+                onReportIssue: controller.reportIssue
             )
         }
         MenuBarExtra {
@@ -85,6 +86,7 @@ struct QuillCodeDesktopApp: App {
                 onDisconnectAll: controller.disconnectAll,
                 onComputerUseSetup: controller.openSettings,
                 onCheckForUpdates: controller.checkForUpdates,
+                onReportIssue: controller.reportIssue,
                 onQuit: {
                     NSApplication.shared.terminate(nil)
                 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopBuildMetadata.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopBuildMetadata.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+struct QuillCodeDesktopBuildMetadata: Equatable, Sendable {
+    static let commitInfoKey = "QuillCodeBuildCommit"
+
+    var version: String
+    var build: String
+    var commit: String
+    var channel: String
+    var architecture: String
+    var operatingSystem: String
+
+    static func current(
+        configuration: QuillCodeDesktopUpdateConfiguration?,
+        bundle: Bundle = .main,
+        architecture: String = QuillCodeDesktopArchitecture.current,
+        operatingSystemVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) -> Self {
+        let version = configuration?.currentVersion
+            ?? infoString("CFBundleShortVersionString", bundle: bundle)
+            ?? "development"
+        let build = configuration?.currentBuild
+            ?? infoString("CFBundleVersion", bundle: bundle)
+            ?? "development"
+        let rawCommit = infoString(commitInfoKey, bundle: bundle) ?? "development"
+        let commit = isCanonicalCommit(rawCommit) ? rawCommit : "development"
+        let channel = configuration?.channel.rawValue
+            ?? infoString(QuillCodeDesktopUpdateConfiguration.channelInfoKey, bundle: bundle)
+            ?? "development"
+        let resolvedArchitecture = configuration?.architecture ?? architecture
+        let system = [
+            operatingSystemVersion.majorVersion,
+            operatingSystemVersion.minorVersion,
+            operatingSystemVersion.patchVersion
+        ].map(String.init).joined(separator: ".")
+        return Self(
+            version: version,
+            build: build,
+            commit: commit,
+            channel: channel,
+            architecture: resolvedArchitecture,
+            operatingSystem: "macOS \(system)"
+        )
+    }
+
+    static func isCanonicalCommit(_ value: String) -> Bool {
+        value.count == 40 && value.unicodeScalars.allSatisfy { scalar in
+            ("0"..."9").contains(Character(scalar)) || ("a"..."f").contains(Character(scalar))
+        }
+    }
+
+    private static func infoString(_ key: String, bundle: Bundle) -> String? {
+        guard let value = bundle.object(forInfoDictionaryKey: key) as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Support.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Support.swift
@@ -1,0 +1,5 @@
+extension QuillCodeDesktopController {
+    func reportIssue() {
+        QuillCodeDesktopIssueReporter.open(configuration: updateController.configuration)
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
@@ -16,6 +16,11 @@ enum QuillCodeDesktopDownloadedApplicationValidator {
         else {
             throw QuillCodeDesktopUpdateError.invalidApplication("its identity or version does not match")
         }
+        guard bundle.object(
+            forInfoDictionaryKey: QuillCodeDesktopBuildMetadata.commitInfoKey
+        ) as? String == release.commit else {
+            throw QuillCodeDesktopUpdateError.invalidApplication("its source commit does not match")
+        }
 
         let signature = try QuillCodeDesktopUpdateProcessRunner.run(
             executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),

--- a/Sources/quill-code-desktop/QuillCodeDesktopIssueReporter.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopIssueReporter.swift
@@ -1,0 +1,55 @@
+import AppKit
+import Foundation
+
+enum QuillCodeDesktopIssueReporter {
+    private static let issuesURL = URL(string: "https://github.com/Lore-Hex/QuillCode/issues/new")!
+
+    static func issueURL(metadata: QuillCodeDesktopBuildMetadata) -> URL? {
+        guard var components = URLComponents(url: issuesURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.queryItems = [
+            URLQueryItem(name: "labels", value: "bug"),
+            URLQueryItem(name: "title", value: "[Bug] "),
+            URLQueryItem(name: "body", value: issueBody(metadata: metadata))
+        ]
+        return components.url
+    }
+
+    @MainActor
+    static func open(
+        configuration: QuillCodeDesktopUpdateConfiguration?,
+        bundle: Bundle = .main
+    ) {
+        let metadata = QuillCodeDesktopBuildMetadata.current(
+            configuration: configuration,
+            bundle: bundle
+        )
+        guard let url = issueURL(metadata: metadata) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private static func issueBody(metadata: QuillCodeDesktopBuildMetadata) -> String {
+        """
+        <!-- Describe what happened. Do not include API keys, credentials, or private project data. -->
+
+        ## What happened
+
+
+        ## Steps to reproduce
+
+        1.
+
+        ## Expected behavior
+
+
+        ## Build information
+
+        - Version: \(metadata.version) (\(metadata.build))
+        - Commit: \(metadata.commit)
+        - Channel: \(metadata.channel)
+        - System: \(metadata.operatingSystem)
+        - Architecture: \(metadata.architecture)
+        """
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
@@ -48,7 +48,8 @@ enum QuillCodeDesktopUpdateHelper {
                 request.incomingApplicationURL,
                 identifier: request.expectedBundleIdentifier,
                 version: request.expectedVersion,
-                build: request.expectedBuild
+                build: request.expectedBuild,
+                commit: request.expectedCommit
               )
         else {
             return
@@ -72,13 +73,15 @@ enum QuillCodeDesktopUpdateHelper {
                 request.destinationApplicationURL,
                 identifier: request.expectedBundleIdentifier,
                 version: nil,
-                build: nil
+                build: nil,
+                commit: nil
               ),
               bundleMatches(
                 request.incomingApplicationURL,
                 identifier: request.expectedBundleIdentifier,
                 version: request.expectedVersion,
-                build: request.expectedBuild
+                build: request.expectedBuild,
+                commit: request.expectedCommit
               ),
               QuillCodeDesktopUpdateLaunchHandshake.isAllowed(
                 request.handshakeURL,
@@ -216,7 +219,8 @@ enum QuillCodeDesktopUpdateHelper {
         _ url: URL,
         identifier: String,
         version: String?,
-        build: String?
+        build: String?,
+        commit: String?
     ) -> Bool {
         guard let bundle = Bundle(url: url), bundle.bundleIdentifier == identifier else { return false }
         if let version,
@@ -225,6 +229,10 @@ enum QuillCodeDesktopUpdateHelper {
         }
         if let build,
            bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String != build {
+            return false
+        }
+        if let commit,
+           bundle.object(forInfoDictionaryKey: QuillCodeDesktopBuildMetadata.commitInfoKey) as? String != commit {
             return false
         }
         return true

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
@@ -107,7 +107,8 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             logURL: logURL,
             expectedBundleIdentifier: configuration.bundleIdentifier,
             expectedVersion: preparedUpdate.release.version,
-            expectedBuild: preparedUpdate.release.build
+            expectedBuild: preparedUpdate.release.build,
+            expectedCommit: preparedUpdate.release.commit
         )
     }
 
@@ -141,6 +142,7 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
     var expectedBundleIdentifier: String
     var expectedVersion: String
     var expectedBuild: String
+    var expectedCommit: String
 
     var arguments: [String] {
         [
@@ -153,7 +155,8 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
             "--log", logURL.path,
             "--bundle-id", expectedBundleIdentifier,
             "--version", expectedVersion,
-            "--build", expectedBuild
+            "--build", expectedBuild,
+            "--commit", expectedCommit
         ]
     }
 
@@ -180,7 +183,9 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
               let log = values["--log"],
               let bundleIdentifier = values["--bundle-id"],
               let version = values["--version"],
-              let build = values["--build"]
+              let build = values["--build"],
+              let commit = values["--commit"],
+              QuillCodeDesktopBuildMetadata.isCanonicalCommit(commit)
         else {
             return nil
         }
@@ -194,7 +199,8 @@ struct QuillCodeDesktopUpdateHelperRequest: Equatable, Sendable {
             logURL: URL(fileURLWithPath: log).standardizedFileURL,
             expectedBundleIdentifier: bundleIdentifier,
             expectedVersion: version,
-            expectedBuild: build
+            expectedBuild: build,
+            expectedCommit: commit
         )
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeMenuBarView.swift
+++ b/Sources/quill-code-desktop/QuillCodeMenuBarView.swift
@@ -18,6 +18,7 @@ struct QuillCodeMenuBarView: View {
     var onDisconnectAll: () -> Void
     var onComputerUseSetup: () -> Void
     var onCheckForUpdates: () -> Void
+    var onReportIssue: () -> Void
     var onQuit: () -> Void
 
     var body: some View {
@@ -59,6 +60,7 @@ struct QuillCodeMenuBarView: View {
         }
         menuActionButton("Settings...", action: onSettings)
         menuActionButton("Check for Updates...", action: onCheckForUpdates)
+        menuActionButton("Report an Issue...", action: onReportIssue)
         Divider()
         menuActionButton("Stop All", isDisabled: stopAllCommand?.isEnabled != true, action: onStopAll)
         menuActionButton(

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopIssueReporterTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopIssueReporterTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopIssueReporterTests: XCTestCase {
+    func testIssueURLContainsOnlyBoundedBuildAndSystemMetadata() throws {
+        let commit = String(repeating: "a", count: 40)
+        let metadata = QuillCodeDesktopBuildMetadata(
+            version: "0.2.0",
+            build: "641",
+            commit: commit,
+            channel: "tester",
+            architecture: "arm64",
+            operatingSystem: "macOS 15.6.0"
+        )
+
+        let url = try XCTUnwrap(QuillCodeDesktopIssueReporter.issueURL(metadata: metadata))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: try components.queryItems.orEmpty.map { item in
+            (item.name, try XCTUnwrap(item.value))
+        })
+
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "github.com")
+        XCTAssertEqual(url.path, "/Lore-Hex/QuillCode/issues/new")
+        XCTAssertEqual(query["labels"], "bug")
+        XCTAssertEqual(query["title"], "[Bug] ")
+        let body = try XCTUnwrap(query["body"])
+        for expected in ["0.2.0 (641)", commit, "tester", "macOS 15.6.0", "arm64"] {
+            XCTAssertTrue(body.contains(expected), body)
+        }
+        for forbidden in ["/Users/", "transcript", "API key:", "project path"] {
+            XCTAssertFalse(body.contains(forbidden), body)
+        }
+    }
+
+    func testBuildMetadataRejectsNoncanonicalEmbeddedCommit() {
+        XCTAssertTrue(
+            QuillCodeDesktopBuildMetadata.isCanonicalCommit(String(repeating: "a", count: 40))
+        )
+        XCTAssertFalse(
+            QuillCodeDesktopBuildMetadata.isCanonicalCommit(String(repeating: "A", count: 40))
+        )
+        XCTAssertFalse(QuillCodeDesktopBuildMetadata.isCanonicalCommit("development"))
+    }
+}
+
+private extension Optional where Wrapped == [URLQueryItem] {
+    var orEmpty: [URLQueryItem] { self ?? [] }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -266,6 +266,32 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         }
     }
 
+    func testDownloadedApplicationRejectsMismatchedSourceCommitBeforeSystemValidation() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let applicationURL = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        try makeFakeApplication(
+            at: applicationURL,
+            version: "0.1.0",
+            build: "43",
+            commit: String(repeating: "b", count: 40),
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+
+        XCTAssertThrowsError(
+            try QuillCodeDesktopDownloadedApplicationValidator.validate(
+                applicationURL,
+                release: makeRelease(),
+                configuration: makeConfiguration()
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? QuillCodeDesktopUpdateError,
+                .invalidApplication("its source commit does not match")
+            )
+        }
+    }
+
     func testPreparerPrunesPreviousUpdateWorkspaces() async throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -444,7 +470,8 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             logURL: root.appendingPathComponent("install.log"),
             expectedBundleIdentifier: "co.lorehex.QuillCowork",
             expectedVersion: "0.2.0",
-            expectedBuild: "99"
+            expectedBuild: "99",
+            expectedCommit: String(repeating: "a", count: 40)
         )
 
         let parsed = try XCTUnwrap(QuillCodeDesktopUpdateHelperRequest.parse(
@@ -460,6 +487,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         XCTAssertEqual(parsed.logURL, request.logURL)
         XCTAssertEqual(parsed.expectedVersion, request.expectedVersion)
         XCTAssertEqual(parsed.expectedBuild, request.expectedBuild)
+        XCTAssertEqual(parsed.expectedCommit, request.expectedCommit)
     }
 
     func testHelperCompletesVerifiedSwapAfterLaunchHandshake() throws {
@@ -685,7 +713,8 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             logURL: workspace.appendingPathComponent("install.log"),
             expectedBundleIdentifier: "co.lorehex.QuillCowork",
             expectedVersion: expectedVersion,
-            expectedBuild: expectedBuild
+            expectedBuild: expectedBuild,
+            expectedCommit: String(repeating: "a", count: 40)
         )
     }
 
@@ -1017,6 +1046,7 @@ private func makeFakeApplication(
     at root: URL,
     version: String,
     build: String,
+    commit: String = String(repeating: "a", count: 40),
     executableScript: String
 ) throws {
     let contents = root.appendingPathComponent("Contents", isDirectory: true)
@@ -1030,7 +1060,8 @@ private func makeFakeApplication(
         "CFBundleIdentifier": "co.lorehex.QuillCowork",
         "CFBundlePackageType": "APPL",
         "CFBundleShortVersionString": version,
-        "CFBundleVersion": build
+        "CFBundleVersion": build,
+        QuillCodeDesktopBuildMetadata.commitInfoKey: commit
     ]
     let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
     try data.write(to: contents.appendingPathComponent("Info.plist"))

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -68,6 +68,9 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         let menuText = try Self.desktopSourceText(named: "QuillCodeMenuBarView.swift")
         Self.assertSource(menuText, contains: "onDisconnectAll")
         Self.assertSource(menuText, contains: "onOpenBrowserSession")
+        Self.assertSource(menuText, contains: "onReportIssue")
+        Self.assertSource(commandsText, contains: "quillcode-menu-report-issue")
+        Self.assertSource(appText, contains: "onReportIssue: controller.reportIssue")
         XCTAssertFalse(
             menuText.contains(#"Button("Disconnect All") {}"#),
             "Disconnect All must not regress to a no-op button."

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -318,6 +318,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "<key>QuillCodeUpdateManifestURL</key>",
             "<key>QuillCodeStableUpdateManifestURL</key>",
             "<key>QuillCodeTesterUpdateManifestURL</key>",
+            "<key>QuillCodeBuildCommit</key>",
             "QuillCodeSigningTeamIdentifier"
         ])
         Self.assertSource(packageScript, containsAll: [
@@ -327,6 +328,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "updateManifestURL=$UPDATE_MANIFEST_URL",
             "stableUpdateManifestURL=$STABLE_MANIFEST_URL",
             "testerUpdateManifestURL=$TESTER_MANIFEST_URL",
+            "QUILLCODE_MACOS_BUILD_COMMIT=\"$COMMIT\"",
             "installer=Quill-Cowork-macOS-$ARCH.dmg",
             "performance=Quill-Cowork-macOS-$ARCH-PERFORMANCE.json",
             "scripts/packaged-macos-performance-smoke.sh",
@@ -344,6 +346,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         ])
         Self.assertSource(smokeScript, containsAll: [
             "assert_plist_value QuillCodeUpdateChannel tester",
+            "assert_plist_value QuillCodeBuildCommit \"$EXPECTED_BUILD_COMMIT\"",
             "assert_plist_value QuillCodeUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json",
             "assert_plist_value QuillCodeStableUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json",
             "assert_plist_value QuillCodeTesterUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"

--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -66,6 +66,32 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         XCTAssertTrue(tagResult.output.contains("release tag resolves to"), tagResult.output)
     }
 
+    func testVerifierRejectsAppArchiveCommitDriftAfterIntegrityChecksPass() throws {
+        let fixture = try makeFixture(appCommit: String(repeating: "b", count: 40))
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("Info.plist QuillCodeBuildCommit disagrees with the manifest"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsSymlinkedAppInfoAfterIntegrityChecksPass() throws {
+        let fixture = try makeFixture(appInfoIsSymlink: true)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("Info.plist must be a readable regular entry"),
+            result.output
+        )
+    }
+
     private struct Fixture {
         var root: URL
         var assets: URL
@@ -73,7 +99,10 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         var releaseJSON: URL
     }
 
-    private func makeFixture() throws -> Fixture {
+    private func makeFixture(
+        appCommit: String? = nil,
+        appInfoIsSymlink: Bool = false
+    ) throws -> Fixture {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("quill-cowork-release-verifier-tests")
             .appendingPathComponent(UUID().uuidString)
@@ -84,7 +113,12 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         let cliName = "quill-code-macOS-arm64.tar.gz"
         let buildInfoName = "BUILD_INFO.txt"
         let checksumsName = "SHASUMS256.txt"
-        try Data("verified app payload".utf8).write(to: assetsURL.appendingPathComponent(appName))
+        try writeAppArchive(
+            to: assetsURL.appendingPathComponent(appName),
+            commit: appCommit ?? commit,
+            root: root,
+            infoIsSymlink: appInfoIsSymlink
+        )
         try Data("verified cli payload".utf8).write(to: assetsURL.appendingPathComponent(cliName))
         try """
         product=Quill Cowork
@@ -235,6 +269,58 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             "sha256": try sha256(at: url),
             "url": releaseDownloadURL(named: name)
         ]
+    }
+
+    private func writeAppArchive(
+        to archiveURL: URL,
+        commit: String,
+        root: URL,
+        infoIsSymlink: Bool
+    ) throws {
+        let scriptURL = root.appendingPathComponent("make-app-archive.py")
+        try """
+        import plistlib
+        import sys
+        import zipfile
+
+        values = {
+            "CFBundleName": "Quill Cowork",
+            "CFBundleDisplayName": "Quill Cowork",
+            "CFBundleIdentifier": "co.lorehex.QuillCowork",
+            "CFBundleShortVersionString": "0.2.0",
+            "CFBundleVersion": "123",
+            "LSMinimumSystemVersion": "14.0",
+            "QuillCodeBuildCommit": sys.argv[2],
+            "QuillCodeUpdateChannel": "tester",
+            "QuillCodeUpdateManifestURL": sys.argv[3],
+            "QuillCodeStableUpdateManifestURL": sys.argv[4],
+            "QuillCodeTesterUpdateManifestURL": sys.argv[3],
+        }
+        with zipfile.ZipFile(sys.argv[1], "w", zipfile.ZIP_DEFLATED) as archive:
+            path = "Quill Cowork.app/Contents/Info.plist"
+            if sys.argv[5] == "symlink":
+                entry = zipfile.ZipInfo(path)
+                entry.create_system = 3
+                entry.external_attr = 0o120777 << 16
+                archive.writestr(entry, b"Info.plist")
+            else:
+                archive.writestr(path, plistlib.dumps(values))
+        """.write(to: scriptURL, atomically: true, encoding: .utf8)
+        let result = try Self.runPython(scriptURL, arguments: [
+            archiveURL.path,
+            commit,
+            testerManifestURL,
+            stableManifestURL,
+            infoIsSymlink ? "symlink" : "regular"
+        ])
+        try FileManager.default.removeItem(at: scriptURL)
+        guard result.exitCode == 0 else {
+            throw NSError(
+                domain: "ParityPublishedReleaseVerificationGateTests",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: result.output]
+            )
+        }
     }
 
     private func runVerifier(

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3560,3 +3560,21 @@
 - **Evidence:** The public performance manifest records every attempt, pass counts, aggregation,
   the selected median-launch attempt, and budgets; `ParityPackagedPerformanceGateTests` covers
   passing and failing majorities.
+
+## 2026-08-07: packaged source provenance is end-to-end verified
+
+- **Decision:** Every packaged macOS app embeds its exact lowercase 40-character Git commit in
+  `QuillCodeBuildCommit`. Public release verification requires the updater ZIP's bounded
+  `Info.plist` identity, version, build, commit, update channel, feed URLs, minimum system version,
+  and optional signing team to agree with the public manifest.
+- **Updater boundary:** The downloaded-app validator and detached activation helper both require the
+  incoming app's embedded commit to equal the selected release. The currently installed app is not
+  required to carry the new key, preserving upgrades from earlier tester builds while preventing a
+  manifest and replacement app from naming different source revisions.
+- **Support boundary:** **Report an Issue...** opens the public GitHub issue form with only bounded
+  version, build, commit, channel, macOS, and architecture metadata. It does not collect logs,
+  transcripts, project paths, or credentials.
+- **Evidence:** `build-macos-app.sh`, `package-macos-downloads.sh`, packaged smoke,
+  `release_verification_files.py`, `QuillCodeDesktopDownloadedApplicationValidator`,
+  `QuillCodeDesktopUpdateHelper`, `QuillCodeDesktopIssueReporter`, and their focused parity and unit
+  tests.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -58,7 +58,10 @@ same public GitHub API and download URLs users receive. It resolves the release
 tag to the expected commit, checks the exact release inventory and updater feed
 contract, then downloads every declared asset with bounded streaming and
 verifies GitHub's digest, manifest size/SHA-256, `SHASUMS256.txt`, and
-`BUILD_INFO.txt`. A publication is not green until this consumer check passes.
+`BUILD_INFO.txt`. It also reads the updater ZIP's bounded `Info.plist` and requires
+the product identity, version, build, exact source commit, channel, feed URLs,
+minimum macOS version, and signing team to agree with the public manifest. A
+publication is not green until this consumer check passes.
 
 The release-configured macOS app must also open a real native window within three
 seconds and remain below 256 MiB of resident memory at that initial-window
@@ -73,6 +76,7 @@ turning one loaded-runner outlier into the product metric.
 
 The packaged macOS app embeds update metadata in `Info.plist`:
 
+- `QuillCodeBuildCommit`
 - `QuillCodeUpdateChannel`
 - `QuillCodeUpdateManifestURL`
 - `QuillCodeStableUpdateManifestURL`
@@ -103,8 +107,9 @@ next automatic due time when it succeeds. Quiet background failures retry after
 work for five minutes. The updater compares `CFBundleShortVersionString` plus
 `CFBundleVersion`, requires the configured repository, product, channel, bundle
 identifier, architecture, and signing identity, downloads on demand, and verifies
-the exact size, SHA-256 digest, app identity, version, architecture, and macOS code
-signature before installation.
+the exact size, SHA-256 digest, app identity, version, embedded source commit,
+architecture, and macOS code signature before installation. The detached helper
+checks that same commit again immediately before the atomic swap.
 
 Archive bytes stream directly to an updater-owned partial file instead of being
 buffered in memory. A declared oversized response is rejected immediately; a
@@ -136,10 +141,11 @@ Tester builds support the same user-initiated update and rollback flow. A stable
 tag cannot publish a macOS app unless Developer ID signing and Apple notarization
 are configured.
 
-The app is still a tester build, so ask testers to include:
+The app is still a tester build. **Report an Issue...** in the app menu opens a
+GitHub report prefilled only with the app version, build, source commit, channel,
+macOS version, and architecture. It does not include workspace paths, transcripts,
+or credentials. Ask testers to add:
 
-- their operating system and CPU architecture
-- the `BUILD_INFO.txt` or `BUILD_INFO-linux-*.txt` asset contents
 - what they clicked or typed before the issue
 - a screenshot when the issue is visual
 

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -9,6 +9,7 @@ BUNDLE_ID="${QUILLCODE_MACOS_BUNDLE_ID:-co.lorehex.QuillCowork}"
 MINIMUM_SYSTEM_VERSION="${QUILLCODE_MACOS_MINIMUM_SYSTEM_VERSION:-14.0}"
 VERSION="${QUILLCODE_MACOS_APP_VERSION:-0.1.0}"
 BUILD_NUMBER="${QUILLCODE_MACOS_BUILD_NUMBER:-1}"
+BUILD_COMMIT="${QUILLCODE_MACOS_BUILD_COMMIT:-}"
 UPDATE_CHANNEL="${QUILLCODE_MACOS_UPDATE_CHANNEL:-tester}"
 UPDATE_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json}"
 UPDATE_STABLE_MANIFEST_URL="${QUILLCODE_MACOS_UPDATE_STABLE_MANIFEST_URL:-https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json}"
@@ -41,6 +42,14 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
 fi
 
 cd "$ROOT_DIR"
+
+if [[ -z "$BUILD_COMMIT" ]]; then
+  BUILD_COMMIT="$(git rev-parse HEAD 2>/dev/null || printf 'development')"
+fi
+if [[ "$BUILD_COMMIT" != "development" && ! "$BUILD_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "QUILLCODE_MACOS_BUILD_COMMIT must be a lowercase 40-character commit or development." >&2
+  exit 2
+fi
 
 SWIFT_BUILD_ARGUMENTS=(--configuration "$CONFIGURATION" --product quill-code-desktop)
 if [[ -n "$SWIFT_DEBUG_INFO_FORMAT" ]]; then
@@ -107,6 +116,8 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
   <string>$BUILD_NUMBER</string>
+  <key>QuillCodeBuildCommit</key>
+  <string>$BUILD_COMMIT</string>
   <key>LSMinimumSystemVersion</key>
   <string>$MINIMUM_SYSTEM_VERSION</string>
   <key>LSApplicationCategoryType</key>

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -31,6 +31,11 @@ if [[ "$UPDATE_CHANNEL" == "stable" ]]; then
 else
   DEFAULT_UPDATE_MANIFEST_URL="$TESTER_MANIFEST_URL"
 fi
+
+if [[ ! "$COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Download packaging requires an exact lowercase Git commit." >&2
+  exit 2
+fi
 UPDATE_MANIFEST_URL="${QUILLCODE_UPDATE_MANIFEST_URL:-$DEFAULT_UPDATE_MANIFEST_URL}"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
@@ -57,6 +62,7 @@ echo "==> Packaging Quill Cowork macOS app ($ARCH, version $VERSION build $BUILD
 APP_BUNDLE="$(
   QUILLCODE_MACOS_APP_VERSION="$VERSION" \
   QUILLCODE_MACOS_BUILD_NUMBER="$BUILD_NUMBER" \
+  QUILLCODE_MACOS_BUILD_COMMIT="$COMMIT" \
   QUILLCODE_MACOS_BUNDLE_ID="$BUNDLE_ID" \
   QUILLCODE_MACOS_MINIMUM_SYSTEM_VERSION="$MINIMUM_SYSTEM_VERSION" \
   QUILLCODE_MACOS_UPDATE_CHANNEL="$UPDATE_CHANNEL" \

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -115,6 +115,7 @@ echo "==> Building packaged macOS app"
 APP_BUNDLE="$("$ROOT_DIR/scripts/build-macos-app.sh" --output "$APP_OUTPUT_DIR")"
 INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
 APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/Quill Cowork"
+EXPECTED_BUILD_COMMIT="$(git rev-parse HEAD)"
 
 assert_plist_value() {
   local key="$1"
@@ -162,6 +163,7 @@ assert_plist_value CFBundleDisplayName "Quill Cowork"
 assert_plist_value CFBundleExecutable "Quill Cowork"
 assert_plist_value CFBundleIdentifier co.lorehex.QuillCowork
 assert_plist_value CFBundlePackageType APPL
+assert_plist_value QuillCodeBuildCommit "$EXPECTED_BUILD_COMMIT"
 assert_plist_value LSApplicationCategoryType public.app-category.developer-tools
 assert_plist_value NSPrincipalClass NSApplication
 assert_plist_value QuillCodeUpdateChannel tester

--- a/scripts/release_verification_files.py
+++ b/scripts/release_verification_files.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import plistlib
 import re
+import stat
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +15,10 @@ from release_verification_contract import (
     PRODUCT,
     VerificationError,
 )
+
+
+APP_INFO_BYTE_LIMIT = 256 * 1024
+APP_ARCHIVE_ENTRY_LIMIT = 20_000
 
 
 def read_bounded(path: Path, byte_limit: int, label: str) -> bytes:
@@ -136,6 +143,71 @@ def verify_primary_checksums(
         )
 
 
+def verify_app_archive(
+    asset_directory: Path,
+    manifest: dict[str, Any],
+    *,
+    channel: str,
+    commit: str,
+) -> None:
+    updater = manifest["updater"]
+    app_asset = updater["macOSAppAsset"]
+    archive_path = asset_directory / app_asset["name"]
+    info_path = f"{PRODUCT}.app/Contents/Info.plist"
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            entries = archive.infolist()
+            if len(entries) > APP_ARCHIVE_ENTRY_LIMIT:
+                raise VerificationError("macOS app archive contains too many entries")
+            matching_entries = [entry for entry in entries if entry.filename == info_path]
+            if len(matching_entries) != 1:
+                raise VerificationError("macOS app archive does not contain one canonical Info.plist")
+            info_entry = matching_entries[0]
+            if info_entry.is_dir() or info_entry.flag_bits & 0x1:
+                raise VerificationError("macOS app Info.plist must be a readable regular entry")
+            unix_file_type = stat.S_IFMT(info_entry.external_attr >> 16)
+            if unix_file_type not in (0, stat.S_IFREG):
+                raise VerificationError("macOS app Info.plist must be a readable regular entry")
+            if info_entry.file_size > APP_INFO_BYTE_LIMIT:
+                raise VerificationError("macOS app Info.plist exceeds its size limit")
+            with archive.open(info_entry) as handle:
+                info_bytes = handle.read(APP_INFO_BYTE_LIMIT + 1)
+    except VerificationError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as error:
+        raise VerificationError("macOS app archive is not a readable ZIP") from error
+    if len(info_bytes) > APP_INFO_BYTE_LIMIT:
+        raise VerificationError("macOS app Info.plist exceeds its size limit")
+    try:
+        values = plistlib.loads(info_bytes)
+    except (plistlib.InvalidFileException, ValueError, TypeError) as error:
+        raise VerificationError("macOS app Info.plist is invalid") from error
+    if not isinstance(values, dict):
+        raise VerificationError("macOS app Info.plist must contain a dictionary")
+
+    expected = {
+        "CFBundleName": PRODUCT,
+        "CFBundleDisplayName": PRODUCT,
+        "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+        "CFBundleShortVersionString": manifest["version"],
+        "CFBundleVersion": manifest["build"],
+        "LSMinimumSystemVersion": updater["minimumSystemVersion"],
+        "QuillCodeBuildCommit": commit,
+        "QuillCodeUpdateChannel": channel,
+        "QuillCodeUpdateManifestURL": updater["manifestURL"],
+        "QuillCodeStableUpdateManifestURL": updater["stableManifestURL"],
+        "QuillCodeTesterUpdateManifestURL": updater["testerManifestURL"],
+    }
+    signing_team = updater.get("signingTeamIdentifier")
+    if signing_team is not None:
+        expected["QuillCodeSigningTeamIdentifier"] = signing_team
+    for key, expected_value in expected.items():
+        if values.get(key) != expected_value:
+            raise VerificationError(
+                f"macOS app Info.plist {key} disagrees with the manifest"
+            )
+
+
 def verify_asset_files(
     asset_directory: Path,
     assets: list[dict[str, Any]],
@@ -163,6 +235,12 @@ def verify_asset_files(
     verify_build_info(
         asset_directory,
         assets,
+        manifest,
+        channel=channel,
+        commit=commit,
+    )
+    verify_app_archive(
+        asset_directory,
         manifest,
         channel=channel,
         commit=commit,


### PR DESCRIPTION
## Summary

- embed the exact source commit in every packaged macOS app and require it through download validation, helper activation, packaged smoke, and public release verification
- add Report an Issue to the app and menu bar with a bounded prefilled GitHub report containing build and system metadata only
- document the provenance and support contracts, including compatibility with tester builds that predate embedded commits

## Verification

- swift test -Xswiftc -gnone: 5,410 passed, 5 skipped, 0 failed
- focused updater, issue reporter, parity, and public verifier tests: 36 passed
- adversarial public verifier suite: 5 passed, including internally consistent commit drift and symlinked Info.plist archives
- release package: DMG, updater ZIP, CLI, checksums, and performance evidence produced successfully
- packaged performance: 334.14 ms median launch ready, 97.20 MiB resident, 3/3 attempts within budget
- independent codesign, DMG verification, updater ZIP commit inspection, and release checksum verification passed
- shell syntax, Python compile, git diff check, and deterministic quality grader passed; touched modules remain A+
