### PR TITLE
Shrink release app executable before signing

### DIFF
--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -18,6 +18,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             build=123
             commit=\(commit)
             configuration=release
+            symbolsStripped=true
+            executableSizeBytes=28311552
             bundleIdentifier=co.lorehex.QuillCowork
             minimumSystemVersion=14.0
             updateChannel=tester
@@ -200,6 +202,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             build=456
             commit=\(commit)
             configuration=release
+            symbolsStripped=true
+            executableSizeBytes=28311552
             bundleIdentifier=co.lorehex.QuillCowork
             minimumSystemVersion=14.0
             updateChannel=stable
@@ -440,6 +444,12 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "QUILLCODE_MACOS_BUILD_COMMIT=\"$COMMIT\"",
             "installer=Quill-Cowork-macOS-$ARCH.dmg",
             "performance=Quill-Cowork-macOS-$ARCH-PERFORMANCE.json",
+            "SYMBOLS_STRIPPED=false",
+            #"if [[ "$CONFIGURATION" == "release" ]]; then"#,
+            "SYMBOLS_STRIPPED=true",
+            "symbolsStripped=$SYMBOLS_STRIPPED",
+            "executableSizeBytes=$APP_EXECUTABLE_SIZE_BYTES",
+            "stat -f '%z' \"$APP_EXECUTABLE\"",
             "scripts/packaged-macos-performance-smoke.sh",
             "scripts/create-macos-disk-image.sh",
             "signingTeamIdentifier=${SIGNING_TEAM_IDENTIFIER:-none}",

--- a/Tests/QuillCodeParityTests/ParityMacOSReleaseExecutableStripTests.swift
+++ b/Tests/QuillCodeParityTests/ParityMacOSReleaseExecutableStripTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import XCTest
+
+final class ParityMacOSReleaseExecutableStripTests: QuillCodeParityTestCase {
+    func testStripHelperUsesSizeOptimizedSymbolPolicy() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runStrip(fixture: fixture, executable: fixture.executable)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertEqual(result.arguments, ["-S", "-x", fixture.executable.path])
+        XCTAssertEqual(try Data(contentsOf: fixture.executable), Data("stripped-release-binary".utf8))
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fixture.executable.path))
+        XCTAssertTrue(result.output.contains("Stripped release executable:"))
+        XCTAssertTrue(result.output.contains("removed"))
+    }
+
+    func testStripHelperRejectsSymlinkBeforeInvokingTool() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let symlink = fixture.root.appendingPathComponent("linked-executable")
+        try FileManager.default.createSymbolicLink(
+            at: symlink,
+            withDestinationURL: fixture.executable
+        )
+        let original = try Data(contentsOf: fixture.executable)
+
+        let result = try runStrip(fixture: fixture, executable: symlink)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(result.output.contains("must be a regular executable file"))
+        XCTAssertTrue(result.arguments.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: fixture.executable), original)
+    }
+
+    func testReleaseBuildStripsAfterCopyAndBeforeSigning() throws {
+        let root = Self.packageRoot()
+        let buildScript = try String(
+            contentsOf: root.appendingPathComponent("scripts/build-macos-app.sh"),
+            encoding: .utf8
+        )
+        let stripScript = try String(
+            contentsOf: root.appendingPathComponent("scripts/strip-macos-release-executable.sh"),
+            encoding: .utf8
+        )
+
+        Self.assertSource(buildScript, containsAll: [
+            #"if [[ "$CONFIGURATION" == "release" ]]; then"#,
+            #""$ROOT_DIR/scripts/strip-macos-release-executable.sh" "$MACOS_DIR/$APP_NAME""#,
+        ])
+        Self.assertSource(stripScript, containsAll: [
+            #"STRIP_BIN="${QUILLCODE_MACOS_STRIP_BIN:-/usr/bin/strip}""#,
+            #""$STRIP_BIN" -S -x "$EXECUTABLE""#,
+            #"[[ -L "$EXECUTABLE" || ! -f "$EXECUTABLE" || ! -x "$EXECUTABLE" ]]"#,
+        ])
+
+        let copy = try XCTUnwrap(buildScript.range(
+            of: #"cp "$SOURCE_EXECUTABLE" "$MACOS_DIR/$APP_NAME""#
+        ))
+        let strip = try XCTUnwrap(buildScript.range(of: "strip-macos-release-executable.sh"))
+        let signing = try XCTUnwrap(buildScript.range(of: #"if [[ -n "$SIGNING_IDENTITY" ]]; then"#))
+        XCTAssertLessThan(copy.lowerBound, strip.lowerBound)
+        XCTAssertLessThan(strip.lowerBound, signing.lowerBound)
+    }
+
+    private struct Fixture {
+        var root: URL
+        var executable: URL
+        var stripTool: URL
+        var argumentsLog: URL
+    }
+
+    private struct StripResult {
+        var exitCode: Int32
+        var output: String
+        var arguments: [String]
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-release-strip-tests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let executable = root.appendingPathComponent("Quill Cowork")
+        try Data(repeating: 0x51, count: 4_096).write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executable.path
+        )
+
+        let stripTool = root.appendingPathComponent("strip")
+        let argumentsLog = root.appendingPathComponent("strip-arguments.txt")
+        let fakeStrip = """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\n' "$@" > "${STRIP_TEST_ARGUMENTS_LOG:?}"
+        printf 'stripped-release-binary' > "${@: -1}"
+        """
+        try fakeStrip.write(to: stripTool, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: stripTool.path
+        )
+        return Fixture(
+            root: root,
+            executable: executable,
+            stripTool: stripTool,
+            argumentsLog: argumentsLog
+        )
+    }
+
+    private func runStrip(fixture: Fixture, executable: URL) throws -> StripResult {
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts/strip-macos-release-executable.sh")
+                .path,
+            executable.path,
+        ]
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+        var environment = ProcessInfo.processInfo.environment
+        environment["QUILLCODE_MACOS_STRIP_BIN"] = fixture.stripTool.path
+        environment["STRIP_TEST_ARGUMENTS_LOG"] = fixture.argumentsLog.path
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let arguments = ((try? String(contentsOf: fixture.argumentsLog, encoding: .utf8)) ?? "")
+            .split(separator: "\n")
+            .map(String.init)
+        return StripResult(
+            exitCode: process.terminationStatus,
+            output: output,
+            arguments: arguments
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -302,6 +302,19 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         )
     }
 
+    func testVerifierRejectsExecutableSizeThatDisagreesWithAppArchive() throws {
+        let fixture = try makeFixture(armExecutableSizeBytes: 31)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("macOS app executable size disagrees with BUILD_INFO"),
+            result.output
+        )
+    }
+
     func testVerifierRejectsIncompleteUpdaterArchitectureInventory() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
@@ -360,6 +373,7 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         intelExecutableArchitecture: String = "x86_64",
         channel: String = "tester",
         prerelease: Bool? = nil,
+        armExecutableSizeBytes: Int = 32,
         performanceMutation: ((inout [String: Any]) throws -> Void)? = nil
     ) throws -> Fixture {
         precondition(channel == "tester" || channel == "stable")
@@ -417,6 +431,8 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             commit=\(commit)
             createdAt=2026-08-07T00:00:00Z
             configuration=release
+            symbolsStripped=true
+            executableSizeBytes=\(architecture == "arm64" ? armExecutableSizeBytes : 32)
             bundleIdentifier=co.lorehex.QuillCowork
             minimumSystemVersion=14.0
             updateChannel=\(channel)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,26 @@
 # Code Quality Audit
 
+## 2026-08-09 Pre-Sign Release Executable Stripping
+
+Overall grade after this slice: **A+ binary footprint, A+ signing integrity, A+ public evidence**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Binary footprint | A+ | The measured arm64 release executable falls from 56,099,184 to 28,144,256 bytes after `strip -S -x`, removing 49.8%; the final ad-hoc signed app image is 27,998,784 bytes. |
+| Runtime integrity | A+ | The stripped executable completed the full native window smoke, including launch, two interaction sweeps, Accessibility activation, screenshot capture, memory/thread evidence, and clean exit. |
+| Signing integrity | A+ | Only release builds strip, and the operation is ordered after bundle copy but before every ad-hoc or Developer ID signing path. Debug symbols remain available in development builds. |
+| Public verification | A+ | `BUILD_INFO` declares the strip policy and exact executable bytes; publication compares that value to the regular thin Mach-O entry inside each downloaded app ZIP. |
+| Regression coverage | A+ | Executable helper tests prove exact flags and symlink refusal; packaging-order, manifest, and adversarial public-verifier suites cover the complete release path. |
+
+Validation:
+
+- Focused strip, download-manifest, and published-release suites (31 tests, 0 failures)
+- Full `swift test` (5,711 tests, 5 skipped, 0 failures)
+- `bash -n` for the strip helper and macOS app builder
+- Python compile validation for the manifest generator and public artifact verifier
+- Real stripped and signed release app native window smoke passed with one workspace window,
+  10 Accessibility actions, two interaction sweeps, and 372.73 ms launch-ready
+
 ## 2026-08-09 Bounded Public-Updater Feed Propagation
 
 Overall grade after this slice: **A+ release resilience, A+ failure integrity, A+ regression evidence**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # QuillCode Decisions
 
+## 2026-08-09: release app executables are stripped before signing
+
+- **Decision:** macOS release apps remove debug symbols and local symbols with `strip -S -x` after
+  the Swift executable is copied into the app bundle and before ad-hoc or Developer ID signing.
+  Debug builds retain their symbols for development and CI diagnosis.
+- **Integrity boundary:** The strip helper accepts only one regular executable file, rejects
+  symlinks and unavailable tools, and fails if stripping removes executability, empties the image,
+  or grows it. Signing remains downstream so stripping cannot invalidate a finished signature.
+- **Public evidence:** Architecture-specific `BUILD_INFO` files declare the strip policy and exact
+  executable size. The public verifier compares that size with the regular Mach-O entry inside the
+  downloaded ZIP in addition to checking its thin architecture and app metadata.
+- **Why:** The arm64 release executable measured 56,099,184 bytes before stripping and 28,144,256
+  bytes afterward, a 49.8% reduction. Smaller native images reduce download and cold page-in work
+  while retaining global symbols for useful crash backtraces.
+
 ## 2026-08-09: public updater smoke waits out bounded feed propagation
 
 - **Decision:** The packaged public-updater runner retries only an authenticated, valid feed that

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -41,6 +41,11 @@ version, signing/notarization status, and exact arm64 and x86_64 updater assets.
 The legacy arm64 field remains present so already-installed tester builds continue
 to update. The DMG is the recommended human installation path; the ZIP remains the
 machine-verified updater payload so installation ergonomics cannot change update semantics.
+Every macOS `BUILD_INFO` also records `symbolsStripped=true` and the exact uncompressed
+app-executable byte size. Release builds remove debug and local symbols before any ad-hoc or
+Developer ID signature is applied. Public verification compares the declared size with the Mach-O
+inside each downloaded app ZIP, so a skipped strip step, stale metadata, or post-sign mutation
+cannot pass publication.
 
 When Quill Cowork is launched directly from the read-only DMG or another
 non-replaceable location outside `/Applications`, it offers **Move & Relaunch**.

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -63,6 +63,11 @@ def parse_macos_build_info(asset_directory: Path) -> dict[str, dict[str, str]]:
         values = parse_build_info_file(path)
         if values.get("platform") != "macOS" or values.get("arch") != architecture:
             raise SystemExit(f"{path.name} has the wrong platform or architecture")
+        if values.get("symbolsStripped") != "true":
+            raise SystemExit(f"{path.name} must declare symbolsStripped=true")
+        executable_size = values.get("executableSizeBytes", "")
+        if not executable_size.isdecimal() or int(executable_size) <= 0:
+            raise SystemExit(f"{path.name} executableSizeBytes must be a positive integer")
         values_by_arch[architecture] = values
 
     canonical_path = asset_directory / "BUILD_INFO.txt"
@@ -77,6 +82,7 @@ def parse_macos_build_info(asset_directory: Path) -> dict[str, dict[str, str]]:
         "build",
         "commit",
         "configuration",
+        "symbolsStripped",
         "bundleIdentifier",
         "minimumSystemVersion",
         "updateChannel",

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -84,6 +84,9 @@ rm -rf "$APP_BUNDLE"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 cp "$SOURCE_EXECUTABLE" "$MACOS_DIR/$APP_NAME"
 chmod 755 "$MACOS_DIR/$APP_NAME"
+if [[ "$CONFIGURATION" == "release" ]]; then
+  "$ROOT_DIR/scripts/strip-macos-release-executable.sh" "$MACOS_DIR/$APP_NAME"
+fi
 if [[ -f "$APP_ICON_SOURCE" ]]; then
   cp "$APP_ICON_SOURCE" "$RESOURCES_DIR/QuillCode.icns"
 fi

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -90,6 +90,12 @@ APP_BUNDLE="$(
 APP_ZIP="$ASSET_DIR/Quill-Cowork-macOS-$ARCH.zip"
 APP_DMG="$ASSET_DIR/Quill-Cowork-macOS-$ARCH.dmg"
 PERFORMANCE_MANIFEST="$ASSET_DIR/Quill-Cowork-macOS-$ARCH-PERFORMANCE.json"
+APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/Quill Cowork"
+APP_EXECUTABLE_SIZE_BYTES="$(stat -f '%z' "$APP_EXECUTABLE")"
+SYMBOLS_STRIPPED=false
+if [[ "$CONFIGURATION" == "release" ]]; then
+  SYMBOLS_STRIPPED=true
+fi
 NOTARIZED=false
 CODESIGN_KIND="ad-hoc"
 if [[ -n "$SIGNING_IDENTITY" ]]; then
@@ -163,6 +169,8 @@ build=$BUILD_NUMBER
 commit=$COMMIT
 createdAt=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 configuration=$CONFIGURATION
+symbolsStripped=$SYMBOLS_STRIPPED
+executableSizeBytes=$APP_EXECUTABLE_SIZE_BYTES
 bundleIdentifier=$BUNDLE_ID
 minimumSystemVersion=$MINIMUM_SYSTEM_VERSION
 updateChannel=$UPDATE_CHANNEL

--- a/scripts/release_verification_files.py
+++ b/scripts/release_verification_files.py
@@ -22,6 +22,7 @@ from release_verification_performance import verify_performance_evidence_asset
 
 APP_INFO_BYTE_LIMIT = 256 * 1024
 APP_ARCHIVE_ENTRY_LIMIT = 20_000
+APP_EXECUTABLE_BYTE_LIMIT = 512 * 1024 * 1024
 MACHO_CPU_TYPES = {
     "arm64": 0x0100000C,
     "x86_64": 0x01000007,
@@ -86,10 +87,11 @@ def verify_build_info(
     *,
     channel: str,
     commit: str,
-) -> None:
+) -> dict[str, int]:
     updater = manifest["updater"]
     signing_team = updater.get("signingTeamIdentifier") or "none"
     asset_names = {asset["name"] for asset in assets}
+    executable_sizes: dict[str, int] = {}
     for app_asset in updater["macOSAppAssets"]:
         architecture = app_asset["arch"]
         build_info_name = f"BUILD_INFO-macOS-{architecture}.txt"
@@ -105,6 +107,7 @@ def verify_build_info(
             "build": manifest["build"],
             "commit": commit,
             "configuration": "release",
+            "symbolsStripped": "true",
             "bundleIdentifier": BUNDLE_IDENTIFIER,
             "minimumSystemVersion": updater["minimumSystemVersion"],
             "updateChannel": channel,
@@ -124,6 +127,17 @@ def verify_build_info(
                 raise VerificationError(
                     f"{build_info_name} {key} disagrees with the manifest"
                 )
+        raw_executable_size = build_info.get("executableSizeBytes", "")
+        if not raw_executable_size.isdecimal():
+            raise VerificationError(
+                f"{build_info_name} executableSizeBytes is not a positive integer"
+            )
+        executable_size = int(raw_executable_size)
+        if executable_size <= 0 or executable_size > APP_EXECUTABLE_BYTE_LIMIT:
+            raise VerificationError(
+                f"{build_info_name} executableSizeBytes is outside the allowed range"
+            )
+        executable_sizes[architecture] = executable_size
         for asset_key in ("installer", "app", "performance", "cli"):
             if build_info[asset_key] not in asset_names:
                 raise VerificationError(
@@ -144,6 +158,7 @@ def verify_build_info(
         raise VerificationError(
             "BUILD_INFO.txt must exactly mirror BUILD_INFO-macOS-arm64.txt"
         )
+    return executable_sizes
 
 
 def verify_primary_checksums(
@@ -207,6 +222,7 @@ def verify_app_archive(
     *,
     channel: str,
     commit: str,
+    expected_executable_size: int,
 ) -> None:
     updater = manifest["updater"]
     archive_path = asset_directory / app_asset["name"]
@@ -227,6 +243,10 @@ def verify_app_archive(
                 executable_path,
                 "executable",
             )
+            if executable_entry.file_size != expected_executable_size:
+                raise VerificationError(
+                    "macOS app executable size disagrees with BUILD_INFO"
+                )
             with archive.open(executable_entry) as handle:
                 executable_header = handle.read(8)
     except VerificationError:
@@ -291,7 +311,7 @@ def verify_asset_files(
             )
     verify_primary_checksums(asset_directory, assets)
     verify_performance_evidence_asset(asset_directory, assets, manifest)
-    verify_build_info(
+    executable_sizes = verify_build_info(
         asset_directory,
         assets,
         manifest,
@@ -310,4 +330,5 @@ def verify_asset_files(
             manifest,
             channel=channel,
             commit=commit,
+            expected_executable_size=executable_sizes[architecture],
         )

--- a/scripts/strip-macos-release-executable.sh
+++ b/scripts/strip-macos-release-executable.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: strip-macos-release-executable.sh EXECUTABLE" >&2
+  exit 2
+fi
+
+EXECUTABLE="$1"
+STRIP_BIN="${QUILLCODE_MACOS_STRIP_BIN:-/usr/bin/strip}"
+
+if [[ -L "$EXECUTABLE" || ! -f "$EXECUTABLE" || ! -x "$EXECUTABLE" ]]; then
+  echo "Release executable must be a regular executable file: $EXECUTABLE" >&2
+  exit 2
+fi
+if [[ ! -x "$STRIP_BIN" ]]; then
+  echo "macOS strip tool is missing or not executable: $STRIP_BIN" >&2
+  exit 2
+fi
+
+BEFORE_BYTES="$(wc -c < "$EXECUTABLE")"
+BEFORE_BYTES=$((BEFORE_BYTES))
+"$STRIP_BIN" -S -x "$EXECUTABLE"
+
+if [[ -L "$EXECUTABLE" || ! -f "$EXECUTABLE" || ! -x "$EXECUTABLE" ]]; then
+  echo "Stripping did not preserve a regular executable file: $EXECUTABLE" >&2
+  exit 1
+fi
+
+AFTER_BYTES="$(wc -c < "$EXECUTABLE")"
+AFTER_BYTES=$((AFTER_BYTES))
+if [[ "$AFTER_BYTES" -le 0 || "$AFTER_BYTES" -gt "$BEFORE_BYTES" ]]; then
+  echo "Stripping produced an invalid release executable size: $BEFORE_BYTES -> $AFTER_BYTES" >&2
+  exit 1
+fi
+
+SAVED_BYTES=$((BEFORE_BYTES - AFTER_BYTES))
+echo "Stripped release executable: $BEFORE_BYTES -> $AFTER_BYTES bytes ($SAVED_BYTES removed)." >&2


### PR DESCRIPTION
## Summary
- strip release-only macOS executables before signing, reducing the measured arm64 binary by 49.8%
- publish exact executable size and strip policy in BUILD_INFO
- verify that public app ZIPs contain a matching regular thin Mach-O executable

## Verification
- focused release-strip and publication suites: 31 tests, 0 failures
- full swift test: 5,711 tests, 5 skipped, 0 failures
- real stripped and signed release app native-window smoke: launch, Accessibility, interaction, memory, and clean exit passed
- bash syntax, Python compile, diff hygiene, code-quality, and secret-pattern checks passed