### PR TITLE
Stabilize local macOS app identity

### DIFF
--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -394,7 +394,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "<key>QuillCodeStableUpdateManifestURL</key>",
             "<key>QuillCodeTesterUpdateManifestURL</key>",
             "<key>QuillCodeBuildCommit</key>",
-            "QuillCodeSigningTeamIdentifier"
+            "QuillCodeSigningTeamIdentifier",
+            #"${QUILLCODE_MACOS_ADHOC_CODESIGN:-1}"#
         ])
         Self.assertSource(packageScript, containsAll: [
             "bundleIdentifier=$BUNDLE_ID",

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -167,7 +167,7 @@ if [[ -n "$SIGNING_IDENTITY" ]]; then
   fi
   codesign "${CODESIGN_ARGUMENTS[@]}" "$APP_BUNDLE" >&2
   codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE" >&2
-elif [[ "${QUILLCODE_MACOS_ADHOC_CODESIGN:-0}" == "1" ]]; then
+elif [[ "${QUILLCODE_MACOS_ADHOC_CODESIGN:-1}" == "1" ]]; then
   codesign --force --deep --sign - "$APP_BUNDLE" >&2
 fi
 


### PR DESCRIPTION
## Summary
- ad-hoc sign local Quill Cowork bundles by default when Developer ID signing is not configured
- keep the bundle identifier and Info.plist bound to the packaged app so macOS permissions do not see the SwiftPM executable as a separate identity
- add a packaging regression assertion

## Verification
- bash -n scripts/build-macos-app.sh
- swift test --filter ParityDownloadBuildsGateTests/testMacOSDownloadPackagingEmbedsUpdaterMetadata
- ./scripts/packaged-macos-smoke.sh
- codesign --verify --deep --strict --verbose=2 .build/quillcode-macos-app/Quill Cowork.app