### PR TITLE
Test updates from the previous public build

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -41,6 +41,41 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/plan-download-build.sh
 
+  capture-updater-source:
+    needs: release-policy
+    if: needs.release-policy.outputs.build-required == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Capture previous public updater sources
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            RELEASE_CHANNEL="stable"
+          else
+            RELEASE_CHANNEL="tester"
+          fi
+          for architecture in arm64 x86_64; do
+            scripts/capture-public-updater-source.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --channel "$RELEASE_CHANNEL" \
+              --arch "$architecture" \
+              --output-dir "$RUNNER_TEMP/prior-updater/$architecture" \
+              --allow-missing
+          done
+      - name: Upload previous public updater sources
+        uses: actions/upload-artifact@v7
+        with:
+          name: quillcode-prior-updater-sources
+          path: ${{ runner.temp }}/prior-updater
+          if-no-files-found: error
+          retention-days: 14
+
   macos:
     needs: release-policy
     if: needs.release-policy.outputs.build-required == 'true'
@@ -143,7 +178,7 @@ jobs:
           retention-days: 14
 
   publish:
-    needs: [macos, linux]
+    needs: [macos, linux, capture-updater-source]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -156,6 +191,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/download-artifact@v8
         with:
+          pattern: quillcode-*-downloads*
           path: ${{ runner.temp }}/downloaded-artifacts
       - name: Prepare release assets
         run: |
@@ -313,12 +349,13 @@ jobs:
           --repo "$GITHUB_REPOSITORY"
 
   verify-updater:
-    needs: [publish, verify-published, promote-stable]
+    needs: [publish, verify-published, promote-stable, capture-updater-source]
     if: >-
       ${{
         always() &&
         needs.publish.result == 'success' &&
         needs.verify-published.result == 'success' &&
+        needs.capture-updater-source.result == 'success' &&
         (
           !(github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
           needs.promote-stable.result == 'success'
@@ -339,6 +376,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - name: Download previous public updater source
+        uses: actions/download-artifact@v8
+        with:
+          name: quillcode-prior-updater-sources
+          path: ${{ runner.temp }}/prior-updater
       - name: Verify native updater architecture
         run: |
           if [[ "$(uname -m)" != "${{ matrix.arch }}" ]]; then
@@ -367,15 +409,24 @@ jobs:
         env:
           QUILLCODE_UPDATER_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/updater-smoke-artifacts
         run: |
-          APP_ZIPS=("$RUNNER_TEMP"/public-updater/Quill-Cowork-macOS-${{ matrix.arch }}.zip)
-          MANIFESTS=("$RUNNER_TEMP"/public-updater/latest-*-build.json)
-          if [[ ${#APP_ZIPS[@]} -ne 1 || ${#MANIFESTS[@]} -ne 1 ]]; then
-            echo "Expected exactly one public app archive and one updater manifest." >&2
+          TARGET_APP_ZIPS=("$RUNNER_TEMP"/public-updater/Quill-Cowork-macOS-${{ matrix.arch }}.zip)
+          TARGET_MANIFESTS=("$RUNNER_TEMP"/public-updater/latest-*-build.json)
+          CAPTURE_DIR="$RUNNER_TEMP/prior-updater/${{ matrix.arch }}"
+          if [[ ${#TARGET_APP_ZIPS[@]} -ne 1 || ${#TARGET_MANIFESTS[@]} -ne 1 ||
+                ! -f "$CAPTURE_DIR/capture.json" ]]; then
+            echo "Expected one target app, target manifest, and prior-source capture." >&2
             exit 1
           fi
-          scripts/packaged-macos-updater-smoke.sh \
-            --app-zip "${APP_ZIPS[0]}" \
-            --manifest "${MANIFESTS[0]}"
+          UPDATER_ARGUMENTS=(--manifest "${TARGET_MANIFESTS[0]}")
+          if [[ "$(plutil -extract sourceAvailable raw "$CAPTURE_DIR/capture.json")" == "true" ]]; then
+            UPDATER_ARGUMENTS+=(
+              --app-zip "$CAPTURE_DIR/source-app.zip"
+              --source-manifest "$CAPTURE_DIR/source-manifest.json"
+            )
+          else
+            UPDATER_ARGUMENTS+=(--app-zip "${TARGET_APP_ZIPS[0]}")
+          fi
+          scripts/packaged-macos-updater-smoke.sh "${UPDATER_ARGUMENTS[@]}"
       - name: Upload updater smoke evidence
         if: always()
         uses: actions/upload-artifact@v7

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -294,6 +294,11 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "if: needs.release-policy.outputs.build-required == 'true'",
             "persist-credentials: false",
             "needs: release-policy",
+            "capture-updater-source:",
+            "scripts/capture-public-updater-source.py",
+            "--output-dir \"$RUNNER_TEMP/prior-updater/$architecture\"",
+            "--allow-missing",
+            "name: quillcode-prior-updater-sources",
             "group: download-builds-${{ github.ref }}",
             "cancel-in-progress: false",
             "QUILLCODE_UPDATE_CHANNEL=stable",
@@ -316,6 +321,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "--commit \"$GITHUB_SHA\"",
             "--output \"$RUNNER_TEMP/release-notes.md\"",
             "scripts/plan-download-publication.sh",
+            "needs: [macos, linux, capture-updater-source]",
+            "pattern: quillcode-*-downloads*",
             "published: ${{ steps.publication.outputs.publish-required }}",
             "if: steps.publication.outputs.publish-required == 'true'",
             "if: needs.publish.outputs.published == 'true'",
@@ -342,7 +349,11 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "promote-stable:",
             "Promote verified stable candidate",
             "--prerelease=false",
-            "needs: [publish, verify-published, promote-stable]",
+            "needs: [publish, verify-published, promote-stable, capture-updater-source]",
+            "needs.capture-updater-source.result == 'success'",
+            "Download previous public updater source",
+            "sourceAvailable raw",
+            "--source-manifest \"$CAPTURE_DIR/source-manifest.json\"",
             "verify-stable-promotion:",
             "needs: [promote-stable, verify-updater]",
             "Verify promoted stable release",
@@ -370,12 +381,14 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertLessThan(validationIndex.lowerBound, ciGateIndex.lowerBound)
         XCTAssertLessThan(ciGateIndex.lowerBound, planningIndex.lowerBound)
         let publishIndex = try XCTUnwrap(workflow.range(of: "  publish:"))
+        let sourceCaptureIndex = try XCTUnwrap(workflow.range(of: "  capture-updater-source:"))
         let freshnessIndex = try XCTUnwrap(workflow.range(of: "scripts/plan-download-publication.sh"))
         let releaseMutationIndex = try XCTUnwrap(workflow.range(of: "scripts/publish-tester-release.py"))
         let publicVerificationIndex = try XCTUnwrap(workflow.range(of: "  verify-published:"))
         let promotionIndex = try XCTUnwrap(workflow.range(of: "  promote-stable:"))
         let updaterIndex = try XCTUnwrap(workflow.range(of: "  verify-updater:"))
         let finalVerificationIndex = try XCTUnwrap(workflow.range(of: "  verify-stable-promotion:"))
+        XCTAssertLessThan(sourceCaptureIndex.lowerBound, publishIndex.lowerBound)
         XCTAssertLessThan(publishIndex.lowerBound, publicVerificationIndex.lowerBound)
         XCTAssertLessThan(freshnessIndex.lowerBound, releaseMutationIndex.lowerBound)
         XCTAssertLessThan(publicVerificationIndex.lowerBound, promotionIndex.lowerBound)
@@ -407,6 +420,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "returns the new release to draft",
             "previous stable feed",
             "avoids no-op build-number updates and unnecessary",
+            "untouched previous public app",
+            "synthetic one-build-behind fallback",
             "channel is `tester`",
             "channel is `stable`"
         ])

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -55,21 +55,37 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         Self.assertSource(script, containsAll: [
             "--native-updater-smoke",
             "--updater-smoke-report",
+            "--source-manifest",
+            "SOURCE_MODE=\"previous-public-build\"",
+            "SOURCE_MODE=\"synthetic-first-release\"",
+            "Previous public app metadata disagrees with its captured manifest.",
             "codesign --verify --deep --strict",
             "CFBundleVersion $SOURCE_BUILD",
+            "sourceVersion",
             "targetCommit",
             "STAGING_APPS",
+            "PUBLIC_APP_PARENT=\"${APP_PARENT#/private}\"",
+            "kill -0 \"$UPDATED_PID\"",
             "Updated app did not remain running"
         ])
         Self.assertSource(workflow, containsAll: [
+            "capture-updater-source:",
+            "Capture previous public updater sources",
+            "scripts/capture-public-updater-source.py",
+            "name: quillcode-prior-updater-sources",
+            "pattern: quillcode-*-downloads*",
+            "needs: [macos, linux, capture-updater-source]",
             "verify-updater:",
             "runner: macos-15",
             "runner: macos-15-intel",
             "runs-on: ${{ matrix.runner }}",
             "arch: arm64",
             "arch: x86_64",
-            "needs: [publish, verify-published, promote-stable]",
+            "needs: [publish, verify-published, promote-stable, capture-updater-source]",
+            "needs.capture-updater-source.result == 'success'",
             "needs.promote-stable.result == 'success'",
+            "sourceAvailable raw",
+            "--source-manifest \"$CAPTURE_DIR/source-manifest.json\"",
             "scripts/packaged-macos-updater-smoke.sh",
             "quillcode-public-updater-smoke-${{ matrix.arch }}"
         ])

--- a/Tests/QuillCodeParityTests/ParityUpdaterSourceCaptureTests.swift
+++ b/Tests/QuillCodeParityTests/ParityUpdaterSourceCaptureTests.swift
@@ -1,0 +1,305 @@
+import Foundation
+import XCTest
+
+final class ParityUpdaterSourceCaptureTests: QuillCodeParityTestCase {
+    private let commit = String(repeating: "a", count: 40)
+
+    func testCaptureVerifiesAndPersistsThePreviousPublicApp() throws {
+        let result = try runCapture()
+        defer { try? FileManager.default.removeItem(at: result.root) }
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Captured tester arm64 updater source"), result.output)
+        let capture = try jsonObject(at: result.outputDirectory.appendingPathComponent("capture.json"))
+        XCTAssertEqual(capture["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(capture["sourceAvailable"] as? Bool, true)
+        XCTAssertEqual(capture["channel"] as? String, "tester")
+        XCTAssertEqual(capture["tag"] as? String, "tester-latest")
+        XCTAssertEqual(capture["architecture"] as? String, "arm64")
+        XCTAssertEqual(capture["version"] as? String, "0.1.0")
+        XCTAssertEqual(capture["build"] as? String, "695")
+        XCTAssertEqual(capture["commit"] as? String, commit)
+        XCTAssertEqual(capture["appName"] as? String, "Quill-Cowork-macOS-arm64.zip")
+        XCTAssertEqual(
+            try Data(contentsOf: result.outputDirectory.appendingPathComponent("source-app.zip")),
+            result.appData
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: result.outputDirectory.appendingPathComponent("source-manifest.json")),
+            result.manifestData
+        )
+        XCTAssertEqual(
+            result.operations,
+            [
+                "api:repos/Lore-Hex/QuillCode/releases/tags/tester-latest",
+                "download:tester-latest:latest-tester-build.json",
+                "download:tester-latest:Quill-Cowork-macOS-arm64.zip"
+            ]
+        )
+    }
+
+    func testMissingFirstReleaseWritesOnlyAnExplicitFallbackRecord() throws {
+        let result = try runCapture(missing: true)
+        defer { try? FileManager.default.removeItem(at: result.root) }
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let capture = try jsonObject(at: result.outputDirectory.appendingPathComponent("capture.json"))
+        XCTAssertEqual(capture["sourceAvailable"] as? Bool, false)
+        XCTAssertEqual(capture["reason"] as? String, "release-not-found")
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: result.outputDirectory.appendingPathComponent("source-app.zip").path
+            )
+        )
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(atPath: result.outputDirectory.path),
+            ["capture.json"]
+        )
+        XCTAssertEqual(
+            result.operations,
+            ["api:repos/Lore-Hex/QuillCode/releases/tags/tester-latest"]
+        )
+    }
+
+    func testMissingStableChannelUsesTheLatestReleaseEndpoint() throws {
+        let result = try runCapture(missing: true, channel: "stable")
+        defer { try? FileManager.default.removeItem(at: result.root) }
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let capture = try jsonObject(at: result.outputDirectory.appendingPathComponent("capture.json"))
+        XCTAssertEqual(capture["sourceAvailable"] as? Bool, false)
+        XCTAssertEqual(capture["channel"] as? String, "stable")
+        XCTAssertEqual(result.operations, ["api:repos/Lore-Hex/QuillCode/releases/latest"])
+    }
+
+    func testCorruptDownloadFailsTransactionallyWithoutPublishingCapture() throws {
+        let result = try runCapture(corruptAsset: "Quill-Cowork-macOS-arm64.zip")
+        defer { try? FileManager.default.removeItem(at: result.root) }
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.output.contains("digest disagrees"), result.output)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: result.outputDirectory.path))
+        let abandonedStaging = try FileManager.default.contentsOfDirectory(atPath: result.root.path)
+            .filter { $0.hasPrefix(".capture.capture-") }
+        XCTAssertEqual(abandonedStaging, [])
+    }
+
+    func testUnsafeRepositoryFailsBeforeCallingGitHub() throws {
+        let result = try runCapture(repository: "owner/..")
+        defer { try? FileManager.default.removeItem(at: result.root) }
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.output.contains("Repository must use owner/name syntax"), result.output)
+        XCTAssertEqual(result.operations, [])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: result.outputDirectory.path))
+    }
+
+    private struct CaptureResult {
+        let exitCode: Int32
+        let output: String
+        let root: URL
+        let outputDirectory: URL
+        let appData: Data
+        let manifestData: Data
+        let operations: [String]
+    }
+
+    private func runCapture(
+        missing: Bool = false,
+        corruptAsset: String? = nil,
+        repository: String = "Lore-Hex/QuillCode",
+        channel: String = "tester"
+    ) throws -> CaptureResult {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-updater-source-capture-tests")
+            .appendingPathComponent(UUID().uuidString)
+        let bin = root.appendingPathComponent("bin")
+        let fixtures = root.appendingPathComponent("fixtures")
+        let stateURL = root.appendingPathComponent("state.json")
+        let outputDirectory = root.appendingPathComponent("capture")
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: fixtures, withIntermediateDirectories: true)
+
+        let appName = "Quill-Cowork-macOS-arm64.zip"
+        let manifestName = "latest-tester-build.json"
+        let appData = Data("previous public app archive".utf8)
+        let appDigest = try sha256(appData, in: root)
+        let manifest: [String: Any] = [
+            "schemaVersion": 1,
+            "product": "Quill Cowork",
+            "channel": "tester",
+            "tag": "tester-latest",
+            "commit": commit,
+            "version": "0.1.0",
+            "build": "695",
+            "updater": [
+                "bundleIdentifier": "co.lorehex.QuillCowork",
+                "channel": "tester",
+                "macOSAppAssets": [[
+                    "arch": "arm64",
+                    "name": appName,
+                    "platform": "macOS",
+                    "kind": "app",
+                    "install": "zip-app",
+                    "url": "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/\(appName)",
+                    "sizeBytes": appData.count,
+                    "sha256": appDigest
+                ]]
+            ]
+        ]
+        let manifestData = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        let manifestDigest = try sha256(manifestData, in: root)
+        try appData.write(to: fixtures.appendingPathComponent(appName))
+        try manifestData.write(to: fixtures.appendingPathComponent(manifestName))
+
+        let state: [String: Any] = [
+            "missing": missing,
+            "corruptAsset": (corruptAsset as Any?) ?? NSNull(),
+            "operations": [],
+            "fixtures": fixtures.path,
+            "release": [
+                "tag_name": "tester-latest",
+                "target_commitish": commit,
+                "draft": false,
+                "prerelease": true,
+                "assets": [
+                    remoteAsset(name: manifestName, data: manifestData, digest: manifestDigest),
+                    remoteAsset(name: appName, data: appData, digest: appDigest)
+                ]
+            ]
+        ]
+        try JSONSerialization.data(withJSONObject: state, options: [.sortedKeys]).write(to: stateURL)
+        try writeExecutable(fakeGitHub, to: bin.appendingPathComponent("gh"))
+
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [
+            "python3",
+            Self.packageRoot().appendingPathComponent("scripts/capture-public-updater-source.py").path,
+            "--repo", repository,
+            "--channel", channel,
+            "--arch", "arm64",
+            "--output-dir", outputDirectory.path,
+            "--allow-missing"
+        ]
+        process.standardOutput = pipe
+        process.standardError = pipe
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(bin.path):\(environment["PATH"] ?? "")"
+        environment["FAKE_CAPTURE_STATE"] = stateURL.path
+        environment["PYTHONDONTWRITEBYTECODE"] = "1"
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let finalState = try jsonObject(at: stateURL)
+        let operations = try XCTUnwrap(finalState["operations"] as? [String])
+        return CaptureResult(
+            exitCode: process.terminationStatus,
+            output: output,
+            root: root,
+            outputDirectory: outputDirectory,
+            appData: appData,
+            manifestData: manifestData,
+            operations: operations
+        )
+    }
+
+    private func remoteAsset(name: String, data: Data, digest: String) -> [String: Any] {
+        [
+            "name": name,
+            "size": data.count,
+            "digest": "sha256:\(digest)",
+            "state": "uploaded"
+        ]
+    }
+
+    private func sha256(_ data: Data, in directory: URL) throws -> String {
+        let input = directory.appendingPathComponent("digest-\(UUID().uuidString)")
+        try data.write(to: input)
+        defer { try? FileManager.default.removeItem(at: input) }
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [
+            "python3", "-c",
+            "import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())",
+            input.path
+        ]
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, output)
+        XCTAssertEqual(output.count, 64)
+        return output
+    }
+
+    private func jsonObject(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func writeExecutable(_ source: String, to url: URL) throws {
+        try source.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    private var fakeGitHub: String {
+        #"""
+        #!/usr/bin/env python3
+        import json
+        import os
+        from pathlib import Path
+        import shutil
+        import sys
+
+        state_path = Path(os.environ["FAKE_CAPTURE_STATE"])
+
+        def load():
+            return json.loads(state_path.read_text())
+
+        def save(state):
+            temporary = state_path.with_suffix(".tmp")
+            temporary.write_text(json.dumps(state, sort_keys=True))
+            temporary.replace(state_path)
+
+        args = sys.argv[1:]
+        state = load()
+        if args[:1] == ["api"]:
+            endpoint = next(value for value in args if value.startswith("repos/"))
+            state["operations"].append("api:" + endpoint)
+            save(state)
+            if state["missing"]:
+                print("HTTP 404: Not Found", file=sys.stderr)
+                raise SystemExit(1)
+            print(json.dumps(state["release"], sort_keys=True))
+            raise SystemExit(0)
+        if args[:2] == ["release", "download"]:
+            tag = args[2]
+            name = args[args.index("--pattern") + 1]
+            destination = Path(args[args.index("--dir") + 1]) / name
+            state["operations"].append("download:" + tag + ":" + name)
+            save(state)
+            shutil.copyfile(Path(state["fixtures"]) / name, destination)
+            if state.get("corruptAsset") == name:
+                contents = bytearray(destination.read_bytes())
+                contents[0] ^= 0xff
+                destination.write_bytes(contents)
+            raise SystemExit(0)
+        print("unsupported fake gh invocation: " + " ".join(args), file=sys.stderr)
+        raise SystemExit(64)
+        """#
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,29 @@
 # Code Quality Audit
 
+## 2026-08-09 Previous-Public-Build Updater Gate
+
+Overall grade after this slice: **A+ compatibility evidence, A+ publication ordering, A+ failure isolation**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Real upgrade coverage | A+ | Native arm64 and Intel gates consume the untouched app that users could already have installed, including its real embedded feed and source metadata, instead of modifying newly built code to update to itself. |
+| Capture integrity | A+ | Release and manifest contracts are decoded strictly; downloaded bytes must match bounded GitHub size/digest and manifest size/SHA-256 before a transactional directory swap exposes them. |
+| Publication ordering | A+ | New release publication depends on prior-source capture, and artifact assembly selects only packaging artifacts, so the snapshot is necessarily old and can never leak into the new release inventory. |
+| Failure isolation | A+ | Missing first releases produce one explicit fallback record; malformed metadata, corrupt bytes, unsafe inputs, command failures, and existing outputs fail closed and remove staging data. |
+| Architecture | A+ | Contract decoding, bounded hashing, GitHub operations, transaction orchestration, and the CLI entry point remain focused modules with deterministic stateful parity coverage. |
+
+Validation:
+
+- Focused capture, updater, and Download Builds parity suite: 12 tests, 0 failures
+- Authoritative full suite outside the managed macOS service sandbox: 5,761 tests,
+  5 skipped, 0 failures
+- Python compile validation, shell syntax validation, and workflow YAML parsing
+- Stateful fake-GitHub verification of exact capture, first-release fallback, same-size corruption,
+  cleanup, and mutation-free repository rejection
+- Read-only production captures matched public tester build 695 at exact commit `7e4347e4` and the
+  published arm64 and x86_64 archive sizes and SHA-256 digests
+- Deterministic grader: every new production and test module A+
+
 ## 2026-08-09 Transactional Tester Publication
 
 Overall grade after this slice: **A+ publication integrity, A+ recovery, A+ maintainability**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # QuillCode Decisions
 
+## 2026-08-09: releases update from the untouched previous public app
+
+- **Decision:** Download Builds captures the current public manifest and matching arm64 and x86_64
+  updater archives before publication begins. GitHub upload state, bounded size, release digest,
+  manifest identity, commit, architecture, URL, and SHA-256 must agree before the snapshot is kept.
+- **Release ordering:** Tester or stable publication depends on the capture job, while release-asset
+  assembly downloads only packaging artifacts. The prior binaries therefore cannot be mistaken for
+  new release assets and cannot be captured after a moving release changes.
+- **Compatibility proof:** Native post-publication jobs update the untouched captured app through its
+  real embedded channel feed to the newly published build, then require exact source/target metadata,
+  activation, signature, relaunch, process liveness, and staging cleanup.
+- **First release:** A missing channel release is recorded explicitly and permits the existing
+  synthetic one-build-behind smoke. Once a public source is available, the workflow cannot rewrite or
+  re-sign it to manufacture the upgrade path.
+- **Evidence:** Transactional capture modules, stateful fake-GitHub tests for success, absence,
+  corruption, and preflight rejection, workflow ordering assertions, and both native updater runners.
+
 ## 2026-08-09: moving tester publication retains a verified rollback snapshot
 
 - **Decision:** Tester assets upload under run-scoped candidate names and must match GitHub's

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -130,13 +130,18 @@ source commit, channel, feed URLs, minimum macOS version, and signing team to ag
 with the public manifest. A publication is not green until this consumer check passes.
 
 A separate native post-publication gate runs on Apple silicon and Intel macOS
-runners. Each downloads its matching public app archive, re-signs an isolated copy
-with its build number set one revision behind, and launches the packaged updater
-against the live feed. The gate requires the app
+runners. Before publication can begin, a read-only job captures the current public
+manifest and both architecture-specific updater archives, verifies their GitHub and
+manifest size/SHA-256 contracts, and stores them outside the release-asset input set.
+After publication, each native runner launches that untouched previous public app
+against the newly live feed. The gate requires the app
 to stream, verify, unpack, validate, atomically replace, and relaunch itself; it
-then checks the activated version and source commit, code signature, launch
-handshake, and staging cleanup. This catches failures that manifest-only and
-unit-level updater checks cannot prove.
+then checks the exact source and target metadata, activated version and source
+commit, code signature, launch handshake, and staging cleanup. A channel with no
+previous release uses an explicitly recorded synthetic one-build-behind fallback;
+once a public source exists, metadata rewriting and re-signing are not allowed.
+This catches cross-version compatibility failures that a self-update of newly built
+code, manifest-only checks, and unit-level updater tests cannot prove.
 
 The release-configured macOS app must also open a real native window within three
 seconds and remain below 256 MiB of resident memory at that initial-window

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -299,7 +299,11 @@ Drive the QuillCode test harness with mock LLM:
 - Packaged performance smoke must run the reversible native Accessibility interaction sweep twice in every fresh process. It records initial-window, first-settled, and repeated-settled resident memory/thread snapshots, recomputes both signed deltas from raw values, and fails if any sample exceeds 256 MiB or 64 threads, first-pass retained growth exceeds 80 MiB, or the repeated pass adds more than 16 MiB or four threads.
 - Download publication must package arm64 on `macos-15` and x86_64 on `macos-15-intel`, first proving
   `uname -m` matches the matrix architecture. Each runner executes the packaged performance smoke;
-  each post-publication runner downloads only its exact ZIP and completes the real update/relaunch gate.
+  before publication, the workflow must capture and verify the prior public manifest plus both exact
+  architecture ZIPs outside the release-asset input set. Each post-publication runner must update the
+  untouched matching prior app through its live embedded feed and complete the real update/relaunch
+  gate. Synthetic metadata rewriting is permitted only when the capture explicitly proves that the
+  channel has no previous release.
 - Offline and public release verification must require one DMG, app ZIP, CLI archive, build-info file,
   and semantic performance report per macOS architecture. It must reject duplicate/missing assets,
   noncanonical updater ordering, legacy-field drift, and an x86_64 ZIP carrying an arm64 Mach-O header
@@ -359,7 +363,8 @@ Drive the QuillCode test harness with mock LLM:
 - Live TrustedRouter smoke is not required for normal PRs. Run `./scripts/real-world-smoke.sh` before releases, model-prompt changes, parser changes, runtime changes, or safety-review changes; use `QUILLCODE_REQUIRE_LIVE_SMOKE=1` when the live model path must be proven. Release-candidate runs should set `QUILLCODE_REAL_WORLD_SMOKE_ARTIFACT_DIR` and preserve the resulting `real-world-smoke-manifest.json` with CI or release notes.
 - All unit tests pass on macOS and Linux before a stable release.
 - Native arm64 and x86_64 packaging, performance, semantic publication, and updater-relaunch jobs pass
-  before either tester or stable macOS assets are considered publishable.
+  before either tester or stable macOS assets are considered publishable. For every non-initial channel
+  release, both updater jobs must identify `previous-public-build` mode and the exact prior public build.
 - Native app smoke tests pass on packaged macOS and Linux builds.
 - No app target contains `#if linux`; CI enforces this.
 - `docs/CODEX_PARITY_MATRIX.md` marks each feature as implemented, deferred with reason, or not applicable.

--- a/scripts/capture-public-updater-source.py
+++ b/scripts/capture-public-updater-source.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Capture and verify the public app that must update to the next release."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from updater_source_capture.capture import capture_source
+from updater_source_capture.contracts import CaptureError, repository_is_valid
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--channel", choices=["tester", "stable"], required=True)
+    parser.add_argument("--arch", choices=["arm64", "x86_64"], required=True)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--allow-missing", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    if not repository_is_valid(arguments.repo):
+        raise CaptureError("Repository must use owner/name syntax.")
+    capture_source(
+        arguments.repo,
+        arguments.channel,
+        arguments.arch,
+        arguments.output_dir,
+        allow_missing=arguments.allow_missing,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except CaptureError as error:
+        print(f"Updater source capture failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/packaged-macos-updater-smoke.sh
+++ b/scripts/packaged-macos-updater-smoke.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 APP_ZIP=""
 MANIFEST_PATH=""
+SOURCE_MANIFEST_PATH=""
 ARTIFACT_DIR="${QUILLCODE_UPDATER_SMOKE_ARTIFACT_DIR:-}"
 TEMP_ROOT="${TMPDIR:-/tmp}"
 SMOKE_ROOT="$(mktemp -d "${TEMP_ROOT%/}/quillcode-packaged-updater.XXXXXX")"
@@ -22,7 +23,10 @@ cleanup() {
     mkdir -p "$ARTIFACT_DIR"
     [[ -f "$REPORT_PATH" ]] && cp "$REPORT_PATH" "$ARTIFACT_DIR/updater-stage.json"
     [[ -f "$LOG_PATH" ]] && cp "$LOG_PATH" "$ARTIFACT_DIR/updater.log"
-    printf 'status=%s\n' "$status" > "$ARTIFACT_DIR/manifest.txt"
+    [[ -n "$SOURCE_MANIFEST_PATH" && -f "$SOURCE_MANIFEST_PATH" ]] &&
+      cp "$SOURCE_MANIFEST_PATH" "$ARTIFACT_DIR/source-manifest.json"
+    printf 'status=%s\nsource_mode=%s\n' \
+      "$status" "${SOURCE_MODE:-unknown}" > "$ARTIFACT_DIR/manifest.txt"
   fi
   rm -rf "$SMOKE_ROOT"
   exit "$status"
@@ -39,6 +43,10 @@ while [[ $# -gt 0 ]]; do
       MANIFEST_PATH="$2"
       shift 2
       ;;
+    --source-manifest)
+      SOURCE_MANIFEST_PATH="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown argument: $1" >&2
       exit 2
@@ -50,8 +58,9 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "packaged-macos-updater-smoke.sh must run on macOS." >&2
   exit 2
 fi
-if [[ ! -f "$APP_ZIP" || ! -f "$MANIFEST_PATH" ]]; then
-  echo "Usage: packaged-macos-updater-smoke.sh --app-zip APP_ZIP --manifest MANIFEST_JSON" >&2
+if [[ ! -f "$APP_ZIP" || ! -f "$MANIFEST_PATH" ||
+      ( -n "$SOURCE_MANIFEST_PATH" && ! -f "$SOURCE_MANIFEST_PATH" ) ]]; then
+  echo "Usage: packaged-macos-updater-smoke.sh --app-zip APP_ZIP --manifest TARGET_JSON [--source-manifest SOURCE_JSON]" >&2
   exit 2
 fi
 
@@ -80,15 +89,46 @@ APP_BASE_NAME="$(basename "$APP_BUNDLE" .app)"
 INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
 EXECUTABLE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST")"
 APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/$EXECUTABLE_NAME"
-SOURCE_BUILD=$((EXPECTED_BUILD - 1))
 
 codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
-/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $SOURCE_BUILD" "$INFO_PLIST"
-/usr/libexec/PlistBuddy -c "Set :QuillCodeBuildCommit 0000000000000000000000000000000000000000" "$INFO_PLIST"
-codesign --force --deep --sign - "$APP_BUNDLE"
-codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 
-echo "==> Updating packaged Quill Cowork $EXPECTED_VERSION ($SOURCE_BUILD) to ($EXPECTED_BUILD)"
+if [[ -n "$SOURCE_MANIFEST_PATH" ]]; then
+  SOURCE_MODE="previous-public-build"
+  SOURCE_VERSION="$(plutil -extract version raw "$SOURCE_MANIFEST_PATH")"
+  SOURCE_BUILD="$(plutil -extract build raw "$SOURCE_MANIFEST_PATH")"
+  SOURCE_COMMIT="$(plutil -extract commit raw "$SOURCE_MANIFEST_PATH")"
+  SOURCE_CHANNEL="$(plutil -extract channel raw "$SOURCE_MANIFEST_PATH")"
+  if [[ ! "$SOURCE_BUILD" =~ ^[0-9]+$ ]] || (( SOURCE_BUILD >= EXPECTED_BUILD )); then
+    echo "Previous public updater source must have a lower numeric build." >&2
+    exit 2
+  fi
+  if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ || "$SOURCE_CHANNEL" != "$EXPECTED_CHANNEL" ]]; then
+    echo "Previous public updater source has an invalid commit or channel." >&2
+    exit 2
+  fi
+  ACTUAL_SOURCE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
+  ACTUAL_SOURCE_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+  ACTUAL_SOURCE_COMMIT="$(/usr/libexec/PlistBuddy -c 'Print :QuillCodeBuildCommit' "$INFO_PLIST")"
+  ACTUAL_SOURCE_CHANNEL="$(/usr/libexec/PlistBuddy -c 'Print :QuillCodeUpdateChannel' "$INFO_PLIST")"
+  if [[ "$ACTUAL_SOURCE_VERSION" != "$SOURCE_VERSION" ||
+        "$ACTUAL_SOURCE_BUILD" != "$SOURCE_BUILD" ||
+        "$ACTUAL_SOURCE_COMMIT" != "$SOURCE_COMMIT" ||
+        "$ACTUAL_SOURCE_CHANNEL" != "$SOURCE_CHANNEL" ]]; then
+    echo "Previous public app metadata disagrees with its captured manifest." >&2
+    exit 1
+  fi
+else
+  SOURCE_MODE="synthetic-first-release"
+  SOURCE_VERSION="$EXPECTED_VERSION"
+  SOURCE_BUILD=$((EXPECTED_BUILD - 1))
+  SOURCE_COMMIT="0000000000000000000000000000000000000000"
+  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $SOURCE_BUILD" "$INFO_PLIST"
+  /usr/libexec/PlistBuddy -c "Set :QuillCodeBuildCommit $SOURCE_COMMIT" "$INFO_PLIST"
+  codesign --force --deep --sign - "$APP_BUNDLE"
+  codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+fi
+
+echo "==> Updating $SOURCE_MODE Quill Cowork $SOURCE_VERSION ($SOURCE_BUILD) to $EXPECTED_VERSION ($EXPECTED_BUILD)"
 CFFIXED_USER_HOME="$SMOKE_ROOT/home" HOME="$SMOKE_ROOT/home" \
   "$APP_EXECUTABLE" \
     --native-updater-smoke \
@@ -115,6 +155,7 @@ fi
 
 if [[ "$(plutil -extract ok raw "$REPORT_PATH")" != "true" ]] ||
    [[ "$(plutil -extract sourceBuild raw "$REPORT_PATH")" != "$SOURCE_BUILD" ]] ||
+   [[ "$(plutil -extract sourceVersion raw "$REPORT_PATH")" != "$SOURCE_VERSION" ]] ||
    [[ "$(plutil -extract targetBuild raw "$REPORT_PATH")" != "$EXPECTED_BUILD" ]] ||
    [[ "$(plutil -extract targetCommit raw "$REPORT_PATH")" != "$EXPECTED_COMMIT" ]]; then
   echo "Packaged updater smoke stage report disagrees with the public manifest." >&2
@@ -149,10 +190,19 @@ if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" || "$ACTUAL_CHANNEL" != "$EXPECTE
 fi
 codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 
-UPDATED_PID="$(pgrep -f "$APP_EXECUTABLE --quillcode-update-handshake" | head -n 1 || true)"
-if [[ -z "$UPDATED_PID" ]]; then
+UPDATED_PIDS="$(pgrep -f "$EXECUTABLE_NAME --quillcode-update-handshake" || true)"
+PUBLIC_APP_PARENT="${APP_PARENT#/private}"
+for candidate_pid in $UPDATED_PIDS; do
+  candidate_command="$(ps -p "$candidate_pid" -o command= 2>/dev/null || true)"
+  if [[ "$candidate_command" == *"$APP_PARENT"* ||
+        "$candidate_command" == *"$PUBLIC_APP_PARENT"* ]]; then
+    UPDATED_PID="$candidate_pid"
+    break
+  fi
+done
+if [[ -z "$UPDATED_PID" ]] || ! kill -0 "$UPDATED_PID" 2>/dev/null; then
   echo "Updated app did not remain running after its launch handshake." >&2
   exit 1
 fi
 
-echo "Verified packaged Quill Cowork updater: $SOURCE_BUILD -> $EXPECTED_BUILD ($EXPECTED_COMMIT)."
+echo "Verified $SOURCE_MODE Quill Cowork updater: $SOURCE_BUILD -> $EXPECTED_BUILD ($EXPECTED_COMMIT)."

--- a/scripts/updater_source_capture/__init__.py
+++ b/scripts/updater_source_capture/__init__.py
@@ -1,0 +1,1 @@
+"""Verified capture of the currently published updater source."""

--- a/scripts/updater_source_capture/capture.py
+++ b/scripts/updater_source_capture/capture.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import tempfile
+
+from updater_source_capture.contracts import (
+    CaptureError,
+    ReleaseAsset,
+    SourceMetadata,
+    decode_manifest,
+    file_digest,
+)
+from updater_source_capture.remote import CaptureRemote
+
+
+def validate_download(path: Path, release_asset: ReleaseAsset, expected_digest: str) -> None:
+    size = path.stat().st_size
+    digest = file_digest(path)
+    if release_asset.state != "uploaded" or size != release_asset.size:
+        raise CaptureError(f"Downloaded source asset size or state disagrees for {release_asset.name}.")
+    if release_asset.digest != f"sha256:{digest}" or digest != expected_digest:
+        raise CaptureError(f"Downloaded source asset digest disagrees for {release_asset.name}.")
+
+
+def capture_payload(metadata: SourceMetadata) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "sourceAvailable": True,
+        "channel": metadata.channel,
+        "tag": metadata.tag,
+        "architecture": metadata.architecture,
+        "version": metadata.version,
+        "build": metadata.build,
+        "commit": metadata.commit,
+        "appName": metadata.app_name,
+        "appSizeBytes": metadata.app_size,
+        "appSHA256": metadata.app_digest,
+    }
+
+
+def write_json(path: Path, value: dict[str, object]) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def capture_source(
+    repository: str,
+    channel: str,
+    architecture: str,
+    output_directory: Path,
+    *,
+    allow_missing: bool,
+) -> None:
+    if output_directory.exists() or output_directory.is_symlink():
+        raise CaptureError("Capture output directory must not already exist.")
+    output_directory.parent.mkdir(parents=True, exist_ok=True)
+    remote = CaptureRemote(repository, channel)
+    release = remote.get_release(missing_ok=allow_missing)
+
+    staging = Path(
+        tempfile.mkdtemp(
+            prefix=f".{output_directory.name}.capture-",
+            dir=output_directory.parent,
+        )
+    )
+    try:
+        if release is None:
+            write_json(
+                staging / "capture.json",
+                {
+                    "schemaVersion": 1,
+                    "sourceAvailable": False,
+                    "channel": channel,
+                    "architecture": architecture,
+                    "reason": "release-not-found",
+                },
+            )
+            os.replace(staging, output_directory)
+            print(f"No previous {channel} release exists for {architecture}; using first-release fallback.")
+            return
+
+        manifest_name = f"latest-{channel}-build.json"
+        app_name = f"Quill-Cowork-macOS-{architecture}.zip"
+        manifest_asset = release.assets.get(manifest_name)
+        app_asset = release.assets.get(app_name)
+        if manifest_asset is None or app_asset is None:
+            raise CaptureError("Published source release is missing required updater assets.")
+
+        downloads = staging / "downloads"
+        downloads.mkdir()
+        manifest_path = remote.download_asset(release, manifest_name, downloads)
+        app_path = remote.download_asset(release, app_name, downloads)
+        validate_download(
+            manifest_path,
+            manifest_asset,
+            manifest_asset.digest.removeprefix("sha256:"),
+        )
+        manifest_bytes = manifest_path.read_bytes()
+        metadata = decode_manifest(
+            manifest_bytes,
+            repository,
+            channel,
+            architecture,
+            release,
+        )
+        validate_download(app_path, app_asset, metadata.app_digest)
+        if app_path.stat().st_size != metadata.app_size:
+            raise CaptureError("Downloaded source app size disagrees with its manifest.")
+
+        shutil.copyfile(manifest_path, staging / "source-manifest.json")
+        shutil.copyfile(app_path, staging / "source-app.zip")
+        write_json(staging / "capture.json", capture_payload(metadata))
+        shutil.rmtree(downloads)
+        os.replace(staging, output_directory)
+        print(
+            f"Captured {channel} {architecture} updater source "
+            f"{metadata.version} ({metadata.build}) at {metadata.commit}."
+        )
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise

--- a/scripts/updater_source_capture/contracts.py
+++ b/scripts/updater_source_capture/contracts.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+PRODUCT = "Quill Cowork"
+BUNDLE_IDENTIFIER = "co.lorehex.QuillCowork"
+MANIFEST_MAX_BYTES = 1_048_576
+APP_MAX_BYTES = 536_870_912
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+STABLE_TAG_PATTERN = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+")
+VERSION_PATTERN = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+
+
+class CaptureError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    name: str
+    size: int
+    digest: str
+    state: str
+
+
+@dataclass(frozen=True)
+class Release:
+    tag: str
+    target_commit: str
+    draft: bool
+    prerelease: bool
+    assets: dict[str, ReleaseAsset]
+
+
+@dataclass(frozen=True)
+class SourceMetadata:
+    channel: str
+    tag: str
+    architecture: str
+    version: str
+    build: str
+    commit: str
+    app_name: str
+    app_size: int
+    app_digest: str
+
+
+def require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise CaptureError(f"{label} must be a non-empty string.")
+    return value
+
+
+def require_boolean(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise CaptureError(f"{label} must be a boolean.")
+    return value
+
+
+def require_integer(
+    value: Any,
+    label: str,
+    *,
+    minimum: int = 0,
+    maximum: int | None = None,
+) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise CaptureError(f"{label} must be an integer of at least {minimum}.")
+    if maximum is not None and value > maximum:
+        raise CaptureError(f"{label} exceeds its supported size limit.")
+    return value
+
+
+def decode_release(payload: str, channel: str) -> Release:
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise CaptureError(f"GitHub returned malformed release JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise CaptureError("GitHub release response must be an object.")
+
+    tag = require_string(value.get("tag_name"), "Release tag")
+    target = require_string(value.get("target_commitish"), "Release target")
+    if not COMMIT_PATTERN.fullmatch(target):
+        raise CaptureError("Published source release must target an exact commit.")
+    if channel == "tester" and tag != "tester-latest":
+        raise CaptureError("Tester source release must use tester-latest.")
+    if channel == "stable" and not STABLE_TAG_PATTERN.fullmatch(tag):
+        raise CaptureError("Stable source release must use a canonical version tag.")
+
+    values = value.get("assets")
+    if not isinstance(values, list) or not values or len(values) > 64:
+        raise CaptureError("Published source release must contain between 1 and 64 assets.")
+    assets: dict[str, ReleaseAsset] = {}
+    for index, item in enumerate(values):
+        if not isinstance(item, dict):
+            raise CaptureError(f"Release asset {index} must be an object.")
+        name = require_string(item.get("name"), f"Release asset {index} name")
+        if name in assets:
+            raise CaptureError(f"Release asset name is duplicated: {name}")
+        size_limit = MANIFEST_MAX_BYTES if name.endswith("-build.json") else APP_MAX_BYTES
+        size = require_integer(
+            item.get("size"),
+            f"Release asset {name} size",
+            minimum=1,
+            maximum=size_limit,
+        )
+        digest = require_string(item.get("digest"), f"Release asset {name} digest")
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise CaptureError(f"Release asset {name} has an invalid SHA-256 digest.")
+        assets[name] = ReleaseAsset(
+            name=name,
+            size=size,
+            digest=digest,
+            state=require_string(item.get("state"), f"Release asset {name} state"),
+        )
+
+    release = Release(
+        tag=tag,
+        target_commit=target,
+        draft=require_boolean(value.get("draft"), "Release draft state"),
+        prerelease=require_boolean(value.get("prerelease"), "Release prerelease state"),
+        assets=assets,
+    )
+    if release.draft or (channel == "tester" and not release.prerelease):
+        raise CaptureError("Published updater source has an invalid release state.")
+    if channel == "stable" and release.prerelease:
+        raise CaptureError("Stable updater source must be a final release.")
+    return release
+
+
+def decode_manifest(
+    payload: bytes,
+    repository: str,
+    channel: str,
+    architecture: str,
+    release: Release,
+) -> SourceMetadata:
+    if not payload or len(payload) > MANIFEST_MAX_BYTES:
+        raise CaptureError("Published source manifest has an invalid byte size.")
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise CaptureError(f"Published source manifest is malformed: {error}") from error
+    if not isinstance(value, dict):
+        raise CaptureError("Published source manifest must be an object.")
+
+    if value.get("schemaVersion") != 1 or value.get("product") != PRODUCT:
+        raise CaptureError("Published source manifest has an unsupported product contract.")
+    if value.get("channel") != channel or value.get("tag") != release.tag:
+        raise CaptureError("Published source manifest channel or tag disagrees with its release.")
+    commit = require_string(value.get("commit"), "Source manifest commit")
+    if commit != release.target_commit:
+        raise CaptureError("Published source manifest commit disagrees with its release.")
+    version = require_string(value.get("version"), "Source manifest version")
+    if not VERSION_PATTERN.fullmatch(version):
+        raise CaptureError("Published source manifest version must be canonical.")
+    if channel == "stable" and release.tag != f"v{version}":
+        raise CaptureError("Stable source manifest version disagrees with its release tag.")
+    build = require_string(value.get("build"), "Source manifest build")
+    if not re.fullmatch(r"[1-9][0-9]*", build):
+        raise CaptureError("Published source manifest build must be a positive integer.")
+
+    updater = value.get("updater")
+    if not isinstance(updater, dict):
+        raise CaptureError("Published source manifest updater must be an object.")
+    if updater.get("bundleIdentifier") != BUNDLE_IDENTIFIER or updater.get("channel") != channel:
+        raise CaptureError("Published source updater identity disagrees with its manifest.")
+    assets = updater.get("macOSAppAssets")
+    if not isinstance(assets, list):
+        raise CaptureError("Published source updater assets must be an array.")
+    matches = [asset for asset in assets if isinstance(asset, dict) and asset.get("arch") == architecture]
+    if len(matches) != 1:
+        raise CaptureError(f"Published source manifest must contain one {architecture} app asset.")
+    asset = matches[0]
+    expected_name = f"Quill-Cowork-macOS-{architecture}.zip"
+    expected_url = (
+        f"https://github.com/{repository}/releases/download/{release.tag}/{expected_name}"
+    )
+    if (
+        asset.get("name") != expected_name
+        or asset.get("platform") != "macOS"
+        or asset.get("kind") != "app"
+        or asset.get("install") != "zip-app"
+        or asset.get("url") != expected_url
+    ):
+        raise CaptureError("Published source updater app asset has an invalid identity.")
+    app_size = require_integer(
+        asset.get("sizeBytes"),
+        "Source app size",
+        minimum=1,
+        maximum=APP_MAX_BYTES,
+    )
+    app_digest = require_string(asset.get("sha256"), "Source app SHA-256")
+    if not re.fullmatch(r"[0-9a-f]{64}", app_digest):
+        raise CaptureError("Published source app SHA-256 is invalid.")
+
+    return SourceMetadata(
+        channel=channel,
+        tag=release.tag,
+        architecture=architecture,
+        version=version,
+        build=build,
+        commit=commit,
+        app_name=expected_name,
+        app_size=app_size,
+        app_digest=app_digest,
+    )
+
+
+def file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def repository_is_valid(value: str) -> bool:
+    if not REPOSITORY_PATTERN.fullmatch(value):
+        return False
+    owner, name = value.split("/", maxsplit=1)
+    return owner not in {".", ".."} and name not in {".", ".."}

--- a/scripts/updater_source_capture/remote.py
+++ b/scripts/updater_source_capture/remote.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+
+from updater_source_capture.contracts import CaptureError, Release, decode_release
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def command_result(arguments: list[str]) -> CommandResult:
+    completed = subprocess.run(
+        arguments,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def run_command(arguments: list[str]) -> str:
+    result = command_result(arguments)
+    if result.exit_code != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        raise CaptureError(f"Command failed ({' '.join(arguments)}): {detail}")
+    return result.stdout
+
+
+class CaptureRemote:
+    def __init__(self, repository: str, channel: str) -> None:
+        self.repository = repository
+        self.channel = channel
+
+    def release_endpoint(self) -> str:
+        if self.channel == "tester":
+            return f"repos/{self.repository}/releases/tags/tester-latest"
+        return f"repos/{self.repository}/releases/latest"
+
+    def get_release(self, *, missing_ok: bool) -> Release | None:
+        result = command_result(["gh", "api", "--method", "GET", self.release_endpoint()])
+        if result.exit_code == 0:
+            return decode_release(result.stdout, self.channel)
+        if missing_ok and ("HTTP 404" in result.stderr or "Not Found" in result.stderr):
+            return None
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        raise CaptureError(f"Could not read the published {self.channel} source release: {detail}")
+
+    def download_asset(self, release: Release, name: str, directory: Path) -> Path:
+        run_command(
+            [
+                "gh",
+                "release",
+                "download",
+                release.tag,
+                "--repo",
+                self.repository,
+                "--pattern",
+                name,
+                "--dir",
+                str(directory),
+            ]
+        )
+        path = directory / name
+        if not path.is_file() or path.is_symlink():
+            raise CaptureError(f"GitHub did not download exactly one regular asset named {name}.")
+        return path


### PR DESCRIPTION
## Summary
- capture and verify the current public app for both macOS architectures before publication
- update untouched prior builds through the newly published live feed
- retain the synthetic updater smoke only as an explicit first-release fallback
- add transactional fake-GitHub tests, workflow contracts, and release documentation

## Validation
- 5,761 Swift tests, 5 skipped, 0 failures
- 12 focused capture/updater/workflow tests
- live read-only capture of public build 695 on arm64 and x86_64
- Python compile, Bash syntax, workflow YAML, diff hygiene, credential scan
- deterministic code-quality grader: A+ for every new module