### PR TITLE
Round TrustedRouter key usage amounts

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
@@ -68,9 +68,11 @@ struct QuillCodeTopBarIdentityView: View {
                             .foregroundStyle(accountBalance.tone.quillCodeTint)
                     }
                     .contentShape(Rectangle())
+                    .fixedSize(horizontal: true, vertical: false)
                 }
                 .quillCodeCapsuleButtonTarget()
                 .buttonStyle(QuillCodePressableButtonStyle(enforcesMinimumHitTarget: false))
+                .layoutPriority(2)
                 .help("Show TrustedRouter key usage and limits")
                 .accessibilityLabel(accountBalance.accessibilityLabel)
                 .accessibilityHint("Shows daily, weekly, monthly, and total key usage")

--- a/Sources/QuillCodeApp/WorkspaceTrustedRouterCreditsSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTrustedRouterCreditsSurfaceBuilder.swift
@@ -245,7 +245,7 @@ struct WorkspaceTrustedRouterCreditsSurfaceBuilder: Sendable, Hashable {
     }
 
     private static func money(_ value: Double, currency: String?) -> String {
-        let amount = decimalLabel(value)
+        let amount = decimalLabel(value, fractionDigits: currency == "JPY" ? 0 : 2)
         switch currency {
         case "USD": return "$\(amount)"
         case "EUR": return "€\(amount)"
@@ -256,16 +256,14 @@ struct WorkspaceTrustedRouterCreditsSurfaceBuilder: Sendable, Hashable {
         }
     }
 
-    private static func decimalLabel(_ value: Double) -> String {
-        let normalized = abs(value) < 0.00005 ? 0 : value
-        var label = String(
-            format: "%.4f",
+    private static func decimalLabel(_ value: Double, fractionDigits: Int) -> String {
+        let roundingThreshold = 0.5 / pow(10, Double(fractionDigits))
+        let normalized = abs(value) < roundingThreshold ? 0 : value
+        return String(
+            format: "%.*f",
             locale: Locale(identifier: "en_US_POSIX"),
+            fractionDigits,
             normalized
         )
-        while label.last == "0", label.split(separator: ".").last?.count ?? 0 > 2 {
-            label.removeLast()
-        }
-        return label
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceTrustedRouterCreditsSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceTrustedRouterCreditsSurfaceBuilderTests.swift
@@ -25,9 +25,9 @@ final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
         XCTAssertEqual(surface.visibleLimits.map(\.periodLabel), ["Today", "Week", "Month", "Total"])
         XCTAssertEqual(surface.visibleLimits.map(\.usageLabel), [
             "$1.25 / $40.00",
-            "$2.6439 / $200.00",
-            "$2.6439 / $800.00",
-            "$86.0903 used"
+            "$2.64 / $200.00",
+            "$2.64 / $800.00",
+            "$86.09 used"
         ])
         XCTAssertEqual(surface.visibleLimits.last?.remainingLabel, "No total cap")
         XCTAssertTrue(surface.detailLabel.contains("Updated 1m ago"))
@@ -58,10 +58,10 @@ final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
             "Recent key-limit history: Today $2.00 / $40.00 updated 1m ago; Today $1.00 / $40.00 updated 1h ago."
         )
         XCTAssertTrue(surface.detailLabel.contains("Recent key-limit history"))
-        XCTAssertTrue(surface.accessibilityLabel.contains("Week: $2.6439 / $200.00"))
+        XCTAssertTrue(surface.accessibilityLabel.contains("Week: $2.64 / $200.00"))
     }
 
-    func testStaleSurfaceRetainsPreciseUsageAndFailureReason() throws {
+    func testStaleSurfaceRoundsUsageAndRetainsFailureReason() throws {
         let snapshot = try makeSnapshot(
             lifetimeUsage: 0.0123,
             dailyUsage: 0.0123,
@@ -80,7 +80,7 @@ final class WorkspaceTrustedRouterCreditsSurfaceBuilderTests: XCTestCase {
             now: now
         ).surface())
 
-        XCTAssertEqual(surface.amountLabel, "Today €0.0123 / €40.00")
+        XCTAssertEqual(surface.amountLabel, "Today €0.01 / €40.00")
         XCTAssertEqual(surface.tone, .warning)
         XCTAssertTrue(surface.detailLabel.contains("Network unavailable."))
     }


### PR DESCRIPTION
## Summary
- round key usage and limit currency values to normal display precision
- keep the full account usage chip visible instead of middle-truncating it
- update focused coverage for rounded daily, weekly, monthly, and lifetime amounts

## Validation
- swift test --filter WorkspaceTrustedRouterCreditsSurfaceBuilderTests
- swift test --filter WorkspaceTokenUsageChipRenderTests
- git diff --check