### PR TITLE
Skip superseded tester publications

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -148,6 +148,8 @@ jobs:
     permissions:
       actions: read
       contents: write
+    outputs:
+      published: ${{ steps.publication.outputs.publish-required }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -182,7 +184,11 @@ jobs:
             --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             --output "$RUNNER_TEMP/release-assets/$MANIFEST_NAME"
           find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -print | sort
+      - name: Recheck publication freshness
+        id: publication
+        run: scripts/plan-download-publication.sh
       - name: Publish tester or tagged release
+        if: steps.publication.outputs.publish-required == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -256,6 +262,7 @@ jobs:
 
   verify-published:
     needs: publish
+    if: needs.publish.outputs.published == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -316,6 +316,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "--commit \"$GITHUB_SHA\"",
             "--output \"$RUNNER_TEMP/release-notes.md\"",
             "current-release-assets.txt",
+            "scripts/plan-download-publication.sh",
+            "published: ${{ steps.publication.outputs.publish-required }}",
+            "if: steps.publication.outputs.publish-required == 'true'",
+            "if: needs.publish.outputs.published == 'true'",
             "gh release delete-asset \"$RELEASE_TAG\" \"$asset_name\" --yes",
             "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/* --clobber",
             "--verify-tag",
@@ -362,11 +366,14 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertLessThan(validationIndex.lowerBound, ciGateIndex.lowerBound)
         XCTAssertLessThan(ciGateIndex.lowerBound, planningIndex.lowerBound)
         let publishIndex = try XCTUnwrap(workflow.range(of: "  publish:"))
+        let freshnessIndex = try XCTUnwrap(workflow.range(of: "scripts/plan-download-publication.sh"))
+        let releaseMutationIndex = try XCTUnwrap(workflow.range(of: "git tag -f \"$RELEASE_TAG\""))
         let publicVerificationIndex = try XCTUnwrap(workflow.range(of: "  verify-published:"))
         let promotionIndex = try XCTUnwrap(workflow.range(of: "  promote-stable:"))
         let updaterIndex = try XCTUnwrap(workflow.range(of: "  verify-updater:"))
         let finalVerificationIndex = try XCTUnwrap(workflow.range(of: "  verify-stable-promotion:"))
         XCTAssertLessThan(publishIndex.lowerBound, publicVerificationIndex.lowerBound)
+        XCTAssertLessThan(freshnessIndex.lowerBound, releaseMutationIndex.lowerBound)
         XCTAssertLessThan(publicVerificationIndex.lowerBound, promotionIndex.lowerBound)
         XCTAssertLessThan(promotionIndex.lowerBound, updaterIndex.lowerBound)
         XCTAssertLessThan(updaterIndex.lowerBound, finalVerificationIndex.lowerBound)

--- a/Tests/QuillCodeParityTests/ParityDownloadPublicationFreshnessGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadPublicationFreshnessGateTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+final class ParityDownloadPublicationFreshnessGateTests: QuillCodeParityTestCase {
+    func testCurrentMainTesterBuildRemainsPublishable() throws {
+        let result = try runPlanner(refType: "branch", refName: "main")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertEqual(result.publishRequired, "true")
+        XCTAssertTrue(result.output.contains("is still current main"), result.output)
+    }
+
+    func testSupersededTesterBuildSkipsPublicationWithoutFailingTheWorkflow() throws {
+        let result = try runPlanner(
+            refType: "branch",
+            refName: "main",
+            mainCommit: String(repeating: "b", count: 40)
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertEqual(result.publishRequired, "false")
+        XCTAssertTrue(result.output.contains("Skipping superseded tester build"), result.output)
+    }
+
+    func testImmutableStableTagRemainsPublishableWhenMainAdvances() throws {
+        let result = try runPlanner(
+            refType: "tag",
+            refName: "v1.2.3",
+            mainCommit: String(repeating: "b", count: 40)
+        )
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertEqual(result.publishRequired, "true")
+        XCTAssertTrue(result.output.contains("Immutable stable tag v1.2.3"), result.output)
+    }
+
+    func testUnsupportedRefAndMovedStableTagFailClosed() throws {
+        let feature = try runPlanner(refType: "branch", refName: "feature")
+        let movedTag = try runPlanner(
+            refType: "tag",
+            refName: "v1.2.3",
+            tagCommit: String(repeating: "b", count: 40)
+        )
+
+        XCTAssertEqual(feature.exitCode, 2, feature.output)
+        XCTAssertNil(feature.publishRequired)
+        XCTAssertTrue(feature.output.contains("only be published from main"), feature.output)
+        XCTAssertEqual(movedTag.exitCode, 2, movedTag.output)
+        XCTAssertNil(movedTag.publishRequired)
+        XCTAssertTrue(movedTag.output.contains("no longer resolves"), movedTag.output)
+    }
+
+    private struct PlannerResult {
+        var exitCode: Int32
+        var output: String
+        var publishRequired: String?
+    }
+
+    private func runPlanner(
+        refType: String,
+        refName: String,
+        commit: String = String(repeating: "a", count: 40),
+        mainCommit: String? = nil,
+        tagCommit: String? = nil
+    ) throws -> PlannerResult {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-publication-freshness-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let bin = root.appendingPathComponent("bin")
+        let outputURL = root.appendingPathComponent("github-output")
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let gitURL = bin.appendingPathComponent("git")
+        try fakeGit.write(to: gitURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: gitURL.path)
+
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts")
+                .appendingPathComponent("plan-download-publication.sh")
+                .path
+        ]
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(bin.path):\(environment["PATH"] ?? "")"
+        environment["GITHUB_REF_TYPE"] = refType
+        environment["GITHUB_REF_NAME"] = refName
+        environment["GITHUB_SHA"] = commit
+        environment["GITHUB_OUTPUT"] = outputURL.path
+        environment["PUBLICATION_MAIN_COMMIT"] = mainCommit ?? commit
+        environment["PUBLICATION_TAG_COMMIT"] = tagCommit ?? commit
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let githubOutput = (try? String(contentsOf: outputURL, encoding: .utf8)) ?? ""
+        let publishRequired = githubOutput
+            .split(separator: "\n")
+            .first { $0.hasPrefix("publish-required=") }?
+            .split(separator: "=", maxSplits: 1)
+            .last
+            .map(String.init)
+        return PlannerResult(
+            exitCode: process.terminationStatus,
+            output: output,
+            publishRequired: publishRequired
+        )
+    }
+
+    private var fakeGit: String {
+        """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [[ "$1" == "fetch" ]]; then
+          exit 0
+        fi
+        if [[ "$1" == "rev-parse" && "$2" == "--verify" ]]; then
+          case "$3" in
+            refs/remotes/origin/main*) printf '%s\n' "${PUBLICATION_MAIN_COMMIT:?}" ;;
+            *) printf '%s\n' "${GITHUB_SHA:?}" ;;
+          esac
+          exit 0
+        fi
+        if [[ "$1" == "ls-remote" && "$2" == "--refs" && "$3" == "origin" ]]; then
+          printf '%s\t%s\n' "${PUBLICATION_TAG_COMMIT:?}" "$4"
+          exit 0
+        fi
+        echo "unexpected git invocation: $*" >&2
+        exit 9
+        """
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,27 @@
 # Code Quality Audit
 
+## 2026-08-09 Current-Main Publication Boundary
+
+Overall grade after this slice: **A+ release freshness, A+ supersession safety, A+ stable isolation**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Tester freshness | A+ | The publisher re-fetches `origin/main` after every architecture artifact is ready and immediately before the first moving-release mutation. Only the exact current commit can move `tester-latest`. |
+| Supersession behavior | A+ | A stale tester run records `publish-required=false`, succeeds without touching the tag, release notes, manifest, or assets, and skips public-download and updater verification for a release it did not publish. The newer serialized run proceeds next. |
+| Stable isolation | A+ | Canonical version tags bypass main freshness but are resolved again from the remote and must still equal the workflow commit. Missing, malformed, moved, and unsupported refs fail closed. |
+| Workflow ownership | A+ | Build serialization remains non-cancelling, so a publisher cannot be interrupted during release replacement. The new gate narrows the stale-publication window without weakening artifact, CI, signing, or consumer verification gates. |
+
+Validation:
+
+- Focused publication planner, release policy, and Download Builds parity suites
+  (15 tests, 0 failures)
+- Full `swift test` (5,752 tests, 5 skipped, 0 failures)
+- Real GitHub remote: current `main` emitted `publish-required=true`; superseded build-691 commit
+  `50b88eb5` emitted `publish-required=false` and exited successfully
+- `bash -n` and YAML parsing passed; `git diff --check` passed
+- Deterministic code-quality grader: every module A+; the new planner and parity suite each score
+  100/A+ with no automated issues
+
 ## 2026-08-09 Window-Independent Application Services
 
 Overall grade after this slice: **A+ update reliability, A+ background ownership, A+ lifecycle isolation**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # QuillCode Decisions
 
+## 2026-08-09: superseded tester builds never mutate the moving release
+
+- **Decision:** The Download Builds publisher re-fetches `origin/main` after all architecture
+  artifacts are ready and immediately before any `tester-latest` mutation. A tester run whose
+  commit is no longer current records `publish-required=false` and completes without moving the
+  tag, editing release notes, or replacing assets.
+- **Serialization:** Download builds remain serialized with cancellation disabled. An in-flight
+  publisher cannot be interrupted halfway through replacing a release, while a completed but
+  superseded build yields cleanly to the already queued newer run.
+- **Stable releases:** Canonical immutable version tags remain publishable even when `main` advances,
+  but the planner rechecks that the tag still resolves to the workflow commit and otherwise fails
+  closed.
+- **Evidence:** `scripts/plan-download-publication.sh`, the publish/verification job conditions in
+  `download-builds.yml`, deterministic fresh/stale/tag planner tests, and the workflow parity gate.
+
 ## 2026-08-09: process services start at application entry
 
 - **Decision:** The ordinary `QuillCodeDesktopApp` entry path calls

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -95,7 +95,11 @@ on that commit. This avoids no-op build-number updates and unnecessary updater
 prompts without treating a partial publication as healthy.
 When a build is required, the workflow updates the stable `tester-latest` tag
 and replaces release assets in place, so the links above do not change as new
-builds are published.
+builds are published. Immediately before changing that moving release, the
+publisher fetches `origin/main` again. If another merge has superseded the
+packaged commit, the run exits successfully without touching the tag, manifest,
+or assets; the already queued run for the newer commit becomes the next publisher.
+Immutable stable version tags are unaffected by this tester-channel freshness gate.
 
 DMG construction is transactional and stage-aware. The packager creates each
 candidate beside the destination, then verifies, mounts, inspects, signature-checks,

--- a/scripts/plan-download-publication.sh
+++ b/scripts/plan-download-publication.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REF_TYPE="${GITHUB_REF_TYPE:?GITHUB_REF_TYPE is required}"
+REF_NAME="${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
+COMMIT="${GITHUB_SHA:?GITHUB_SHA is required}"
+OUTPUT_PATH="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+CHECKED_OUT_COMMIT="$(git rev-parse --verify "${COMMIT}^{commit}")"
+if [[ "$CHECKED_OUT_COMMIT" != "$COMMIT" ]]; then
+  echo "Download publication commit did not resolve exactly: $COMMIT" >&2
+  exit 2
+fi
+
+if [[ "$REF_TYPE" == "branch" ]]; then
+  if [[ "$REF_NAME" != "main" ]]; then
+    echo "Tester downloads may only be published from main, not $REF_NAME." >&2
+    exit 2
+  fi
+
+  git fetch --no-tags --prune origin \
+    +refs/heads/main:refs/remotes/origin/main
+  MAIN_COMMIT="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')"
+  if [[ "$COMMIT" != "$MAIN_COMMIT" ]]; then
+    printf 'publish-required=false\n' >> "$OUTPUT_PATH"
+    echo "Skipping superseded tester build $COMMIT; current main is $MAIN_COMMIT."
+    exit 0
+  fi
+
+  printf 'publish-required=true\n' >> "$OUTPUT_PATH"
+  echo "Tester build $COMMIT is still current main and may be published."
+  exit 0
+fi
+
+if [[ "$REF_TYPE" != "tag" ]] ||
+   [[ ! "$REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Download publication requires main or a canonical stable version tag." >&2
+  exit 2
+fi
+
+REMOTE_TAG_ROW="$(git ls-remote --refs origin "refs/tags/$REF_NAME")"
+IFS=$'\t' read -r TAG_COMMIT TAG_REF <<< "$REMOTE_TAG_ROW"
+if [[ "$TAG_REF" != "refs/tags/$REF_NAME" ]] || [[ "$TAG_COMMIT" != "$COMMIT" ]]; then
+  echo "Stable tag $REF_NAME no longer resolves to workflow commit $COMMIT." >&2
+  exit 2
+fi
+
+printf 'publish-required=true\n' >> "$OUTPUT_PATH"
+echo "Immutable stable tag $REF_NAME may be published."


### PR DESCRIPTION
## Summary
- re-fetch current main immediately before mutating the moving tester release
- skip tag, notes, asset, public-download, and updater work when a newer merge supersedes the packaged commit
- re-resolve immutable stable tags from the remote and fail closed if they move

## Why
Build 691 completed after main had already advanced to the build-692 commit. Serialized publication is correct, but a completed older run should yield without temporarily moving tester-latest to a superseded commit.

## Verification
- full swift test: 5,752 tests, 5 skipped, 0 failures
- focused release parity: 15 tests, 0 failures
- real remote: current main emitted publish-required=true; build-691 commit emitted publish-required=false
- workflow YAML and shell syntax valid; all modules A+ in deterministic grader