### PR TITLE
Upgrade TrustedRouter Swift to 0.6.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc5de584874af2469357beddd67d0e04c651cd0143b32450ecc7678713d3f1a3",
+  "originHash" : "d585104da7a2fb269c3766dfd74328a26e5f7903a39b502a6d0d366e3fe84452",
   "pins" : [
     {
       "identity" : "swift-toml",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lore-Hex/trusted-router-swift.git",
       "state" : {
-        "revision" : "6146c458cf46a68e528a70e89f35525f5a718bdf",
-        "version" : "0.6.0"
+        "revision" : "3655851b4fef87256b5203b62c5e5eef45ae0615",
+        "version" : "0.6.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Lore-Hex/trusted-router-swift.git", from: "0.6.0"),
+        .package(url: "https://github.com/Lore-Hex/trusted-router-swift.git", from: "0.6.1"),
         .package(url: "https://github.com/dduan/TOMLDecoder.git", from: "0.4.5"),
         .package(url: "https://github.com/mattt/swift-toml.git", from: "2.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2")


### PR DESCRIPTION
## Summary

- upgrade `Lore-Hex/trusted-router-swift` from 0.6.0 to 0.6.1
- refresh the resolved package pin to the published 0.6.1 release
- inherit the SDK's published attestation rollout-pin support

SDK release: https://github.com/Lore-Hex/trusted-router-swift/releases/tag/0.6.1

## Verification

- 31 focused TrustedRouter credits, workspace runtime, and desktop coordinator tests passed
- packaged macOS `QuillCode.app` build passed
- package resolution pins the tagged 0.6.1 SDK commit
