### PR TITLE
Fix unsafe desktop first launch

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeComposerControls.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerControls.swift
@@ -59,6 +59,7 @@ struct QuillCodeComposerTextField: View {
     var placeholder: String
     @Binding var draft: String
     var isFocused: FocusState<Bool>.Binding
+    var isEnabled = true
     var onDownArrow: () -> KeyPress.Result
     var onUpArrow: () -> KeyPress.Result
     var onTab: () -> KeyPress.Result
@@ -74,6 +75,7 @@ struct QuillCodeComposerTextField: View {
             .padding(.vertical, 8)
             .quillCodeTextEntryTarget()
             .focused(isFocused)
+            .disabled(!isEnabled)
             .onKeyPress(.downArrow, action: onDownArrow)
             .onKeyPress(.upArrow, action: onUpArrow)
             .onKeyPress(.tab, action: onTab)

--- a/Sources/QuillCodeApp/QuillCodeComposerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeComposerView.swift
@@ -19,6 +19,7 @@ struct QuillCodeComposerView: View {
     var onRemoveImage: (UUID) -> Void = { _ in }
     var onStop: () -> Void
     var onDeleteFollowUp: (UUID) -> Void = { _ in }
+    var isWorkspaceAvailable = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.quillCodeConfidentialAppearance) private var isConfidentialAppearance
@@ -121,9 +122,10 @@ struct QuillCodeComposerView: View {
 
             HStack(alignment: .bottom, spacing: QuillCodeMetrics.controlClusterSpacing) {
                 QuillCodeComposerTextField(
-                    placeholder: composer.placeholder,
+                    placeholder: isWorkspaceAvailable ? composer.placeholder : "Open a project to start",
                     draft: $draft,
                     isFocused: isFocused,
+                    isEnabled: isWorkspaceAvailable,
                     onDownArrow: handleDownArrow,
                     onUpArrow: handleUpArrow,
                     onTab: handleTab,
@@ -207,7 +209,8 @@ struct QuillCodeComposerView: View {
     }
 
     private var canSendDraft: Bool {
-        (!draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        isWorkspaceAvailable
+            && (!draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             || !composer.attachments.isEmpty)
             && !composer.isSending
             && modelCommandEmptyCopy == nil
@@ -228,6 +231,7 @@ struct QuillCodeComposerView: View {
             .help("Attach images")
             .accessibilityLabel("Attach images")
             .accessibilityIdentifier("quillcode-attach-images-button")
+            .disabled(!isWorkspaceAvailable)
 
             QuillCodeModelPickerView(
                 topBar: topBar,

--- a/Sources/QuillCodeApp/QuillCodeProjectListSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectListSurface.swift
@@ -52,6 +52,9 @@ public struct ProjectListSurface: Codable, Sendable, Hashable {
     }
 
     public var compactCountLabel: String {
+        guard !items.isEmpty else {
+            return "0"
+        }
         guard remoteProjectCount > 0 else {
             return countLabel
         }

--- a/Sources/QuillCodeApp/QuillCodeProjectListView.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectListView.swift
@@ -59,9 +59,10 @@ struct QuillCodeProjectListView: View {
             }
             .buttonStyle(QuillCodePressableButtonStyle())
             .foregroundStyle(QuillCodePalette.muted)
+            .disabled(projects.selectedProjectID == nil)
             .accessibilityLabel("Clear project")
             .accessibilityIdentifier("quillcode-project-clear-button")
-            .help("Clear project")
+            .help(projects.selectedProjectID == nil ? "No project selected" : "Clear project")
         }
     }
 

--- a/Sources/QuillCodeApp/QuillCodeProjectSetupView.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectSetupView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct QuillCodeProjectSetupView: View {
+    var onOpenProject: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(QuillCodePalette.blue.opacity(0.14))
+                    .frame(width: 60, height: 60)
+                Image(systemName: "folder.badge.plus")
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(QuillCodePalette.blue)
+            }
+            .accessibilityHidden(true)
+
+            Text("Open a project")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(QuillCodePalette.text)
+
+            Text("Choose the workspace folder Quill Cowork can work in.")
+                .font(.callout)
+                .foregroundStyle(QuillCodePalette.muted)
+
+            Button(action: onOpenProject) {
+                Label("Open Project...", systemImage: "folder")
+            }
+            .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 220))
+            .quillCodeFormActionTarget(minWidth: 220)
+            .accessibilityIdentifier("quillcode-empty-open-project")
+            .padding(.top, 2)
+        }
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 560)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 22)
+        .accessibilityIdentifier("quillcode-project-setup-empty-state")
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -38,6 +38,8 @@ struct QuillCodeTranscriptView: View {
     /// silently fail. See ``TranscriptConnectPrompt``.
     var connectPrompt: TranscriptConnectPrompt? = nil
     var onStartTrustedRouterSignIn: () -> Void = {}
+    var requiresProjectSelection = false
+    var onOpenProject: () -> Void = {}
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.quillCodeConfidentialAppearance) private var isConfidentialAppearance
@@ -102,7 +104,27 @@ struct QuillCodeTranscriptView: View {
     }
 
     private var isEmptyStateVisible: Bool {
-        transcript.timelineItems.isEmpty && !review.isVisible && contextBanner == nil && runtimeIssue == nil
+        guard transcript.timelineItems.isEmpty,
+              !review.isVisible,
+              contextBanner == nil
+        else {
+            return false
+        }
+        guard requiresProjectSelection || connectPrompt != nil else {
+            return runtimeIssue == nil
+        }
+        return runtimeIssue == nil || runtimeIssueIsSetupRelated
+    }
+
+    private var runtimeIssueIsSetupRelated: Bool {
+        switch runtimeIssue?.recovery?.reason {
+        case .trustedRouterSignInRequired, .developerKeyMissing:
+            return true
+        case .trustedRouterKeyRejected, .rateLimited, .providerUnavailable,
+             .networkUnreachable, .emptyResponse, .malformedModelAction,
+             .runFailed, .savedChatsUnreadable, nil:
+            return false
+        }
     }
 
     private var scrollAnchorID: String? {
@@ -339,7 +361,9 @@ struct QuillCodeTranscriptView: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        if let connectPrompt {
+        if requiresProjectSelection {
+            QuillCodeProjectSetupView(onOpenProject: onOpenProject)
+        } else if let connectPrompt {
             // Not connected yet: the sign-in gate takes precedence over the starter cards (and even
             // confidential mode) — there is nothing to start until an account is connected.
             QuillCodeConnectView(prompt: connectPrompt, onSignIn: onStartTrustedRouterSignIn)

--- a/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
+++ b/Sources/QuillCodeApp/QuillCodeWorkspaceMainPaneView.swift
@@ -96,7 +96,9 @@ struct QuillCodeWorkspaceMainPaneView: View {
                         connectPrompt: TranscriptConnectPrompt.make(
                             hasStoredAPIKey: surface.settings.hasStoredAPIKey
                         ),
-                        onStartTrustedRouterSignIn: onStartTrustedRouterSignIn
+                        onStartTrustedRouterSignIn: onStartTrustedRouterSignIn,
+                        requiresProjectSelection: surface.projects.items.isEmpty,
+                        onOpenProject: { runCommand(id: "add-project") }
                     )
                 } else {
                     Spacer(minLength: 0)
@@ -173,7 +175,8 @@ struct QuillCodeWorkspaceMainPaneView: View {
                     onAddImagesRequested: onAddImagesRequested,
                     onRemoveImage: onRemoveImage,
                     onStop: stopActiveRun,
-                    onDeleteFollowUp: onDeleteFollowUp
+                    onDeleteFollowUp: onDeleteFollowUp,
+                    isWorkspaceAvailable: !surface.projects.items.isEmpty
                 )
             }
             if surface.activity.isVisible {

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -34,7 +34,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
         let projectStore = JSONProjectStore(fileURL: paths.projectsFile)
         let automationStore = JSONAutomationStore(fileURL: paths.automationsFile)
         let sidebarSavedSearchStore = JSONSidebarSavedSearchStore(fileURL: paths.sidebarSavedSearchesFile)
-        let projects = try projectStore.load()
+        let storedProjects = try projectStore.load()
         let childStore = SubagentThreadStore(directory: paths.subagentThreadsDirectory)
         let payloadStore = SubagentApprovalPayloadStore(directory: paths.subagentApprovalPayloadsDirectory)
         let threadListing = threadStore.listing()
@@ -44,6 +44,20 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             payloadStore: payloadStore
         )
         let threads = reconciliation.threads
+        let projects: [ProjectRef]
+        if WorkspaceBootstrapProjectMigration.isComplete(in: paths.home) {
+            projects = storedProjects
+        } else {
+            projects = WorkspaceBootstrapProjectMigration.removingUnusedLegacyRootProject(
+                from: storedProjects,
+                threads: threads,
+                hasThreadLoadIssues: !threadListing.issues.isEmpty
+            )
+            if projects != storedProjects {
+                try projectStore.save(projects)
+            }
+            try WorkspaceBootstrapProjectMigration.markComplete(in: paths.home)
+        }
         for thread in threads where reconciliation.changedThreadIDs.contains(thread.id) {
             try threadStore.save(thread)
         }

--- a/Sources/QuillCodeApp/WorkspaceBootstrapProjectMigration.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrapProjectMigration.swift
@@ -1,0 +1,50 @@
+import Foundation
+import QuillCodeCore
+
+enum WorkspaceBootstrapProjectMigration {
+    private static let completionMarkerName = ".unused-legacy-root-project-migration-v1"
+
+    static func completionMarkerURL(in stateDirectory: URL) -> URL {
+        stateDirectory.appendingPathComponent(completionMarkerName, isDirectory: false)
+    }
+
+    static func isComplete(in stateDirectory: URL) -> Bool {
+        FileManager.default.fileExists(atPath: completionMarkerURL(in: stateDirectory).path)
+    }
+
+    static func markComplete(in stateDirectory: URL) throws {
+        try Data("complete\n".utf8).write(
+            to: completionMarkerURL(in: stateDirectory),
+            options: .atomic
+        )
+    }
+
+    static func removingUnusedLegacyRootProject(
+        from projects: [ProjectRef],
+        threads: [ChatThread],
+        hasThreadLoadIssues: Bool
+    ) -> [ProjectRef] {
+        guard !hasThreadLoadIssues,
+              threads.isEmpty,
+              projects.count == 1,
+              let project = projects.first,
+              isUnusedLegacyRootProject(project)
+        else {
+            return projects
+        }
+        return []
+    }
+
+    private static func isUnusedLegacyRootProject(_ project: ProjectRef) -> Bool {
+        project.name == "/"
+            && project.path == "/"
+            && !project.isRemote
+            && project.connection.path == "/"
+            && project.instructions.isEmpty
+            && project.instructionDiagnosticResolutions.isEmpty
+            && project.localActions.isEmpty
+            && project.runHooks.isEmpty
+            && project.pluginHooks.isEmpty
+            && project.memories.isEmpty
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -63,8 +63,9 @@ final class QuillCodeDesktopController: ObservableObject {
         transcriptExportCoordinator: QuillCodeDesktopTranscriptExportCoordinator =
             QuillCodeDesktopTranscriptExportCoordinator(),
         updateController: QuillCodeDesktopUpdateController? = nil,
-        workspaceRoot: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        workspaceRoot: URL? = nil
     ) {
+        let launchWorkspaceRoot = workspaceRoot?.standardizedFileURL
         self.bootstrap = bootstrap
         self.computerUseCoordinator = QuillCodeDesktopComputerUseCoordinator()
         self.activeWorkCoordinator = QuillCodeDesktopActiveWorkCoordinator()
@@ -99,8 +100,11 @@ final class QuillCodeDesktopController: ObservableObject {
         } catch {
             self.model = QuillCodeWorkspaceModel()
         }
-        self.workspaceRoot = workspaceRoot
-        modelStateCoordinator.ensureDefaultProject(on: model, workspaceRoot: workspaceRoot)
+        self.workspaceRoot = launchWorkspaceRoot
+            ?? FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
+        if let launchWorkspaceRoot {
+            modelStateCoordinator.ensureDefaultProject(on: model, workspaceRoot: launchWorkspaceRoot)
+        }
         self.computerUseCoordinator.install(on: model)
         // Opt-in (QUILLCODE_USE_CUA_DRIVER=1): asynchronously upgrade to the cua-driver backend so
         // computer use runs in the background without stealing focus/cursor. Native stays live until

--- a/Tests/QuillCodeAppTests/QuillCodeProjectListSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeProjectListSurfaceTests.swift
@@ -12,7 +12,7 @@ final class QuillCodeProjectListSurfaceTests: XCTestCase {
         let multiple = ProjectListSurface(items: [first, second], selectedProjectID: nil)
 
         XCTAssertEqual(empty.countLabel, "No projects")
-        XCTAssertEqual(empty.compactCountLabel, "No projects")
+        XCTAssertEqual(empty.compactCountLabel, "0")
         XCTAssertEqual(empty.connectionSummaryLabel, "No project connections")
         XCTAssertEqual(empty.accessibilitySummary, "Projects, no projects")
         XCTAssertEqual(single.countLabel, "1 project")

--- a/Tests/QuillCodeAppTests/WorkspaceBootstrapProjectMigrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceBootstrapProjectMigrationTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import QuillCodeCore
+import QuillCodePersistence
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceBootstrapProjectMigrationTests: XCTestCase {
+    func testBootstrapRemovesAndPersistsUnusedLegacyFilesystemRootProject() throws {
+        let home = try makeQuillCodeTestDirectory()
+        let paths = QuillCodePaths(home: home)
+        try paths.ensure()
+        let store = JSONProjectStore(fileURL: paths.projectsFile)
+        try store.save([ProjectRef(name: "/", path: "/")])
+
+        let model = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
+
+        XCTAssertTrue(model.root.projects.isEmpty)
+        XCTAssertTrue(try store.load().isEmpty)
+        XCTAssertTrue(WorkspaceBootstrapProjectMigration.isComplete(in: paths.home))
+    }
+
+    func testCompletedMigrationPreservesAProjectThatLaterTargetsFilesystemRoot() throws {
+        let home = try makeQuillCodeTestDirectory()
+        let paths = QuillCodePaths(home: home)
+        try paths.ensure()
+        let store = JSONProjectStore(fileURL: paths.projectsFile)
+
+        _ = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
+        let intentionalRootProject = ProjectRef(name: "/", path: "/")
+        try store.save([intentionalRootProject])
+
+        let relaunchedModel = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
+
+        XCTAssertEqual(relaunchedModel.root.projects.map(\.id), [intentionalRootProject.id])
+        XCTAssertEqual(relaunchedModel.root.projects.first?.path, "/")
+        XCTAssertEqual(try store.load().map(\.id), [intentionalRootProject.id])
+    }
+
+    func testMigrationPreservesRootProjectWithAChat() {
+        let project = ProjectRef(name: "/", path: "/")
+        let thread = ChatThread(title: "Existing work", projectID: project.id)
+
+        let projects = WorkspaceBootstrapProjectMigration.removingUnusedLegacyRootProject(
+            from: [project],
+            threads: [thread],
+            hasThreadLoadIssues: false
+        )
+
+        XCTAssertEqual(projects, [project])
+    }
+
+    func testMigrationPreservesRootProjectWhenThreadRecoveryIsIncomplete() {
+        let project = ProjectRef(name: "/", path: "/")
+
+        let projects = WorkspaceBootstrapProjectMigration.removingUnusedLegacyRootProject(
+            from: [project],
+            threads: [],
+            hasThreadLoadIssues: true
+        )
+
+        XCTAssertEqual(projects, [project])
+    }
+
+    func testMigrationPreservesExplicitlyNamedRootProject() {
+        let project = ProjectRef(name: "Entire system", path: "/")
+
+        let projects = WorkspaceBootstrapProjectMigration.removingUnusedLegacyRootProject(
+            from: [project],
+            threads: [],
+            hasThreadLoadIssues: false
+        )
+
+        XCTAssertEqual(projects, [project])
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -10,6 +10,31 @@ import QuillComputerUseKit
 @MainActor
 final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
 
+    func testOrdinaryDesktopLaunchStartsWithoutRegisteringTheProcessDirectory() throws {
+        let stateRoot = try makeTempDirectory()
+        let paths = QuillCodePaths(home: stateRoot)
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+        )
+        let controller = QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            browserLiveDOMCapturer: nil,
+            updateController: QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            ),
+            workspaceRoot: nil
+        )
+
+        XCTAssertTrue(controller.model.root.projects.isEmpty)
+        XCTAssertTrue(controller.surface.projects.items.isEmpty)
+        XCTAssertEqual(
+            controller.workspaceRoot,
+            FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
+        )
+    }
+
     func testDesktopRegistersOnlyAProbedSSHProjectAndUsesResolvedFolder() async throws {
         let root = try makeTempDirectory()
         let fakeSSH = root.appendingPathComponent("fake-ssh")

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -9,6 +9,28 @@ import QuillCodeTools
 
 @MainActor
 final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
+    func testRenderedProjectlessWorkspaceShowsSafeFirstLaunchSetup() throws {
+        let model = QuillCodeWorkspaceModel()
+        model.root.topBar.agentStatus = QuillCodeRuntimeStatusLabel.signInWithTrustedRouter
+        let surface = model.surface()
+
+        XCTAssertTrue(surface.projects.items.isEmpty)
+        XCTAssertTrue(surface.transcript.timelineItems.isEmpty)
+        XCTAssertEqual(
+            surface.runtimeIssue?.recovery?.reason,
+            .trustedRouterSignInRequired
+        )
+
+        let image = try renderWorkspace(surface)
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 1280)
+        XCTAssertEqual(stats.height, 900)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.blueAccentPixelRatio, 0.001)
+    }
+
     func testRenderedEmptyWorkspaceShowsSavedChatRecoveryIssue() throws {
         let invalidID = UUID()
         let listing = ThreadListing(


### PR DESCRIPTION
## Summary
- stop ordinary desktop launches from registering the process directory as a project
- remove the accidental legacy filesystem-root project once, without affecting later intentional root projects
- add a polished project setup state and disable composer actions until a workspace is open

## Verification
- swift test: 5,421 tests, 5 skipped, 0 failures
- release-mode macOS app build
- native rendered smoke screenshot
- packaged app launch while signed out
- Open Project folder-picker interaction and cancellation
- one-time migration marker and empty project registry persistence