### PR TITLE
Harden updater post-launch recovery

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -125,6 +125,7 @@ let package = Package(
                 "QuillCodeCore",
                 "QuillCodeApp",
                 "QuillCodeAgent",
+                "QuillCodePersistence",
                 "QuillCodeReview",
                 "QuillCodeTools",
                 "QuillComputerUseKit",

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -1,10 +1,9 @@
 import AppKit
 import Foundation
+import QuillCodePersistence
 
 @MainActor
 final class QuillCodeDesktopUpdateController: ObservableObject {
-    private static let installResultByteLimit = 64 * 1_024
-
     enum State: Equatable {
         case idle
         case checking
@@ -339,21 +338,13 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     }
 
     private func consumePreviousInstallResult() {
-        guard let installResultURL,
-              FileManager.default.fileExists(atPath: installResultURL.path)
-        else {
-            return
-        }
+        guard let installResultURL else { return }
         defer { try? FileManager.default.removeItem(at: installResultURL) }
 
-        guard let values = try? installResultURL.resourceValues(
-            forKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey]
+        guard let data = try? BoundedFileDataReader.readIfPresent(
+            from: installResultURL,
+            maximumBytes: QuillCodeDesktopUpdateInstallResult.maximumEncodedBytes
         ),
-              values.isRegularFile == true,
-              values.isSymbolicLink != true,
-              let fileSize = values.fileSize,
-              fileSize <= Self.installResultByteLimit,
-              let data = try? Data(contentsOf: installResultURL, options: .mappedIfSafe),
               let result = try? JSONDecoder().decode(QuillCodeDesktopUpdateInstallResult.self, from: data)
         else {
             return

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
@@ -103,9 +103,9 @@ enum QuillCodeDesktopUpdateHelper {
             request.incomingApplicationURL
         )
 
-        let launchedProcessID: Int32
+        let launchedProcess: Process
         do {
-            launchedProcessID = try launch(
+            launchedProcess = try launch(
                 request.destinationApplicationURL,
                 handshakeURL: request.handshakeURL
             )
@@ -120,10 +120,20 @@ enum QuillCodeDesktopUpdateHelper {
             request.handshakeURL,
             timeout: environment.launchHandshakeTimeout
         ) else {
-            terminateProcess(launchedProcessID)
+            terminateProcess(launchedProcess.processIdentifier)
             try rollback(request)
             throw QuillCodeDesktopUpdateError.installationFailed(
                 "the new build did not finish launching; the previous build was restored"
+            )
+        }
+        guard remainsRunning(
+            launchedProcess,
+            for: environment.launchStabilityDuration
+        ) else {
+            terminateProcess(launchedProcess.processIdentifier)
+            try rollback(request)
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the new build stopped during startup; the previous build was restored"
             )
         }
 
@@ -193,7 +203,7 @@ enum QuillCodeDesktopUpdateHelper {
     private static func launch(
         _ applicationURL: URL,
         handshakeURL: URL?
-    ) throws -> Int32 {
+    ) throws -> Process {
         guard let bundle = Bundle(url: applicationURL),
               let executableURL = bundle.executableURL,
               FileManager.default.isExecutableFile(atPath: executableURL.path)
@@ -212,7 +222,7 @@ enum QuillCodeDesktopUpdateHelper {
         } catch {
             throw QuillCodeDesktopUpdateError.installationFailed("the updated app could not be launched")
         }
-        return process.processIdentifier
+        return process
     }
 
     private static func bundleMatches(
@@ -256,6 +266,17 @@ enum QuillCodeDesktopUpdateHelper {
         return FileManager.default.fileExists(atPath: url.path)
     }
 
+    private static func remainsRunning(_ process: Process, for duration: TimeInterval) -> Bool {
+        guard process.isRunning else { return false }
+        guard duration.isFinite, duration > 0 else { return true }
+        let deadline = Date().addingTimeInterval(duration)
+        while Date() < deadline {
+            usleep(100_000)
+            guard process.isRunning else { return false }
+        }
+        return process.isRunning
+    }
+
     private static func terminateProcess(_ processID: Int32) {
         guard processID > 1 else { return }
         _ = kill(processID, SIGTERM)
@@ -270,7 +291,8 @@ enum QuillCodeDesktopUpdateHelper {
         allowedResultURL: URL
     ) {
         guard url.standardizedFileURL == allowedResultURL.standardizedFileURL,
-              let data = try? JSONEncoder().encode(result)
+              let data = try? JSONEncoder().encode(result),
+              data.count <= QuillCodeDesktopUpdateInstallResult.maximumEncodedBytes
         else {
             return
         }
@@ -283,13 +305,15 @@ struct QuillCodeDesktopUpdateHelperEnvironment: Sendable {
     var resultURL: URL
     var parentExitTimeout: TimeInterval
     var launchHandshakeTimeout: TimeInterval
+    var launchStabilityDuration: TimeInterval
 
     static func production() throws -> Self {
         Self(
             cacheRootURL: try QuillCodeDesktopUpdatePaths.cacheRoot(),
             resultURL: try QuillCodeDesktopUpdatePaths.installResultURL(),
             parentExitTimeout: 30,
-            launchHandshakeTimeout: 45
+            launchHandshakeTimeout: 45,
+            launchStabilityDuration: 3
         )
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
@@ -28,6 +28,8 @@ enum QuillCodeDesktopUpdateLaunchHandshake {
 }
 
 struct QuillCodeDesktopUpdateInstallResult: Codable, Equatable, Sendable {
+    static let maximumEncodedBytes = 64 * 1_024
+
     enum Status: String, Codable, Sendable {
         case success
         case failure

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -105,7 +105,10 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             at: resultURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try Data(repeating: 0x41, count: 64 * 1_024 + 1).write(to: resultURL)
+        try Data(
+            repeating: 0x41,
+            count: QuillCodeDesktopUpdateInstallResult.maximumEncodedBytes + 1
+        ).write(to: resultURL)
         let controller = QuillCodeDesktopUpdateController(
             configuration: nil,
             defaults: makeDefaults(),
@@ -118,6 +121,33 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         XCTAssertEqual(controller.state, .idle)
         XCTAssertFalse(controller.isPresented)
         XCTAssertFalse(FileManager.default.fileExists(atPath: resultURL.path))
+    }
+
+    func testDanglingInstallResultSymlinkIsDiscardedWithoutPresenting() throws {
+        let resultURL = temporaryInstallResultURL()
+        try FileManager.default.createDirectory(
+            at: resultURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(
+            at: resultURL,
+            withDestinationURL: resultURL.deletingLastPathComponent()
+                .appendingPathComponent("missing-result.json")
+        )
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: nil,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(),
+            installResultURL: resultURL
+        )
+
+        controller.startAutomaticChecks()
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.isPresented)
+        XCTAssertThrowsError(
+            try FileManager.default.destinationOfSymbolicLink(atPath: resultURL.path)
+        )
     }
 
     func testAutomaticChecksContinueWhileAppRemainsOpen() async throws {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -515,6 +515,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             if [ "$1" = "--quillcode-update-handshake" ] && [ -n "$2" ]; then
               printf 'ready\n' > "$2"
             fi
+            sleep 1
             exit 0
             """
         )
@@ -533,7 +534,8 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             cacheRootURL: cacheRoot,
             resultURL: resultURL,
             parentExitTimeout: 0.1,
-            launchHandshakeTimeout: 2
+            launchHandshakeTimeout: 2,
+            launchStabilityDuration: 0.1
         )
 
         let parsedRequest = try XCTUnwrap(QuillCodeDesktopUpdateHelperRequest.parse(
@@ -552,6 +554,75 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         XCTAssertEqual(result.version, "0.2.0")
         XCTAssertEqual(result.build, "2")
         XCTAssertFalse(FileManager.default.fileExists(atPath: workspace.path))
+    }
+
+    func testHelperRollsBackWhenUpdatedAppExitsImmediatelyAfterHandshake() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cacheRoot = root.appendingPathComponent("cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+        let workspace = cacheRoot.appendingPathComponent("early-exit-workspace", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: false)
+        let destination = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        let incoming = root.appendingPathComponent(
+            ".Quill Cowork.update-early-exit.app",
+            isDirectory: true
+        )
+        let rollbackLaunchedURL = root.appendingPathComponent("rollback-launched")
+        try makeFakeApplication(
+            at: destination,
+            version: "0.1.0",
+            build: "1",
+            executableScript: "#!/bin/sh\nprintf 'ready' > '\(rollbackLaunchedURL.path)'\nexit 0\n"
+        )
+        try makeFakeApplication(
+            at: incoming,
+            version: "0.2.0",
+            build: "2",
+            executableScript: """
+            #!/bin/sh
+            if [ "$1" = "--quillcode-update-handshake" ] && [ -n "$2" ]; then
+              printf 'ready\n' > "$2"
+            fi
+            exit 0
+            """
+        )
+        let resultURL = root.appendingPathComponent("UpdateResult.json")
+        let request = makeHelperRequest(
+            cacheRoot: cacheRoot,
+            destination: destination,
+            incoming: incoming,
+            resultURL: resultURL,
+            expectedVersion: "0.2.0",
+            expectedBuild: "2",
+            suffix: "early-exit",
+            workspace: workspace
+        )
+        let environment = QuillCodeDesktopUpdateHelperEnvironment(
+            cacheRootURL: cacheRoot,
+            resultURL: resultURL,
+            parentExitTimeout: 0.1,
+            launchHandshakeTimeout: 1,
+            launchStabilityDuration: 0.2
+        )
+
+        XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 1)
+        XCTAssertEqual(try bundleBuild(at: destination), "1")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: incoming.path))
+        let result = try JSONDecoder().decode(
+            QuillCodeDesktopUpdateInstallResult.self,
+            from: Data(contentsOf: resultURL)
+        )
+        XCTAssertEqual(result.status, .failure)
+        XCTAssertTrue(result.message.contains("stopped during startup"))
+        XCTAssertTrue(result.message.contains("previous build was restored"))
+        let rollbackDeadline = Date().addingTimeInterval(1)
+        while !FileManager.default.fileExists(atPath: rollbackLaunchedURL.path),
+              Date() < rollbackDeadline {
+            usleep(10_000)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rollbackLaunchedURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: workspace.path))
     }
 
     func testHelperTerminatesFailedChildAndRollsBack() throws {
@@ -592,7 +663,8 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             cacheRootURL: cacheRoot,
             resultURL: resultURL,
             parentExitTimeout: 0.1,
-            launchHandshakeTimeout: 1
+            launchHandshakeTimeout: 1,
+            launchStabilityDuration: 0.1
         )
 
         XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 1)
@@ -653,7 +725,8 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             cacheRootURL: cacheRoot,
             resultURL: resultURL,
             parentExitTimeout: 0.1,
-            launchHandshakeTimeout: 0.1
+            launchHandshakeTimeout: 0.1,
+            launchStabilityDuration: 0.1
         )
 
         XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(request, environment: environment), 1)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,27 @@
 # Code Quality Audit
 
+## 2026-08-08 Post-Launch Update Stability
+
+Overall grade after this slice: **A+ transactional recovery, A+ bounded state, A+ continuity**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Crash resilience | A+ | The helper keeps the prior app available through a three-second post-handshake observation window and atomically restores it if the replacement exits. |
+| Memory safety | A+ | Install-result reads use the shared descriptor-bounded reader with a 64 KiB cap; helper writes enforce the same cap. No result read can follow a symlink or allocate from an unbounded file. |
+| Architecture | A+ | Activation retains the launched `Process`, update support owns the shared result-size contract, and persistence owns filesystem validation. |
+| UX | A+ | Immediate startup failure reopens the working build and presents a specific rollback result. A healthy app remains visible while detached cleanup finishes. |
+| Tests | A+ | Real-process fixtures cover healthy activation and acknowledge-then-exit rollback; controller tests cover oversized and dangling-symlink results. |
+
+Validation:
+
+- Focused updater model, controller, and smoke suites (40 tests, 0 failures)
+- Full `swift test --skip-build` (5,436 tests, 5 skipped, 0 failures)
+- Release package: 3 of 3 fresh launches within budget; 257.69 ms median launch-ready
+  and 88.25 MiB resident memory
+- Packaged macOS update, direct-executable, Launch Services, and live-window smoke
+- `python3 scripts/grade-code-quality.py --root .`
+- `git diff --check`
+
 ## 2026-08-08 Crash-Safe Workspace Bootstrap
 
 Overall grade after this slice: **A+ bounded persistence, A+ recovery isolation, A+ visible failure**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,23 @@
 # QuillCode Decisions
 
+## 2026-08-08: update activation survives an immediate post-launch crash
+
+- **Decision:** The detached updater retains the previous application until the replacement both
+  writes its launch handshake and remains alive for a three-second startup observation window. If
+  the replacement exits during that window, the helper atomically restores and reopens the previous
+  build instead of treating the handshake alone as a successful installation.
+- **Persistence boundary:** The one-shot install result is accepted only as a regular non-symlink
+  file of at most 64 KiB through the shared bounded persistence reader. Missing, malformed,
+  oversized, and unexpected filesystem entries are removed without becoming visible update state;
+  helper result writes enforce the same size contract.
+- **User experience:** A replacement that crashes immediately returns the user to the working build
+  and reports that startup stopped and rollback succeeded. Healthy replacements still appear at
+  once; only the detached helper waits before deleting the backup and reporting final success.
+- **Evidence:** `QuillCodeDesktopUpdateModelTests` launches a fixture that acknowledges and exits,
+  then verifies restoration and relaunch of the prior build. `QuillCodeDesktopUpdateControllerTests`
+  covers oversized and dangling-symlink result rejection, while the packaged updater smoke exercises
+  the complete signed-bundle swap, observation, cleanup, and relaunch path.
+
 ## 2026-08-08: damaged workspace registries recover independently
 
 - **Decision:** Config, projects, automations, and saved-search registries are accepted only as

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -128,16 +128,19 @@ and app-validation phases separately.
 
 Installation stages the verified app beside the running bundle, then uses a
 detached helper for the final rename and relaunch. The new app must complete a
-launch handshake within 45 seconds. Otherwise the helper restores and reopens the
-previous bundle. Background check failures stay quiet; user-initiated failures
-remain visible and retain direct retry and browser-download actions. Repeated
-menu checks cannot cancel an active download or the non-cancellable activation
-phase, and a background result never replaces update UI that is already visible.
-Failed or cancelled preparation removes its cache workspace immediately. After a
-two-minute active-helper grace period on launch, the app also removes only its
-exact hidden `.Quill Cowork.update-<lowercase UUID>.app` sibling directories left
-by an interrupted install; symlinks, lookalikes, and unexpected app identities are
-never treated as updater-owned staging.
+launch handshake within 45 seconds and remain running for a three-second startup
+observation window. If either check fails, the helper restores and reopens the
+previous bundle. The one-shot install result is read only when it is a regular,
+non-symlink file no larger than 64 KiB; malformed or unexpected entries are
+discarded. Background check failures stay quiet; user-initiated failures remain
+visible and retain direct retry and browser-download actions. Repeated menu checks
+cannot cancel an active download or the non-cancellable activation phase, and a
+background result never replaces update UI that is already visible. Failed or
+cancelled preparation removes its cache workspace immediately. After a two-minute
+active-helper grace period on launch, the app also removes only its exact hidden
+`.Quill Cowork.update-<lowercase UUID>.app` sibling directories left by an
+interrupted install; symlinks, lookalikes, and unexpected app identities are never
+treated as updater-owned staging.
 
 ## Tester Install Notes
 


### PR DESCRIPTION
## Summary
- keep the previous app available through a 3-second post-handshake observation window
- roll back and relaunch the previous build when the replacement exits during startup
- bound updater result persistence to 64 KiB and reject symlinks through the shared descriptor-based reader

## Validation
- focused updater model, controller, and smoke suites: 40 tests, 0 failures
- full Swift suite: 5,436 tests, 5 skipped, 0 failures
- release package: 257.69 ms median launch-ready, 88.25 MiB resident, 3/3 within budget
- packaged direct, Launch Services, live-window, accessibility, and coworker workflow smoke
- code-quality grader: all affected modules A+
- git diff --check