### PR TITLE
Harden Apple signing setup

### DIFF
--- a/Tests/QuillCodeParityTests/ParityMacOSDistributionSigningGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityMacOSDistributionSigningGateTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import XCTest
+
+final class ParityMacOSDistributionSigningGateTests: QuillCodeParityTestCase {
+    func testMissingCredentialsKeepTesterSigningUnconfigured() throws {
+        let result = try runSigningConfiguration()
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("tester builds will use ad-hoc signing"))
+        XCTAssertTrue(result.exportedEnvironment.isEmpty)
+        XCTAssertTrue(result.securityLog.isEmpty)
+        XCTAssertFalse(result.signingRootExists)
+    }
+
+    func testPartialCredentialsFailBeforeCreatingSensitiveFiles() throws {
+        let result = try runSigningConfiguration(overrides: [
+            "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64": Data("certificate".utf8).base64EncodedString()
+        ])
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(result.output.contains("only partially configured"))
+        XCTAssertTrue(result.exportedEnvironment.isEmpty)
+        XCTAssertTrue(result.securityLog.isEmpty)
+        XCTAssertFalse(result.signingRootExists)
+    }
+
+    func testMalformedAppleIdentifiersFailBeforeCreatingSensitiveFiles() throws {
+        let cases = [
+            ("APPLE_TEAM_ID", "lowercase", "APPLE_TEAM_ID must be"),
+            ("APPLE_NOTARY_KEY_ID", "short", "APPLE_NOTARY_KEY_ID must be"),
+            ("APPLE_NOTARY_ISSUER_ID", "not-a-uuid", "APPLE_NOTARY_ISSUER_ID must be")
+        ]
+
+        for (key, value, expectedMessage) in cases {
+            var credentials = validCredentials
+            credentials[key] = value
+            let result = try runSigningConfiguration(overrides: credentials)
+
+            XCTAssertEqual(result.exitCode, 2, "\(key): \(result.output)")
+            XCTAssertTrue(result.output.contains(expectedMessage), "\(key): \(result.output)")
+            XCTAssertTrue(result.exportedEnvironment.isEmpty, key)
+            XCTAssertTrue(result.securityLog.isEmpty, key)
+            XCTAssertFalse(result.signingRootExists, key)
+        }
+    }
+
+    func testSuccessfulConfigurationExportsOnlyOwnedPaths() throws {
+        let result = try runSigningConfiguration(overrides: validCredentials)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Configured Developer ID signing"))
+        XCTAssertTrue(result.exportedEnvironment.contains("QUILLCODE_MACOS_SIGNING_IDENTITY="))
+        XCTAssertTrue(result.exportedEnvironment.contains("QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER=ABCDE12345"))
+        XCTAssertTrue(result.exportedEnvironment.contains("QUILLCODE_MACOS_SIGNING_KEYCHAIN="))
+        XCTAssertTrue(result.exportedEnvironment.contains("QUILLCODE_MACOS_NOTARY_KEY_PATH="))
+        XCTAssertFalse(result.exportedEnvironment.contains("certificate-password"))
+        XCTAssertFalse(result.exportedEnvironment.contains(validCredentials["APPLE_DEVELOPER_ID_CERTIFICATE_BASE64"]!))
+        XCTAssertEqual(result.certificateContents, "certificate-bytes")
+        XCTAssertEqual(result.notaryKeyContents, "notary-key-bytes")
+        XCTAssertEqual(result.certificatePermissions, 0o600)
+        XCTAssertEqual(result.notaryKeyPermissions, 0o600)
+        XCTAssertTrue(result.securityLog.contains("create-keychain"))
+        XCTAssertTrue(result.securityLog.contains("find-identity"))
+        XCTAssertFalse(result.securityLog.contains("delete-keychain"))
+        XCTAssertTrue(result.signingRootExists)
+    }
+
+    func testImportFailureDeletesKeychainAndDecodedCredentials() throws {
+        let result = try runSigningConfiguration(
+            overrides: validCredentials,
+            importFails: true
+        )
+
+        XCTAssertEqual(result.exitCode, 7, result.output)
+        XCTAssertTrue(result.securityLog.contains("import"))
+        XCTAssertTrue(result.securityLog.contains("delete-keychain"))
+        XCTAssertTrue(result.exportedEnvironment.isEmpty)
+        XCTAssertFalse(result.signingRootExists)
+        XCTAssertNil(result.certificateContents)
+        XCTAssertNil(result.notaryKeyContents)
+    }
+
+    func testImportedIdentityMustBelongToConfiguredTeam() throws {
+        var credentials = validCredentials
+        credentials["APPLE_DEVELOPER_ID_APPLICATION_IDENTITY"] = "IDENTITY-HASH"
+        let result = try runSigningConfiguration(
+            overrides: credentials,
+            identityLine: #"1) IDENTITY-HASH "Developer ID Application: Quill Cowork (ZZZZZ99999)""#
+        )
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(result.output.contains("configured Apple team does not own"))
+        XCTAssertTrue(result.securityLog.contains("delete-keychain"))
+        XCTAssertTrue(result.exportedEnvironment.isEmpty)
+        XCTAssertFalse(result.signingRootExists)
+    }
+
+    private struct SigningResult {
+        var exitCode: Int32
+        var output: String
+        var exportedEnvironment: String
+        var securityLog: String
+        var signingRootExists: Bool
+        var certificateContents: String?
+        var notaryKeyContents: String?
+        var certificatePermissions: Int?
+        var notaryKeyPermissions: Int?
+    }
+
+    private func runSigningConfiguration(
+        overrides: [String: String] = [:],
+        importFails: Bool = false,
+        identityLine: String = #"1) ABCDEF "Developer ID Application: Quill Cowork (ABCDE12345)""#
+    ) throws -> SigningResult {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-signing-configuration-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let binDirectory = temporaryDirectory.appendingPathComponent("bin")
+        let runnerTemp = temporaryDirectory.appendingPathComponent("runner")
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: runnerTemp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let securityURL = binDirectory.appendingPathComponent("security")
+        let securityLogURL = temporaryDirectory.appendingPathComponent("security.log")
+        let githubEnvironmentURL = temporaryDirectory.appendingPathComponent("github.env")
+        try fakeSecurity.write(to: securityURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: securityURL.path)
+        try Data().write(to: githubEnvironmentURL)
+
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts")
+                .appendingPathComponent("configure-macos-distribution-signing.sh")
+                .path
+        ]
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(binDirectory.path):\(environment["PATH"] ?? "")"
+        environment["RUNNER_TEMP"] = runnerTemp.path
+        environment["GITHUB_ENV"] = githubEnvironmentURL.path
+        environment["SIGNING_TEST_SECURITY_LOG"] = securityLogURL.path
+        environment["SIGNING_TEST_IMPORT_FAILS"] = importFails ? "true" : "false"
+        environment["SIGNING_TEST_IDENTITY_LINE"] = identityLine
+        for key in Self.credentialKeys {
+            environment[key] = ""
+        }
+        for (key, value) in overrides {
+            environment[key] = value
+        }
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let signingRoot = runnerTemp.appendingPathComponent("quill-cowork-signing")
+        let certificate = signingRoot.appendingPathComponent("developer-id.p12")
+        let notaryKey = signingRoot.appendingPathComponent("AuthKey_KEYID12345.p8")
+        return SigningResult(
+            exitCode: process.terminationStatus,
+            output: output,
+            exportedEnvironment: (try? String(contentsOf: githubEnvironmentURL, encoding: .utf8)) ?? "",
+            securityLog: (try? String(contentsOf: securityLogURL, encoding: .utf8)) ?? "",
+            signingRootExists: FileManager.default.fileExists(atPath: signingRoot.path),
+            certificateContents: try? String(contentsOf: certificate, encoding: .utf8),
+            notaryKeyContents: try? String(contentsOf: notaryKey, encoding: .utf8),
+            certificatePermissions: permissions(at: certificate),
+            notaryKeyPermissions: permissions(at: notaryKey)
+        )
+    }
+
+    private func permissions(at url: URL) -> Int? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let permissions = attributes[.posixPermissions] as? NSNumber
+        else { return nil }
+        return permissions.intValue
+    }
+
+    private var validCredentials: [String: String] {
+        [
+            "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64": Data("certificate-bytes".utf8).base64EncodedString(),
+            "APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD": "certificate-password",
+            "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY": "Developer ID Application: Quill Cowork (ABCDE12345)",
+            "APPLE_TEAM_ID": "ABCDE12345",
+            "APPLE_NOTARY_KEY_ID": "KEYID12345",
+            "APPLE_NOTARY_ISSUER_ID": "01234567-89ab-cdef-0123-456789abcdef",
+            "APPLE_NOTARY_PRIVATE_KEY_BASE64": Data("notary-key-bytes".utf8).base64EncodedString()
+        ]
+    }
+
+    private var fakeSecurity: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$*" >> "${SIGNING_TEST_SECURITY_LOG:?}"
+        case "$1" in
+          create-keychain)
+            touch "${@: -1}"
+            ;;
+          import)
+            if [[ "${SIGNING_TEST_IMPORT_FAILS:?}" == "true" ]]; then
+              exit 7
+            fi
+            ;;
+          find-identity)
+            printf '%s\n' "${SIGNING_TEST_IDENTITY_LINE:?}"
+            ;;
+          delete-keychain)
+            rm -f "${@: -1}"
+            ;;
+          set-keychain-settings|unlock-keychain|set-key-partition-list)
+            ;;
+          *)
+            echo "unexpected security invocation: $*" >&2
+            exit 9
+            ;;
+        esac
+        """
+    }
+
+    private static let credentialKeys = [
+        "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64",
+        "APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD",
+        "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY",
+        "APPLE_TEAM_ID",
+        "APPLE_NOTARY_KEY_ID",
+        "APPLE_NOTARY_ISSUER_ID",
+        "APPLE_NOTARY_PRIVATE_KEY_BASE64"
+    ]
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-08-09 Transactional Apple Signing Setup
+
+Overall grade after this slice: **A+ credential safety, A+ release integrity, A+ failure recovery**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Credential safety | A+ | The certificate and notary key decode only inside a mode-700 runner directory, receive mode 600, and never enter the workflow environment; only owned temporary paths and non-secret identifiers are exported. |
+| Release integrity | A+ | Team and key IDs must use Apple's 10-character form, the issuer must be a UUID, and the configured Developer ID identity must exist in the imported keychain and belong to the configured team. |
+| Failure recovery | A+ | A local exit trap deletes the temporary keychain and complete signing directory on decode, import, partition-list, identity, ownership, or environment-export failure. |
+| Regression coverage | A+ | Executable fake-`security` tests cover absent and partial configuration, malformed identifiers, complete success, import failure cleanup, and wrong-team rejection without requiring Apple credentials. |
+
+Validation:
+
+- Focused Apple signing configuration suite (6 tests, 0 failures)
+- Stable-release, download-workflow, and updater-signing contract suite (27 tests, 0 failures)
+- Full `swift test` (5,679 tests, 5 skipped, 0 failures)
+- `bash -n scripts/configure-macos-distribution-signing.sh`
+
 ## 2026-08-09 Bounded Native Smoke Wall Clock
 
 Overall grade after this slice: **A+ release fidelity, A+ bounded recovery, A+ configurability**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,27 @@
 # QuillCode Decisions
 
+## 2026-08-09: Apple signing setup is transactional and team-bound
+
+- **Decision:** Distribution setup validates Apple team and key identifiers plus the App Store
+  Connect issuer UUID before decoding secrets. After certificate import, the selected Developer ID
+  identity must be present in the private build keychain and its identity line must name the same
+  Apple team.
+- **Credential boundary:** Certificate and notary bytes remain in a mode-700 runner directory as
+  mode-600 files. The workflow environment receives only their paths and the non-secret signing
+  identifiers; certificate bytes, private-key bytes, certificate password, and generated keychain
+  password are never exported.
+- **Recovery:** Once sensitive files can exist, a local exit trap owns failure cleanup. Any decode,
+  keychain, import, partition, identity, ownership, or environment-write failure deletes the
+  temporary keychain and the complete signing directory before preserving the original exit status.
+  Successful setup transfers cleanup ownership to the workflow's unconditional cleanup step.
+- **Why:** Stable release automation was already fail-closed, but an import failure occurred before
+  cleanup paths were exported and therefore left decoded files for ephemeral-runner disposal. Stable
+  publication should be ready for real credentials without depending on runner destruction for
+  secret cleanup or discovering a team mismatch during final package validation.
+- **Evidence:** Six executable fake-tool cases prove no-op tester behavior, partial and malformed
+  rejection before disk writes, path-only success, import-failure cleanup, and wrong-team cleanup.
+  The complete stable-release, download, updater-signing, and full Swift suites remain green.
+
 ## 2026-08-09: native smoke wall-clock guards encompass semantic retry budgets
 
 - **Decision:** The packaged live-window process receives a named 90-second wall-clock guard. CI and

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -272,9 +272,17 @@ The certificate secret is a base64-encoded Developer ID Application `.p12`. The
 notary key secret is a base64-encoded App Store Connect API `.p8`. The workflow
 imports both into a temporary runner-only signing area, enables the hardened
 runtime, submits the zipped app to `notarytool`, staples and validates the ticket,
-and deletes temporary credential files. Partial secret configuration fails the
-macOS job. Missing secrets still permit ad-hoc tester builds, but stable `v*` tags
-fail before packaging.
+and deletes temporary credential files. `APPLE_TEAM_ID` and
+`APPLE_NOTARY_KEY_ID` must be their 10-character uppercase Apple identifiers;
+`APPLE_NOTARY_ISSUER_ID` must be the App Store Connect issuer UUID. The imported
+Developer ID identity must resolve inside the private build keychain and belong
+to `APPLE_TEAM_ID`.
+
+Partial configuration and malformed identifiers fail before decoded files are
+created. Once files can exist, any setup failure deletes the private keychain and
+complete signing directory locally; only successful setup transfers cleanup
+ownership to the workflow's unconditional cleanup step. Missing secrets still
+permit ad-hoc tester builds, but stable `v*` tags fail before packaging.
 
 ## Manual Build Refresh
 

--- a/scripts/configure-macos-distribution-signing.sh
+++ b/scripts/configure-macos-distribution-signing.sh
@@ -37,6 +37,18 @@ if [[ -z "${RUNNER_TEMP:-}" || -z "${GITHUB_ENV:-}" ]]; then
   echo "RUNNER_TEMP and GITHUB_ENV are required on the signing runner." >&2
   exit 2
 fi
+if [[ ! "$SIGNING_TEAM_IDENTIFIER" =~ ^[A-Z0-9]{10}$ ]]; then
+  echo "APPLE_TEAM_ID must be a 10-character uppercase Apple team identifier." >&2
+  exit 2
+fi
+if [[ ! "$NOTARY_KEY_ID" =~ ^[A-Z0-9]{10}$ ]]; then
+  echo "APPLE_NOTARY_KEY_ID must be a 10-character uppercase App Store Connect key identifier." >&2
+  exit 2
+fi
+if [[ ! "$NOTARY_ISSUER_ID" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]]; then
+  echo "APPLE_NOTARY_ISSUER_ID must be an App Store Connect issuer UUID." >&2
+  exit 2
+fi
 
 SIGNING_ROOT="$RUNNER_TEMP/quill-cowork-signing"
 CERTIFICATE_PATH="$SIGNING_ROOT/developer-id.p12"
@@ -44,11 +56,27 @@ NOTARY_KEY_PATH="$SIGNING_ROOT/AuthKey_${NOTARY_KEY_ID}.p8"
 KEYCHAIN_PATH="$SIGNING_ROOT/build.keychain-db"
 KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
 
+cleanup_failed_configuration() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if [[ -e "$KEYCHAIN_PATH" ]]; then
+    security delete-keychain "$KEYCHAIN_PATH" >/dev/null 2>&1
+  fi
+  rm -rf "$SIGNING_ROOT"
+  exit "$status"
+}
+trap cleanup_failed_configuration EXIT
+
 mkdir -p "$SIGNING_ROOT"
 chmod 700 "$SIGNING_ROOT"
 printf '%s' "$CERTIFICATE_BASE64" | openssl base64 -d -A > "$CERTIFICATE_PATH"
 printf '%s' "$NOTARY_KEY_BASE64" | openssl base64 -d -A > "$NOTARY_KEY_PATH"
 chmod 600 "$CERTIFICATE_PATH" "$NOTARY_KEY_PATH"
+if [[ ! -s "$CERTIFICATE_PATH" || ! -s "$NOTARY_KEY_PATH" ]]; then
+  echo "Apple signing credentials decoded to an empty file." >&2
+  exit 2
+fi
 
 security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
@@ -63,7 +91,22 @@ security set-key-partition-list \
   -s \
   -k "$KEYCHAIN_PASSWORD" \
   "$KEYCHAIN_PATH"
-security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -F "$SIGNING_IDENTITY" >/dev/null
+IDENTITY_OUTPUT="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH")"
+IDENTITY_LINE=""
+while IFS= read -r line; do
+  if [[ "$line" == *"$SIGNING_IDENTITY"* ]]; then
+    IDENTITY_LINE="$line"
+    break
+  fi
+done <<< "$IDENTITY_OUTPUT"
+if [[ -z "$IDENTITY_LINE" ]]; then
+  echo "The imported keychain does not contain the configured Developer ID identity." >&2
+  exit 2
+fi
+if [[ "$IDENTITY_LINE" != *"($SIGNING_TEAM_IDENTIFIER)"* ]]; then
+  echo "The configured Apple team does not own the imported Developer ID identity." >&2
+  exit 2
+fi
 
 {
   echo "QUILLCODE_MACOS_SIGNING_IDENTITY=$SIGNING_IDENTITY"
@@ -75,4 +118,5 @@ security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -F "$SIGNING_ID
   echo "QUILLCODE_MACOS_NOTARY_KEY_PATH=$NOTARY_KEY_PATH"
 } >> "$GITHUB_ENV"
 
+trap - EXIT
 echo "Configured Developer ID signing and App Store Connect notarization credentials."


### PR DESCRIPTION
## Summary
- validate Apple team, key, and issuer identifiers before decoding credentials
- clean up the private keychain and decoded secrets transactionally on every setup failure
- require the imported Developer ID identity to belong to the configured Apple team
- add executable fake-security coverage for success and failure paths

## Validation
- `bash -n scripts/configure-macos-distribution-signing.sh`
- focused signing suite: 6 tests, 0 failures
- release/signing contract suite: 27 tests, 0 failures
- full `swift test`: 5,679 tests, 5 skipped, 0 failures
- all module quality grades: A+