### PR TITLE
Harden updater feed propagation verification

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdaterSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdaterSmokeRunner.swift
@@ -31,6 +31,9 @@ struct QuillCodeDesktopUpdaterSmokeReport: Codable, Equatable, Sendable {
 
 @MainActor
 enum QuillCodeDesktopUpdaterSmokeRunner {
+    static let feedPropagationAttemptLimit = 6
+    private static let feedPropagationRetryDelayNanoseconds: UInt64 = 2_000_000_000
+
     static func runAndExit(_ request: QuillCodeDesktopUpdaterSmokeRequest) async -> Never {
         let report: QuillCodeDesktopUpdaterSmokeReport
         do {
@@ -66,12 +69,7 @@ enum QuillCodeDesktopUpdaterSmokeRunner {
         guard let configuration = QuillCodeDesktopUpdateConfiguration.bundled() else {
             throw QuillCodeDesktopUpdateError.updatesUnavailable
         }
-        let result = try await QuillCodeDesktopUpdateChecker().check(configuration: configuration)
-        guard case .updateAvailable(let release) = result else {
-            throw QuillCodeDesktopUpdateError.installationFailed(
-                "the smoke fixture was not older than the published update"
-            )
-        }
+        let release = try await waitForAvailableUpdate(configuration: configuration)
         let prepared = try await QuillCodeDesktopUpdatePreparer().prepare(
             release: release,
             configuration: configuration
@@ -88,6 +86,27 @@ enum QuillCodeDesktopUpdaterSmokeRunner {
             targetBuild: release.build,
             targetCommit: release.commit,
             message: "The verified update was staged and its detached installer started."
+        )
+    }
+
+    static func waitForAvailableUpdate(
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        checker: any QuillCodeDesktopUpdateChecking = QuillCodeDesktopUpdateChecker(),
+        retryDelay: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(nanoseconds: feedPropagationRetryDelayNanoseconds)
+        }
+    ) async throws -> QuillCodeDesktopUpdateRelease {
+        for attempt in 1...feedPropagationAttemptLimit {
+            let result = try await checker.check(configuration: configuration)
+            if case .updateAvailable(let release) = result {
+                return release
+            }
+            if attempt < feedPropagationAttemptLimit {
+                try await retryDelay()
+            }
+        }
+        throw QuillCodeDesktopUpdateError.installationFailed(
+            "the published update feed did not advance beyond the smoke fixture after bounded retries"
         )
     }
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdaterSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdaterSmokeTests.swift
@@ -37,4 +37,123 @@ final class QuillCodeDesktopUpdaterSmokeTests: XCTestCase {
         )
         XCTAssertEqual(decoded, report)
     }
+
+    @MainActor
+    func testAvailableUpdateRetriesAStalePublishedFeed() async throws {
+        let release = makeRelease()
+        let checker = UpdaterSmokeCheckerStub(results: [
+            .upToDate(latestVersion: "0.1.0", latestBuild: "680"),
+            .upToDate(latestVersion: "0.1.0", latestBuild: "680"),
+            .updateAvailable(release),
+        ])
+        let delay = UpdaterSmokeRetryDelaySpy()
+
+        let result = try await QuillCodeDesktopUpdaterSmokeRunner.waitForAvailableUpdate(
+            configuration: makeConfiguration(),
+            checker: checker,
+            retryDelay: { await delay.record() }
+        )
+
+        XCTAssertEqual(result, release)
+        let checkCallCount = await checker.callCount
+        let delayCallCount = await delay.callCount
+        XCTAssertEqual(checkCallCount, 3)
+        XCTAssertEqual(delayCallCount, 2)
+    }
+
+    @MainActor
+    func testAvailableUpdateFailsAfterBoundedStaleFeedRetries() async throws {
+        let checker = UpdaterSmokeCheckerStub(results: [
+            .upToDate(latestVersion: "0.1.0", latestBuild: "680"),
+        ])
+        let delay = UpdaterSmokeRetryDelaySpy()
+
+        do {
+            _ = try await QuillCodeDesktopUpdaterSmokeRunner.waitForAvailableUpdate(
+                configuration: makeConfiguration(),
+                checker: checker,
+                retryDelay: { await delay.record() }
+            )
+            XCTFail("Expected a stale feed to fail after bounded retries")
+        } catch {
+            XCTAssertEqual(
+                error as? QuillCodeDesktopUpdateError,
+                .installationFailed(
+                    "the published update feed did not advance beyond the smoke fixture after bounded retries"
+                )
+            )
+        }
+
+        let checkCallCount = await checker.callCount
+        let delayCallCount = await delay.callCount
+        XCTAssertEqual(checkCallCount, QuillCodeDesktopUpdaterSmokeRunner.feedPropagationAttemptLimit)
+        XCTAssertEqual(delayCallCount, QuillCodeDesktopUpdaterSmokeRunner.feedPropagationAttemptLimit - 1)
+    }
+
+    private func makeConfiguration() -> QuillCodeDesktopUpdateConfiguration {
+        QuillCodeDesktopUpdateConfiguration(
+            channel: .tester,
+            manifestURL: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json")!,
+            stableManifestURL: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json")!,
+            testerManifestURL: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json")!,
+            currentVersion: "0.1.0",
+            currentBuild: "680",
+            bundleIdentifier: "co.lorehex.QuillCowork",
+            architecture: "arm64",
+            applicationURL: URL(fileURLWithPath: "/Applications/Quill Cowork.app"),
+            expectedSigningTeamIdentifier: nil
+        )
+    }
+
+    private func makeRelease() -> QuillCodeDesktopUpdateRelease {
+        QuillCodeDesktopUpdateRelease(
+            channel: .tester,
+            tag: "tester-latest",
+            releaseURL: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest")!,
+            commit: String(repeating: "a", count: 40),
+            version: "0.1.0",
+            build: "681",
+            asset: QuillCodeDesktopUpdateManifest.Asset(
+                name: "Quill-Cowork-macOS-arm64.zip",
+                kind: "app-zip",
+                platform: "macOS",
+                arch: "arm64",
+                install: "Applications",
+                sizeBytes: 1,
+                sha256: String(repeating: "b", count: 64),
+                url: URL(string: "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip")!
+            ),
+            signingRequirement: .adHoc
+        )
+    }
+}
+
+private actor UpdaterSmokeCheckerStub: QuillCodeDesktopUpdateChecking {
+    private var results: [QuillCodeDesktopUpdateCheckResult]
+    private(set) var callCount = 0
+
+    init(results: [QuillCodeDesktopUpdateCheckResult]) {
+        self.results = results
+    }
+
+    func check(
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws -> QuillCodeDesktopUpdateCheckResult {
+        callCount += 1
+        guard let result = results.first else {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+        if results.count > 1 {
+            results.removeFirst()
+        }
+        return result
+    }
+}
+
+private actor UpdaterSmokeRetryDelaySpy {
+    private(set) var callCount = 0
+
+    func record() {
+        callCount += 1
+    }
 }

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -12,7 +12,10 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "QuillCodeDesktopUpdaterSmokeRunner.runAndExit"
         ])
         Self.assertSource(runner, containsAll: [
-            "QuillCodeDesktopUpdateChecker().check",
+            "waitForAvailableUpdate(configuration: configuration)",
+            "feedPropagationAttemptLimit = 6",
+            "if case .updateAvailable(let release) = result",
+            "try await retryDelay()",
             "QuillCodeDesktopUpdatePreparer().prepare",
             "QuillCodeDesktopUpdateInstaller().stageAndLaunch",
             "targetCommit: release.commit"

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-08-09 Bounded Public-Updater Feed Propagation
+
+Overall grade after this slice: **A+ release resilience, A+ failure integrity, A+ regression evidence**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Release resilience | A+ | Public updater smoke tolerates the short GitHub release-asset replacement window with six bounded feed checks separated by two seconds. |
+| Failure integrity | A+ | Only a valid but not-yet-newer feed is retried; transport, schema, product, architecture, signing, checksum, preparation, installation, and relaunch failures still fail immediately. |
+| Operational evidence | A+ | Build 681 initially observed the previous build 680 feed on Apple silicon while Intel updated successfully; a workflow rerun after propagation then verified both architectures end to end. |
+| Regression coverage | A+ | Unit tests prove eventual success, exact retry and delay counts, and bounded exhaustion; the packaged-updater parity gate pins retry ownership beside download, swap, cleanup, and relaunch evidence. |
+
+Validation:
+
+- Focused updater-smoke and packaged parity suites (5 tests, 0 failures)
+- Full `swift test` (5,707 tests, 5 skipped, 0 failures)
+- Public build 681 updater rerun: arm64 and x86_64 both passed update, activation, cleanup, and relaunch
+- Public build and download manifest verification passed for exact main commit `5aa35a70c42c3fcd010c5dbfde46109f1b8cfc95`
+
 ## 2026-08-09 Unique Main-Window Ownership
 
 Overall grade after this slice: **A+ memory ownership, A+ lifecycle UX, A+ release hygiene**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,17 @@
 # QuillCode Decisions
 
+## 2026-08-09: public updater smoke waits out bounded feed propagation
+
+- **Decision:** The packaged public-updater runner retries only an authenticated, valid feed that
+  still reports the smoke fixture as current. It makes at most six checks with a two-second delay.
+- **Failure boundary:** Invalid responses, malformed or mismatched manifests, unsupported
+  architecture, signing or checksum failures, preparation errors, activation failures, and relaunch
+  failures remain immediate hard failures. Exhausted stale-feed retries fail publication.
+- **Why:** GitHub replaces the stable manifest asset in place. During build 681 publication, the
+  Apple silicon verifier reached that URL seconds before propagation completed and saw build 680;
+  Intel reached it moments later and completed 680-to-681 update and relaunch. A short bounded wait
+  distinguishes eventual release propagation from a broken updater without masking integrity bugs.
+
 ## 2026-08-09: the desktop has one main-window owner
 
 - **Decision:** The product workspace is a uniquely identified SwiftUI `Window`, not a


### PR DESCRIPTION
## Summary
- retry a valid but stale public updater feed for six bounded checks with two-second delays
- preserve immediate failure for malformed feeds, integrity errors, preparation, installation, cleanup, and relaunch failures
- add deterministic retry/exhaustion tests, parity coverage, and release audit evidence

## Incident
During build 681 publication, the arm64 verifier reached GitHub while the moving tester manifest still served build 680. The x86_64 verifier fetched build 681 seconds later and passed. Rerunning after propagation verified both architectures.

## Verification
- focused updater-smoke and packaged parity suites: 5 tests, 0 failures
- full `swift test`: 5,707 tests, 5 skipped, 0 failures
- code-quality modules remain A+
- `git diff --check`
- secret-pattern scan passed
- public build 681 updater rerun passed arm64 and x86_64 end to end