### PR TITLE
Surface workspace registry save failures

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -79,9 +79,8 @@ public final class QuillCodeWorkspaceModel {
     var verificationRunner: (@Sendable (LocalEnvironmentAction, URL) async -> ToolResult)?
     let threadPersistence: WorkspaceThreadPersistence
     let threadPersistenceIssueTracker: WorkspaceThreadPersistenceIssueTracker
-    private let projectStore: JSONProjectStore?
-    private let automationStore: JSONAutomationStore?
-    private let sidebarSavedSearchStore: JSONSidebarSavedSearchStore?
+    let registryPersistence: WorkspaceRegistryPersistence
+    let registryPersistenceIssueTracker: WorkspaceRegistryPersistenceIssueTracker
     let agentImporter: ClaudeCodeAgentImporter?
     /// Persisted per-project permission rules ("always allow/deny"). The agent's safety gate reads
     /// this same store per review, so a rule saved here applies to the very next tool call. Nil
@@ -229,14 +228,19 @@ public final class QuillCodeWorkspaceModel {
             store: threadStore,
             issueTracker: threadPersistenceIssueTracker
         )
+        let registryPersistenceIssueTracker = WorkspaceRegistryPersistenceIssueTracker()
+        self.registryPersistenceIssueTracker = registryPersistenceIssueTracker
+        self.registryPersistence = WorkspaceRegistryPersistence(
+            projectStore: projectStore,
+            automationStore: automationStore,
+            sidebarSavedSearchStore: sidebarSavedSearchStore,
+            issueTracker: registryPersistenceIssueTracker
+        )
         self.startupLoadIssue = startupLoadIssue ?? WorkspaceStartupLoadIssue(
             loadedThreadCount: root.threads.count,
             threadLoadIssue: threadLoadIssue,
             unreadableDataKinds: []
         )
-        self.projectStore = projectStore
-        self.automationStore = automationStore
-        self.sidebarSavedSearchStore = sidebarSavedSearchStore
         self.agentImporter = agentImporter
         self.permissionRuleStore = permissionRuleStore
         self.projectHookTrustStore = projectHookTrustStore
@@ -472,11 +476,11 @@ public final class QuillCodeWorkspaceModel {
     }
 
     func saveProjects() {
-        try? projectStore?.save(root.projects)
+        registryPersistence.saveProjects(root.projects)
     }
 
     func saveProjectsOrThrow(_ projects: [ProjectRef]) throws {
-        try projectStore?.save(projects)
+        try registryPersistence.saveProjectsOrThrow(projects)
     }
 
     func applyAutomationState(_ state: AutomationsState) {
@@ -493,11 +497,11 @@ public final class QuillCodeWorkspaceModel {
     }
 
     private func saveAutomations() {
-        try? automationStore?.save(automations.items)
+        registryPersistence.saveAutomations(automations.items)
     }
 
     func saveSidebarSavedSearches() {
-        try? sidebarSavedSearchStore?.save(sidebarSavedSearches)
+        registryPersistence.saveSidebarSavedSearches(sidebarSavedSearches)
     }
 
 }

--- a/Sources/QuillCodeApp/WorkspaceRegistryPersistence.swift
+++ b/Sources/QuillCodeApp/WorkspaceRegistryPersistence.swift
@@ -1,0 +1,74 @@
+import QuillCodeCore
+import QuillCodePersistence
+
+struct WorkspaceRegistryPersistence {
+    let projectStore: JSONProjectStore?
+    let automationStore: JSONAutomationStore?
+    let sidebarSavedSearchStore: JSONSidebarSavedSearchStore?
+    let issueTracker: WorkspaceRegistryPersistenceIssueTracker
+
+    init(
+        projectStore: JSONProjectStore?,
+        automationStore: JSONAutomationStore?,
+        sidebarSavedSearchStore: JSONSidebarSavedSearchStore?,
+        issueTracker: WorkspaceRegistryPersistenceIssueTracker = WorkspaceRegistryPersistenceIssueTracker()
+    ) {
+        self.projectStore = projectStore
+        self.automationStore = automationStore
+        self.sidebarSavedSearchStore = sidebarSavedSearchStore
+        self.issueTracker = issueTracker
+    }
+
+    func saveProjects(_ projects: [ProjectRef]) {
+        guard let projectStore else { return }
+        save(.projects) {
+            try projectStore.save(projects)
+        }
+    }
+
+    func saveProjectsOrThrow(_ projects: [ProjectRef]) throws {
+        guard let projectStore else { return }
+        try saveOrThrow(.projects) {
+            try projectStore.save(projects)
+        }
+    }
+
+    func saveAutomations(_ automations: [QuillAutomation]) {
+        guard let automationStore else { return }
+        save(.automations) {
+            try automationStore.save(automations)
+        }
+    }
+
+    func saveSidebarSavedSearches(_ savedSearches: [SidebarSavedSearch]) {
+        guard let sidebarSavedSearchStore else { return }
+        save(.savedSearches) {
+            try sidebarSavedSearchStore.save(savedSearches)
+        }
+    }
+
+    private func save(
+        _ kind: WorkspaceRegistryPersistenceKind,
+        operation: () throws -> Void
+    ) {
+        do {
+            try operation()
+            issueTracker.recordSuccess(for: kind)
+        } catch {
+            issueTracker.recordFailure(for: kind)
+        }
+    }
+
+    private func saveOrThrow(
+        _ kind: WorkspaceRegistryPersistenceKind,
+        operation: () throws -> Void
+    ) throws {
+        do {
+            try operation()
+            issueTracker.recordSuccess(for: kind)
+        } catch {
+            issueTracker.recordFailure(for: kind)
+            throw error
+        }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceRegistryPersistenceIssue.swift
+++ b/Sources/QuillCodeApp/WorkspaceRegistryPersistenceIssue.swift
@@ -1,0 +1,54 @@
+enum WorkspaceRegistryPersistenceKind: CaseIterable, Hashable {
+    case projects
+    case automations
+    case savedSearches
+
+    var label: String {
+        switch self {
+        case .projects:
+            "Projects"
+        case .automations:
+            "Automations"
+        case .savedSearches:
+            "Saved searches"
+        }
+    }
+}
+
+final class WorkspaceRegistryPersistenceIssueTracker {
+    private var failedKinds: Set<WorkspaceRegistryPersistenceKind> = []
+
+    var failedKindCount: Int {
+        failedKinds.count
+    }
+
+    var runtimeIssue: RuntimeIssueSurface? {
+        let affectedKinds = WorkspaceRegistryPersistenceKind.allCases.filter(failedKinds.contains)
+        guard !affectedKinds.isEmpty else { return nil }
+        return RuntimeIssueSurface(
+            severity: .error,
+            title: affectedKinds.count == 1
+                ? "A workspace change is not saved"
+                : "Some workspace changes are not saved",
+            message: "Quill Cowork could not update one or more workspace data files. "
+                + "Changes to the affected data remain available in this session, but may not "
+                + "survive a relaunch. Check available disk space and app-data permissions, then "
+                + "change each affected item again to retry its complete saved state.",
+            diagnostics: [
+                RuntimeDiagnosticSurface(
+                    label: "Affected data",
+                    value: affectedKinds.map(\.label).joined(separator: ", ")
+                ),
+                RuntimeDiagnosticSurface(label: "Private content included", value: "No")
+            ]
+        )
+    }
+
+    func recordFailure(for kind: WorkspaceRegistryPersistenceKind) {
+        failedKinds.insert(kind)
+    }
+
+    func recordSuccess(for kind: WorkspaceRegistryPersistenceKind) {
+        failedKinds.remove(kind)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -311,6 +311,9 @@ public extension QuillCodeWorkspaceModel {
         if let persistenceIssue = threadPersistenceIssueTracker.runtimeIssue {
             return persistenceIssue
         }
+        if let persistenceIssue = registryPersistenceIssueTracker.runtimeIssue {
+            return persistenceIssue
+        }
         return WorkspaceRuntimeIssueBuilder(
             config: root.config,
             hasStoredAPIKey: root.trustedRouterAPIKeyConfigured,

--- a/Tests/QuillCodeAppTests/WorkspaceRegistryPersistenceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRegistryPersistenceTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import QuillCodeCore
+import QuillCodePersistence
+@testable import QuillCodeApp
+
+final class WorkspaceRegistryPersistenceTests: XCTestCase {
+    func testFailedRegistriesRequireTheirOwnSuccessfulSnapshots() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let privateDirectoryName = "private-customer-registry"
+        let blockingFile = root.appendingPathComponent(privateDirectoryName)
+        try Data("not-a-directory".utf8).write(to: blockingFile)
+        let registryDirectory = blockingFile.appendingPathComponent("state")
+        let projectStore = JSONProjectStore(
+            fileURL: registryDirectory.appendingPathComponent("projects.json")
+        )
+        let automationStore = JSONAutomationStore(
+            fileURL: registryDirectory.appendingPathComponent("automations.json")
+        )
+        let savedSearchStore = JSONSidebarSavedSearchStore(
+            fileURL: registryDirectory.appendingPathComponent("saved-searches.json")
+        )
+        let tracker = WorkspaceRegistryPersistenceIssueTracker()
+        let persistence = WorkspaceRegistryPersistence(
+            projectStore: projectStore,
+            automationStore: automationStore,
+            sidebarSavedSearchStore: savedSearchStore,
+            issueTracker: tracker
+        )
+        let projects = [ProjectRef(name: "Confidential project", path: root.path)]
+        let automations = [QuillAutomation(
+            title: "Confidential monitor",
+            detail: "Private instructions",
+            kind: .monitor,
+            scheduleKind: .event,
+            scheduleDescription: "Event"
+        )]
+        let savedSearches = [SidebarSavedSearch(title: "Confidential search", query: "secret")]
+
+        persistence.saveProjects(projects)
+        persistence.saveAutomations(automations)
+        persistence.saveSidebarSavedSearches(savedSearches)
+
+        let issue = try XCTUnwrap(tracker.runtimeIssue)
+        XCTAssertEqual(tracker.failedKindCount, 3)
+        XCTAssertEqual(issue.title, "Some workspace changes are not saved")
+        XCTAssertEqual(
+            issue.diagnostics.first { $0.label == "Affected data" }?.value,
+            "Projects, Automations, Saved searches"
+        )
+        let visibleText = ([issue.title, issue.message] + issue.diagnostics.flatMap {
+            [$0.label, $0.value]
+        }).joined(separator: " ")
+        XCTAssertFalse(visibleText.contains(privateDirectoryName))
+        XCTAssertFalse(visibleText.contains(projects[0].name))
+        XCTAssertFalse(visibleText.contains(automations[0].title))
+        XCTAssertFalse(visibleText.contains(savedSearches[0].title))
+
+        try FileManager.default.removeItem(at: blockingFile)
+        persistence.saveProjects(projects)
+
+        XCTAssertEqual(tracker.failedKindCount, 2)
+        XCTAssertEqual(tracker.runtimeIssue?.title, "Some workspace changes are not saved")
+        XCTAssertEqual(try projectStore.load().map(\.name), [projects[0].name])
+
+        persistence.saveAutomations(automations)
+
+        XCTAssertEqual(tracker.failedKindCount, 1)
+        XCTAssertEqual(tracker.runtimeIssue?.title, "A workspace change is not saved")
+        XCTAssertEqual(try automationStore.load().map(\.title), [automations[0].title])
+
+        persistence.saveSidebarSavedSearches(savedSearches)
+
+        XCTAssertEqual(tracker.failedKindCount, 0)
+        XCTAssertNil(tracker.runtimeIssue)
+        XCTAssertEqual(try savedSearchStore.load(), savedSearches)
+    }
+
+    func testThrowingProjectSaveRecordsFailureBeforeRethrowing() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let blockingFile = root.appendingPathComponent("blocked")
+        try Data().write(to: blockingFile)
+        let tracker = WorkspaceRegistryPersistenceIssueTracker()
+        let persistence = WorkspaceRegistryPersistence(
+            projectStore: JSONProjectStore(
+                fileURL: blockingFile.appendingPathComponent("projects.json")
+            ),
+            automationStore: nil,
+            sidebarSavedSearchStore: nil,
+            issueTracker: tracker
+        )
+
+        XCTAssertThrowsError(try persistence.saveProjectsOrThrow([
+            ProjectRef(name: "Important", path: root.path)
+        ]))
+        XCTAssertEqual(tracker.failedKindCount, 1)
+        XCTAssertEqual(tracker.runtimeIssue?.title, "A workspace change is not saved")
+    }
+
+    func testMissingStoresAreNoopsForStartupRecoveryMode() throws {
+        let tracker = WorkspaceRegistryPersistenceIssueTracker()
+        let persistence = WorkspaceRegistryPersistence(
+            projectStore: nil,
+            automationStore: nil,
+            sidebarSavedSearchStore: nil,
+            issueTracker: tracker
+        )
+
+        persistence.saveProjects([])
+        try persistence.saveProjectsOrThrow([])
+        persistence.saveAutomations([])
+        persistence.saveSidebarSavedSearches([])
+
+        XCTAssertEqual(tracker.failedKindCount, 0)
+        XCTAssertNil(tracker.runtimeIssue)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueIntegrationTests.swift
@@ -78,6 +78,67 @@ final class WorkspaceRuntimeIssueIntegrationTests: XCTestCase {
         XCTAssertNotEqual(model.surface().runtimeIssue?.title, issue.title)
     }
 
+    func testFailedRegistrySaveSurfacesContentFreeDurabilityWarning() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let privateDirectoryName = "private-acquisition-registry"
+        let blockingFile = root.appendingPathComponent(privateDirectoryName)
+        try Data().write(to: blockingFile)
+        let privateProjectName = "Private acquisition project"
+        let model = QuillCodeWorkspaceModel(
+            projectStore: JSONProjectStore(
+                fileURL: blockingFile.appendingPathComponent("projects.json")
+            )
+        )
+
+        _ = model.addProject(path: root, name: privateProjectName)
+
+        let surface = model.surface()
+        let issue = try XCTUnwrap(surface.runtimeIssue)
+        XCTAssertEqual(issue.severity, .error)
+        XCTAssertEqual(issue.title, "A workspace change is not saved")
+        XCTAssertNil(issue.actionLabel)
+        XCTAssertNil(issue.recovery)
+        XCTAssertEqual(surface.topBar.runtimeIssueLabel, issue.title)
+        XCTAssertEqual(surface.settings.runtimeIssue, issue)
+        XCTAssertEqual(
+            issue.diagnostics.first { $0.label == "Affected data" }?.value,
+            "Projects"
+        )
+        let visibleText = ([issue.title, issue.message] + issue.diagnostics.flatMap {
+            [$0.label, $0.value]
+        }).joined(separator: " ")
+        XCTAssertFalse(visibleText.contains(privateDirectoryName))
+        XCTAssertFalse(visibleText.contains(privateProjectName))
+
+        try FileManager.default.removeItem(at: blockingFile)
+        model.saveProjects()
+
+        XCTAssertNotEqual(model.surface().runtimeIssue?.title, issue.title)
+    }
+
+    func testChatSaveFailureKeepsPriorityOverRegistrySaveFailure() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let blockingFile = root.appendingPathComponent("blocked")
+        try Data().write(to: blockingFile)
+        let thread = ChatThread(title: "Unsaved chat")
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread]),
+            threadStore: JSONThreadStore(
+                directory: blockingFile.appendingPathComponent("threads")
+            ),
+            projectStore: JSONProjectStore(
+                fileURL: blockingFile.appendingPathComponent("projects.json")
+            )
+        )
+
+        model.threadPersistence.save(thread)
+        _ = model.addProject(path: root, name: "Unsaved project")
+
+        XCTAssertEqual(model.threadPersistenceIssueTracker.failedThreadCount, 1)
+        XCTAssertEqual(model.registryPersistenceIssueTracker.failedKindCount, 1)
+        XCTAssertEqual(model.surface().runtimeIssue?.title, "A chat change is not saved")
+    }
+
     func testStartupLoadIssueKeepsPriorityOverLaterSaveFailure() throws {
         let root = try makeQuillCodeTestDirectory()
         let blockingFile = root.appendingPathComponent("blocked")

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -87,6 +87,29 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
     }
 
+    func testRenderedWorkspaceShowsUnsavedRegistryDurabilityWarning() throws {
+        let root = try makeTempDirectory()
+        let blockingFile = root.appendingPathComponent("blocked")
+        try Data().write(to: blockingFile)
+        let model = QuillCodeWorkspaceModel(
+            projectStore: JSONProjectStore(
+                fileURL: blockingFile.appendingPathComponent("projects.json")
+            )
+        )
+        _ = model.addProject(path: root, name: "Unsaved project")
+        let surface = model.surface()
+        XCTAssertEqual(surface.runtimeIssue?.title, "A workspace change is not saved")
+
+        let image = try renderWorkspace(surface)
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 1280)
+        XCTAssertEqual(stats.height, 900)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
+    }
+
     func testRenderedEmptyWorkspaceShowsAggregatedRegistryRecoveryIssue() throws {
         let firstThread = ChatThread(title: "Recovered chat A")
         let secondThread = ChatThread(title: "Recovered chat B")

--- a/Tests/QuillCodeParityTests/ParityWorkspaceRegistryPersistenceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceRegistryPersistenceGateTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+final class ParityWorkspaceRegistryPersistenceGateTests: QuillCodeParityTestCase {
+    func testWorkspaceRegistriesShareOneTrackedPersistenceBoundary() throws {
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let persistenceText = try Self.appSourceText(named: "WorkspaceRegistryPersistence.swift")
+        let issueText = try Self.appSourceText(named: "WorkspaceRegistryPersistenceIssue.swift")
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+
+        Self.assertSource(persistenceText, containsAll: [
+            "struct WorkspaceRegistryPersistence",
+            "func saveProjects(",
+            "func saveProjectsOrThrow(",
+            "func saveAutomations(",
+            "func saveSidebarSavedSearches("
+        ])
+        Self.assertSource(issueText, containsAll: [
+            "final class WorkspaceRegistryPersistenceIssueTracker",
+            "private var failedKinds: Set<WorkspaceRegistryPersistenceKind>",
+            "Private content included"
+        ])
+        Self.assertSource(modelText, containsAll: [
+            "let registryPersistenceIssueTracker = WorkspaceRegistryPersistenceIssueTracker()",
+            "self.registryPersistenceIssueTracker = registryPersistenceIssueTracker",
+            "self.registryPersistence = WorkspaceRegistryPersistence(",
+            "registryPersistence.saveProjects(root.projects)",
+            "registryPersistence.saveAutomations(automations.items)",
+            "registryPersistence.saveSidebarSavedSearches(sidebarSavedSearches)"
+        ])
+        Self.assertSource(modelText, excludesAll: [
+            "try? projectStore?.save",
+            "try? automationStore?.save",
+            "try? sidebarSavedSearchStore?.save"
+        ])
+        Self.assertSource(
+            surfaceText,
+            contains: "registryPersistenceIssueTracker.runtimeIssue"
+        )
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,28 @@
 # Code Quality Audit
 
+## 2026-08-09 Visible Workspace Registry Durability Failures
+
+Overall grade after this slice: **A+ data integrity, A+ recovery UX, A+ privacy**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Data integrity | A+ | Projects, automations, and saved searches share one full-snapshot persistence boundary; every write reports success or failure instead of silently swallowing errors. |
+| Exact recovery | A+ | A successful snapshot clears only its own registry kind, so repairing projects cannot hide an automation or saved-search failure. Throwing project-import saves record failure before rethrowing. |
+| Recovery UX | A+ | The existing top-bar and Settings issue surface explains that affected changes remain available for the session but may not survive relaunch, and gives disk-space and permission guidance. |
+| Privacy | A+ | The bounded tracker retains enum cases only. Diagnostics expose affected data types and explicitly contain no private content, paths, names, queries, automation details, raw errors, or credentials. |
+| Priority integrity | A+ | Startup load damage remains highest priority, followed by unsaved chat snapshots, registry snapshots, and provider/runtime issues. Startup recovery mode keeps unavailable stores disabled instead of overwriting damaged data. |
+
+Validation:
+
+- Focused registry persistence, runtime-issue, parity, and native rendered suites
+  (19 tests, 0 failures)
+- Full `swift test` (5,725 tests, 5 skipped, 0 failures)
+- Optimized packaged app Launch Services smoke passed with 126 transcript messages,
+  79 tool cards, 205 timeline items, and 186 native click probes
+- Release executable stripped from 56,129,056 to 28,160,848 bytes; strict code-signature
+  verification passed
+- `python3 scripts/grade-code-quality.py --root .` reports every module at A+
+
 ## 2026-08-09 Visible Chat Durability Failures
 
 Overall grade after this slice: **A+ data integrity, A+ privacy, A+ recovery UX**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # QuillCode Decisions
 
+## 2026-08-09: workspace registry persistence failures remain visible until exact recovery
+
+- **Decision:** Project, automation, and saved-search snapshots share a focused registry
+  persistence helper. Every attempted write records success or failure for its exact registry kind;
+  a successful project save never clears an automation or saved-search warning.
+- **UX:** The normal runtime-issue surface reports that workspace changes are not durable and names
+  only the affected data types. Startup load damage and failed chat snapshots remain higher priority,
+  and provider/runtime issues return automatically after every affected registry becomes durable.
+- **Privacy:** The tracker stores only enum cases in memory. It never retains or displays filesystem
+  errors, paths, project names, automation details, saved-search queries, or credentials.
+- **Recovery mode:** A nil store remains a no-op because bootstrap already uses nil to protect data
+  that could not be loaded. Its startup recovery issue stays visible, and later in-memory edits do
+  not overwrite the original damaged file.
+- **Why:** These registries previously used `try?` in the central model. Disk exhaustion, read-only
+  storage, permission loss, or bounded-file limits could leave visible project, automation, and
+  saved-search changes available only in memory without telling the user.
+
 ## 2026-08-09: failed chat persistence is visible until that snapshot recovers
 
 - **Decision:** Every non-ephemeral chat save and delete reports success or failure to a shared,

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -245,6 +245,12 @@ the chat title, transcript, filesystem path, underlying error text, or credentia
 keep the app open while they free disk space, restore application-data permissions, or compact an
 oversized chat, then make another change so Quill Cowork can retry the complete snapshot.
 
+Project, automation, and saved-search write failures use the same durable-warning pattern. The
+warning names only the affected data types and remains visible until each registry writes a complete
+snapshot successfully. Testers should keep the app open, restore disk space or application-data
+permissions, then change each affected data type again. Reports must not include private project
+names, automation details, saved-search queries, filesystem paths, raw errors, or credentials.
+
 ## Versioned Releases
 
 Stable releases are immutable and must use a canonical `vMAJOR.MINOR.PATCH` tag


### PR DESCRIPTION
## Summary
- stop silently swallowing project, automation, and saved-search snapshot failures
- track exact registry recovery with content-free diagnostics in the existing runtime issue surface
- preserve startup-load and chat-durability warning priority

## Verification
- focused persistence, integration, parity, and rendered suites: 19 tests, 0 failures
- full swift test: 5,725 tests, 5 skipped, 0 failures
- optimized packaged Launch Services smoke: 126 messages, 79 tool cards, 205 timeline items, 186 click probes
- strict code-signature verification passed; every quality-grader module remains A+