### PR TITLE
Show TrustedRouter key usage limits

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6bcd2a35cc90ce5f3c5a8c65ba83285582a7184e878df5fea51a4075777f3cae",
+  "originHash" : "cc5de584874af2469357beddd67d0e04c651cd0143b32450ecc7678713d3f1a3",
   "pins" : [
     {
       "identity" : "swift-toml",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lore-Hex/trusted-router-swift.git",
       "state" : {
-        "revision" : "410cb034ce5a20b62f209d03d46a256cafe7b54f",
-        "version" : "0.4.1"
+        "revision" : "6146c458cf46a68e528a70e89f35525f5a718bdf",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Lore-Hex/trusted-router-swift.git", from: "0.4.1"),
+        .package(url: "https://github.com/Lore-Hex/trusted-router-swift.git", from: "0.6.0"),
         .package(url: "https://github.com/dduan/TOMLDecoder.git", from: "0.4.5"),
         .package(url: "https://github.com/mattt/swift-toml.git", from: "2.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2")

--- a/Sources/QuillCodeAgent/TrustedRouterCreditsClient.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterCreditsClient.swift
@@ -8,14 +8,14 @@ import FoundationNetworking
 
 public enum TrustedRouterCreditsClientError: Error, CustomStringConvertible {
     case missingAPIKey
-    case invalidBalance
+    case invalidKeyUsage
 
     public var description: String {
         switch self {
         case .missingAPIKey:
-            "TrustedRouter sign-in is required to load account credits."
-        case .invalidBalance:
-            "TrustedRouter returned an invalid account balance."
+            "TrustedRouter sign-in is required to load key usage and limits."
+        case .invalidKeyUsage:
+            "TrustedRouter returned invalid key usage or limits."
         }
     }
 }
@@ -38,16 +38,18 @@ public struct TrustedRouterCreditsClient: Sendable {
     public func fetch(fetchedAt: Date = Date()) async throws -> TrustedRouterCreditsSnapshot {
         let key = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !key.isEmpty else { throw TrustedRouterCreditsClientError.missingAPIKey }
-        let client = try TrustedRouter(options: .init(apiKey: key, baseUrl: baseURL, urlSession: urlSession))
-        let response = try await client.credits()
-        guard let snapshot = TrustedRouterCreditsSnapshot(
-            balance: response.balance,
-            currency: response.currency,
-            fetchedAt: fetchedAt
-        ) else {
-            throw TrustedRouterCreditsClientError.invalidBalance
-        }
-        return snapshot
+        let client = try TrustedRouter(options: .init(
+            apiKey: key,
+            baseUrl: baseURL,
+            controlBaseURL: currentKeyControlBaseURL,
+            urlSession: urlSession
+        ))
+        let response: CurrentKeyEnvelope = try await client.request(
+            method: "GET",
+            path: "/key",
+            plane: .control
+        )
+        return try response.data.snapshot(fetchedAt: fetchedAt)
     }
 
     public static func userFacingFailure(for error: Error) -> String {
@@ -59,32 +61,126 @@ public struct TrustedRouterCreditsClient: Sendable {
             case .authentication:
                 return "TrustedRouter rejected the saved account credentials."
             case .permissionDenied:
-                return "The TrustedRouter account cannot read its credit balance."
+                return "The TrustedRouter key cannot read its usage and limits."
             case .notFound, .endpointNotSupported:
-                return "This TrustedRouter endpoint does not provide account credits."
+                return "This TrustedRouter endpoint does not provide key usage and limits."
             case .rateLimit(_, _, _, let retryAfterSeconds):
                 guard let retryAfterSeconds,
                       retryAfterSeconds.isFinite,
                       retryAfterSeconds > 0,
                       retryAfterSeconds <= 86_400 else {
-                    return "TrustedRouter rate-limited the account balance refresh."
+                    return "TrustedRouter rate-limited the key usage refresh."
                 }
-                return "TrustedRouter rate-limited the account balance refresh; "
+                return "TrustedRouter rate-limited the key usage refresh; "
                     + "retry in \(Int(ceil(retryAfterSeconds)))s."
             case .badRequest(let statusCode, _, _), .generic(let statusCode, _, _):
-                return "TrustedRouter account credits returned HTTP \(statusCode)."
+                return "TrustedRouter key usage returned HTTP \(statusCode)."
             case .internalError:
-                return "TrustedRouter account credits could not be refreshed."
+                return "TrustedRouter key usage could not be refreshed."
             case .invalidResponse:
-                return "TrustedRouter returned an unreadable account balance."
+                return "TrustedRouter returned unreadable key usage."
             }
         }
         if let error = error as? URLError {
-            return "TrustedRouter account credits are temporarily unreachable (network \(error.code.rawValue))."
+            return "TrustedRouter key usage is temporarily unreachable (network \(error.code.rawValue))."
         }
         if error is DecodingError {
-            return "TrustedRouter returned an unreadable account balance."
+            return "TrustedRouter returned unreadable key usage."
         }
-        return "TrustedRouter account credits could not be refreshed."
+        return "TrustedRouter key usage could not be refreshed."
+    }
+
+    private var currentKeyControlBaseURL: String? {
+        let configured = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let standard = TrustedRouterDefaults.defaultAPIBaseURL
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return configured == standard ? nil : configured
+    }
+}
+
+private struct CurrentKeyEnvelope: Decodable {
+    var data: CurrentKeyCredits
+}
+
+private struct CurrentKeyCredits: Decodable {
+    var usage: Double
+    var limit: Double?
+    var limitRemaining: Double?
+    var usageDaily: Double
+    var limitDaily: Double?
+    var limitDailyRemaining: Double?
+    var limitDailyResetsAt: String?
+    var usageWeekly: Double
+    var limitWeekly: Double?
+    var limitWeeklyRemaining: Double?
+    var limitWeeklyResetsAt: String?
+    var usageMonthly: Double
+    var limitMonthly: Double?
+    var limitMonthlyRemaining: Double?
+    var limitMonthlyResetsAt: String?
+    var budgetAlertOnly: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case usage
+        case limit
+        case limitRemaining = "limit_remaining"
+        case usageDaily = "usage_daily"
+        case limitDaily = "limit_daily"
+        case limitDailyRemaining = "limit_daily_remaining"
+        case limitDailyResetsAt = "limit_daily_resets_at"
+        case usageWeekly = "usage_weekly"
+        case limitWeekly = "limit_weekly"
+        case limitWeeklyRemaining = "limit_weekly_remaining"
+        case limitWeeklyResetsAt = "limit_weekly_resets_at"
+        case usageMonthly = "usage_monthly"
+        case limitMonthly = "limit_monthly"
+        case limitMonthlyRemaining = "limit_monthly_remaining"
+        case limitMonthlyResetsAt = "limit_monthly_resets_at"
+        case budgetAlertOnly = "budget_alert_only"
+    }
+
+    func snapshot(fetchedAt: Date) throws -> TrustedRouterCreditsSnapshot {
+        guard let lifetime = TrustedRouterCreditsWindowSnapshot(
+            window: .lifetime,
+            usage: usage,
+            limit: limit,
+            remaining: limitRemaining
+        ), let daily = TrustedRouterCreditsWindowSnapshot(
+            window: .daily,
+            usage: usageDaily,
+            limit: limitDaily,
+            remaining: limitDailyRemaining,
+            resetsAt: Self.date(limitDailyResetsAt)
+        ), let weekly = TrustedRouterCreditsWindowSnapshot(
+            window: .weekly,
+            usage: usageWeekly,
+            limit: limitWeekly,
+            remaining: limitWeeklyRemaining,
+            resetsAt: Self.date(limitWeeklyResetsAt)
+        ), let monthly = TrustedRouterCreditsWindowSnapshot(
+            window: .monthly,
+            usage: usageMonthly,
+            limit: limitMonthly,
+            remaining: limitMonthlyRemaining,
+            resetsAt: Self.date(limitMonthlyResetsAt)
+        ), let snapshot = TrustedRouterCreditsSnapshot(
+            lifetime: lifetime,
+            daily: daily,
+            weekly: weekly,
+            monthly: monthly,
+            currency: "USD",
+            fetchedAt: fetchedAt,
+            budgetAlertOnly: budgetAlertOnly
+        ) else {
+            throw TrustedRouterCreditsClientError.invalidKeyUsage
+        }
+        return snapshot
+    }
+
+    private static func date(_ value: String?) -> Date? {
+        guard let value else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: value) ?? ISO8601DateFormatter().date(from: value)
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct QuillCodeTopBarIdentityView: View {
     var topBar: TopBarSurface
+    @State private var showsKeyUsageDetails = false
 
     var body: some View {
         HStack(alignment: .center, spacing: 9) {
@@ -61,12 +62,28 @@ struct QuillCodeTopBarIdentityView: View {
             }
 
             if let accountBalance = topBar.accountBalance {
-                statusChip(
-                    accountBalance.compactLabel,
-                    tint: accountBalance.tone.quillCodeTint
-                )
-                .help(accountBalance.detailLabel)
+                Button {
+                    showsKeyUsageDetails.toggle()
+                } label: {
+                    HStack(spacing: 4) {
+                        statusChip(
+                            accountBalance.compactLabel,
+                            tint: accountBalance.tone.quillCodeTint
+                        )
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundStyle(accountBalance.tone.quillCodeTint)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .quillCodeCapsuleButtonTarget()
+                .buttonStyle(QuillCodePressableButtonStyle(enforcesMinimumHitTarget: false))
+                .help("Show TrustedRouter key usage and limits")
                 .accessibilityLabel(accountBalance.accessibilityLabel)
+                .accessibilityHint("Shows daily, weekly, monthly, and total key usage")
+                .popover(isPresented: $showsKeyUsageDetails, arrowEdge: .bottom) {
+                    keyUsagePopover(accountBalance)
+                }
             }
 
             if let spendStatusLabel = topBar.spendStatusLabel {
@@ -90,6 +107,29 @@ struct QuillCodeTopBarIdentityView: View {
                 RoundedRectangle(cornerRadius: 7, style: .continuous)
                     .fill(tint.opacity(0.08))
             )
+    }
+
+    private func keyUsagePopover(_ balance: ProviderAccountBalanceSurface) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("TrustedRouter limits")
+                    .font(.headline)
+                Spacer()
+                Text(balance.statusLabel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(balance.tone.quillCodeTint)
+            }
+            if !balance.visibleLimits.isEmpty {
+                QuillCodeTrustedRouterKeyLimitsView(limits: balance.visibleLimits)
+            }
+            Text(balance.detailLabel)
+                .font(.caption)
+                .foregroundStyle(QuillCodePalette.muted)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(width: 340)
+        .background(QuillCodePalette.background)
     }
 
     /// The context chip stays SHORT on purpose: "Context 70.4k / 200k" plus a small meter. Remaining,

--- a/Sources/QuillCodeApp/QuillCodeTrustedRouterCreditsSettingsCard.swift
+++ b/Sources/QuillCodeApp/QuillCodeTrustedRouterCreditsSettingsCard.swift
@@ -9,7 +9,7 @@ struct QuillCodeTrustedRouterCreditsSettingsCard: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: QuillCodeMetrics.controlClusterSpacing) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text("TrustedRouter account")
+                    Text("TrustedRouter key usage")
                         .font(.headline)
                     Text(balance.amountLabel ?? balance.statusLabel)
                         .font(.title2.weight(.semibold).monospacedDigit())
@@ -34,6 +34,10 @@ struct QuillCodeTrustedRouterCreditsSettingsCard: View {
                 .foregroundStyle(QuillCodePalette.muted)
                 .fixedSize(horizontal: false, vertical: true)
 
+            if !balance.visibleLimits.isEmpty {
+                QuillCodeTrustedRouterKeyLimitsView(limits: balance.visibleLimits)
+            }
+
             Button {
                 onCommand(refreshCommand)
             } label: {
@@ -41,9 +45,9 @@ struct QuillCodeTrustedRouterCreditsSettingsCard: View {
                     if balance.tone == .updating {
                         ProgressView()
                             .controlSize(.small)
-                        Text("Refreshing balance")
+                        Text("Refreshing key limits")
                     } else {
-                        Label("Refresh balance", systemImage: "arrow.clockwise")
+                        Label("Refresh key limits", systemImage: "arrow.clockwise")
                     }
                 }
             }

--- a/Sources/QuillCodeApp/QuillCodeTrustedRouterKeyLimitsView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTrustedRouterKeyLimitsView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct QuillCodeTrustedRouterKeyLimitsView: View {
+    var limits: [ProviderKeyLimitSurface]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(limits.enumerated()), id: \.element.id) { index, limit in
+                if index > 0 {
+                    Divider()
+                        .opacity(0.45)
+                }
+                limitRow(limit)
+                    .padding(.vertical, 9)
+            }
+        }
+    }
+
+    private func limitRow(_ limit: ProviderKeyLimitSurface) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(limit.periodLabel)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.text)
+                if let resetLabel = limit.resetLabel {
+                    Text(resetLabel)
+                        .font(.caption)
+                        .foregroundStyle(QuillCodePalette.muted)
+                }
+            }
+            Spacer(minLength: 12)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(limit.usageLabel)
+                    .font(.callout.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(QuillCodePalette.text)
+                    .lineLimit(1)
+                if let remainingLabel = limit.remainingLabel {
+                    Text(remainingLabel)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(QuillCodePalette.muted)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(limit.detailLabel)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceTrustedRouterCreditsSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTrustedRouterCreditsSurfaceBuilder.swift
@@ -7,33 +7,70 @@ public enum ProviderAccountBalanceTone: String, Codable, Sendable, Hashable {
     case warning
 }
 
+public struct ProviderKeyLimitSurface: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { periodLabel }
+    public var periodLabel: String
+    public var usageLabel: String
+    public var remainingLabel: String?
+    public var resetLabel: String?
+    public var detailLabel: String
+
+    public init(
+        periodLabel: String,
+        usageLabel: String,
+        remainingLabel: String?,
+        resetLabel: String?,
+        detailLabel: String
+    ) {
+        self.periodLabel = periodLabel
+        self.usageLabel = usageLabel
+        self.remainingLabel = remainingLabel
+        self.resetLabel = resetLabel
+        self.detailLabel = detailLabel
+    }
+}
+
 public struct ProviderAccountBalanceSurface: Codable, Sendable, Hashable {
     public var amountLabel: String?
     public var statusLabel: String
     public var detailLabel: String
     public var historyLabel: String?
     public var tone: ProviderAccountBalanceTone
+    public var limits: [ProviderKeyLimitSurface]?
 
     public init(
         amountLabel: String?,
         statusLabel: String,
         detailLabel: String,
         historyLabel: String? = nil,
-        tone: ProviderAccountBalanceTone
+        tone: ProviderAccountBalanceTone,
+        limits: [ProviderKeyLimitSurface] = []
     ) {
         self.amountLabel = amountLabel
         self.statusLabel = statusLabel
         self.detailLabel = detailLabel
         self.historyLabel = historyLabel
         self.tone = tone
+        self.limits = limits.isEmpty ? nil : limits
     }
 
     public var compactLabel: String {
-        amountLabel.map { "Balance \($0)" } ?? statusLabel
+        amountLabel ?? statusLabel
+    }
+
+    public var visibleLimits: [ProviderKeyLimitSurface] {
+        limits ?? []
     }
 
     public var accessibilityLabel: String {
-        "TrustedRouter account balance: \(amountLabel ?? statusLabel). \(detailLabel)"
+        let limitDetails = visibleLimits.map(\.detailLabel).joined(separator: ". ")
+        return [
+            "TrustedRouter key usage: \(amountLabel ?? statusLabel).",
+            detailLabel,
+            limitDetails
+        ]
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
     }
 }
 
@@ -49,44 +86,48 @@ struct WorkspaceTrustedRouterCreditsSurfaceBuilder: Sendable, Hashable {
         case .unavailable:
             return ProviderAccountBalanceSurface(
                 amountLabel: nil,
-                statusLabel: "Balance not loaded",
-                detailLabel: "Refresh to load the current TrustedRouter account balance.",
+                statusLabel: "Key limits not loaded",
+                detailLabel: "Refresh to load usage and limits for this TrustedRouter key.",
                 tone: .updating
             )
         case .refreshing:
             return ProviderAccountBalanceSurface(
-                amountLabel: state.snapshot.map(Self.amountLabel),
-                statusLabel: "Refreshing balance",
+                amountLabel: state.snapshot.map(primaryAmountLabel),
+                statusLabel: "Refreshing key limits",
                 detailLabel: refreshingDetail,
-                tone: .updating
+                tone: .updating,
+                limits: state.snapshot.map(limitSurfaces) ?? []
             )
         case .current:
             guard let snapshot = state.snapshot else {
                 return missingSnapshotSurface
             }
+            let limits = limitSurfaces(snapshot)
             return ProviderAccountBalanceSurface(
-                amountLabel: Self.amountLabel(snapshot),
-                statusLabel: "Balance current",
-                detailLabel: detailWithHistory("Current TrustedRouter account balance. \(ageLabel(snapshot.fetchedAt))."),
+                amountLabel: primaryAmountLabel(snapshot),
+                statusLabel: currentStatusLabel(snapshot),
+                detailLabel: detailWithHistory(currentDetail(snapshot)),
                 historyLabel: historyLabel,
-                tone: .normal
+                tone: currentTone(snapshot),
+                limits: limits
             )
         case .stale:
             guard let snapshot = state.snapshot else {
                 return missingSnapshotSurface
             }
             return ProviderAccountBalanceSurface(
-                amountLabel: Self.amountLabel(snapshot),
-                statusLabel: "Balance may be stale",
+                amountLabel: primaryAmountLabel(snapshot),
+                statusLabel: "Key limits may be stale",
                 detailLabel: detailWithHistory(staleDetail(snapshot)),
                 historyLabel: historyLabel,
-                tone: .warning
+                tone: .warning,
+                limits: limitSurfaces(snapshot)
             )
         case .failed:
             return ProviderAccountBalanceSurface(
                 amountLabel: nil,
-                statusLabel: "Balance unavailable",
-                detailLabel: state.failureMessage ?? "TrustedRouter account balance could not be refreshed.",
+                statusLabel: "Key limits unavailable",
+                detailLabel: state.failureMessage ?? "TrustedRouter key usage could not be refreshed.",
                 tone: .warning
             )
         }
@@ -95,17 +136,17 @@ struct WorkspaceTrustedRouterCreditsSurfaceBuilder: Sendable, Hashable {
     private var missingSnapshotSurface: ProviderAccountBalanceSurface {
         ProviderAccountBalanceSurface(
             amountLabel: nil,
-            statusLabel: "Balance unavailable",
-            detailLabel: "TrustedRouter did not return a usable account balance.",
+            statusLabel: "Key limits unavailable",
+            detailLabel: "TrustedRouter did not return usable key usage and limits.",
             tone: .warning
         )
     }
 
     private var refreshingDetail: String {
         guard let snapshot = state.snapshot else {
-            return "Loading the current TrustedRouter account balance."
+            return "Loading usage and limits for this TrustedRouter key."
         }
-        return "Refreshing the TrustedRouter account balance. "
+        return "Refreshing TrustedRouter key usage and limits. "
             + "Last successful update \(ageLabel(snapshot.fetchedAt).lowercased())."
     }
 
@@ -118,16 +159,16 @@ struct WorkspaceTrustedRouterCreditsSurfaceBuilder: Sendable, Hashable {
     }
 
     private func detailWithHistory(_ detail: String) -> String {
-        guard let historyLabel else { return detail }
-        return "\(detail) \(historyLabel)"
+        let history = historyLabel.map { " \($0)" } ?? ""
+        return "\(detail)\(history)"
     }
 
     private var historyLabel: String? {
         let entries = state.history.prefix(4).map { snapshot in
-            "\(Self.amountLabel(snapshot)) \(ageLabel(snapshot.fetchedAt).lowercased())"
+            "\(primaryAmountLabel(snapshot)) \(ageLabel(snapshot.fetchedAt).lowercased())"
         }
         guard !entries.isEmpty else { return nil }
-        return "Recent provider balance history: \(entries.joined(separator: "; "))."
+        return "Recent key-limit history: \(entries.joined(separator: "; "))."
     }
 
     private func ageLabel(_ fetchedAt: Date) -> String {
@@ -144,9 +185,68 @@ struct WorkspaceTrustedRouterCreditsSurfaceBuilder: Sendable, Hashable {
         return "Updated \(Int(elapsed / (24 * 60 * 60)))d ago"
     }
 
-    private static func amountLabel(_ snapshot: TrustedRouterCreditsSnapshot) -> String {
-        let amount = decimalLabel(snapshot.balance)
-        switch snapshot.currency {
+    private func primaryAmountLabel(_ snapshot: TrustedRouterCreditsSnapshot) -> String {
+        limitSurface(snapshot.primaryWindow, currency: snapshot.currency).map {
+            "\($0.periodLabel) \($0.usageLabel)"
+        } ?? "Total \(Self.money(snapshot.lifetime.usage, currency: snapshot.currency)) used"
+    }
+
+    private func currentDetail(_ snapshot: TrustedRouterCreditsSnapshot) -> String {
+        let enforcement = snapshot.budgetAlertOnly
+            ? "Limits send alerts without stopping requests."
+            : "Requests stop when a limit is reached."
+        return "\(ageLabel(snapshot.fetchedAt)). \(enforcement)"
+    }
+
+    private func limitSurfaces(_ snapshot: TrustedRouterCreditsSnapshot) -> [ProviderKeyLimitSurface] {
+        snapshot.windows.compactMap { window in
+            guard window.window == .lifetime || window.limit != nil || window.usage > 0 else { return nil }
+            return limitSurface(window, currency: snapshot.currency)
+        }
+    }
+
+    private func limitSurface(
+        _ window: TrustedRouterCreditsWindowSnapshot,
+        currency: String?
+    ) -> ProviderKeyLimitSurface? {
+        let usage = Self.money(window.usage, currency: currency)
+        let usageLabel = window.limit.map { "\(usage) / \(Self.money($0, currency: currency))" }
+            ?? "\(usage) used"
+        let remainingLabel = window.remaining.map { "\(Self.money($0, currency: currency)) left" }
+            ?? (window.window == .lifetime && window.limit == nil ? "No total cap" : nil)
+        let resetLabel = window.resetsAt.map(resetLabel)
+        var details = ["\(window.window.displayLabel): \(usageLabel)"]
+        if let remainingLabel { details.append(remainingLabel) }
+        if let resetLabel { details.append(resetLabel.lowercased()) }
+        if let usedPercent = window.usedPercent { details.append("\(usedPercent)% used") }
+        return ProviderKeyLimitSurface(
+            periodLabel: window.window.displayLabel,
+            usageLabel: usageLabel,
+            remainingLabel: remainingLabel,
+            resetLabel: resetLabel,
+            detailLabel: details.joined(separator: " · ")
+        )
+    }
+
+    private func currentStatusLabel(_ snapshot: TrustedRouterCreditsSnapshot) -> String {
+        currentTone(snapshot) == .warning ? "Key limit nearly reached" : "Key limits current"
+    }
+
+    private func currentTone(_ snapshot: TrustedRouterCreditsSnapshot) -> ProviderAccountBalanceTone {
+        snapshot.windows.contains { ($0.usedPercent ?? 0) >= 90 } ? .warning : .normal
+    }
+
+    private func resetLabel(_ date: Date) -> String {
+        let elapsed = date.timeIntervalSince(now)
+        guard elapsed > 0 else { return "Reset due" }
+        if elapsed < 60 * 60 { return "Resets in \(max(1, Int(ceil(elapsed / 60))))m" }
+        if elapsed < 24 * 60 * 60 { return "Resets in \(max(1, Int(ceil(elapsed / 3_600))))h" }
+        return "Resets in \(max(1, Int(ceil(elapsed / 86_400))))d"
+    }
+
+    private static func money(_ value: Double, currency: String?) -> String {
+        let amount = decimalLabel(value)
+        switch currency {
         case "USD": return "$\(amount)"
         case "EUR": return "€\(amount)"
         case "GBP": return "£\(amount)"

--- a/Sources/QuillCodeCore/TrustedRouterCredits.swift
+++ b/Sources/QuillCodeCore/TrustedRouterCredits.swift
@@ -1,15 +1,91 @@
 import Foundation
 
+public enum TrustedRouterCreditsWindow: String, Codable, Sendable, Hashable, CaseIterable {
+    case daily
+    case weekly
+    case monthly
+    case lifetime
+
+    public var displayLabel: String {
+        switch self {
+        case .daily: "Today"
+        case .weekly: "Week"
+        case .monthly: "Month"
+        case .lifetime: "Total"
+        }
+    }
+}
+
+public struct TrustedRouterCreditsWindowSnapshot: Codable, Sendable, Hashable {
+    public var window: TrustedRouterCreditsWindow
+    public var usage: Double
+    public var limit: Double?
+    public var remaining: Double?
+    public var resetsAt: Date?
+
+    public init?(
+        window: TrustedRouterCreditsWindow,
+        usage: Double,
+        limit: Double? = nil,
+        remaining: Double? = nil,
+        resetsAt: Date? = nil
+    ) {
+        guard usage.isFinite, usage >= 0 else { return nil }
+        guard limit.map({ $0.isFinite && $0 >= 0 }) ?? true else { return nil }
+        guard remaining.map({ $0.isFinite && $0 >= 0 }) ?? true else { return nil }
+
+        self.window = window
+        self.usage = usage
+        self.limit = limit
+        self.remaining = remaining ?? limit.map { max(0, $0 - usage) }
+        self.resetsAt = resetsAt
+    }
+
+    public var usedPercent: Int? {
+        guard let limit, limit > 0 else { return nil }
+        return max(0, Int((usage / limit * 100).rounded()))
+    }
+}
+
 public struct TrustedRouterCreditsSnapshot: Codable, Sendable, Hashable {
-    public var balance: Double
+    public var lifetime: TrustedRouterCreditsWindowSnapshot
+    public var daily: TrustedRouterCreditsWindowSnapshot
+    public var weekly: TrustedRouterCreditsWindowSnapshot
+    public var monthly: TrustedRouterCreditsWindowSnapshot
     public var currency: String?
     public var fetchedAt: Date
+    public var budgetAlertOnly: Bool
 
-    public init?(balance: Double, currency: String?, fetchedAt: Date = Date()) {
-        guard balance.isFinite else { return nil }
-        self.balance = balance
+    public init?(
+        lifetime: TrustedRouterCreditsWindowSnapshot,
+        daily: TrustedRouterCreditsWindowSnapshot,
+        weekly: TrustedRouterCreditsWindowSnapshot,
+        monthly: TrustedRouterCreditsWindowSnapshot,
+        currency: String?,
+        fetchedAt: Date = Date(),
+        budgetAlertOnly: Bool = false
+    ) {
+        guard lifetime.window == .lifetime,
+              daily.window == .daily,
+              weekly.window == .weekly,
+              monthly.window == .monthly else {
+            return nil
+        }
+        self.lifetime = lifetime
+        self.daily = daily
+        self.weekly = weekly
+        self.monthly = monthly
         self.currency = Self.normalizedCurrency(currency)
         self.fetchedAt = fetchedAt
+        self.budgetAlertOnly = budgetAlertOnly
+    }
+
+    public var windows: [TrustedRouterCreditsWindowSnapshot] {
+        [daily, weekly, monthly, lifetime]
+    }
+
+    public var primaryWindow: TrustedRouterCreditsWindowSnapshot {
+        windows.first(where: { $0.limit != nil }) ?? lifetime
     }
 
     private static func normalizedCurrency(_ value: String?) -> String? {
@@ -34,7 +110,7 @@ public struct TrustedRouterCreditsState: Codable, Sendable, Hashable {
 
     public var phase: TrustedRouterCreditsPhase
     public var snapshot: TrustedRouterCreditsSnapshot?
-    /// Most-recent-first successful TrustedRouter credit snapshots observed by this client.
+    /// Most-recent-first successful TrustedRouter key-usage snapshots observed by this client.
     /// This is local observation history, not a provider-side ledger.
     public var history: [TrustedRouterCreditsSnapshot]
     public var lastAttemptAt: Date?

--- a/Tests/QuillCodeAgentTests/TrustedRouterCreditsClientTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterCreditsClientTests.swift
@@ -12,16 +12,12 @@ final class TrustedRouterCreditsClientTests: XCTestCase {
         super.tearDown()
     }
 
-    func testFetchUsesAuthenticatedCreditsEndpointAndDecodesBalance() async throws {
+    func testFetchUsesAuthenticatedCurrentKeyEndpointAndDecodesLimits() async throws {
         CreditsURLProtocol.handler = { request in
-            XCTAssertEqual(request.url?.absoluteString, "https://api.trustedrouter.test/v1/credits")
+            XCTAssertEqual(request.url?.absoluteString, "https://api.trustedrouter.test/v1/key")
             XCTAssertEqual(request.httpMethod, "GET")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-test-secret")
-            return Self.response(
-                request: request,
-                statusCode: 200,
-                body: #"{"balance":12.5,"currency":"usd"}"#
-            )
+            return Self.response(request: request, statusCode: 200, body: Self.keyUsageBody)
         }
         let fetchedAt = Date(timeIntervalSince1970: 200)
 
@@ -31,24 +27,51 @@ final class TrustedRouterCreditsClientTests: XCTestCase {
             urlSession: CreditsURLProtocol.session()
         ).fetch(fetchedAt: fetchedAt)
 
-        XCTAssertEqual(snapshot.balance, 12.5)
+        XCTAssertEqual(snapshot.lifetime.usage, 86.090316)
+        XCTAssertNil(snapshot.lifetime.limit)
+        XCTAssertEqual(snapshot.daily.usage, 1.25)
+        XCTAssertEqual(snapshot.daily.limit, 40)
+        XCTAssertEqual(snapshot.daily.remaining, 38.75)
+        XCTAssertEqual(snapshot.weekly.remaining, 197.356056)
+        XCTAssertEqual(snapshot.monthly.limit, 800)
         XCTAssertEqual(snapshot.currency, "USD")
         XCTAssertEqual(snapshot.fetchedAt, fetchedAt)
+        XCTAssertFalse(snapshot.budgetAlertOnly)
+        XCTAssertNotNil(snapshot.daily.resetsAt)
     }
 
-    func testMissingKeyAndInvalidBalanceFailClosed() async {
+    func testDefaultInferenceBaseRoutesCurrentKeyMetadataToControlHost() async throws {
+        CreditsURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://trustedrouter.com/v1/key")
+            return Self.response(request: request, statusCode: 200, body: Self.keyUsageBody)
+        }
+
+        _ = try await TrustedRouterCreditsClient(
+            apiKey: "sk-test",
+            urlSession: CreditsURLProtocol.session()
+        ).fetch()
+    }
+
+    func testMissingKeyAndInvalidUsageFailClosed() async {
         do {
             _ = try await TrustedRouterCreditsClient(apiKey: " \n").fetch()
             XCTFail("Expected a missing-key error")
         } catch {
             XCTAssertEqual(
                 TrustedRouterCreditsClient.userFacingFailure(for: error),
-                "TrustedRouter sign-in is required to load account credits."
+                "TrustedRouter sign-in is required to load key usage and limits."
             )
         }
 
         CreditsURLProtocol.handler = { request in
-            Self.response(request: request, statusCode: 200, body: #"{"balance":1e999,"currency":"USD"}"#)
+            Self.response(
+                request: request,
+                statusCode: 200,
+                body: Self.keyUsageBody.replacingOccurrences(
+                    of: "\"usage\":86.090316",
+                    with: "\"usage\":-1"
+                )
+            )
         }
         do {
             _ = try await TrustedRouterCreditsClient(
@@ -60,7 +83,7 @@ final class TrustedRouterCreditsClientTests: XCTestCase {
         } catch {
             XCTAssertEqual(
                 TrustedRouterCreditsClient.userFacingFailure(for: error),
-                "TrustedRouter account credits could not be refreshed."
+                "TrustedRouter returned invalid key usage or limits."
             )
         }
     }
@@ -98,7 +121,7 @@ final class TrustedRouterCreditsClientTests: XCTestCase {
         )
         XCTAssertEqual(
             TrustedRouterCreditsClient.userFacingFailure(for: bounded),
-            "TrustedRouter rate-limited the account balance refresh; retry in 91s."
+            "TrustedRouter rate-limited the key usage refresh; retry in 91s."
         )
 
         let extreme = TrustedRouterError.rateLimit(
@@ -109,9 +132,30 @@ final class TrustedRouterCreditsClientTests: XCTestCase {
         )
         XCTAssertEqual(
             TrustedRouterCreditsClient.userFacingFailure(for: extreme),
-            "TrustedRouter rate-limited the account balance refresh."
+            "TrustedRouter rate-limited the key usage refresh."
         )
     }
+
+    private static let keyUsageBody = #"""
+    {"data":{
+      "usage":86.090316,
+      "limit":null,
+      "limit_remaining":null,
+      "usage_daily":1.25,
+      "limit_daily":40.0,
+      "limit_daily_remaining":38.75,
+      "limit_daily_resets_at":"2026-08-09T00:00:00Z",
+      "usage_weekly":2.643944,
+      "limit_weekly":200.0,
+      "limit_weekly_remaining":197.356056,
+      "limit_weekly_resets_at":"2026-08-10T00:00:00Z",
+      "usage_monthly":2.643944,
+      "limit_monthly":800.0,
+      "limit_monthly_remaining":797.356056,
+      "limit_monthly_resets_at":"2026-09-01T00:00:00Z",
+      "budget_alert_only":false
+    }}
+    """#
 
     private static func response(
         request: URLRequest,

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeFactoryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeFactoryTests.swift
@@ -131,11 +131,11 @@ final class WorkspaceRuntimeFactoryTests: XCTestCase {
         let paths = QuillCodePaths(home: try makeQuillCodeTestDirectory())
         try paths.ensure()
         RuntimeFactoryCatalogURLProtocol.handler = { request in
-            XCTAssertEqual(request.url?.absoluteString, "https://api.trustedrouter.test/v1/credits")
+            XCTAssertEqual(request.url?.absoluteString, "https://api.trustedrouter.test/v1/key")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-test")
             return (
                 HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
-                Data(#"{"balance":7.25,"currency":"USD"}"#.utf8)
+                Data(#"{"data":{"usage":7.25,"limit":null,"limit_remaining":null,"usage_daily":1.25,"limit_daily":40,"limit_daily_remaining":38.75,"limit_daily_resets_at":"2026-08-09T00:00:00Z","usage_weekly":2,"limit_weekly":200,"limit_weekly_remaining":198,"limit_weekly_resets_at":"2026-08-10T00:00:00Z","usage_monthly":3,"limit_monthly":800,"limit_monthly_remaining":797,"limit_monthly_resets_at":"2026-09-01T00:00:00Z","budget_alert_only":false}}"#.utf8)
             )
         }
 
@@ -150,7 +150,8 @@ final class WorkspaceRuntimeFactoryTests: XCTestCase {
         guard case .success(let snapshot) = result else {
             return XCTFail("Expected a live account credit snapshot")
         }
-        XCTAssertEqual(snapshot.balance, 7.25)
+        XCTAssertEqual(snapshot.lifetime.usage, 7.25)
+        XCTAssertEqual(snapshot.daily.limit, 40)
         XCTAssertEqual(snapshot.currency, "USD")
     }
 

--- a/Tests/QuillCodeAppTests/WorkspaceSettingsRuntimeSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSettingsRuntimeSurfaceTests.swift
@@ -88,11 +88,13 @@ final class WorkspaceSettingsRuntimeSurfaceTests: XCTestCase {
         XCTAssertEqual(settings.accountLabel, "quill@example.com")
     }
 
-    func testSettingsSurfaceShowsLiveTrustedRouterBalanceAndRefreshCommand() throws {
+    func testSettingsSurfaceShowsLiveTrustedRouterKeyLimitsAndRefreshCommand() throws {
         let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 19.75,
-            currency: "USD",
-            fetchedAt: Date()
+            lifetime: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .lifetime, usage: 19.75)),
+            daily: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: 1.25, limit: 40)),
+            weekly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .weekly, usage: 3, limit: 200)),
+            monthly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .monthly, usage: 7, limit: 800)),
+            currency: "USD"
         ))
         let settings = WorkspaceSettingsSurface(
             config: AppConfig(),
@@ -100,8 +102,9 @@ final class WorkspaceSettingsRuntimeSurfaceTests: XCTestCase {
             trustedRouterCredits: .current(snapshot)
         )
 
-        XCTAssertEqual(settings.trustedRouterAccountBalance?.amountLabel, "$19.75")
-        XCTAssertEqual(settings.trustedRouterAccountBalance?.statusLabel, "Balance current")
+        XCTAssertEqual(settings.trustedRouterAccountBalance?.amountLabel, "Today $1.25 / $40.00")
+        XCTAssertEqual(settings.trustedRouterAccountBalance?.statusLabel, "Key limits current")
+        XCTAssertEqual(settings.trustedRouterAccountBalance?.visibleLimits.count, 4)
         XCTAssertEqual(settings.trustedRouterCreditsRefreshCommand.id, "trustedrouter-credits-refresh")
         XCTAssertTrue(settings.trustedRouterCreditsRefreshCommand.isEnabled)
     }

--- a/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTokenUsageChipRenderTests.swift
@@ -75,12 +75,21 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
         XCTAssertTrue(decoded.tokenBudget?.visibleQuotaLimits.isEmpty == true)
     }
 
-    func testTopBarRoundTripsAndRendersAccountBalanceSeparatelyFromQuota() throws {
+    func testTopBarRoundTripsAndRendersKeyLimitsSeparatelyFromContextQuota() throws {
         let accountBalance = ProviderAccountBalanceSurface(
-            amountLabel: "$12.50",
-            statusLabel: "Balance current",
-            detailLabel: "Current TrustedRouter account balance.",
-            tone: .normal
+            amountLabel: "Today $1.25 / $40.00",
+            statusLabel: "Key limits current",
+            detailLabel: "Current TrustedRouter key usage.",
+            tone: .normal,
+            limits: [
+                ProviderKeyLimitSurface(
+                    periodLabel: "Today",
+                    usageLabel: "$1.25 / $40.00",
+                    remainingLabel: "$38.75 left",
+                    resetLabel: "Resets in 8h",
+                    detailLabel: "Today: $1.25 / $40.00 · $38.75 left · resets in 8h"
+                )
+            ]
         )
         let topBar = makeTopBar(usageStatusLabel: nil, accountBalance: accountBalance)
 
@@ -89,7 +98,8 @@ final class WorkspaceTokenUsageChipRenderTests: XCTestCase {
 
         XCTAssertEqual(decoded.accountBalance, accountBalance)
         XCTAssertTrue(html.contains(#"data-testid="top-bar-account-balance""#))
-        XCTAssertTrue(html.contains("Balance $12.50"))
+        XCTAssertEqual(decoded.accountBalance?.visibleLimits.count, 1)
+        XCTAssertTrue(html.contains("Today $1.25 / $40.00"))
         XCTAssertFalse(html.contains(#"data-testid="top-bar-token-quota-limits""#))
     }
 

--- a/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTopBarSurfaceBuilderTests.swift
@@ -97,12 +97,8 @@ final class WorkspaceTopBarSurfaceBuilderTests: XCTestCase {
         XCTAssertTrue(topBar.showsComputerUseSetup)
     }
 
-    func testProjectsTrustedRouterAccountBalanceIntoTopBar() throws {
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 6.5,
-            currency: "USD",
-            fetchedAt: Date()
-        ))
+    func testProjectsTrustedRouterKeyLimitsIntoTopBar() throws {
+        let snapshot = try makeCreditsSnapshot(dailyUsage: 6.5)
         let topBar = WorkspaceTopBarSurfaceBuilder(
             topBarState: TopBarState(model: TrustedRouterDefaults.fastModel),
             thread: nil,
@@ -118,8 +114,19 @@ final class WorkspaceTopBarSurfaceBuilderTests: XCTestCase {
             hasTrustedRouterCredential: true
         ).surface()
 
-        XCTAssertEqual(topBar.accountBalance?.amountLabel, "$6.50")
-        XCTAssertTrue(topBar.topBarAccessibilityLabel.contains("TrustedRouter account balance"))
+        XCTAssertEqual(topBar.accountBalance?.amountLabel, "Today $6.50 / $40.00")
+        XCTAssertEqual(topBar.accountBalance?.visibleLimits.count, 4)
+        XCTAssertTrue(topBar.topBarAccessibilityLabel.contains("TrustedRouter key usage"))
+    }
+
+    private func makeCreditsSnapshot(dailyUsage: Double) throws -> TrustedRouterCreditsSnapshot {
+        try XCTUnwrap(TrustedRouterCreditsSnapshot(
+            lifetime: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .lifetime, usage: 20)),
+            daily: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: dailyUsage, limit: 40)),
+            weekly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .weekly, usage: 8, limit: 200)),
+            monthly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .monthly, usage: 16, limit: 800)),
+            currency: "USD"
+        ))
     }
 
     func testShowsResolvableWorktreeBindingInTopBar() throws {

--- a/Tests/QuillCodeAppTests/WorkspaceTrustedRouterCreditsRefreshPolicyTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTrustedRouterCreditsRefreshPolicyTests.swift
@@ -21,11 +21,7 @@ final class WorkspaceTrustedRouterCreditsRefreshPolicyTests: XCTestCase {
     }
 
     func testUsesFreshnessAndFailureBackoffWithoutOverlappingRefreshes() throws {
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 10,
-            currency: "USD",
-            fetchedAt: now.addingTimeInterval(-59)
-        ))
+        let snapshot = try makeSnapshot(fetchedAt: now.addingTimeInterval(-59))
         let policy = WorkspaceTrustedRouterCreditsRefreshPolicy(
             staleAfter: 60,
             retryAfterFailure: 30
@@ -37,11 +33,7 @@ final class WorkspaceTrustedRouterCreditsRefreshPolicyTests: XCTestCase {
             now: now
         ))
         XCTAssertTrue(policy.shouldRefresh(
-            state: .current(try XCTUnwrap(TrustedRouterCreditsSnapshot(
-                balance: 10,
-                currency: "USD",
-                fetchedAt: now.addingTimeInterval(-60)
-            ))),
+            state: .current(try makeSnapshot(fetchedAt: now.addingTimeInterval(-60))),
             hasTrustedRouterAPIKey: true,
             now: now
         ))
@@ -69,16 +61,23 @@ final class WorkspaceTrustedRouterCreditsRefreshPolicyTests: XCTestCase {
     }
 
     func testInvalidThresholdsDoNotDisableRefresh() throws {
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 10,
-            currency: "USD",
-            fetchedAt: now
-        ))
+        let snapshot = try makeSnapshot(fetchedAt: now)
 
         XCTAssertTrue(WorkspaceTrustedRouterCreditsRefreshPolicy(staleAfter: .nan).shouldRefresh(
             state: .current(snapshot),
             hasTrustedRouterAPIKey: true,
             now: now
+        ))
+    }
+
+    private func makeSnapshot(fetchedAt: Date) throws -> TrustedRouterCreditsSnapshot {
+        try XCTUnwrap(TrustedRouterCreditsSnapshot(
+            lifetime: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .lifetime, usage: 10)),
+            daily: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: 1, limit: 40)),
+            weekly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .weekly, usage: 2, limit: 200)),
+            monthly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .monthly, usage: 3, limit: 800)),
+            currency: "USD",
+            fetchedAt: fetchedAt
         ))
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceTrustedRouterCreditsSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTrustedRouterCreditsSurfaceBuilderTests.swift
@@ -5,12 +5,12 @@ import QuillCodeCore
 final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
     private let now = Date(timeIntervalSince1970: 10_000)
 
-    func testFormatsCurrentUSDAccountBalanceWithoutCallingItQuota() throws {
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 12.5,
-            currency: "USD",
+    func testFormatsCurrentKeyUsageAndAllLimitWindows() throws {
+        let snapshot = try makeSnapshot(
+            lifetimeUsage: 86.090316,
+            dailyUsage: 1.25,
             fetchedAt: now.addingTimeInterval(-90)
-        ))
+        )
 
         let surface = try XCTUnwrap(WorkspaceTrustedRouterCreditsSurfaceBuilder(
             state: .current(snapshot),
@@ -18,29 +18,34 @@ final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
             now: now
         ).surface())
 
-        XCTAssertEqual(surface.amountLabel, "$12.50")
-        XCTAssertEqual(surface.compactLabel, "Balance $12.50")
-        XCTAssertEqual(surface.statusLabel, "Balance current")
+        XCTAssertEqual(surface.amountLabel, "Today $1.25 / $40.00")
+        XCTAssertEqual(surface.compactLabel, "Today $1.25 / $40.00")
+        XCTAssertEqual(surface.statusLabel, "Key limits current")
         XCTAssertEqual(surface.tone, .normal)
+        XCTAssertEqual(surface.visibleLimits.map(\.periodLabel), ["Today", "Week", "Month", "Total"])
+        XCTAssertEqual(surface.visibleLimits.map(\.usageLabel), [
+            "$1.25 / $40.00",
+            "$2.6439 / $200.00",
+            "$2.6439 / $800.00",
+            "$86.0903 used"
+        ])
+        XCTAssertEqual(surface.visibleLimits.last?.remainingLabel, "No total cap")
         XCTAssertTrue(surface.detailLabel.contains("Updated 1m ago"))
-        XCTAssertFalse(surface.accessibilityLabel.localizedCaseInsensitiveContains("quota"))
+        XCTAssertTrue(surface.accessibilityLabel.contains("$38.75 left"))
     }
 
-    func testCurrentBalanceDetailIncludesBoundedProviderHistory() throws {
-        let older = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 14,
-            currency: "USD",
+    func testCurrentDetailIncludesBoundedKeyLimitHistory() throws {
+        let older = try makeSnapshot(
+            lifetimeUsage: 84,
+            dailyUsage: 1,
             fetchedAt: now.addingTimeInterval(-3_600)
-        ))
-        let current = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 12.5,
-            currency: "USD",
-            fetchedAt: now.addingTimeInterval(-90)
-        ))
-        let state = TrustedRouterCreditsState.current(
-            current,
-            previous: .current(older)
         )
+        let current = try makeSnapshot(
+            lifetimeUsage: 86,
+            dailyUsage: 2,
+            fetchedAt: now.addingTimeInterval(-90)
+        )
+        let state = TrustedRouterCreditsState.current(current, previous: .current(older))
 
         let surface = try XCTUnwrap(WorkspaceTrustedRouterCreditsSurfaceBuilder(
             state: state,
@@ -48,17 +53,21 @@ final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
             now: now
         ).surface())
 
-        XCTAssertEqual(surface.historyLabel, "Recent provider balance history: $12.50 updated 1m ago; $14.00 updated 1h ago.")
-        XCTAssertTrue(surface.detailLabel.contains("Recent provider balance history"))
-        XCTAssertTrue(surface.accessibilityLabel.contains("$14.00 updated 1h ago"))
+        XCTAssertEqual(
+            surface.historyLabel,
+            "Recent key-limit history: Today $2.00 / $40.00 updated 1m ago; Today $1.00 / $40.00 updated 1h ago."
+        )
+        XCTAssertTrue(surface.detailLabel.contains("Recent key-limit history"))
+        XCTAssertTrue(surface.accessibilityLabel.contains("Week: $2.6439 / $200.00"))
     }
 
-    func testStaleSurfaceRetainsPreciseSmallBalanceAndFailureReason() throws {
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 0.0123,
+    func testStaleSurfaceRetainsPreciseUsageAndFailureReason() throws {
+        let snapshot = try makeSnapshot(
+            lifetimeUsage: 0.0123,
+            dailyUsage: 0.0123,
             currency: "EUR",
             fetchedAt: now.addingTimeInterval(-3_600)
-        ))
+        )
         let state = TrustedRouterCreditsState.failed(
             previous: .current(snapshot),
             attemptedAt: now,
@@ -71,9 +80,21 @@ final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
             now: now
         ).surface())
 
-        XCTAssertEqual(surface.amountLabel, "€0.0123")
+        XCTAssertEqual(surface.amountLabel, "Today €0.0123 / €40.00")
         XCTAssertEqual(surface.tone, .warning)
         XCTAssertTrue(surface.detailLabel.contains("Network unavailable."))
+    }
+
+    func testNearLimitUsesWarningTone() throws {
+        let snapshot = try makeSnapshot(lifetimeUsage: 90, dailyUsage: 38)
+        let surface = try XCTUnwrap(WorkspaceTrustedRouterCreditsSurfaceBuilder(
+            state: .current(snapshot),
+            hasCredential: true,
+            now: now
+        ).surface())
+
+        XCTAssertEqual(surface.statusLabel, "Key limit nearly reached")
+        XCTAssertEqual(surface.tone, .warning)
     }
 
     func testNoCredentialProducesNoAccountSurface() {
@@ -82,5 +103,39 @@ final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
             hasCredential: false,
             now: now
         ).surface())
+    }
+
+    private func makeSnapshot(
+        lifetimeUsage: Double,
+        dailyUsage: Double,
+        currency: String = "USD",
+        fetchedAt: Date? = nil
+    ) throws -> TrustedRouterCreditsSnapshot {
+        try XCTUnwrap(TrustedRouterCreditsSnapshot(
+            lifetime: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .lifetime, usage: lifetimeUsage)),
+            daily: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(
+                window: .daily,
+                usage: dailyUsage,
+                limit: 40,
+                remaining: max(0, 40 - dailyUsage),
+                resetsAt: now.addingTimeInterval(7_200)
+            )),
+            weekly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(
+                window: .weekly,
+                usage: 2.643944,
+                limit: 200,
+                remaining: 197.356056,
+                resetsAt: now.addingTimeInterval(2 * 86_400)
+            )),
+            monthly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(
+                window: .monthly,
+                usage: 2.643944,
+                limit: 800,
+                remaining: 797.356056,
+                resetsAt: now.addingTimeInterval(20 * 86_400)
+            )),
+            currency: currency,
+            fetchedAt: fetchedAt ?? now
+        ))
     }
 }

--- a/Tests/QuillCodeCoreTests/TrustedRouterCreditsTests.swift
+++ b/Tests/QuillCodeCoreTests/TrustedRouterCreditsTests.swift
@@ -2,25 +2,41 @@ import XCTest
 @testable import QuillCodeCore
 
 final class TrustedRouterCreditsTests: XCTestCase {
-    func testSnapshotNormalizesCurrencyAndRejectsNonFiniteBalances() throws {
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 12.5,
+    func testSnapshotNormalizesCurrencyAndExposesOrderedWindows() throws {
+        let snapshot = try makeSnapshot(
+            lifetimeUsage: 12.5,
+            dailyUsage: 1.25,
+            dailyLimit: 10,
             currency: " usd \n",
             fetchedAt: Date(timeIntervalSince1970: 100)
-        ))
+        )
 
-        XCTAssertEqual(snapshot.balance, 12.5)
+        XCTAssertEqual(snapshot.lifetime.usage, 12.5)
+        XCTAssertEqual(snapshot.daily.remaining, 8.75)
+        XCTAssertEqual(snapshot.daily.usedPercent, 13)
         XCTAssertEqual(snapshot.currency, "USD")
-        XCTAssertNil(TrustedRouterCreditsSnapshot(balance: .nan, currency: "USD"))
-        XCTAssertNil(TrustedRouterCreditsSnapshot(balance: .infinity, currency: "USD"))
+        XCTAssertEqual(snapshot.windows.map(\.window), [.daily, .weekly, .monthly, .lifetime])
+        XCTAssertEqual(snapshot.primaryWindow, snapshot.daily)
     }
 
-    func testRefreshAndFailureTransitionsRetainLastKnownBalance() throws {
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 4.25,
-            currency: "USD",
-            fetchedAt: Date(timeIntervalSince1970: 100)
+    func testWindowRejectsInvalidMoneyValuesAndSnapshotRejectsMismatchedWindows() throws {
+        XCTAssertNil(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: .nan))
+        XCTAssertNil(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: .infinity))
+        XCTAssertNil(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: -1))
+        XCTAssertNil(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: 1, limit: -1))
+
+        let daily = try XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: 1))
+        XCTAssertNil(TrustedRouterCreditsSnapshot(
+            lifetime: daily,
+            daily: daily,
+            weekly: try XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .weekly, usage: 0)),
+            monthly: try XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .monthly, usage: 0)),
+            currency: "USD"
         ))
+    }
+
+    func testRefreshAndFailureTransitionsRetainLastKnownUsage() throws {
+        let snapshot = try makeSnapshot(lifetimeUsage: 4.25, fetchedAt: Date(timeIntervalSince1970: 100))
         let current = TrustedRouterCreditsState.current(snapshot)
         let refreshing = TrustedRouterCreditsState.refreshing(
             previous: current,
@@ -43,11 +59,10 @@ final class TrustedRouterCreditsTests: XCTestCase {
 
     func testSuccessfulRefreshHistoryIsMostRecentFirstDeduplicatedAndBounded() throws {
         let snapshots = try (0..<30).map { index in
-            try XCTUnwrap(TrustedRouterCreditsSnapshot(
-                balance: Double(index),
-                currency: "USD",
+            try makeSnapshot(
+                lifetimeUsage: Double(index),
                 fetchedAt: Date(timeIntervalSince1970: Double(index))
-            ))
+            )
         }
 
         let state = snapshots.reduce(TrustedRouterCreditsState.unavailable) { previous, snapshot in
@@ -61,27 +76,20 @@ final class TrustedRouterCreditsTests: XCTestCase {
         XCTAssertEqual(repeated.history, state.history)
     }
 
-    func testDecodesOlderStateWithoutHistoryAndSeedsSnapshotAsHistory() throws {
-        let json = """
-        {
-          "phase": "current",
-          "snapshot": {
-            "balance": 4.25,
-            "currency": "USD",
-            "fetchedAt": 100
-          },
-          "lastAttemptAt": 100
-        }
-        """
+    func testDecodesStateWithoutHistoryAndSeedsSnapshotAsHistory() throws {
+        let snapshot = try makeSnapshot(lifetimeUsage: 4.25, fetchedAt: Date(timeIntervalSince1970: 100))
+        let encoded = try JSONEncoder().encode(TrustedRouterCreditsState.current(snapshot))
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object.removeValue(forKey: "history")
 
         let state = try JSONDecoder().decode(
             TrustedRouterCreditsState.self,
-            from: Data(json.utf8)
+            from: JSONSerialization.data(withJSONObject: object)
         )
 
         XCTAssertEqual(state.phase, .current)
-        XCTAssertEqual(state.snapshot?.balance, 4.25)
-        XCTAssertEqual(state.history, [state.snapshot].compactMap { $0 })
+        XCTAssertEqual(state.snapshot?.lifetime.usage, 4.25)
+        XCTAssertEqual(state.history, [snapshot])
     }
 
     func testFailureWithoutSnapshotIsFailedAndBoundsDiagnosticText() {
@@ -93,5 +101,26 @@ final class TrustedRouterCreditsTests: XCTestCase {
         XCTAssertEqual(failure.phase, .failed)
         XCTAssertNil(failure.snapshot)
         XCTAssertEqual(failure.failureMessage?.count, 240)
+    }
+
+    private func makeSnapshot(
+        lifetimeUsage: Double,
+        dailyUsage: Double = 0,
+        dailyLimit: Double? = 40,
+        currency: String = "USD",
+        fetchedAt: Date = Date()
+    ) throws -> TrustedRouterCreditsSnapshot {
+        try XCTUnwrap(TrustedRouterCreditsSnapshot(
+            lifetime: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .lifetime, usage: lifetimeUsage)),
+            daily: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(
+                window: .daily,
+                usage: dailyUsage,
+                limit: dailyLimit
+            )),
+            weekly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .weekly, usage: 0, limit: 200)),
+            monthly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .monthly, usage: 0, limit: 800)),
+            currency: currency,
+            fetchedAt: fetchedAt
+        ))
     }
 }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -452,10 +452,22 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         hostingView.layoutSubtreeIfNeeded()
         hostingView.displayIfNeeded()
 
-        guard let bitmap = hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds) else {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(width),
+            pixelsHigh: Int(height),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
             window.orderOut(nil)
             throw RenderedWorkspaceSmokeFailure.bitmapContextFailed
         }
+        bitmap.size = hostingView.bounds.size
         hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
         window.orderOut(nil)
         guard let image = bitmap.cgImage else {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopTrustedRouterCreditsCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopTrustedRouterCreditsCoordinatorTests.swift
@@ -10,11 +10,7 @@ final class QuillCodeDesktopTrustedRouterCreditsCoordinatorTests: XCTestCase {
         let paths = QuillCodePaths(home: try makeTempDirectory())
         try paths.ensure()
         let fetchedAt = Date(timeIntervalSince1970: 100)
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 8.5,
-            currency: "USD",
-            fetchedAt: fetchedAt
-        ))
+        let snapshot = try makeCreditsSnapshot(usage: 8.5, fetchedAt: fetchedAt)
         let recorder = CreditsFetchRecorder(results: [.success(snapshot)])
         let coordinator = QuillCodeDesktopTrustedRouterCreditsCoordinator(
             bootstrap: bootstrap(paths: paths, recorder: recorder),
@@ -48,11 +44,10 @@ final class QuillCodeDesktopTrustedRouterCreditsCoordinatorTests: XCTestCase {
     func testFailedForcedRefreshRetainsLastKnownBalanceAsStale() async throws {
         let paths = QuillCodePaths(home: try makeTempDirectory())
         try paths.ensure()
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 4,
-            currency: "USD",
+        let snapshot = try makeCreditsSnapshot(
+            usage: 4,
             fetchedAt: Date(timeIntervalSince1970: 100)
-        ))
+        )
         let failureDate = Date(timeIntervalSince1970: 200)
         let recorder = CreditsFetchRecorder(results: [
             .failure(attemptedAt: failureDate, message: "Network unavailable.")
@@ -79,7 +74,7 @@ final class QuillCodeDesktopTrustedRouterCreditsCoordinatorTests: XCTestCase {
     func testMissingCredentialClearsBalanceWithoutNetworkRequest() async throws {
         let paths = QuillCodePaths(home: try makeTempDirectory())
         try paths.ensure()
-        let snapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(balance: 4, currency: "USD"))
+        let snapshot = try makeCreditsSnapshot(usage: 4)
         let recorder = CreditsFetchRecorder(results: [])
         let bootstrap = QuillCodeWorkspaceBootstrap(
             paths: paths,
@@ -108,16 +103,14 @@ final class QuillCodeDesktopTrustedRouterCreditsCoordinatorTests: XCTestCase {
     func testCancelledRefreshRestoresPreviousBalanceAndIgnoresLateResult() async throws {
         let paths = QuillCodePaths(home: try makeTempDirectory())
         try paths.ensure()
-        let previousSnapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 4,
-            currency: "USD",
+        let previousSnapshot = try makeCreditsSnapshot(
+            usage: 4,
             fetchedAt: Date(timeIntervalSince1970: 100)
-        ))
-        let lateSnapshot = try XCTUnwrap(TrustedRouterCreditsSnapshot(
-            balance: 999,
-            currency: "USD",
+        )
+        let lateSnapshot = try makeCreditsSnapshot(
+            usage: 999,
             fetchedAt: Date(timeIntervalSince1970: 200)
-        ))
+        )
         let deferredFetch = DeferredCreditsFetch()
         let bootstrap = QuillCodeWorkspaceBootstrap(
             paths: paths,
@@ -156,6 +149,20 @@ final class QuillCodeDesktopTrustedRouterCreditsCoordinatorTests: XCTestCase {
             ),
             accountCreditsFetcher: { config in await recorder.fetch(config: config) }
         )
+    }
+
+    private func makeCreditsSnapshot(
+        usage: Double,
+        fetchedAt: Date = Date()
+    ) throws -> TrustedRouterCreditsSnapshot {
+        try XCTUnwrap(TrustedRouterCreditsSnapshot(
+            lifetime: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .lifetime, usage: usage)),
+            daily: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .daily, usage: usage, limit: 40)),
+            weekly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .weekly, usage: usage, limit: 200)),
+            monthly: XCTUnwrap(TrustedRouterCreditsWindowSnapshot(window: .monthly, usage: usage, limit: 800)),
+            currency: "USD",
+            fetchedAt: fetchedAt
+        ))
     }
 
     private func makeTempDirectory() throws -> URL {


### PR DESCRIPTION
## What changed

- replace the obsolete account credits request with the authenticated current-key control-plane endpoint
- show daily, weekly, monthly, and lifetime TrustedRouter usage, limits, remaining allowance, and reset times
- make the title-bar value an accessible 40-point details control and reuse the same rows in Settings
- update QuillCode to `Lore-Hex/trusted-router-swift` 0.6.0
- make native SwiftUI render smoke tests deterministic across Retina and 1x environments

## Root cause

QuillCode requested `/v1/credits` from the inference host. That route does not expose limits for inference keys. TrustedRouter exposes the signed-in key's usage and limits from the control plane at `/v1/key`.

## User impact

The title bar now shows a concrete value such as `Today $0.00 / $40.00`. Opening it shows today, week, month, total usage, remaining allowance, reset timing, and whether limits stop requests or only alert.

## Validation

- 5,472 Swift tests passed, 5 skipped, 0 failed before rebase
- 53 focused key-limit, native-render, interaction-audit, and newly landed release-verification tests passed after rebase
- packaged macOS app built successfully
- real-key smoke test verified the compact title-bar value and all four detail rows without exposing the key
