### PR TITLE
Stabilize macOS disk image packaging

### DIFF
--- a/Tests/QuillCodeParityTests/ParityDiskImagePackagingGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDiskImagePackagingGateTests.swift
@@ -1,0 +1,300 @@
+import XCTest
+
+final class ParityDiskImagePackagingGateTests: QuillCodeParityTestCase {
+    func testRetriesEachTransientImageOperationAndPublishesOnlyVerifiedCandidate() throws {
+        for stage in ["create", "verify", "attach"] {
+            var overrides = [failureKey(for: stage): "1"]
+            if stage == "attach" {
+                overrides["FAKE_ATTACH_PARTIAL_MOUNT"] = "true"
+            }
+            let result = try runPackager(overrides: overrides)
+
+            XCTAssertEqual(result.exitCode, 0, "\(stage): \(result.output)")
+            XCTAssertEqual(result.publishedBytes, Data("candidate-2".utf8), result.output)
+            XCTAssertTrue(
+                result.output.contains("Disk-image \(stage) failed on attempt 1/3"),
+                result.output
+            )
+            XCTAssertTrue(
+                result.output.contains("Retrying disk-image packaging after transient \(stage) failure"),
+                result.output
+            )
+            XCTAssertTrue(result.output.contains("Disk image ready after 2 attempt(s)"), result.output)
+            XCTAssertEqual(result.operationCount(stage), 2, result.operationLog)
+            XCTAssertEqual(result.sleepCount, 1, result.sleepLog)
+            if stage == "attach" {
+                XCTAssertTrue(result.operationLog.contains("detach -force"), result.operationLog)
+            }
+        }
+    }
+
+    func testExhaustedRetriesKeepExistingOutputAndNameTheLastStage() throws {
+        let result = try runPackager(
+            existingOutput: Data("last-good-image".utf8),
+            overrides: [failureKey(for: "create"): "3"]
+        )
+
+        XCTAssertEqual(result.exitCode, 1, result.output)
+        XCTAssertEqual(result.publishedBytes, Data("last-good-image".utf8))
+        XCTAssertEqual(result.operationCount("create"), 3, result.operationLog)
+        XCTAssertEqual(result.sleepCount, 2, result.sleepLog)
+        XCTAssertTrue(
+            result.output.contains("failed after 3 attempts; last failed stage: create"),
+            result.output
+        )
+    }
+
+    func testInvalidMountedSignatureFailsWithoutRetryOrPublication() throws {
+        let result = try runPackager(overrides: ["FAKE_CODESIGN_FAIL": "true"])
+
+        XCTAssertEqual(result.exitCode, 1, result.output)
+        XCTAssertNil(result.publishedBytes)
+        XCTAssertEqual(result.operationCount("create"), 1, result.operationLog)
+        XCTAssertEqual(result.operationCount("verify"), 1, result.operationLog)
+        XCTAssertEqual(result.operationCount("attach"), 1, result.operationLog)
+        XCTAssertEqual(result.codesignCount, 1, result.codesignLog)
+        XCTAssertEqual(result.sleepCount, 0, result.sleepLog)
+        XCTAssertTrue(result.output.contains("invalid code signature; refusing to retry"), result.output)
+    }
+
+    func testRejectsInvalidRetryPolicyBeforeDiskImageWork() throws {
+        let result = try runPackager(overrides: ["QUILLCODE_DISK_IMAGE_MAX_ATTEMPTS": "6"])
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertNil(result.publishedBytes)
+        XCTAssertTrue(result.operationLog.isEmpty, result.operationLog)
+        XCTAssertTrue(result.output.contains("must be an integer from 1 through 5"), result.output)
+    }
+
+    private struct PackagingResult {
+        var exitCode: Int32
+        var output: String
+        var publishedBytes: Data?
+        var operationLog: String
+        var codesignLog: String
+        var sleepLog: String
+
+        func operationCount(_ operation: String) -> Int {
+            operationLog
+                .split(separator: "\n")
+                .filter { $0.split(separator: " ").first == Substring(operation) }
+                .count
+        }
+
+        var codesignCount: Int {
+            codesignLog.split(separator: "\n").count
+        }
+
+        var sleepCount: Int {
+            sleepLog.split(separator: "\n").count
+        }
+    }
+
+    private func runPackager(
+        existingOutput: Data? = nil,
+        overrides: [String: String] = [:]
+    ) throws -> PackagingResult {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-disk-image-packaging-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let binDirectory = temporaryDirectory.appendingPathComponent("bin")
+        let appURL = temporaryDirectory.appendingPathComponent("Quill Cowork.app")
+        let executableURL = appURL.appendingPathComponent("Contents/MacOS/Quill Cowork")
+        let infoPlistURL = appURL.appendingPathComponent("Contents/Info.plist")
+        let outputURL = temporaryDirectory.appendingPathComponent("downloads/Quill-Cowork.dmg")
+        let operationLogURL = temporaryDirectory.appendingPathComponent("hdiutil.log")
+        let stateDirectory = temporaryDirectory.appendingPathComponent("hdiutil-state")
+        let codesignLogURL = temporaryDirectory.appendingPathComponent("codesign.log")
+        let sleepLogURL = temporaryDirectory.appendingPathComponent("sleep.log")
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: executableURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: executableURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
+        try Data("plist-fixture".utf8).write(to: infoPlistURL)
+        if let existingOutput {
+            try FileManager.default.createDirectory(
+                at: outputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try existingOutput.write(to: outputURL)
+        }
+
+        let tools = [
+            "hdiutil": fakeHDIUtil,
+            "ditto": fakeDitto,
+            "codesign": fakeCodesign,
+            "PlistBuddy": fakePlistBuddy,
+            "sleep": fakeSleep,
+        ]
+        for (name, contents) in tools {
+            let url = binDirectory.appendingPathComponent(name)
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        }
+
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts/create-macos-disk-image.sh")
+                .path,
+            "--app", appURL.path,
+            "--output", outputURL.path,
+        ]
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(binDirectory.path):\(environment["PATH"] ?? "")"
+        environment["QUILLCODE_DISK_IMAGE_PLATFORM"] = "Darwin"
+        environment["QUILLCODE_HDIUTIL_BIN"] = binDirectory.appendingPathComponent("hdiutil").path
+        environment["QUILLCODE_DITTO_BIN"] = binDirectory.appendingPathComponent("ditto").path
+        environment["QUILLCODE_CODESIGN_BIN"] = binDirectory.appendingPathComponent("codesign").path
+        environment["QUILLCODE_PLIST_BUDDY_BIN"] = binDirectory.appendingPathComponent("PlistBuddy").path
+        environment["QUILLCODE_DISK_IMAGE_RETRY_DELAY_SECONDS"] = "0"
+        environment["FAKE_DISK_IMAGE_APP"] = appURL.path
+        environment["FAKE_HDIUTIL_LOG"] = operationLogURL.path
+        environment["FAKE_HDIUTIL_STATE"] = stateDirectory.path
+        environment["FAKE_CODESIGN_LOG"] = codesignLogURL.path
+        environment["FAKE_SLEEP_LOG"] = sleepLogURL.path
+        for (key, value) in overrides {
+            environment[key] = value
+        }
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        return PackagingResult(
+            exitCode: process.terminationStatus,
+            output: String(
+                data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? "",
+            publishedBytes: try? Data(contentsOf: outputURL),
+            operationLog: (try? String(contentsOf: operationLogURL, encoding: .utf8)) ?? "",
+            codesignLog: (try? String(contentsOf: codesignLogURL, encoding: .utf8)) ?? "",
+            sleepLog: (try? String(contentsOf: sleepLogURL, encoding: .utf8)) ?? ""
+        )
+    }
+
+    private func failureKey(for stage: String) -> String {
+        switch stage {
+        case "create": "FAKE_CREATE_FAILURES"
+        case "verify": "FAKE_VERIFY_FAILURES"
+        case "attach": "FAKE_ATTACH_FAILURES"
+        default: preconditionFailure("Unsupported fake disk-image stage: \(stage)")
+        }
+    }
+
+    private var fakeHDIUtil: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        operation="$1"
+        shift
+        printf '%s %s\n' "$operation" "$*" >> "${FAKE_HDIUTIL_LOG:?}"
+        count_file="${FAKE_HDIUTIL_STATE:?}/$operation"
+        count=0
+        if [[ -f "$count_file" ]]; then
+          read -r count < "$count_file"
+        fi
+        count=$((count + 1))
+        printf '%s\n' "$count" > "$count_file"
+
+        failure_limit=0
+        case "$operation" in
+          create) failure_limit="${FAKE_CREATE_FAILURES:-0}" ;;
+          verify) failure_limit="${FAKE_VERIFY_FAILURES:-0}" ;;
+          attach) failure_limit="${FAKE_ATTACH_FAILURES:-0}" ;;
+        esac
+        if (( count <= failure_limit )); then
+          if [[ "$operation" == "attach" && "${FAKE_ATTACH_PARTIAL_MOUNT:-false}" == "true" ]]; then
+            mount_point=""
+            while [[ $# -gt 0 ]]; do
+              if [[ "$1" == "-mountpoint" ]]; then
+                mount_point="$2"
+                break
+              fi
+              shift
+            done
+            touch "$mount_point/partial-mount"
+          fi
+          echo "simulated $operation failure" >&2
+          exit 17
+        fi
+
+        case "$operation" in
+          create)
+            candidate=""
+            for argument in "$@"; do
+              candidate="$argument"
+            done
+            printf 'candidate-%s' "$count" > "$candidate"
+            ;;
+          verify)
+            [[ -s "$1" ]]
+            ;;
+          attach)
+            mount_point=""
+            while [[ $# -gt 0 ]]; do
+              if [[ "$1" == "-mountpoint" ]]; then
+                mount_point="$2"
+                break
+              fi
+              shift
+            done
+            [[ -n "$mount_point" ]]
+            cp -R "${FAKE_DISK_IMAGE_APP:?}" "$mount_point/Quill Cowork.app"
+            ln -s /Applications "$mount_point/Applications"
+            ;;
+          detach)
+            ;;
+          *)
+            echo "unexpected hdiutil operation: $operation" >&2
+            exit 19
+            ;;
+        esac
+        """
+    }
+
+    private var fakeDitto: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        cp -R "$1" "$2"
+        """
+    }
+
+    private var fakeCodesign: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${FAKE_CODESIGN_LOG:?}"
+        [[ "${FAKE_CODESIGN_FAIL:-false}" != "true" ]]
+        """
+    }
+
+    private var fakePlistBuddy: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' 'Quill Cowork'
+        """
+    }
+
+    private var fakeSleep: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${FAKE_SLEEP_LOG:?}"
+        """
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -443,13 +443,18 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "BUILD_INFO-macOS-$ARCH.txt"
         ])
         Self.assertSource(diskImageScript, containsAll: [
-            "ditto \"$APP_BUNDLE\" \"$STAGING_DIR/$APP_NAME\"",
+            "\"$DITTO_BIN\" \"$APP_BUNDLE\" \"$STAGING_DIR/$APP_NAME\"",
             "ln -s /Applications \"$STAGING_DIR/Applications\"",
-            "hdiutil create",
-            "hdiutil verify",
-            "hdiutil attach",
-            "codesign --verify --deep --strict"
+            "\"$HDIUTIL_BIN\" create",
+            "\"$HDIUTIL_BIN\" verify",
+            "\"$HDIUTIL_BIN\" attach",
+            "run_image_operation",
+            "Retrying disk-image packaging after transient $FAILED_STAGE failure.",
+            "refusing to retry",
+            "mv -f \"$CANDIDATE_PATH\" \"$OUTPUT_PATH\"",
+            "\"$CODESIGN_BIN\" --verify --deep --strict"
         ])
+        Self.assertSource(diskImageScript, excludes: "-quiet")
         Self.assertSource(smokeScript, containsAll: [
             "assert_plist_value QuillCodeUpdateChannel tester",
             "assert_plist_value QuillCodeBuildCommit \"$EXPECTED_BUILD_COMMIT\"",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,29 @@
 # Code Quality Audit
 
+## 2026-08-09 Transactional Disk-Image Packaging
+
+Overall grade after this slice: **A+ publication resilience, A+ failure visibility, A+ integrity**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Publication resilience | A+ | Create, verify, and attach each receive three bounded attempts with a fresh candidate and mount point. |
+| Artifact integrity | A+ | The destination changes only after mounted-content, shortcut, signature, size, and detach checks pass. |
+| Failure visibility | A+ | Quiet `hdiutil` calls are gone; every failed image-service operation reports stage, attempt, bound, and exit status. |
+| Fail-closed policy | A+ | Bundle, shortcut, signature, and detach failures never retry; exhausted transient failures preserve the prior installer. |
+
+Validation:
+
+- Executable fake-tool packaging suite covers independent create, verify, and attach recovery,
+  partial-attach cleanup, retry exhaustion, prior-output preservation, invalid policy, and fail-fast
+  signature rejection (4 tests, 0 failures)
+- Real ad-hoc signed app DMG creation, verification, mount inspection, signature validation, detach,
+  and transactional replacement all passed against the release-mode Quill Cowork bundle
+- Focused disk-image and distribution contract suite (10 tests, 0 failures)
+- Full `swift test` (5,668 tests, 5 skipped, 0 failures)
+- Exact native package and public dual-architecture publication pending in this release follow-up
+- `python3 scripts/grade-code-quality.py --root .` reports every module A+
+- `bash -n scripts/create-macos-disk-image.sh`; `git diff --check`
+
 ## 2026-08-08 Unified Transcript Surface Projection
 
 Overall grade after this slice: **A+ main-actor latency, A+ transient memory, A+ semantic fidelity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,25 @@
 # QuillCode Decisions
 
+## 2026-08-09: disk-image publication is transactional and bounded-retry
+
+- **Decision:** DMG packaging builds a private candidate beside the requested output and replaces
+  the public artifact only after `hdiutil` create, verify, and read-only attach; mounted bundle and
+  `/Applications` validation; code-signature verification; and clean detach all succeed.
+- **Retry boundary:** Create, verify, and attach are macOS disk-image service operations and receive
+  up to three attempts with the exact stage and exit status in logs. Bundle shape, install shortcut,
+  code signature, empty output, and detach safety remain fail-fast correctness checks. Normal detach
+  gets one force fallback, but packaging never treats an invalid app as transient.
+- **Recovery:** Each attempt uses a fresh candidate and mount point. Exhaustion removes only private
+  temporary state and preserves a pre-existing destination byte-for-byte, so an infrastructure blip
+  cannot silently destroy the last usable installer.
+- **Why:** Public build 671 passed all three Intel launches, both real Accessibility sweeps, and every
+  memory/thread budget, then the quiet `hdiutil` step exited without diagnostics. A workflow rerun
+  recovered, proving infrastructure transience while also exposing an avoidable publication delay.
+- **Evidence:** Executable fake-tool tests recover independent create, verify, and attach failures;
+  clean a simulated partial attach before retry; prove three-attempt exhaustion preserves the
+  previous output; reject invalid retry policy before work; and prove signature rejection performs
+  no retry or publication.
+
 ## 2026-08-08: workspace surface refreshes project transcript history once
 
 - **Decision:** The selected chat now produces messages, canonical tool cards, and chronological

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -65,6 +65,13 @@ When a build is required, the workflow updates the stable `tester-latest` tag
 and replaces release assets in place, so the links above do not change as new
 builds are published.
 
+DMG construction is transactional and stage-aware. The packager creates each
+candidate beside the destination, then verifies, mounts, inspects, signature-checks,
+and detaches it before an atomic replacement. Transient macOS disk-image service
+failures during create, verify, or attach receive up to three bounded attempts with
+the exact failed stage in the log. Bundle-content and code-signature failures never
+retry, and an exhausted attempt set leaves any prior installer untouched.
+
 After publishing, a separate read-only job consumes the release through the
 same public GitHub API and download URLs users receive. It resolves the release
 tag to the expected commit, checks the exact release inventory and updater feed

--- a/scripts/create-macos-disk-image.sh
+++ b/scripts/create-macos-disk-image.sh
@@ -4,17 +4,45 @@ set -euo pipefail
 APP_BUNDLE=""
 OUTPUT_PATH=""
 VOLUME_NAME="Quill Cowork"
-WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/quill-cowork-disk-image.XXXXXX")"
-STAGING_DIR="$WORK_ROOT/staging"
-MOUNT_POINT="$WORK_ROOT/mounted"
+MAX_ATTEMPTS="${QUILLCODE_DISK_IMAGE_MAX_ATTEMPTS:-3}"
+RETRY_DELAY_SECONDS="${QUILLCODE_DISK_IMAGE_RETRY_DELAY_SECONDS:-2}"
+PLATFORM="${QUILLCODE_DISK_IMAGE_PLATFORM:-$(uname -s)}"
+HDIUTIL_BIN="${QUILLCODE_HDIUTIL_BIN:-hdiutil}"
+DITTO_BIN="${QUILLCODE_DITTO_BIN:-ditto}"
+CODESIGN_BIN="${QUILLCODE_CODESIGN_BIN:-codesign}"
+PLIST_BUDDY_BIN="${QUILLCODE_PLIST_BUDDY_BIN:-/usr/libexec/PlistBuddy}"
+WORK_ROOT=""
+MOUNT_POINT=""
 MOUNTED=false
+
+detach_mounted_image() {
+  if [[ "$MOUNTED" != true ]]; then
+    return 0
+  fi
+
+  if "$HDIUTIL_BIN" detach "$MOUNT_POINT"; then
+    MOUNTED=false
+    return 0
+  fi
+
+  echo "Normal disk-image detach failed; forcing detach of $MOUNT_POINT." >&2
+  if "$HDIUTIL_BIN" detach -force "$MOUNT_POINT"; then
+    MOUNTED=false
+    return 0
+  fi
+
+  echo "Unable to detach disk image from $MOUNT_POINT." >&2
+  return 1
+}
 
 cleanup() {
   set +e
-  if [[ "$MOUNTED" == true ]]; then
-    hdiutil detach -quiet "$MOUNT_POINT" || hdiutil detach -quiet -force "$MOUNT_POINT"
+  if ! detach_mounted_image; then
+    echo "Disk-image cleanup could not detach the private mount." >&2
   fi
-  rm -rf "$WORK_ROOT"
+  if [[ -n "$WORK_ROOT" ]]; then
+    rm -rf "$WORK_ROOT"
+  fi
 }
 trap cleanup EXIT
 
@@ -39,7 +67,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$(uname -s)" != "Darwin" ]]; then
+if [[ "$PLATFORM" != "Darwin" ]]; then
   echo "create-macos-disk-image.sh must run on macOS." >&2
   exit 2
 fi
@@ -47,45 +75,101 @@ if [[ ! -d "$APP_BUNDLE" || "$APP_BUNDLE" != *.app || -z "$OUTPUT_PATH" ]]; then
   echo "Usage: create-macos-disk-image.sh --app APP_BUNDLE --output OUTPUT_DMG" >&2
   exit 2
 fi
+if [[ ! "$MAX_ATTEMPTS" =~ ^[1-5]$ ]]; then
+  echo "QUILLCODE_DISK_IMAGE_MAX_ATTEMPTS must be an integer from 1 through 5." >&2
+  exit 2
+fi
+if [[ ! "$RETRY_DELAY_SECONDS" =~ ^[0-9]+$ || "$RETRY_DELAY_SECONDS" -gt 30 ]]; then
+  echo "QUILLCODE_DISK_IMAGE_RETRY_DELAY_SECONDS must be an integer from 0 through 30." >&2
+  exit 2
+fi
 
 APP_NAME="$(basename "$APP_BUNDLE")"
-APP_EXECUTABLE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP_BUNDLE/Contents/Info.plist")"
+APP_EXECUTABLE_NAME="$("$PLIST_BUDDY_BIN" -c 'Print :CFBundleExecutable' "$APP_BUNDLE/Contents/Info.plist")"
 if [[ ! -x "$APP_BUNDLE/Contents/MacOS/$APP_EXECUTABLE_NAME" ]]; then
   echo "App executable is missing from $APP_BUNDLE" >&2
   exit 1
 fi
 
-mkdir -p "$STAGING_DIR" "$MOUNT_POINT" "$(dirname "$OUTPUT_PATH")"
-ditto "$APP_BUNDLE" "$STAGING_DIR/$APP_NAME"
+OUTPUT_DIRECTORY="$(dirname "$OUTPUT_PATH")"
+mkdir -p "$OUTPUT_DIRECTORY"
+WORK_ROOT="$(mktemp -d "$OUTPUT_DIRECTORY/.quill-cowork-disk-image.XXXXXX")"
+STAGING_DIR="$WORK_ROOT/staging"
+mkdir -p "$STAGING_DIR"
+"$DITTO_BIN" "$APP_BUNDLE" "$STAGING_DIR/$APP_NAME"
 ln -s /Applications "$STAGING_DIR/Applications"
 touch "$STAGING_DIR/.metadata_never_index"
 
-hdiutil create \
-  -quiet \
-  -ov \
-  -format UDZO \
-  -fs HFS+ \
-  -volname "$VOLUME_NAME" \
-  -srcfolder "$STAGING_DIR" \
-  "$OUTPUT_PATH"
-hdiutil verify -quiet "$OUTPUT_PATH"
+run_image_operation() {
+  local stage="$1"
+  shift
+  if "$@"; then
+    return 0
+  else
+    local status=$?
+    echo "Disk-image $stage failed on attempt $ATTEMPT/$MAX_ATTEMPTS (exit $status)." >&2
+    return "$status"
+  fi
+}
 
-hdiutil attach -quiet -readonly -nobrowse -mountpoint "$MOUNT_POINT" "$OUTPUT_PATH"
-MOUNTED=true
-if [[ ! -d "$MOUNT_POINT/$APP_NAME" || ! -x "$MOUNT_POINT/$APP_NAME/Contents/MacOS/$APP_EXECUTABLE_NAME" ]]; then
-  echo "Mounted disk image does not contain an executable $APP_NAME bundle." >&2
-  exit 1
-fi
-if [[ ! -L "$MOUNT_POINT/Applications" || "$(readlink "$MOUNT_POINT/Applications")" != "/Applications" ]]; then
-  echo "Mounted disk image does not contain the /Applications install shortcut." >&2
-  exit 1
-fi
-codesign --verify --deep --strict "$MOUNT_POINT/$APP_NAME"
-hdiutil detach -quiet "$MOUNT_POINT"
-MOUNTED=false
+for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT += 1)); do
+  CANDIDATE_PATH="$WORK_ROOT/Quill-Cowork-attempt-$ATTEMPT.dmg"
+  MOUNT_POINT="$WORK_ROOT/mounted-$ATTEMPT"
+  mkdir -p "$MOUNT_POINT"
+  FAILED_STAGE=""
 
-if [[ ! -s "$OUTPUT_PATH" ]]; then
-  echo "Disk image was not created: $OUTPUT_PATH" >&2
-  exit 1
-fi
-echo "$OUTPUT_PATH"
+  echo "==> Creating Quill Cowork disk image (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+  if ! run_image_operation create \
+    "$HDIUTIL_BIN" create \
+      -ov \
+      -format UDZO \
+      -fs HFS+ \
+      -volname "$VOLUME_NAME" \
+      -srcfolder "$STAGING_DIR" \
+      "$CANDIDATE_PATH"; then
+    FAILED_STAGE="create"
+  elif ! run_image_operation verify "$HDIUTIL_BIN" verify "$CANDIDATE_PATH"; then
+    FAILED_STAGE="verify"
+  elif ! run_image_operation attach \
+    "$HDIUTIL_BIN" attach -readonly -nobrowse -mountpoint "$MOUNT_POINT" "$CANDIDATE_PATH"; then
+    FAILED_STAGE="attach"
+    "$HDIUTIL_BIN" detach -force "$MOUNT_POINT" >/dev/null 2>&1 || true
+  else
+    MOUNTED=true
+  fi
+
+  if [[ -n "$FAILED_STAGE" ]]; then
+    rm -f "$CANDIDATE_PATH"
+    if (( ATTEMPT < MAX_ATTEMPTS )); then
+      echo "Retrying disk-image packaging after transient $FAILED_STAGE failure." >&2
+      sleep "$RETRY_DELAY_SECONDS"
+      continue
+    fi
+    echo "Disk-image packaging failed after $MAX_ATTEMPTS attempts; last failed stage: $FAILED_STAGE." >&2
+    exit 1
+  fi
+
+  if [[ ! -d "$MOUNT_POINT/$APP_NAME" || ! -x "$MOUNT_POINT/$APP_NAME/Contents/MacOS/$APP_EXECUTABLE_NAME" ]]; then
+    echo "Mounted disk image does not contain an executable $APP_NAME bundle." >&2
+    exit 1
+  fi
+  if [[ ! -L "$MOUNT_POINT/Applications" || "$(readlink "$MOUNT_POINT/Applications")" != "/Applications" ]]; then
+    echo "Mounted disk image does not contain the /Applications install shortcut." >&2
+    exit 1
+  fi
+  if ! "$CODESIGN_BIN" --verify --deep --strict "$MOUNT_POINT/$APP_NAME"; then
+    echo "Mounted disk image contains an app with an invalid code signature; refusing to retry." >&2
+    exit 1
+  fi
+  if ! detach_mounted_image; then
+    exit 1
+  fi
+
+  if [[ ! -s "$CANDIDATE_PATH" ]]; then
+    echo "Disk image candidate is empty: $CANDIDATE_PATH" >&2
+    exit 1
+  fi
+  mv -f "$CANDIDATE_PATH" "$OUTPUT_PATH"
+  echo "Disk image ready after $ATTEMPT attempt(s): $OUTPUT_PATH"
+  exit 0
+done


### PR DESCRIPTION
## Summary
- make DMG publication transactional so a prior installer survives failed packaging
- retry only transient hdiutil create, verify, and attach stages with clear diagnostics and partial-mount cleanup
- keep bundle, shortcut, signature, size, and detach correctness failures fail-fast

## Validation
- full swift test: 5,668 tests, 5 skipped, 0 failures
- focused disk-image and distribution suite: 10 tests, 0 failures
- real release-mode app DMG create, verify, mount, signature, detach, and transactional replacement passed
- all code-quality modules A+
- bash syntax and diff checks passed