### PR TITLE
Recover safely from damaged workspace state

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeRuntimeSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeRuntimeSurface.swift
@@ -23,6 +23,7 @@ public enum RuntimeRecoveryReason: String, Codable, Sendable, Hashable {
     case malformedModelAction = "malformed-model-action"
     case runFailed = "run-failed"
     case savedChatsUnreadable = "saved-chats-unreadable"
+    case savedWorkspaceDataUnreadable = "saved-workspace-data-unreadable"
 }
 
 public struct RuntimeRecoveryTelemetry: Codable, Sendable, Hashable {

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -122,7 +122,7 @@ struct QuillCodeTranscriptView: View {
             return true
         case .trustedRouterKeyRejected, .rateLimited, .providerUnavailable,
              .networkUnreachable, .emptyResponse, .malformedModelAction,
-             .runFailed, .savedChatsUnreadable, nil:
+             .runFailed, .savedChatsUnreadable, .savedWorkspaceDataUnreadable, nil:
             return false
         }
     }

--- a/Sources/QuillCodeApp/SidebarSavedSearchStore.swift
+++ b/Sources/QuillCodeApp/SidebarSavedSearchStore.swift
@@ -1,6 +1,9 @@
 import Foundation
+import QuillCodePersistence
 
 public struct JSONSidebarSavedSearchStore: Sendable {
+    public static let maximumBytes = 4 * 1_024 * 1_024
+
     public var fileURL: URL
 
     public init(fileURL: URL) {
@@ -15,15 +18,18 @@ public struct JSONSidebarSavedSearchStore: Sendable {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(Self.normalized(savedSearches))
+        guard data.count <= Self.maximumBytes else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: Self.maximumBytes)
+        }
         try data.write(to: fileURL, options: .atomic)
     }
 
     public func load() throws -> [SidebarSavedSearch] {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
-        let decoded = try JSONDecoder().decode(
-            [SidebarSavedSearch].self,
-            from: Data(contentsOf: fileURL)
-        )
+        guard let data = try BoundedFileDataReader.readIfPresent(
+            from: fileURL,
+            maximumBytes: Self.maximumBytes
+        ) else { return [] }
+        let decoded = try JSONDecoder().decode([SidebarSavedSearch].self, from: data)
         return Self.normalized(decoded)
     }
 

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -28,13 +28,30 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
 
     @MainActor
     public func makeModel() throws -> QuillCodeWorkspaceModel {
-        try paths.ensure()
-        let config = try ConfigStore(fileURL: paths.configFile).load()
+        var unreadableDataKinds: [WorkspaceStartupDataKind] = []
+        do {
+            try paths.ensure()
+        } catch {
+            unreadableDataKinds.append(.workspaceStorage)
+        }
+        let config: AppConfig
+        do {
+            config = try ConfigStore(fileURL: paths.configFile).load()
+        } catch {
+            config = AppConfig()
+            unreadableDataKinds.append(.configuration)
+        }
         let threadStore = JSONThreadStore(directory: paths.threadsDirectory)
         let projectStore = JSONProjectStore(fileURL: paths.projectsFile)
         let automationStore = JSONAutomationStore(fileURL: paths.automationsFile)
         let sidebarSavedSearchStore = JSONSidebarSavedSearchStore(fileURL: paths.sidebarSavedSearchesFile)
-        let storedProjects = try projectStore.load()
+        let storedProjects: [ProjectRef]
+        do {
+            storedProjects = try projectStore.load()
+        } catch {
+            storedProjects = []
+            unreadableDataKinds.append(.projects)
+        }
         let childStore = SubagentThreadStore(directory: paths.subagentThreadsDirectory)
         let payloadStore = SubagentApprovalPayloadStore(directory: paths.subagentApprovalPayloadsDirectory)
         let threadListing = threadStore.listing()
@@ -44,25 +61,47 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             payloadStore: payloadStore
         )
         let threads = reconciliation.threads
-        let projects: [ProjectRef]
-        if WorkspaceBootstrapProjectMigration.isComplete(in: paths.home) {
-            projects = storedProjects
-        } else {
-            projects = WorkspaceBootstrapProjectMigration.removingUnusedLegacyRootProject(
+        var projects = storedProjects
+        if !WorkspaceBootstrapProjectMigration.isComplete(in: paths.home)
+            && !unreadableDataKinds.contains(.projects) {
+            let migratedProjects = WorkspaceBootstrapProjectMigration.removingUnusedLegacyRootProject(
                 from: storedProjects,
                 threads: threads,
                 hasThreadLoadIssues: !threadListing.issues.isEmpty
             )
-            if projects != storedProjects {
-                try projectStore.save(projects)
+            if migratedProjects != storedProjects {
+                do {
+                    try projectStore.save(migratedProjects)
+                    projects = migratedProjects
+                    try? WorkspaceBootstrapProjectMigration.markComplete(in: paths.home)
+                } catch {
+                    unreadableDataKinds.append(.projects)
+                }
+            } else {
+                try? WorkspaceBootstrapProjectMigration.markComplete(in: paths.home)
             }
-            try WorkspaceBootstrapProjectMigration.markComplete(in: paths.home)
         }
         for thread in threads where reconciliation.changedThreadIDs.contains(thread.id) {
-            try threadStore.save(thread)
+            do {
+                try threadStore.save(thread)
+            } catch {
+                unreadableDataKinds.append(.chats)
+            }
         }
-        let automations = try automationStore.load()
-        let sidebarSavedSearches = try sidebarSavedSearchStore.load()
+        let automations: [QuillAutomation]
+        do {
+            automations = try automationStore.load()
+        } catch {
+            automations = []
+            unreadableDataKinds.append(.automations)
+        }
+        let sidebarSavedSearches: [SidebarSavedSearch]
+        do {
+            sidebarSavedSearches = try sidebarSavedSearchStore.load()
+        } catch {
+            sidebarSavedSearches = []
+            unreadableDataKinds.append(.savedSearches)
+        }
         let selectedThreadID = threads.first(where: { !$0.isArchived })?.id
         let selectedProjectID = selectedThreadID
             .flatMap { id in threads.first { $0.id == id }?.projectID }
@@ -96,10 +135,16 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             runner: runtime.runner,
             contextSummaryGenerator: runtime.contextSummaryGenerator,
             threadStore: threadStore,
-            threadLoadIssue: WorkspaceThreadLoadIssue(listing: threadListing),
-            projectStore: projectStore,
-            automationStore: automationStore,
-            sidebarSavedSearchStore: sidebarSavedSearchStore,
+            startupLoadIssue: WorkspaceStartupLoadIssue(
+                loadedThreadCount: threads.count,
+                threadLoadIssue: WorkspaceThreadLoadIssue(listing: threadListing),
+                unreadableDataKinds: unreadableDataKinds
+            ),
+            projectStore: unreadableDataKinds.contains(.projects) ? nil : projectStore,
+            automationStore: unreadableDataKinds.contains(.automations) ? nil : automationStore,
+            sidebarSavedSearchStore: unreadableDataKinds.contains(.savedSearches)
+                ? nil
+                : sidebarSavedSearchStore,
             agentImporter: ClaudeCodeAgentImporter(
                 sourceHomeDirectory: FileManager.default.homeDirectoryForCurrentUser,
                 destinationPaths: paths

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -36,7 +36,7 @@ public final class QuillCodeWorkspaceModel {
     public internal(set) var sidebarSelection: SidebarSelectionState
     public internal(set) var agentRuns: WorkspaceAgentRunRegistry
     public private(set) var lastError: String?
-    let threadLoadIssue: WorkspaceThreadLoadIssue?
+    let startupLoadIssue: WorkspaceStartupLoadIssue?
 
     /// Set by the desktop layer to post a "come back and look" OS notification when an agent run
     /// finishes while the user is away — finished, errored, or blocked on an approval gate. The whole
@@ -152,6 +152,7 @@ public final class QuillCodeWorkspaceModel {
         contextSummaryGenerator: any WorkspaceContextSummaryGenerating = DeterministicWorkspaceContextSummaryGenerator(),
         threadStore: JSONThreadStore? = nil,
         threadLoadIssue: WorkspaceThreadLoadIssue? = nil,
+        startupLoadIssue: WorkspaceStartupLoadIssue? = nil,
         projectStore: JSONProjectStore? = nil,
         automationStore: JSONAutomationStore? = nil,
         sidebarSavedSearchStore: JSONSidebarSavedSearchStore? = nil,
@@ -199,7 +200,11 @@ public final class QuillCodeWorkspaceModel {
         self.subagentSchedulerOverride = nil
         self.contextSummaryGenerator = contextSummaryGenerator
         self.threadPersistence = WorkspaceThreadPersistence(store: threadStore)
-        self.threadLoadIssue = threadLoadIssue
+        self.startupLoadIssue = startupLoadIssue ?? WorkspaceStartupLoadIssue(
+            loadedThreadCount: root.threads.count,
+            threadLoadIssue: threadLoadIssue,
+            unreadableDataKinds: []
+        )
         self.projectStore = projectStore
         self.automationStore = automationStore
         self.sidebarSavedSearchStore = sidebarSavedSearchStore

--- a/Sources/QuillCodeApp/WorkspaceStartupLoadIssue.swift
+++ b/Sources/QuillCodeApp/WorkspaceStartupLoadIssue.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+public enum WorkspaceStartupDataKind: String, CaseIterable, Sendable, Hashable {
+    case workspaceStorage
+    case configuration
+    case chats
+    case projects
+    case automations
+    case savedSearches
+
+    var label: String {
+        switch self {
+        case .workspaceStorage:
+            "Workspace storage"
+        case .configuration:
+            "Settings"
+        case .chats:
+            "Chats"
+        case .projects:
+            "Projects"
+        case .automations:
+            "Automations"
+        case .savedSearches:
+            "Saved searches"
+        }
+    }
+}
+
+public struct WorkspaceStartupLoadIssue: Sendable, Hashable {
+    private var loadedThreadCount: Int
+    private var threadLoadIssue: WorkspaceThreadLoadIssue?
+    private var unreadableDataKinds: [WorkspaceStartupDataKind]
+
+    public init?(
+        loadedThreadCount: Int,
+        threadLoadIssue: WorkspaceThreadLoadIssue? = nil,
+        unreadableDataKinds: [WorkspaceStartupDataKind]
+    ) {
+        let requestedKinds = Set(unreadableDataKinds)
+        let normalizedKinds = WorkspaceStartupDataKind.allCases.filter(requestedKinds.contains)
+        guard threadLoadIssue != nil || !normalizedKinds.isEmpty else { return nil }
+        self.loadedThreadCount = max(0, loadedThreadCount)
+        self.threadLoadIssue = threadLoadIssue
+        self.unreadableDataKinds = normalizedKinds
+    }
+
+    var runtimeIssue: RuntimeIssueSurface {
+        if unreadableDataKinds.isEmpty, let threadLoadIssue {
+            return threadLoadIssue.runtimeIssue
+        }
+        let storageUnavailable = unreadableDataKinds.contains(.workspaceStorage)
+        return RuntimeIssueSurface(
+            severity: .warning,
+            title: storageUnavailable
+                ? "Workspace storage could not be opened"
+                : "Some saved workspace data could not be loaded",
+            message: storageUnavailable ? storageUnavailableMessage : partialRecoveryMessage,
+            actionLabel: "Review diagnostics",
+            recovery: RuntimeRecoveryTelemetry(
+                route: .settings,
+                reason: .savedWorkspaceDataUnreadable,
+                commandID: "settings"
+            ),
+            diagnostics: diagnostics
+        )
+    }
+
+    private var storageUnavailableMessage: String {
+        "Quill Cowork started in recovery mode without changing your saved workspace data. " +
+            "Review storage permissions and available disk space before continuing."
+    }
+
+    private var partialRecoveryMessage: String {
+        let healthyChats = loadedThreadCount == 0
+            ? ""
+            : " Your \(loadedThreadCount) saved \(loadedThreadCount == 1 ? "chat is" : "chats are") still available."
+        return "Quill Cowork loaded every healthy record and used safe defaults for the affected data." +
+            healthyChats + " The original files were left unchanged so they can be recovered."
+    }
+
+    private var diagnostics: [RuntimeDiagnosticSurface] {
+        var rows = [
+            RuntimeDiagnosticSurface(
+                label: "Affected data",
+                value: unreadableDataKinds.map(\.label).joined(separator: ", ")
+            ),
+            RuntimeDiagnosticSurface(label: "Loaded chats", value: String(loadedThreadCount)),
+        ]
+        if let threadIssue = threadLoadIssue?.runtimeIssue {
+            rows.append(contentsOf: threadIssue.diagnostics.compactMap { diagnostic in
+                switch diagnostic.label {
+                case "Loaded chats", "Recovery":
+                    return nil
+                case "Affected files":
+                    return RuntimeDiagnosticSurface(label: "Affected chat files", value: diagnostic.value)
+                default:
+                    return diagnostic
+                }
+            })
+        }
+        rows.append(RuntimeDiagnosticSurface(
+            label: "Recovery",
+            value: "Back up ~/.quillcode, then run quill-code doctor."
+        ))
+        return rows
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -296,8 +296,8 @@ public extension QuillCodeWorkspaceModel {
     }
 
     private func runtimeIssueSurface() -> RuntimeIssueSurface? {
-        if let threadLoadIssue {
-            return threadLoadIssue.runtimeIssue
+        if let startupLoadIssue {
+            return startupLoadIssue.runtimeIssue
         }
         return WorkspaceRuntimeIssueBuilder(
             config: root.config,

--- a/Sources/QuillCodePersistence/AutomationStore.swift
+++ b/Sources/QuillCodePersistence/AutomationStore.swift
@@ -2,6 +2,8 @@ import Foundation
 import QuillCodeCore
 
 public struct JSONAutomationStore: Sendable {
+    public static let maximumBytes = 16 * 1_024 * 1_024
+
     public var fileURL: URL
 
     public init(fileURL: URL) {
@@ -17,14 +19,19 @@ public struct JSONAutomationStore: Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(QuillAutomation.sortedForDisplay(automations))
+        guard data.count <= Self.maximumBytes else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: Self.maximumBytes)
+        }
         try data.write(to: fileURL, options: .atomic)
     }
 
     public func load() throws -> [QuillAutomation] {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
+        guard let data = try BoundedFileDataReader.readIfPresent(
+            from: fileURL,
+            maximumBytes: Self.maximumBytes
+        ) else { return [] }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let data = try Data(contentsOf: fileURL)
         return QuillAutomation.sortedForDisplay(try decoder.decode([QuillAutomation].self, from: data))
     }
 }

--- a/Sources/QuillCodePersistence/BoundedFileDataReader.swift
+++ b/Sources/QuillCodePersistence/BoundedFileDataReader.swift
@@ -1,0 +1,116 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+public enum BoundedFileDataError: LocalizedError, Equatable, Sendable {
+    case invalidSizeLimit
+    case notRegularFile
+    case symbolicLink
+    case exceedsSizeLimit(maximumBytes: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidSizeLimit:
+            "The file loading limit is invalid."
+        case .notRegularFile:
+            "The path is not a regular file."
+        case .symbolicLink:
+            "The path is a symbolic link."
+        case .exceedsSizeLimit(let maximumBytes):
+            "The file exceeds the \(maximumBytes)-byte loading limit."
+        }
+    }
+}
+
+/// Reads a known persistence file without following links or mapping an unbounded payload.
+public enum BoundedFileDataReader {
+    public static func readIfPresent(from fileURL: URL, maximumBytes: Int) throws -> Data? {
+        do {
+            return try read(from: fileURL, maximumBytes: maximumBytes)
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain
+                && error.code == NSFileReadNoSuchFileError {
+            return nil
+        }
+    }
+
+    public static func read(from fileURL: URL, maximumBytes: Int) throws -> Data {
+        guard maximumBytes >= 0 else {
+            throw BoundedFileDataError.invalidSizeLimit
+        }
+#if canImport(Darwin) || canImport(Glibc)
+        let descriptor = fileURL.path.withCString {
+            open($0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard descriptor >= 0 else {
+            let code = errno
+            if code == ELOOP {
+                throw BoundedFileDataError.symbolicLink
+            }
+            if code == ENOENT {
+                throw NSError(
+                    domain: NSCocoaErrorDomain,
+                    code: NSFileReadNoSuchFileError,
+                    userInfo: [NSFilePathErrorKey: fileURL.path]
+                )
+            }
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(code))
+        }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        defer { try? handle.close() }
+
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+            throw BoundedFileDataError.notRegularFile
+        }
+        guard metadata.st_size >= 0,
+              UInt64(metadata.st_size) <= UInt64(maximumBytes)
+        else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+        }
+
+        var data = Data()
+        data.reserveCapacity(Int(metadata.st_size))
+        while true {
+            let remainingBytes = maximumBytes - data.count
+            let requestedBytes = remainingBytes == 0 ? 1 : min(64 * 1_024, remainingBytes)
+            guard let chunk = try handle.read(upToCount: requestedBytes), !chunk.isEmpty else {
+                return data
+            }
+            guard chunk.count <= remainingBytes else {
+                throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+            }
+            data.append(chunk)
+        }
+#else
+        let values = try fileURL.resourceValues(forKeys: [
+            .fileSizeKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+        ])
+        guard values.isSymbolicLink != true else {
+            throw BoundedFileDataError.symbolicLink
+        }
+        guard values.isRegularFile == true else {
+            throw BoundedFileDataError.notRegularFile
+        }
+        guard let fileSize = values.fileSize,
+              fileSize >= 0,
+              fileSize <= maximumBytes
+        else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+        }
+        let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+        guard data.count <= maximumBytes else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+        }
+        return data
+#endif
+    }
+}

--- a/Sources/QuillCodePersistence/ConfigDocument.swift
+++ b/Sources/QuillCodePersistence/ConfigDocument.swift
@@ -206,14 +206,11 @@ public struct ConfigDocumentStore: Sendable {
     }
 
     public func loadSnapshot() throws -> ConfigDocumentSnapshot {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        guard let bytes = try BoundedFileDataReader.readIfPresent(
+            from: fileURL,
+            maximumBytes: Self.maximumBytes
+        ) else {
             return ConfigDocumentSnapshot(document: ConfigDocument(), bytes: Data())
-        }
-        let bytes = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-        guard bytes.count <= Self.maximumBytes else {
-            throw ConfigDocumentError.invalidValue(
-                "Config exceeds the \(Self.maximumBytes)-byte limit."
-            )
         }
         guard let source = String(data: bytes, encoding: .utf8) else {
             throw ConfigDocumentError.invalidValue("Config must be UTF-8.")

--- a/Sources/QuillCodePersistence/ConfigStore.swift
+++ b/Sources/QuillCodePersistence/ConfigStore.swift
@@ -20,9 +20,6 @@ public struct ConfigStore: Sendable {
     }
 
     public func load() throws -> AppConfig {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return AppConfig()
-        }
         if let document = try? ConfigDocumentStore(fileURL: fileURL).load() {
             return Self.config(from: document)
         }
@@ -30,7 +27,13 @@ public struct ConfigStore: Sendable {
         // Keep accepting early QuillCode files containing invalid bare values. New writes always
         // use the strict TOML document store, but silently discarding an older user's settings
         // because one boolean was malformed would be a worse migration failure.
-        let text = try String(contentsOf: fileURL, encoding: .utf8)
+        let bytes = try BoundedFileDataReader.read(
+            from: fileURL,
+            maximumBytes: ConfigDocumentStore.maximumBytes
+        )
+        guard let text = String(data: bytes, encoding: .utf8) else {
+            throw ConfigDocumentError.invalidValue("Config must be UTF-8.")
+        }
         var config = AppConfig()
         var explicitAuthMode: TrustedRouterAuthMode?
         var legacyDeveloperOverrideEnabled: Bool?

--- a/Sources/QuillCodePersistence/ProjectStore.swift
+++ b/Sources/QuillCodePersistence/ProjectStore.swift
@@ -2,6 +2,8 @@ import Foundation
 import QuillCodeCore
 
 public struct JSONProjectStore: Sendable {
+    public static let maximumBytes = 16 * 1_024 * 1_024
+
     public var fileURL: URL
 
     public init(fileURL: URL) {
@@ -16,15 +18,21 @@ public struct JSONProjectStore: Sendable {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
-        try encoder.encode(projects)
-            .write(to: fileURL, options: .atomic)
+        let data = try encoder.encode(projects)
+        guard data.count <= Self.maximumBytes else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: Self.maximumBytes)
+        }
+        try data.write(to: fileURL, options: .atomic)
     }
 
     public func load() throws -> [ProjectRef] {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
+        guard let data = try BoundedFileDataReader.readIfPresent(
+            from: fileURL,
+            maximumBytes: Self.maximumBytes
+        ) else { return [] }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let projects = try decoder.decode([ProjectRef].self, from: Data(contentsOf: fileURL))
+        let projects = try decoder.decode([ProjectRef].self, from: data)
         return projects.sorted { $0.lastOpenedAt > $1.lastOpenedAt }
     }
 }

--- a/Sources/QuillCodePersistence/ThreadStore.swift
+++ b/Sources/QuillCodePersistence/ThreadStore.swift
@@ -148,28 +148,27 @@ public struct JSONThreadStore: Sendable {
     }
 
     private static func boundedData(contentsOf url: URL) throws -> Data {
-        let values = try url.resourceValues(forKeys: [
-            .fileSizeKey,
-            .isRegularFileKey,
-            .isSymbolicLinkKey,
-        ])
-        guard values.isSymbolicLink != true else {
-            throw JSONThreadStoreError.symbolicLink
+        do {
+            return try BoundedFileDataReader.read(
+                from: url,
+                maximumBytes: maximumThreadFileBytes
+            )
+        } catch let error as BoundedFileDataError {
+            switch error {
+            case .invalidSizeLimit:
+                throw JSONThreadStoreError.exceedsSizeLimit(
+                    maximumBytes: maximumThreadFileBytes
+                )
+            case .notRegularFile:
+                throw JSONThreadStoreError.notRegularFile
+            case .symbolicLink:
+                throw JSONThreadStoreError.symbolicLink
+            case .exceedsSizeLimit:
+                throw JSONThreadStoreError.exceedsSizeLimit(
+                    maximumBytes: maximumThreadFileBytes
+                )
+            }
         }
-        guard values.isRegularFile == true else {
-            throw JSONThreadStoreError.notRegularFile
-        }
-        guard let fileSize = values.fileSize,
-              fileSize >= 0,
-              fileSize <= maximumThreadFileBytes
-        else {
-            throw JSONThreadStoreError.exceedsSizeLimit(maximumBytes: maximumThreadFileBytes)
-        }
-        let data = try Data(contentsOf: url, options: .mappedIfSafe)
-        guard data.count <= maximumThreadFileBytes else {
-            throw JSONThreadStoreError.exceedsSizeLimit(maximumBytes: maximumThreadFileBytes)
-        }
-        return data
     }
 
     private static func issueReason(for error: JSONThreadStoreError) -> ThreadFileIssueReason {

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -98,7 +98,12 @@ final class QuillCodeDesktopController: ObservableObject {
         do {
             self.model = try bootstrap.makeModel()
         } catch {
-            self.model = QuillCodeWorkspaceModel()
+            self.model = QuillCodeWorkspaceModel(
+                startupLoadIssue: WorkspaceStartupLoadIssue(
+                    loadedThreadCount: 0,
+                    unreadableDataKinds: [.workspaceStorage]
+                )
+            )
         }
         self.workspaceRoot = launchWorkspaceRoot
             ?? FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL

--- a/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfigurationIntegrationTests.swift
@@ -199,6 +199,119 @@ final class WorkspaceConfigurationIntegrationTests: XCTestCase {
         XCTAssertEqual(model.surface().settings.runtimeIssue, issue)
     }
 
+    func testBootstrapRecoversEachDamagedWorkspaceRegistryWithoutHidingHealthyChats() throws {
+        let root = try makeTempDirectory()
+        let paths = QuillCodePaths(home: root.appendingPathComponent(".quillcode"))
+        try paths.ensure()
+        let threadStore = JSONThreadStore(directory: paths.threadsDirectory)
+        try threadStore.save(ChatThread(title: "Still here"))
+        let corruptThreadID = UUID()
+        try Data("{ truncated".utf8).write(
+            to: paths.threadsDirectory.appendingPathComponent("\(corruptThreadID.uuidString).json")
+        )
+        let rejectedBytes = Data([0xFF, 0x00, 0xFE, 0x7F])
+        let rejectedFiles = [
+            paths.configFile,
+            paths.projectsFile,
+            paths.automationsFile,
+            paths.sidebarSavedSearchesFile,
+        ]
+        for fileURL in rejectedFiles {
+            try rejectedBytes.write(to: fileURL)
+        }
+
+        let model = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
+
+        XCTAssertEqual(model.root.threads.map(\.title), ["Still here"])
+        XCTAssertEqual(model.root.config, AppConfig())
+        XCTAssertTrue(model.root.projects.isEmpty)
+        XCTAssertTrue(model.automations.items.isEmpty)
+        XCTAssertTrue(model.sidebarSavedSearches.isEmpty)
+
+        let issue = try XCTUnwrap(model.surface().runtimeIssue)
+        XCTAssertEqual(issue.severity, .warning)
+        XCTAssertEqual(issue.title, "Some saved workspace data could not be loaded")
+        XCTAssertEqual(issue.actionLabel, "Review diagnostics")
+        XCTAssertEqual(issue.recovery?.route, .settings)
+        XCTAssertEqual(issue.recovery?.reason, .savedWorkspaceDataUnreadable)
+        let diagnostics = Dictionary(uniqueKeysWithValues: issue.diagnostics.map { ($0.label, $0.value) })
+        XCTAssertEqual(diagnostics["Affected data"], "Settings, Projects, Automations, Saved searches")
+        XCTAssertEqual(diagnostics["Loaded chats"], "1")
+        XCTAssertEqual(diagnostics["Affected chat files"], "1")
+        XCTAssertEqual(diagnostics["Chat IDs"], corruptThreadID.uuidString.lowercased())
+        let visibleRecoveryText = ([issue.title, issue.message] + issue.diagnostics.flatMap {
+            [$0.label, $0.value]
+        }).joined(separator: "\n")
+        XCTAssertFalse(visibleRecoveryText.contains(root.path))
+
+        _ = model.addProject(path: root, name: "Recovery session project")
+        _ = model.saveSidebarSavedSearch(title: "Recovery search", query: "error")
+        model.applyAutomationState(AutomationsState(items: [QuillAutomation(
+            title: "Recovery automation",
+            detail: "Should remain in memory only.",
+            kind: .monitor,
+            scheduleKind: .event,
+            scheduleDescription: "Event"
+        )]))
+        for fileURL in rejectedFiles {
+            XCTAssertEqual(try Data(contentsOf: fileURL), rejectedBytes)
+        }
+    }
+
+    func testBootstrapKeepsHealthyRegistriesWhenOneRegistryIsDamaged() throws {
+        let root = try makeTempDirectory()
+        let paths = QuillCodePaths(home: root.appendingPathComponent(".quillcode"))
+        try paths.ensure()
+        let config = AppConfig(defaultModel: "trustedrouter/glm-5.2", mode: .review)
+        let project = ProjectRef(name: "Healthy project", path: root.path)
+        let savedSearch = SidebarSavedSearch(title: "Failures", query: "failed")
+        try ConfigStore(fileURL: paths.configFile).save(config)
+        try JSONProjectStore(fileURL: paths.projectsFile).save([project])
+        try JSONSidebarSavedSearchStore(fileURL: paths.sidebarSavedSearchesFile).save([savedSearch])
+        let rejectedBytes = Data("{ truncated".utf8)
+        try rejectedBytes.write(to: paths.automationsFile)
+
+        let model = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
+
+        XCTAssertEqual(model.root.config, config)
+        XCTAssertEqual(model.root.projects.map(\.id), [project.id])
+        XCTAssertEqual(model.root.projects.map(\.name), [project.name])
+        XCTAssertEqual(model.root.projects.map(\.path), [project.path])
+        XCTAssertEqual(model.sidebarSavedSearches, [savedSearch])
+        XCTAssertTrue(model.automations.items.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: paths.automationsFile), rejectedBytes)
+        let issue = try XCTUnwrap(model.surface().runtimeIssue)
+        XCTAssertEqual(issue.diagnostics.first?.value, "Automations")
+    }
+
+    func testBootstrapKeepsHealthyStateWhenAnAuxiliaryStorageDirectoryIsBlocked() throws {
+        let root = try makeTempDirectory()
+        let paths = QuillCodePaths(home: root.appendingPathComponent(".quillcode"))
+        try paths.ensure()
+        let config = AppConfig(defaultModel: "trustedrouter/glm-5.2", mode: .review)
+        let project = ProjectRef(name: "Healthy project", path: root.path)
+        let chat = ChatThread(title: "Healthy chat", projectID: project.id)
+        try ConfigStore(fileURL: paths.configFile).save(config)
+        try JSONProjectStore(fileURL: paths.projectsFile).save([project])
+        try JSONThreadStore(directory: paths.threadsDirectory).save(chat)
+        try FileManager.default.removeItem(at: paths.attachmentsDirectory)
+        try Data("blocked".utf8).write(to: paths.attachmentsDirectory)
+
+        let model = try QuillCodeWorkspaceBootstrap(paths: paths).makeModel()
+
+        XCTAssertEqual(model.root.config, config)
+        XCTAssertEqual(model.root.projects.map(\.id), [project.id])
+        XCTAssertEqual(model.root.threads.map(\.id), [chat.id])
+        let issue = try XCTUnwrap(model.surface().runtimeIssue)
+        XCTAssertEqual(issue.title, "Workspace storage could not be opened")
+        XCTAssertEqual(issue.recovery?.reason, .savedWorkspaceDataUnreadable)
+        XCTAssertEqual(issue.diagnostics.first?.value, "Workspace storage")
+        XCTAssertEqual(
+            try String(contentsOf: paths.attachmentsDirectory, encoding: .utf8),
+            "blocked"
+        )
+    }
+
     func testBootstrapPersistsAndClearsTrustedRouterAPIKey() throws {
         let paths = QuillCodePaths(home: try makeTempDirectory())
         let bootstrap = QuillCodeWorkspaceBootstrap(

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -35,6 +35,37 @@ final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
         )
     }
 
+    func testDesktopLaunchSurfacesWorkspaceStorageFailureInsteadOfSilentBlankState() throws {
+        let root = try makeTempDirectory()
+        let blockedHome = root.appendingPathComponent("state-is-a-file")
+        try Data("not a directory".utf8).write(to: blockedHome)
+        let paths = QuillCodePaths(home: blockedHome)
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+        )
+
+        let controller = QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            browserLiveDOMCapturer: nil,
+            updateController: QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            ),
+            workspaceRoot: nil
+        )
+
+        let issue = try XCTUnwrap(controller.surface.runtimeIssue)
+        XCTAssertEqual(issue.severity, .warning)
+        XCTAssertEqual(issue.title, "Workspace storage could not be opened")
+        XCTAssertEqual(issue.recovery?.route, .settings)
+        XCTAssertEqual(issue.recovery?.reason, .savedWorkspaceDataUnreadable)
+        XCTAssertTrue(
+            issue.diagnostics.first?.value.contains("Workspace storage") == true
+        )
+        XCTAssertFalse(issue.message.contains(blockedHome.path))
+    }
+
     func testDesktopRegistersOnlyAProbedSSHProjectAndUsesResolvedFolder() async throws {
         let root = try makeTempDirectory()
         let fakeSSH = root.appendingPathComponent("fake-ssh")

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -59,6 +59,40 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
     }
 
+    func testRenderedEmptyWorkspaceShowsAggregatedRegistryRecoveryIssue() throws {
+        let firstThread = ChatThread(title: "Recovered chat A")
+        let secondThread = ChatThread(title: "Recovered chat B")
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                threads: [firstThread, secondThread],
+                selectedThreadID: firstThread.id
+            ),
+            startupLoadIssue: WorkspaceStartupLoadIssue(
+                loadedThreadCount: 2,
+                unreadableDataKinds: [.configuration, .projects, .automations, .savedSearches]
+            )
+        )
+        let surface = model.surface()
+        XCTAssertEqual(
+            surface.runtimeIssue?.title,
+            "Some saved workspace data could not be loaded"
+        )
+        XCTAssertEqual(
+            surface.runtimeIssue?.recovery?.reason,
+            .savedWorkspaceDataUnreadable
+        )
+        XCTAssertTrue(surface.transcript.timelineItems.isEmpty)
+
+        let image = try renderWorkspace(surface)
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 1280)
+        XCTAssertEqual(stats.height, 900)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
+    }
+
     func testRenderedUpdaterShowsDeterminateDownloadProgressInsideSheet() async throws {
         let release = makeRelease(version: "0.2.0", build: "7")
         let controller = QuillCodeDesktopUpdateController(

--- a/Tests/QuillCodePersistenceTests/BoundedFileDataReaderTests.swift
+++ b/Tests/QuillCodePersistenceTests/BoundedFileDataReaderTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import QuillCodePersistence
+
+final class BoundedFileDataReaderTests: PersistenceTestCase {
+    func testMissingFileReturnsNil() throws {
+        let fileURL = try makeTempDirectory().appendingPathComponent("missing.json")
+
+        XCTAssertNil(
+            try BoundedFileDataReader.readIfPresent(from: fileURL, maximumBytes: 4_096)
+        )
+    }
+
+    func testReadsRegularFileWithinLimit() throws {
+        let fileURL = try makeTempDirectory().appendingPathComponent("state.json")
+        let expected = Data("healthy".utf8)
+        try expected.write(to: fileURL)
+
+        XCTAssertEqual(
+            try BoundedFileDataReader.read(from: fileURL, maximumBytes: expected.count),
+            expected
+        )
+    }
+
+    func testRejectsOversizedSparseFileBeforeLoadingIt() throws {
+        let fileURL = try makeTempDirectory().appendingPathComponent("state.json")
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: Data()))
+        let handle = try FileHandle(forWritingTo: fileURL)
+        try handle.truncate(atOffset: 4_097)
+        try handle.close()
+
+        XCTAssertThrowsError(
+            try BoundedFileDataReader.read(from: fileURL, maximumBytes: 4_096)
+        ) { error in
+            XCTAssertEqual(
+                error as? BoundedFileDataError,
+                .exceedsSizeLimit(maximumBytes: 4_096)
+            )
+        }
+    }
+
+    func testRejectsSymbolicLink() throws {
+        let directory = try makeTempDirectory()
+        let target = directory.appendingPathComponent("target.json")
+        let link = directory.appendingPathComponent("state.json")
+        try Data("healthy".utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertThrowsError(
+            try BoundedFileDataReader.read(from: link, maximumBytes: 4_096)
+        ) { error in
+            XCTAssertEqual(error as? BoundedFileDataError, .symbolicLink)
+        }
+    }
+
+    func testRejectsDanglingSymbolicLinkInsteadOfTreatingItAsMissing() throws {
+        let directory = try makeTempDirectory()
+        let target = directory.appendingPathComponent("missing-target.json")
+        let link = directory.appendingPathComponent("state.json")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertThrowsError(
+            try BoundedFileDataReader.readIfPresent(from: link, maximumBytes: 4_096)
+        ) { error in
+            XCTAssertEqual(error as? BoundedFileDataError, .symbolicLink)
+        }
+    }
+
+    func testRejectsDirectory() throws {
+        let directory = try makeTempDirectory()
+
+        XCTAssertThrowsError(
+            try BoundedFileDataReader.read(from: directory, maximumBytes: 4_096)
+        ) { error in
+            XCTAssertEqual(error as? BoundedFileDataError, .notRegularFile)
+        }
+    }
+}

--- a/Tests/QuillCodePersistenceTests/ConfigStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/ConfigStoreTests.swift
@@ -399,6 +399,34 @@ final class ConfigStoreTests: PersistenceTestCase {
         XCTAssertFalse(loaded.developerOverrideEnabled)
         XCTAssertEqual(loaded.defaultModel, TrustedRouterDefaults.prometheusModel)
     }
+
+    func testConfigRejectsOversizedFileWithoutFallingBackToUnboundedLegacyRead() throws {
+        let fileURL = try makeTempDirectory().appendingPathComponent("config.toml")
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: Data()))
+        let handle = try FileHandle(forWritingTo: fileURL)
+        try handle.truncate(atOffset: UInt64(ConfigDocumentStore.maximumBytes + 1))
+        try handle.close()
+
+        XCTAssertThrowsError(try ConfigStore(fileURL: fileURL).load()) { error in
+            XCTAssertEqual(
+                error as? BoundedFileDataError,
+                .exceedsSizeLimit(maximumBytes: ConfigDocumentStore.maximumBytes)
+            )
+        }
+    }
+
+    func testConfigRejectsDanglingSymbolicLinkInsteadOfTreatingItAsMissing() throws {
+        let directory = try makeTempDirectory()
+        let fileURL = directory.appendingPathComponent("config.toml")
+        try FileManager.default.createSymbolicLink(
+            at: fileURL,
+            withDestinationURL: directory.appendingPathComponent("missing.toml")
+        )
+
+        XCTAssertThrowsError(try ConfigStore(fileURL: fileURL).load()) { error in
+            XCTAssertEqual(error as? BoundedFileDataError, .symbolicLink)
+        }
+    }
 }
 
 private extension ConfigStoreTests {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,29 @@
 # Code Quality Audit
 
+## 2026-08-08 Crash-Safe Workspace Bootstrap
+
+Overall grade after this slice: **A+ bounded persistence, A+ recovery isolation, A+ visible failure**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Memory safety | A+ | One shared reader preflights file type, symlink status, and byte size before mapped loading. Config and saved searches cap at 4 MiB; projects and automations cap at 16 MiB; chat behavior retains its 128 MiB contract. |
+| Crash resilience | A+ | Config, projects, automations, saved searches, chat reconciliation, and workspace-directory setup recover independently. A rejected registry cannot collapse healthy startup or be replaced by automatic recovery-session saves. |
+| Architecture | A+ | Persistence owns bounded bytes, bootstrap owns per-store fallback, and one typed startup issue owns content-free UI diagnostics. Thread storage now reuses the same bounded reader while preserving its public error contract. |
+| UX | A+ | Partial startup states exactly which data needs attention and how many chats survived. Total workspace-directory failure is visible instead of presenting an unexplained empty app. |
+| Tests | A+ | Sparse oversized files, symlinks, non-files, mixed corruption, healthy-registry isolation, unchanged bytes, desktop fallback, and existing chat-store behavior are covered. |
+
+Validation:
+
+- Focused persistence, startup, compatibility, and native-render suite (78 tests, 0 failures)
+- Desktop catastrophic-storage fallback (1 test, 0 failures)
+- Full `swift test --skip-build` (5,434 tests, 5 skipped, 0 failures)
+- Packaged macOS direct-executable, Launch Services, live SwiftUI window,
+  accessibility/click-target, and coworker-workflow smoke passed
+- Release package: 3 of 3 fresh launches within budget; 262.68 ms median launch-ready,
+  88.02 MiB resident memory, and 7 threads
+- `python3 scripts/grade-code-quality.py --root .` (all affected modules A+)
+- `git diff --check`
+
 ## 2026-07-13 Managed Worktree Publish Branch Slice
 
 Overall grade after this slice: **A+ inspected publication architecture, A worktree parity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,27 @@
 # QuillCode Decisions
 
+## 2026-08-08: damaged workspace registries recover independently
+
+- **Decision:** Config, projects, automations, and saved-search registries are accepted only as
+  regular non-symlink files within explicit 4 MiB or 16 MiB limits. Bootstrap loads each registry
+  independently, so one rejected file uses a safe in-memory default without hiding healthy chats or
+  other registries.
+- **Preservation boundary:** Startup never rewrites a rejected registry. Its store is detached for
+  the recovery session, preventing automatic model saves from replacing recoverable bytes. Failed
+  subagent reconciliation saves are also reported without aborting launch.
+- **User experience:** One content-free warning names affected data categories and the number of
+  healthy chats loaded. It routes to Settings diagnostics without exposing absolute paths, file
+  contents, or decoder errors. If workspace-directory setup is incomplete, bootstrap still loads
+  readable state and presents an explicit storage-recovery warning instead of silently constructing
+  a blank-looking workspace.
+- **Why:** Singleton registry loads previously shared one throwing bootstrap path. A malformed
+  `projects.json`, `automations.json`, `sidebar-saved-searches.json`, or `config.toml` therefore made
+  every healthy conversation appear gone for that launch, and several reads had no preflight bound.
+- **Evidence:** `BoundedFileDataReaderTests`, `ConfigStoreTests`,
+  `WorkspaceConfigurationIntegrationTests`, `JSONThreadStoreTests`, and
+  `QuillCodeDesktopControllerSmokeTests` cover bounded rejection, independent recovery, unchanged
+  source bytes, healthy-state preservation, aggregated diagnostics, and catastrophic storage failure.
+
 ## 2026-08-07: damaged saved chats stay bounded, visible, and recoverable
 
 - **Decision:** Persisted chat files are inspected as regular non-symlink files before decoding,
@@ -1229,7 +1251,7 @@
 - Model picker detail browsing is deterministic but can now include live TrustedRouter capability metadata. `TrustedRouterModelCatalogDecoding` owns flexible `/models` response parsing for context window, pricing, input/output modalities, capability tags, status, and summaries. `ModelInfo` stores normalized `ModelCapabilities`, and the app projects those claims into structured metadata rows/search terms rather than prose summaries so ordinary queries like `coding` do not match every recommended model just because a sentence mentions coding.
 - TrustedRouter model-catalog freshness is a root-state status, not a per-row capability. `ModelCatalogStatus` records bundled fallback, live TrustedRouter fetches, and fallback-after-refresh-failure with fetch age and bounded failure detail; the model picker and Settings render that shared label while individual `ModelInfo.capabilities.status` remains the provider/model health row. This keeps catalog-source diagnostics visible without repeating a global freshness badge on every model.
 - Provider health summaries are catalog-derived until TrustedRouter publishes a stable provider-status endpoint. `ModelProviderHealthSummary` groups live `ModelInfo.capabilities.status` values by canonical provider and feeds the picker/Settings header. Proactive desktop refresh polls the keyed TrustedRouter model catalog at startup and on a bounded stale interval, then derives provider health from that single catalog source instead of inventing a second status loop.
-- The first project UX is a native project rail backed by explicit selected-project state and `~/.quillcode/projects.json`. The desktop app seeds the launch working directory as the initial project, and `Open project` uses a desktop folder picker while the surface contract keeps the project action as a platform-neutral command.
+- The first project UX is a native project rail backed by explicit selected-project state and `~/.quillcode/projects.json`. Ordinary desktop launch waits for explicit project selection; only an explicit launch workspace is registered. `Open project` uses a desktop folder picker while the surface contract keeps the project action as a platform-neutral command.
 - Project registry mutation rules live in `WorkspaceProjectEngine`. The workspace model owns loaders, stores, terminal synchronization, and top-bar refresh, while the engine owns local/SSH project upsert, selected-project thread selection, project removal cleanup, metadata application, timestamp touches, and default naming. This keeps Codex-style project/worktree/remote behavior testable without booting the whole workspace model.
 - Native developer settings save the TrustedRouter API base URL in `config.toml` and the local API key through `QuillSecretStore`. Saving settings rebuilds the active desktop runtime immediately so the user does not need to relaunch to switch from mock to live mode.
 - TrustedRouter authentication has an explicit persisted mode. `oauth` is the default user-facing path, while `developer-override` is an intentional settings choice that reveals API key/base URL controls and preserves compatibility with older `developer_override_enabled` configs.


### PR DESCRIPTION
## Summary
- bound config, project, automation, saved-search, and chat reads without following final symlinks
- recover each workspace store independently and preserve every healthy chat and registry
- surface content-free startup recovery diagnostics while leaving rejected files unchanged

## Validation
- `swift test --skip-build`: 5,434 tests, 5 skipped, 0 failures
- packaged macOS direct, Launch Services, live-window, accessibility, click-target, and coworker workflow smoke passed
- release package: 3/3 fresh launches within budget, 262.68 ms median launch-ready, 88.02 MiB resident, 7 threads
- all affected modules grade A+
- `git diff --check`