### PR TITLE
Gate stable release promotion on public verification

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -240,7 +240,10 @@ jobs:
               --notes-file "$RUNNER_TEMP/release-notes.md" \
               --target "$GITHUB_SHA"
             gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/*
-            gh release edit "$RELEASE_TAG" --draft=false --latest
+            gh release edit "$RELEASE_TAG" \
+              --draft=false \
+              --prerelease \
+              --latest=false
           else
             if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
               gh release edit "$RELEASE_TAG" \
@@ -288,15 +291,72 @@ jobs:
             RELEASE_TAG="tester-latest"
             RELEASE_CHANNEL="tester"
           fi
-          scripts/verify-published-release.py \
-            --repo "$GITHUB_REPOSITORY" \
-            --tag "$RELEASE_TAG" \
-            --channel "$RELEASE_CHANNEL" \
-            --commit "$GITHUB_SHA" \
+          VERIFY_ARGUMENTS=(
+            --repo "$GITHUB_REPOSITORY"
+            --tag "$RELEASE_TAG"
+            --channel "$RELEASE_CHANNEL"
+            --commit "$GITHUB_SHA"
             --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          )
+          if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
+            VERIFY_ARGUMENTS+=(--stable-candidate)
+          fi
+          scripts/verify-published-release.py "${VERIFY_ARGUMENTS[@]}"
+
+  quarantine-stable-candidate:
+    needs: [publish, verify-published]
+    if: >-
+      ${{
+        always() &&
+        github.ref_type == 'tag' &&
+        startsWith(github.ref_name, 'v') &&
+        needs.publish.result == 'success' &&
+        needs.verify-published.result != 'success'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Return failed stable candidate to draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft --latest=false --repo "$GITHUB_REPOSITORY"
+
+  promote-stable:
+    needs: [publish, verify-published]
+    if: >-
+      ${{
+        github.ref_type == 'tag' &&
+        startsWith(github.ref_name, 'v') &&
+        needs.publish.result == 'success' &&
+        needs.verify-published.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Promote verified stable candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release edit "$GITHUB_REF_NAME"
+          --draft=false
+          --prerelease=false
+          --latest
+          --repo "$GITHUB_REPOSITORY"
 
   verify-updater:
-    needs: publish
+    needs: [publish, verify-published, promote-stable]
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.verify-published.result == 'success' &&
+        (
+          !(github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
+          needs.promote-stable.result == 'success'
+        )
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -357,3 +417,53 @@ jobs:
           path: ${{ runner.temp }}/updater-smoke-artifacts
           if-no-files-found: error
           retention-days: 14
+
+  verify-stable-promotion:
+    needs: [promote-stable, verify-updater]
+    if: >-
+      ${{
+        github.ref_type == 'tag' &&
+        startsWith(github.ref_name, 'v') &&
+        needs.promote-stable.result == 'success' &&
+        needs.verify-updater.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Verify promoted stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/verify-published-release.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag "$GITHUB_REF_NAME" \
+            --channel stable \
+            --commit "$GITHUB_SHA" \
+            --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+  quarantine-promoted-stable:
+    needs: [publish, promote-stable, verify-updater, verify-stable-promotion]
+    if: >-
+      ${{
+        always() &&
+        github.ref_type == 'tag' &&
+        startsWith(github.ref_name, 'v') &&
+        needs.publish.result == 'success' &&
+        needs.promote-stable.result == 'success' &&
+        (
+          needs.verify-updater.result != 'success' ||
+          needs.verify-stable-promotion.result != 'success'
+        )
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Return failed promoted stable release to draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft --latest=false --repo "$GITHUB_REPOSITORY"

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -315,13 +315,30 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "--verify-tag",
             "--draft",
             "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/*",
-            "gh release edit \"$RELEASE_TAG\" --draft=false --latest",
+            "--prerelease",
+            "--latest=false",
             "Stable release $RELEASE_TAG already exists and is immutable.",
             "verify-published:",
             "needs: publish",
             "Verify public release downloads",
             "scripts/verify-published-release.py",
-            "--workflow-run-url \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\""
+            "--workflow-run-url \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"",
+            "VERIFY_ARGUMENTS+=(--stable-candidate)",
+            "quarantine-stable-candidate:",
+            "Return failed stable candidate to draft",
+            "needs.verify-published.result != 'success'",
+            "promote-stable:",
+            "Promote verified stable candidate",
+            "--prerelease=false",
+            "needs: [publish, verify-published, promote-stable]",
+            "verify-stable-promotion:",
+            "needs: [promote-stable, verify-updater]",
+            "Verify promoted stable release",
+            "quarantine-promoted-stable:",
+            "Return failed promoted stable release to draft",
+            "needs.verify-updater.result != 'success'",
+            "needs.verify-stable-promotion.result != 'success'",
+            "--draft --latest=false"
         ])
         XCTAssertFalse(
             workflow.contains("cancel-in-progress: true"),
@@ -336,6 +353,15 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         let planningIndex = try XCTUnwrap(workflow.range(of: "scripts/plan-download-build.sh"))
         XCTAssertLessThan(validationIndex.lowerBound, ciGateIndex.lowerBound)
         XCTAssertLessThan(ciGateIndex.lowerBound, planningIndex.lowerBound)
+        let publishIndex = try XCTUnwrap(workflow.range(of: "  publish:"))
+        let publicVerificationIndex = try XCTUnwrap(workflow.range(of: "  verify-published:"))
+        let promotionIndex = try XCTUnwrap(workflow.range(of: "  promote-stable:"))
+        let updaterIndex = try XCTUnwrap(workflow.range(of: "  verify-updater:"))
+        let finalVerificationIndex = try XCTUnwrap(workflow.range(of: "  verify-stable-promotion:"))
+        XCTAssertLessThan(publishIndex.lowerBound, publicVerificationIndex.lowerBound)
+        XCTAssertLessThan(publicVerificationIndex.lowerBound, promotionIndex.lowerBound)
+        XCTAssertLessThan(promotionIndex.lowerBound, updaterIndex.lowerBound)
+        XCTAssertLessThan(updaterIndex.lowerBound, finalVerificationIndex.lowerBound)
     }
 
     func testDownloadDocsExposeStableManifestLink() throws {
@@ -357,7 +383,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "same moving channel feed embedded",
             "publication is not green until this consumer check passes",
             "creates one annotated tag and pushes it without force",
-            "an existing stable release is never edited or clobbered automatically",
+            "Pre-existing stable releases remain untouched",
+            "non-latest prerelease candidate",
+            "returns the new release to draft",
+            "previous stable feed",
             "avoids no-op build-number updates and unnecessary",
             "channel is `tester`",
             "channel is `stable`"

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -33,7 +33,8 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "runs-on: ${{ matrix.runner }}",
             "arch: arm64",
             "arch: x86_64",
-            "needs: publish",
+            "needs: [publish, verify-published, promote-stable]",
+            "needs.promote-stable.result == 'success'",
             "scripts/packaged-macos-updater-smoke.sh",
             "quillcode-public-updater-smoke-${{ matrix.arch }}"
         ])

--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -18,6 +18,83 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         XCTAssertTrue(result.output.contains("Verified public Quill Cowork tester release tester-latest"))
     }
 
+    func testVerifierAcceptsAnExplicitStableCandidateBeforePromotion() throws {
+        let fixture = try makeFixture(channel: "stable", prerelease: true)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture, stableCandidate: true)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Verified public Quill Cowork stable release v0.2.0"))
+    }
+
+    func testVerifierRejectsStableCandidateModeForTesterChannel() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture, stableCandidate: true)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("--stable-candidate requires --channel stable"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsStableCandidateUnderFinalReleaseRules() throws {
+        let fixture = try makeFixture(channel: "stable", prerelease: true)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("prerelease state does not match its channel"),
+            result.output
+        )
+    }
+
+    func testVerifierAcceptsPromotedStableReleaseAndExactLatestFeed() throws {
+        let fixture = try makeFixture(channel: "stable", prerelease: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Verified public Quill Cowork stable release v0.2.0"))
+    }
+
+    func testVerifierRejectsPromotedStableReleaseWhenLatestFeedDrifts() throws {
+        let fixture = try makeFixture(channel: "stable", prerelease: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try Data("{}\n".utf8).write(to: try XCTUnwrap(fixture.stableFeedManifest))
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("latest stable feed does not match"),
+            result.output
+        )
+    }
+
+    func testVerifierRejectsPromotedStableReleaseWhenLatestIdentityDrifts() throws {
+        let fixture = try makeFixture(channel: "stable", prerelease: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let latestReleaseURL = try XCTUnwrap(fixture.latestReleaseJSON)
+        var latestRelease = try jsonObject(at: latestReleaseURL)
+        latestRelease["id"] = 54_321
+        try writeJSON(latestRelease, to: latestReleaseURL)
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("latest release is not the verified stable release"),
+            result.output
+        )
+    }
+
     func testVerifierRejectsPerformanceSchemaDriftAfterIntegrityChecksPass() throws {
         let fixture = try makeFixture { evidence in
             evidence["schemaVersion"] = 2
@@ -270,6 +347,10 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         var assets: URL
         var manifest: URL
         var releaseJSON: URL
+        var latestReleaseJSON: URL?
+        var stableFeedManifest: URL?
+        var tag: String
+        var channel: String
     }
 
     private func makeFixture(
@@ -277,8 +358,16 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         appInfoIsSymlink: Bool = false,
         includePerformanceAsset: Bool = true,
         intelExecutableArchitecture: String = "x86_64",
+        channel: String = "tester",
+        prerelease: Bool? = nil,
         performanceMutation: ((inout [String: Any]) throws -> Void)? = nil
     ) throws -> Fixture {
+        precondition(channel == "tester" || channel == "stable")
+        let releaseTag = channel == "stable" ? "v0.2.0" : tag
+        let updateManifestURL = channel == "stable" ? stableManifestURL : testerManifestURL
+        let signingTeamIdentifier = channel == "stable" ? "A1B2C3D4E5" : nil
+        let codesign = channel == "stable" ? "developer-id" : "ad-hoc"
+        let notarized = channel == "stable"
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("quill-cowork-release-verifier-tests")
             .appendingPathComponent(UUID().uuidString)
@@ -301,7 +390,10 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 commit: appCommit ?? commit,
                 architecture: executableArchitecture,
                 root: root,
-                infoIsSymlink: appInfoIsSymlink
+                infoIsSymlink: appInfoIsSymlink,
+                channel: channel,
+                updateManifestURL: updateManifestURL,
+                signingTeamIdentifier: signingTeamIdentifier
             )
             try Data("verified installer \(architecture)".utf8).write(
                 to: assetsURL.appendingPathComponent(installerName)
@@ -327,17 +419,17 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             configuration=release
             bundleIdentifier=co.lorehex.QuillCowork
             minimumSystemVersion=14.0
-            updateChannel=tester
-            updateManifestURL=\(testerManifestURL)
+            updateChannel=\(channel)
+            updateManifestURL=\(updateManifestURL)
             stableUpdateManifestURL=\(stableManifestURL)
             testerUpdateManifestURL=\(testerManifestURL)
             installer=\(installerName)
             app=\(appName)
             performance=\(performanceName)
             cli=\(cliName)
-            codesign=ad-hoc
-            signingTeamIdentifier=none
-            notarized=false
+            codesign=\(codesign)
+            signingTeamIdentifier=\(signingTeamIdentifier ?? "none")
+            notarized=\(notarized)
             """
             try buildInfo.write(
                 to: assetsURL.appendingPathComponent("BUILD_INFO-macOS-\(architecture).txt"),
@@ -374,7 +466,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 platform: "macOS",
                 arch: "any",
                 install: "text",
-                assetsURL: assetsURL
+                assetsURL: assetsURL,
+                releaseTag: releaseTag
             )
         ]
         var appAssets: [[String: Any]] = []
@@ -385,7 +478,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 platform: "macOS",
                 arch: architecture,
                 install: "text",
-                assetsURL: assetsURL
+                assetsURL: assetsURL,
+                releaseTag: releaseTag
             ))
             manifestAssets.append(try manifestAsset(
                 named: "Quill-Cowork-macOS-\(architecture).dmg",
@@ -393,7 +487,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 platform: "macOS",
                 arch: architecture,
                 install: "dmg-app",
-                assetsURL: assetsURL
+                assetsURL: assetsURL,
+                releaseTag: releaseTag
             ))
             let appAsset = try manifestAsset(
                 named: "Quill-Cowork-macOS-\(architecture).zip",
@@ -401,7 +496,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 platform: "macOS",
                 arch: architecture,
                 install: "zip-app",
-                assetsURL: assetsURL
+                assetsURL: assetsURL,
+                releaseTag: releaseTag
             )
             appAssets.append(appAsset)
             manifestAssets.append(appAsset)
@@ -412,7 +508,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                     platform: "macOS",
                     arch: architecture,
                     install: "json",
-                    assetsURL: assetsURL
+                    assetsURL: assetsURL,
+                    releaseTag: releaseTag
                 ))
             }
             manifestAssets.append(try manifestAsset(
@@ -421,7 +518,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 platform: "macOS",
                 arch: architecture,
                 install: "tarball",
-                assetsURL: assetsURL
+                assetsURL: assetsURL,
+                releaseTag: releaseTag
             ))
         }
         manifestAssets.append(contentsOf: try [
@@ -431,15 +529,16 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 platform: "any",
                 arch: "any",
                 install: "text",
-                assetsURL: assetsURL
+                assetsURL: assetsURL,
+                releaseTag: releaseTag
             )
         ])
         let manifest: [String: Any] = [
             "schemaVersion": 1,
             "product": "Quill Cowork",
-            "channel": "tester",
-            "tag": tag,
-            "releaseURL": "https://github.com/\(repository)/releases/tag/\(tag)",
+            "channel": channel,
+            "tag": releaseTag,
+            "releaseURL": "https://github.com/\(repository)/releases/tag/\(releaseTag)",
             "commit": commit,
             "version": "0.2.0",
             "build": "123",
@@ -448,21 +547,21 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             "updater": [
                 "schemaVersion": 1,
                 "format": "github-release-manifest",
-                "channel": "tester",
-                "manifestURL": testerManifestURL,
+                "channel": channel,
+                "manifestURL": updateManifestURL,
                 "stableManifestURL": stableManifestURL,
                 "testerManifestURL": testerManifestURL,
                 "bundleIdentifier": "co.lorehex.QuillCowork",
                 "minimumSystemVersion": "14.0",
-                "codesign": "ad-hoc",
-                "signingTeamIdentifier": NSNull(),
-                "notarized": false,
+                "codesign": codesign,
+                "signingTeamIdentifier": signingTeamIdentifier.map { $0 as Any } ?? NSNull(),
+                "notarized": notarized,
                 "macOSAppAsset": appAssets[0],
                 "macOSAppAssets": appAssets
             ],
             "assets": manifestAssets
         ]
-        let manifestURL = root.appendingPathComponent("latest-tester-build.json")
+        let manifestURL = root.appendingPathComponent("latest-\(channel)-build.json")
         try writeJSON(manifest, to: manifestURL)
 
         var releaseAssets = try manifestAssets.map { asset -> [String: Any] in
@@ -472,7 +571,7 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 "state": "uploaded",
                 "size": try XCTUnwrap(asset["sizeBytes"] as? Int),
                 "digest": "sha256:\(try XCTUnwrap(asset["sha256"] as? String))",
-                "browser_download_url": releaseDownloadURL(named: name)
+                "browser_download_url": releaseDownloadURL(named: name, tag: releaseTag)
             ]
         }
         releaseAssets.append([
@@ -480,17 +579,40 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             "state": "uploaded",
             "size": try Data(contentsOf: manifestURL).count,
             "digest": "sha256:\(try sha256(at: manifestURL))",
-            "browser_download_url": releaseDownloadURL(named: manifestURL.lastPathComponent)
+            "browser_download_url": releaseDownloadURL(
+                named: manifestURL.lastPathComponent,
+                tag: releaseTag
+            )
         ])
         let release: [String: Any] = [
-            "tag_name": tag,
+            "id": 12_345,
+            "tag_name": releaseTag,
             "draft": false,
-            "prerelease": true,
+            "prerelease": prerelease ?? (channel == "tester"),
             "assets": releaseAssets
         ]
         let releaseJSONURL = root.appendingPathComponent("release.json")
         try writeJSON(release, to: releaseJSONURL)
-        return Fixture(root: root, assets: assetsURL, manifest: manifestURL, releaseJSON: releaseJSONURL)
+        var latestReleaseJSON: URL?
+        var stableFeedManifest: URL?
+        if channel == "stable" {
+            let latestURL = root.appendingPathComponent("latest-release.json")
+            let feedURL = root.appendingPathComponent("latest-stable-feed.json")
+            try writeJSON(release, to: latestURL)
+            try Data(contentsOf: manifestURL).write(to: feedURL)
+            latestReleaseJSON = latestURL
+            stableFeedManifest = feedURL
+        }
+        return Fixture(
+            root: root,
+            assets: assetsURL,
+            manifest: manifestURL,
+            releaseJSON: releaseJSONURL,
+            latestReleaseJSON: latestReleaseJSON,
+            stableFeedManifest: stableFeedManifest,
+            tag: releaseTag,
+            channel: channel
+        )
     }
 
     private func performanceEvidence() -> [String: Any] {
@@ -627,7 +749,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         platform: String,
         arch: String,
         install: String,
-        assetsURL: URL
+        assetsURL: URL,
+        releaseTag: String
     ) throws -> [String: Any] {
         let url = assetsURL.appendingPathComponent(name)
         return [
@@ -638,7 +761,7 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             "install": install,
             "sizeBytes": try Data(contentsOf: url).count,
             "sha256": try sha256(at: url),
-            "url": releaseDownloadURL(named: name)
+            "url": releaseDownloadURL(named: name, tag: releaseTag)
         ]
     }
 
@@ -647,7 +770,10 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         commit: String,
         architecture: String,
         root: URL,
-        infoIsSymlink: Bool
+        infoIsSymlink: Bool,
+        channel: String,
+        updateManifestURL: String,
+        signingTeamIdentifier: String?
     ) throws {
         let scriptURL = root.appendingPathComponent("make-app-archive.py")
         try """
@@ -664,14 +790,16 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             "CFBundleVersion": "123",
             "LSMinimumSystemVersion": "14.0",
             "QuillCodeBuildCommit": sys.argv[2],
-            "QuillCodeUpdateChannel": "tester",
-            "QuillCodeUpdateManifestURL": sys.argv[3],
-            "QuillCodeStableUpdateManifestURL": sys.argv[4],
-            "QuillCodeTesterUpdateManifestURL": sys.argv[3],
+            "QuillCodeUpdateChannel": sys.argv[3],
+            "QuillCodeUpdateManifestURL": sys.argv[4],
+            "QuillCodeStableUpdateManifestURL": sys.argv[5],
+            "QuillCodeTesterUpdateManifestURL": sys.argv[6],
         }
+        if sys.argv[7] != "none":
+            values["QuillCodeSigningTeamIdentifier"] = sys.argv[7]
         with zipfile.ZipFile(sys.argv[1], "w", zipfile.ZIP_DEFLATED) as archive:
             path = "Quill Cowork.app/Contents/Info.plist"
-            if sys.argv[5] == "symlink":
+            if sys.argv[8] == "symlink":
                 entry = zipfile.ZipInfo(path)
                 entry.create_system = 3
                 entry.external_attr = 0o120777 << 16
@@ -680,15 +808,18 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 archive.writestr(path, plistlib.dumps(values))
             cpu_types = {"arm64": 0x0100000C, "x86_64": 0x01000007}
             executable = struct.pack(
-                "<IIIIIIII", 0xFEEDFACF, cpu_types[sys.argv[6]], 0, 2, 0, 0, 0, 0
+                "<IIIIIIII", 0xFEEDFACF, cpu_types[sys.argv[9]], 0, 2, 0, 0, 0, 0
             )
             archive.writestr("Quill Cowork.app/Contents/MacOS/Quill Cowork", executable)
         """.write(to: scriptURL, atomically: true, encoding: .utf8)
         let result = try Self.runPython(scriptURL, arguments: [
             archiveURL.path,
             commit,
-            testerManifestURL,
+            channel,
+            updateManifestURL,
             stableManifestURL,
+            testerManifestURL,
+            signingTeamIdentifier ?? "none",
             infoIsSymlink ? "symlink" : "regular",
             architecture
         ])
@@ -704,22 +835,32 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
 
     private func runVerifier(
         _ fixture: Fixture,
-        tagCommit: String? = nil
+        tagCommit: String? = nil,
+        stableCandidate: Bool = false
     ) throws -> ScriptResult {
         let script = Self.packageRoot()
             .appendingPathComponent("scripts")
             .appendingPathComponent("verify-published-release.py")
-        return try Self.runPython(script, arguments: [
+        var arguments = [
             "--repo", repository,
-            "--tag", tag,
-            "--channel", "tester",
+            "--tag", fixture.tag,
+            "--channel", fixture.channel,
             "--commit", commit,
             "--workflow-run-url", workflowRunURL,
             "--release-json", fixture.releaseJSON.path,
             "--tag-commit", tagCommit ?? commit,
             "--manifest", fixture.manifest.path,
             "--assets-dir", fixture.assets.path
-        ])
+        ]
+        if stableCandidate {
+            arguments.append("--stable-candidate")
+        } else if fixture.channel == "stable" {
+            arguments.append(contentsOf: [
+                "--latest-release-json", try XCTUnwrap(fixture.latestReleaseJSON).path,
+                "--stable-feed-manifest", try XCTUnwrap(fixture.stableFeedManifest).path
+            ])
+        }
+        return try Self.runPython(script, arguments: arguments)
     }
 
     private func mutateManifest(
@@ -754,8 +895,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
-    private func releaseDownloadURL(named name: String) -> String {
-        "https://github.com/\(repository)/releases/download/\(tag)/\(name)"
+    private func releaseDownloadURL(named name: String, tag releaseTag: String? = nil) -> String {
+        "https://github.com/\(repository)/releases/download/\(releaseTag ?? tag)/\(name)"
     }
 
     private var testerManifestURL: String {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,28 @@
 # Code Quality Audit
 
+## 2026-08-08 Transactional Stable Release Promotion
+
+Overall grade after this slice: **A+ release control, A+ feed integrity, A+ recovery**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Release control | A+ | Versioned artifacts become a non-latest prerelease candidate, pass public semantic verification, and only then become the stable latest release. |
+| Feed integrity | A+ | Final verification requires GitHub's latest-release identity and the moving stable manifest bytes to match the already-verified versioned release exactly. |
+| Native updates | A+ | Apple silicon and Intel updater relaunch gates depend on successful promotion and exercise the actual stable latest feed. |
+| Recovery | A+ | A failed candidate returns to draft before promotion; a failed native update or final feed check returns the promoted release to draft so the previous stable feed resumes. |
+| Compatibility | A+ | Tester publication and its updater path retain their existing prerelease contract; the changed verifier independently accepts the current public tester build. |
+
+Validation:
+
+- Full `swift test --skip-build` (5,652 tests, 5 skipped, 0 failures)
+- Complete parity suite (370 tests, 0 failures)
+- Published-release verifier suite (21 tests, 0 failures), including stable candidate, promotion,
+  latest-release identity, feed drift, CPU architecture, symlink, provenance, and performance attacks
+- Download workflow suite (6 tests, 0 failures) and packaged updater parity gate (1 test, 0 failures)
+- Current public tester build 661 passed the changed semantic verifier at exact commit `65aca0bd`
+- Workflow parses as YAML; `python3 scripts/grade-code-quality.py --root .` reports every module A+
+- `git diff --check`
+
 ## 2026-08-08 Native Dual-Architecture macOS Distribution
 
 Overall grade after this slice: **A+ distribution architecture, A+ compatibility, A+ native verification**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # QuillCode Decisions
 
+## 2026-08-08: stable releases use verified promotion and automatic quarantine
+
+- **Decision:** A versioned release first becomes a non-latest prerelease candidate. The exact public
+  inventory and semantic contract must pass before the candidate can become GitHub's stable latest
+  release. Candidate verification is an explicit verifier mode and remains invalid for tester builds.
+- **Promotion proof:** After promotion, native Apple silicon and Intel runners update and relaunch
+  through the real stable latest feed. Final verification requires both GitHub's latest-release
+  identity and the moving stable manifest bytes to match the verified versioned release.
+- **Recovery:** Candidate verification failure returns the new release to draft before promotion.
+  Native updater or final feed failure returns a promoted release to draft, causing GitHub to resume
+  the previous stable latest release without modifying that prior release.
+- **Why:** Upload completion does not prove public asset semantics, and a successful release-edit
+  command does not prove the moving updater feed. Stable publication must be an ordered, observable,
+  fail-closed state transition with an automatic path back to the last known-good release.
+
 ## 2026-08-08: macOS distribution is native on Apple silicon and Intel
 
 - **Decision:** Every public macOS release contains exactly one native arm64 and one native x86_64

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -228,9 +228,23 @@ If that push fails, the command removes only the local tag it just created.
 
 The workflow rejects tags that are malformed, off `main`, missing successful CI,
 or already published. It creates the stable release as a draft, uploads every
-asset, and only then publishes it as the latest release. If a stable publish
-fails after creating its draft, inspect and delete that draft before retrying;
-an existing stable release is never edited or clobbered automatically.
+asset, and exposes it first as a non-latest prerelease candidate. The public
+consumer verifier must accept the candidate's exact inventory, hashes, bundle
+metadata, CPU architectures, performance evidence, signing identity, and
+notarization declaration before GitHub promotes it to the stable latest feed.
+Both native updater runners then install and relaunch through that live feed.
+A final verifier requires GitHub's `releases/latest` API object to identify the
+same release and requires the moving `latest-stable-build.json` bytes to match
+the versioned manifest exactly.
+
+If candidate verification fails, the workflow returns the new release to draft
+without changing the previous stable feed. If either native updater gate or the
+final feed verification fails after promotion, the workflow also returns the new
+release to draft so GitHub falls back to the previous stable feed. Inspect and
+delete that failed draft before retrying; an existing stable release is never
+edited or clobbered automatically. Treat a versioned release as announced only
+after the complete **Download Builds** run is green.
+Pre-existing stable releases remain untouched throughout this recovery flow.
 
 Use versioned releases for public announcements. Use `tester-latest` for quick
 iteration with early testers.

--- a/scripts/release_verification_contract.py
+++ b/scripts/release_verification_contract.py
@@ -154,9 +154,14 @@ def validate_manifest(
     channel: str,
     commit: str,
     workflow_run_url: str,
+    stable_candidate: bool = False,
 ) -> list[dict[str, Any]]:
     urls = expected_urls(repo, tag, channel)
-    expected_prerelease = channel == "tester"
+    if stable_candidate and channel != "stable":
+        raise VerificationError(
+            "stable-candidate verification is only valid for the stable channel"
+        )
+    expected_prerelease = channel == "tester" or stable_candidate
     if release.get("tag_name") != tag:
         raise VerificationError("GitHub release tag does not match the requested tag")
     if release.get("draft") is not False:

--- a/scripts/verify-published-release.py
+++ b/scripts/verify-published-release.py
@@ -38,6 +38,11 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--repo", required=True, help="GitHub owner/repository slug.")
     parser.add_argument("--tag", required=True, help="Published release tag.")
     parser.add_argument("--channel", required=True, choices=("stable", "tester"))
+    parser.add_argument(
+        "--stable-candidate",
+        action="store_true",
+        help="Require a public stable prerelease that has not been promoted to latest.",
+    )
     parser.add_argument("--commit", required=True, help="Expected 40-character commit SHA.")
     parser.add_argument(
         "--workflow-run-url",
@@ -57,8 +62,18 @@ def parse_arguments() -> argparse.Namespace:
         help="Seconds between retries.",
     )
     parser.add_argument("--release-json", type=Path, help="Offline release API fixture.")
+    parser.add_argument(
+        "--latest-release-json",
+        type=Path,
+        help="Offline GitHub latest-release API fixture for final stable verification.",
+    )
     parser.add_argument("--tag-commit", help="Offline resolved tag commit.")
     parser.add_argument("--manifest", type=Path, help="Offline manifest fixture.")
+    parser.add_argument(
+        "--stable-feed-manifest",
+        type=Path,
+        help="Offline latest-stable-build.json fixture for final stable verification.",
+    )
     parser.add_argument(
         "--assets-dir",
         type=Path,
@@ -73,6 +88,8 @@ def parse_arguments() -> argparse.Namespace:
         parser.error("--attempts must be between 1 and 20")
     if arguments.retry_delay < 0 or arguments.retry_delay > 60:
         parser.error("--retry-delay must be between 0 and 60 seconds")
+    if arguments.stable_candidate and arguments.channel != "stable":
+        parser.error("--stable-candidate requires --channel stable")
     offline_values = (
         arguments.release_json,
         arguments.tag_commit,
@@ -85,6 +102,24 @@ def parse_arguments() -> argparse.Namespace:
         parser.error(
             "offline verification requires --release-json, --tag-commit, "
             "--manifest, and --assets-dir"
+        )
+    final_stable = arguments.channel == "stable" and not arguments.stable_candidate
+    stable_promotion_values = (
+        arguments.latest_release_json,
+        arguments.stable_feed_manifest,
+    )
+    if arguments.release_json is not None and final_stable and not all(
+        value is not None for value in stable_promotion_values
+    ):
+        parser.error(
+            "offline final stable verification requires --latest-release-json "
+            "and --stable-feed-manifest"
+        )
+    if (arguments.release_json is None or not final_stable) and any(
+        value is not None for value in stable_promotion_values
+    ):
+        parser.error(
+            "latest-release fixtures are only valid for offline final stable verification"
         )
     return arguments
 
@@ -259,8 +294,27 @@ def validate_snapshot(
         channel=arguments.channel,
         commit=arguments.commit,
         workflow_run_url=arguments.workflow_run_url,
+        stable_candidate=arguments.stable_candidate,
     )
     return manifest, assets
+
+
+def validate_stable_promotion(
+    release: dict[str, Any],
+    latest_release: dict[str, Any],
+    manifest_bytes: bytes,
+    stable_feed_bytes: bytes,
+    tag: str,
+) -> None:
+    release_id = release.get("id")
+    if type(release_id) is not int or latest_release.get("id") != release_id:
+        raise VerificationError("GitHub latest release is not the verified stable release")
+    if latest_release.get("tag_name") != tag:
+        raise VerificationError("GitHub latest release tag does not match the stable tag")
+    if stable_feed_bytes != manifest_bytes:
+        raise VerificationError(
+            "latest stable feed does not match the versioned release manifest"
+        )
 
 
 def verify_offline(arguments: argparse.Namespace) -> None:
@@ -286,6 +340,27 @@ def verify_offline(arguments: argparse.Namespace) -> None:
         arguments.tag_commit,
         arguments,
     )
+    if arguments.channel == "stable" and not arguments.stable_candidate:
+        latest_release = load_json_bytes(
+            read_bounded(
+                arguments.latest_release_json,
+                API_BYTE_LIMIT,
+                "latest release JSON",
+            ),
+            "latest release JSON",
+        )
+        stable_feed_bytes = read_bounded(
+            arguments.stable_feed_manifest,
+            MANIFEST_BYTE_LIMIT,
+            "stable feed manifest",
+        )
+        validate_stable_promotion(
+            release,
+            latest_release,
+            manifest_bytes,
+            stable_feed_bytes,
+            arguments.tag,
+        )
     verify_asset_files(
         arguments.assets_dir,
         assets,
@@ -307,6 +382,16 @@ def verify_public(arguments: argparse.Namespace) -> None:
         )
         tag_commit = resolve_tag_commit(arguments.repo, arguments.tag, token)
         manifest_bytes = fetch_bytes(urls["manifest"], MANIFEST_BYTE_LIMIT)
+        if arguments.channel == "stable" and not arguments.stable_candidate:
+            latest_release = api_json(arguments.repo, "releases/latest", token)
+            stable_feed_bytes = fetch_bytes(urls["stable"], MANIFEST_BYTE_LIMIT)
+            validate_stable_promotion(
+                release,
+                latest_release,
+                manifest_bytes,
+                stable_feed_bytes,
+                arguments.tag,
+            )
         return validate_snapshot(release, manifest_bytes, tag_commit, arguments)
 
     manifest, assets = retry(


### PR DESCRIPTION
Stages versioned stable releases as non-latest candidates, verifies public artifacts before promotion, proves the final latest feed, and automatically re-drafts failed candidates or promotions. Tester publication remains unchanged.\n\nVerified on the exact rebased head with 5,652 tests (5 skipped, 0 failures), 370 parity tests, 21 adversarial published-release verifier tests, the live public tester release, YAML parsing, whitespace checks, secret scanning, and A+ module grading.