### PR TITLE
Guide read-only app updates to installer

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -42,6 +42,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     private let checker: any QuillCodeDesktopUpdateChecking
     private let preparer: any QuillCodeDesktopUpdatePreparing
     private let installer: any QuillCodeDesktopUpdateInstalling
+    private let installationInspector: any QuillCodeDesktopUpdateInstallationInspecting
     private let recovery: any QuillCodeDesktopUpdateRecovering
     private let defaults: UserDefaults
     private let now: () -> Date
@@ -66,6 +67,8 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         checker: any QuillCodeDesktopUpdateChecking = QuillCodeDesktopUpdateChecker(),
         preparer: any QuillCodeDesktopUpdatePreparing = QuillCodeDesktopUpdatePreparer(),
         installer: any QuillCodeDesktopUpdateInstalling = QuillCodeDesktopUpdateInstaller(),
+        installationInspector: any QuillCodeDesktopUpdateInstallationInspecting =
+            QuillCodeDesktopUpdateInstallationInspector(),
         recovery: any QuillCodeDesktopUpdateRecovering = QuillCodeDesktopUpdateRecovery(),
         defaults: UserDefaults = .standard,
         now: @escaping () -> Date = Date.init,
@@ -78,6 +81,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         self.checker = checker
         self.preparer = preparer
         self.installer = installer
+        self.installationInspector = installationInspector
         self.recovery = recovery
         self.defaults = defaults
         self.now = now
@@ -159,6 +163,14 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             )
             return
         }
+        guard installationInspector.availability(for: configuration) == .available else {
+            state = .failed(
+                message: QuillCodeDesktopUpdateError.installationUnavailable.localizedDescription,
+                release: release
+            )
+            isPresented = true
+            return
+        }
         let generation = beginNewOperation()
         state = .downloading(release)
         preparationProgress = .downloading(receivedBytes: 0, totalBytes: release.asset.sizeBytes)
@@ -210,9 +222,18 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         NSWorkspace.shared.open(release.releaseURL)
     }
 
-    func openDownloadInBrowser() {
+    func openManualInstaller() {
         guard let release = state.release else { return }
-        NSWorkspace.shared.open(release.asset.url)
+        NSWorkspace.shared.open(release.manualInstallationURL)
+    }
+
+    var updateRequiresManualInstallation: Bool {
+        guard state.release != nil,
+              let configuration
+        else {
+            return false
+        }
+        return installationInspector.availability(for: configuration) == .requiresRelocation
     }
 
     private func performUserCheck(generation: UUID) async {

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
@@ -1,5 +1,47 @@
 import Foundation
 
+enum QuillCodeDesktopUpdateInstallationAvailability: Equatable, Sendable {
+    case available
+    case requiresRelocation
+}
+
+protocol QuillCodeDesktopUpdateInstallationInspecting: Sendable {
+    func availability(
+        for configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> QuillCodeDesktopUpdateInstallationAvailability
+}
+
+struct QuillCodeDesktopUpdateInstallationInspector: QuillCodeDesktopUpdateInstallationInspecting, Sendable {
+    private let runningExecutableURL: URL?
+
+    init(runningExecutableURL: URL? = Bundle.main.executableURL) {
+        self.runningExecutableURL = runningExecutableURL
+    }
+
+    func availability(
+        for configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> QuillCodeDesktopUpdateInstallationAvailability {
+        let applicationURL = configuration.applicationURL.standardizedFileURL
+        let parentURL = applicationURL.deletingLastPathComponent()
+        let executableURL = runningExecutableURL?.standardizedFileURL
+        var isApplicationDirectory: ObjCBool = false
+        guard applicationURL.pathExtension == "app",
+              FileManager.default.fileExists(
+                atPath: applicationURL.path,
+                isDirectory: &isApplicationDirectory
+              ),
+              isApplicationDirectory.boolValue,
+              FileManager.default.isWritableFile(atPath: parentURL.path),
+              let executableURL,
+              executableURL.path.hasPrefix(applicationURL.path + "/"),
+              FileManager.default.isExecutableFile(atPath: executableURL.path)
+        else {
+            return .requiresRelocation
+        }
+        return .available
+    }
+}
+
 protocol QuillCodeDesktopUpdateInstalling: Sendable {
     func stageAndLaunch(
         preparedUpdate: QuillCodeDesktopPreparedUpdate,

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateManifestValidator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateManifestValidator.swift
@@ -50,6 +50,11 @@ enum QuillCodeDesktopUpdateManifestValidator {
             throw QuillCodeDesktopUpdateError.unexpectedFeed
         }
         let asset = try compatibleAsset(in: manifest, configuration: configuration, scope: repositoryScope)
+        let installerAsset = try compatibleInstallerAsset(
+            in: manifest,
+            configuration: configuration,
+            scope: repositoryScope
+        )
         guard releaseVersion > currentVersion || (
             releaseVersion == currentVersion && releaseBuild > currentBuild
         ) else {
@@ -63,6 +68,7 @@ enum QuillCodeDesktopUpdateManifestValidator {
             version: manifest.version,
             build: manifest.build,
             asset: asset,
+            installerAsset: installerAsset,
             signingRequirement: signingRequirement
         ))
     }
@@ -121,6 +127,36 @@ enum QuillCodeDesktopUpdateManifestValidator {
               asset.sizeBytes <= maximumAssetBytes,
               isSafeAssetName(asset.name),
               isHex(asset.sha256, length: 64),
+              scope.containsDownloadURL(asset.url, tag: manifest.tag)
+        else {
+            throw QuillCodeDesktopUpdateError.noCompatibleApplication
+        }
+        return asset
+    }
+
+    private static func compatibleInstallerAsset(
+        in manifest: QuillCodeDesktopUpdateManifest,
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        scope: GitHubReleaseRepositoryScope
+    ) throws -> QuillCodeDesktopUpdateManifest.Asset? {
+        let candidates = manifest.assets.filter { asset in
+            asset.kind == "installer" &&
+                asset.platform == "macOS" &&
+                asset.arch == configuration.architecture
+        }
+        guard candidates.count <= 1 else {
+            throw QuillCodeDesktopUpdateError.noCompatibleApplication
+        }
+        guard let asset = candidates.first else { return nil }
+        guard asset.install == "dmg-app",
+              asset.sizeBytes > 0,
+              asset.sizeBytes <= maximumAssetBytes,
+              isSafeAssetName(asset.name),
+              asset.name.lowercased().hasSuffix(".dmg"),
+              isHex(asset.sha256, length: 64),
+              asset.url.lastPathComponent == asset.name,
+              asset.url.query == nil,
+              asset.url.fragment == nil,
               scope.containsDownloadURL(asset.url, tag: manifest.tag)
         else {
             throw QuillCodeDesktopUpdateError.noCompatibleApplication

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateModels.swift
@@ -137,10 +137,15 @@ struct QuillCodeDesktopUpdateRelease: Equatable, Sendable {
     var version: String
     var build: String
     var asset: QuillCodeDesktopUpdateManifest.Asset
+    var installerAsset: QuillCodeDesktopUpdateManifest.Asset? = nil
     var signingRequirement: QuillCodeDesktopUpdateSigningRequirement
 
     var displayVersion: String {
         "\(version) (\(build))"
+    }
+
+    var manualInstallationURL: URL {
+        installerAsset?.url ?? releaseURL
     }
 }
 
@@ -211,7 +216,7 @@ enum QuillCodeDesktopUpdateError: LocalizedError, Equatable, Sendable {
         case .invalidApplication(let reason):
             "The downloaded app could not be verified: \(reason)"
         case .installationUnavailable:
-            "Quill Cowork cannot replace itself from its current location."
+            "This copy cannot replace itself. Install Quill Cowork in Applications, reopen it, and try again."
         case .installationFailed(let reason):
             "The update could not be installed: \(reason)"
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
@@ -159,8 +159,18 @@ struct QuillCodeDesktopUpdateView: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Label("SHA-256 integrity verified before install", systemImage: "checkmark.shield")
-                Label("Automatic rollback if the new build cannot launch", systemImage: "arrow.uturn.backward.circle")
+                if controller.updateRequiresManualInstallation {
+                    Label(
+                        "Install Quill Cowork in Applications, then reopen it to receive updates.",
+                        systemImage: "externaldrive.badge.exclamationmark"
+                    )
+                } else {
+                    Label("SHA-256 integrity verified before install", systemImage: "checkmark.shield")
+                    Label(
+                        "Automatic rollback if the new build cannot launch",
+                        systemImage: "arrow.uturn.backward.circle"
+                    )
+                }
             }
             .font(.callout)
             .foregroundStyle(.secondary)
@@ -229,12 +239,21 @@ struct QuillCodeDesktopUpdateView: View {
                     .buttonStyle(QuillCodeActionButtonStyle())
                     .quillCodeFormActionTarget()
                 Spacer()
-                Button(action: controller.updateAndRelaunch) {
-                    Label("Update and Relaunch", systemImage: "arrow.down.circle.fill")
+                if controller.updateRequiresManualInstallation {
+                    Button(action: controller.openManualInstaller) {
+                        Label("Download Installer", systemImage: "arrow.down.app.fill")
+                    }
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 168))
+                    .quillCodeFormActionTarget(minWidth: 168)
+                    .accessibilityIdentifier("quillcode-update-manual-installer")
+                } else {
+                    Button(action: controller.updateAndRelaunch) {
+                        Label("Update and Relaunch", systemImage: "arrow.down.circle.fill")
+                    }
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 168))
+                    .quillCodeFormActionTarget(minWidth: 168)
+                    .accessibilityIdentifier("quillcode-update-install")
                 }
-                .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 168))
-                .quillCodeFormActionTarget(minWidth: 168)
-                .accessibilityIdentifier("quillcode-update-install")
             case .downloading:
                 Spacer()
                 Button("Cancel", action: controller.cancelCurrentOperation)
@@ -246,15 +265,22 @@ struct QuillCodeDesktopUpdateView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             case .failed(_, let release):
-                if release != nil {
-                    Button(action: controller.openDownloadInBrowser) {
-                        Label("Browser Download", systemImage: "safari")
+                if release != nil && !controller.updateRequiresManualInstallation {
+                    Button(action: controller.openManualInstaller) {
+                        Label("Download Installer", systemImage: "arrow.down.app")
                     }
                     .buttonStyle(QuillCodeActionButtonStyle())
                     .quillCodeFormActionTarget()
                 }
                 Spacer()
-                if release != nil {
+                if release != nil && controller.updateRequiresManualInstallation {
+                    Button(action: controller.openManualInstaller) {
+                        Label("Download Installer", systemImage: "arrow.down.app.fill")
+                    }
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 150))
+                    .quillCodeFormActionTarget(minWidth: 150)
+                    .accessibilityIdentifier("quillcode-update-manual-installer")
+                } else if release != nil {
                     Button(action: controller.updateAndRelaunch) {
                         Label("Try Again", systemImage: "arrow.down.circle.fill")
                     }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -99,6 +99,7 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
             configuration: makeConfiguration(),
             checker: RenderedUpdateChecker(release: release),
             preparer: RenderedProgressUpdatePreparer(),
+            installationInspector: RenderedUpdateInstallationInspector(.available),
             defaults: UserDefaults(suiteName: "RenderedUpdaterProgress.\(UUID().uuidString)") ?? .standard,
             automaticSchedule: .production,
             installResultURL: nil
@@ -139,6 +140,7 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
             configuration: makeConfiguration(),
             checker: RenderedUpdateChecker(release: release),
             preparer: RenderedFailingUpdatePreparer(),
+            installationInspector: RenderedUpdateInstallationInspector(.available),
             defaults: UserDefaults(suiteName: "RenderedUpdaterFailure.\(UUID().uuidString)") ?? .standard,
             automaticSchedule: .production,
             installResultURL: nil
@@ -166,6 +168,36 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
         XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
         XCTAssertGreaterThan(stats.brightPixelRatio, 0.001)
+        XCTAssertGreaterThan(stats.blueAccentPixelRatio, 0.001)
+    }
+
+    func testRenderedUpdaterOffersManualInstallerFromReadOnlyLocation() async throws {
+        var release = makeRelease(version: "0.2.0", build: "7")
+        release.installerAsset = makeManualInstallerAsset()
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: RenderedUpdateChecker(release: release),
+            installationInspector: RenderedUpdateInstallationInspector(.requiresRelocation),
+            defaults: UserDefaults(suiteName: "RenderedUpdaterRelocation.\(UUID().uuidString)") ?? .standard,
+            automaticSchedule: .production,
+            installResultURL: nil
+        )
+        controller.checkForUpdates()
+        try await waitForUpdaterState(controller) { $0 == .updateAvailable(release) }
+        XCTAssertTrue(controller.updateRequiresManualInstallation)
+
+        let image = try renderHostedView(
+            QuillCodeDesktopUpdateView(controller: controller),
+            width: 470,
+            height: 340,
+            debugPathEnvironmentKey: "QUILLCODE_RENDER_UPDATE_RELOCATION_IMAGE_PATH"
+        )
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 470)
+        XCTAssertEqual(stats.height, 340)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
         XCTAssertGreaterThan(stats.blueAccentPixelRatio, 0.001)
     }
 
@@ -480,6 +512,20 @@ private struct RenderedUpdateChecker: QuillCodeDesktopUpdateChecking {
         configuration: QuillCodeDesktopUpdateConfiguration
     ) async throws -> QuillCodeDesktopUpdateCheckResult {
         .updateAvailable(release)
+    }
+}
+
+private struct RenderedUpdateInstallationInspector: QuillCodeDesktopUpdateInstallationInspecting {
+    var value: QuillCodeDesktopUpdateInstallationAvailability
+
+    init(_ value: QuillCodeDesktopUpdateInstallationAvailability) {
+        self.value = value
+    }
+
+    func availability(
+        for configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> QuillCodeDesktopUpdateInstallationAvailability {
+        value
     }
 }
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -15,6 +15,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             checker: checker,
             preparer: preparer,
             installer: installer,
+            installationInspector: UpdateInstallationInspectorStub(.available),
             defaults: defaults,
             automaticSchedule: makeAutomaticSchedule(),
             installResultURL: temporaryInstallResultURL(),
@@ -32,6 +33,42 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         let installCallCount = await installer.callCount
         XCTAssertEqual(prepareCallCount, 1)
         XCTAssertEqual(installCallCount, 1)
+    }
+
+    func testReadOnlyLocationStopsBeforeDownloadAndKeepsManualInstaller() async throws {
+        var release = makeRelease(version: "0.2.0", build: "7")
+        release.installerAsset = makeManualInstallerAsset()
+        let preparer = UpdatePreparerSpy(release: release)
+        let installer = UpdateInstallerSpy()
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: UpdateCheckerSpy(result: .updateAvailable(release)),
+            preparer: preparer,
+            installer: installer,
+            installationInspector: UpdateInstallationInspectorStub(.requiresRelocation),
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(),
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.checkForUpdates()
+        try await waitUntil { controller.state == .updateAvailable(release) }
+        XCTAssertTrue(controller.updateRequiresManualInstallation)
+        XCTAssertEqual(release.manualInstallationURL, makeManualInstallerAsset().url)
+
+        controller.updateAndRelaunch()
+
+        XCTAssertEqual(
+            controller.state,
+            .failed(
+                message: QuillCodeDesktopUpdateError.installationUnavailable.localizedDescription,
+                release: release
+            )
+        )
+        let prepareCallCount = await preparer.callCount
+        let installCallCount = await installer.callCount
+        XCTAssertEqual(prepareCallCount, 0)
+        XCTAssertEqual(installCallCount, 0)
     }
 
     func testRecentSuccessfulAutomaticCheckSuppressesNetworkWork() async throws {
@@ -224,6 +261,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             checker: checker,
             preparer: preparer,
             installer: installer,
+            installationInspector: UpdateInstallationInspectorStub(.available),
             defaults: makeDefaults(),
             automaticSchedule: makeAutomaticSchedule(),
             installResultURL: temporaryInstallResultURL(),
@@ -256,6 +294,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             checker: checker,
             preparer: UpdatePreparerSpy(release: release),
             installer: installer,
+            installationInspector: UpdateInstallationInspectorStub(.available),
             defaults: makeDefaults(),
             automaticSchedule: makeAutomaticSchedule(),
             installResultURL: temporaryInstallResultURL(),
@@ -297,6 +336,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
             checker: UpdateCheckerSpy(result: .updateAvailable(release)),
             preparer: preparer,
             installer: installer,
+            installationInspector: UpdateInstallationInspectorStub(.available),
             defaults: makeDefaults(),
             automaticSchedule: makeAutomaticSchedule(),
             installResultURL: temporaryInstallResultURL(),
@@ -534,6 +574,20 @@ private actor UpdateInstallerSpy: QuillCodeDesktopUpdateInstalling {
         if let delay {
             try await Task.sleep(for: delay)
         }
+    }
+}
+
+private struct UpdateInstallationInspectorStub: QuillCodeDesktopUpdateInstallationInspecting {
+    let value: QuillCodeDesktopUpdateInstallationAvailability
+
+    init(_ value: QuillCodeDesktopUpdateInstallationAvailability) {
+        self.value = value
+    }
+
+    func availability(
+        for configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> QuillCodeDesktopUpdateInstallationAvailability {
+        value
     }
 }
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateInstallationTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateInstallationTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopUpdateInstallationTests: XCTestCase {
+    func testReleaseFallsBackToReleasePageWithoutInstallerMetadata() {
+        let release = makeRelease()
+
+        XCTAssertNil(release.installerAsset)
+        XCTAssertEqual(release.manualInstallationURL, release.releaseURL)
+    }
+
+    func testValidatorCarriesOnlyATrustedArchitectureMatchingInstaller() throws {
+        let configuration = makeConfiguration()
+        let installer = makeManualInstallerAsset()
+        let result = try QuillCodeDesktopUpdateManifestValidator.validate(
+            installationManifest(configuration: configuration, installers: [installer]),
+            configuration: configuration
+        )
+        guard case .updateAvailable(let release) = result else {
+            return XCTFail("Expected an available update")
+        }
+        XCTAssertEqual(release.installerAsset, installer)
+        XCTAssertEqual(release.manualInstallationURL, installer.url)
+
+        var otherArchitecture = installer
+        otherArchitecture.arch = "x86_64"
+        let otherResult = try QuillCodeDesktopUpdateManifestValidator.validate(
+            installationManifest(configuration: configuration, installers: [otherArchitecture]),
+            configuration: configuration
+        )
+        guard case .updateAvailable(let releaseWithoutInstaller) = otherResult else {
+            return XCTFail("Expected an available app update")
+        }
+        XCTAssertNil(releaseWithoutInstaller.installerAsset)
+    }
+
+    func testValidatorRejectsHostileMalformedAndDuplicateInstallers() {
+        let configuration = makeConfiguration()
+        var hostile = makeManualInstallerAsset()
+        hostile.url = URL(
+            string: "https://github.com/Elsewhere/Other/releases/download/tester-latest/Quill-Cowork.dmg"
+        )!
+        var mismatchedName = makeManualInstallerAsset()
+        mismatchedName.url = mismatchedName.url.deletingLastPathComponent()
+            .appendingPathComponent("another-installer.dmg")
+        var wrongExtension = makeManualInstallerAsset()
+        wrongExtension.name = "Quill-Cowork-macOS-arm64.zip"
+        wrongExtension.url = wrongExtension.url.deletingLastPathComponent()
+            .appendingPathComponent(wrongExtension.name)
+        var queryURL = makeManualInstallerAsset()
+        queryURL.url = URL(string: queryURL.url.absoluteString + "?download=1")!
+        var invalidDigest = makeManualInstallerAsset()
+        invalidDigest.sha256 = "not-a-digest"
+        let manifests = [
+            installationManifest(configuration: configuration, installers: [hostile]),
+            installationManifest(configuration: configuration, installers: [mismatchedName]),
+            installationManifest(configuration: configuration, installers: [wrongExtension]),
+            installationManifest(configuration: configuration, installers: [queryURL]),
+            installationManifest(configuration: configuration, installers: [invalidDigest]),
+            installationManifest(
+                configuration: configuration,
+                installers: [makeManualInstallerAsset(), makeManualInstallerAsset()]
+            ),
+        ]
+
+        for manifest in manifests {
+            XCTAssertThrowsError(
+                try QuillCodeDesktopUpdateManifestValidator.validate(
+                    manifest,
+                    configuration: configuration
+                )
+            ) { error in
+                XCTAssertEqual(error as? QuillCodeDesktopUpdateError, .noCompatibleApplication)
+            }
+        }
+    }
+
+    func testInspectorDetectsWritableReadOnlyAndIncompleteLocations() throws {
+        let root = try temporaryDirectory()
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+        let applicationURL = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        let executableURL = applicationURL.appendingPathComponent(
+            "Contents/MacOS/Quill Cowork",
+            isDirectory: false
+        )
+        try FileManager.default.createDirectory(
+            at: executableURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: executableURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executableURL.path)
+        var configuration = makeConfiguration()
+        configuration.applicationURL = applicationURL
+        let inspector = QuillCodeDesktopUpdateInstallationInspector(
+            runningExecutableURL: executableURL
+        )
+
+        XCTAssertEqual(inspector.availability(for: configuration), .available)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: root.path)
+        XCTAssertEqual(inspector.availability(for: configuration), .requiresRelocation)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        let outsideExecutableURL = root.appendingPathComponent("outside-executable", isDirectory: false)
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: outsideExecutableURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: outsideExecutableURL.path
+        )
+        XCTAssertEqual(
+            QuillCodeDesktopUpdateInstallationInspector(runningExecutableURL: outsideExecutableURL)
+                .availability(for: configuration),
+            .requiresRelocation
+        )
+
+        configuration.applicationURL = root.appendingPathComponent("Missing.app", isDirectory: true)
+        XCTAssertEqual(inspector.availability(for: configuration), .requiresRelocation)
+        XCTAssertEqual(
+            QuillCodeDesktopUpdateInstallationInspector(runningExecutableURL: nil)
+                .availability(for: configuration),
+            .requiresRelocation
+        )
+
+        let regularFileURL = root.appendingPathComponent("NotADirectory.app", isDirectory: false)
+        try Data().write(to: regularFileURL)
+        configuration.applicationURL = regularFileURL
+        XCTAssertEqual(inspector.availability(for: configuration), .requiresRelocation)
+    }
+}
+
+func makeManualInstallerAsset() -> QuillCodeDesktopUpdateManifest.Asset {
+    QuillCodeDesktopUpdateManifest.Asset(
+        name: "Quill-Cowork-macOS-arm64.dmg",
+        kind: "installer",
+        platform: "macOS",
+        arch: "arm64",
+        install: "dmg-app",
+        sizeBytes: 12_000,
+        sha256: String(repeating: "c", count: 64),
+        url: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg"
+        )!
+    )
+}
+
+private func installationManifest(
+    configuration: QuillCodeDesktopUpdateConfiguration,
+    installers: [QuillCodeDesktopUpdateManifest.Asset]
+) -> QuillCodeDesktopUpdateManifest {
+    let app = QuillCodeDesktopUpdateManifest.Asset(
+        name: "Quill-Cowork-macOS-arm64.zip",
+        kind: "app",
+        platform: "macOS",
+        arch: "arm64",
+        install: "zip-app",
+        sizeBytes: 10_000,
+        sha256: String(repeating: "b", count: 64),
+        url: URL(
+            string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip"
+        )!
+    )
+    return QuillCodeDesktopUpdateManifest(
+        schemaVersion: 1,
+        product: "Quill Cowork",
+        channel: .tester,
+        tag: "tester-latest",
+        releaseURL: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest")!,
+        commit: String(repeating: "a", count: 40),
+        version: "0.1.0",
+        build: "43",
+        generatedAt: "2026-08-08T00:00:00Z",
+        workflowRunURL: URL(string: "https://github.com/Lore-Hex/QuillCode/actions/runs/1")!,
+        updater: .init(
+            schemaVersion: 1,
+            format: "github-release-manifest",
+            channel: .tester,
+            manifestURL: configuration.manifestURL,
+            stableManifestURL: configuration.stableManifestURL,
+            testerManifestURL: configuration.testerManifestURL,
+            bundleIdentifier: configuration.bundleIdentifier,
+            minimumSystemVersion: "14.0",
+            codesign: "ad-hoc",
+            signingTeamIdentifier: nil,
+            notarized: false,
+            macOSAppAsset: app
+        ),
+        assets: [app] + installers
+    )
+}
+
+private func temporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "QuillCodeUpdateInstallationTests-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    return url
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,32 @@
 # Code Quality Audit
 
+## 2026-08-08 Read-Only Update Recovery
+
+Overall grade after this slice: **A+ preflight, A+ recovery UX, A+ race safety**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| UX | A+ | A non-replaceable copy offers the human DMG before any download; ordinary users are no longer sent to the updater ZIP after avoidable work. |
+| Performance | A+ | Constant-space filesystem checks replace a full download, digest, extraction, signature validation, and staging attempt on a path that cannot be updated. |
+| Security | A+ | The manual DMG must match architecture, kind, install mode, size, digest, safe-name, tag, and repository scope before its URL reaches the UI. |
+| Resilience | A+ | Controller preflight improves feedback while installer-time destination checks remain authoritative against permission and location races. |
+| Architecture | A+ | A small injected inspector owns environment capability; manifest validation owns external URLs; controller owns state; SwiftUI only projects the result. |
+
+Validation:
+
+- Focused updater, signing, controller, updater-smoke, and rendered suite (61 tests, 0 failures)
+- Full `swift test --skip-build` (5,455 tests, 5 skipped, 0 failures)
+- Exact release-source build 653 passed direct-executable, Launch Services, live-window,
+  accessibility, scheduled-coworker, multi-file, one-turn, browser, and Computer Use contracts
+- Release package: 3 of 3 fresh launches within budget; 282.05 ms median launch-ready,
+  88.45 MiB resident memory, and 7 threads
+- A signed build-651 fixture launched from a read-only mounted DMG, discovered public build 652,
+  and presented the Applications relocation message and `Download Installer` action
+- The packaged public updater smoke completed download, validation, swap, cleanup, and relaunch from
+  build 651 to build 652 (`b45c786ebc752116b828ea492564ded9cf3f145c`)
+- `python3 scripts/grade-code-quality.py --root .`
+- `git diff --check`
+
 ## 2026-08-08 Update Signing Trust Chain
 
 Overall grade after this slice: **A+ signing policy, A+ migration safety, A+ payload verification**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,27 @@
 # QuillCode Decisions
 
+## 2026-08-08: updater preflights read-only installation locations
+
+- **Decision:** The desktop updater inspects the running app bundle, executable, and parent-directory
+  writability before downloading an available update. A copy launched from a read-only disk image,
+  App Translocation, or another non-replaceable location presents a manual installer action instead
+  of starting preparation that cannot finish.
+- **Recovery contract:** The release model carries the architecture-matching DMG only after its kind,
+  install mode, bounded size, digest, safe `.dmg` name, exact URL filename, tag, and repository URL
+  pass manifest validation. Query and fragment suffixes are rejected. Manual recovery opens that
+  installer, falling back to the scoped release page for older manifests that do not declare one.
+  It never sends an ordinary user to the machine-oriented updater ZIP.
+- **Race boundary:** Preflight is a UX optimization, not the authority for mutation. The installer
+  rechecks the app identity, executable, destination existence, and parent writability immediately
+  before staging beside the running bundle.
+- **Why:** The DMG is intentionally read-only and is also the first place many users launch a newly
+  downloaded app. Previously Quill Cowork could download and validate the entire update before
+  reporting that it could not replace itself, then offer the ZIP as its browser fallback.
+- **Evidence:** Filesystem tests cover writable and read-only parents, non-directory app paths, and
+  executables outside the bundle; controller tests prove no preparation or installation starts when
+  relocation is required; manifest tests reject hostile and malformed installer URLs; fixed-size
+  rendering and a real mounted-DMG launch cover the dedicated installer state.
+
 ## 2026-08-08: updater signing policy survives the Developer ID cutover
 
 - **Decision:** Manifest validation derives one typed payload requirement. Tester updates are either

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -133,6 +133,16 @@ size. Cancellation and failure remove the partial file. The update sheet reports
 bounded determinate byte progress, then identifies the verification, unpacking,
 and app-validation phases separately.
 
+Before downloading, the app verifies that its running bundle exists beside a
+writable destination and has a runnable helper executable. Copies launched from
+the read-only DMG, App Translocation, or another non-replaceable location show a
+direct **Download Installer** action instead. That action uses only an
+architecture-matching DMG whose bounded metadata and GitHub release URL passed
+the same manifest scope checks. Its URL must use the declared `.dmg` filename
+exactly and cannot carry a query or fragment; older manifests fall back to the release page.
+The installer repeats the destination checks immediately before staging, so a
+permission change after preflight still fails without replacing the app.
+
 Installation stages the verified app beside the running bundle, then uses a
 detached helper for the final rename and relaunch. The new app must complete a
 launch handshake within 45 seconds and remain running for a three-second startup

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -7,6 +7,10 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 
 ## Unit Tests
 
+- Updater install-location UX: writable/read-only parent detection, missing app/executable refusal,
+  non-directory app and out-of-bundle executable refusal, zero preparation from a non-replaceable
+  copy, trusted architecture-matching DMG selection, hostile/malformed/duplicate installer rejection,
+  release-page fallback, fixed-size manual-installer UI, and a real mounted-DMG update check.
 - Updater signing trust: exact ad-hoc metadata, notarized Developer ID transition, ten-character
   team validation, pinned-team continuity, ad-hoc downgrade and cross-team refusal, stable-channel
   requirements, Developer ID Application authority parsing, and Installer-authority rejection.


### PR DESCRIPTION
## Summary

- Preflight read-only and otherwise non-replaceable app locations before updater download, then route users to the architecture-matching DMG.
- Validate the manual installer as a bounded, exact-name, query-free GitHub release asset while retaining the release-page fallback for older manifests.
- Keep installer-time destination checks authoritative and add focused controller, filesystem, adversarial manifest, and rendered UI coverage.

## Verification

- `swift test --filter 'QuillCodeDesktopUpdate|QuillCodeDesktopRenderedSmokeTests'` (61 tests, 0 failures)
- `swift test --skip-build` (5,455 tests, 5 skipped, 0 failures)
- Exact build 653 direct-executable, Launch Services, live-window, accessibility, scheduled-coworker, multi-file, one-turn, browser, and Computer Use contracts
- Signed build-651 read-only DMG discovered public build 652 and offered `Download Installer` before any updater download
- Public packaged updater smoke completed build 651 to 652 download, validation, swap, cleanup, and relaunch
- Final commit artifact: 258.01 ms median launch-ready, 88.47 MiB resident memory, 3/3 launches in budget
- Code-quality grader: A+ overall; changed production and new installation tests 100/A+
- `git diff --check`

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing UI was checked for keyboard, accessibility, compact-window, and failure states.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release, updater, dependency, or workflow changes include their contract-level verification.