### PR TITLE
Gate releases on packaged self-update

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -280,3 +280,52 @@ jobs:
             --channel "$RELEASE_CHANNEL" \
             --commit "$GITHUB_SHA" \
             --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+  verify-updater:
+    needs: publish
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download public updater inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            RELEASE_TAG="${GITHUB_REF_NAME}"
+            RELEASE_CHANNEL="stable"
+          else
+            RELEASE_TAG="tester-latest"
+            RELEASE_CHANNEL="tester"
+          fi
+          mkdir -p "$RUNNER_TEMP/public-updater"
+          gh release download "$RELEASE_TAG" \
+            --pattern 'Quill-Cowork-macOS-*.zip' \
+            --dir "$RUNNER_TEMP/public-updater"
+          gh release download "$RELEASE_TAG" \
+            --pattern "latest-${RELEASE_CHANNEL}-build.json" \
+            --dir "$RUNNER_TEMP/public-updater"
+      - name: Verify public app updates and relaunches itself
+        env:
+          QUILLCODE_UPDATER_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/updater-smoke-artifacts
+        run: |
+          APP_ZIPS=("$RUNNER_TEMP"/public-updater/Quill-Cowork-macOS-*.zip)
+          MANIFESTS=("$RUNNER_TEMP"/public-updater/latest-*-build.json)
+          if [[ ${#APP_ZIPS[@]} -ne 1 || ${#MANIFESTS[@]} -ne 1 ]]; then
+            echo "Expected exactly one public app archive and one updater manifest." >&2
+            exit 1
+          fi
+          scripts/packaged-macos-updater-smoke.sh \
+            --app-zip "${APP_ZIPS[0]}" \
+            --manifest "${MANIFESTS[0]}"
+      - name: Upload updater smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: quillcode-public-updater-smoke
+          path: ${{ runner.temp }}/updater-smoke-artifacts
+          if-no-files-found: error
+          retention-days: 14

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -14,6 +14,22 @@ struct QuillCodeDesktopApp: App {
             Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
         }
 
+        if let updaterSmokeRequest = QuillCodeDesktopUpdaterSmokeRequest(
+            arguments: CommandLine.arguments
+        ) {
+            let controller = QuillCodeDesktopController(
+                updateController: QuillCodeDesktopUpdateController(
+                    configuration: nil,
+                    installResultURL: nil
+                )
+            )
+            _controller = StateObject(wrappedValue: controller)
+            Task { @MainActor in
+                await QuillCodeDesktopUpdaterSmokeRunner.runAndExit(updaterSmokeRequest)
+            }
+            return
+        }
+
         // Quill Cowork is a dark-themed appliance: pin the whole app (every window, sheet, popover, and
         // system-drawn control) to the dark aqua appearance. Without this, system chrome — .roundedBorder
         // text fields, sheet/popover backgrounds, menu text — follows the user's macOS appearance, so on a

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdaterSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdaterSmokeRunner.swift
@@ -1,0 +1,107 @@
+import Darwin
+import Foundation
+
+struct QuillCodeDesktopUpdaterSmokeRequest: Equatable, Sendable {
+    static let modeArgument = "--native-updater-smoke"
+
+    var reportURL: URL
+
+    init?(arguments: [String]) {
+        guard arguments.contains(Self.modeArgument),
+              let flagIndex = arguments.firstIndex(of: "--updater-smoke-report"),
+              arguments.indices.contains(flagIndex + 1)
+        else {
+            return nil
+        }
+        let value = arguments[flagIndex + 1]
+        guard value.hasPrefix("/"), !value.isEmpty else { return nil }
+        reportURL = URL(fileURLWithPath: value).standardizedFileURL
+    }
+}
+
+struct QuillCodeDesktopUpdaterSmokeReport: Codable, Equatable, Sendable {
+    var ok: Bool
+    var sourceVersion: String?
+    var sourceBuild: String?
+    var targetVersion: String?
+    var targetBuild: String?
+    var targetCommit: String?
+    var message: String
+}
+
+@MainActor
+enum QuillCodeDesktopUpdaterSmokeRunner {
+    static func runAndExit(_ request: QuillCodeDesktopUpdaterSmokeRequest) async -> Never {
+        let report: QuillCodeDesktopUpdaterSmokeReport
+        do {
+            report = try await stageLatestUpdate()
+        } catch {
+            report = QuillCodeDesktopUpdaterSmokeReport(
+                ok: false,
+                sourceVersion: Bundle.main.object(
+                    forInfoDictionaryKey: "CFBundleShortVersionString"
+                ) as? String,
+                sourceBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+                targetVersion: nil,
+                targetBuild: nil,
+                targetCommit: nil,
+                message: error.localizedDescription
+            )
+        }
+
+        let exitCode: Int32
+        do {
+            try write(report, to: request.reportURL)
+            exitCode = report.ok ? 0 : 1
+        } catch {
+            FileHandle.standardError.write(Data(
+                "quill-code-desktop updater smoke could not write its report: \(error)\n".utf8
+            ))
+            exitCode = 1
+        }
+        Darwin.exit(exitCode)
+    }
+
+    private static func stageLatestUpdate() async throws -> QuillCodeDesktopUpdaterSmokeReport {
+        guard let configuration = QuillCodeDesktopUpdateConfiguration.bundled() else {
+            throw QuillCodeDesktopUpdateError.updatesUnavailable
+        }
+        let result = try await QuillCodeDesktopUpdateChecker().check(configuration: configuration)
+        guard case .updateAvailable(let release) = result else {
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the smoke fixture was not older than the published update"
+            )
+        }
+        let prepared = try await QuillCodeDesktopUpdatePreparer().prepare(
+            release: release,
+            configuration: configuration
+        )
+        try await QuillCodeDesktopUpdateInstaller().stageAndLaunch(
+            preparedUpdate: prepared,
+            configuration: configuration
+        )
+        return QuillCodeDesktopUpdaterSmokeReport(
+            ok: true,
+            sourceVersion: configuration.currentVersion,
+            sourceBuild: configuration.currentBuild,
+            targetVersion: release.version,
+            targetBuild: release.build,
+            targetCommit: release.commit,
+            message: "The verified update was staged and its detached installer started."
+        )
+    }
+
+    private static func write(
+        _ report: QuillCodeDesktopUpdaterSmokeReport,
+        to reportURL: URL
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: reportURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(report).write(to: reportURL, options: [.atomic])
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdaterSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdaterSmokeTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopUpdaterSmokeTests: XCTestCase {
+    func testRequestRequiresModeAndAbsoluteReportPath() throws {
+        let request = try XCTUnwrap(QuillCodeDesktopUpdaterSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--native-updater-smoke",
+            "--updater-smoke-report",
+            "/tmp/updater-smoke.json",
+        ]))
+
+        XCTAssertEqual(request.reportURL.path, "/tmp/updater-smoke.json")
+        XCTAssertNil(QuillCodeDesktopUpdaterSmokeRequest(arguments: ["Quill Cowork"]))
+        XCTAssertNil(QuillCodeDesktopUpdaterSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--native-updater-smoke",
+            "--updater-smoke-report",
+            "relative.json",
+        ]))
+    }
+
+    func testReportEncodesReleaseProvenance() throws {
+        let report = QuillCodeDesktopUpdaterSmokeReport(
+            ok: true,
+            sourceVersion: "0.1.0",
+            sourceBuild: "642",
+            targetVersion: "0.1.0",
+            targetBuild: "643",
+            targetCommit: String(repeating: "a", count: 40),
+            message: "staged"
+        )
+
+        let decoded = try JSONDecoder().decode(
+            QuillCodeDesktopUpdaterSmokeReport.self,
+            from: JSONEncoder().encode(report)
+        )
+        XCTAssertEqual(decoded, report)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
+    func testPublishedBuildMustUpdateAndRelaunchItself() throws {
+        let app = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let runner = try Self.desktopSourceText(named: "QuillCodeDesktopUpdaterSmokeRunner.swift")
+        let script = try Self.scriptText(named: "packaged-macos-updater-smoke.sh")
+        let workflow = try Self.workflowText(named: "download-builds.yml")
+
+        Self.assertSource(app, containsAll: [
+            "QuillCodeDesktopUpdaterSmokeRequest",
+            "QuillCodeDesktopUpdaterSmokeRunner.runAndExit"
+        ])
+        Self.assertSource(runner, containsAll: [
+            "QuillCodeDesktopUpdateChecker().check",
+            "QuillCodeDesktopUpdatePreparer().prepare",
+            "QuillCodeDesktopUpdateInstaller().stageAndLaunch",
+            "targetCommit: release.commit"
+        ])
+        Self.assertSource(script, containsAll: [
+            "--native-updater-smoke",
+            "--updater-smoke-report",
+            "codesign --verify --deep --strict",
+            "CFBundleVersion $SOURCE_BUILD",
+            "targetCommit",
+            "STAGING_APPS",
+            "Updated app did not remain running"
+        ])
+        Self.assertSource(workflow, containsAll: [
+            "verify-updater:",
+            "runs-on: macos-15",
+            "needs: publish",
+            "scripts/packaged-macos-updater-smoke.sh",
+            "quillcode-public-updater-smoke"
+        ])
+    }
+}

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -63,6 +63,14 @@ the product identity, version, build, exact source commit, channel, feed URLs,
 minimum macOS version, and signing team to agree with the public manifest. A
 publication is not green until this consumer check passes.
 
+A separate macOS post-publication gate downloads that exact public app archive,
+re-signs an isolated copy with its build number set one revision behind, and
+launches the packaged updater against the live feed. The gate requires the app
+to stream, verify, unpack, validate, atomically replace, and relaunch itself; it
+then checks the activated version and source commit, code signature, launch
+handshake, and staging cleanup. This catches failures that manifest-only and
+unit-level updater checks cannot prove.
+
 The release-configured macOS app must also open a real native window within three
 seconds and remain below 256 MiB of resident memory at that initial-window
 boundary. Release packaging measures three fresh processes with isolated state,

--- a/scripts/packaged-macos-updater-smoke.sh
+++ b/scripts/packaged-macos-updater-smoke.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ZIP=""
+MANIFEST_PATH=""
+ARTIFACT_DIR="${QUILLCODE_UPDATER_SMOKE_ARTIFACT_DIR:-}"
+TEMP_ROOT="${TMPDIR:-/tmp}"
+SMOKE_ROOT="$(mktemp -d "${TEMP_ROOT%/}/quillcode-packaged-updater.XXXXXX")"
+APP_PARENT="$SMOKE_ROOT/application"
+REPORT_PATH="$SMOKE_ROOT/updater-stage.json"
+LOG_PATH="$SMOKE_ROOT/updater.log"
+UPDATED_PID=""
+
+cleanup() {
+  local status=$?
+  set +e
+  if [[ -n "$UPDATED_PID" ]]; then
+    kill "$UPDATED_PID" 2>/dev/null || true
+    wait "$UPDATED_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$ARTIFACT_DIR" ]]; then
+    mkdir -p "$ARTIFACT_DIR"
+    [[ -f "$REPORT_PATH" ]] && cp "$REPORT_PATH" "$ARTIFACT_DIR/updater-stage.json"
+    [[ -f "$LOG_PATH" ]] && cp "$LOG_PATH" "$ARTIFACT_DIR/updater.log"
+    printf 'status=%s\n' "$status" > "$ARTIFACT_DIR/manifest.txt"
+  fi
+  rm -rf "$SMOKE_ROOT"
+  exit "$status"
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-zip)
+      APP_ZIP="$2"
+      shift 2
+      ;;
+    --manifest)
+      MANIFEST_PATH="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "packaged-macos-updater-smoke.sh must run on macOS." >&2
+  exit 2
+fi
+if [[ ! -f "$APP_ZIP" || ! -f "$MANIFEST_PATH" ]]; then
+  echo "Usage: packaged-macos-updater-smoke.sh --app-zip APP_ZIP --manifest MANIFEST_JSON" >&2
+  exit 2
+fi
+
+EXPECTED_VERSION="$(plutil -extract version raw "$MANIFEST_PATH")"
+EXPECTED_BUILD="$(plutil -extract build raw "$MANIFEST_PATH")"
+EXPECTED_COMMIT="$(plutil -extract commit raw "$MANIFEST_PATH")"
+EXPECTED_CHANNEL="$(plutil -extract channel raw "$MANIFEST_PATH")"
+if [[ ! "$EXPECTED_BUILD" =~ ^[0-9]+$ ]] || (( EXPECTED_BUILD < 2 )); then
+  echo "Published updater smoke requires a numeric build greater than one." >&2
+  exit 2
+fi
+if [[ ! "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Published updater smoke manifest has an invalid commit." >&2
+  exit 2
+fi
+
+mkdir -p "$APP_PARENT" "$SMOKE_ROOT/home"
+ditto -x -k "$APP_ZIP" "$APP_PARENT"
+APP_CANDIDATES=("$APP_PARENT"/*.app)
+if [[ ${#APP_CANDIDATES[@]} -ne 1 || ! -d "${APP_CANDIDATES[0]}" ]]; then
+  echo "Updater archive must contain exactly one top-level app bundle." >&2
+  exit 1
+fi
+APP_BUNDLE="${APP_CANDIDATES[0]}"
+APP_BASE_NAME="$(basename "$APP_BUNDLE" .app)"
+INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
+EXECUTABLE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST")"
+APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/$EXECUTABLE_NAME"
+SOURCE_BUILD=$((EXPECTED_BUILD - 1))
+
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $SOURCE_BUILD" "$INFO_PLIST"
+/usr/libexec/PlistBuddy -c "Set :QuillCodeBuildCommit 0000000000000000000000000000000000000000" "$INFO_PLIST"
+codesign --force --deep --sign - "$APP_BUNDLE"
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+
+echo "==> Updating packaged Quill Cowork $EXPECTED_VERSION ($SOURCE_BUILD) to ($EXPECTED_BUILD)"
+CFFIXED_USER_HOME="$SMOKE_ROOT/home" HOME="$SMOKE_ROOT/home" \
+  "$APP_EXECUTABLE" \
+    --native-updater-smoke \
+    --updater-smoke-report "$REPORT_PATH" \
+    >"$LOG_PATH" 2>&1 &
+SMOKE_PID="$!"
+
+elapsed=0
+while kill -0 "$SMOKE_PID" 2>/dev/null; do
+  if (( elapsed >= 180 )); then
+    echo "Packaged updater smoke timed out while staging after 180 seconds." >&2
+    kill "$SMOKE_PID" 2>/dev/null || true
+    wait "$SMOKE_PID" 2>/dev/null || true
+    exit 124
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+done
+if ! wait "$SMOKE_PID"; then
+  cat "$LOG_PATH" >&2
+  [[ -f "$REPORT_PATH" ]] && cat "$REPORT_PATH" >&2
+  exit 1
+fi
+
+if [[ "$(plutil -extract ok raw "$REPORT_PATH")" != "true" ]] ||
+   [[ "$(plutil -extract sourceBuild raw "$REPORT_PATH")" != "$SOURCE_BUILD" ]] ||
+   [[ "$(plutil -extract targetBuild raw "$REPORT_PATH")" != "$EXPECTED_BUILD" ]] ||
+   [[ "$(plutil -extract targetCommit raw "$REPORT_PATH")" != "$EXPECTED_COMMIT" ]]; then
+  echo "Packaged updater smoke stage report disagrees with the public manifest." >&2
+  cat "$REPORT_PATH" >&2
+  exit 1
+fi
+
+elapsed=0
+while true; do
+  ACTUAL_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST" 2>/dev/null || true)"
+  ACTUAL_COMMIT="$(/usr/libexec/PlistBuddy -c 'Print :QuillCodeBuildCommit' "$INFO_PLIST" 2>/dev/null || true)"
+  STAGING_APPS=("$APP_PARENT"/."$APP_BASE_NAME".update-*.app)
+  if [[ "$ACTUAL_BUILD" == "$EXPECTED_BUILD" &&
+        "$ACTUAL_COMMIT" == "$EXPECTED_COMMIT" &&
+        ! -e "${STAGING_APPS[0]}" ]]; then
+    break
+  fi
+  if (( elapsed >= 60 )); then
+    echo "Packaged updater helper did not activate and clean up within 60 seconds." >&2
+    cat "$LOG_PATH" >&2
+    exit 124
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+done
+
+ACTUAL_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
+ACTUAL_CHANNEL="$(/usr/libexec/PlistBuddy -c 'Print :QuillCodeUpdateChannel' "$INFO_PLIST")"
+if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" || "$ACTUAL_CHANNEL" != "$EXPECTED_CHANNEL" ]]; then
+  echo "Activated app metadata disagrees with the public updater manifest." >&2
+  exit 1
+fi
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+
+UPDATED_PID="$(pgrep -f "$APP_EXECUTABLE --quillcode-update-handshake" | head -n 1 || true)"
+if [[ -z "$UPDATED_PID" ]]; then
+  echo "Updated app did not remain running after its launch handshake." >&2
+  exit 1
+fi
+
+echo "Verified packaged Quill Cowork updater: $SOURCE_BUILD -> $EXPECTED_BUILD ($EXPECTED_COMMIT)."


### PR DESCRIPTION
## Summary
- add a hidden packaged-app smoke mode that exercises the production updater path
- verify each published GitHub artifact can update, atomically replace, relaunch, and complete its handshake
- document the live post-publication updater gate

## Verification
- full Swift suite: 5,414 tests, 5 skipped, 0 failures
- focused updater and workflow tests: 47 tests, 0 failures
- real public artifact update: build 642 to 643, signature and relaunch verified
- shell syntax and staged diff checks passed