### PR TITLE
Make settings persistence transactional

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -176,6 +176,61 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
         try ConfigStore(fileURL: paths.configFile).save(config)
     }
 
+    public func saveSettingsTransaction(
+        currentConfig: AppConfig,
+        proposedConfig: AppConfig,
+        credentialMutation: WorkspaceTrustedRouterCredentialMutation
+    ) throws {
+        let normalizedMutation: WorkspaceTrustedRouterCredentialMutation
+        switch credentialMutation {
+        case .replace(let credential):
+            let trimmed = credential.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw WorkspaceSettingsPersistenceError(
+                    failedKinds: [.trustedRouterCredential],
+                    rollbackFailed: false
+                )
+            }
+            normalizedMutation = .replace(trimmed)
+        case .unchanged, .clear:
+            normalizedMutation = credentialMutation
+        }
+
+        do {
+            try paths.ensure()
+        } catch {
+            var kinds: Set<WorkspaceSettingsPersistenceKind> = [.configuration]
+            if normalizedMutation.changesCredential {
+                kinds.insert(.trustedRouterCredential)
+            }
+            throw WorkspaceSettingsPersistenceError(
+                failedKinds: kinds,
+                rollbackFailed: false
+            )
+        }
+
+        let credentialStore = FileSecretStore(directory: paths.secretsDirectory)
+        let transaction = WorkspaceSettingsPersistenceTransaction(
+            saveConfiguration: { config in
+                try ConfigStore(fileURL: paths.configFile).save(config)
+            },
+            readCredential: {
+                try credentialStore.read(QuillSecretKeys.trustedRouterAPIKey)
+            },
+            writeCredential: { credential in
+                try credentialStore.write(credential, for: QuillSecretKeys.trustedRouterAPIKey)
+            },
+            clearCredential: {
+                try credentialStore.delete(QuillSecretKeys.trustedRouterAPIKey)
+            }
+        )
+        try transaction.apply(
+            currentConfig: currentConfig,
+            proposedConfig: proposedConfig,
+            credentialMutation: normalizedMutation
+        )
+    }
+
     public func makeRuntime(config: AppConfig) -> QuillCodeRuntime {
         runtimeFactory.makeRuntime(config: config)
     }

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -81,6 +81,7 @@ public final class QuillCodeWorkspaceModel {
     let threadPersistenceIssueTracker: WorkspaceThreadPersistenceIssueTracker
     let registryPersistence: WorkspaceRegistryPersistence
     let registryPersistenceIssueTracker: WorkspaceRegistryPersistenceIssueTracker
+    let settingsPersistenceIssueTracker: WorkspaceSettingsPersistenceIssueTracker
     let agentImporter: ClaudeCodeAgentImporter?
     /// Persisted per-project permission rules ("always allow/deny"). The agent's safety gate reads
     /// this same store per review, so a rule saved here applies to the very next tool call. Nil
@@ -236,6 +237,7 @@ public final class QuillCodeWorkspaceModel {
             sidebarSavedSearchStore: sidebarSavedSearchStore,
             issueTracker: registryPersistenceIssueTracker
         )
+        self.settingsPersistenceIssueTracker = WorkspaceSettingsPersistenceIssueTracker()
         self.startupLoadIssue = startupLoadIssue ?? WorkspaceStartupLoadIssue(
             loadedThreadCount: root.threads.count,
             threadLoadIssue: threadLoadIssue,

--- a/Sources/QuillCodeApp/WorkspaceSettingsPersistence.swift
+++ b/Sources/QuillCodeApp/WorkspaceSettingsPersistence.swift
@@ -1,0 +1,145 @@
+import QuillCodeCore
+
+public enum WorkspaceSettingsPersistenceKind: CaseIterable, Hashable, Sendable {
+    case configuration
+    case trustedRouterCredential
+
+    var label: String {
+        switch self {
+        case .configuration:
+            "Configuration"
+        case .trustedRouterCredential:
+            "TrustedRouter credential"
+        }
+    }
+}
+
+public enum WorkspaceTrustedRouterCredentialMutation: Sendable {
+    case unchanged
+    case replace(String)
+    case clear
+
+    public var changesCredential: Bool {
+        switch self {
+        case .unchanged:
+            false
+        case .replace, .clear:
+            true
+        }
+    }
+}
+
+public struct WorkspaceSettingsPersistenceError: Error, CustomStringConvertible, Sendable {
+    public let failedKinds: Set<WorkspaceSettingsPersistenceKind>
+    public let rollbackFailed: Bool
+
+    public init(
+        failedKinds: Set<WorkspaceSettingsPersistenceKind>,
+        rollbackFailed: Bool
+    ) {
+        self.failedKinds = failedKinds
+        self.rollbackFailed = rollbackFailed
+    }
+
+    public var description: String {
+        "Quill Cowork could not safely save the settings change."
+    }
+}
+
+struct WorkspaceSettingsPersistenceTransaction {
+    var saveConfiguration: (AppConfig) throws -> Void
+    var readCredential: () throws -> String?
+    var writeCredential: (String) throws -> Void
+    var clearCredential: () throws -> Void
+
+    func apply(
+        currentConfig: AppConfig,
+        proposedConfig: AppConfig,
+        credentialMutation: WorkspaceTrustedRouterCredentialMutation
+    ) throws {
+        guard credentialMutation.changesCredential else {
+            do {
+                try saveConfiguration(proposedConfig)
+            } catch {
+                throw WorkspaceSettingsPersistenceError(
+                    failedKinds: [.configuration],
+                    rollbackFailed: false
+                )
+            }
+            return
+        }
+
+        let priorCredential: String?
+        do {
+            priorCredential = try readCredential()
+        } catch {
+            throw failure(
+                currentConfig: currentConfig,
+                proposedConfig: proposedConfig,
+                rollbackFailed: false
+            )
+        }
+
+        do {
+            try applyCredentialMutation(credentialMutation)
+        } catch {
+            let rollbackFailed = !restoreCredential(priorCredential)
+            throw failure(
+                currentConfig: currentConfig,
+                proposedConfig: proposedConfig,
+                rollbackFailed: rollbackFailed
+            )
+        }
+
+        do {
+            try saveConfiguration(proposedConfig)
+        } catch {
+            let rollbackFailed = !restoreCredential(priorCredential)
+            throw WorkspaceSettingsPersistenceError(
+                failedKinds: [.configuration, .trustedRouterCredential],
+                rollbackFailed: rollbackFailed
+            )
+        }
+    }
+
+    private func applyCredentialMutation(
+        _ mutation: WorkspaceTrustedRouterCredentialMutation
+    ) throws {
+        switch mutation {
+        case .unchanged:
+            break
+        case .replace(let credential):
+            try writeCredential(credential)
+        case .clear:
+            try clearCredential()
+        }
+    }
+
+    private func restoreCredential(_ credential: String?) -> Bool {
+        do {
+            if let credential {
+                try writeCredential(credential)
+            } else {
+                try clearCredential()
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func failure(
+        currentConfig: AppConfig,
+        proposedConfig: AppConfig,
+        rollbackFailed: Bool
+    ) -> WorkspaceSettingsPersistenceError {
+        var kinds: Set<WorkspaceSettingsPersistenceKind> = [.trustedRouterCredential]
+        if proposedConfig != currentConfig {
+            kinds.insert(.configuration)
+        }
+        return WorkspaceSettingsPersistenceError(
+            failedKinds: kinds,
+            rollbackFailed: rollbackFailed
+        )
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSettingsPersistenceIssue.swift
+++ b/Sources/QuillCodeApp/WorkspaceSettingsPersistenceIssue.swift
@@ -1,0 +1,51 @@
+final class WorkspaceSettingsPersistenceIssueTracker {
+    private var failedKinds: Set<WorkspaceSettingsPersistenceKind> = []
+
+    var failedKindCount: Int {
+        failedKinds.count
+    }
+
+    var runtimeIssue: RuntimeIssueSurface? {
+        let affectedKinds = WorkspaceSettingsPersistenceKind.allCases.filter(failedKinds.contains)
+        guard !affectedKinds.isEmpty else { return nil }
+        return RuntimeIssueSurface(
+            severity: .error,
+            title: affectedKinds.count == 1
+                ? "A settings change is not saved"
+                : "Some settings changes are not saved",
+            message: "Quill Cowork could not safely update one or more settings files. "
+                + "Affected changes may remain available only in this session or may have been "
+                + "left unapplied to protect the previous configuration. Check available disk "
+                + "space and app-data permissions, then retry each affected setting.",
+            diagnostics: [
+                RuntimeDiagnosticSurface(
+                    label: "Affected data",
+                    value: affectedKinds.map(\.label).joined(separator: ", ")
+                ),
+                RuntimeDiagnosticSurface(label: "Private content included", value: "No")
+            ]
+        )
+    }
+
+    func recordFailure(for kinds: Set<WorkspaceSettingsPersistenceKind>) {
+        failedKinds.formUnion(kinds)
+    }
+
+    func recordSuccess(for kinds: Set<WorkspaceSettingsPersistenceKind>) {
+        failedKinds.subtract(kinds)
+    }
+}
+
+public extension QuillCodeWorkspaceModel {
+    func recordSettingsPersistenceFailure(
+        _ kinds: Set<WorkspaceSettingsPersistenceKind>
+    ) {
+        settingsPersistenceIssueTracker.recordFailure(for: kinds)
+    }
+
+    func recordSettingsPersistenceSuccess(
+        _ kinds: Set<WorkspaceSettingsPersistenceKind>
+    ) {
+        settingsPersistenceIssueTracker.recordSuccess(for: kinds)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -314,6 +314,9 @@ public extension QuillCodeWorkspaceModel {
         if let persistenceIssue = registryPersistenceIssueTracker.runtimeIssue {
             return persistenceIssue
         }
+        if let persistenceIssue = settingsPersistenceIssueTracker.runtimeIssue {
+            return persistenceIssue
+        }
         return WorkspaceRuntimeIssueBuilder(
             config: root.config,
             hasStoredAPIKey: root.trustedRouterAPIKeyConfigured,

--- a/Sources/quill-code-desktop/QuillCodeDesktopSettingsCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSettingsCoordinator.swift
@@ -6,6 +6,7 @@ struct QuillCodeDesktopSettingsResult {
     var config: AppConfig
     var runtime: QuillCodeRuntime
     var trustedRouterAPIKeyConfigured: Bool
+    var persistedKinds: Set<WorkspaceSettingsPersistenceKind>
 }
 
 @MainActor
@@ -18,17 +19,17 @@ struct QuillCodeDesktopSettingsCoordinator {
 
     func setMode(_ mode: AgentMode, on model: QuillCodeWorkspaceModel) {
         model.setMode(mode)
-        persist(model.root.config)
+        persist(model.root.config, on: model)
     }
 
     func setModel(_ modelID: String, on model: QuillCodeWorkspaceModel) {
         model.setModel(modelID)
-        persist(model.root.config)
+        persist(model.root.config, on: model)
     }
 
     func toggleModelFavorite(_ modelID: String, on model: QuillCodeWorkspaceModel) {
         model.toggleModelFavorite(modelID)
-        persist(model.root.config)
+        persist(model.root.config, on: model)
     }
 
     func setKeyboardShortcutPreferences(
@@ -36,7 +37,7 @@ struct QuillCodeDesktopSettingsCoordinator {
         on model: QuillCodeWorkspaceModel
     ) {
         model.setKeyboardShortcutPreferences(preferences)
-        persist(model.root.config)
+        persist(model.root.config, on: model)
     }
 
     func refreshModelCatalog(on model: QuillCodeWorkspaceModel) async {
@@ -49,15 +50,34 @@ struct QuillCodeDesktopSettingsCoordinator {
         to model: QuillCodeWorkspaceModel,
         refresh: @escaping @MainActor () -> Void
     ) {
-        let result = apply(
-            update: update,
-            currentConfig: model.root.config
-        )
+        let currentConfig = model.root.config
+        let appliedResult: QuillCodeDesktopSettingsResult
+        do {
+            appliedResult = try apply(
+                update: update,
+                currentConfig: currentConfig
+            )
+            model.recordSettingsPersistenceSuccess(appliedResult.persistedKinds)
+        } catch let error as WorkspaceSettingsPersistenceError {
+            model.recordSettingsPersistenceFailure(error.failedKinds)
+            let currentResult = result(for: currentConfig)
+            model.applySettings(
+                config: currentResult.config,
+                trustedRouterAPIKeyConfigured: currentResult.trustedRouterAPIKeyConfigured
+            )
+            model.applyRuntime(currentResult.runtime)
+            refresh()
+            return
+        } catch {
+            model.recordSettingsPersistenceFailure([.configuration])
+            refresh()
+            return
+        }
         model.applySettings(
-            config: result.config,
-            trustedRouterAPIKeyConfigured: result.trustedRouterAPIKeyConfigured
+            config: appliedResult.config,
+            trustedRouterAPIKeyConfigured: appliedResult.trustedRouterAPIKeyConfigured
         )
-        model.applyRuntime(result.runtime)
+        model.applyRuntime(appliedResult.runtime)
         refresh()
         Task { @MainActor in
             await refreshModelCatalog(on: model)
@@ -65,14 +85,19 @@ struct QuillCodeDesktopSettingsCoordinator {
         }
     }
 
-    func persist(_ config: AppConfig) {
-        try? bootstrap.saveConfig(config)
+    func persist(_ config: AppConfig, on model: QuillCodeWorkspaceModel) {
+        do {
+            try bootstrap.saveConfig(config)
+            model.recordSettingsPersistenceSuccess([.configuration])
+        } catch {
+            model.recordSettingsPersistenceFailure([.configuration])
+        }
     }
 
     func apply(
         update: WorkspaceSettingsUpdate,
         currentConfig: AppConfig
-    ) -> QuillCodeDesktopSettingsResult {
+    ) throws -> QuillCodeDesktopSettingsResult {
         var config = currentConfig
         config.apiBaseURL = update.apiBaseURL
         config.authMode = update.authMode
@@ -89,31 +114,58 @@ struct QuillCodeDesktopSettingsCoordinator {
         config.reviewDelivery = update.reviewDelivery
         config.defaultPersonality = update.defaultPersonality
 
-        if update.shouldClearAPIKey {
-            try? bootstrap.clearTrustedRouterAPIKey()
-            config.trustedRouterAccount = nil
-        }
+        let credentialMutation: WorkspaceTrustedRouterCredentialMutation
         if let replacementAPIKey = update.replacementAPIKey {
-            try? bootstrap.saveTrustedRouterAPIKey(replacementAPIKey)
+            credentialMutation = .replace(replacementAPIKey)
             config.trustedRouterAccount = nil
+        } else if update.shouldClearAPIKey {
+            credentialMutation = .clear
+            config.trustedRouterAccount = nil
+        } else {
+            credentialMutation = .unchanged
         }
         if config.authMode == .developerOverride {
             config.trustedRouterAccount = nil
         }
 
-        return persistAndBuildResult(config)
+        do {
+            try bootstrap.saveSettingsTransaction(
+                currentConfig: currentConfig,
+                proposedConfig: config,
+                credentialMutation: credentialMutation
+            )
+        } catch let error as WorkspaceSettingsPersistenceError {
+            throw error
+        } catch {
+            var kinds: Set<WorkspaceSettingsPersistenceKind> = [.configuration]
+            if credentialMutation.changesCredential {
+                kinds.insert(.trustedRouterCredential)
+            }
+            throw WorkspaceSettingsPersistenceError(
+                failedKinds: kinds,
+                rollbackFailed: true
+            )
+        }
+        var persistedKinds: Set<WorkspaceSettingsPersistenceKind> = [.configuration]
+        if credentialMutation.changesCredential {
+            persistedKinds.insert(.trustedRouterCredential)
+        }
+        return result(for: config, persistedKinds: persistedKinds)
     }
 
     func result(for config: AppConfig) -> QuillCodeDesktopSettingsResult {
-        persistAndBuildResult(config)
+        result(for: config, persistedKinds: [])
     }
 
-    private func persistAndBuildResult(_ config: AppConfig) -> QuillCodeDesktopSettingsResult {
-        try? bootstrap.saveConfig(config)
+    private func result(
+        for config: AppConfig,
+        persistedKinds: Set<WorkspaceSettingsPersistenceKind>
+    ) -> QuillCodeDesktopSettingsResult {
         return QuillCodeDesktopSettingsResult(
             config: config,
             runtime: bootstrap.makeRuntime(config: config),
-            trustedRouterAPIKeyConfigured: bootstrap.hasTrustedRouterAPIKey()
+            trustedRouterAPIKeyConfigured: bootstrap.hasTrustedRouterAPIKey(),
+            persistedKinds: persistedKinds
         )
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopSignInCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSignInCoordinator.swift
@@ -57,8 +57,11 @@ struct QuillCodeDesktopSignInCoordinator {
         config.developerOverrideEnabled = false
         config.trustedRouterAccount = await client.accountProfile(from: token)
 
-        try bootstrap.saveTrustedRouterAPIKey(token.key)
-        try bootstrap.saveConfig(config)
+        try bootstrap.saveSettingsTransaction(
+            currentConfig: currentConfig,
+            proposedConfig: config,
+            credentialMutation: .replace(token.key)
+        )
         return QuillCodeDesktopSignInResult(
             config: config,
             trustedRouterAPIKeyConfigured: true
@@ -77,10 +80,21 @@ struct QuillCodeDesktopSignInCoordinator {
                 model.setAgentStatus(label, lastError: error)
                 refresh()
             }
+            model.recordSettingsPersistenceSuccess([
+                .configuration,
+                .trustedRouterCredential
+            ])
             applySignInResult(result, to: model, settingsCoordinator: settingsCoordinator)
             refresh()
             let catalog = await bootstrap.fetchModelCatalog(config: model.root.config)
             model.setModelCatalog(catalog)
+            refresh()
+        } catch let error as WorkspaceSettingsPersistenceError {
+            model.recordSettingsPersistenceFailure(error.failedKinds)
+            model.setAgentStatus(
+                QuillCodeRuntimeStatusLabel.signInFailed,
+                lastError: error.description
+            )
             refresh()
         } catch {
             model.setAgentStatus(

--- a/Tests/QuillCodeAppTests/WorkspaceSettingsPersistenceIssueTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSettingsPersistenceIssueTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceSettingsPersistenceIssueTests: XCTestCase {
+    func testIssueTracksExactKindsAndRecoversIndependently() throws {
+        let model = QuillCodeWorkspaceModel()
+
+        model.recordSettingsPersistenceFailure([
+            .configuration,
+            .trustedRouterCredential
+        ])
+
+        let issue = try XCTUnwrap(model.surface().runtimeIssue)
+        XCTAssertEqual(model.settingsPersistenceIssueTracker.failedKindCount, 2)
+        XCTAssertEqual(issue.severity, .error)
+        XCTAssertEqual(issue.title, "Some settings changes are not saved")
+        XCTAssertEqual(
+            issue.diagnostics.first { $0.label == "Affected data" }?.value,
+            "Configuration, TrustedRouter credential"
+        )
+        XCTAssertEqual(
+            issue.diagnostics.first { $0.label == "Private content included" }?.value,
+            "No"
+        )
+
+        model.recordSettingsPersistenceSuccess([.configuration])
+
+        XCTAssertEqual(model.settingsPersistenceIssueTracker.failedKindCount, 1)
+        XCTAssertEqual(model.surface().runtimeIssue?.title, "A settings change is not saved")
+        XCTAssertEqual(
+            model.surface().runtimeIssue?.diagnostics.first { $0.label == "Affected data" }?.value,
+            "TrustedRouter credential"
+        )
+
+        model.recordSettingsPersistenceSuccess([.trustedRouterCredential])
+
+        XCTAssertEqual(model.settingsPersistenceIssueTracker.failedKindCount, 0)
+        XCTAssertNotEqual(model.surface().runtimeIssue?.title, issue.title)
+    }
+
+    func testRegistryFailureKeepsPriorityOverSettingsFailure() {
+        let model = QuillCodeWorkspaceModel()
+
+        model.registryPersistenceIssueTracker.recordFailure(for: .projects)
+        model.recordSettingsPersistenceFailure([.configuration])
+
+        XCTAssertEqual(model.surface().runtimeIssue?.title, "A workspace change is not saved")
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceSettingsPersistenceTransactionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceSettingsPersistenceTransactionTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceSettingsPersistenceTransactionTests: XCTestCase {
+    private enum StubError: Error {
+        case failed
+    }
+
+    func testConfigurationOnlySaveDoesNotReadCredential() throws {
+        var savedConfiguration: AppConfig?
+        var credentialReadCount = 0
+        let proposed = AppConfig(apiBaseURL: "https://settings.example")
+        let transaction = WorkspaceSettingsPersistenceTransaction(
+            saveConfiguration: { savedConfiguration = $0 },
+            readCredential: {
+                credentialReadCount += 1
+                return nil
+            },
+            writeCredential: { _ in XCTFail("Credential must remain untouched") },
+            clearCredential: { XCTFail("Credential must remain untouched") }
+        )
+
+        try transaction.apply(
+            currentConfig: AppConfig(),
+            proposedConfig: proposed,
+            credentialMutation: .unchanged
+        )
+
+        XCTAssertEqual(savedConfiguration, proposed)
+        XCTAssertEqual(credentialReadCount, 0)
+    }
+
+    func testPartialCredentialWriteIsCompensatedBeforeConfigurationSave() throws {
+        let current = AppConfig(apiBaseURL: "https://current.example")
+        let proposed = AppConfig(apiBaseURL: "https://private-proposed.example")
+        let priorCredential = "prior-private-credential"
+        let replacementCredential = "replacement-private-credential"
+        var storedCredential: String? = priorCredential
+        var credentialWriteCount = 0
+        var configurationSaveCount = 0
+        let transaction = WorkspaceSettingsPersistenceTransaction(
+            saveConfiguration: { _ in configurationSaveCount += 1 },
+            readCredential: { storedCredential },
+            writeCredential: { credential in
+                storedCredential = credential
+                credentialWriteCount += 1
+                if credentialWriteCount == 1 {
+                    throw StubError.failed
+                }
+            },
+            clearCredential: { storedCredential = nil }
+        )
+
+        let error = try persistenceError {
+            try transaction.apply(
+                currentConfig: current,
+                proposedConfig: proposed,
+                credentialMutation: .replace(replacementCredential)
+            )
+        }
+
+        XCTAssertEqual(storedCredential, priorCredential)
+        XCTAssertEqual(credentialWriteCount, 2)
+        XCTAssertEqual(configurationSaveCount, 0)
+        XCTAssertEqual(error.failedKinds, [.configuration, .trustedRouterCredential])
+        XCTAssertFalse(error.rollbackFailed)
+        assertContentFree(error, secrets: [priorCredential, replacementCredential, proposed.apiBaseURL])
+    }
+
+    func testConfigurationFailureRestoresPriorCredential() throws {
+        let current = AppConfig(apiBaseURL: "https://current.example")
+        let proposed = AppConfig(apiBaseURL: "https://private-proposed.example")
+        let priorCredential = "prior-private-credential"
+        let replacementCredential = "replacement-private-credential"
+        var storedCredential: String? = priorCredential
+        var configurationSaveCount = 0
+        let transaction = WorkspaceSettingsPersistenceTransaction(
+            saveConfiguration: { _ in
+                configurationSaveCount += 1
+                throw StubError.failed
+            },
+            readCredential: { storedCredential },
+            writeCredential: { storedCredential = $0 },
+            clearCredential: { storedCredential = nil }
+        )
+
+        let error = try persistenceError {
+            try transaction.apply(
+                currentConfig: current,
+                proposedConfig: proposed,
+                credentialMutation: .replace(replacementCredential)
+            )
+        }
+
+        XCTAssertEqual(storedCredential, priorCredential)
+        XCTAssertEqual(configurationSaveCount, 1)
+        XCTAssertEqual(error.failedKinds, [.configuration, .trustedRouterCredential])
+        XCTAssertFalse(error.rollbackFailed)
+        assertContentFree(error, secrets: [priorCredential, replacementCredential, proposed.apiBaseURL])
+    }
+
+    func testRollbackFailureReportsOnlyBoundedCategories() throws {
+        let current = AppConfig(apiBaseURL: "https://current.example")
+        let proposed = AppConfig(apiBaseURL: "https://private-proposed.example")
+        let priorCredential = "prior-private-credential"
+        let replacementCredential = "replacement-private-credential"
+        var storedCredential: String? = priorCredential
+        var credentialWriteCount = 0
+        let transaction = WorkspaceSettingsPersistenceTransaction(
+            saveConfiguration: { _ in throw StubError.failed },
+            readCredential: { storedCredential },
+            writeCredential: { credential in
+                credentialWriteCount += 1
+                if credentialWriteCount > 1 {
+                    throw StubError.failed
+                }
+                storedCredential = credential
+            },
+            clearCredential: { throw StubError.failed }
+        )
+
+        let error = try persistenceError {
+            try transaction.apply(
+                currentConfig: current,
+                proposedConfig: proposed,
+                credentialMutation: .replace(replacementCredential)
+            )
+        }
+
+        XCTAssertEqual(storedCredential, replacementCredential)
+        XCTAssertEqual(error.failedKinds, [.configuration, .trustedRouterCredential])
+        XCTAssertTrue(error.rollbackFailed)
+        assertContentFree(error, secrets: [priorCredential, replacementCredential, proposed.apiBaseURL])
+    }
+
+    func testCredentialReadFailureDoesNotAttemptAnyWrite() throws {
+        var configurationSaveCount = 0
+        var credentialWriteCount = 0
+        let transaction = WorkspaceSettingsPersistenceTransaction(
+            saveConfiguration: { _ in configurationSaveCount += 1 },
+            readCredential: { throw StubError.failed },
+            writeCredential: { _ in credentialWriteCount += 1 },
+            clearCredential: { credentialWriteCount += 1 }
+        )
+
+        let error = try persistenceError {
+            try transaction.apply(
+                currentConfig: AppConfig(),
+                proposedConfig: AppConfig(),
+                credentialMutation: .clear
+            )
+        }
+
+        XCTAssertEqual(configurationSaveCount, 0)
+        XCTAssertEqual(credentialWriteCount, 0)
+        XCTAssertEqual(error.failedKinds, [.trustedRouterCredential])
+        XCTAssertFalse(error.rollbackFailed)
+    }
+
+    private func persistenceError(
+        _ operation: () throws -> Void
+    ) throws -> WorkspaceSettingsPersistenceError {
+        do {
+            try operation()
+            XCTFail("Expected settings persistence to fail")
+            throw StubError.failed
+        } catch let error as WorkspaceSettingsPersistenceError {
+            return error
+        }
+    }
+
+    private func assertContentFree(
+        _ error: WorkspaceSettingsPersistenceError,
+        secrets: [String]
+    ) {
+        for secret in secrets {
+            XCTAssertFalse(error.description.contains(secret))
+        }
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -110,6 +110,25 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
     }
 
+    func testRenderedWorkspaceShowsUnsavedSettingsDurabilityWarning() throws {
+        let model = QuillCodeWorkspaceModel()
+        model.recordSettingsPersistenceFailure([
+            .configuration,
+            .trustedRouterCredential
+        ])
+        let surface = model.surface()
+        XCTAssertEqual(surface.runtimeIssue?.title, "Some settings changes are not saved")
+
+        let image = try renderWorkspace(surface)
+        let stats = try RenderedWorkspacePixelStats(image: image)
+
+        XCTAssertEqual(stats.width, 1280)
+        XCTAssertEqual(stats.height, 900)
+        XCTAssertGreaterThan(stats.opaquePixelRatio, 0.98)
+        XCTAssertGreaterThan(stats.distinctColorBuckets, 24)
+        XCTAssertGreaterThan(stats.brightPixelRatio, 0.0008)
+    }
+
     func testRenderedEmptyWorkspaceShowsAggregatedRegistryRecoveryIssue() throws {
         let firstThread = ChatThread(title: "Recovered chat A")
         let secondThread = ChatThread(title: "Recovered chat B")

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopSettingsPersistenceTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopSettingsPersistenceTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import QuillCodeApp
+import QuillCodeCore
+import QuillCodePersistence
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopSettingsPersistenceTests: XCTestCase {
+    func testQuickConfigurationFailureRemainsVisibleUntilFullSnapshotSucceeds() throws {
+        let root = try makeTempDirectory()
+        let paths = QuillCodePaths(home: root)
+        let bootstrap = makeBootstrap(paths: paths)
+        try bootstrap.saveConfig(AppConfig())
+        let model = try bootstrap.makeModel()
+        let coordinator = QuillCodeDesktopSettingsCoordinator(bootstrap: bootstrap)
+        try replaceConfigFileWithDirectory(paths.configFile)
+
+        coordinator.setMode(.plan, on: model)
+
+        let issue = try XCTUnwrap(model.surface().runtimeIssue)
+        XCTAssertEqual(model.root.config.mode, .plan)
+        XCTAssertEqual(issue.title, "A settings change is not saved")
+        XCTAssertEqual(
+            issue.diagnostics.first { $0.label == "Affected data" }?.value,
+            "Configuration"
+        )
+        XCTAssertFalse(issue.message.contains(root.path))
+
+        try FileManager.default.removeItem(at: paths.configFile)
+        coordinator.setMode(.plan, on: model)
+
+        XCTAssertNotEqual(model.surface().runtimeIssue?.title, issue.title)
+        XCTAssertEqual(try ConfigStore(fileURL: paths.configFile).load().mode, .plan)
+    }
+
+    func testCredentialAndConfigurationFailureRollsBackThenRetriesAtomically() throws {
+        let root = try makeTempDirectory()
+        let paths = QuillCodePaths(home: root)
+        let bootstrap = makeBootstrap(paths: paths)
+        let currentConfig = AppConfig(apiBaseURL: "https://current.example")
+        let priorCredential = "prior-private-credential"
+        let replacementCredential = "replacement-private-credential"
+        let privateAPIBaseURL = "https://private-acquisition.example"
+        try bootstrap.saveConfig(currentConfig)
+        try bootstrap.saveTrustedRouterAPIKey(priorCredential)
+        let model = try bootstrap.makeModel()
+        let coordinator = QuillCodeDesktopSettingsCoordinator(bootstrap: bootstrap)
+        try replaceConfigFileWithDirectory(paths.configFile)
+        let update = WorkspaceSettingsUpdate(
+            apiBaseURL: privateAPIBaseURL,
+            replacementAPIKey: replacementCredential
+        )
+        var refreshCount = 0
+
+        coordinator.saveSettings(update, to: model) {
+            refreshCount += 1
+        }
+
+        let issue = try XCTUnwrap(model.surface().runtimeIssue)
+        XCTAssertEqual(refreshCount, 1)
+        XCTAssertEqual(model.root.config, currentConfig)
+        XCTAssertEqual(try storedCredential(paths: paths), priorCredential)
+        XCTAssertEqual(issue.title, "Some settings changes are not saved")
+        XCTAssertEqual(
+            issue.diagnostics.first { $0.label == "Affected data" }?.value,
+            "Configuration, TrustedRouter credential"
+        )
+        let visibleText = ([issue.title, issue.message] + issue.diagnostics.flatMap {
+            [$0.label, $0.value]
+        }).joined(separator: " ")
+        XCTAssertFalse(visibleText.contains(root.path))
+        XCTAssertFalse(visibleText.contains(privateAPIBaseURL))
+        XCTAssertFalse(visibleText.contains(priorCredential))
+        XCTAssertFalse(visibleText.contains(replacementCredential))
+
+        try FileManager.default.removeItem(at: paths.configFile)
+        coordinator.saveSettings(update, to: model) {}
+
+        XCTAssertEqual(model.root.config.apiBaseURL, privateAPIBaseURL)
+        XCTAssertEqual(try storedCredential(paths: paths), replacementCredential)
+        XCTAssertNotEqual(model.surface().runtimeIssue?.title, issue.title)
+        XCTAssertEqual(
+            try ConfigStore(fileURL: paths.configFile).load().apiBaseURL,
+            privateAPIBaseURL
+        )
+    }
+
+    private func makeBootstrap(paths: QuillCodePaths) -> QuillCodeWorkspaceBootstrap {
+        QuillCodeWorkspaceBootstrap(
+            paths: paths,
+            runtimeFactory: QuillCodeRuntimeFactory(
+                paths: paths,
+                environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+            )
+        )
+    }
+
+    private func replaceConfigFileWithDirectory(_ fileURL: URL) throws {
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+        try FileManager.default.createDirectory(at: fileURL, withIntermediateDirectories: false)
+    }
+
+    private func storedCredential(paths: QuillCodePaths) throws -> String? {
+        try FileSecretStore(directory: paths.secretsDirectory)
+            .read(QuillSecretKeys.trustedRouterAPIKey)
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopTrustedRouterAuthGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopTrustedRouterAuthGateTests.swift
@@ -15,7 +15,7 @@ final class ParityDesktopTrustedRouterAuthGateTests: QuillCodeParityTestCase {
         Self.assertSource(text, contains: "TrustedRouterDefaults.loopbackCallbackURL")
         Self.assertSource(text, contains: "createAuthorization")
         Self.assertSource(text, contains: "exchangeCode")
-        Self.assertSource(text, contains: "saveTrustedRouterAPIKey")
+        Self.assertSource(text, contains: "saveSettingsTransaction")
         Self.assertSource(text, contains: "fetchModelCatalog")
         Self.assertSource(signInText, contains: "func completeSignInAndApply")
         Self.assertSource(signInText, contains: "model.applySettings")
@@ -28,6 +28,8 @@ final class ParityDesktopTrustedRouterAuthGateTests: QuillCodeParityTestCase {
         Self.assertSource(controllerText, excludes: "LoopbackHTTPCallbackServer")
         Self.assertSource(controllerText, excludes: "private func completeTrustedRouterSignIn")
         Self.assertSource(controllerText, excludes: "QuillCodeRuntimeStatusLabel.signInFailed")
+        Self.assertSource(signInText, excludes: "try bootstrap.saveTrustedRouterAPIKey(token.key)")
+        Self.assertSource(signInText, excludes: "try bootstrap.saveConfig(config)")
         XCTAssertFalse(
             text.contains("NSWorkspace.shared.open(url)") && text.contains("TrustedRouterDefaults.signInURL"),
             "Desktop sign-in should not regress to opening the static sign-in documentation page."

--- a/Tests/QuillCodeParityTests/ParityWorkspaceSettingsPersistenceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceSettingsPersistenceGateTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+final class ParityWorkspaceSettingsPersistenceGateTests: QuillCodeParityTestCase {
+    func testDesktopSettingsUseCompensatedContentFreePersistence() throws {
+        let bootstrapText = try Self.appSourceText(named: "WorkspaceBootstrap.swift")
+        let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
+        let persistenceText = try Self.appSourceText(named: "WorkspaceSettingsPersistence.swift")
+        let issueText = try Self.appSourceText(named: "WorkspaceSettingsPersistenceIssue.swift")
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+        let coordinatorText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopSettingsCoordinator.swift"
+        )
+        let signInText = try Self.desktopSourceText(named: "QuillCodeDesktopSignInCoordinator.swift")
+
+        Self.assertSource(persistenceText, containsAll: [
+            "struct WorkspaceSettingsPersistenceTransaction",
+            "private func restoreCredential(",
+            "public struct WorkspaceSettingsPersistenceError",
+            "failedKinds: Set<WorkspaceSettingsPersistenceKind>",
+            "rollbackFailed: Bool"
+        ])
+        Self.assertSource(issueText, containsAll: [
+            "final class WorkspaceSettingsPersistenceIssueTracker",
+            "private var failedKinds: Set<WorkspaceSettingsPersistenceKind>",
+            "Private content included"
+        ])
+        Self.assertSource(bootstrapText, contains: "public func saveSettingsTransaction(")
+        Self.assertSource(modelText, contains: "let settingsPersistenceIssueTracker")
+        Self.assertSource(
+            surfaceText,
+            contains: "settingsPersistenceIssueTracker.runtimeIssue"
+        )
+        Self.assertSource(coordinatorText, containsAll: [
+            "bootstrap.saveSettingsTransaction(",
+            "model.recordSettingsPersistenceFailure(",
+            "model.recordSettingsPersistenceSuccess("
+        ])
+        Self.assertSource(coordinatorText, excludesAll: [
+            "try? bootstrap.saveConfig",
+            "try? bootstrap.clearTrustedRouterAPIKey",
+            "try? bootstrap.saveTrustedRouterAPIKey"
+        ])
+        Self.assertSource(signInText, containsAll: [
+            "bootstrap.saveSettingsTransaction(",
+            "catch let error as WorkspaceSettingsPersistenceError"
+        ])
+        Self.assertSource(signInText, excludesAll: [
+            "try bootstrap.saveTrustedRouterAPIKey(token.key)",
+            "try bootstrap.saveConfig(config)"
+        ])
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-09 Transactional Desktop Settings Persistence
+
+Overall grade after this slice: **A+ data integrity, A+ recovery UX, A+ privacy**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Transaction integrity | A+ | Full settings saves snapshot the previous credential, apply a requested replacement or clear, persist configuration last, and restore the previous credential when either step fails. Proposed settings enter the live model only after the transaction succeeds. |
+| OAuth integrity | A+ | TrustedRouter sign-in persists its credential and account configuration through the same transaction, removing the former split-write state where one could succeed without the other. |
+| Recovery UX | A+ | Quick mode, model, favorite, and shortcut changes remain usable for the session when configuration persistence fails, while the normal runtime-issue surface keeps an exact warning visible until that data kind saves successfully. |
+| Privacy | A+ | Failures retain only bounded configuration/credential enum cases and one rollback-failure boolean. Diagnostics contain no key material, account data, paths, URLs, or raw filesystem errors. |
+| Failure compensation | A+ | Credential read failures perform no writes, partial credential mutations are compensated before returning, and configuration failures restore the prior credential. A failed rollback remains visible without exposing the underlying error. |
+
+Validation:
+
+- Focused transaction, persistence issue, desktop recovery, parity, settings regression, and
+  native rendered suites (12 tests, 0 failures)
+- OAuth and settings transaction parity guards (2 tests, 0 failures)
+- Full `swift test` (5,736 tests, 5 skipped, 0 failures)
+- Complete packaged direct, Launch Services, live-window, Accessibility, and repeated-interaction
+  smoke passed with 126 messages, 79 tool cards, 205 timeline items, and 186 click probes
+- Packaged performance passed at 279.59 ms launch-ready, 98.41 MiB initial, 158.27 MiB
+  post-interaction, and 162.66 MiB repeated-interaction memory with 4.39 MiB repeated growth
+- Optimized release executable stripped from 56,189,744 to 28,197,968 bytes before signing;
+  final executable is 28,052,176 bytes, strict signature verification and Launch Services passed
+- `python3 scripts/grade-code-quality.py --root .` reports every module at A+
+
 ## 2026-08-09 Visible Workspace Registry Durability Failures
 
 Overall grade after this slice: **A+ data integrity, A+ recovery UX, A+ privacy**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # QuillCode Decisions
 
+## 2026-08-09: settings and credentials persist as one compensated transaction
+
+- **Decision:** A full desktop settings save snapshots the existing TrustedRouter credential,
+  applies the requested credential mutation, and saves configuration last. Any mutation or
+  configuration failure attempts to restore the previous credential before returning failure.
+- **Live state:** Proposed full settings do not enter the workspace model until both durable writes
+  succeed. Quick mode, model, favorite, and keyboard-shortcut changes still apply to the current
+  session immediately, but a failed configuration save remains visibly unsaved until a retry works.
+- **OAuth:** Loopback sign-in uses the same transaction for its exchanged credential and account
+  configuration, so the app cannot report a completed sign-in from only one durable half.
+- **Privacy:** Persistence errors and the issue tracker retain only affected enum kinds and a bounded
+  rollback-failure boolean. Raw errors, paths, URLs, account details, and credential values never
+  enter runtime diagnostics.
+- **Why:** Separate best-effort writes could leave a new credential paired with old configuration,
+  old credentials paired with new configuration, or session-only settings with no visible warning.
+  Compensation preserves the last known durable pair whenever the filesystem permits recovery.
+
 ## 2026-08-09: workspace registry persistence failures remain visible until exact recovery
 
 - **Decision:** Project, automation, and saved-search snapshots share a focused registry

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -59,6 +59,18 @@ suppresses it for the current build; a newer build may remind the user again.
 Writable installed copies do not show it. Installation guidance and available-update
 state use one coordinated sheet, so they cannot overlap.
 
+## Tester Recovery: Unsaved Settings
+
+If Quill Cowork reports that a settings change is not saved, keep the app open and retry the
+change after checking available disk space and write access to the app-data directory. The app
+keeps quick preference changes usable for the current session and protects the previous durable
+configuration and TrustedRouter credential whenever recovery is possible. A successful retry for
+the affected data clears the warning; an unrelated successful save does not hide it.
+
+For a bug report, include the warning title, affected data labels, app version, and build number.
+Do not include API keys, account details, filesystem paths, URLs, or raw private content. The
+in-app diagnostic is deliberately content-free and should report `Private content included: No`.
+
 ## Build Cadence
 
 The tester release is refreshed:


### PR DESCRIPTION
## Summary
- persist desktop configuration and TrustedRouter credential changes as one compensated transaction
- surface exact, content-free persistence failures until the affected setting saves successfully
- route OAuth sign-in through the same persistence boundary and guard the contract with parity tests

## Verification
- focused persistence, recovery, parity, and rendered tests: 12 passed
- OAuth/settings parity guards: 2 passed
- full Swift suite: 5,736 passed, 5 skipped, 0 failures
- all code-quality modules: A+
- packaged direct, Launch Services, live-window, Accessibility, and repeated-interaction smoke passed
- packaged performance: 279.59 ms launch-ready; 98.41 MiB initial; 158.27 MiB post-interaction; 162.66 MiB repeated
- optimized release bundle passed strict signature verification and Launch Services smoke