### PR TITLE
Surface failed chat persistence

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -78,6 +78,7 @@ public final class QuillCodeWorkspaceModel {
     /// can supply a fake `ToolResult` instead of spawning a real shell. nil = run the real command.
     var verificationRunner: (@Sendable (LocalEnvironmentAction, URL) async -> ToolResult)?
     let threadPersistence: WorkspaceThreadPersistence
+    let threadPersistenceIssueTracker: WorkspaceThreadPersistenceIssueTracker
     private let projectStore: JSONProjectStore?
     private let automationStore: JSONAutomationStore?
     private let sidebarSavedSearchStore: JSONSidebarSavedSearchStore?
@@ -222,7 +223,12 @@ public final class QuillCodeWorkspaceModel {
         self.runner = runner
         self.subagentSchedulerOverride = nil
         self.contextSummaryGenerator = contextSummaryGenerator
-        self.threadPersistence = WorkspaceThreadPersistence(store: threadStore)
+        let threadPersistenceIssueTracker = WorkspaceThreadPersistenceIssueTracker()
+        self.threadPersistenceIssueTracker = threadPersistenceIssueTracker
+        self.threadPersistence = WorkspaceThreadPersistence(
+            store: threadStore,
+            issueTracker: threadPersistenceIssueTracker
+        )
         self.startupLoadIssue = startupLoadIssue ?? WorkspaceStartupLoadIssue(
             loadedThreadCount: root.threads.count,
             threadLoadIssue: threadLoadIssue,

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -308,6 +308,9 @@ public extension QuillCodeWorkspaceModel {
         if let startupLoadIssue {
             return startupLoadIssue.runtimeIssue
         }
+        if let persistenceIssue = threadPersistenceIssueTracker.runtimeIssue {
+            return persistenceIssue
+        }
         return WorkspaceRuntimeIssueBuilder(
             config: root.config,
             hasStoredAPIKey: root.trustedRouterAPIKeyConfigured,

--- a/Sources/QuillCodeApp/WorkspaceThreadPersistence.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadPersistence.swift
@@ -5,20 +5,37 @@ import QuillCodePersistence
 struct WorkspaceThreadPersistence {
     let store: JSONThreadStore?
     let now: @Sendable () -> Date
+    let issueTracker: WorkspaceThreadPersistenceIssueTracker
 
-    init(store: JSONThreadStore?, now: @escaping @Sendable () -> Date = Date.init) {
+    init(
+        store: JSONThreadStore?,
+        now: @escaping @Sendable () -> Date = Date.init,
+        issueTracker: WorkspaceThreadPersistenceIssueTracker = WorkspaceThreadPersistenceIssueTracker()
+    ) {
         self.store = store
         self.now = now
+        self.issueTracker = issueTracker
     }
 
     func save(_ thread: ChatThread) {
-        guard !thread.runtimeContext.isEphemeral else { return }
-        try? store?.save(thread)
+        guard !thread.runtimeContext.isEphemeral, let store else { return }
+        do {
+            try store.save(thread)
+            issueTracker.recordSuccess(for: thread.id)
+        } catch {
+            issueTracker.recordFailure(for: thread.id)
+        }
     }
 
     func saveOrThrow(_ thread: ChatThread) throws {
-        guard !thread.runtimeContext.isEphemeral else { return }
-        try store?.save(thread)
+        guard !thread.runtimeContext.isEphemeral, let store else { return }
+        do {
+            try store.save(thread)
+            issueTracker.recordSuccess(for: thread.id)
+        } catch {
+            issueTracker.recordFailure(for: thread.id)
+            throw error
+        }
     }
 
     func save(_ threads: [ChatThread]) {
@@ -28,7 +45,13 @@ struct WorkspaceThreadPersistence {
     }
 
     func delete(_ id: UUID) {
-        try? store?.delete(id)
+        guard let store else { return }
+        do {
+            try store.delete(id)
+            issueTracker.recordSuccess(for: id)
+        } catch {
+            issueTracker.recordFailure(for: id)
+        }
     }
 
     @discardableResult

--- a/Sources/QuillCodeApp/WorkspaceThreadPersistenceIssue.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadPersistenceIssue.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+final class WorkspaceThreadPersistenceIssueTracker {
+    private var failedThreadIDs: Set<UUID> = []
+
+    var failedThreadCount: Int {
+        failedThreadIDs.count
+    }
+
+    var runtimeIssue: RuntimeIssueSurface? {
+        guard !failedThreadIDs.isEmpty else { return nil }
+        let chatLabel = failedThreadIDs.count == 1 ? "chat" : "chats"
+        return RuntimeIssueSurface(
+            severity: .error,
+            title: failedThreadIDs.count == 1
+                ? "A chat change is not saved"
+                : "Some chat changes are not saved",
+            message: "Quill Cowork could not update its saved-chat files for "
+                + "\(failedThreadIDs.count) \(chatLabel). The current session can continue, "
+                + "but affected changes may not survive a relaunch. Check available disk space "
+                + "and app-data permissions, or compact a very large chat. Make another change "
+                + "to retry its full snapshot.",
+            diagnostics: [
+                RuntimeDiagnosticSurface(
+                    label: "Affected chats",
+                    value: String(failedThreadIDs.count)
+                ),
+                RuntimeDiagnosticSurface(label: "Private content included", value: "No")
+            ]
+        )
+    }
+
+    func recordFailure(for threadID: UUID) {
+        failedThreadIDs.insert(threadID)
+    }
+
+    func recordSuccess(for threadID: UUID) {
+        failedThreadIDs.remove(threadID)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueIntegrationTests.swift
@@ -43,6 +43,69 @@ final class WorkspaceRuntimeIssueIntegrationTests: XCTestCase {
         )
     }
 
+    func testFailedChatSaveSurfacesContentFreeDurabilityWarning() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let privateDirectoryName = "acquisition-confidential"
+        let blockingFile = root.appendingPathComponent(privateDirectoryName)
+        try Data().write(to: blockingFile)
+        let thread = ChatThread(title: "Private acquisition plan")
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread]),
+            threadStore: JSONThreadStore(
+                directory: blockingFile.appendingPathComponent("threads")
+            )
+        )
+
+        model.threadPersistence.save(thread)
+
+        let surface = model.surface()
+        let issue = try XCTUnwrap(surface.runtimeIssue)
+        XCTAssertEqual(issue.severity, .error)
+        XCTAssertEqual(issue.title, "A chat change is not saved")
+        XCTAssertNil(issue.actionLabel)
+        XCTAssertNil(issue.recovery)
+        XCTAssertEqual(surface.topBar.runtimeIssueLabel, issue.title)
+        XCTAssertEqual(surface.settings.runtimeIssue, issue)
+        let visibleText = ([issue.title, issue.message] + issue.diagnostics.flatMap {
+            [$0.label, $0.value]
+        }).joined(separator: " ")
+        XCTAssertFalse(visibleText.contains(privateDirectoryName))
+        XCTAssertFalse(visibleText.contains(thread.title))
+
+        try FileManager.default.removeItem(at: blockingFile)
+        model.threadPersistence.save(thread)
+
+        XCTAssertNotEqual(model.surface().runtimeIssue?.title, issue.title)
+    }
+
+    func testStartupLoadIssueKeepsPriorityOverLaterSaveFailure() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let blockingFile = root.appendingPathComponent("blocked")
+        try Data().write(to: blockingFile)
+        let thread = ChatThread(title: "Unsaved")
+        let listing = ThreadListing(
+            threads: [thread],
+            issues: [
+                ThreadFileIssue(
+                    fileURL: URL(fileURLWithPath: "/ignored/unreadable.json"),
+                    reason: .unreadable
+                )
+            ]
+        )
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread]),
+            threadStore: JSONThreadStore(
+                directory: blockingFile.appendingPathComponent("threads")
+            ),
+            threadLoadIssue: try XCTUnwrap(WorkspaceThreadLoadIssue(listing: listing))
+        )
+
+        model.threadPersistence.save(thread)
+
+        XCTAssertEqual(model.threadPersistenceIssueTracker.failedThreadCount, 1)
+        XCTAssertEqual(model.surface().runtimeIssue?.title, "A saved chat could not be loaded")
+    }
+
     func testApplyRuntimeRefreshesAgentStatus() {
         let model = QuillCodeWorkspaceModel()
 

--- a/Tests/QuillCodeAppTests/WorkspaceThreadPersistenceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceThreadPersistenceTests.swift
@@ -112,4 +112,116 @@ final class WorkspaceThreadPersistenceTests: XCTestCase {
 
         XCTAssertThrowsError(try store.load(side.id))
     }
+
+    func testFailedSaveIsVisibleUntilAFullSnapshotSucceeds() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let privateDirectoryName = "private-customer-project"
+        let blockingFile = root.appendingPathComponent(privateDirectoryName)
+        try Data("not-a-directory".utf8).write(to: blockingFile)
+        let store = JSONThreadStore(
+            directory: blockingFile.appendingPathComponent("threads")
+        )
+        let tracker = WorkspaceThreadPersistenceIssueTracker()
+        let persistence = WorkspaceThreadPersistence(store: store, issueTracker: tracker)
+        let thread = ChatThread(title: "Unsaved customer plan")
+
+        persistence.save(thread)
+
+        let issue = try XCTUnwrap(tracker.runtimeIssue)
+        XCTAssertEqual(tracker.failedThreadCount, 1)
+        XCTAssertEqual(issue.severity, .error)
+        XCTAssertEqual(issue.title, "A chat change is not saved")
+        XCTAssertEqual(
+            issue.diagnostics.first { $0.label == "Affected chats" }?.value,
+            "1"
+        )
+        XCTAssertFalse(issue.message.contains(privateDirectoryName))
+        XCTAssertFalse(issue.diagnostics.contains { $0.value.contains(privateDirectoryName) })
+
+        try FileManager.default.removeItem(at: blockingFile)
+        persistence.save(thread)
+
+        XCTAssertEqual(tracker.failedThreadCount, 0)
+        XCTAssertNil(tracker.runtimeIssue)
+        XCTAssertEqual(try store.load(thread.id).title, thread.title)
+    }
+
+    func testThrowingSaveRecordsFailureBeforeRethrowing() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let blockingFile = root.appendingPathComponent("blocked")
+        try Data().write(to: blockingFile)
+        let tracker = WorkspaceThreadPersistenceIssueTracker()
+        let persistence = WorkspaceThreadPersistence(
+            store: JSONThreadStore(directory: blockingFile.appendingPathComponent("threads")),
+            issueTracker: tracker
+        )
+
+        XCTAssertThrowsError(try persistence.saveOrThrow(ChatThread(title: "Important")))
+        XCTAssertEqual(tracker.failedThreadCount, 1)
+    }
+
+    func testFailedDeleteIsVisibleUntilDeleteCanComplete() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let storeDirectory = root.appendingPathComponent("threads", isDirectory: true)
+        let store = JSONThreadStore(directory: storeDirectory)
+        let thread = ChatThread(title: "Delete me")
+        try store.save(thread)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o500],
+            ofItemAtPath: storeDirectory.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: storeDirectory.path
+            )
+        }
+        let tracker = WorkspaceThreadPersistenceIssueTracker()
+        let persistence = WorkspaceThreadPersistence(
+            store: store,
+            issueTracker: tracker
+        )
+
+        persistence.delete(thread.id)
+
+        XCTAssertEqual(tracker.failedThreadCount, 1)
+        XCTAssertEqual(tracker.runtimeIssue?.title, "A chat change is not saved")
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: storeDirectory.path
+        )
+        persistence.delete(thread.id)
+
+        XCTAssertEqual(tracker.failedThreadCount, 0)
+        XCTAssertNil(tracker.runtimeIssue)
+        XCTAssertThrowsError(try store.load(thread.id))
+    }
+
+    func testEachAffectedChatRequiresItsOwnSuccessfulSnapshot() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let blockingFile = root.appendingPathComponent("blocked")
+        try Data().write(to: blockingFile)
+        let store = JSONThreadStore(directory: blockingFile.appendingPathComponent("threads"))
+        let tracker = WorkspaceThreadPersistenceIssueTracker()
+        let persistence = WorkspaceThreadPersistence(store: store, issueTracker: tracker)
+        let first = ChatThread(title: "First")
+        let second = ChatThread(title: "Second")
+
+        persistence.save([first, second])
+
+        XCTAssertEqual(tracker.failedThreadCount, 2)
+        XCTAssertEqual(tracker.runtimeIssue?.title, "Some chat changes are not saved")
+
+        try FileManager.default.removeItem(at: blockingFile)
+        persistence.save(first)
+
+        XCTAssertEqual(tracker.failedThreadCount, 1)
+        XCTAssertEqual(tracker.runtimeIssue?.title, "A chat change is not saved")
+
+        persistence.save(second)
+
+        XCTAssertEqual(tracker.failedThreadCount, 0)
+        XCTAssertNil(tracker.runtimeIssue)
+    }
 }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -59,6 +59,34 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
     }
 
+    func testRenderedWorkspaceShowsUnsavedChatDurabilityWarning() throws {
+        let root = try makeTempDirectory()
+        let blockingFile = root.appendingPathComponent("blocked")
+        try Data().write(to: blockingFile)
+        let thread = ChatThread(title: "Unsaved work")
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                threads: [thread],
+                selectedThreadID: thread.id
+            ),
+            threadStore: JSONThreadStore(
+                directory: blockingFile.appendingPathComponent("threads")
+            )
+        )
+        model.threadPersistence.save(thread)
+        let surface = model.surface()
+        XCTAssertEqual(surface.runtimeIssue?.title, "A chat change is not saved")
+
+        let image = try renderWorkspace(surface)
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 1280)
+        XCTAssertEqual(stats.height, 900)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
+    }
+
     func testRenderedEmptyWorkspaceShowsAggregatedRegistryRecoveryIssue() throws {
         let firstThread = ChatThread(title: "Recovered chat A")
         let secondThread = ChatThread(title: "Recovered chat B")

--- a/Tests/QuillCodeParityTests/ParityWorkspaceThreadLifecycleGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceThreadLifecycleGateTests.swift
@@ -14,10 +14,12 @@ final class ParityWorkspaceThreadLifecycleGateTests: QuillCodeParityTestCase {
         assertPersistenceContracts(persistenceText)
         assertLifecycleActionsDelegate(lifecycleActionsText)
         assertSelectionAndMutationDelegates(selectionText, mutationText)
-        Self.assertSource(
-            modelText,
-            contains: "WorkspaceThreadPersistence(store: threadStore)"
-        )
+        [
+            "let threadPersistenceIssueTracker = WorkspaceThreadPersistenceIssueTracker()",
+            "self.threadPersistenceIssueTracker = threadPersistenceIssueTracker",
+            "store: threadStore,",
+            "issueTracker: threadPersistenceIssueTracker"
+        ].forEach { Self.assertSource(modelText, contains: $0) }
         assertWorkspaceModelAvoidsLifecycleOwnership(modelText)
         assertThreadCreationAPIsAvoidLifecycleOwnership(threadText)
     }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,27 @@
 # Code Quality Audit
 
+## 2026-08-09 Visible Chat Durability Failures
+
+Overall grade after this slice: **A+ data integrity, A+ privacy, A+ recovery UX**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Data integrity | A+ | Every durable chat save/delete now records failure instead of silently swallowing it; only a successful operation for that exact chat clears its pending durability state. |
+| Recovery UX | A+ | The existing runtime-issue surface explains that the session can continue but changes may not survive relaunch, and gives disk-space, permission, and compaction guidance. |
+| Privacy | A+ | The bounded in-memory tracker retains UUIDs only; rendered diagnostics expose one count and explicitly contain no private content, paths, titles, transcripts, raw errors, or credentials. |
+| Priority integrity | A+ | Startup load damage remains above session write failures, while provider/runtime issues return automatically after all affected snapshots become durable. |
+| Regression coverage | A+ | Focused tests force real filesystem failures, prove per-chat recovery, throwing-path tracking, confidential/ephemeral exclusion, diagnostic redaction, startup priority, and native rendered output. |
+
+Validation:
+
+- Focused persistence, runtime-issue, parity, and native rendered suites (24 tests, 0 failures)
+- Full `swift test` (5,718 tests, 5 skipped, 0 failures)
+- Optimized packaged app Launch Services smoke passed with 126 transcript messages,
+  79 tool cards, 205 timeline items, and 186 native click probes
+- Release executable stripped from 56,101,392 to 28,144,272 bytes; strict code-signature
+  verification passed
+- `python3 scripts/grade-code-quality.py --root .` reports every module A+
+
 ## 2026-08-09 Pre-Sign Release Executable Stripping
 
 Overall grade after this slice: **A+ binary footprint, A+ signing integrity, A+ public evidence**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,21 @@
 # QuillCode Decisions
 
+## 2026-08-09: failed chat persistence is visible until that snapshot recovers
+
+- **Decision:** Every non-ephemeral chat save and delete reports success or failure to a shared,
+  session-bounded tracker. A failed chat stays in the tracker until a later full snapshot or delete
+  for that exact chat succeeds; repairing one chat never clears another chat's warning.
+- **UX:** The normal runtime-issue surface reports that changes are not durable, counts affected
+  chats, and suggests disk-space, app-data permission, and large-chat compaction recovery. Startup
+  load damage remains higher priority because it describes data that was already unavailable when
+  the session opened.
+- **Privacy:** The tracker stores only chat UUIDs in memory. Its diagnostics contain a count and an
+  explicit no-private-content statement; filesystem errors, paths, titles, transcript text, and
+  credentials are never copied into the surface.
+- **Why:** Persistence previously used `try?` for ordinary saves and deletes. Disk exhaustion,
+  read-only storage, permission loss, or the bounded transcript-size limit could therefore leave
+  the workspace looking saved even though its latest state existed only in memory.
+
 ## 2026-08-09: release app executables are stripped before signing
 
 - **Decision:** macOS release apps remove debug symbols and local symbols with `strip -S -x` after

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -239,6 +239,12 @@ or credentials. Ask testers to add:
 - what they clicked or typed before the issue
 - a screenshot when the issue is visual
 
+If a saved-chat write or delete fails, the workspace shows a durability warning until a full
+snapshot for each affected chat succeeds. The warning includes only the affected-chat count, never
+the chat title, transcript, filesystem path, underlying error text, or credentials. Testers should
+keep the app open while they free disk space, restore application-data permissions, or compact an
+oversized chat, then make another change so Quill Cowork can retry the complete snapshot.
+
 ## Versioned Releases
 
 Stable releases are immutable and must use a canonical `vMAJOR.MINOR.PATCH` tag


### PR DESCRIPTION
## Summary
- surface failed chat saves and deletes instead of silently swallowing them
- track only affected chat UUIDs and clear each warning after that exact snapshot recovers
- preserve startup-load issue priority and keep diagnostics free of paths, titles, transcripts, errors, and credentials

## Verification
- focused persistence, runtime issue, parity, and native rendered suites: 24 tests, 0 failures
- full swift test: 5,718 tests, 5 skipped, 0 failures
- optimized packaged app Launch Services smoke passed
- strict ad-hoc code-signature verification passed
- every module remains A+ under the deterministic quality grader
- staged credential-pattern and whitespace scans passed