### PR TITLE
Fix optimized dialog autofocus

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import QuillCodePlatformUI
 
 struct QuillCodeModelPickerView: View {
     var topBar: TopBarSurface
@@ -10,7 +11,7 @@ struct QuillCodeModelPickerView: View {
     @State private var searchText = ""
     @State private var expandedModelID: String?
     @State private var selection = ModelPickerSelection()
-    @FocusState private var isSearchFocused: Bool
+    @State private var focusRequest = 0
 
     private var filteredCategories: [ModelCategorySurface] {
         topBar.filteredModelCategories(matching: searchText)
@@ -70,7 +71,6 @@ struct QuillCodeModelPickerView: View {
                 searchText = ""
                 expandedModelID = nil
                 selection.reconcile(with: [])
-                isSearchFocused = false
             }
         }
     }
@@ -127,16 +127,19 @@ struct QuillCodeModelPickerView: View {
     }
 
     private var searchField: some View {
-        TextField("Search models", text: $searchText)
-            .textFieldStyle(.roundedBorder)
-            .focused($isSearchFocused)
+        QuillCodeAutofocusTextField(
+            placeholder: "Search models",
+            text: $searchText,
+            accessibilityIdentifier: "quillcode-model-picker-search",
+            isActive: isPresented,
+            focusRequest: focusRequest,
+            onSubmit: selectHighlightedModel,
+            onMove: { selection.move(by: $0, in: filteredModels) },
+            onCancel: { isPresented = false }
+        )
             .quillCodeTextEntryTarget()
             .accessibilityLabel("Search models")
             .accessibilityIdentifier("quillcode-model-picker-search")
-            .task {
-                await focusSearchFieldAfterPresentation()
-            }
-            .onSubmit(selectHighlightedModel)
     }
 
     @ViewBuilder
@@ -250,13 +253,7 @@ struct QuillCodeModelPickerView: View {
 
     private func focusSearchField() {
         guard isPresented else { return }
-        isSearchFocused = true
-    }
-
-    private func focusSearchFieldAfterPresentation() async {
-        try? await Task.sleep(for: .milliseconds(200))
-        guard !Task.isCancelled else { return }
-        focusSearchField()
+        focusRequest &+= 1
     }
 
     private func ensureHighlightedModel(preferredID: String?) {

--- a/Sources/QuillCodeApp/QuillCodeSearchView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSearchView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import QuillCodePlatformUI
 
 struct QuillCodeSearchView: View {
     var sidebar: SidebarSurface
@@ -8,8 +9,6 @@ struct QuillCodeSearchView: View {
 
     @State private var localQuery: String
     @State private var selection = WorkspaceSearchSelection()
-    @State private var isVisible = false
-    @FocusState private var isSearchFocused: Bool
 
     init(
         sidebar: SidebarSurface,
@@ -37,15 +36,16 @@ struct QuillCodeSearchView: View {
                 onClose: onClose
             )
 
-            TextField("Search chats", text: $localQuery)
-                .textFieldStyle(.roundedBorder)
-                .focused($isSearchFocused)
+            QuillCodeAutofocusTextField(
+                placeholder: "Search chats",
+                text: $localQuery,
+                accessibilityIdentifier: "quillcode-search-input",
+                onSubmit: selectHighlightedResult,
+                onMove: { selection.move(by: $0, in: results) },
+                onCancel: onClose
+            )
                 .accessibilityIdentifier("quillcode-search-input")
                 .quillCodeTextEntryTarget()
-                .task {
-                    await focusSearchField()
-                }
-                .onSubmit(selectHighlightedResult)
 
             if results.isEmpty {
                 QuillCodeDialogEmptyState(
@@ -71,7 +71,6 @@ struct QuillCodeSearchView: View {
         .frame(width: 560, height: 520)
         .background(QuillCodePalette.background)
         .onAppear {
-            isVisible = true
             selection.reconcile(with: results, preferredID: sidebar.selectedThreadID)
         }
         .onChange(of: localQuery) { _, newValue in
@@ -100,8 +99,6 @@ struct QuillCodeSearchView: View {
             return .handled
         }
         .onDisappear {
-            isVisible = false
-            isSearchFocused = false
             selection = WorkspaceSearchSelection()
         }
     }
@@ -115,12 +112,6 @@ struct QuillCodeSearchView: View {
         guard let item = results.first(where: { $0.id == id }) else { return }
         selection.select(item)
         onSelectThread(id)
-    }
-
-    private func focusSearchField() async {
-        try? await Task.sleep(for: .milliseconds(200))
-        guard !Task.isCancelled, isVisible else { return }
-        isSearchFocused = true
     }
 }
 

--- a/Sources/QuillCodePlatformUI/QuillCodeAutofocusTextField.swift
+++ b/Sources/QuillCodePlatformUI/QuillCodeAutofocusTextField.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+public struct QuillCodeAutofocusTextField: View {
+    private var placeholder: String
+    @Binding private var text: String
+    private var accessibilityIdentifier: String
+    private var isActive: Bool
+    private var focusRequest: Int
+    private var onSubmit: () -> Void
+    private var onMove: (Int) -> Void
+    private var onCancel: () -> Void
+
+    public init(
+        placeholder: String,
+        text: Binding<String>,
+        accessibilityIdentifier: String,
+        isActive: Bool = true,
+        focusRequest: Int = 0,
+        onSubmit: @escaping () -> Void = {},
+        onMove: @escaping (Int) -> Void = { _ in },
+        onCancel: @escaping () -> Void = {}
+    ) {
+        self.placeholder = placeholder
+        self._text = text
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.isActive = isActive
+        self.focusRequest = focusRequest
+        self.onSubmit = onSubmit
+        self.onMove = onMove
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        #if canImport(AppKit)
+        PlatformAutofocusTextField(
+            placeholder: placeholder,
+            text: $text,
+            accessibilityIdentifier: accessibilityIdentifier,
+            isActive: isActive,
+            focusRequest: focusRequest,
+            onSubmit: onSubmit,
+            onMove: onMove,
+            onCancel: onCancel
+        )
+        #else
+        TextField(placeholder, text: $text)
+            .onSubmit(onSubmit)
+        #endif
+    }
+}
+
+#if canImport(AppKit)
+private struct PlatformAutofocusTextField: NSViewRepresentable {
+    var placeholder: String
+    @Binding var text: String
+    var accessibilityIdentifier: String
+    var isActive: Bool
+    var focusRequest: Int
+    var onSubmit: () -> Void
+    var onMove: (Int) -> Void
+    var onCancel: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> QuillCodeAutofocusNativeTextField {
+        let textField = QuillCodeAutofocusNativeTextField()
+        textField.delegate = context.coordinator
+        textField.target = context.coordinator
+        textField.action = #selector(Coordinator.submit(_:))
+        textField.placeholderString = placeholder
+        textField.stringValue = text
+        textField.bezelStyle = .roundedBezel
+        textField.setAccessibilityIdentifier(accessibilityIdentifier)
+        textField.configureAutofocus(isActive: isActive, request: focusRequest)
+        return textField
+    }
+
+    func updateNSView(_ nsView: QuillCodeAutofocusNativeTextField, context: Context) {
+        context.coordinator.parent = self
+        nsView.placeholderString = placeholder
+        nsView.setAccessibilityIdentifier(accessibilityIdentifier)
+        if nsView.stringValue != text {
+            nsView.stringValue = text
+        }
+        nsView.configureAutofocus(isActive: isActive, request: focusRequest)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: PlatformAutofocusTextField
+
+        init(_ parent: PlatformAutofocusTextField) {
+            self.parent = parent
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let textField = notification.object as? NSTextField else { return }
+            parent.text = textField.stringValue
+        }
+
+        func control(
+            _ control: NSControl,
+            textView: NSTextView,
+            doCommandBy commandSelector: Selector
+        ) -> Bool {
+            switch commandSelector {
+            case #selector(NSResponder.moveUp(_:)):
+                parent.onMove(-1)
+            case #selector(NSResponder.moveDown(_:)):
+                parent.onMove(1)
+            case #selector(NSResponder.cancelOperation(_:)):
+                parent.onCancel()
+            default:
+                return false
+            }
+            return true
+        }
+
+        @objc func submit(_ sender: NSTextField) {
+            parent.onSubmit()
+        }
+    }
+}
+
+@MainActor
+private final class QuillCodeAutofocusNativeTextField: NSTextField {
+    private static let maximumAttempts = 20
+    private static let retryInterval = Duration.milliseconds(50)
+
+    private var autofocusIsActive = false
+    private var autofocusRequest = -1
+    private var focusTask: Task<Void, Never>?
+
+    deinit {
+        focusTask?.cancel()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        scheduleFocus()
+    }
+
+    func configureAutofocus(isActive: Bool, request: Int) {
+        guard autofocusIsActive != isActive || autofocusRequest != request else { return }
+        autofocusIsActive = isActive
+        autofocusRequest = request
+        scheduleFocus()
+    }
+
+    private func scheduleFocus() {
+        focusTask?.cancel()
+        guard autofocusIsActive, window != nil else { return }
+        focusTask = Task { @MainActor [weak self] in
+            for _ in 0..<Self.maximumAttempts {
+                guard !Task.isCancelled, let self, self.autofocusIsActive else { return }
+                guard let window = self.window else { return }
+                if window.firstResponder === self || window.firstResponder === self.currentEditor() {
+                    return
+                }
+                if window.makeFirstResponder(self) {
+                    return
+                }
+                try? await Task.sleep(for: Self.retryInterval)
+            }
+        }
+    }
+}
+#endif

--- a/Tests/QuillCodeParityTests/ParityAutofocusTextFieldGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAutofocusTextFieldGateTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+final class ParityAutofocusTextFieldGateTests: QuillCodeParityTestCase {
+    func testAutofocusTextFieldStaysBoundedCancellableAndNative() throws {
+        let fieldURL = try XCTUnwrap(
+            Self.swiftSourceFiles(in: "Sources/QuillCodePlatformUI")
+                .first { $0.lastPathComponent == "QuillCodeAutofocusTextField.swift" }
+        )
+        let fieldText = try String(contentsOf: fieldURL, encoding: .utf8)
+
+        for expected in [
+            "public struct QuillCodeAutofocusTextField: View",
+            "private struct PlatformAutofocusTextField: NSViewRepresentable",
+            "private final class QuillCodeAutofocusNativeTextField: NSTextField",
+            "private static let maximumAttempts = 20",
+            "private static let retryInterval = Duration.milliseconds(50)",
+            "focusTask?.cancel()",
+            "guard !Task.isCancelled",
+            "window.makeFirstResponder(self)",
+            "func controlTextDidChange",
+            "doCommandBy commandSelector: Selector",
+            "parent.onSubmit()",
+            "parent.onCancel()"
+        ] {
+            Self.assertSource(fieldText, contains: expected)
+        }
+        for excluded in [
+            "AXUIElementCreateApplication",
+            "DispatchQueue.main.asyncAfter",
+            "Timer."
+        ] {
+            Self.assertSource(fieldText, excludes: excluded)
+        }
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityNativeModelPickerGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityNativeModelPickerGateTests.swift
@@ -9,9 +9,10 @@ final class ParityNativeModelPickerGateTests: QuillCodeParityTestCase {
             "struct QuillCodeModelPickerView",
             "@State private var searchText",
             "ensureHighlightedModel",
-            "focusSearchFieldAfterPresentation()",
-            "Task.sleep(for: .milliseconds(200))",
-            "guard !Task.isCancelled else { return }"
+            "QuillCodeAutofocusTextField(",
+            "accessibilityIdentifier: \"quillcode-model-picker-search\"",
+            "isActive: isPresented",
+            "focusRequest: focusRequest"
         ].forEach { Self.assertSource(pickerText, contains: $0) }
         [
             "struct QuillCodeModelCategorySection",

--- a/Tests/QuillCodeParityTests/ParitySearchDialogGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParitySearchDialogGateTests.swift
@@ -10,20 +10,16 @@ final class ParitySearchDialogGateTests: QuillCodeParityTestCase {
         for expected in [
             "@State private var localQuery",
             "@State private var selection = WorkspaceSearchSelection()",
-            "TextField(\"Search chats\", text: $localQuery)",
+            "QuillCodeAutofocusTextField(",
+            "placeholder: \"Search chats\"",
             ".accessibilityIdentifier(\"quillcode-search-input\")",
             ".onMoveCommand",
             ".onKeyPress(.escape)",
             "selection.move(by: -1, in: results)",
             "selection.move(by: 1, in: results)",
             "selection.selectedItem(in: results)",
-            "selectHighlightedResult()",
-            "@State private var isVisible = false",
-            "isVisible = true",
-            "private func focusSearchField() async",
-            "Task.sleep(for: .milliseconds(200))",
-            "guard !Task.isCancelled, isVisible else { return }",
-            "isVisible = false"
+            "onSubmit: selectHighlightedResult",
+            "onCancel: onClose"
         ] {
             Self.assertSource(searchDialogText, contains: expected)
         }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsSheetGateTests.swift
@@ -49,7 +49,7 @@ final class ParityWorkspaceSettingsSheetGateTests: QuillCodeParityTestCase {
         Self.assertSource(commandPaletteText, contains: "QuillCodeCommandIconCatalog.systemImage")
         Self.assertSource(commandPaletteText, excludes: "enum QuillCodeCommandIcon")
         Self.assertSource(searchText, contains: "struct QuillCodeSearchView")
-        Self.assertSource(searchText, contains: "TextField(\"Search chats\", text: $localQuery)")
+        Self.assertSource(searchText, contains: "QuillCodeAutofocusTextField(")
         Self.assertSource(shortcutText, contains: "struct QuillCodeKeyboardShortcutsView")
         Self.assertSource(shortcutText, contains: "accessibilityIdentifier(\"quillcode-shortcuts-search-input\")")
         Self.assertSource(shortcutText, contains: "editor.groups(commands: commands, query: query, mode: searchMode)")


### PR DESCRIPTION
## Summary
- replace release-fragile SwiftUI focus timers with a concrete native text field behind QuillCodePlatformUI
- keep Search and model-picker text binding, submit, arrow navigation, Escape, and clear-to-refocus behavior
- add bounded/cancellable focus and architecture parity contracts

## Verification
- 5,411 tests; 5 skipped; 0 failures
- final optimized package: 6/6 cold launches within budget
- median launch-ready: 317-327 ms; resident memory: 96.8-96.9 MiB
- direct executable and Launch Services full workflow smokes pass
- hands-on packaged Search and model-picker focus, typing, filtering, Escape, and visual pass
- all touched files grade A+