### PR TITLE
Harden packaged performance smoke timeouts

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopWindowSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWindowSmokeRunner.swift
@@ -13,6 +13,7 @@ enum QuillCodeDesktopWindowSmokeRunner {
         controller: QuillCodeDesktopController,
         workspaceRoot: QuillCodeDesktopWindowSmokeWorkspaceRoot
     ) async {
+        markStage("smoke-task-started")
         do {
             let report = try await run(
                 request,
@@ -28,10 +29,12 @@ enum QuillCodeDesktopWindowSmokeRunner {
                 )
                 try json.write(to: reportURL, options: .atomic)
             }
+            markStage("complete")
             FileHandle.standardOutput.write(json)
             FileHandle.standardOutput.write(Data("\n".utf8))
             exit(0)
         } catch {
+            markStage("failed")
             FileHandle.standardError.write(Data("quill-code-desktop window smoke failed: \(error)\n".utf8))
             exit(1)
         }
@@ -57,16 +60,20 @@ enum QuillCodeDesktopWindowSmokeRunner {
         let initialPerformance = try QuillCodeDesktopInitialPerformanceSnapshot.capture(
             launchStartedAtUptime: QuillCodeDesktopLaunchClock.appEntryUptime
         )
+        markStage("launch-window-ready")
 
         let screenshotURL = screenshotURL(request: request)
+        markStage("validating-window-render")
         let stats = try await captureValidatedImageStats(
             window: window,
             contentView: contentView,
             bounds: bounds,
             to: screenshotURL
         )
+        markStage("validating-native-hit-targets")
         let workspaceSurface = try smokeSurface()
         let nativeHitTargets = try QuillCodeDesktopNativeHitTargetSmoke.validatedReport(for: workspaceSurface)
+        markStage("sampling-accessibility-frames")
         let accessibilityFrameSamples = try QuillCodeDesktopAccessibilityFrameSampler.validatedReport(
             window: window,
             contentView: contentView,
@@ -75,23 +82,28 @@ enum QuillCodeDesktopWindowSmokeRunner {
         guard let smokeController else {
             throw QuillCodeDesktopSmokeFailure.windowSurfaceIncomplete("smoke controller was not retained")
         }
+        markStage("interaction-sweep-1")
         let accessibilityActivation = try await QuillCodeDesktopAccessibilityActivationSampler.validatedReport(
             contentView: contentView,
             controller: smokeController,
             nativeHitTargets: nativeHitTargets
         )
+        markStage("settling-after-interaction-sweep-1")
         try await Task.sleep(for: .seconds(1))
         let firstSweepResources = try QuillCodeDesktopProcessResourceSnapshot.capture()
+        markStage("interaction-sweep-2")
         _ = try await QuillCodeDesktopAccessibilityActivationSampler.validatedReport(
             contentView: contentView,
             controller: smokeController,
             nativeHitTargets: nativeHitTargets
         )
         let surface = try QuillCodeDesktopWindowSmokeSurfaceReport(surface: workspaceSurface)
+        markStage("settling-after-interaction-sweep-2")
         try await Task.sleep(for: .seconds(1))
         let performance = try initialPerformance.completingRepeatedInteractionSweep(
             firstSweepResources: firstSweepResources
         )
+        markStage("report-ready")
 
         return QuillCodeDesktopWindowSmokeReport(
             ok: true,
@@ -110,6 +122,12 @@ enum QuillCodeDesktopWindowSmokeRunner {
             accessibilityFrameSamples: accessibilityFrameSamples,
             accessibilityActivation: accessibilityActivation,
             surface: surface
+        )
+    }
+
+    private static func markStage(_ stage: String) {
+        FileHandle.standardError.write(
+            Data("quill-code-desktop window smoke stage: \(stage)\n".utf8)
         )
     }
 

--- a/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
@@ -36,7 +36,10 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
         Self.assertSource(runner, containsAll: [
             "QuillCodeDesktopInitialPerformanceSnapshot.capture(",
             "QuillCodeDesktopProcessResourceSnapshot.capture()",
-            "initialPerformance.completingRepeatedInteractionSweep("
+            "initialPerformance.completingRepeatedInteractionSweep(",
+            #"markStage("interaction-sweep-1")"#,
+            #"markStage("interaction-sweep-2")"#,
+            #"markStage("complete")"#
         ])
         XCTAssertEqual(
             runner.components(
@@ -71,6 +74,9 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
             "--max-repeated-resident-memory-growth-bytes",
             "--max-thread-count",
             "--max-repeated-thread-growth",
+            "QUILLCODE_PACKAGED_PERFORMANCE_ATTEMPT_TIMEOUT_SECONDS",
+            #"ATTEMPT_TIMEOUT_SECONDS="${QUILLCODE_PACKAGED_PERFORMANCE_ATTEMPT_TIMEOUT_SECONDS:-180}""#,
+            "terminate_smoke_process",
             "QUILLCODE_MAX_LAUNCH_READY_MILLISECONDS",
             "QUILLCODE_MAX_RESIDENT_MEMORY_BYTES",
             "QUILLCODE_MAX_RESIDENT_MEMORY_GROWTH_BYTES",

--- a/scripts/packaged-macos-performance-smoke.sh
+++ b/scripts/packaged-macos-performance-smoke.sh
@@ -10,10 +10,34 @@ MAX_RESIDENT_MEMORY_GROWTH_BYTES="${QUILLCODE_MAX_RESIDENT_MEMORY_GROWTH_BYTES:-
 MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES="${QUILLCODE_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES:-16777216}"
 MAX_THREAD_COUNT="${QUILLCODE_MAX_THREAD_COUNT:-64}"
 MAX_REPEATED_THREAD_GROWTH="${QUILLCODE_MAX_REPEATED_THREAD_GROWTH:-4}"
+ATTEMPT_TIMEOUT_SECONDS="${QUILLCODE_PACKAGED_PERFORMANCE_ATTEMPT_TIMEOUT_SECONDS:-180}"
 SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/quillcode-packaged-performance.XXXXXX")"
 PERFORMANCE_ATTEMPT_COUNT=3
+SMOKE_PID=""
+
+terminate_smoke_process() {
+  if [[ -z "$SMOKE_PID" ]]; then
+    return
+  fi
+
+  if kill -0 "$SMOKE_PID" 2>/dev/null; then
+    kill "$SMOKE_PID" 2>/dev/null || true
+    for ((shutdown_attempt = 0; shutdown_attempt < 5; shutdown_attempt += 1)); do
+      if ! kill -0 "$SMOKE_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if kill -0 "$SMOKE_PID" 2>/dev/null; then
+      kill -KILL "$SMOKE_PID" 2>/dev/null || true
+    fi
+  fi
+  wait "$SMOKE_PID" 2>/dev/null || true
+  SMOKE_PID=""
+}
 
 cleanup() {
+  terminate_smoke_process
   rm -rf "$SMOKE_ROOT"
 }
 trap cleanup EXIT
@@ -43,6 +67,10 @@ if [[ ! -d "$APP_BUNDLE" || -z "$MANIFEST_PATH" ]]; then
   echo "Usage: packaged-macos-performance-smoke.sh --app APP_BUNDLE --manifest OUTPUT_JSON" >&2
   exit 2
 fi
+if [[ ! "$ATTEMPT_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "QUILLCODE_PACKAGED_PERFORMANCE_ATTEMPT_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
 
 INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
 EXECUTABLE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST")"
@@ -69,16 +97,16 @@ for ((attempt = 1; attempt <= PERFORMANCE_ATTEMPT_COUNT; attempt += 1)); do
 
   elapsed=0
   while kill -0 "$SMOKE_PID" 2>/dev/null; do
-    if [[ "$elapsed" -ge 60 ]]; then
-      echo "Packaged performance attempt $attempt timed out after 60s." >&2
-      kill "$SMOKE_PID" 2>/dev/null || true
-      wait "$SMOKE_PID" 2>/dev/null || true
+    if [[ "$elapsed" -ge "$ATTEMPT_TIMEOUT_SECONDS" ]]; then
+      echo "Packaged performance attempt $attempt exceeded its ${ATTEMPT_TIMEOUT_SECONDS}s wall-clock guard." >&2
+      terminate_smoke_process
       exit 124
     fi
     sleep 1
     elapsed=$((elapsed + 1))
   done
   wait "$SMOKE_PID"
+  SMOKE_PID=""
   REPORT_PATHS+=("$REPORT_PATH")
 done
 


### PR DESCRIPTION
## Summary

- Keep the 3-second launch, memory, growth, and thread budgets unchanged while giving the full native UX sweep a 180-second wall-clock guard on slower Intel runners.
- Terminate timed-out smoke processes reliably and emit bounded stage markers so failures identify the exact native interaction phase.

## Verification

- Focused performance and window-report suites: 27 tests passed, 0 failures.
- Complete release-harness parity slice: 22 tests passed, 0 failures.
- Local packaged smoke: 3/3 fresh launches passed; 289.42 ms median readiness, 96.67 MiB initial memory, 5.14 MiB repeated-sweep growth, 8 converged threads.
- Deliberate 1-second overrun returned 124 at interaction-sweep-1 and left no process running.
- Bash syntax, diff check, credential substring scan, and all code-quality modules passed at A+.

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing UI was checked for keyboard, accessibility, compact-window, and failure states.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release, updater, dependency, or workflow changes include their contract-level verification.
