### PR TITLE
Pin desktop update signing trust

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
@@ -30,15 +30,26 @@ enum QuillCodeDesktopDownloadedApplicationValidator {
             throw QuillCodeDesktopUpdateError.invalidApplication("its code signature is invalid")
         }
 
-        if let expectedTeam = configuration.expectedSigningTeamIdentifier {
-            let details = try QuillCodeDesktopUpdateProcessRunner.run(
-                executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
-                arguments: ["--display", "--verbose=4", applicationURL.path]
+        try validateSigningRequirement(release.signingRequirement, configuration: configuration)
+        let details = try QuillCodeDesktopUpdateProcessRunner.run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+            arguments: ["--display", "--verbose=4", applicationURL.path]
+        )
+        guard details.exitCode == 0,
+              QuillCodeDesktopCodeSignatureMetadata(
+                codesignOutput: details.combinedOutput
+              ).satisfies(release.signingRequirement)
+        else {
+            throw QuillCodeDesktopUpdateError.invalidApplication("its signing identity does not match")
+        }
+
+        if case .developerID = release.signingRequirement {
+            let assessment = try QuillCodeDesktopUpdateProcessRunner.run(
+                executableURL: URL(fileURLWithPath: "/usr/sbin/spctl"),
+                arguments: ["--assess", "--type", "execute", "--verbose=2", applicationURL.path]
             )
-            guard details.exitCode == 0,
-                  details.combinedOutput.contains("TeamIdentifier=\(expectedTeam)")
-            else {
-                throw QuillCodeDesktopUpdateError.invalidApplication("its signing identity does not match")
+            guard assessment.exitCode == 0 else {
+                throw QuillCodeDesktopUpdateError.invalidApplication("Gatekeeper did not accept it")
             }
         }
 
@@ -53,6 +64,21 @@ enum QuillCodeDesktopDownloadedApplicationValidator {
               availableArchitectures.contains(configuration.architecture)
         else {
             throw QuillCodeDesktopUpdateError.invalidApplication("it does not support this Mac")
+        }
+    }
+
+    private static func validateSigningRequirement(
+        _ requirement: QuillCodeDesktopUpdateSigningRequirement,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) throws {
+        if let expectedTeam = configuration.expectedSigningTeamIdentifier {
+            guard requirement == .developerID(teamIdentifier: expectedTeam) else {
+                throw QuillCodeDesktopUpdateError.invalidApplication("its signing identity does not match")
+            }
+        }
+        if configuration.channel == .stable,
+           case .adHoc = requirement {
+            throw QuillCodeDesktopUpdateError.invalidApplication("the stable app is not Developer ID signed")
         }
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateManifestValidator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateManifestValidator.swift
@@ -21,7 +21,10 @@ enum QuillCodeDesktopUpdateManifestValidator {
         else {
             throw QuillCodeDesktopUpdateError.wrongProductOrChannel
         }
-        try validateSigning(manifest.updater, configuration: configuration)
+        let signingRequirement = try signingRequirement(
+            for: manifest.updater,
+            configuration: configuration
+        )
         guard manifest.updater.manifestURL == configuration.manifestURL,
               manifest.updater.stableManifestURL == configuration.stableManifestURL,
               manifest.updater.testerManifestURL == configuration.testerManifestURL
@@ -59,28 +62,47 @@ enum QuillCodeDesktopUpdateManifestValidator {
             commit: manifest.commit,
             version: manifest.version,
             build: manifest.build,
-            asset: asset
+            asset: asset,
+            signingRequirement: signingRequirement
         ))
     }
 
-    private static func validateSigning(
-        _ updater: QuillCodeDesktopUpdateManifest.Updater,
+    private static func signingRequirement(
+        for updater: QuillCodeDesktopUpdateManifest.Updater,
         configuration: QuillCodeDesktopUpdateConfiguration
-    ) throws {
-        if let expectedTeam = configuration.expectedSigningTeamIdentifier {
-            guard updater.codesign == "developer-id",
-                  updater.signingTeamIdentifier == expectedTeam
+    ) throws -> QuillCodeDesktopUpdateSigningRequirement {
+        let requirement: QuillCodeDesktopUpdateSigningRequirement
+        switch updater.codesign {
+        case "ad-hoc":
+            guard updater.signingTeamIdentifier == nil,
+                  updater.notarized == false
             else {
                 throw QuillCodeDesktopUpdateError.wrongSigningIdentity
             }
-        }
-        if configuration.channel == .stable {
-            guard configuration.expectedSigningTeamIdentifier != nil,
+            requirement = .adHoc
+        case "developer-id":
+            guard let teamIdentifier = updater.signingTeamIdentifier,
+                  isSigningTeamIdentifier(teamIdentifier),
                   updater.notarized == true
+            else {
+                throw QuillCodeDesktopUpdateError.wrongSigningIdentity
+            }
+            requirement = .developerID(teamIdentifier: teamIdentifier)
+        default:
+            throw QuillCodeDesktopUpdateError.wrongSigningIdentity
+        }
+
+        if configuration.channel == .stable {
+            guard let expectedTeam = configuration.expectedSigningTeamIdentifier,
+                  requirement == .developerID(teamIdentifier: expectedTeam)
             else {
                 throw QuillCodeDesktopUpdateError.unsignedStableUpdate
             }
+        } else if let expectedTeam = configuration.expectedSigningTeamIdentifier,
+                  requirement != .developerID(teamIdentifier: expectedTeam) {
+            throw QuillCodeDesktopUpdateError.wrongSigningIdentity
         }
+        return requirement
     }
 
     private static func compatibleAsset(
@@ -128,6 +150,12 @@ enum QuillCodeDesktopUpdateManifestValidator {
     private static func isHex(_ value: String, length: Int) -> Bool {
         value.count == length && value.unicodeScalars.allSatisfy { scalar in
             ("0"..."9").contains(Character(scalar)) || ("a"..."f").contains(Character(scalar))
+        }
+    }
+
+    private static func isSigningTeamIdentifier(_ value: String) -> Bool {
+        value.count == 10 && value.unicodeScalars.allSatisfy { scalar in
+            ("0"..."9").contains(Character(scalar)) || ("A"..."Z").contains(Character(scalar))
         }
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
@@ -137,6 +137,7 @@ struct QuillCodeDesktopUpdateRelease: Equatable, Sendable {
     var version: String
     var build: String
     var asset: QuillCodeDesktopUpdateManifest.Asset
+    var signingRequirement: QuillCodeDesktopUpdateSigningRequirement
 
     var displayVersion: String {
         "\(version) (\(build))"
@@ -200,7 +201,7 @@ enum QuillCodeDesktopUpdateError: LocalizedError, Equatable, Sendable {
         case .noCompatibleApplication:
             "No compatible macOS app is available for this Mac."
         case .wrongSigningIdentity:
-            "The update was not signed by Quill Cowork's configured distribution identity."
+            "The update's signing identity does not match Quill Cowork's trusted update requirements."
         case .unsignedStableUpdate:
             "The stable update is not marked as signed and notarized."
         case .downloadSizeMismatch:

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateSigning.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateSigning.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum QuillCodeDesktopUpdateSigningRequirement: Equatable, Sendable {
+    case adHoc
+    case developerID(teamIdentifier: String)
+}
+
+struct QuillCodeDesktopCodeSignatureMetadata: Equatable, Sendable {
+    var signature: String?
+    var teamIdentifier: String?
+    var authorities: [String]
+
+    init(codesignOutput: String) {
+        var signature: String?
+        var teamIdentifier: String?
+        var authorities: [String] = []
+
+        for rawLine in codesignOutput.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            let fields = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard fields.count == 2 else { continue }
+            let key = fields[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = fields[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            switch key {
+            case "Signature":
+                signature = value
+            case "TeamIdentifier":
+                teamIdentifier = value
+            case "Authority":
+                authorities.append(value)
+            default:
+                break
+            }
+        }
+
+        self.signature = signature
+        self.teamIdentifier = teamIdentifier
+        self.authorities = authorities
+    }
+
+    func satisfies(_ requirement: QuillCodeDesktopUpdateSigningRequirement) -> Bool {
+        switch requirement {
+        case .adHoc:
+            return signature == "adhoc" && teamIdentifier == "not set" && authorities.isEmpty
+        case .developerID(let expectedTeamIdentifier):
+            return teamIdentifier == expectedTeamIdentifier && authorities.contains { authority in
+                authority.hasPrefix("Developer ID Application:")
+            }
+        }
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateSigningTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateSigningTests.swift
@@ -1,0 +1,264 @@
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopUpdateSigningTests: XCTestCase {
+    func testAdHocTesterManifestCarriesExactPayloadRequirement() throws {
+        let configuration = makeConfiguration()
+
+        let result = try QuillCodeDesktopUpdateManifestValidator.validate(
+            signingManifest(configuration: configuration),
+            configuration: configuration
+        )
+
+        guard case .updateAvailable(let release) = result else {
+            return XCTFail("Expected an available update")
+        }
+        XCTAssertEqual(release.signingRequirement, .adHoc)
+    }
+
+    func testAdHocMetadataRejectsContradictoryTeamAndNotarizationClaims() {
+        let configuration = makeConfiguration()
+        let manifests = [
+            signingManifest(
+                configuration: configuration,
+                signingTeamIdentifier: "ABCD123456"
+            ),
+            signingManifest(configuration: configuration, notarized: true),
+            signingManifest(configuration: configuration, codesign: nil),
+            signingManifest(configuration: configuration, codesign: "unknown")
+        ]
+
+        for manifest in manifests {
+            XCTAssertThrowsError(
+                try QuillCodeDesktopUpdateManifestValidator.validate(
+                    manifest,
+                    configuration: configuration
+                )
+            ) { error in
+                XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .wrongSigningIdentity)
+            }
+        }
+    }
+
+    func testAdHocTesterCanUpgradeOnlyToNotarizedDeveloperID() throws {
+        let configuration = makeConfiguration()
+        let manifest = signingManifest(
+            configuration: configuration,
+            codesign: "developer-id",
+            signingTeamIdentifier: "ABCD123456",
+            notarized: true
+        )
+
+        let result = try QuillCodeDesktopUpdateManifestValidator.validate(
+            manifest,
+            configuration: configuration
+        )
+
+        guard case .updateAvailable(let release) = result else {
+            return XCTFail("Expected an available update")
+        }
+        XCTAssertEqual(
+            release.signingRequirement,
+            .developerID(teamIdentifier: "ABCD123456")
+        )
+    }
+
+    func testDeveloperIDUpgradeRejectsMissingNotarizationAndInvalidTeams() {
+        let configuration = makeConfiguration()
+        let manifests = [
+            signingManifest(
+                configuration: configuration,
+                codesign: "developer-id",
+                signingTeamIdentifier: "ABCD123456",
+                notarized: false
+            ),
+            signingManifest(
+                configuration: configuration,
+                codesign: "developer-id",
+                signingTeamIdentifier: nil,
+                notarized: true
+            ),
+            signingManifest(
+                configuration: configuration,
+                codesign: "developer-id",
+                signingTeamIdentifier: "abcd123456",
+                notarized: true
+            ),
+            signingManifest(
+                configuration: configuration,
+                codesign: "developer-id",
+                signingTeamIdentifier: "TOO-SHORT",
+                notarized: true
+            )
+        ]
+
+        for manifest in manifests {
+            XCTAssertThrowsError(
+                try QuillCodeDesktopUpdateManifestValidator.validate(
+                    manifest,
+                    configuration: configuration
+                )
+            ) { error in
+                XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .wrongSigningIdentity)
+            }
+        }
+    }
+
+    func testPinnedTesterRejectsAdHocDowngradeAndDifferentDeveloperTeam() throws {
+        var configuration = makeConfiguration()
+        configuration.expectedSigningTeamIdentifier = "ABCD123456"
+
+        XCTAssertThrowsError(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                signingManifest(configuration: configuration),
+                configuration: configuration
+            )
+        ) { error in
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .wrongSigningIdentity)
+        }
+        XCTAssertThrowsError(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                signingManifest(
+                    configuration: configuration,
+                    codesign: "developer-id",
+                    signingTeamIdentifier: "OTHER12345",
+                    notarized: true
+                ),
+                configuration: configuration
+            )
+        ) { error in
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .wrongSigningIdentity)
+        }
+
+        let result = try QuillCodeDesktopUpdateManifestValidator.validate(
+            signingManifest(
+                configuration: configuration,
+                codesign: "developer-id",
+                signingTeamIdentifier: "ABCD123456",
+                notarized: true
+            ),
+            configuration: configuration
+        )
+        guard case .updateAvailable(let release) = result else {
+            return XCTFail("Expected an available update")
+        }
+        XCTAssertEqual(
+            release.signingRequirement,
+            .developerID(teamIdentifier: "ABCD123456")
+        )
+    }
+
+    func testStableChannelRequiresPinnedMatchingDeveloperID() throws {
+        var configuration = makeConfiguration()
+        configuration.channel = .stable
+        configuration.manifestURL = configuration.stableManifestURL
+
+        XCTAssertThrowsError(
+            try QuillCodeDesktopUpdateManifestValidator.validate(
+                signingManifest(configuration: configuration),
+                configuration: configuration
+            )
+        ) { error in
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .unsignedStableUpdate)
+        }
+
+        configuration.expectedSigningTeamIdentifier = "ABCD123456"
+        let result = try QuillCodeDesktopUpdateManifestValidator.validate(
+            signingManifest(
+                configuration: configuration,
+                codesign: "developer-id",
+                signingTeamIdentifier: "ABCD123456",
+                notarized: true
+            ),
+            configuration: configuration
+        )
+        guard case .updateAvailable(let release) = result else {
+            return XCTFail("Expected an available update")
+        }
+        XCTAssertEqual(
+            release.signingRequirement,
+            .developerID(teamIdentifier: "ABCD123456")
+        )
+    }
+
+    func testCodeSignatureMetadataDistinguishesAdHocAndDeveloperID() {
+        let adHoc = QuillCodeDesktopCodeSignatureMetadata(codesignOutput: """
+        Signature=adhoc
+        TeamIdentifier=not set
+        """)
+        XCTAssertTrue(adHoc.satisfies(.adHoc))
+        XCTAssertFalse(adHoc.satisfies(.developerID(teamIdentifier: "ABCD123456")))
+
+        let developerID = QuillCodeDesktopCodeSignatureMetadata(codesignOutput: """
+        Authority=Developer ID Application: Lore Hex LLC (ABCD123456)
+        Authority=Developer ID Certification Authority
+        Authority=Apple Root CA
+        TeamIdentifier=ABCD123456
+        """)
+        XCTAssertTrue(developerID.satisfies(.developerID(teamIdentifier: "ABCD123456")))
+        XCTAssertFalse(developerID.satisfies(.developerID(teamIdentifier: "OTHER12345")))
+        XCTAssertFalse(developerID.satisfies(.adHoc))
+    }
+
+    func testDeveloperIDRequirementRejectsInstallerAuthority() {
+        let metadata = QuillCodeDesktopCodeSignatureMetadata(codesignOutput: """
+        Authority=Developer ID Installer: Lore Hex LLC (ABCD123456)
+        TeamIdentifier=ABCD123456
+        """)
+
+        XCTAssertFalse(metadata.satisfies(.developerID(teamIdentifier: "ABCD123456")))
+    }
+}
+
+private func signingManifest(
+    configuration: QuillCodeDesktopUpdateConfiguration,
+    codesign: String? = "ad-hoc",
+    signingTeamIdentifier: String? = nil,
+    notarized: Bool? = false
+) -> QuillCodeDesktopUpdateManifest {
+    let tag = configuration.channel == .stable ? "v0.2.0" : "tester-latest"
+    let asset = QuillCodeDesktopUpdateManifest.Asset(
+        name: "Quill-Cowork-macOS-arm64.zip",
+        kind: "app",
+        platform: "macOS",
+        arch: "arm64",
+        install: "zip-app",
+        sizeBytes: 10_000,
+        sha256: String(repeating: "b", count: 64),
+        url: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/download/\(tag)/" +
+                "Quill-Cowork-macOS-arm64.zip"
+        )!
+    )
+    return QuillCodeDesktopUpdateManifest(
+        schemaVersion: 1,
+        product: "Quill Cowork",
+        channel: configuration.channel,
+        tag: tag,
+        releaseURL: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/tag/\(tag)"
+        )!,
+        commit: String(repeating: "a", count: 40),
+        version: "0.2.0",
+        build: "43",
+        generatedAt: "2026-08-08T00:00:00Z",
+        workflowRunURL: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/actions/runs/1"
+        )!,
+        updater: .init(
+            schemaVersion: 1,
+            format: "github-release-manifest",
+            channel: configuration.channel,
+            manifestURL: configuration.manifestURL,
+            stableManifestURL: configuration.stableManifestURL,
+            testerManifestURL: configuration.testerManifestURL,
+            bundleIdentifier: configuration.bundleIdentifier,
+            minimumSystemVersion: "14.0",
+            codesign: codesign,
+            signingTeamIdentifier: signingTeamIdentifier,
+            notarized: notarized,
+            macOSAppAsset: asset
+        ),
+        assets: [asset]
+    )
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -1060,7 +1060,8 @@ private func makeManifest(
 
 func makeRelease(
     version: String = "0.1.0",
-    build: String = "43"
+    build: String = "43",
+    signingRequirement: QuillCodeDesktopUpdateSigningRequirement = .adHoc
 ) -> QuillCodeDesktopUpdateRelease {
     QuillCodeDesktopUpdateRelease(
         channel: .tester,
@@ -1069,7 +1070,8 @@ func makeRelease(
         commit: String(repeating: "a", count: 40),
         version: version,
         build: build,
-        asset: makeAsset()
+        asset: makeAsset(),
+        signingRequirement: signingRequirement
     )
 }
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-08 Update Signing Trust Chain
+
+Overall grade after this slice: **A+ signing policy, A+ migration safety, A+ payload verification**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Security | A+ | Manifest metadata becomes a typed ad-hoc or Developer ID payload requirement; contradictory modes, malformed teams, false notarization, cross-team updates, and signed-to-ad-hoc downgrades fail closed. |
+| Distribution | A+ | Existing ad-hoc testers can move to the first notarized Developer ID Application without a manifest schema break; that app embeds the team and pins every later update. |
+| Payload integrity | A+ | The extracted app must match exact `codesign` signature/team/authority metadata; Developer ID apps additionally pass Gatekeeper assessment before staging. |
+| Architecture | A+ | Manifest policy, release state, pure signature parsing, system validation, preparation, and installation retain separate focused owners. |
+| Tests | A+ | An adversarial signing matrix covers all accepted transitions and rejection classes; the existing public updater gate exercises the real app swap and relaunch. |
+
+Validation:
+
+- Focused updater, controller, signing, smoke-contract, and release-parity suite (54 tests, 0 failures)
+- Full `swift test --skip-build` (5,449 tests, 5 skipped, 0 failures)
+- Exact release build 652 direct-executable and Launch Services smoke passed with matching
+  scheduled-task, browser, multi-file, one-turn coworker, and computer-use action reports
+- Packaged live-window and accessibility smoke passed at 1280x900 with the expected
+  TrustedRouter sign-in state and no clipped or overlapping controls
+- Release package: 3 of 3 fresh launches within budget; 268.61 ms median launch-ready,
+  88.22 MiB resident memory, and 6 threads
+- Exact ad-hoc payload metadata and strict `codesign` verification matched the typed signing policy
+- `python3 scripts/grade-code-quality.py --root .`
+- `git diff --check`
+
 ## 2026-08-08 Bounded Streaming Presentation
 
 Overall grade after this slice: **A+ bounded UI work, A+ lifecycle, A+ responsiveness**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,29 @@
 # QuillCode Decisions
 
+## 2026-08-08: updater signing policy survives the Developer ID cutover
+
+- **Decision:** Manifest validation derives one typed payload requirement. Tester updates are either
+  exactly ad-hoc with no team or notarization claim, or Developer ID Application signed with a valid
+  ten-character team and Apple notarization. Stable updates require the latter and an already pinned
+  matching team.
+- **Payload boundary:** Archive verification carries that requirement into app validation. The
+  downloaded bundle must pass strict `codesign` verification, its `Signature`, `Authority`, and
+  `TeamIdentifier` fields must match the manifest-derived requirement, and Developer ID payloads must
+  also pass `spctl --assess`. A valid signature from another team, an Installer certificate, a false
+  notarization claim, or an ad-hoc downgrade is rejected before staging.
+- **Migration boundary:** An existing ad-hoc tester may trust its first notarized Developer ID
+  Application through the configured GitHub feed and Apple assessment. That replacement embeds its
+  team identifier, after which tester and stable updates are pinned to that exact team. The public
+  manifest schema stays unchanged, so build 651 can still install the first hardened ad-hoc build.
+- **Why:** Before this change, an ad-hoc tester accepted Developer ID metadata without requiring
+  notarization, while downloaded-app validation accepted any internally valid signature when no team
+  was embedded. Adding Apple credentials could therefore make the signing transition less strict
+  than steady-state updates.
+- **Evidence:** `QuillCodeDesktopUpdateSigningTests` cover contradictory metadata, malformed teams,
+  notarization, trust transition, downgrade/cross-team refusal, stable pinning, and signature output
+  parsing. The public updater smoke continues to exercise download, payload validation, swap, and
+  relaunch against the published ad-hoc channel.
+
 ## 2026-08-08: streaming progress coalesces expensive desktop projection
 
 - **Decision:** Every model progress callback still updates the authoritative thread and run state,

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -119,6 +119,13 @@ the exact size, SHA-256 digest, app identity, version, embedded source commit,
 architecture, and macOS code signature before installation. The detached helper
 checks that same commit again immediately before the atomic swap.
 
+Signing metadata is also a payload requirement, not only a feed label. Ad-hoc
+updates must contain an actual ad-hoc signature with no team. A Developer ID
+update must declare a valid team, be notarized, contain a Developer ID Application
+authority for that same team, and pass Gatekeeper assessment. The first such
+update from an ad-hoc tester pins its embedded team; signed builds reject later
+ad-hoc downgrades and any other team.
+
 Archive bytes stream directly to an updater-owned partial file instead of being
 buffered in memory. A declared oversized response is rejected immediately; a
 chunked response is cancelled at the first chunk that would exceed the manifest

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -7,6 +7,9 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 
 ## Unit Tests
 
+- Updater signing trust: exact ad-hoc metadata, notarized Developer ID transition, ten-character
+  team validation, pinned-team continuity, ad-hoc downgrade and cross-team refusal, stable-channel
+  requirements, Developer ID Application authority parsing, and Installer-authority rejection.
 - Record & Replay contracts: request/status/capture encoding, event and snapshot bounds, skill-drafting prompt shape, empty-goal rejection, generic-backend unavailability, permission preflight, owner task/project/workspace propagation, stop-after-permission-revocation, event rejection once stop begins, protected-field redaction, and owner-only artifact permissions.
 - Config parsing, model catalog, auth state, secret store.
 - Non-interactive CLI parsing and contracts: legacy/exec routing, relative path resolution, stdin


### PR DESCRIPTION
## Summary
- derive an exact ad-hoc or notarized Developer ID payload requirement from update manifests
- reject signing downgrades, malformed or cross-team updates, and non-Application identities
- verify downloaded Developer ID apps with strict codesign metadata and Gatekeeper assessment

## Validation
- 5,449 Swift tests, 5 skipped, 0 failures
- focused updater/signing/parity suite: 54 tests, 0 failures
- exact release build 652 direct and Launch Services smoke with all workflow parity contracts
- packaged live-window/accessibility smoke at 1280x900
- 3/3 launch performance passes: 268.61 ms median, 88.22 MiB resident, 6 threads
- affected production and new test files grade A+