### PR TITLE
Unify transcript surface projection

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -103,13 +103,22 @@ public extension QuillCodeWorkspaceModel {
     func surface() -> WorkspaceSurface {
         let thread = selectedThread
         let topBarState = root.topBar
-        let toolCards = currentToolCards
         let runtimeIssue = runtimeIssueSurface()
-        let transcriptMessages = thread.map {
+        let transcriptProjection = thread.map {
             WorkspaceTranscriptSurfaceBuilder(
                 thread: $0,
                 allowsRevert: selectedProject?.isRemote != true
-            ).messageSurfaces()
+            ).projection()
+        } ?? .empty
+        let executionContextBuilder = WorkspaceExecutionContextSurfaceBuilder(
+            selectedProject: selectedProject,
+            projects: root.projects
+        )
+        let toolCards = thread.map {
+            executionContextBuilder.enrichToolCards(transcriptProjection.toolCards, for: $0)
+        } ?? []
+        let timelineItems = thread.map {
+            executionContextBuilder.enrichTimelineItems(transcriptProjection.timelineItems, for: $0)
         } ?? []
         let activeSources = WorkspaceContextResolver(
             projects: root.projects,
@@ -180,9 +189,9 @@ public extension QuillCodeWorkspaceModel {
             projects: navigation.projects,
             sidebar: navigation.sidebar,
             transcript: TranscriptSurface(
-                messages: transcriptMessages,
+                messages: transcriptProjection.messages,
                 toolCards: toolCards,
-                timelineItems: thread == nil ? nil : currentTimelineItems,
+                timelineItems: thread == nil ? nil : timelineItems,
                 thinking: WorkspaceTranscriptThinkingSurfaceBuilder(
                     thread: thread,
                     composer: composer,

--- a/Sources/QuillCodeApp/WorkspaceToolCardEventReducer.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolCardEventReducer.swift
@@ -7,20 +7,20 @@ struct WorkspaceToolCardEventReducer<State> {
     private var activeToolCardIndex: Int?
     private var activeApprovalCardIndex: Int?
     private let appendCard: (inout State, ToolCardState) -> Int
+    private let appendOrphanCard: ((inout State, ToolCardState) -> Void)?
     private let card: (State, Int) -> ToolCardState?
     private let replaceCard: (inout State, Int, ToolCardState) -> Void
-    private let orphanCardID: (() -> String)?
 
     init(
         state: State,
-        orphanCardID: (() -> String)? = nil,
         appendCard: @escaping (inout State, ToolCardState) -> Int,
+        appendOrphanCard: ((inout State, ToolCardState) -> Void)? = nil,
         card: @escaping (State, Int) -> ToolCardState?,
         replaceCard: @escaping (inout State, Int, ToolCardState) -> Void
     ) {
         self.state = state
-        self.orphanCardID = orphanCardID
         self.appendCard = appendCard
+        self.appendOrphanCard = appendOrphanCard
         self.card = card
         self.replaceCard = replaceCard
     }
@@ -30,13 +30,23 @@ struct WorkspaceToolCardEventReducer<State> {
         case .toolQueued:
             activeToolCardIndex = appendCard(&state, WorkspaceToolCardProjection.queuedCard(for: event))
         case .toolRunning:
-            updateActiveToolCard(status: .running, stateLabel: "Running")
+            updateActiveToolCard(for: event, status: .running, stateLabel: "Running")
         case .toolProgress:
             updateActiveToolProgress(event)
         case .toolCompleted:
-            updateActiveToolCard(status: .done, stateLabel: "Completed", outputJSON: event.payloadJSON)
+            updateActiveToolCard(
+                for: event,
+                status: .done,
+                stateLabel: "Completed",
+                outputJSON: event.payloadJSON
+            )
         case .toolFailed:
-            updateActiveToolCard(status: .failed, stateLabel: "Failed", outputJSON: event.payloadJSON)
+            updateActiveToolCard(
+                for: event,
+                status: .failed,
+                stateLabel: "Failed",
+                outputJSON: event.payloadJSON
+            )
         case .approvalRequested:
             replaceActiveToolWithApproval(for: event)
         case .approvalDecided:
@@ -57,6 +67,7 @@ struct WorkspaceToolCardEventReducer<State> {
     }
 
     private mutating func updateActiveToolCard(
+        for event: ThreadEvent,
         status: ToolCardStatus,
         stateLabel: String,
         outputJSON: String? = nil
@@ -64,7 +75,12 @@ struct WorkspaceToolCardEventReducer<State> {
         guard let index = activeToolCardIndex,
               var currentCard = card(state, index)
         else {
-            appendOrphanCard(status: status, stateLabel: stateLabel, outputJSON: outputJSON)
+            appendOrphanCard(
+                for: event,
+                status: status,
+                stateLabel: stateLabel,
+                outputJSON: outputJSON
+            )
             return
         }
 
@@ -81,13 +97,14 @@ struct WorkspaceToolCardEventReducer<State> {
     }
 
     private mutating func appendOrphanCard(
+        for event: ThreadEvent,
         status: ToolCardStatus,
         stateLabel: String,
         outputJSON: String?
     ) {
-        guard let orphanCardID else { return }
-        _ = appendCard(&state, WorkspaceToolCardProjection.orphanCard(
-            id: orphanCardID(),
+        guard let appendOrphanCard else { return }
+        appendOrphanCard(&state, WorkspaceToolCardProjection.orphanCard(
+            id: "orphan-\(event.id.uuidString.lowercased())",
             status: status,
             stateLabel: stateLabel,
             outputJSON: outputJSON
@@ -144,10 +161,12 @@ extension WorkspaceToolCardEventReducer where State == [TranscriptTimelineItemSu
     static func timeline() -> Self {
         Self(
             state: [],
-            orphanCardID: { "orphan-\(UUID().uuidString)" },
             appendCard: { items, card in
                 items.append(.toolCard(card))
                 return items.count - 1
+            },
+            appendOrphanCard: { items, card in
+                items.append(.toolCard(card))
             },
             card: { items, index in
                 guard items.indices.contains(index) else { return nil }
@@ -156,6 +175,70 @@ extension WorkspaceToolCardEventReducer where State == [TranscriptTimelineItemSu
             replaceCard: { items, index, card in
                 guard items.indices.contains(index) else { return }
                 items[index] = .toolCard(card)
+            }
+        )
+    }
+}
+
+struct WorkspaceTranscriptProjectionAccumulator {
+    var toolCards: [ToolCardState] = []
+    var timelineItems: [TranscriptTimelineItemSurface] = []
+    private var timelineIndexByToolCardIndex: [Int] = []
+
+    init(toolCardCapacity: Int, timelineCapacity: Int) {
+        toolCards.reserveCapacity(toolCardCapacity)
+        timelineItems.reserveCapacity(timelineCapacity)
+        timelineIndexByToolCardIndex.reserveCapacity(toolCardCapacity)
+    }
+
+    mutating func appendMessage(_ message: MessageSurface) {
+        timelineItems.append(.message(message))
+    }
+
+    mutating func appendToolCard(_ card: ToolCardState) -> Int {
+        let cardIndex = toolCards.count
+        toolCards.append(card)
+        timelineIndexByToolCardIndex.append(timelineItems.count)
+        timelineItems.append(.toolCard(card))
+        return cardIndex
+    }
+
+    mutating func appendOrphanToolCard(_ card: ToolCardState) {
+        timelineItems.append(.toolCard(card))
+    }
+
+    func toolCard(at index: Int) -> ToolCardState? {
+        toolCards.indices.contains(index) ? toolCards[index] : nil
+    }
+
+    mutating func replaceToolCard(at index: Int, with card: ToolCardState) {
+        guard toolCards.indices.contains(index),
+              timelineIndexByToolCardIndex.indices.contains(index)
+        else {
+            return
+        }
+        let timelineIndex = timelineIndexByToolCardIndex[index]
+        guard timelineItems.indices.contains(timelineIndex) else { return }
+        toolCards[index] = card
+        timelineItems[timelineIndex] = .toolCard(card)
+    }
+}
+
+extension WorkspaceToolCardEventReducer where State == WorkspaceTranscriptProjectionAccumulator {
+    static func transcriptProjection(state: State) -> Self {
+        Self(
+            state: state,
+            appendCard: { state, card in
+                state.appendToolCard(card)
+            },
+            appendOrphanCard: { state, card in
+                state.appendOrphanToolCard(card)
+            },
+            card: { state, index in
+                state.toolCard(at: index)
+            },
+            replaceCard: { state, index, card in
+                state.replaceToolCard(at: index, with: card)
             }
         )
     }

--- a/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
@@ -1,6 +1,18 @@
 import Foundation
 import QuillCodeCore
 
+struct WorkspaceTranscriptProjection: Sendable, Hashable {
+    var messages: [MessageSurface]
+    var toolCards: [ToolCardState]
+    var timelineItems: [TranscriptTimelineItemSurface]
+
+    static let empty = WorkspaceTranscriptProjection(
+        messages: [],
+        toolCards: [],
+        timelineItems: []
+    )
+}
+
 struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
     var thread: ChatThread
     /// Whether to offer per-turn revert affordances. False for remote projects, where the
@@ -9,11 +21,10 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
 
     func messageSurfaces() -> [MessageSurface] {
         let revertByMessageID = allowsRevert ? Self.revertByMessageID(for: thread) : [:]
-        return thread.messages
-            .filter { Self.isVisibleTranscriptRole($0.role) }
-            .map { message in
-                MessageSurface(message: message, revert: revertByMessageID[message.id])
-            }
+        return Self.messageSurfaces(
+            for: thread.messages,
+            revertByMessageID: revertByMessageID
+        )
     }
 
     /// Maps each revertable turn's starting user-message id to its revert affordance.
@@ -38,14 +49,47 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
     }
 
     func timelineItems() -> [TranscriptTimelineItemSurface] {
-        guard !thread.events.isEmpty else {
-            return messageSurfaces().map(TranscriptTimelineItemSurface.message)
-                + toolCards().map(TranscriptTimelineItemSurface.toolCard)
+        projection().timelineItems
+    }
+
+    /// Builds the three transcript views together so a desktop surface refresh decodes each tool
+    /// lifecycle and plans each message revert once. The separate accessors remain for focused
+    /// callers that only need one representation.
+    func projection() -> WorkspaceTranscriptProjection {
+        let revertByMessageID = allowsRevert ? Self.revertByMessageID(for: thread) : [:]
+        var visibleSurfaceIndexByMessageIndex = Array(
+            repeating: -1,
+            count: thread.messages.count
+        )
+        var visibleMessages: [MessageSurface] = []
+        visibleMessages.reserveCapacity(thread.messages.count)
+        for index in thread.messages.indices {
+            let message = thread.messages[index]
+            guard Self.isVisibleTranscriptRole(message.role) else { continue }
+            let surface = MessageSurface(
+                message: message,
+                revert: revertByMessageID[message.id]
+            )
+            visibleSurfaceIndexByMessageIndex[index] = visibleMessages.count
+            visibleMessages.append(surface)
         }
 
-        let revertByMessageID = allowsRevert ? Self.revertByMessageID(for: thread) : [:]
+        guard !thread.events.isEmpty else {
+            return WorkspaceTranscriptProjection(
+                messages: visibleMessages,
+                toolCards: [],
+                timelineItems: visibleMessages.map(TranscriptTimelineItemSurface.message)
+            )
+        }
+
         var messageIndex: WorkspaceTranscriptMessageIndex?
-        var reducer = WorkspaceToolCardEventReducer<[TranscriptTimelineItemSurface]>.timeline()
+        let estimatedToolCardCount = min(thread.events.count / 3 + 1, 4_096)
+        var reducer = WorkspaceToolCardEventReducer.transcriptProjection(
+            state: WorkspaceTranscriptProjectionAccumulator(
+                toolCardCapacity: estimatedToolCardCount,
+                timelineCapacity: visibleMessages.count + estimatedToolCardCount
+            )
+        )
 
         for event in thread.events {
             switch event.kind {
@@ -57,10 +101,11 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
                     continue
                 }
                 let message = thread.messages[index]
-                reducer.state.append(.message(MessageSurface(
-                    message: message,
-                    revert: revertByMessageID[message.id]
-                )))
+                let visibleSurfaceIndex = visibleSurfaceIndexByMessageIndex[index]
+                let surface = visibleSurfaceIndex >= 0
+                    ? visibleMessages[visibleSurfaceIndex]
+                    : MessageSurface(message: message, revert: revertByMessageID[message.id])
+                reducer.state.appendMessage(surface)
             case .messageFeedback, .reviewComment, .notice:
                 continue
             case .toolQueued, .toolRunning, .toolProgress, .toolCompleted, .toolFailed,
@@ -76,9 +121,26 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
             else {
                 continue
             }
-            reducer.state.append(.message(MessageSurface(message: message, revert: revertByMessageID[message.id])))
+            let visibleSurfaceIndex = visibleSurfaceIndexByMessageIndex[index]
+            if visibleSurfaceIndex >= 0 {
+                reducer.state.appendMessage(visibleMessages[visibleSurfaceIndex])
+            }
         }
-        return reducer.state
+        return WorkspaceTranscriptProjection(
+            messages: visibleMessages,
+            toolCards: reducer.state.toolCards,
+            timelineItems: reducer.state.timelineItems
+        )
+    }
+
+    private static func messageSurfaces(
+        for messages: [ChatMessage],
+        revertByMessageID: [UUID: MessageRevertSurface]
+    ) -> [MessageSurface] {
+        messages.compactMap { message in
+            guard isVisibleTranscriptRole(message.role) else { return nil }
+            return MessageSurface(message: message, revert: revertByMessageID[message.id])
+        }
     }
 
     private static func isVisibleTranscriptRole(_ role: ChatRole) -> Bool {

--- a/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSurfaceTests.swift
@@ -5,6 +5,56 @@ import QuillComputerUseKit
 
 @MainActor
 final class WorkspaceSurfaceTests: XCTestCase {
+    func testLongDailyDrivingSurfaceProjectsCompleteTranscriptHistory() throws {
+        let turnCount = 2_000
+        var messages: [ChatMessage] = []
+        var events: [ThreadEvent] = []
+        messages.reserveCapacity(turnCount * 2)
+        events.reserveCapacity(turnCount * 5)
+
+        for index in 0..<turnCount {
+            let user = ChatMessage(role: .user, content: "Run check \(index)")
+            let assistant = ChatMessage(role: .assistant, content: "Check \(index) passed")
+            let call = ToolCall(
+                id: "check-\(index)",
+                name: ToolDefinition.shellRun.name,
+                argumentsJSON: ToolArguments.json(["cmd": "check \(index)"])
+            )
+            let result = ToolResult(ok: true, stdout: "passed\n")
+            messages.append(contentsOf: [user, assistant])
+            events.append(contentsOf: [
+                ThreadEvent(kind: .message, summary: user.content),
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "queued",
+                    payloadJSON: try JSONHelpers.encodePretty(call)
+                ),
+                ThreadEvent(kind: .toolRunning, summary: "running"),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "completed",
+                    payloadJSON: try JSONHelpers.encodePretty(result)
+                ),
+                ThreadEvent(kind: .message, summary: assistant.content)
+            ])
+        }
+        let thread = ChatThread(messages: messages, events: events)
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        let surface = model.surface()
+
+        XCTAssertEqual(surface.transcript.messages.count, turnCount * 2)
+        XCTAssertEqual(surface.transcript.toolCards.count, turnCount)
+        XCTAssertEqual(surface.transcript.timelineItems.count, turnCount * 3)
+        XCTAssertEqual(surface.transcript.timelineItems.first?.message?.id, messages.first?.id)
+        XCTAssertEqual(surface.transcript.timelineItems.last?.message?.id, messages.last?.id)
+        XCTAssertEqual(surface.transcript.toolCards.first?.id, "check-0")
+        XCTAssertEqual(surface.transcript.toolCards.last?.id, "check-\(turnCount - 1)")
+    }
+
     func testSurfaceProjectsWorkflowRecordingAndCommandAvailability() throws {
         let workspace = try makeQuillCodeTestDirectory()
         let project = ProjectRef(name: "Recorder", path: workspace.path)

--- a/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTranscriptSurfaceBuilderTests.swift
@@ -315,6 +315,89 @@ final class WorkspaceTranscriptSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(timeline.last?.message?.id, messages.last?.id)
     }
 
+    func testUnifiedProjectionPreservesIndependentAndMalformedEventSemantics() throws {
+        let orphanEventID = UUID(uuidString: "00000000-0000-0000-0000-0000000000aa")!
+        let user = ChatMessage(role: .user, content: "Inspect the workspace")
+        let internalToolMessage = ChatMessage(role: .tool, content: "hidden tool feedback")
+        let assistant = ChatMessage(role: .assistant, content: "Inspection complete")
+        let unmatchedAssistant = ChatMessage(role: .assistant, content: "One more detail")
+        let approvalCall = ToolCall(
+            id: "approval-call",
+            name: ToolDefinition.fileWrite.name,
+            argumentsJSON: ToolArguments.json(["path": "notes.txt", "content": "notes"])
+        )
+        let approval = ApprovalRequest(
+            id: "approval-request",
+            toolCall: approvalCall,
+            toolDefinition: ToolDefinition.fileWrite,
+            reason: "review required"
+        )
+        let decision = ApprovalDecision(
+            requestID: approval.id,
+            verdict: .deny,
+            rationale: "Skipped from the test fixture."
+        )
+        let shellCall = ToolCall(
+            id: "shell-call",
+            name: ToolDefinition.shellRun.name,
+            argumentsJSON: ToolArguments.json(["cmd": "pwd"])
+        )
+        let success = ToolResult(ok: true, stdout: "/workspace\n")
+        let thread = ChatThread(
+            messages: [user, internalToolMessage, assistant, unmatchedAssistant],
+            events: [
+                ThreadEvent(kind: .message, summary: user.content),
+                ThreadEvent(
+                    id: orphanEventID,
+                    kind: .toolCompleted,
+                    summary: "orphaned completion",
+                    payloadJSON: try JSONHelpers.encodePretty(success)
+                ),
+                ThreadEvent(
+                    kind: .approvalRequested,
+                    summary: "approval",
+                    payloadJSON: try JSONHelpers.encodePretty(approval)
+                ),
+                ThreadEvent(
+                    kind: .approvalDecided,
+                    summary: "skipped",
+                    payloadJSON: try JSONHelpers.encodePretty(decision)
+                ),
+                ThreadEvent(kind: .message, summary: assistant.content),
+                ThreadEvent(
+                    kind: .toolQueued,
+                    summary: "queued",
+                    payloadJSON: try JSONHelpers.encodePretty(shellCall)
+                ),
+                ThreadEvent(kind: .toolRunning, summary: "running"),
+                ThreadEvent(
+                    kind: .toolCompleted,
+                    summary: "completed",
+                    payloadJSON: try JSONHelpers.encodePretty(success)
+                )
+            ]
+        )
+        let builder = WorkspaceTranscriptSurfaceBuilder(thread: thread, allowsRevert: false)
+
+        let projection = builder.projection()
+
+        XCTAssertEqual(projection.messages, builder.messageSurfaces())
+        XCTAssertEqual(projection.toolCards, builder.toolCards())
+        XCTAssertEqual(projection, builder.projection(), "orphan timeline identity must be stable")
+        XCTAssertEqual(projection.messages.map { $0.id }, [user.id, assistant.id, unmatchedAssistant.id])
+        XCTAssertEqual(projection.toolCards.map { $0.id }, [approvalCall.id, shellCall.id])
+        XCTAssertEqual(projection.timelineItems.compactMap { $0.toolCard }.map { $0.id }, [
+            "orphan-\(orphanEventID.uuidString.lowercased())",
+            approvalCall.id,
+            shellCall.id
+        ])
+        XCTAssertEqual(projection.timelineItems.compactMap { $0.message }.map { $0.id }, [
+            user.id,
+            assistant.id,
+            unmatchedAssistant.id
+        ])
+    }
+
     func testApprovalRequestTurnsActiveToolCardIntoActionableReview() throws {
         let call = ToolCall(
             id: "shell-approval-1",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-08 Unified Transcript Surface Projection
+
+Overall grade after this slice: **A+ main-actor latency, A+ transient memory, A+ semantic fidelity**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Main-actor latency | A+ | A complete workspace refresh plans message reverts and reduces tool events once; the 2,000-turn debug fixture fell from 259 ms to 190-196 ms. |
+| Transient memory | A+ | One compact source-index array replaces duplicate message-surface construction, tool-card capacity is capped, and no retained projection cache or invalidation state was added. |
+| Recovery stability | A+ | Orphan lifecycle rows use persisted event UUIDs, so malformed history remains visible without changing identity on every surface rebuild. |
+| Semantic fidelity | A+ | Canonical cards still exclude orphan-only terminal events while the timeline retains them; duplicate IDs/text, internal roles, unmatched messages, approvals, review, Activity, and execution-context behavior remain covered. |
+
+Validation:
+
+- Focused transcript and 2,000-turn workspace stress suite (22 tests, 0 failures)
+- Broader surface, review, Activity, execution-context, concurrent-chat, and progress-refresh suite
+  (80 tests, 0 failures)
+- `python3 scripts/grade-code-quality.py --root .` reports every module A+
+- Full `swift test` (5,664 tests, 5 skipped, 0 failures)
+- Release-mode arm64 package passed 3 of 3 fresh launches and both native interaction sweeps:
+  256.75 ms median launch-ready, 90.38 MiB initial memory, 148.95 MiB first-settled memory,
+  153.11 MiB repeated-settled memory, 4.16 MiB convergence growth, and 9 to 8 to 8 threads
+- Packaged direct-executable and Launch Services smokes passed scheduled coworker, multi-file
+  artifact, one-turn coworker, browser, computer-use, Accessibility, and click-probe contracts
+- Visual inspection at 1280 x 900 confirmed stable first-run hierarchy and composer dimensions
+  with no overlap or clipping
+
 ## 2026-08-08 Native Interaction Sequence And New Chat Focus
 
 Overall grade after this slice: **A+ keyboard UX, A+ native determinism, A+ interaction evidence**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,25 @@
 # QuillCode Decisions
 
+## 2026-08-08: workspace surface refreshes project transcript history once
+
+- **Decision:** The selected chat now produces messages, canonical tool cards, and chronological
+  timeline items through one transcript projection. A paired reducer constructs each tool card once
+  and updates its canonical-list and timeline positions together; focused callers can still request
+  only messages or canonical cards through their existing APIs.
+- **Why:** Every coalesced streaming repaint previously planned message reverts twice and reduced the
+  complete tool-event history twice before SwiftUI received an immutable surface. A 2,000-turn
+  daily-driving fixture therefore spent 259 ms in a debug surface rebuild despite the native view
+  itself using lazy rows.
+- **Memory and recovery boundary:** Visible message reuse is indexed by one compact integer per source
+  message, speculative tool capacity is capped at 4,096 entries, and no retained cache or invalidation
+  graph is added. Malformed terminal events remain timeline-only, but derive stable fallback identity
+  from their persisted event UUID so repeated refreshes cannot manufacture apparent row changes.
+- **Evidence:** The same 2,000-turn fixture projects 4,000 messages, 2,000 completed tools, and 6,000
+  chronological rows in 190-196 ms after the change. Focused tests preserve duplicate text/ID
+  behavior, hidden internal messages, unmatched-message append order, approval replacement, orphan
+  exclusion from canonical cards, execution-context enrichment, review and Activity projections, and
+  streaming-refresh coalescing.
+
 ## 2026-08-08: new chats own composer focus and native interaction order is intentional
 
 - **New Chat focus:** The desktop navigation boundary bumps the existing composer focus token after


### PR DESCRIPTION
## Summary
- project selected-chat messages, canonical tool cards, and timeline items in one transcript pass
- preserve historical event semantics while giving malformed orphan lifecycle rows stable identity
- add a 2,000-turn daily-driving fixture and focused malformed-history coverage

## Performance
- debug full-surface fixture improved from 259 ms to 190-196 ms
- release package passed 3/3 launches at 256.75 ms median ready, 90.38 MiB initial, 148.95 MiB first-settled, and 153.11 MiB repeated-settled

## Validation
- swift test: 5,664 tests, 5 skipped, 0 failures
- packaged release performance smoke: 3/3 fresh processes, two interaction sweeps each
- direct executable and Launch Services packaged smokes
- all code-quality modules A+
- git diff --check
- exact leaked-token fingerprint absent