### PR TITLE
Verify published performance semantics

### DIFF
--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -18,6 +18,124 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         XCTAssertTrue(result.output.contains("Verified public Quill Cowork tester release tester-latest"))
     }
 
+    func testVerifierRejectsPerformanceSchemaDriftAfterIntegrityChecksPass() throws {
+        let fixture = try makeFixture { evidence in
+            evidence["schemaVersion"] = 2
+        }
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("performance evidence schemaVersion is invalid"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsForgedPerformanceDeltaAfterIntegrityChecksPass() throws {
+        let fixture = try makeFixture { evidence in
+            var attempts = try XCTUnwrap(evidence["attempts"] as? [[String: Any]])
+            attempts[2]["repeatedInteractionResidentMemoryGrowthBytes"] = 1
+            evidence["attempts"] = attempts
+        }
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("performance attempt 3 repeated resident-memory delta is forged"),
+            result.output
+        )
+    }
+
+    func testVerifierRecomputesPublishedPerformanceBudgetsAfterIntegrityChecksPass() throws {
+        let fixture = try makeFixture { evidence in
+            var attempts = try XCTUnwrap(evidence["attempts"] as? [[String: Any]])
+            let postResident = try XCTUnwrap(
+                attempts[2]["postInteractionResidentMemoryBytes"] as? Int
+            )
+            let repeatedGrowth = 17 * 1_024 * 1_024
+            attempts[2]["repeatedInteractionResidentMemoryBytes"] = postResident + repeatedGrowth
+            attempts[2]["repeatedInteractionResidentMemoryMiB"] = 119.0
+            attempts[2]["repeatedInteractionResidentMemoryGrowthBytes"] = repeatedGrowth
+            attempts[2]["repeatedInteractionResidentMemoryGrowthMiB"] = 17.0
+            evidence["attempts"] = attempts
+        }
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("performance attempt 3 violates the repeated resident-memory growth budget"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsMissingPublishedPerformanceEvidence() throws {
+        let fixture = try makeFixture(includePerformanceAsset: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("release must contain exactly one packaged performance asset"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsPublishedPerformancePolicyDriftAfterIntegrityChecksPass() throws {
+        let fixture = try makeFixture { evidence in
+            var budgets = try XCTUnwrap(evidence["budgets"] as? [String: Any])
+            budgets["maximumRepeatedResidentMemoryGrowthBytes"] = 32 * 1_024 * 1_024
+            evidence["budgets"] = budgets
+        }
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("is not production policy"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsIncompletePublishedPerformanceAggregation() throws {
+        let fixture = try makeFixture { evidence in
+            var attempts = try XCTUnwrap(evidence["attempts"] as? [[String: Any]])
+            attempts.removeLast()
+            evidence["attempts"] = attempts
+        }
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("performance evidence must contain 3 attempts"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsPublishedPerformanceHeadlineDrift() throws {
+        let fixture = try makeFixture { evidence in
+            evidence["repeatedInteractionThreadGrowth"] = 1
+        }
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("disagrees with selectedAttempt"),
+            result.output
+        )
+    }
+
     func testVerifierRejectsFeedDriftAndPayloadCorruption() throws {
         let feedFixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: feedFixture.root) }
@@ -101,7 +219,9 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
 
     private func makeFixture(
         appCommit: String? = nil,
-        appInfoIsSymlink: Bool = false
+        appInfoIsSymlink: Bool = false,
+        includePerformanceAsset: Bool = true,
+        performanceMutation: ((inout [String: Any]) throws -> Void)? = nil
     ) throws -> Fixture {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("quill-cowork-release-verifier-tests")
@@ -112,6 +232,7 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         let appName = "Quill-Cowork-macOS-arm64.zip"
         let cliName = "quill-code-macOS-arm64.tar.gz"
         let buildInfoName = "BUILD_INFO.txt"
+        let performanceName = "Quill-Cowork-macOS-arm64-PERFORMANCE.json"
         let checksumsName = "SHASUMS256.txt"
         try writeAppArchive(
             to: assetsURL.appendingPathComponent(appName),
@@ -120,6 +241,14 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             infoIsSymlink: appInfoIsSymlink
         )
         try Data("verified cli payload".utf8).write(to: assetsURL.appendingPathComponent(cliName))
+        if includePerformanceAsset {
+            var performanceEvidence = performanceEvidence()
+            try performanceMutation?(&performanceEvidence)
+            try writeJSON(
+                performanceEvidence,
+                to: assetsURL.appendingPathComponent(performanceName)
+            )
+        }
         try """
         product=Quill Cowork
         platform=macOS
@@ -146,7 +275,11 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             encoding: .utf8
         )
 
-        let checksummedNames = [buildInfoName, appName, cliName].sorted()
+        var checksummedNames = [buildInfoName, appName, cliName]
+        if includePerformanceAsset {
+            checksummedNames.append(performanceName)
+        }
+        checksummedNames.sort()
         let checksumText = try checksummedNames.map { name in
             let digest = try sha256(at: assetsURL.appendingPathComponent(name))
             return "\(digest)  \(name)"
@@ -165,7 +298,7 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             install: "zip-app",
             assetsURL: assetsURL
         )
-        let manifestAssets = try [
+        var manifestAssets = try [
             manifestAsset(
                 named: buildInfoName,
                 kind: "metadata",
@@ -173,7 +306,19 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 arch: "any",
                 install: "text",
                 assetsURL: assetsURL
-            ),
+            )
+        ]
+        if includePerformanceAsset {
+            manifestAssets.append(try manifestAsset(
+                named: performanceName,
+                kind: "performance",
+                platform: "macOS",
+                arch: "arm64",
+                install: "json",
+                assetsURL: assetsURL
+            ))
+        }
+        manifestAssets.append(contentsOf: try [
             appAsset,
             manifestAsset(
                 named: checksumsName,
@@ -191,7 +336,7 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 install: "tarball",
                 assetsURL: assetsURL
             )
-        ]
+        ])
         let manifest: [String: Any] = [
             "schemaVersion": 1,
             "product": "Quill Cowork",
@@ -248,6 +393,134 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         let releaseJSONURL = root.appendingPathComponent("release.json")
         try writeJSON(release, to: releaseJSONURL)
         return Fixture(root: root, assets: assetsURL, manifest: manifestURL, releaseJSON: releaseJSONURL)
+    }
+
+    private func performanceEvidence() -> [String: Any] {
+        let attempts = [
+            performanceAttempt(
+                number: 1,
+                launchReadyMilliseconds: 3_100,
+                residentMiB: 96,
+                postInteractionMiB: 100,
+                repeatedInteractionMiB: 102,
+                threadCount: 18,
+                postInteractionThreadCount: 20,
+                repeatedInteractionThreadCount: 19
+            ),
+            performanceAttempt(
+                number: 2,
+                launchReadyMilliseconds: 500,
+                residentMiB: 97,
+                postInteractionMiB: 101,
+                repeatedInteractionMiB: 103,
+                threadCount: 19,
+                postInteractionThreadCount: 20,
+                repeatedInteractionThreadCount: 20
+            ),
+            performanceAttempt(
+                number: 3,
+                launchReadyMilliseconds: 400,
+                residentMiB: 98,
+                postInteractionMiB: 102,
+                repeatedInteractionMiB: 104,
+                threadCount: 20,
+                postInteractionThreadCount: 21,
+                repeatedInteractionThreadCount: 21
+            )
+        ]
+        let selectedAttempt = attempts[1]
+        var evidence: [String: Any] = [
+            "schemaVersion": 3,
+            "ok": true,
+            "product": "Quill Cowork",
+            "measurement": "initial-live-window",
+            "postInteractionMeasurement": "settled-after-native-interaction-sweep",
+            "repeatedInteractionMeasurement": "settled-after-repeated-native-interaction-sweep",
+            "interactionSweepCount": 2,
+            "aggregation": "median-of-fresh-processes",
+            "attemptCount": 3,
+            "selectedAttempt": 2,
+            "passingAttemptCount": 2,
+            "requiredPassingAttemptCount": 2,
+            "attempts": attempts,
+            "budgets": [
+                "maximumLaunchReadyMilliseconds": 3_000.0,
+                "maximumResidentMemoryBytes": 256 * 1_024 * 1_024,
+                "maximumResidentMemoryGrowthBytes": 80 * 1_024 * 1_024,
+                "maximumRepeatedResidentMemoryGrowthBytes": 16 * 1_024 * 1_024,
+                "maximumThreadCount": 64,
+                "maximumRepeatedThreadGrowth": 4
+            ],
+            "withinBudget": true
+        ]
+        let summaryFields = [
+            "launchReadyMilliseconds",
+            "residentMemoryBytes",
+            "residentMemoryMiB",
+            "threadCount",
+            "postInteractionResidentMemoryBytes",
+            "postInteractionResidentMemoryMiB",
+            "postInteractionThreadCount",
+            "residentMemoryGrowthBytes",
+            "residentMemoryGrowthMiB",
+            "threadGrowth",
+            "repeatedInteractionResidentMemoryBytes",
+            "repeatedInteractionResidentMemoryMiB",
+            "repeatedInteractionThreadCount",
+            "repeatedInteractionResidentMemoryGrowthBytes",
+            "repeatedInteractionResidentMemoryGrowthMiB",
+            "repeatedInteractionThreadGrowth"
+        ]
+        for field in summaryFields {
+            evidence[field] = selectedAttempt[field]
+        }
+        return evidence
+    }
+
+    private func performanceAttempt(
+        number: Int,
+        launchReadyMilliseconds: Double,
+        residentMiB: Int,
+        postInteractionMiB: Int,
+        repeatedInteractionMiB: Int,
+        threadCount: Int,
+        postInteractionThreadCount: Int,
+        repeatedInteractionThreadCount: Int
+    ) -> [String: Any] {
+        let resident = residentMiB * 1_024 * 1_024
+        let postResident = postInteractionMiB * 1_024 * 1_024
+        let repeatedResident = repeatedInteractionMiB * 1_024 * 1_024
+        let residentGrowth = postResident - resident
+        let repeatedResidentGrowth = repeatedResident - postResident
+        return [
+            "attempt": number,
+            "launchReadyMilliseconds": launchReadyMilliseconds,
+            "residentMemoryBytes": resident,
+            "residentMemoryMiB": Double(residentMiB),
+            "threadCount": threadCount,
+            "postInteractionResidentMemoryBytes": postResident,
+            "postInteractionResidentMemoryMiB": Double(postInteractionMiB),
+            "postInteractionThreadCount": postInteractionThreadCount,
+            "residentMemoryGrowthBytes": residentGrowth,
+            "residentMemoryGrowthMiB": Double(residentGrowth) / Double(1_024 * 1_024),
+            "threadGrowth": postInteractionThreadCount - threadCount,
+            "repeatedInteractionResidentMemoryBytes": repeatedResident,
+            "repeatedInteractionResidentMemoryMiB": Double(repeatedInteractionMiB),
+            "repeatedInteractionThreadCount": repeatedInteractionThreadCount,
+            "repeatedInteractionResidentMemoryGrowthBytes": repeatedResidentGrowth,
+            "repeatedInteractionResidentMemoryGrowthMiB": (
+                Double(repeatedResidentGrowth) / Double(1_024 * 1_024)
+            ),
+            "repeatedInteractionThreadGrowth": (
+                repeatedInteractionThreadCount - postInteractionThreadCount
+            ),
+            "withinLaunchBudget": launchReadyMilliseconds <= 3_000,
+            "withinResidentMemoryBudget": true,
+            "withinResidentMemoryGrowthBudget": true,
+            "withinRepeatedResidentMemoryGrowthBudget": true,
+            "withinThreadCountBudget": true,
+            "withinRepeatedThreadGrowthBudget": true
+        ]
     }
 
     private func manifestAsset(

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,29 @@
 # Code Quality Audit
 
+## 2026-08-08 Published Performance Semantics Gate
+
+Overall grade after this slice: **A+ public integrity, A+ semantic verification, A+ fail-closed policy**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Evidence integrity | A+ | The verifier checks the exact public asset size, digest, and checksums before parsing a bounded regular JSON file. |
+| Semantics | A+ | Schema, product, measurement boundaries, two sweeps, three attempts, launch majority, median selection, and every headline field are independently checked. |
+| Resource policy | A+ | Canonical production limits are shared with the evidence producer; every memory/thread delta, MiB projection, pass flag, and budget result is recomputed. |
+| Resilience | A+ | Missing evidence, policy weakening, incomplete aggregation, forged values, non-finite numbers, resource misses, and summary drift fail publication closed. |
+| Architecture | A+ | Production policy, package generation, release-asset ownership, top-level aggregation, and per-attempt validation remain focused modules. |
+
+Validation:
+
+- Focused package and public-verifier suites (26 tests, 0 failures)
+- Full `swift test --skip-build` (5,476 tests, 5 skipped, 0 failures)
+- Strengthened verifier passed against exact public build 656 at
+  `c0f05fff192bfdd8f01630576797e6e5aa361899`
+- Adversarial fixtures regenerate asset digests, checksums, manifests, and release metadata before
+  proving schema drift, forged deltas, weakened budgets, missing evidence, incomplete attempts, and
+  headline drift are rejected semantically
+- Changed files and all repository modules grade A+
+- `git diff --check`
+
 ## 2026-08-08 Repeated-Interaction Resource Convergence
 
 Overall grade after this slice: **A+ lifecycle evidence, A+ fail-closed budgets, A+ release parity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,19 @@
 # QuillCode Decisions
 
+## 2026-08-08: public performance evidence is verified semantically
+
+- **Decision:** The post-publication release verifier must require exactly one architecture-matched
+  macOS performance asset and validate its meaning after size, digest, and checksum verification.
+- **Contract:** Published evidence uses the canonical production schema, boundaries, two-sweep count,
+  three fresh attempts, two-of-three launch policy, median selected headline, and exact production
+  budgets. The verifier recomputes raw memory/thread deltas, MiB projections, every budget result,
+  launch pass counts, and headline fields instead of trusting embedded success flags.
+- **Failure behavior:** Missing evidence, extra/missing fields without a schema bump, weakened limits,
+  incomplete aggregation, forged deltas, non-finite values, resource overruns, or selected-attempt
+  drift fail the public release job even when all published hashes are internally consistent.
+- **Why:** Checksums prove which bytes were published, not that those bytes still prove Quill Cowork's
+  native speed and resource promises. Distribution readiness requires both integrity and semantics.
+
 ## 2026-08-08: repeated native interactions must converge
 
 - **Decision:** Every packaged performance process runs the same reversible native Accessibility

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -94,6 +94,11 @@ than another 16 MiB or 4 additional threads. All three samples must stay at or b
 64 threads. The public performance asset records every raw snapshot and signed delta
 so a release cannot hide resource regressions behind a fast first frame or one-time
 UI warming.
+The post-publication verifier downloads that exact performance asset after its
+checksum passes, requires the production schema and three-process aggregation,
+recomputes every memory/thread delta and budget result, checks the median headline,
+and rejects missing evidence or weakened production limits. Publication therefore
+proves the public JSON's meaning as well as its bytes.
 These intentionally conservative first budgets catch major regressions without
 turning one loaded-runner outlier into the product metric.
 

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -21,7 +21,9 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 - Packaged resource gates: three fresh launch samples, majority launch-time enforcement, per-process
   initial and settled post-interaction resident-memory ceilings, retained-growth validation, bounded
   initial and post-interaction thread counts, recomputed delta integrity, and a public performance
-  manifest carrying every attempt and enforced budget.
+  manifest carrying every attempt and enforced budget. Post-publication verification requires the
+  exact performance asset, production schema and limits, three attempts, median headline, recomputed
+  deltas/flags, and a passing launch majority after file-integrity checks succeed.
 - Record & Replay contracts: request/status/capture encoding, event and snapshot bounds, skill-drafting prompt shape, empty-goal rejection, generic-backend unavailability, permission preflight, owner task/project/workspace propagation, stop-after-permission-revocation, event rejection once stop begins, protected-field redaction, and owner-only artifact permissions.
 - Config parsing, model catalog, auth state, secret store.
 - Non-interactive CLI parsing and contracts: legacy/exec routing, relative path resolution, stdin

--- a/scripts/native_click_probe_contracts/performance.py
+++ b/scripts/native_click_probe_contracts/performance.py
@@ -8,15 +8,22 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
 
+from performance_evidence_contract import (
+    DEFAULT_MAX_LAUNCH_READY_MILLISECONDS,
+    DEFAULT_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES,
+    DEFAULT_MAX_REPEATED_THREAD_GROWTH,
+    DEFAULT_MAX_RESIDENT_MEMORY_BYTES,
+    DEFAULT_MAX_RESIDENT_MEMORY_GROWTH_BYTES,
+    DEFAULT_MAX_THREAD_COUNT,
+    INITIAL_MEASUREMENT,
+    INTERACTION_SWEEP_COUNT,
+    PERFORMANCE_PRODUCT,
+    PERFORMANCE_SCHEMA_VERSION,
+    POST_INTERACTION_MEASUREMENT,
+    REPEATED_INTERACTION_MEASUREMENT,
+)
+
 from .json_io import load_report, require
-
-
-DEFAULT_MAX_LAUNCH_READY_MILLISECONDS = 3_000.0
-DEFAULT_MAX_RESIDENT_MEMORY_BYTES = 256 * 1024 * 1024
-DEFAULT_MAX_RESIDENT_MEMORY_GROWTH_BYTES = 80 * 1024 * 1024
-DEFAULT_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES = 16 * 1024 * 1024
-DEFAULT_MAX_THREAD_COUNT = 64
-DEFAULT_MAX_REPEATED_THREAD_GROWTH = 4
 
 
 @dataclass(frozen=True)
@@ -78,12 +85,15 @@ def _integer(value: Any, label: str) -> int:
 def _load_attempt(report_path: Path) -> PerformanceAttempt:
     report = load_report(report_path)
     require(report.get("ok") is True, f"{report_path} does not report ok=true")
-    require(report.get("appName") == "Quill Cowork", f"{report_path} has the wrong app identity")
+    require(report.get("appName") == PERFORMANCE_PRODUCT, f"{report_path} has the wrong app identity")
     performance = report.get("performance")
     require(isinstance(performance, dict), f"{report_path} is missing performance evidence")
-    require(performance.get("schemaVersion") == 3, "unsupported performance evidence schema")
     require(
-        performance.get("measurement") == "initial-live-window",
+        performance.get("schemaVersion") == PERFORMANCE_SCHEMA_VERSION,
+        "unsupported performance evidence schema",
+    )
+    require(
+        performance.get("measurement") == INITIAL_MEASUREMENT,
         "unexpected performance measurement boundary",
     )
 
@@ -101,7 +111,7 @@ def _load_attempt(report_path: Path) -> PerformanceAttempt:
     )
     require(
         performance.get("postInteractionMeasurement")
-        == "settled-after-native-interaction-sweep",
+        == POST_INTERACTION_MEASUREMENT,
         "unexpected post-interaction performance measurement boundary",
     )
     post_interaction_resident = _positive_integer(
@@ -122,11 +132,11 @@ def _load_attempt(report_path: Path) -> PerformanceAttempt:
     )
     require(
         performance.get("repeatedInteractionMeasurement")
-        == "settled-after-repeated-native-interaction-sweep",
+        == REPEATED_INTERACTION_MEASUREMENT,
         "unexpected repeated-interaction performance measurement boundary",
     )
     require(
-        performance.get("interactionSweepCount") == 2,
+        performance.get("interactionSweepCount") == INTERACTION_SWEEP_COUNT,
         "performance evidence must contain exactly two native interaction sweeps",
     )
     repeated_interaction_resident = _positive_integer(
@@ -311,11 +321,11 @@ def write_performance_manifest(
     repeated_thread_growth = selected_attempt.repeated_interaction_thread_growth
 
     manifest = {
-        "schemaVersion": 3,
+        "schemaVersion": PERFORMANCE_SCHEMA_VERSION,
         "ok": True,
-        "product": "Quill Cowork",
-        "measurement": "initial-live-window",
-        "postInteractionMeasurement": "settled-after-native-interaction-sweep",
+        "product": PERFORMANCE_PRODUCT,
+        "measurement": INITIAL_MEASUREMENT,
+        "postInteractionMeasurement": POST_INTERACTION_MEASUREMENT,
         "launchReadyMilliseconds": launch_ready,
         "residentMemoryBytes": resident,
         "residentMemoryMiB": round(resident / (1024 * 1024), 2),
@@ -329,8 +339,8 @@ def write_performance_manifest(
         "residentMemoryGrowthBytes": resident_growth,
         "residentMemoryGrowthMiB": round(resident_growth / (1024 * 1024), 2),
         "threadGrowth": thread_growth,
-        "repeatedInteractionMeasurement": "settled-after-repeated-native-interaction-sweep",
-        "interactionSweepCount": 2,
+        "repeatedInteractionMeasurement": REPEATED_INTERACTION_MEASUREMENT,
+        "interactionSweepCount": INTERACTION_SWEEP_COUNT,
         "repeatedInteractionResidentMemoryBytes": repeated_interaction_resident,
         "repeatedInteractionResidentMemoryMiB": round(
             repeated_interaction_resident / (1024 * 1024),

--- a/scripts/performance_evidence_contract.py
+++ b/scripts/performance_evidence_contract.py
@@ -1,0 +1,34 @@
+"""Canonical schema and production budgets for packaged performance evidence."""
+
+from __future__ import annotations
+
+
+PERFORMANCE_SCHEMA_VERSION = 3
+PERFORMANCE_PRODUCT = "Quill Cowork"
+INITIAL_MEASUREMENT = "initial-live-window"
+POST_INTERACTION_MEASUREMENT = "settled-after-native-interaction-sweep"
+REPEATED_INTERACTION_MEASUREMENT = (
+    "settled-after-repeated-native-interaction-sweep"
+)
+INTERACTION_SWEEP_COUNT = 2
+RELEASE_ATTEMPT_COUNT = 3
+
+DEFAULT_MAX_LAUNCH_READY_MILLISECONDS = 3_000.0
+DEFAULT_MAX_RESIDENT_MEMORY_BYTES = 256 * 1024 * 1024
+DEFAULT_MAX_RESIDENT_MEMORY_GROWTH_BYTES = 80 * 1024 * 1024
+DEFAULT_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES = 16 * 1024 * 1024
+DEFAULT_MAX_THREAD_COUNT = 64
+DEFAULT_MAX_REPEATED_THREAD_GROWTH = 4
+
+
+def production_budgets() -> dict[str, int | float]:
+    return {
+        "maximumLaunchReadyMilliseconds": DEFAULT_MAX_LAUNCH_READY_MILLISECONDS,
+        "maximumResidentMemoryBytes": DEFAULT_MAX_RESIDENT_MEMORY_BYTES,
+        "maximumResidentMemoryGrowthBytes": DEFAULT_MAX_RESIDENT_MEMORY_GROWTH_BYTES,
+        "maximumRepeatedResidentMemoryGrowthBytes": (
+            DEFAULT_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES
+        ),
+        "maximumThreadCount": DEFAULT_MAX_THREAD_COUNT,
+        "maximumRepeatedThreadGrowth": DEFAULT_MAX_REPEATED_THREAD_GROWTH,
+    }

--- a/scripts/release_verification_files.py
+++ b/scripts/release_verification_files.py
@@ -15,6 +15,7 @@ from release_verification_contract import (
     PRODUCT,
     VerificationError,
 )
+from release_verification_performance import verify_performance_evidence_asset
 
 
 APP_INFO_BYTE_LIMIT = 256 * 1024
@@ -232,6 +233,7 @@ def verify_asset_files(
                 f"downloaded asset {asset['name']!r} failed SHA-256 verification"
             )
     verify_primary_checksums(asset_directory, assets)
+    verify_performance_evidence_asset(asset_directory, assets, manifest)
     verify_build_info(
         asset_directory,
         assets,

--- a/scripts/release_verification_performance.py
+++ b/scripts/release_verification_performance.py
@@ -1,0 +1,196 @@
+"""Semantic validation for published packaged-performance evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from performance_evidence_contract import (
+    DEFAULT_MAX_LAUNCH_READY_MILLISECONDS,
+    INITIAL_MEASUREMENT,
+    INTERACTION_SWEEP_COUNT,
+    PERFORMANCE_PRODUCT,
+    PERFORMANCE_SCHEMA_VERSION,
+    POST_INTERACTION_MEASUREMENT,
+    RELEASE_ATTEMPT_COUNT,
+    REPEATED_INTERACTION_MEASUREMENT,
+    production_budgets,
+)
+from release_verification_contract import VerificationError, load_json_bytes
+from release_verification_performance_attempt import (
+    finite_number,
+    integer,
+    require_keys,
+    validate_attempt,
+)
+
+
+PERFORMANCE_EVIDENCE_BYTE_LIMIT = 256 * 1024
+
+TOP_LEVEL_KEYS = frozenset(
+    {
+        "aggregation",
+        "attemptCount",
+        "attempts",
+        "budgets",
+        "interactionSweepCount",
+        "launchReadyMilliseconds",
+        "measurement",
+        "ok",
+        "passingAttemptCount",
+        "postInteractionMeasurement",
+        "postInteractionResidentMemoryBytes",
+        "postInteractionResidentMemoryMiB",
+        "postInteractionThreadCount",
+        "product",
+        "repeatedInteractionMeasurement",
+        "repeatedInteractionResidentMemoryBytes",
+        "repeatedInteractionResidentMemoryGrowthBytes",
+        "repeatedInteractionResidentMemoryGrowthMiB",
+        "repeatedInteractionResidentMemoryMiB",
+        "repeatedInteractionThreadCount",
+        "repeatedInteractionThreadGrowth",
+        "requiredPassingAttemptCount",
+        "residentMemoryBytes",
+        "residentMemoryGrowthBytes",
+        "residentMemoryGrowthMiB",
+        "residentMemoryMiB",
+        "schemaVersion",
+        "selectedAttempt",
+        "threadCount",
+        "threadGrowth",
+        "withinBudget",
+    }
+)
+
+SUMMARY_FIELDS = (
+    "launchReadyMilliseconds",
+    "residentMemoryBytes",
+    "residentMemoryMiB",
+    "threadCount",
+    "postInteractionResidentMemoryBytes",
+    "postInteractionResidentMemoryMiB",
+    "postInteractionThreadCount",
+    "residentMemoryGrowthBytes",
+    "residentMemoryGrowthMiB",
+    "threadGrowth",
+    "repeatedInteractionResidentMemoryBytes",
+    "repeatedInteractionResidentMemoryMiB",
+    "repeatedInteractionThreadCount",
+    "repeatedInteractionResidentMemoryGrowthBytes",
+    "repeatedInteractionResidentMemoryGrowthMiB",
+    "repeatedInteractionThreadGrowth",
+)
+
+
+def validate_performance_evidence(evidence: dict[str, Any]) -> None:
+    require_keys(evidence, TOP_LEVEL_KEYS, "performance evidence")
+    expected_identity = {
+        "schemaVersion": PERFORMANCE_SCHEMA_VERSION,
+        "ok": True,
+        "product": PERFORMANCE_PRODUCT,
+        "measurement": INITIAL_MEASUREMENT,
+        "postInteractionMeasurement": POST_INTERACTION_MEASUREMENT,
+        "repeatedInteractionMeasurement": REPEATED_INTERACTION_MEASUREMENT,
+        "interactionSweepCount": INTERACTION_SWEEP_COUNT,
+        "aggregation": "median-of-fresh-processes",
+        "attemptCount": RELEASE_ATTEMPT_COUNT,
+        "requiredPassingAttemptCount": RELEASE_ATTEMPT_COUNT // 2 + 1,
+        "withinBudget": True,
+    }
+    for field, expected in expected_identity.items():
+        if evidence[field] != expected or type(evidence[field]) is not type(expected):
+            raise VerificationError(f"performance evidence {field} is invalid")
+
+    budgets = evidence["budgets"]
+    expected_budgets = production_budgets()
+    if not isinstance(budgets, dict):
+        raise VerificationError("performance evidence budgets must be an object")
+    require_keys(budgets, frozenset(expected_budgets), "performance budgets")
+    for field, expected in expected_budgets.items():
+        actual = finite_number(budgets[field], f"performance budgets {field}")
+        if actual != expected:
+            raise VerificationError(f"performance budgets {field} is not production policy")
+
+    raw_attempts = evidence["attempts"]
+    if not isinstance(raw_attempts, list) or len(raw_attempts) != RELEASE_ATTEMPT_COUNT:
+        raise VerificationError(
+            f"performance evidence must contain {RELEASE_ATTEMPT_COUNT} attempts"
+        )
+    attempts = [
+        validate_attempt(raw_attempt, index)
+        for index, raw_attempt in enumerate(raw_attempts, start=1)
+    ]
+    passing_attempts = sum(
+        attempt.launch_ready_milliseconds <= DEFAULT_MAX_LAUNCH_READY_MILLISECONDS
+        for attempt in attempts
+    )
+    required_passing = RELEASE_ATTEMPT_COUNT // 2 + 1
+    if passing_attempts < required_passing:
+        raise VerificationError("performance evidence misses the launch-ready majority")
+    if integer(
+        evidence["passingAttemptCount"],
+        "performance evidence passingAttemptCount",
+    ) != passing_attempts:
+        raise VerificationError("performance evidence passingAttemptCount is inconsistent")
+
+    selected_number = integer(
+        evidence["selectedAttempt"],
+        "performance evidence selectedAttempt",
+    )
+    if selected_number not in range(1, RELEASE_ATTEMPT_COUNT + 1):
+        raise VerificationError("performance evidence selectedAttempt is invalid")
+    selected = attempts[selected_number - 1]
+    median_launch = sorted(
+        attempt.launch_ready_milliseconds for attempt in attempts
+    )[RELEASE_ATTEMPT_COUNT // 2]
+    if selected.launch_ready_milliseconds != median_launch:
+        raise VerificationError("performance evidence selectedAttempt is not the median launch")
+    for field in SUMMARY_FIELDS:
+        if (
+            evidence[field] != selected.values[field]
+            or type(evidence[field]) is not type(selected.values[field])
+        ):
+            raise VerificationError(
+                f"performance evidence {field} disagrees with selectedAttempt"
+            )
+
+
+def verify_performance_evidence_asset(
+    asset_directory: Path,
+    assets: list[dict[str, Any]],
+    manifest: dict[str, Any],
+) -> None:
+    performance_assets = [asset for asset in assets if asset["kind"] == "performance"]
+    if len(performance_assets) != 1:
+        raise VerificationError(
+            "release must contain exactly one packaged performance asset"
+        )
+    performance_asset = performance_assets[0]
+    app_arch = manifest["updater"]["macOSAppAsset"]["arch"]
+    expected_name = f"Quill-Cowork-macOS-{app_arch}-PERFORMANCE.json"
+    expected_metadata = {
+        "name": expected_name,
+        "platform": "macOS",
+        "arch": app_arch,
+        "install": "json",
+    }
+    for field, expected in expected_metadata.items():
+        if performance_asset.get(field) != expected:
+            raise VerificationError(
+                f"packaged performance asset {field} disagrees with the macOS app"
+            )
+
+    path = asset_directory / expected_name
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise VerificationError("packaged performance evidence must be a regular file")
+        if path.stat().st_size > PERFORMANCE_EVIDENCE_BYTE_LIMIT:
+            raise VerificationError("packaged performance evidence exceeds its size limit")
+        evidence_bytes = path.read_bytes()
+    except VerificationError:
+        raise
+    except OSError as error:
+        raise VerificationError("packaged performance evidence could not be read") from error
+    evidence = load_json_bytes(evidence_bytes, "packaged performance evidence")
+    validate_performance_evidence(evidence)

--- a/scripts/release_verification_performance_attempt.py
+++ b/scripts/release_verification_performance_attempt.py
@@ -1,0 +1,231 @@
+"""Validate one published packaged-performance attempt."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from performance_evidence_contract import (
+    DEFAULT_MAX_LAUNCH_READY_MILLISECONDS,
+    DEFAULT_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES,
+    DEFAULT_MAX_REPEATED_THREAD_GROWTH,
+    DEFAULT_MAX_RESIDENT_MEMORY_BYTES,
+    DEFAULT_MAX_RESIDENT_MEMORY_GROWTH_BYTES,
+    DEFAULT_MAX_THREAD_COUNT,
+)
+from release_verification_contract import VerificationError
+
+
+MIB = 1024 * 1024
+ATTEMPT_KEYS = frozenset(
+    {
+        "attempt",
+        "launchReadyMilliseconds",
+        "postInteractionResidentMemoryBytes",
+        "postInteractionResidentMemoryMiB",
+        "postInteractionThreadCount",
+        "repeatedInteractionResidentMemoryBytes",
+        "repeatedInteractionResidentMemoryGrowthBytes",
+        "repeatedInteractionResidentMemoryGrowthMiB",
+        "repeatedInteractionResidentMemoryMiB",
+        "repeatedInteractionThreadCount",
+        "repeatedInteractionThreadGrowth",
+        "residentMemoryBytes",
+        "residentMemoryGrowthBytes",
+        "residentMemoryGrowthMiB",
+        "residentMemoryMiB",
+        "threadCount",
+        "threadGrowth",
+        "withinLaunchBudget",
+        "withinRepeatedResidentMemoryGrowthBudget",
+        "withinRepeatedThreadGrowthBudget",
+        "withinResidentMemoryBudget",
+        "withinResidentMemoryGrowthBudget",
+        "withinThreadCountBudget",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ValidatedPerformanceAttempt:
+    number: int
+    launch_ready_milliseconds: float
+    values: dict[str, Any]
+
+
+def require_keys(
+    value: dict[str, Any],
+    expected: frozenset[str],
+    label: str,
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        raise VerificationError(
+            f"{label} fields do not match schema "
+            f"(missing={missing}, unexpected={unexpected})"
+        )
+
+
+def integer(value: Any, label: str) -> int:
+    if type(value) is not int:
+        raise VerificationError(f"{label} must be an integer")
+    return value
+
+
+def finite_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VerificationError(f"{label} must be numeric")
+    number = float(value)
+    if not math.isfinite(number):
+        raise VerificationError(f"{label} must be finite")
+    return number
+
+
+def _positive_integer(value: Any, label: str) -> int:
+    number = integer(value, label)
+    if number <= 0:
+        raise VerificationError(f"{label} must be positive")
+    return number
+
+
+def _boolean(value: Any, label: str) -> bool:
+    if type(value) is not bool:
+        raise VerificationError(f"{label} must be a Boolean")
+    return value
+
+
+def _validate_mib(
+    values: dict[str, Any],
+    byte_field: str,
+    mib_field: str,
+    label: str,
+) -> None:
+    expected = round(integer(values[byte_field], f"{label} {byte_field}") / MIB, 2)
+    actual = finite_number(values[mib_field], f"{label} {mib_field}")
+    if actual != expected:
+        raise VerificationError(f"{label} {mib_field} disagrees with its byte value")
+
+
+def validate_attempt(
+    raw_attempt: Any,
+    expected_number: int,
+) -> ValidatedPerformanceAttempt:
+    label = f"performance attempt {expected_number}"
+    if not isinstance(raw_attempt, dict):
+        raise VerificationError(f"{label} must be an object")
+    require_keys(raw_attempt, ATTEMPT_KEYS, label)
+    if integer(raw_attempt["attempt"], f"{label} number") != expected_number:
+        raise VerificationError(f"{label} has a noncanonical attempt number")
+
+    launch = finite_number(
+        raw_attempt["launchReadyMilliseconds"],
+        f"{label} launchReadyMilliseconds",
+    )
+    if launch < 0:
+        raise VerificationError(f"{label} launchReadyMilliseconds cannot be negative")
+
+    resident = _positive_integer(
+        raw_attempt["residentMemoryBytes"],
+        f"{label} residentMemoryBytes",
+    )
+    post_resident = _positive_integer(
+        raw_attempt["postInteractionResidentMemoryBytes"],
+        f"{label} postInteractionResidentMemoryBytes",
+    )
+    repeated_resident = _positive_integer(
+        raw_attempt["repeatedInteractionResidentMemoryBytes"],
+        f"{label} repeatedInteractionResidentMemoryBytes",
+    )
+    threads = _positive_integer(raw_attempt["threadCount"], f"{label} threadCount")
+    post_threads = _positive_integer(
+        raw_attempt["postInteractionThreadCount"],
+        f"{label} postInteractionThreadCount",
+    )
+    repeated_threads = _positive_integer(
+        raw_attempt["repeatedInteractionThreadCount"],
+        f"{label} repeatedInteractionThreadCount",
+    )
+
+    resident_growth = integer(
+        raw_attempt["residentMemoryGrowthBytes"],
+        f"{label} residentMemoryGrowthBytes",
+    )
+    thread_growth = integer(raw_attempt["threadGrowth"], f"{label} threadGrowth")
+    repeated_resident_growth = integer(
+        raw_attempt["repeatedInteractionResidentMemoryGrowthBytes"],
+        f"{label} repeatedInteractionResidentMemoryGrowthBytes",
+    )
+    repeated_thread_growth = integer(
+        raw_attempt["repeatedInteractionThreadGrowth"],
+        f"{label} repeatedInteractionThreadGrowth",
+    )
+    if resident_growth != post_resident - resident:
+        raise VerificationError(f"{label} resident-memory delta is forged")
+    if thread_growth != post_threads - threads:
+        raise VerificationError(f"{label} thread delta is forged")
+    if repeated_resident_growth != repeated_resident - post_resident:
+        raise VerificationError(f"{label} repeated resident-memory delta is forged")
+    if repeated_thread_growth != repeated_threads - post_threads:
+        raise VerificationError(f"{label} repeated thread delta is forged")
+
+    for byte_field, mib_field in (
+        ("residentMemoryBytes", "residentMemoryMiB"),
+        ("postInteractionResidentMemoryBytes", "postInteractionResidentMemoryMiB"),
+        (
+            "repeatedInteractionResidentMemoryBytes",
+            "repeatedInteractionResidentMemoryMiB",
+        ),
+        ("residentMemoryGrowthBytes", "residentMemoryGrowthMiB"),
+        (
+            "repeatedInteractionResidentMemoryGrowthBytes",
+            "repeatedInteractionResidentMemoryGrowthMiB",
+        ),
+    ):
+        _validate_mib(raw_attempt, byte_field, mib_field, label)
+
+    within_launch = launch <= DEFAULT_MAX_LAUNCH_READY_MILLISECONDS
+    within_memory = max(resident, post_resident, repeated_resident) <= (
+        DEFAULT_MAX_RESIDENT_MEMORY_BYTES
+    )
+    within_growth = resident_growth <= DEFAULT_MAX_RESIDENT_MEMORY_GROWTH_BYTES
+    within_repeated_growth = repeated_resident_growth <= (
+        DEFAULT_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES
+    )
+    within_threads = max(threads, post_threads, repeated_threads) <= (
+        DEFAULT_MAX_THREAD_COUNT
+    )
+    within_repeated_thread_growth = (
+        repeated_thread_growth <= DEFAULT_MAX_REPEATED_THREAD_GROWTH
+    )
+
+    resource_checks = (
+        (within_memory, "resident-memory"),
+        (within_growth, "resident-memory growth"),
+        (within_repeated_growth, "repeated resident-memory growth"),
+        (within_threads, "thread-count"),
+        (within_repeated_thread_growth, "repeated thread-growth"),
+    )
+    for passed, budget_name in resource_checks:
+        if not passed:
+            raise VerificationError(f"{label} violates the {budget_name} budget")
+
+    expected_flags = {
+        "withinLaunchBudget": within_launch,
+        "withinResidentMemoryBudget": within_memory,
+        "withinResidentMemoryGrowthBudget": within_growth,
+        "withinRepeatedResidentMemoryGrowthBudget": within_repeated_growth,
+        "withinThreadCountBudget": within_threads,
+        "withinRepeatedThreadGrowthBudget": within_repeated_thread_growth,
+    }
+    for field, expected in expected_flags.items():
+        if _boolean(raw_attempt[field], f"{label} {field}") is not expected:
+            raise VerificationError(f"{label} {field} is inconsistent")
+
+    return ValidatedPerformanceAttempt(
+        number=expected_number,
+        launch_ready_milliseconds=launch,
+        values=raw_attempt,
+    )


### PR DESCRIPTION
## Summary

- Require the public macOS performance asset after release file-integrity verification.
- Recompute schema, attempt aggregation, median selection, memory/thread deltas, projections, flags, and production budgets instead of trusting published success fields.
- Share canonical performance policy with the package producer and document the fail-closed release contract.

## Verification

- Focused package and public-verifier suites: 26 tests passed, 0 failures.
- Full `swift test --skip-build`: 5,476 tests passed, 5 expected skips, 0 failures.
- Strengthened verifier passed against exact public build 656 at `c0f05fff192bfdd8f01630576797e6e5aa361899`.
- Adversarial fixtures rebuild hashes, checksums, manifests, and API metadata before testing semantic rejection.
- All modules grade A+; `git diff --check` passed.
- Credential scan found no TrustedRouter secret material.

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing UI is unchanged; no rendering QA is required.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release, updater, dependency, or workflow changes include their contract-level verification.