### PR TITLE
Preserve quoted multiline action content

### DIFF
--- a/Sources/QuillCodeAgent/AgentActionIntentSegments.swift
+++ b/Sources/QuillCodeAgent/AgentActionIntentSegments.swift
@@ -24,6 +24,7 @@ enum AgentActionIntentSegments {
         var output: [String] = []
         var start = request.startIndex
         var index = start
+        var quotedCloser: Character?
 
         func appendClause(endingAt end: String.Index) {
             output.append(String(request[start..<end]))
@@ -33,6 +34,23 @@ enum AgentActionIntentSegments {
         while index < request.endIndex {
             let character = request[index]
             let next = request.index(after: index)
+            if let closer = quotedCloser {
+                if character == closer,
+                   !(closer == "'" && isWordApostrophe(at: index, in: request)) {
+                    quotedCloser = nil
+                }
+                index = next
+                continue
+            }
+            if let closer = quoteCloser(
+                for: character,
+                at: index,
+                in: request
+            ) {
+                quotedCloser = closer
+                index = next
+                continue
+            }
             let isBoundary = character == ";"
                 || character == "?"
                 || character == "!"
@@ -48,6 +66,32 @@ enum AgentActionIntentSegments {
             output.append(String(request[start..<request.endIndex]))
         }
         return output
+    }
+
+    private static func quoteCloser(
+        for character: Character,
+        at index: String.Index,
+        in request: String
+    ) -> Character? {
+        switch character {
+        case "`", "\"":
+            return character
+        case "'":
+            return isWordApostrophe(at: index, in: request) ? nil : character
+        case "“":
+            return "”"
+        case "‘":
+            return "’"
+        default:
+            return nil
+        }
+    }
+
+    private static func isWordApostrophe(at index: String.Index, in request: String) -> Bool {
+        guard index > request.startIndex else { return false }
+        let next = request.index(after: index)
+        guard next < request.endIndex else { return false }
+        return request[request.index(before: index)].isLetter && request[next].isLetter
     }
 
     private static func containsNegatedActionIntent(_ segment: String) -> Bool {

--- a/Tests/QuillCodeAgentTests/AgentImmediateFileActionTests.swift
+++ b/Tests/QuillCodeAgentTests/AgentImmediateFileActionTests.swift
@@ -118,6 +118,27 @@ final class AgentImmediateFileActionTests: XCTestCase {
         )
     }
 
+    func testNamedFileWritePreservesMultilineQuotedContent() async throws {
+        let root = try makeTempDirectory()
+        let runner = preflightFailingAgentRunner()
+        let content = "Subject: Delay\n\nDelivery moves to Friday.\n"
+
+        let result = try await runner.send(
+            "Create a file named notice.md that says `\(content)`",
+            in: ChatThread(mode: .auto),
+            workspaceRoot: root
+        )
+
+        try assertSingleSuccessfulToolResult(in: result)
+        XCTAssertEqual(
+            try String(contentsOf: root.appendingPathComponent("notice.md"), encoding: .utf8),
+            content
+        )
+        let write = try queuedFileWrite(in: result)
+        XCTAssertEqual(write.path, "notice.md")
+        XCTAssertEqual(write.content, content)
+    }
+
     func testBacktickFileReadExecutesImmediatelyWithoutProviderRoundTrip() async throws {
         let root = try makeTempDirectory()
         try "hello world\n".write(to: root.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)


### PR DESCRIPTION
## Summary

Preserves embedded newlines in quoted immediate file-write prompts so the desktop agent writes the requested content exactly.

## Verification

- `swift test --filter AgentImmediateFileActionTests` (12 passed)
- `./scripts/smoke.sh` (5,646 tests; 5 skipped; 0 failures; CLI, app-server, MCP, native desktop, packaged app, Launch Services, and performance checks passed)

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing desktop flows were exercised by packaged-app smoke tests.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release, updater, dependency, or workflow contracts are unchanged.