### PR TITLE
Guide first launch from disk images

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -21,6 +21,9 @@ struct QuillCodeDesktopApp: App {
                 updateController: QuillCodeDesktopUpdateController(
                     configuration: nil,
                     installResultURL: nil
+                ),
+                installationLocationController: QuillCodeDesktopInstallationLocationController(
+                    configuration: nil
                 )
             )
             _controller = StateObject(wrappedValue: controller)
@@ -54,7 +57,10 @@ struct QuillCodeDesktopApp: App {
             updateController: smokeRequest == nil ? nil : QuillCodeDesktopUpdateController(
                 configuration: nil,
                 installResultURL: nil
-            )
+            ),
+            installationLocationController: smokeRequest == nil
+                ? nil
+                : QuillCodeDesktopInstallationLocationController(configuration: nil)
         )
         _controller = StateObject(wrappedValue: controller)
 
@@ -121,7 +127,10 @@ struct QuillCodeDesktopRootView: View {
         workspaceContent
             .preferredColorScheme(.dark)
             .quillCodeDesktopCommandBindings(controller: controller)
-            .modifier(QuillCodeDesktopUpdatePresentation(controller: controller.updateController))
+            .modifier(QuillCodeDesktopDistributionPresentation(
+                installationLocationController: controller.installationLocationController,
+                updateController: controller.updateController
+            ))
             .fileImporter(
                 isPresented: $controller.isProjectImporterPresented,
                 allowedContentTypes: [.folder],
@@ -141,6 +150,7 @@ struct QuillCodeDesktopRootView: View {
             }
             .task {
                 QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()
+                controller.installationLocationController.startIfNeeded()
                 controller.updateController.startAutomaticChecks()
             }
     }
@@ -226,13 +236,36 @@ struct QuillCodeDesktopRootView: View {
     }
 }
 
-private struct QuillCodeDesktopUpdatePresentation: ViewModifier {
-    @ObservedObject var controller: QuillCodeDesktopUpdateController
+private struct QuillCodeDesktopDistributionPresentation: ViewModifier {
+    @ObservedObject var installationLocationController: QuillCodeDesktopInstallationLocationController
+    @ObservedObject var updateController: QuillCodeDesktopUpdateController
 
     func body(content: Content) -> some View {
-        content.sheet(isPresented: $controller.isPresented) {
-            QuillCodeDesktopUpdateView(controller: controller)
+        content.sheet(isPresented: presentationBinding) {
+            if installationLocationController.isPresented {
+                QuillCodeDesktopInstallationLocationView(
+                    controller: installationLocationController
+                )
+            } else {
+                QuillCodeDesktopUpdateView(controller: updateController)
+            }
         }
+    }
+
+    private var presentationBinding: Binding<Bool> {
+        Binding(
+            get: {
+                installationLocationController.isPresented || updateController.isPresented
+            },
+            set: { isPresented in
+                guard !isPresented else { return }
+                if installationLocationController.isPresented {
+                    installationLocationController.dismiss()
+                } else {
+                    updateController.dismiss()
+                }
+            }
+        )
     }
 }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -48,6 +48,7 @@ final class QuillCodeDesktopController: ObservableObject {
     let worktreeCoordinator: QuillCodeDesktopWorktreeCoordinator
     let workflowRecordingCoordinator: QuillCodeDesktopWorkflowRecordingCoordinator
     let updateController: QuillCodeDesktopUpdateController
+    let installationLocationController: QuillCodeDesktopInstallationLocationController
     let tasks = QuillCodeDesktopTaskCoordinator()
     let progressRefreshScheduler = QuillCodeDesktopProgressRefreshScheduler()
     // Retained here because UNUserNotificationCenter.delegate is weak; nil until the window installs it.
@@ -64,6 +65,7 @@ final class QuillCodeDesktopController: ObservableObject {
         transcriptExportCoordinator: QuillCodeDesktopTranscriptExportCoordinator =
             QuillCodeDesktopTranscriptExportCoordinator(),
         updateController: QuillCodeDesktopUpdateController? = nil,
+        installationLocationController: QuillCodeDesktopInstallationLocationController? = nil,
         workspaceRoot: URL? = nil
     ) {
         let launchWorkspaceRoot = workspaceRoot?.standardizedFileURL
@@ -96,6 +98,8 @@ final class QuillCodeDesktopController: ObservableObject {
         self.worktreeCoordinator = QuillCodeDesktopWorktreeCoordinator()
         self.workflowRecordingCoordinator = QuillCodeDesktopWorkflowRecordingCoordinator()
         self.updateController = updateController ?? QuillCodeDesktopUpdateController()
+        self.installationLocationController = installationLocationController
+            ?? QuillCodeDesktopInstallationLocationController()
         do {
             self.model = try bootstrap.makeModel()
         } catch {

--- a/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationController.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Combine
+import Foundation
+
+@MainActor
+final class QuillCodeDesktopInstallationLocationController: ObservableObject {
+    @Published var isPresented = false
+
+    private let configuration: QuillCodeDesktopUpdateConfiguration?
+    private let inspector: any QuillCodeDesktopUpdateInstallationInspecting
+    private let defaults: UserDefaults
+    private let applicationsURL: URL
+    private let openApplications: @MainActor (URL) -> Void
+
+    init(
+        configuration: QuillCodeDesktopUpdateConfiguration? = .bundled(),
+        inspector: any QuillCodeDesktopUpdateInstallationInspecting =
+            QuillCodeDesktopUpdateInstallationInspector(),
+        defaults: UserDefaults = .standard,
+        applicationsURL: URL = URL(fileURLWithPath: "/Applications", isDirectory: true),
+        openApplications: @escaping @MainActor (URL) -> Void = {
+            _ = NSWorkspace.shared.open($0)
+        }
+    ) {
+        self.configuration = configuration
+        self.inspector = inspector
+        self.defaults = defaults
+        self.applicationsURL = applicationsURL.standardizedFileURL
+        self.openApplications = openApplications
+    }
+
+    func startIfNeeded() {
+        guard !isPresented,
+              let configuration,
+              inspector.availability(for: configuration) == .requiresRelocation,
+              !Self.isInsideApplications(
+                  configuration.applicationURL,
+                  applicationsURL: applicationsURL
+              ),
+              !defaults.bool(forKey: dismissalKey(for: configuration))
+        else {
+            return
+        }
+        isPresented = true
+    }
+
+    func dismiss() {
+        guard let configuration else {
+            isPresented = false
+            return
+        }
+        defaults.set(true, forKey: dismissalKey(for: configuration))
+        isPresented = false
+    }
+
+    func openApplicationsFolder() {
+        dismiss()
+        openApplications(applicationsURL)
+    }
+
+    private func dismissalKey(for configuration: QuillCodeDesktopUpdateConfiguration) -> String {
+        "QuillCodeInstallLocation.dismissed.\(configuration.bundleIdentifier).\(configuration.currentBuild)"
+    }
+
+    private static func isInsideApplications(
+        _ applicationURL: URL,
+        applicationsURL: URL
+    ) -> Bool {
+        let applicationPath = applicationURL.standardizedFileURL.path
+        let applicationsPath = applicationsURL.standardizedFileURL.path
+        return applicationPath.hasPrefix(applicationsPath + "/")
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import QuillCodeApp
+
+struct QuillCodeDesktopInstallationLocationView: View {
+    @ObservedObject var controller: QuillCodeDesktopInstallationLocationController
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 20)
+                .padding(.top, 18)
+                .padding(.bottom, 14)
+
+            Divider().opacity(0.55)
+
+            VStack(spacing: 18) {
+                Image(systemName: "arrow.down.app.fill")
+                    .font(.system(size: 42, weight: .medium))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(Color.accentColor)
+
+                VStack(spacing: 7) {
+                    Text("Move Quill Cowork to Applications")
+                        .font(.headline)
+                        .multilineTextAlignment(.center)
+                    Text("Install the app in Applications for reliable updates and relaunches.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 28)
+
+            Divider().opacity(0.55)
+
+            HStack(spacing: 12) {
+                Button("Not Now", action: controller.dismiss)
+                    .buttonStyle(QuillCodeActionButtonStyle())
+                    .quillCodeFormActionTarget()
+                    .accessibilityIdentifier("quillcode-install-location-not-now")
+                Spacer()
+                Button(action: controller.openApplicationsFolder) {
+                    Label("Open Applications", systemImage: "folder")
+                }
+                .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 170))
+                .quillCodeFormActionTarget(minWidth: 170)
+                .accessibilityIdentifier("quillcode-install-location-open-applications")
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 470, height: 320)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "app.badge.checkmark")
+                .font(.system(size: 28, weight: .medium))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Color.accentColor)
+            Text("Finish Installing Quill Cowork")
+                .font(.title3.weight(.semibold))
+                .accessibilityIdentifier("quillcode-install-location-title")
+            Spacer()
+            Button(action: controller.dismiss) {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.bold))
+                    .quillCodeIconButtonTarget(size: 36, radius: 9)
+            }
+            .buttonStyle(QuillCodePressableButtonStyle())
+            .help("Close")
+            .accessibilityLabel("Close installation reminder")
+            .accessibilityIdentifier("quillcode-install-location-close")
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -89,6 +89,9 @@ struct QuillCodeDesktopWindowSmokeWorkspaceRoot: Sendable, Hashable {
                 configuration: nil,
                 installResultURL: nil
             ),
+            installationLocationController: QuillCodeDesktopInstallationLocationController(
+                configuration: nil
+            ),
             workspaceRoot: workspace
         )
     }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopInstallationLocationTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopInstallationLocationTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopInstallationLocationTests: XCTestCase {
+    func testWritableApplicationDoesNotPresentReminder() {
+        let controller = makeController(availability: .available)
+
+        controller.startIfNeeded()
+
+        XCTAssertFalse(controller.isPresented)
+    }
+
+    func testReadOnlyApplicationAlreadyInApplicationsDoesNotPresentReminder() {
+        var configuration = makeConfiguration()
+        configuration.applicationURL = URL(
+            fileURLWithPath: "/Applications/Quill Cowork.app",
+            isDirectory: true
+        )
+        let controller = makeController(
+            configuration: configuration,
+            availability: .requiresRelocation
+        )
+
+        controller.startIfNeeded()
+
+        XCTAssertFalse(controller.isPresented)
+    }
+
+    func testReadOnlyApplicationPresentsAndDismissesOncePerBuild() {
+        let defaults = makeDefaults()
+        let configuration = makeDiskImageConfiguration(currentBuild: "43")
+        let controller = makeController(
+            configuration: configuration,
+            availability: .requiresRelocation,
+            defaults: defaults
+        )
+
+        controller.startIfNeeded()
+        XCTAssertTrue(controller.isPresented)
+
+        controller.dismiss()
+        XCTAssertFalse(controller.isPresented)
+        controller.startIfNeeded()
+        XCTAssertFalse(controller.isPresented)
+
+        var nextBuild = configuration
+        nextBuild.currentBuild = "44"
+        let nextBuildController = makeController(
+            configuration: nextBuild,
+            availability: .requiresRelocation,
+            defaults: defaults
+        )
+        nextBuildController.startIfNeeded()
+        XCTAssertTrue(nextBuildController.isPresented)
+    }
+
+    func testOpenApplicationsDismissesAndOpensConfiguredFolder() {
+        let applicationsURL = URL(fileURLWithPath: "/Test Applications", isDirectory: true)
+        var openedURL: URL?
+        let controller = makeController(
+            availability: .requiresRelocation,
+            applicationsURL: applicationsURL,
+            openApplications: { openedURL = $0 }
+        )
+        controller.startIfNeeded()
+        XCTAssertTrue(controller.isPresented)
+
+        controller.openApplicationsFolder()
+
+        XCTAssertFalse(controller.isPresented)
+        XCTAssertEqual(openedURL, applicationsURL.standardizedFileURL)
+    }
+
+    func testUnavailableConfigurationNeverPresents() {
+        let controller = QuillCodeDesktopInstallationLocationController(
+            configuration: nil,
+            inspector: InstallationLocationInspectorStub(.requiresRelocation),
+            defaults: makeDefaults(),
+            openApplications: { _ in XCTFail("Should not open Applications") }
+        )
+
+        controller.startIfNeeded()
+        controller.dismiss()
+
+        XCTAssertFalse(controller.isPresented)
+    }
+
+    private func makeController(
+        configuration: QuillCodeDesktopUpdateConfiguration? = nil,
+        availability: QuillCodeDesktopUpdateInstallationAvailability,
+        defaults: UserDefaults? = nil,
+        applicationsURL: URL = URL(fileURLWithPath: "/Applications", isDirectory: true),
+        openApplications: @escaping @MainActor (URL) -> Void = { _ in }
+    ) -> QuillCodeDesktopInstallationLocationController {
+        QuillCodeDesktopInstallationLocationController(
+            configuration: configuration ?? makeDiskImageConfiguration(),
+            inspector: InstallationLocationInspectorStub(availability),
+            defaults: defaults ?? makeDefaults(),
+            applicationsURL: applicationsURL,
+            openApplications: openApplications
+        )
+    }
+
+    private func makeDiskImageConfiguration(
+        currentBuild: String = "42"
+    ) -> QuillCodeDesktopUpdateConfiguration {
+        var configuration = makeConfiguration(currentBuild: currentBuild)
+        configuration.applicationURL = URL(
+            fileURLWithPath: "/Volumes/Quill Cowork/Quill Cowork.app",
+            isDirectory: true
+        )
+        return configuration
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "InstallationLocationTests.\(UUID().uuidString)") ?? .standard
+    }
+}
+
+private struct InstallationLocationInspectorStub: QuillCodeDesktopUpdateInstallationInspecting {
+    var availabilityValue: QuillCodeDesktopUpdateInstallationAvailability
+
+    init(_ availabilityValue: QuillCodeDesktopUpdateInstallationAvailability) {
+        self.availabilityValue = availabilityValue
+    }
+
+    func availability(
+        for configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> QuillCodeDesktopUpdateInstallationAvailability {
+        availabilityValue
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -201,6 +201,38 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTAssertGreaterThan(stats.blueAccentPixelRatio, 0.001)
     }
 
+    func testRenderedFirstLaunchFromReadOnlyLocationOffersApplicationsFolder() throws {
+        var configuration = makeConfiguration()
+        configuration.applicationURL = URL(
+            fileURLWithPath: "/Volumes/Quill Cowork/Quill Cowork.app",
+            isDirectory: true
+        )
+        let controller = QuillCodeDesktopInstallationLocationController(
+            configuration: configuration,
+            inspector: RenderedUpdateInstallationInspector(.requiresRelocation),
+            defaults: UserDefaults(
+                suiteName: "RenderedInstallLocation.\(UUID().uuidString)"
+            ) ?? .standard,
+            openApplications: { _ in }
+        )
+        controller.startIfNeeded()
+        XCTAssertTrue(controller.isPresented)
+
+        let image = try renderHostedView(
+            QuillCodeDesktopInstallationLocationView(controller: controller),
+            width: 470,
+            height: 320,
+            debugPathEnvironmentKey: "QUILLCODE_RENDER_INSTALL_LOCATION_IMAGE_PATH"
+        )
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 470)
+        XCTAssertEqual(stats.height, 320)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.blueAccentPixelRatio, 0.001)
+    }
+
     func testRenderedSSHConnectionDialogShowsConfiguredHostsAndActions() throws {
         let coordinator = QuillCodeSSHConnectionDialogCoordinator()
         coordinator.isPresented = true

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-08 First-Launch Installation Guidance
+
+Overall grade after this slice: **A+ first-run UX, A+ presentation ownership, A+ bounded state**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| UX | A+ | A user who launches from the DMG gets concise installation guidance immediately, before an update exists, with one clear Applications action and a quiet deferral. |
+| Resilience | A+ | Writable installed copies and copies already in `/Applications` proceed untouched; other non-replaceable copies reuse the updater's filesystem inspector. |
+| Memory | A+ | The feature owns one Boolean and one build-scoped preference; it creates no timers, network work, background tasks, or retained application process. |
+| Architecture | A+ | Inspector, controller, view, and the shared distribution-sheet presenter each have one narrow role; observing both child controllers keeps state transitions live. |
+| Tests | A+ | Controller tests cover availability, persistence, new builds, and routing; fixed-size rendering and mounted-DMG launch cover the native surface. |
+
+Validation:
+
+- Focused installation-location, updater-controller, and rendered suite (21 tests, 0 failures)
+- Fixed 470x320 native rendering with opaque background, distinct-color, and accent checks
+- Full `swift test --skip-build` (5,461 tests, 5 skipped, 0 failures)
+- Release-mode build 654 passed direct-executable, Launch Services, live-window, Accessibility,
+  scheduled-coworker, multi-file, one-turn, browser, and Computer Use contracts
+- Release package: 3 of 3 fresh launches within budget; 268.99 ms median launch-ready,
+  88.44 MiB resident memory, and 8 threads on the median attempt
+- A normal first launch from the read-only mounted DMG exposed every identified reminder action;
+  `Open Applications` opened Finder at `/Applications`, and the same build did not prompt on relaunch
+- `python3 scripts/grade-code-quality.py --root .`
+- `git diff --check`
+
 ## 2026-08-08 Read-Only Update Recovery
 
 Overall grade after this slice: **A+ preflight, A+ recovery UX, A+ race safety**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,25 @@
 # QuillCode Decisions
 
+## 2026-08-08: first launch explains relocation before updates are needed
+
+- **Decision:** A packaged app launched from a read-only disk image, App Translocation, or another
+  non-replaceable location outside `/Applications` presents a native installation reminder
+  immediately. The primary action opens `/Applications`; the user can still defer or close the sheet.
+- **Frequency:** Deferral is remembered once per bundle identifier and build. The same build does not
+  interrupt every launch, while a newly downloaded build can explain its installation state again.
+  Writable installed copies and copies already inside `/Applications` never present the reminder.
+- **Presentation boundary:** Installation guidance and updater state share one sheet presenter. The
+  installation reminder has priority while visible, then an already available update can occupy the
+  same surface after dismissal. Smoke modes disable the reminder so automation remains deterministic.
+- **Ownership:** The reminder reuses the updater's injected installation-location inspector. The
+  inspector decides whether the bundle is replaceable, a small controller owns persistence and the
+  Applications action, and SwiftUI only projects state.
+- **Why:** The updater could explain a read-only location only after a newer build existed. A new user
+  launching directly from the DMG therefore received no guidance at the moment moving the app mattered.
+- **Evidence:** Controller tests cover writable suppression, read-only presentation, once-per-build
+  dismissal, disabled configuration, and the Applications action. A fixed-size rendered test and a
+  normal launch from a mounted packaged DMG cover the real first-run surface.
+
 ## 2026-08-08: updater preflights read-only installation locations
 
 - **Decision:** The desktop updater inspects the running app bundle, executable, and parent-directory

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -27,6 +27,13 @@ version, signing/notarization status, and current macOS updater asset. The DMG
 is the recommended human installation path; the ZIP remains the machine-verified
 updater payload so installation ergonomics cannot change update semantics.
 
+When Quill Cowork is launched directly from the read-only DMG or another
+non-replaceable location outside `/Applications`, it immediately offers to open
+`/Applications`. Dismissing that reminder suppresses it for the current build; a
+newer build may remind the user again. Installed copies already in `/Applications`
+do not show it. Installation guidance and available-update state use one coordinated
+sheet, so they cannot overlap.
+
 ## Build Cadence
 
 The tester release is refreshed:

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -7,6 +7,10 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 
 ## Unit Tests
 
+- First-launch installation guidance: writable-copy suppression, already-installed suppression,
+  read-only presentation, once-per-build dismissal, a new-build reminder, disabled smoke
+  configuration, Applications-folder routing, fixed-size rendering, coordinated updater-sheet
+  presentation, and a normal launch from a real mounted packaged DMG.
 - Updater install-location UX: writable/read-only parent detection, missing app/executable refusal,
   non-directory app and out-of-bundle executable refusal, zero preparation from a non-replaceable
   copy, trusted architecture-matching DMG selection, hostile/malformed/duplicate installer rejection,


### PR DESCRIPTION
## Summary

- Show a native first-launch reminder when Quill Cowork runs from a read-only DMG, App Translocation, or another nonreplaceable location outside `/Applications`.
- Remember deferral once per build, open `/Applications` from the primary action, and suppress the prompt for writable or already-installed copies.
- Coordinate installation guidance and updater state through one observed sheet presenter.

## Verification

- Focused installation-location, updater-controller, and rendered suite: 21 tests passed.
- Full `swift test --skip-build`: 5,461 tests passed, 5 skipped, 0 failures.
- Release-mode build 654 passed direct executable, Launch Services, live-window, Accessibility, browser, Computer Use, and coworker workflow gates.
- Packaged performance: 268.99 ms median launch-ready, 88.44 MiB resident, 8 threads on the median attempt.
- Mounted-DMG daily-drive check: first launch showed all identified actions, Open Applications opened Finder at `/Applications`, and the same build did not prompt on relaunch.
- `python3 scripts/grade-code-quality.py --root .`
- `git diff --check`

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing UI was checked for keyboard, accessibility, compact-window, and failure states.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release, updater, dependency, or workflow changes include their contract-level verification.