### PR TITLE
Make tester publication recoverable

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -202,12 +202,7 @@ jobs:
             RELEASE_TAG="tester-latest"
             RELEASE_TITLE="Quill Cowork Tester Build"
             RELEASE_CHANNEL="tester"
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -f "$RELEASE_TAG" "$GITHUB_SHA"
-            git push origin "refs/tags/$RELEASE_TAG" --force
           fi
-          MANIFEST_NAME="latest-${RELEASE_CHANNEL}-build.json"
           scripts/build-release-notes.py \
             --build-info "$RUNNER_TEMP/release-assets/BUILD_INFO.txt" \
             --repo "$GITHUB_REPOSITORY" \
@@ -234,30 +229,12 @@ jobs:
               --prerelease \
               --latest=false
           else
-            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-              gh release edit "$RELEASE_TAG" \
-                --title "$RELEASE_TITLE" \
-                --notes-file "$RUNNER_TEMP/release-notes.md" \
-                --target "$GITHUB_SHA" \
-                --prerelease
-            else
-              gh release create "$RELEASE_TAG" \
-                --title "$RELEASE_TITLE" \
-                --notes-file "$RUNNER_TEMP/release-notes.md" \
-                --target "$GITHUB_SHA" \
-                --prerelease \
-                --latest=false
-            fi
-
-            find "$RUNNER_TEMP/release-assets" -maxdepth 1 -type f -printf '%f\n' | sort > "$RUNNER_TEMP/current-release-assets.txt"
-            gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' |
-              while IFS= read -r asset_name; do
-                if [[ -n "$asset_name" ]] && ! grep -Fxq "$asset_name" "$RUNNER_TEMP/current-release-assets.txt"; then
-                  gh release delete-asset "$RELEASE_TAG" "$asset_name" --yes
-                fi
-              done
-
-            gh release upload "$RELEASE_TAG" "$RUNNER_TEMP"/release-assets/* --clobber
+            scripts/publish-tester-release.py \
+              --assets-dir "$RUNNER_TEMP/release-assets" \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              --repo "$GITHUB_REPOSITORY" \
+              --commit "$GITHUB_SHA" \
+              --run-id "$GITHUB_RUN_ID"
           fi
 
   verify-published:

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -315,13 +315,15 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "--channel \"$RELEASE_CHANNEL\"",
             "--commit \"$GITHUB_SHA\"",
             "--output \"$RUNNER_TEMP/release-notes.md\"",
-            "current-release-assets.txt",
             "scripts/plan-download-publication.sh",
             "published: ${{ steps.publication.outputs.publish-required }}",
             "if: steps.publication.outputs.publish-required == 'true'",
             "if: needs.publish.outputs.published == 'true'",
-            "gh release delete-asset \"$RELEASE_TAG\" \"$asset_name\" --yes",
-            "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/* --clobber",
+            "scripts/publish-tester-release.py",
+            "--assets-dir \"$RUNNER_TEMP/release-assets\"",
+            "--notes-file \"$RUNNER_TEMP/release-notes.md\"",
+            "--repo \"$GITHUB_REPOSITORY\"",
+            "--run-id \"$GITHUB_RUN_ID\"",
             "--verify-tag",
             "--draft",
             "gh release upload \"$RELEASE_TAG\" \"$RUNNER_TEMP\"/release-assets/*",
@@ -360,6 +362,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         )
         XCTAssertFalse(workflow.contains("cat > \"$RUNNER_TEMP/release-notes.md\""))
         XCTAssertFalse(workflow.contains("MACOS_DISTRIBUTION_NOTE"))
+        XCTAssertFalse(workflow.contains("--clobber"))
+        XCTAssertFalse(workflow.contains("gh release delete-asset"))
         let validationIndex = try XCTUnwrap(workflow.range(of: "scripts/validate-download-build-ref.sh"))
         let ciGateIndex = try XCTUnwrap(workflow.range(of: "scripts/wait-for-successful-ci.sh"))
         let planningIndex = try XCTUnwrap(workflow.range(of: "scripts/plan-download-build.sh"))
@@ -367,7 +371,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertLessThan(ciGateIndex.lowerBound, planningIndex.lowerBound)
         let publishIndex = try XCTUnwrap(workflow.range(of: "  publish:"))
         let freshnessIndex = try XCTUnwrap(workflow.range(of: "scripts/plan-download-publication.sh"))
-        let releaseMutationIndex = try XCTUnwrap(workflow.range(of: "git tag -f \"$RELEASE_TAG\""))
+        let releaseMutationIndex = try XCTUnwrap(workflow.range(of: "scripts/publish-tester-release.py"))
         let publicVerificationIndex = try XCTUnwrap(workflow.range(of: "  verify-published:"))
         let promotionIndex = try XCTUnwrap(workflow.range(of: "  promote-stable:"))
         let updaterIndex = try XCTUnwrap(workflow.range(of: "  verify-updater:"))

--- a/Tests/QuillCodeParityTests/ParityTransactionalTesterPublicationTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTransactionalTesterPublicationTests.swift
@@ -1,0 +1,386 @@
+import XCTest
+
+final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
+    private let oldCommit = String(repeating: "b", count: 40)
+    private let newCommit = String(repeating: "a", count: 40)
+
+    func testSuccessfulPublicationStagesVerifiesSwapsAndMovesTagLast() throws {
+        let result = try runPublisher()
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Published transactional tester release"), result.output)
+        XCTAssertEqual(result.state["tag"] as? String, newCommit)
+        let release = try release(from: result.state)
+        XCTAssertEqual(release["target_commitish"] as? String, newCommit)
+        XCTAssertEqual(release["name"] as? String, "Quill Cowork Tester Build")
+        XCTAssertEqual(release["body"] as? String, "New release notes\n")
+        XCTAssertEqual(release["draft"] as? Bool, false)
+        XCTAssertEqual(release["prerelease"] as? Bool, true)
+        XCTAssertEqual(
+            try assetNames(in: release),
+            ["Quill-Cowork-macOS-arm64.zip", "latest-tester-build.json", "new-evidence.json"]
+        )
+
+        let operations = try XCTUnwrap(result.state["operations"] as? [String])
+        let uploadIndexes = operations.indices.filter { operations[$0].hasPrefix("upload:") }
+        let firstRename = try XCTUnwrap(
+            operations.firstIndex { $0.hasPrefix("rename:") }
+        )
+        let releasePatch = try XCTUnwrap(operations.firstIndex(of: "patch-release"))
+        let tagPush = try XCTUnwrap(operations.firstIndex(of: "push-tag:\(newCommit)"))
+        let firstDelete = try XCTUnwrap(
+            operations.firstIndex { $0.hasPrefix("delete:") }
+        )
+        XCTAssertEqual(uploadIndexes.count, 3)
+        XCTAssertTrue(uploadIndexes.allSatisfy { $0 < firstRename }, operations.joined(separator: "\n"))
+        XCTAssertLessThan(firstRename, releasePatch)
+        XCTAssertLessThan(releasePatch, tagPush)
+        XCTAssertLessThan(tagPush, firstDelete)
+
+        let canonicalRenames = operations.filter { operation in
+            operation.hasPrefix("rename:") &&
+                !operation.contains("quill-cowork-rollback-")
+        }
+        XCTAssertEqual(canonicalRenames.last?.split(separator: ":").last.map(String.init), "latest-tester-build.json")
+        XCTAssertFalse(operations.contains { $0.contains("--clobber") })
+    }
+
+    func testFailuresRestorePreviousReleaseAndTag() throws {
+        for failure in ["upload", "patch-asset", "patch-release", "push-tag"] {
+            let result = try runPublisher(failure: failure)
+
+            XCTAssertNotEqual(result.exitCode, 0, "\(failure) unexpectedly succeeded")
+            XCTAssertTrue(
+                result.output.contains("Restored the previous tester release"),
+                "\(failure): \(result.output)"
+            )
+            XCTAssertEqual(result.state["tag"] as? String, oldCommit, failure)
+            let release = try release(from: result.state)
+            XCTAssertEqual(release["target_commitish"] as? String, oldCommit, failure)
+            XCTAssertEqual(release["name"] as? String, "Previous tester", failure)
+            XCTAssertEqual(release["body"] as? String, "Previous notes\n", failure)
+            XCTAssertEqual(
+                try assetNames(in: release),
+                ["Quill-Cowork-macOS-arm64.zip", "latest-tester-build.json", "obsolete.txt"],
+                failure
+            )
+            let assets = try assets(in: release)
+            XCTAssertEqual(
+                assets.compactMap { $0["digest"] as? String }.sorted(),
+                ["sha256:old-app", "sha256:old-manifest", "sha256:old-obsolete"],
+                failure
+            )
+            XCTAssertFalse(
+                try assetNames(in: release).contains { $0.hasPrefix("quill-cowork-") },
+                failure
+            )
+        }
+    }
+
+    func testTransientRollbackAssetDeletionRetriesAfterCommit() throws {
+        let result = try runPublisher(failure: "delete-asset")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let operations = try XCTUnwrap(result.state["operations"] as? [String])
+        XCTAssertEqual(operations.filter { $0 == "failure:delete-asset" }.count, 1)
+        XCTAssertEqual(
+            try assetNames(in: release(from: result.state)),
+            ["Quill-Cowork-macOS-arm64.zip", "latest-tester-build.json", "new-evidence.json"]
+        )
+    }
+
+    func testUnsafeInputsFailBeforeGitHubMutation() throws {
+        let result = try runPublisher(commit: "short")
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.output.contains("Commit must be a full lowercase SHA-1"), result.output)
+        XCTAssertEqual(result.state["operations"] as? [String], [])
+        XCTAssertEqual(result.state["tag"] as? String, oldCommit)
+    }
+
+    private struct PublisherResult {
+        var exitCode: Int32
+        var output: String
+        var state: [String: Any]
+    }
+
+    private func runPublisher(
+        failure: String? = nil,
+        commit: String? = nil
+    ) throws -> PublisherResult {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-transactional-publication-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let bin = root.appendingPathComponent("bin")
+        let assetsDirectory = root.appendingPathComponent("assets")
+        let stateURL = root.appendingPathComponent("state.json")
+        let notesURL = root.appendingPathComponent("release-notes.md")
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: assetsDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try Data("new app".utf8).write(
+            to: assetsDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64.zip")
+        )
+        try Data(#"{"build":"new"}"#.utf8).write(
+            to: assetsDirectory.appendingPathComponent("latest-tester-build.json")
+        )
+        try Data(#"{"withinBudget":true}"#.utf8).write(
+            to: assetsDirectory.appendingPathComponent("new-evidence.json")
+        )
+        try "New release notes\n".write(to: notesURL, atomically: true, encoding: .utf8)
+
+        let initialState: [String: Any] = [
+            "tag": oldCommit,
+            "localTag": oldCommit,
+            "nextAssetID": 100,
+            "operations": [],
+            "failures": failure.map { [$0: 1] } ?? [:],
+            "release": [
+                "id": 77,
+                "tag_name": "tester-latest",
+                "target_commitish": oldCommit,
+                "name": "Previous tester",
+                "body": "Previous notes\n",
+                "draft": false,
+                "prerelease": true,
+                "immutable": false,
+                "assets": [
+                    remoteAsset(id: 1, name: "Quill-Cowork-macOS-arm64.zip", size: 7, digest: "sha256:old-app"),
+                    remoteAsset(id: 2, name: "latest-tester-build.json", size: 18, digest: "sha256:old-manifest"),
+                    remoteAsset(id: 3, name: "obsolete.txt", size: 8, digest: "sha256:old-obsolete")
+                ]
+            ]
+        ]
+        let stateData = try JSONSerialization.data(withJSONObject: initialState, options: [.sortedKeys])
+        try stateData.write(to: stateURL)
+
+        try writeExecutable(fakeGitHub, to: bin.appendingPathComponent("gh"))
+        try writeExecutable(fakeGit, to: bin.appendingPathComponent("git"))
+
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [
+            "python3",
+            Self.packageRoot().appendingPathComponent("scripts/publish-tester-release.py").path,
+            "--assets-dir", assetsDirectory.path,
+            "--notes-file", notesURL.path,
+            "--repo", "Lore-Hex/QuillCode",
+            "--commit", commit ?? newCommit,
+            "--run-id", "1234",
+            "--retry-delay-seconds", "0"
+        ]
+        process.standardOutput = pipe
+        process.standardError = pipe
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(bin.path):\(environment["PATH"] ?? "")"
+        environment["FAKE_PUBLICATION_STATE"] = stateURL.path
+        environment["PYTHONDONTWRITEBYTECODE"] = "1"
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let finalData = try Data(contentsOf: stateURL)
+        let finalState = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: finalData) as? [String: Any]
+        )
+        return PublisherResult(
+            exitCode: process.terminationStatus,
+            output: output,
+            state: finalState
+        )
+    }
+
+    private func remoteAsset(id: Int, name: String, size: Int, digest: String) -> [String: Any] {
+        [
+            "id": id,
+            "name": name,
+            "size": size,
+            "digest": digest,
+            "state": "uploaded"
+        ]
+    }
+
+    private func release(from state: [String: Any]) throws -> [String: Any] {
+        try XCTUnwrap(state["release"] as? [String: Any])
+    }
+
+    private func assets(in release: [String: Any]) throws -> [[String: Any]] {
+        try XCTUnwrap(release["assets"] as? [[String: Any]])
+    }
+
+    private func assetNames(in release: [String: Any]) throws -> [String] {
+        try assets(in: release).compactMap { $0["name"] as? String }.sorted()
+    }
+
+    private func writeExecutable(_ source: String, to url: URL) throws {
+        try source.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    private var fakeGitHub: String {
+        #"""
+        #!/usr/bin/env python3
+        import hashlib
+        import json
+        import os
+        from pathlib import Path
+        import sys
+
+        state_path = Path(os.environ["FAKE_PUBLICATION_STATE"])
+
+        def load():
+            return json.loads(state_path.read_text())
+
+        def save(state):
+            temporary = state_path.with_suffix(".tmp")
+            temporary.write_text(json.dumps(state, sort_keys=True))
+            temporary.replace(state_path)
+
+        def record(state, operation):
+            state["operations"].append(operation)
+
+        def fail_if_requested(state, point):
+            remaining = state.get("failures", {}).get(point, 0)
+            if remaining > 0:
+                state["failures"][point] = remaining - 1
+                record(state, "failure:" + point)
+                save(state)
+                print("injected failure: " + point, file=sys.stderr)
+                raise SystemExit(42)
+
+        def asset_by_id(state, identifier):
+            for asset in state["release"]["assets"]:
+                if asset["id"] == identifier:
+                    return asset
+            print("asset not found", file=sys.stderr)
+            raise SystemExit(44)
+
+        args = sys.argv[1:]
+        state = load()
+        if args[:1] == ["api"]:
+            method = args[args.index("--method") + 1]
+            endpoint = next(value for value in args if value.startswith("repos/"))
+            if method == "GET" and "/releases/tags/" in endpoint:
+                record(state, "get-release")
+                save(state)
+                print(json.dumps(state["release"], sort_keys=True))
+                raise SystemExit(0)
+            if "/releases/assets/" in endpoint:
+                identifier = int(endpoint.rsplit("/", 1)[1])
+                if method == "PATCH":
+                    fail_if_requested(state, "patch-asset")
+                    requested = args[args.index("-f") + 1]
+                    name = requested.split("=", 1)[1]
+                    asset = asset_by_id(state, identifier)
+                    record(state, "rename:{}:{}".format(asset["name"], name))
+                    asset["name"] = name
+                    save(state)
+                    print(json.dumps(asset, sort_keys=True))
+                    raise SystemExit(0)
+                if method == "DELETE":
+                    fail_if_requested(state, "delete-asset")
+                    asset = asset_by_id(state, identifier)
+                    record(state, "delete:" + asset["name"])
+                    state["release"]["assets"] = [
+                        value for value in state["release"]["assets"]
+                        if value["id"] != identifier
+                    ]
+                    save(state)
+                    raise SystemExit(0)
+            if method == "PATCH" and "/releases/" in endpoint:
+                fail_if_requested(state, "patch-release")
+                payload_path = Path(args[args.index("--input") + 1])
+                payload = json.loads(payload_path.read_text())
+                for key in ["tag_name", "target_commitish", "name", "body", "draft", "prerelease"]:
+                    state["release"][key] = payload[key]
+                record(state, "patch-release")
+                save(state)
+                print(json.dumps(state["release"], sort_keys=True))
+                raise SystemExit(0)
+        if args[:2] == ["release", "upload"]:
+            fail_if_requested(state, "upload")
+            path = Path(args[3])
+            data = path.read_bytes()
+            asset = {
+                "id": state["nextAssetID"],
+                "name": path.name,
+                "size": len(data),
+                "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
+                "state": "uploaded"
+            }
+            state["nextAssetID"] += 1
+            state["release"]["assets"].append(asset)
+            record(state, "upload:" + path.name)
+            save(state)
+            raise SystemExit(0)
+        print("unexpected gh invocation: " + " ".join(args), file=sys.stderr)
+        raise SystemExit(49)
+        """#
+    }
+
+    private var fakeGit: String {
+        #"""
+        #!/usr/bin/env python3
+        import json
+        import os
+        from pathlib import Path
+        import sys
+
+        state_path = Path(os.environ["FAKE_PUBLICATION_STATE"])
+
+        def load():
+            return json.loads(state_path.read_text())
+
+        def save(state):
+            temporary = state_path.with_suffix(".tmp")
+            temporary.write_text(json.dumps(state, sort_keys=True))
+            temporary.replace(state_path)
+
+        def fail_if_requested(state, point):
+            remaining = state.get("failures", {}).get(point, 0)
+            if remaining > 0:
+                state["failures"][point] = remaining - 1
+                state["operations"].append("failure:" + point)
+                save(state)
+                print("injected failure: " + point, file=sys.stderr)
+                raise SystemExit(42)
+
+        args = sys.argv[1:]
+        state = load()
+        if args[:1] == ["config"]:
+            raise SystemExit(0)
+        if args[:2] == ["ls-remote", "--refs"]:
+            if state.get("tag"):
+                print("{}\trefs/tags/tester-latest".format(state["tag"]))
+            raise SystemExit(0)
+        if args[:2] == ["tag", "-f"]:
+            state["localTag"] = args[3]
+            state["operations"].append("local-tag:" + args[3])
+            save(state)
+            raise SystemExit(0)
+        if args[:2] == ["tag", "-d"]:
+            state["localTag"] = None
+            save(state)
+            raise SystemExit(0)
+        if args[:2] == ["push", "origin"]:
+            if args[2].startswith(":"):
+                state["tag"] = None
+                state["operations"].append("delete-tag")
+                save(state)
+                raise SystemExit(0)
+            fail_if_requested(state, "push-tag")
+            state["tag"] = state["localTag"]
+            state["operations"].append("push-tag:" + state["tag"])
+            save(state)
+            raise SystemExit(0)
+        print("unexpected git invocation: " + " ".join(args), file=sys.stderr)
+        raise SystemExit(49)
+        """#
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,26 @@
 # Code Quality Audit
 
+## 2026-08-09 Transactional Tester Publication
+
+Overall grade after this slice: **A+ publication integrity, A+ recovery, A+ maintainability**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Pre-mutation integrity | A+ | Every candidate is uploaded under a run-scoped alias and its GitHub state, byte size, and SHA-256 digest must match before canonical names change. |
+| Recovery | A+ | Previous asset IDs, names, digests, metadata, and tag commit remain available until the new metadata and ref pass read-back verification; injected upload, rename, metadata, and tag failures restore the exact snapshot. |
+| User continuity | A+ | The updater manifest swaps after other candidates and the moving tag changes last; old assets are deleted only after commit, with bounded cleanup retries. |
+| Architecture | A+ | Parsing/contracts, bounded file hashing, remote operations, initial publication, transaction orchestration, and CLI validation are separate focused modules. The deterministic grader scores every new production file 100/A+. |
+| Regression coverage | A+ | Focused parity tests drive a stateful fake GitHub release and Git remote, assert operation order, exact final inventory, exact rollback digests, transient cleanup retry, and mutation-free input rejection. |
+
+Validation:
+
+- Transactional publisher, workflow, and freshness suite: 14 tests, 0 failures
+- Authoritative full suite outside the managed macOS service sandbox: 5,756 tests,
+  5 skipped, 0 failures
+- Python compile validation for the entry point and all transaction modules
+- Workflow parser, executable mode, diff hygiene, and secret scan
+- Deterministic production-file grades: 100/A+ for all six publisher files
+
 ## 2026-08-09 Current-Main Publication Boundary
 
 Overall grade after this slice: **A+ release freshness, A+ supersession safety, A+ stable isolation**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,23 @@
 # QuillCode Decisions
 
+## 2026-08-09: moving tester publication retains a verified rollback snapshot
+
+- **Decision:** Tester assets upload under run-scoped candidate names and must match GitHub's
+  recorded size, upload state, and SHA-256 digest before canonical names change. Existing assets
+  move to rollback aliases; they are not clobbered or deleted in place.
+- **Commit order:** Candidates take canonical names with the updater manifest last, then release
+  metadata moves to the new commit, then the `tester-latest` Git ref moves last. Prior assets are
+  deleted only after the new metadata and remote tag have both been read back and verified.
+- **Failure recovery:** Upload, rename, metadata, and tag failures delete every known candidate,
+  restore prior asset names by immutable GitHub asset ID, restore the complete metadata snapshot,
+  force the old tag back, and compare the recovered inventory, digests, metadata, and ref with the
+  snapshot before returning failure. Cleanup deletions receive bounded retries.
+- **Scope:** Immutable stable releases retain their draft, consumer-verification, and promotion
+  transaction. This publisher owns only the deliberately moving tester release.
+- **Evidence:** `scripts/tester_publication`, the thin `publish-tester-release.py` entry point,
+  workflow ordering assertions, and deterministic injected failures at upload, asset rename,
+  release metadata, tag push, and post-commit cleanup.
+
 ## 2026-08-09: superseded tester builds never mutate the moving release
 
 - **Decision:** The Download Builds publisher re-fetches `origin/main` after all architecture

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -101,6 +101,17 @@ packaged commit, the run exits successfully without touching the tag, manifest,
 or assets; the already queued run for the newer commit becomes the next publisher.
 Immutable stable version tags are unaffected by this tester-channel freshness gate.
 
+Tester asset replacement is also recoverable after the freshness decision. The publisher uploads
+every candidate under a run-scoped temporary name, then requires GitHub's recorded size, upload
+state, and SHA-256 digest to match the local artifact before any canonical download name changes.
+Existing assets are renamed to rollback aliases instead of deleted; verified candidates take their
+canonical names with the updater manifest swapped last. Release notes and target commit change only
+after the complete asset inventory is present, and `tester-latest` moves last. A failure during
+upload, asset exchange, metadata update, or tag push deletes candidates and restores the prior
+asset names, release metadata, and remote tag, then verifies that restored snapshot. Rollback assets
+are deleted with bounded retries only after the new metadata and tag both agree. This keeps a
+transport or GitHub API failure from stranding an unrecoverable half-published tester channel.
+
 DMG construction is transactional and stage-aware. The packager creates each
 candidate beside the destination, then verifies, mounts, inspects, signature-checks,
 and detaches it before an atomic replacement. Transient macOS disk-image service

--- a/scripts/publish-tester-release.py
+++ b/scripts/publish-tester-release.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Publish the moving tester release with recoverable asset replacement."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from tester_publication.contracts import (
+    COMMIT_PATTERN,
+    PublicationError,
+    REPOSITORY_PATTERN,
+    RUN_ID_PATTERN,
+    load_local_assets,
+)
+from tester_publication.publisher import TesterReleasePublisher
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--assets-dir", required=True, type=Path)
+    parser.add_argument("--notes-file", required=True, type=Path)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--retry-delay-seconds", type=float, default=1.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    if not REPOSITORY_PATTERN.fullmatch(arguments.repo):
+        raise PublicationError("Repository must use owner/name syntax.")
+    if not COMMIT_PATTERN.fullmatch(arguments.commit):
+        raise PublicationError("Commit must be a full lowercase SHA-1.")
+    if not RUN_ID_PATTERN.fullmatch(arguments.run_id):
+        raise PublicationError("Run ID must be a positive integer.")
+    if arguments.retry_delay_seconds < 0 or arguments.retry_delay_seconds > 30:
+        raise PublicationError("Retry delay must be between zero and 30 seconds.")
+    if not arguments.notes_file.is_file() or arguments.notes_file.is_symlink():
+        raise PublicationError("Release notes must be a regular file.")
+    notes_bytes = arguments.notes_file.read_bytes()
+    if not notes_bytes or len(notes_bytes) > 1_048_576:
+        raise PublicationError("Release notes must contain between 1 byte and 1 MiB.")
+    try:
+        notes = notes_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PublicationError("Release notes must be UTF-8.") from error
+
+    TesterReleasePublisher(
+        repository=arguments.repo,
+        commit=arguments.commit,
+        run_id=arguments.run_id,
+        assets=load_local_assets(arguments.assets_dir),
+        notes=notes,
+        notes_path=arguments.notes_file,
+        retry_delay_seconds=arguments.retry_delay_seconds,
+    ).publish()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PublicationError as error:
+        print(f"Tester publication failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/tester_publication/__init__.py
+++ b/scripts/tester_publication/__init__.py
@@ -1,0 +1,1 @@
+"""Transactional publication support for the moving tester release."""

--- a/scripts/tester_publication/contracts.py
+++ b/scripts/tester_publication/contracts.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any, Iterable
+
+
+TAG = "tester-latest"
+TITLE = "Quill Cowork Tester Build"
+MANIFEST_NAME = "latest-tester-build.json"
+ASSET_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,179}")
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+RUN_ID_PATTERN = re.compile(r"[1-9][0-9]*")
+TRANSACTION_ALIAS_PATTERN = re.compile(
+    r"quill-cowork-(candidate|rollback)-([1-9][0-9]*)-(.+)"
+)
+
+
+class PublicationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class LocalAsset:
+    name: str
+    path: Path
+    size: int
+    digest: str
+
+
+@dataclass(frozen=True)
+class RemoteAsset:
+    identifier: int
+    name: str
+    size: int
+    digest: str
+    state: str
+
+
+@dataclass(frozen=True)
+class ReleaseSnapshot:
+    identifier: int
+    tag_name: str
+    target_commitish: str
+    name: str
+    body: str
+    draft: bool
+    prerelease: bool
+    immutable: bool
+    assets: dict[str, RemoteAsset]
+
+
+def require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise PublicationError(f"GitHub release {label} must be a string.")
+    return value
+
+
+def require_boolean(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise PublicationError(f"GitHub release {label} must be a boolean.")
+    return value
+
+
+def require_integer(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise PublicationError(f"GitHub release {label} must be a positive integer.")
+    return value
+
+
+def decode_release(payload: str) -> ReleaseSnapshot:
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise PublicationError(f"GitHub returned malformed release JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise PublicationError("GitHub release response must be an object.")
+
+    assets_value = value.get("assets")
+    if not isinstance(assets_value, list):
+        raise PublicationError("GitHub release assets must be an array.")
+    assets: dict[str, RemoteAsset] = {}
+    identifiers: set[int] = set()
+    for index, item in enumerate(assets_value):
+        if not isinstance(item, dict):
+            raise PublicationError(f"GitHub release asset {index} must be an object.")
+        name = require_string(item.get("name"), f"asset {index} name")
+        identifier = require_integer(item.get("id"), f"asset {name} id")
+        size = item.get("size")
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise PublicationError(f"GitHub release asset {name} size must be non-negative.")
+        digest = require_string(item.get("digest"), f"asset {name} digest")
+        state = require_string(item.get("state"), f"asset {name} state")
+        if name in assets or identifier in identifiers:
+            raise PublicationError("GitHub release asset names and identifiers must be unique.")
+        assets[name] = RemoteAsset(identifier, name, size, digest, state)
+        identifiers.add(identifier)
+
+    return ReleaseSnapshot(
+        identifier=require_integer(value.get("id"), "id"),
+        tag_name=require_string(value.get("tag_name"), "tag_name"),
+        target_commitish=require_string(value.get("target_commitish"), "target_commitish"),
+        name=require_string(value.get("name"), "name"),
+        body=require_string(value.get("body"), "body"),
+        draft=require_boolean(value.get("draft"), "draft"),
+        prerelease=require_boolean(value.get("prerelease"), "prerelease"),
+        immutable=require_boolean(value.get("immutable", False), "immutable"),
+        assets=assets,
+    )
+
+
+def file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def load_local_assets(directory: Path) -> dict[str, LocalAsset]:
+    if not directory.is_dir() or directory.is_symlink():
+        raise PublicationError("Release assets directory must be a real directory.")
+    assets: dict[str, LocalAsset] = {}
+    for path in directory.iterdir():
+        if not path.is_file() or path.is_symlink():
+            raise PublicationError(f"Release asset must be a regular file: {path.name}")
+        name = path.name
+        if not ASSET_NAME_PATTERN.fullmatch(name):
+            raise PublicationError(f"Release asset has an unsafe name: {name!r}")
+        if TRANSACTION_ALIAS_PATTERN.fullmatch(name):
+            raise PublicationError(f"Release asset collides with transaction namespace: {name}")
+        assets[name] = LocalAsset(name, path, path.stat().st_size, file_digest(path))
+    if not assets or len(assets) > 64:
+        raise PublicationError("Release must contain between 1 and 64 assets.")
+    if MANIFEST_NAME not in assets:
+        raise PublicationError(f"Release assets must include {MANIFEST_NAME}.")
+    return assets
+
+
+def ordered_asset_names(names: Iterable[str]) -> list[str]:
+    name_set = set(names)
+    values = sorted(name for name in name_set if name != MANIFEST_NAME)
+    if MANIFEST_NAME in name_set:
+        values.append(MANIFEST_NAME)
+    return values
+
+
+def validate_release_metadata(
+    release: ReleaseSnapshot,
+    commit: str,
+    notes: str,
+) -> None:
+    if (
+        release.tag_name != TAG
+        or release.target_commitish != commit
+        or release.name != TITLE
+        or release.body != notes
+        or release.draft
+        or not release.prerelease
+        or release.immutable
+    ):
+        raise PublicationError("Published tester release metadata disagrees with the transaction.")
+
+
+def validate_exact_assets(
+    release: ReleaseSnapshot,
+    assets: dict[str, LocalAsset],
+) -> None:
+    if set(release.assets) != set(assets):
+        raise PublicationError("Published tester release has an unexpected asset inventory.")
+    for name, local in assets.items():
+        remote = release.assets[name]
+        if remote.state != "uploaded" or remote.size != local.size or remote.digest != local.digest:
+            raise PublicationError(f"Published GitHub asset metadata disagrees for {name}.")

--- a/scripts/tester_publication/initial.py
+++ b/scripts/tester_publication/initial.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tester_publication.contracts import (
+    LocalAsset,
+    PublicationError,
+    TAG,
+    TITLE,
+    ordered_asset_names,
+    validate_exact_assets,
+    validate_release_metadata,
+)
+from tester_publication.remote import PublicationRemote, command_result, run_command
+
+
+def publish_initial_release(
+    remote: PublicationRemote,
+    commit: str,
+    assets: dict[str, LocalAsset],
+    notes: str,
+    notes_path: Path,
+) -> None:
+    previous_tag_commit = remote.remote_tag_commit(missing_ok=True)
+    remote.configure_git()
+    created_release = False
+    try:
+        remote.force_remote_tag(commit)
+        run_command(
+            [
+                "gh",
+                "release",
+                "create",
+                TAG,
+                "--repo",
+                remote.repository,
+                "--draft",
+                "--title",
+                TITLE,
+                "--notes-file",
+                str(notes_path),
+                "--target",
+                commit,
+                "--latest=false",
+            ]
+        )
+        created_release = True
+        for name in ordered_asset_names(assets):
+            run_command(
+                [
+                    "gh",
+                    "release",
+                    "upload",
+                    TAG,
+                    str(assets[name].path),
+                    "--repo",
+                    remote.repository,
+                ]
+            )
+        run_command(
+            [
+                "gh",
+                "release",
+                "edit",
+                TAG,
+                "--repo",
+                remote.repository,
+                "--draft=false",
+                "--prerelease",
+                "--latest=false",
+                "--title",
+                TITLE,
+                "--notes-file",
+                str(notes_path),
+                "--target",
+                commit,
+            ]
+        )
+        release = remote.get_release()
+        assert release is not None
+        validate_release_metadata(release, commit, notes)
+        validate_exact_assets(release, assets)
+    except Exception as error:
+        if created_release:
+            command_result(
+                ["gh", "release", "delete", TAG, "--repo", remote.repository, "--yes"]
+            )
+        try:
+            if previous_tag_commit is None:
+                remote.delete_remote_tag()
+            else:
+                remote.force_remote_tag(previous_tag_commit)
+        except PublicationError as rollback_error:
+            raise PublicationError(
+                f"{error} | Initial release rollback failed: {rollback_error}"
+            ) from error
+        raise
+    print(f"Published initial tester release {commit}.")

--- a/scripts/tester_publication/publisher.py
+++ b/scripts/tester_publication/publisher.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Any
+
+from tester_publication.contracts import (
+    ASSET_NAME_PATTERN,
+    COMMIT_PATTERN,
+    LocalAsset,
+    PublicationError,
+    ReleaseSnapshot,
+    RemoteAsset,
+    TAG,
+    TITLE,
+    TRANSACTION_ALIAS_PATTERN,
+    ordered_asset_names,
+    validate_exact_assets,
+    validate_release_metadata,
+)
+from tester_publication.initial import publish_initial_release
+from tester_publication.remote import PublicationRemote, run_command
+
+
+class TesterReleasePublisher:
+    def __init__(
+        self,
+        repository: str,
+        commit: str,
+        run_id: str,
+        assets: dict[str, LocalAsset],
+        notes: str,
+        notes_path: Path,
+        retry_delay_seconds: float,
+    ) -> None:
+        self.commit = commit
+        self.run_id = run_id
+        self.assets = assets
+        self.notes = notes
+        self.notes_path = notes_path
+        self.remote = PublicationRemote(repository, retry_delay_seconds)
+        self.candidate_prefix = f"quill-cowork-candidate-{run_id}-"
+        self.rollback_prefix = f"quill-cowork-rollback-{run_id}-"
+        self.snapshot: ReleaseSnapshot | None = None
+        self.previous_tag_commit: str | None = None
+        self.candidate_assets: dict[str, RemoteAsset] = {}
+        self.committed = False
+
+    def recover_stale_aliases(self, release: ReleaseSnapshot) -> ReleaseSnapshot:
+        rollback_groups: dict[str, list[RemoteAsset]] = {}
+        candidate_assets: list[tuple[str, RemoteAsset]] = []
+        for asset in release.assets.values():
+            match = TRANSACTION_ALIAS_PATTERN.fullmatch(asset.name)
+            if match is None:
+                continue
+            kind, _, canonical = match.groups()
+            if not ASSET_NAME_PATTERN.fullmatch(canonical):
+                raise PublicationError(f"Stale transaction asset has an unsafe name: {asset.name}")
+            if kind == "rollback":
+                rollback_groups.setdefault(canonical, []).append(asset)
+            else:
+                candidate_assets.append((canonical, asset))
+
+        if not rollback_groups and not candidate_assets:
+            return release
+        print("Recovering assets left by an interrupted tester publication.")
+        canonical_names = {
+            name for name in release.assets if TRANSACTION_ALIAS_PATTERN.fullmatch(name) is None
+        }
+        for canonical, aliases in sorted(rollback_groups.items()):
+            if canonical in canonical_names:
+                for asset in aliases:
+                    self.remote.delete_asset(asset.identifier)
+            elif len(aliases) == 1:
+                self.remote.rename_asset(aliases[0].identifier, canonical)
+                canonical_names.add(canonical)
+            else:
+                raise PublicationError(
+                    f"Multiple rollback assets exist for missing canonical asset {canonical}."
+                )
+        for canonical, asset in candidate_assets:
+            if canonical not in canonical_names:
+                raise PublicationError(
+                    f"Candidate asset {asset.name} has no verified canonical or rollback copy."
+                )
+            self.remote.delete_asset(asset.identifier)
+
+        recovered = self.remote.get_release()
+        assert recovered is not None
+        leftovers = [
+            name for name in recovered.assets if TRANSACTION_ALIAS_PATTERN.fullmatch(name)
+        ]
+        if leftovers:
+            raise PublicationError("Interrupted publication aliases remain after recovery.")
+        return recovered
+
+    def validate_existing_release(self, release: ReleaseSnapshot) -> None:
+        if release.tag_name != TAG:
+            raise PublicationError(f"Existing tester release must use tag {TAG}.")
+        if release.draft or not release.prerelease or release.immutable:
+            raise PublicationError(
+                "Existing tester release must be a mutable, published prerelease."
+            )
+        if not release.assets:
+            raise PublicationError("Existing tester release must contain rollback-safe assets.")
+        if any(TRANSACTION_ALIAS_PATTERN.fullmatch(name) for name in release.assets):
+            raise PublicationError("Existing tester release still contains transaction aliases.")
+
+    def upload_candidates(self, staging_directory: Path) -> None:
+        for canonical in ordered_asset_names(self.assets):
+            local = self.assets[canonical]
+            candidate_name = f"{self.candidate_prefix}{canonical}"
+            if len(candidate_name) > 240:
+                raise PublicationError(f"Transaction asset name is too long: {candidate_name}")
+            candidate_path = staging_directory / candidate_name
+            shutil.copyfile(local.path, candidate_path)
+            run_command(
+                [
+                    "gh",
+                    "release",
+                    "upload",
+                    TAG,
+                    str(candidate_path),
+                    "--repo",
+                    self.remote.repository,
+                ]
+            )
+
+        staged_release = self.remote.get_release()
+        assert staged_release is not None
+        for canonical, local in self.assets.items():
+            candidate_name = f"{self.candidate_prefix}{canonical}"
+            candidate = staged_release.assets.get(candidate_name)
+            if candidate is None:
+                raise PublicationError(f"GitHub did not retain staged asset {candidate_name}.")
+            if (
+                candidate.state != "uploaded"
+                or candidate.size != local.size
+                or candidate.digest != local.digest
+            ):
+                raise PublicationError(f"GitHub staged asset metadata disagrees for {canonical}.")
+            self.candidate_assets[canonical] = candidate
+
+    def swap_assets(self) -> None:
+        assert self.snapshot is not None
+        for canonical in ordered_asset_names(self.assets):
+            previous = self.snapshot.assets.get(canonical)
+            if previous is not None:
+                self.remote.rename_asset(
+                    previous.identifier,
+                    f"{self.rollback_prefix}{canonical}",
+                )
+            self.remote.rename_asset(self.candidate_assets[canonical].identifier, canonical)
+
+        obsolete = sorted(set(self.snapshot.assets) - set(self.assets))
+        for canonical in obsolete:
+            previous = self.snapshot.assets[canonical]
+            self.remote.rename_asset(
+                previous.identifier,
+                f"{self.rollback_prefix}{canonical}",
+            )
+
+    def validate_swapped_assets(self) -> None:
+        assert self.snapshot is not None
+        release = self.remote.get_release()
+        assert release is not None
+        expected_names = set(self.assets)
+        expected_names.update(
+            f"{self.rollback_prefix}{name}" for name in self.snapshot.assets
+        )
+        if set(release.assets) != expected_names:
+            raise PublicationError("Swapped tester asset inventory is incomplete or unexpected.")
+        for name, local in self.assets.items():
+            remote = release.assets[name]
+            if remote.state != "uploaded" or remote.size != local.size or remote.digest != local.digest:
+                raise PublicationError(f"Canonical GitHub asset metadata disagrees for {name}.")
+
+    def publication_payload(self) -> dict[str, Any]:
+        return {
+            "tag_name": TAG,
+            "target_commitish": self.commit,
+            "name": TITLE,
+            "body": self.notes,
+            "draft": False,
+            "prerelease": True,
+            "make_latest": "false",
+        }
+
+    def restore_payload(self) -> dict[str, Any]:
+        assert self.snapshot is not None
+        return {
+            "tag_name": self.snapshot.tag_name,
+            "target_commitish": self.snapshot.target_commitish,
+            "name": self.snapshot.name,
+            "body": self.snapshot.body,
+            "draft": self.snapshot.draft,
+            "prerelease": self.snapshot.prerelease,
+            "make_latest": "false",
+        }
+
+    def rollback_existing(self) -> None:
+        assert self.snapshot is not None
+        assert self.previous_tag_commit is not None
+        errors: list[str] = []
+
+        try:
+            current = self.remote.get_release()
+            assert current is not None
+            candidate_ids = {asset.identifier for asset in self.candidate_assets.values()}
+            candidate_ids.update(
+                asset.identifier
+                for asset in current.assets.values()
+                if asset.name.startswith(self.candidate_prefix)
+            )
+            current_ids = {asset.identifier for asset in current.assets.values()}
+            for identifier in sorted(candidate_ids & current_ids):
+                self.remote.delete_asset(identifier)
+        except (PublicationError, AssertionError) as error:
+            errors.append(str(error))
+
+        try:
+            current = self.remote.get_release()
+            assert current is not None
+            by_identifier = {asset.identifier: asset for asset in current.assets.values()}
+            for canonical, previous in self.snapshot.assets.items():
+                live = by_identifier.get(previous.identifier)
+                if live is None:
+                    raise PublicationError(f"Rollback asset disappeared: {canonical}")
+                if live.name != canonical:
+                    self.remote.rename_asset(previous.identifier, canonical)
+        except (PublicationError, AssertionError) as error:
+            errors.append(str(error))
+
+        try:
+            self.remote.patch_release(self.snapshot, self.restore_payload())
+        except PublicationError as error:
+            errors.append(str(error))
+        try:
+            self.remote.force_remote_tag(self.previous_tag_commit)
+        except PublicationError as error:
+            errors.append(str(error))
+
+        if not errors:
+            try:
+                self.validate_restored_snapshot()
+            except (PublicationError, AssertionError) as error:
+                errors.append(str(error))
+        if errors:
+            raise PublicationError("Tester publication rollback was incomplete: " + " | ".join(errors))
+        print("Restored the previous tester release after publication failure.")
+
+    def validate_restored_snapshot(self) -> None:
+        assert self.snapshot is not None
+        assert self.previous_tag_commit is not None
+        restored = self.remote.get_release()
+        assert restored is not None
+        if (
+            restored.target_commitish != self.snapshot.target_commitish
+            or restored.name != self.snapshot.name
+            or restored.body != self.snapshot.body
+            or restored.draft != self.snapshot.draft
+            or restored.prerelease != self.snapshot.prerelease
+        ):
+            raise PublicationError("Restored release metadata does not match its snapshot.")
+        if set(restored.assets) != set(self.snapshot.assets):
+            raise PublicationError("Restored release asset inventory does not match its snapshot.")
+        for name, previous in self.snapshot.assets.items():
+            live = restored.assets[name]
+            if live.size != previous.size or live.digest != previous.digest:
+                raise PublicationError(f"Restored release asset metadata differs for {name}.")
+        if self.remote.remote_tag_commit() != self.previous_tag_commit:
+            raise PublicationError("Restored tester tag does not match its snapshot.")
+
+    def cleanup_rollback_assets(self) -> None:
+        assert self.snapshot is not None
+        for previous in self.snapshot.assets.values():
+            self.remote.delete_asset(previous.identifier)
+
+    def publish_existing(self, release: ReleaseSnapshot) -> None:
+        self.validate_existing_release(release)
+        self.snapshot = release
+        self.previous_tag_commit = self.remote.remote_tag_commit()
+        assert self.previous_tag_commit is not None
+        if (
+            COMMIT_PATTERN.fullmatch(release.target_commitish)
+            and self.previous_tag_commit != release.target_commitish
+        ):
+            raise PublicationError("Existing tester release target and remote tag disagree.")
+        self.remote.configure_git()
+
+        try:
+            with tempfile.TemporaryDirectory(prefix="quill-cowork-publication-") as directory:
+                self.upload_candidates(Path(directory))
+            self.swap_assets()
+            self.validate_swapped_assets()
+            self.remote.patch_release(release, self.publication_payload())
+            self.remote.force_remote_tag(self.commit)
+
+            published = self.remote.get_release()
+            assert published is not None
+            validate_release_metadata(published, self.commit, self.notes)
+            if self.remote.remote_tag_commit() != self.commit:
+                raise PublicationError("Published tester tag does not match the requested commit.")
+            self.committed = True
+            self.cleanup_rollback_assets()
+
+            final_release = self.remote.get_release()
+            assert final_release is not None
+            validate_release_metadata(final_release, self.commit, self.notes)
+            validate_exact_assets(final_release, self.assets)
+        except Exception as error:
+            if not self.committed:
+                try:
+                    self.rollback_existing()
+                except PublicationError as rollback_error:
+                    raise PublicationError(f"{error} | {rollback_error}") from error
+            raise
+        print(f"Published transactional tester release {self.commit}.")
+
+    def publish(self) -> None:
+        release = self.remote.get_release(missing_ok=True)
+        if release is None:
+            publish_initial_release(
+                self.remote,
+                self.commit,
+                self.assets,
+                self.notes,
+                self.notes_path,
+            )
+            return
+        recovered = self.recover_stale_aliases(release)
+        self.publish_existing(recovered)

--- a/scripts/tester_publication/remote.py
+++ b/scripts/tester_publication/remote.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+from tester_publication.contracts import (
+    COMMIT_PATTERN,
+    PublicationError,
+    ReleaseSnapshot,
+    TAG,
+    decode_release,
+)
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def command_result(arguments: list[str]) -> CommandResult:
+    completed = subprocess.run(
+        arguments,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def run_command(arguments: list[str]) -> str:
+    result = command_result(arguments)
+    if result.exit_code != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        raise PublicationError(f"Command failed ({' '.join(arguments)}): {detail}")
+    return result.stdout
+
+
+class PublicationRemote:
+    def __init__(self, repository: str, retry_delay_seconds: float) -> None:
+        self.repository = repository
+        self.retry_delay_seconds = retry_delay_seconds
+
+    def release_endpoint(self) -> str:
+        return f"repos/{self.repository}/releases/tags/{TAG}"
+
+    def release_by_id_endpoint(self, identifier: int) -> str:
+        return f"repos/{self.repository}/releases/{identifier}"
+
+    def asset_endpoint(self, identifier: int) -> str:
+        return f"repos/{self.repository}/releases/assets/{identifier}"
+
+    def get_release(self, *, missing_ok: bool = False) -> ReleaseSnapshot | None:
+        result = command_result(["gh", "api", "--method", "GET", self.release_endpoint()])
+        if result.exit_code == 0:
+            return decode_release(result.stdout)
+        if missing_ok and ("HTTP 404" in result.stderr or "Not Found" in result.stderr):
+            return None
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        raise PublicationError(f"Could not read {TAG}: {detail}")
+
+    def remote_tag_commit(self, *, missing_ok: bool = False) -> str | None:
+        output = run_command(
+            ["git", "ls-remote", "--refs", "origin", f"refs/tags/{TAG}"]
+        )
+        rows = [line.split() for line in output.splitlines() if line.strip()]
+        if not rows and missing_ok:
+            return None
+        if len(rows) != 1 or len(rows[0]) != 2 or rows[0][1] != f"refs/tags/{TAG}":
+            raise PublicationError(f"Remote tag {TAG} must resolve to exactly one direct ref.")
+        commit = rows[0][0]
+        if not COMMIT_PATTERN.fullmatch(commit):
+            raise PublicationError(f"Remote tag {TAG} returned an invalid commit.")
+        return commit
+
+    def configure_git(self) -> None:
+        run_command(["git", "config", "user.name", "github-actions[bot]"])
+        run_command(
+            [
+                "git",
+                "config",
+                "user.email",
+                "41898282+github-actions[bot]@users.noreply.github.com",
+            ]
+        )
+
+    def force_remote_tag(self, commit: str) -> None:
+        run_command(["git", "tag", "-f", TAG, commit])
+        run_command(["git", "push", "origin", f"refs/tags/{TAG}", "--force"])
+
+    def delete_remote_tag(self) -> None:
+        run_command(["git", "push", "origin", f":refs/tags/{TAG}"])
+        command_result(["git", "tag", "-d", TAG])
+
+    def rename_asset(self, identifier: int, name: str) -> None:
+        run_command(
+            [
+                "gh",
+                "api",
+                "--method",
+                "PATCH",
+                self.asset_endpoint(identifier),
+                "-f",
+                f"name={name}",
+            ]
+        )
+
+    def delete_asset(self, identifier: int) -> None:
+        last_error: PublicationError | None = None
+        for attempt in range(3):
+            try:
+                run_command(
+                    ["gh", "api", "--method", "DELETE", self.asset_endpoint(identifier)]
+                )
+                return
+            except PublicationError as error:
+                last_error = error
+                if attempt < 2:
+                    time.sleep(self.retry_delay_seconds)
+        assert last_error is not None
+        raise last_error
+
+    def patch_release(self, snapshot: ReleaseSnapshot, payload: dict[str, Any]) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", prefix="quill-cowork-release-", suffix=".json"
+        ) as handle:
+            json.dump(payload, handle, ensure_ascii=True)
+            handle.flush()
+            run_command(
+                [
+                    "gh",
+                    "api",
+                    "--method",
+                    "PATCH",
+                    self.release_by_id_endpoint(snapshot.identifier),
+                    "--input",
+                    handle.name,
+                ]
+            )


### PR DESCRIPTION
## Summary
- stage and verify tester assets before changing canonical downloads
- retain exact rollback aliases until release metadata and tag commit verify
- add injected-failure parity coverage and document the publication contract

## Verification
- 5,756 tests, 5 skipped, 0 failures
- focused publication suite: 14 tests, 0 failures
- Python compile and workflow YAML validation
- git diff hygiene and changed-surface secret scan
- deterministic module grades: A+