### PR TITLE
Acknowledge updater launch at app entry

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -14,6 +14,7 @@ struct QuillCodeDesktopApp: App {
 
     init() {
         _ = QuillCodeDesktopLaunchClock.appEntryUptime
+        QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()
         if let updateRequest = QuillCodeDesktopUpdateHelperRequest.parse(arguments: CommandLine.arguments) {
             Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
         }
@@ -189,7 +190,6 @@ struct QuillCodeDesktopRootView: View {
                     }
             }
             .task {
-                QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()
                 controller.installationLocationController.startIfNeeded()
                 controller.updateController.startAutomaticChecks()
             }

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -8,9 +8,18 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         let workflow = try Self.workflowText(named: "download-builds.yml")
 
         Self.assertSource(app, containsAll: [
+            "_ = QuillCodeDesktopLaunchClock.appEntryUptime",
+            "QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()",
             "QuillCodeDesktopUpdaterSmokeRequest",
             "QuillCodeDesktopUpdaterSmokeRunner.runAndExit"
         ])
+        let handshake = "QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()"
+        XCTAssertEqual(app.components(separatedBy: handshake).count - 1, 1)
+        let entryRange = try XCTUnwrap(app.range(of: "_ = QuillCodeDesktopLaunchClock.appEntryUptime"))
+        let handshakeRange = try XCTUnwrap(app.range(of: handshake))
+        let helperRange = try XCTUnwrap(app.range(of: "QuillCodeDesktopUpdateHelperRequest.parse"))
+        XCTAssertLessThan(entryRange.lowerBound, handshakeRange.lowerBound)
+        XCTAssertLessThan(handshakeRange.lowerBound, helperRange.lowerBound)
         Self.assertSource(runner, containsAll: [
             "waitForAvailableUpdate(configuration: configuration)",
             "feedPropagationAttemptLimit = 6",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,29 @@
 # Code Quality Audit
 
+## 2026-08-09 Window-Independent Updater Launch Handshake
+
+Overall grade after this slice: **A+ update resilience, A+ rollback integrity, A+ lifecycle ownership**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Lifecycle ownership | A+ | The verified-update launch handshake is acknowledged once in `QuillCodeDesktopApp.init`, immediately after the launch clock starts and before helper or scene dispatch. It no longer depends on a workspace window being restored and rendering its root view. |
+| Recovery integrity | A+ | The detached helper still requires the bounded handshake and stable child process before committing activation. Missing handshakes continue to terminate the candidate, atomically restore the previous build, and reopen it. |
+| Security boundary | A+ | Only the ownership of an already validated cache-root token moved. Path containment, extension and filename checks, bundle identity, signature, version, build, commit, and helper request validation remain unchanged. |
+| Regression coverage | A+ | The packaged-updater parity gate requires exactly one acknowledgment and proves its source order between app entry and helper-mode dispatch. Existing swap, rollback, relocation, feed, and updater smoke suites remain green. |
+
+Validation:
+
+- Focused updater model, relocation, smoke-request, and parity suites (38 tests, 0 failures)
+- Full `swift test` (5,740 tests, 5 skipped, 0 failures)
+- Deterministic code-quality grader: every source, test, and script module remains A+
+- Optimized release app wrote the canonical isolated launch token at process entry before scene work
+- Optimized release performance across three fresh processes: 261.55 ms selected median
+  launch-ready, 90.92 MiB initial, 153.45 MiB post-interaction, 157.91 MiB repeated, and
+  4.45 MiB repeated growth; all three attempts passed every budget
+- Complete packaged direct, Launch Services, live-window, Accessibility, and repeated-interaction
+  smoke passed with 126 messages, 79 tool cards, 205 timeline items, 186 click probes, 10 strict
+  Accessibility actions, two interaction sweeps, and one workspace window
+
 ## 2026-08-09 Collision-Safe Targeted Accessibility Readiness
 
 Overall grade after this slice: **A+ launch resilience, A+ bounded work, A+ diagnostics**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,19 @@
 # QuillCode Decisions
 
+## 2026-08-09: verified-update launch acknowledgment belongs to app entry
+
+- **Decision:** `QuillCodeDesktopApp.init` acknowledges a validated updater launch token exactly
+  once, immediately after recording app-entry uptime and before helper-mode or scene dispatch.
+- **Window independence:** The token is not owned by `QuillCodeDesktopRootView.task`; macOS can
+  restore a menu-bar app without materializing its main window, and update success must not depend
+  on a particular scene or view lifecycle.
+- **Recovery boundary:** The detached helper still owns process-exit waiting, atomic activation,
+  handshake timeout, launch stability, rollback, result persistence, and staging cleanup. Moving
+  acknowledgment earlier does not weaken any helper validation or allow an unverified update.
+- **Why:** A daily-driver updater run staged build 687 correctly, but the relaunched app restored
+  without creating the root view. The handshake timed out and the helper correctly restored build
+  686. Process-entry acknowledgment proves the executable launched regardless of window state.
+
 ## 2026-08-09: accessibility readiness uses collision-safe targeted traversal
 
 - **Decision:** Accessibility traversal deduplicates `AXUIElement` values with `CFEqual` and hashes


### PR DESCRIPTION
## Summary
- acknowledge verified updater launches during app initialization
- remove the handshake dependency on workspace-window restoration
- lock lifecycle ownership and ordering with a parity gate

## Verification
- focused updater and parity suites: 38 tests, 0 failures
- full Swift suite: 5,740 tests, 5 skipped, 0 failures
- optimized three-process performance: all attempts within budget
- complete packaged direct, Launch Services, live-window, Accessibility, and repeated-interaction smoke
- deterministic quality grader: all modules A+