### PR TITLE
Recover gracefully after unexpected exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ menu. Downloads are size- and SHA-256-verified, the app identity and code signat
 installation, the packaged source commit must match the public manifest, activation is atomic, and
 the previous build is restored if the new build cannot finish launching. Use **Report an Issue...**
 in the app menu to open a prefilled GitHub report with bounded build and system information; it does
-not attach project paths, transcripts, or credentials.
+not attach project paths, transcripts, or credentials. After an unexpected exit, the next successful
+launch identifies whether the prior session ended during startup or while running, warns that active
+command work may be incomplete, and offers the same privacy-safe report path.
 
 ## Downloads
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -1,7 +1,6 @@
 import AppKit
 import Darwin
 import SwiftUI
-import UniformTypeIdentifiers
 import QuillCodeApp
 
 enum QuillCodeDesktopSceneID {
@@ -103,12 +102,21 @@ struct QuillCodeDesktopApp: App {
             }
             _controller = StateObject(wrappedValue: controller)
             Task { @MainActor in
-                await QuillCodeDesktopSmokeRunner.runAndExit(request)
+                await QuillCodeDesktopLaunchRecoverySmoke.runAndExit(request)
             }
             return
         }
 
+        let updateController = QuillCodeDesktopUpdateController()
+        let launchLifecycleController = updateController.configuration.map { configuration in
+            QuillCodeDesktopLaunchLifecycleController(
+                metadata: QuillCodeDesktopBuildMetadata.current(configuration: configuration)
+            )
+        }
+        _ = launchLifecycleController?.startIfNeeded()
         let controller = QuillCodeDesktopController(
+            updateController: updateController,
+            launchLifecycleController: launchLifecycleController,
             workspaceRoot: QuillCodeDesktopWorkspaceRootResolver.resolve()
         )
         controller.startApplicationServices()
@@ -159,199 +167,6 @@ struct QuillCodeDesktopApp: App {
             Image(nsImage: QuillCodeMenuBarIcon.image)
                 .accessibilityLabel(QuillCodeProduct.displayName)
         }
-    }
-}
-
-struct QuillCodeDesktopRootView: View {
-    @ObservedObject var controller: QuillCodeDesktopController
-
-    var body: some View {
-        workspaceContent
-            .preferredColorScheme(.dark)
-            .quillCodeDesktopCommandBindings(controller: controller)
-            .modifier(QuillCodeDesktopDistributionPresentation(
-                installationLocationController: controller.installationLocationController,
-                updateController: controller.updateController
-            ))
-            .fileImporter(
-                isPresented: $controller.isProjectImporterPresented,
-                allowedContentTypes: [.folder],
-                allowsMultipleSelection: false
-            ) { result in
-                controller.handleProjectImport(result)
-            }
-            .background {
-                Color.clear
-                    .fileImporter(
-                        isPresented: $controller.isImageImporterPresented,
-                        allowedContentTypes: [.png, .jpeg, .gif, .webP],
-                        allowsMultipleSelection: true
-                    ) { result in
-                        controller.handleImageImport(result)
-                    }
-            }
-    }
-
-    private var workspaceContent: some View {
-        QuillCodeWorkspaceView(
-            surface: controller.surface,
-            draft: $controller.draft,
-            terminalDraft: $controller.terminalDraft,
-            browserAddressDraft: $controller.browserAddressDraft,
-            isCommandPalettePresented: $controller.isCommandPalettePresented,
-            isSettingsPresented: $controller.isSettingsPresented,
-            isKeyboardShortcutsPresented: $controller.isKeyboardShortcutsPresented,
-            isSearchPresented: $controller.isSearchPresented,
-            isFindPresented: $controller.isFindPresented,
-            isModelPickerPresented: $controller.isModelPickerPresented,
-            copiedTranscriptItemID: controller.copiedTranscriptItemID,
-            onSend: controller.send,
-            onAddImagesRequested: controller.requestAddImages,
-            onRemoveImage: controller.removeComposerImage,
-            onRunTerminalCommand: controller.runTerminalCommand,
-            onTerminalHistoryPrevious: controller.recallPreviousTerminalCommand,
-            onTerminalHistoryNext: controller.recallNextTerminalCommand,
-            onTerminalResize: controller.resizeTerminal,
-            onTerminalMouseInput: controller.sendTerminalMouseInput,
-            onTerminalKeyboardInput: controller.sendTerminalKeyboardInput,
-            onTerminalSuspend: controller.suspendTerminal,
-            onTerminalResume: controller.resumeTerminal,
-            onOpenBrowserPreview: controller.openBrowserPreview,
-            onOpenBrowserSession: controller.openBrowserSession,
-            onAddBrowserComment: controller.addBrowserComment,
-            onAddProjectRequested: controller.requestAddProject,
-            onDiscoverSSHHosts: controller.discoverSSHHosts,
-            onRegisterSSHProject: controller.registerSSHProject,
-            onSelectThread: controller.selectThread,
-            onThreadAction: controller.runThreadAction,
-            onRenameThread: controller.renameThread,
-            onSelectProject: controller.selectProject,
-            onProjectAction: controller.runProjectAction,
-            onMoveProjectBefore: controller.moveProject,
-            onMoveProjectToBottom: controller.moveProjectToBottom,
-            onRenameProject: controller.renameProject,
-            onSetMode: controller.setMode,
-            onSetModel: controller.setModel,
-            onToggleModelFavorite: controller.toggleModelFavorite,
-            onSaveSettings: controller.saveSettings,
-            onSetRunSpendLimit: controller.setRunSpendLimit,
-            onSaveKeyboardShortcuts: controller.saveKeyboardShortcuts,
-            onStartTrustedRouterSignIn: controller.startTrustedRouterSignIn,
-            agentImportActions: QuillCodeAgentImportActions(
-                discover: controller.discoverAgentImport,
-                perform: controller.performAgentImport
-            ),
-            onDismissCodeReview: controller.dismissCodeReview,
-            onRunCodeReview: controller.runCodeReview,
-            onReviewScopeChange: controller.runReviewScopeChange,
-            onReviewAction: controller.runReviewAction,
-            onPullRequestReviewThreadAction: controller.runPullRequestReviewThreadAction,
-            onPullRequestReviewThreadReply: controller.runPullRequestReviewThreadReply,
-            onPullRequestReviewDraftChange: controller.updatePullRequestReviewDraft,
-            onCancelPullRequestReviewDraft: controller.cancelPullRequestReviewDraft,
-            onSubmitPullRequestReviewDraft: controller.submitPullRequestReviewDraft,
-            onToolCardAction: controller.runToolCardAction,
-            onAddReviewComment: controller.addReviewComment,
-            onCreateWorktreeThread: controller.createWorktreeThread,
-            onCreateWorktree: controller.createWorktree,
-            onCreateWorktreeBranch: controller.createWorktreeBranch,
-            onFinishWorktree: controller.finishWorktree,
-            onListWorktreeChoices: controller.worktreeChoiceLoad,
-            onOpenWorktree: controller.openWorktree,
-            onRemoveWorktree: controller.removeWorktree,
-            onPreviewWorktreePrune: controller.worktreePrunePreview,
-            onPruneWorktrees: controller.pruneWorktrees,
-            onCopyTranscriptItem: controller.copyTranscriptItem,
-            onExportConversationMarkdown: controller.exportConversationMarkdown,
-            onRevertTurn: controller.runTurnRevert,
-            onDeleteFollowUp: controller.deleteFollowUp,
-            onSaveSidebarSavedSearch: controller.saveSidebarSavedSearch,
-            onOpenAttentionDigest: controller.openAttentionDigest,
-            onCloseAttentionDigest: controller.closeAttentionDigest,
-            onLoadSubagentTranscript: controller.loadSubagentTranscript,
-            onCommand: controller.runCommand
-        )
-    }
-}
-
-private struct QuillCodeDesktopDistributionPresentation: ViewModifier {
-    @ObservedObject var installationLocationController: QuillCodeDesktopInstallationLocationController
-    @ObservedObject var updateController: QuillCodeDesktopUpdateController
-
-    func body(content: Content) -> some View {
-        content.sheet(isPresented: presentationBinding) {
-            if installationLocationController.isPresented {
-                QuillCodeDesktopInstallationLocationView(
-                    controller: installationLocationController
-                )
-            } else {
-                QuillCodeDesktopUpdateView(controller: updateController)
-            }
-        }
-    }
-
-    private var presentationBinding: Binding<Bool> {
-        Binding(
-            get: {
-                installationLocationController.isPresented || updateController.isPresented
-            },
-            set: { isPresented in
-                guard !isPresented else { return }
-                if installationLocationController.isPresented {
-                    installationLocationController.dismiss()
-                } else {
-                    updateController.dismiss()
-                }
-            }
-        )
-    }
-}
-
-private struct QuillCodeDesktopCommandBindings: ViewModifier {
-    @ObservedObject var controller: QuillCodeDesktopController
-    @State private var shortcutMonitor: Any?
-
-    func body(content: Content) -> some View {
-        content
-            .onAppear(perform: installShortcutMonitor)
-            .onDisappear(perform: removeBindings)
-            .onChange(of: controller.surface.settings.keyboardShortcuts) { _, _ in
-                installShortcutMonitor()
-            }
-    }
-
-    private func removeBindings() {
-        if let shortcutMonitor {
-            NSEvent.removeMonitor(shortcutMonitor)
-            self.shortcutMonitor = nil
-        }
-    }
-
-    private func installShortcutMonitor() {
-        if let shortcutMonitor {
-            NSEvent.removeMonitor(shortcutMonitor)
-        }
-        let profile = WorkspaceShortcutRegistry.profile(
-            preferences: controller.surface.settings.keyboardShortcuts
-        )
-        shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard let shortcutEvent = QuillCodeDesktopShortcutEvent(event),
-                  let commandID = QuillCodeSecondaryShortcutResolver.commandID(
-                    for: shortcutEvent,
-                    profile: profile
-                  )
-            else { return event }
-            controller.runCommand(commandID: commandID)
-            return nil
-        }
-    }
-}
-
-private extension View {
-    func quillCodeDesktopCommandBindings(
-        controller: QuillCodeDesktopController
-    ) -> some View {
-        modifier(QuillCodeDesktopCommandBindings(controller: controller))
     }
 }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopBuildMetadata.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopBuildMetadata.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct QuillCodeDesktopBuildMetadata: Equatable, Sendable {
+struct QuillCodeDesktopBuildMetadata: Codable, Equatable, Sendable {
     static let commitInfoKey = "QuillCodeBuildCommit"
 
     var version: String
@@ -49,9 +49,28 @@ struct QuillCodeDesktopBuildMetadata: Equatable, Sendable {
         }
     }
 
+    var isSafeForIncidentReporting: Bool {
+        Self.isSafeBuildField(version, allowedPunctuation: ".-+")
+            && Self.isSafeBuildField(build, allowedPunctuation: ".-+")
+            && (Self.isCanonicalCommit(commit) || commit == "development")
+            && ["stable", "tester", "development"].contains(channel)
+            && ["arm64", "x86_64", "unknown", "development"].contains(architecture)
+            && operatingSystem.hasPrefix("macOS ")
+            && Self.isSafeBuildField(String(operatingSystem.dropFirst(6)), allowedPunctuation: ".-() ")
+    }
+
     private static func infoString(_ key: String, bundle: Bundle) -> String? {
         guard let value = bundle.object(forInfoDictionaryKey: key) as? String else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func isSafeBuildField(_ value: String, allowedPunctuation: String) -> Bool {
+        !value.isEmpty
+            && value.utf8.count <= 96
+            && value.unicodeScalars.allSatisfy { scalar in
+                CharacterSet.alphanumerics.contains(scalar)
+                    || allowedPunctuation.unicodeScalars.contains(scalar)
+            }
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Notifications.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Notifications.swift
@@ -1,0 +1,17 @@
+import Foundation
+import QuillCodeApp
+
+extension QuillCodeDesktopController {
+    /// Routes a notification decision through the same serialized path as the in-app tool card.
+    func decideNotificationApproval(requestID: String, approve: Bool, threadID: UUID?) {
+        if let threadID, model.selectedThread?.id != threadID {
+            selectThread(threadID)
+        }
+        runToolCardAction(ToolCardActionSurface(
+            title: approve ? "Approve" : "Skip",
+            kind: approve ? .approve : .deny,
+            requestID: requestID,
+            style: approve ? .primary : .secondary
+        ))
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -50,6 +50,7 @@ final class QuillCodeDesktopController: ObservableObject {
     let workflowRecordingCoordinator: QuillCodeDesktopWorkflowRecordingCoordinator
     let updateController: QuillCodeDesktopUpdateController
     let installationLocationController: QuillCodeDesktopInstallationLocationController
+    let launchLifecycleController: QuillCodeDesktopLaunchLifecycleController?
     let tasks = QuillCodeDesktopTaskCoordinator()
     let progressRefreshScheduler = QuillCodeDesktopProgressRefreshScheduler()
     // Retained here because UNUserNotificationCenter.delegate is weak; nil until app services start.
@@ -67,6 +68,7 @@ final class QuillCodeDesktopController: ObservableObject {
             QuillCodeDesktopTranscriptExportCoordinator(),
         updateController: QuillCodeDesktopUpdateController? = nil,
         installationLocationController: QuillCodeDesktopInstallationLocationController? = nil,
+        launchLifecycleController: QuillCodeDesktopLaunchLifecycleController? = nil,
         workspaceRoot: URL? = nil
     ) {
         let launchWorkspaceRoot = workspaceRoot?.standardizedFileURL
@@ -102,6 +104,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.updateController = updateController ?? QuillCodeDesktopUpdateController()
         self.installationLocationController = installationLocationController
             ?? QuillCodeDesktopInstallationLocationController()
+        self.launchLifecycleController = launchLifecycleController
         do {
             self.model = try bootstrap.makeModel()
         } catch {
@@ -222,24 +225,6 @@ final class QuillCodeDesktopController: ObservableObject {
         let center = UNUserNotificationCenter.current()
         center.delegate = delegate
         center.setNotificationCategories([QuillCodeApprovalNotification.category, QuillCodeRetryNotification.category])
-    }
-
-    /// Decides a blocked approval gate from a tapped notification action. Selects the gate's thread
-    /// first (a notification may target a thread the user is not currently viewing), then routes through
-    /// the SAME coordinator `runToolCardAction` path as the in-app tool card. Going through the one
-    /// path (rather than a bare `Task` calling `decidePendingApproval`) means the notification decision
-    /// serializes on that chat's `.send` slot exactly like the in-app decision, so two decisions for
-    /// the same chat cannot interleave their resume/drain. A Skip still records unconditionally.
-    func decideNotificationApproval(requestID: String, approve: Bool, threadID: UUID?) {
-        if let threadID, model.selectedThread?.id != threadID {
-            selectThread(threadID)
-        }
-        runToolCardAction(ToolCardActionSurface(
-            title: approve ? "Approve" : "Skip",
-            kind: approve ? .approve : .deny,
-            requestID: requestID,
-            style: approve ? .primary : .secondary
-        ))
     }
 
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopIssueReporter.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopIssueReporter.swift
@@ -2,16 +2,21 @@ import AppKit
 import Foundation
 
 enum QuillCodeDesktopIssueReporter {
-    private static let issuesURL = URL(string: "https://github.com/Lore-Hex/QuillCode/issues/new")!
+    private static let issuesURL = URL(string: "https://github.com/Lore-Hex/QuillCode/issues/new")
 
-    static func issueURL(metadata: QuillCodeDesktopBuildMetadata) -> URL? {
-        guard var components = URLComponents(url: issuesURL, resolvingAgainstBaseURL: false) else {
+    static func issueURL(
+        metadata: QuillCodeDesktopBuildMetadata,
+        incident: QuillCodeDesktopUnexpectedExit? = nil
+    ) -> URL? {
+        guard let issuesURL,
+              var components = URLComponents(url: issuesURL, resolvingAgainstBaseURL: false)
+        else {
             return nil
         }
         components.queryItems = [
             URLQueryItem(name: "labels", value: "bug"),
-            URLQueryItem(name: "title", value: "[Bug] "),
-            URLQueryItem(name: "body", value: issueBody(metadata: metadata))
+            URLQueryItem(name: "title", value: incident == nil ? "[Bug] " : "[Crash] "),
+            URLQueryItem(name: "body", value: issueBody(metadata: metadata, incident: incident))
         ]
         return components.url
     }
@@ -19,18 +24,22 @@ enum QuillCodeDesktopIssueReporter {
     @MainActor
     static func open(
         configuration: QuillCodeDesktopUpdateConfiguration?,
+        incident: QuillCodeDesktopUnexpectedExit? = nil,
         bundle: Bundle = .main
     ) {
         let metadata = QuillCodeDesktopBuildMetadata.current(
             configuration: configuration,
             bundle: bundle
         )
-        guard let url = issueURL(metadata: metadata) else { return }
+        guard let url = issueURL(metadata: metadata, incident: incident) else { return }
         NSWorkspace.shared.open(url)
     }
 
-    private static func issueBody(metadata: QuillCodeDesktopBuildMetadata) -> String {
-        """
+    private static func issueBody(
+        metadata: QuillCodeDesktopBuildMetadata,
+        incident: QuillCodeDesktopUnexpectedExit?
+    ) -> String {
+        var body = """
         <!-- Describe what happened. Do not include API keys, credentials, or private project data. -->
 
         ## What happened
@@ -51,5 +60,21 @@ enum QuillCodeDesktopIssueReporter {
         - System: \(metadata.operatingSystem)
         - Architecture: \(metadata.architecture)
         """
+        if let incident {
+            body += """
+
+
+            ## Previous session
+
+            - Outcome: Ended unexpectedly \(incident.phase.incidentDescription)
+            - Started: \(ISO8601DateFormatter().string(from: incident.startedAt))
+            - Version: \(incident.metadata.version) (\(incident.metadata.build))
+            - Commit: \(incident.metadata.commit)
+            - Channel: \(incident.metadata.channel)
+            - System: \(incident.metadata.operatingSystem)
+            - Architecture: \(incident.metadata.architecture)
+            """
+        }
+        return body
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopLaunchLifecycle.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopLaunchLifecycle.swift
@@ -1,0 +1,308 @@
+import AppKit
+import Darwin
+import Foundation
+
+enum QuillCodeDesktopLaunchPhase: String, Codable, Sendable {
+    case starting
+    case ready
+    case terminating
+
+    var incidentDescription: String {
+        switch self {
+        case .starting:
+            "during startup"
+        case .ready:
+            "while the app was running"
+        case .terminating:
+            "while the app was quitting"
+        }
+    }
+}
+
+struct QuillCodeDesktopLaunchRecord: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var launchID: UUID
+    var processIdentifier: Int32
+    var startedAt: Date
+    var phase: QuillCodeDesktopLaunchPhase
+    var metadata: QuillCodeDesktopBuildMetadata
+
+    init(
+        launchID: UUID = UUID(),
+        processIdentifier: Int32,
+        startedAt: Date,
+        phase: QuillCodeDesktopLaunchPhase = .starting,
+        metadata: QuillCodeDesktopBuildMetadata
+    ) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.launchID = launchID
+        self.processIdentifier = processIdentifier
+        self.startedAt = startedAt
+        self.phase = phase
+        self.metadata = metadata
+    }
+
+    var isValid: Bool {
+        schemaVersion == Self.currentSchemaVersion
+            && processIdentifier > 0
+            && metadata.isSafeForIncidentReporting
+    }
+}
+
+struct QuillCodeDesktopUnexpectedExit: Identifiable, Equatable, Sendable {
+    static let maximumIncidentAge: TimeInterval = 30 * 24 * 60 * 60
+    static let maximumFutureClockSkew: TimeInterval = 5 * 60
+
+    var id: UUID { launchID }
+    var launchID: UUID
+    var startedAt: Date
+    var phase: QuillCodeDesktopLaunchPhase
+    var metadata: QuillCodeDesktopBuildMetadata
+
+    init?(record: QuillCodeDesktopLaunchRecord, now: Date) {
+        let age = now.timeIntervalSince(record.startedAt)
+        guard record.isValid,
+              record.phase != .terminating,
+              age <= Self.maximumIncidentAge,
+              age >= -Self.maximumFutureClockSkew
+        else { return nil }
+        self.launchID = record.launchID
+        self.startedAt = record.startedAt
+        self.phase = record.phase
+        self.metadata = record.metadata
+    }
+
+    var userMessage: String {
+        "The previous session ended \(phase.incidentDescription) without a normal quit. "
+            + "Your saved workspace reopened, but work from an in-progress command may be incomplete. "
+            + "Previous build: \(metadata.version) (\(metadata.build))."
+    }
+}
+
+struct QuillCodeDesktopLaunchSession: Equatable, Sendable {
+    var currentRecord: QuillCodeDesktopLaunchRecord
+    var unexpectedExit: QuillCodeDesktopUnexpectedExit?
+}
+
+struct QuillCodeDesktopLaunchStore {
+    private static let maximumRecordBytes = 16 * 1_024
+    private static let directoryPermissions = 0o700
+    private static let filePermissions = 0o600
+
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(fileURL: URL, fileManager: FileManager = .default) {
+        self.fileURL = fileURL.standardizedFileURL
+        self.fileManager = fileManager
+    }
+
+    static func standard() -> Self {
+        let directory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".quillcode/runtime", isDirectory: true)
+        return Self(fileURL: directory.appendingPathComponent("active-launch.json"))
+    }
+
+    func beginLaunch(
+        metadata: QuillCodeDesktopBuildMetadata,
+        now: Date = Date(),
+        processIdentifier: Int32 = getpid(),
+        processIsRunning: (Int32) -> Bool = QuillCodeDesktopProcessInspector.isRunning
+    ) throws -> QuillCodeDesktopLaunchSession {
+        try withExclusiveLock {
+            let previous = loadRecordUnlocked()
+            let current = QuillCodeDesktopLaunchRecord(
+                processIdentifier: processIdentifier,
+                startedAt: now,
+                metadata: metadata
+            )
+            try writeRecordUnlocked(current)
+
+            let incident = previous.flatMap { record -> QuillCodeDesktopUnexpectedExit? in
+                guard record.processIdentifier != processIdentifier,
+                      !processIsRunning(record.processIdentifier)
+                else { return nil }
+                return QuillCodeDesktopUnexpectedExit(record: record, now: now)
+            }
+            return QuillCodeDesktopLaunchSession(currentRecord: current, unexpectedExit: incident)
+        }
+    }
+
+    func markReady(launchID: UUID) throws {
+        try withExclusiveLock {
+            guard var record = loadRecordUnlocked(), record.launchID == launchID else { return }
+            guard record.phase != .ready else { return }
+            record.phase = .ready
+            try writeRecordUnlocked(record)
+        }
+    }
+
+    func finishLaunch(launchID: UUID) throws {
+        try withExclusiveLock {
+            guard var record = loadRecordUnlocked(), record.launchID == launchID else { return }
+            record.phase = .terminating
+            try writeRecordUnlocked(record)
+            try fileManager.removeItem(at: fileURL)
+        }
+    }
+
+    func currentRecord() throws -> QuillCodeDesktopLaunchRecord? {
+        try withExclusiveLock { loadRecordUnlocked() }
+    }
+
+    private var lockURL: URL {
+        fileURL.deletingPathExtension().appendingPathExtension("lock")
+    }
+
+    private func withExclusiveLock<Value>(_ operation: () throws -> Value) throws -> Value {
+        try ensurePrivateDirectory()
+        let descriptor = Darwin.open(lockURL.path, O_CREAT | O_RDWR, mode_t(Self.filePermissions))
+        guard descriptor >= 0 else {
+            throw CocoaError(.fileWriteUnknown, userInfo: [NSFilePathErrorKey: lockURL.path])
+        }
+        defer { Darwin.close(descriptor) }
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            throw CocoaError(.fileWriteUnknown, userInfo: [NSFilePathErrorKey: lockURL.path])
+        }
+        defer { flock(descriptor, LOCK_UN) }
+        try fileManager.setAttributes(
+            [.posixPermissions: Self.filePermissions],
+            ofItemAtPath: lockURL.path
+        )
+        return try operation()
+    }
+
+    private func ensurePrivateDirectory() throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: Self.directoryPermissions]
+        )
+        try fileManager.setAttributes(
+            [.posixPermissions: Self.directoryPermissions],
+            ofItemAtPath: directory.path
+        )
+    }
+
+    private func loadRecordUnlocked() -> QuillCodeDesktopLaunchRecord? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path),
+              let size = attributes[.size] as? NSNumber,
+              size.intValue > 0,
+              size.intValue <= Self.maximumRecordBytes,
+              let data = try? Data(contentsOf: fileURL),
+              data.count <= Self.maximumRecordBytes
+        else { return nil }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(QuillCodeDesktopLaunchRecord.self, from: data)
+    }
+
+    private func writeRecordUnlocked(_ record: QuillCodeDesktopLaunchRecord) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(record)
+        guard data.count <= Self.maximumRecordBytes else {
+            throw CocoaError(.fileWriteOutOfSpace, userInfo: [NSFilePathErrorKey: fileURL.path])
+        }
+        try data.write(to: fileURL, options: .atomic)
+        try fileManager.setAttributes(
+            [.posixPermissions: Self.filePermissions],
+            ofItemAtPath: fileURL.path
+        )
+    }
+}
+
+enum QuillCodeDesktopProcessInspector {
+    static func isRunning(_ processIdentifier: Int32) -> Bool {
+        guard processIdentifier > 0 else { return false }
+        if Darwin.kill(processIdentifier, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
+    }
+}
+
+@MainActor
+final class QuillCodeDesktopLaunchLifecycleController: NSObject {
+    private let store: QuillCodeDesktopLaunchStore
+    private let metadata: QuillCodeDesktopBuildMetadata
+    private let notificationCenter: NotificationCenter
+    private let now: () -> Date
+    private let processIdentifier: Int32
+    private let processIsRunning: (Int32) -> Bool
+    private(set) var unexpectedExit: QuillCodeDesktopUnexpectedExit?
+    private var currentLaunchID: UUID?
+    private var didStart = false
+
+    init(
+        store: QuillCodeDesktopLaunchStore = .standard(),
+        metadata: QuillCodeDesktopBuildMetadata,
+        notificationCenter: NotificationCenter = .default,
+        now: @escaping () -> Date = Date.init,
+        processIdentifier: Int32 = getpid(),
+        processIsRunning: @escaping (Int32) -> Bool = QuillCodeDesktopProcessInspector.isRunning
+    ) {
+        self.store = store
+        self.metadata = metadata
+        self.notificationCenter = notificationCenter
+        self.now = now
+        self.processIdentifier = processIdentifier
+        self.processIsRunning = processIsRunning
+        super.init()
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    @discardableResult
+    func startIfNeeded() -> QuillCodeDesktopUnexpectedExit? {
+        guard !didStart else { return unexpectedExit }
+        didStart = true
+        do {
+            let session = try store.beginLaunch(
+                metadata: metadata,
+                now: now(),
+                processIdentifier: processIdentifier,
+                processIsRunning: processIsRunning
+            )
+            currentLaunchID = session.currentRecord.launchID
+            unexpectedExit = session.unexpectedExit
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(applicationWillTerminate),
+                name: NSApplication.willTerminateNotification,
+                object: nil
+            )
+        } catch {
+            currentLaunchID = nil
+            unexpectedExit = nil
+        }
+        return unexpectedExit
+    }
+
+    func markReady() {
+        guard let currentLaunchID else { return }
+        try? store.markReady(launchID: currentLaunchID)
+    }
+
+    func takeUnexpectedExit() -> QuillCodeDesktopUnexpectedExit? {
+        defer { unexpectedExit = nil }
+        return unexpectedExit
+    }
+
+    func finishCurrentLaunch() {
+        guard let currentLaunchID else { return }
+        try? store.finishLaunch(launchID: currentLaunchID)
+        self.currentLaunchID = nil
+    }
+
+    @objc private func applicationWillTerminate(_ notification: Notification) {
+        finishCurrentLaunch()
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopLaunchRecoverySmoke.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopLaunchRecoverySmoke.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum QuillCodeDesktopLaunchRecoverySmoke {
+    @MainActor
+    static func runAndExit(_ request: QuillCodeDesktopSmokeRequest) async {
+        do {
+            let root = try QuillCodeDesktopSmokeWorkspaceRoot(request: request)
+            try verify(home: root.home)
+        } catch {
+            FileHandle.standardError.write(
+                Data("quill-code-desktop launch recovery smoke failed: \(error)\n".utf8)
+            )
+            exit(1)
+        }
+        await QuillCodeDesktopSmokeRunner.runAndExit(request)
+    }
+
+    static func verify(home: URL) throws {
+        let fileURL = home
+            .appendingPathComponent("launch-recovery-smoke", isDirectory: true)
+            .appendingPathComponent("active-launch.json")
+        let store = QuillCodeDesktopLaunchStore(fileURL: fileURL)
+        let startedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let metadata = QuillCodeDesktopBuildMetadata(
+            version: "0.1.0",
+            build: "1",
+            commit: String(repeating: "a", count: 40),
+            channel: "tester",
+            architecture: QuillCodeDesktopArchitecture.current,
+            operatingSystem: "macOS 14.0.0"
+        )
+
+        let first = try store.beginLaunch(
+            metadata: metadata,
+            now: startedAt,
+            processIdentifier: 70_001,
+            processIsRunning: { _ in false }
+        )
+        try store.markReady(launchID: first.currentRecord.launchID)
+        let second = try store.beginLaunch(
+            metadata: metadata,
+            now: startedAt.addingTimeInterval(10),
+            processIdentifier: 70_002,
+            processIsRunning: { _ in false }
+        )
+        guard second.unexpectedExit?.phase == .ready else {
+            throw Failure.missingReadyIncident
+        }
+        try store.finishLaunch(launchID: second.currentRecord.launchID)
+
+        let clean = try store.beginLaunch(
+            metadata: metadata,
+            now: startedAt.addingTimeInterval(20),
+            processIdentifier: 70_003,
+            processIsRunning: { _ in false }
+        )
+        guard clean.unexpectedExit == nil else {
+            throw Failure.gracefulLaunchReportedAsUnexpected
+        }
+        try store.finishLaunch(launchID: clean.currentRecord.launchID)
+    }
+
+    private enum Failure: LocalizedError {
+        case gracefulLaunchReportedAsUnexpected
+        case missingReadyIncident
+
+        var errorDescription: String? {
+            switch self {
+            case .gracefulLaunchReportedAsUnexpected:
+                "Launch recovery smoke reported a gracefully finished launch as unexpected."
+            case .missingReadyIncident:
+                "Launch recovery smoke did not recover the simulated ready-state unexpected exit."
+            }
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopRootView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopRootView.swift
@@ -1,0 +1,250 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+import QuillCodeApp
+
+struct QuillCodeDesktopRootView: View {
+    @ObservedObject var controller: QuillCodeDesktopController
+    @State private var unexpectedExit: QuillCodeDesktopUnexpectedExit?
+
+    init(controller: QuillCodeDesktopController) {
+        self.controller = controller
+        _unexpectedExit = State(
+            initialValue: controller.launchLifecycleController?.takeUnexpectedExit()
+        )
+    }
+
+    var body: some View {
+        workspaceContent
+            .preferredColorScheme(.dark)
+            .quillCodeDesktopCommandBindings(controller: controller)
+            .modifier(QuillCodeDesktopDistributionPresentation(
+                installationLocationController: controller.installationLocationController,
+                updateController: controller.updateController
+            ))
+            .fileImporter(
+                isPresented: $controller.isProjectImporterPresented,
+                allowedContentTypes: [.folder],
+                allowsMultipleSelection: false
+            ) { result in
+                controller.handleProjectImport(result)
+            }
+            .background {
+                Color.clear
+                    .fileImporter(
+                        isPresented: $controller.isImageImporterPresented,
+                        allowedContentTypes: [.png, .jpeg, .gif, .webP],
+                        allowsMultipleSelection: true
+                    ) { result in
+                        controller.handleImageImport(result)
+                    }
+            }
+            .task {
+                controller.launchLifecycleController?.markReady()
+            }
+            .alert(
+                "Quill Cowork closed unexpectedly",
+                isPresented: unexpectedExitBinding,
+                presenting: unexpectedExit
+            ) { incident in
+                Button("Continue") {
+                    unexpectedExit = nil
+                }
+                .keyboardShortcut(.defaultAction)
+                .quillCodePlatformMenuItemTarget(
+                    reason: "macOS owns alert action geometry."
+                )
+                .accessibilityIdentifier("quillcode-unexpected-exit-continue")
+                Button("Report Issue...") {
+                    reportUnexpectedExit(incident)
+                }
+                .quillCodePlatformMenuItemTarget(
+                    reason: "macOS owns alert action geometry."
+                )
+                .accessibilityIdentifier("quillcode-unexpected-exit-report")
+            } message: { incident in
+                Text(incident.userMessage)
+            }
+    }
+
+    private var unexpectedExitBinding: Binding<Bool> {
+        Binding(
+            get: { unexpectedExit != nil },
+            set: { isPresented in
+                if !isPresented {
+                    unexpectedExit = nil
+                }
+            }
+        )
+    }
+
+    private func reportUnexpectedExit(_ incident: QuillCodeDesktopUnexpectedExit) {
+        unexpectedExit = nil
+        QuillCodeDesktopIssueReporter.open(
+            configuration: controller.updateController.configuration,
+            incident: incident
+        )
+    }
+
+    private var workspaceContent: some View {
+        QuillCodeWorkspaceView(
+            surface: controller.surface,
+            draft: $controller.draft,
+            terminalDraft: $controller.terminalDraft,
+            browserAddressDraft: $controller.browserAddressDraft,
+            isCommandPalettePresented: $controller.isCommandPalettePresented,
+            isSettingsPresented: $controller.isSettingsPresented,
+            isKeyboardShortcutsPresented: $controller.isKeyboardShortcutsPresented,
+            isSearchPresented: $controller.isSearchPresented,
+            isFindPresented: $controller.isFindPresented,
+            isModelPickerPresented: $controller.isModelPickerPresented,
+            copiedTranscriptItemID: controller.copiedTranscriptItemID,
+            onSend: controller.send,
+            onAddImagesRequested: controller.requestAddImages,
+            onRemoveImage: controller.removeComposerImage,
+            onRunTerminalCommand: controller.runTerminalCommand,
+            onTerminalHistoryPrevious: controller.recallPreviousTerminalCommand,
+            onTerminalHistoryNext: controller.recallNextTerminalCommand,
+            onTerminalResize: controller.resizeTerminal,
+            onTerminalMouseInput: controller.sendTerminalMouseInput,
+            onTerminalKeyboardInput: controller.sendTerminalKeyboardInput,
+            onTerminalSuspend: controller.suspendTerminal,
+            onTerminalResume: controller.resumeTerminal,
+            onOpenBrowserPreview: controller.openBrowserPreview,
+            onOpenBrowserSession: controller.openBrowserSession,
+            onAddBrowserComment: controller.addBrowserComment,
+            onAddProjectRequested: controller.requestAddProject,
+            onDiscoverSSHHosts: controller.discoverSSHHosts,
+            onRegisterSSHProject: controller.registerSSHProject,
+            onSelectThread: controller.selectThread,
+            onThreadAction: controller.runThreadAction,
+            onRenameThread: controller.renameThread,
+            onSelectProject: controller.selectProject,
+            onProjectAction: controller.runProjectAction,
+            onMoveProjectBefore: controller.moveProject,
+            onMoveProjectToBottom: controller.moveProjectToBottom,
+            onRenameProject: controller.renameProject,
+            onSetMode: controller.setMode,
+            onSetModel: controller.setModel,
+            onToggleModelFavorite: controller.toggleModelFavorite,
+            onSaveSettings: controller.saveSettings,
+            onSetRunSpendLimit: controller.setRunSpendLimit,
+            onSaveKeyboardShortcuts: controller.saveKeyboardShortcuts,
+            onStartTrustedRouterSignIn: controller.startTrustedRouterSignIn,
+            agentImportActions: QuillCodeAgentImportActions(
+                discover: controller.discoverAgentImport,
+                perform: controller.performAgentImport
+            ),
+            onDismissCodeReview: controller.dismissCodeReview,
+            onRunCodeReview: controller.runCodeReview,
+            onReviewScopeChange: controller.runReviewScopeChange,
+            onReviewAction: controller.runReviewAction,
+            onPullRequestReviewThreadAction: controller.runPullRequestReviewThreadAction,
+            onPullRequestReviewThreadReply: controller.runPullRequestReviewThreadReply,
+            onPullRequestReviewDraftChange: controller.updatePullRequestReviewDraft,
+            onCancelPullRequestReviewDraft: controller.cancelPullRequestReviewDraft,
+            onSubmitPullRequestReviewDraft: controller.submitPullRequestReviewDraft,
+            onToolCardAction: controller.runToolCardAction,
+            onAddReviewComment: controller.addReviewComment,
+            onCreateWorktreeThread: controller.createWorktreeThread,
+            onCreateWorktree: controller.createWorktree,
+            onCreateWorktreeBranch: controller.createWorktreeBranch,
+            onFinishWorktree: controller.finishWorktree,
+            onListWorktreeChoices: controller.worktreeChoiceLoad,
+            onOpenWorktree: controller.openWorktree,
+            onRemoveWorktree: controller.removeWorktree,
+            onPreviewWorktreePrune: controller.worktreePrunePreview,
+            onPruneWorktrees: controller.pruneWorktrees,
+            onCopyTranscriptItem: controller.copyTranscriptItem,
+            onExportConversationMarkdown: controller.exportConversationMarkdown,
+            onRevertTurn: controller.runTurnRevert,
+            onDeleteFollowUp: controller.deleteFollowUp,
+            onSaveSidebarSavedSearch: controller.saveSidebarSavedSearch,
+            onOpenAttentionDigest: controller.openAttentionDigest,
+            onCloseAttentionDigest: controller.closeAttentionDigest,
+            onLoadSubagentTranscript: controller.loadSubagentTranscript,
+            onCommand: controller.runCommand
+        )
+    }
+}
+
+private struct QuillCodeDesktopDistributionPresentation: ViewModifier {
+    @ObservedObject var installationLocationController: QuillCodeDesktopInstallationLocationController
+    @ObservedObject var updateController: QuillCodeDesktopUpdateController
+
+    func body(content: Content) -> some View {
+        content.sheet(isPresented: presentationBinding) {
+            if installationLocationController.isPresented {
+                QuillCodeDesktopInstallationLocationView(
+                    controller: installationLocationController
+                )
+            } else {
+                QuillCodeDesktopUpdateView(controller: updateController)
+            }
+        }
+    }
+
+    private var presentationBinding: Binding<Bool> {
+        Binding(
+            get: {
+                installationLocationController.isPresented || updateController.isPresented
+            },
+            set: { isPresented in
+                guard !isPresented else { return }
+                if installationLocationController.isPresented {
+                    installationLocationController.dismiss()
+                } else {
+                    updateController.dismiss()
+                }
+            }
+        )
+    }
+}
+
+private struct QuillCodeDesktopCommandBindings: ViewModifier {
+    @ObservedObject var controller: QuillCodeDesktopController
+    @State private var shortcutMonitor: Any?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear(perform: installShortcutMonitor)
+            .onDisappear(perform: removeBindings)
+            .onChange(of: controller.surface.settings.keyboardShortcuts) { _, _ in
+                installShortcutMonitor()
+            }
+    }
+
+    private func removeBindings() {
+        if let shortcutMonitor {
+            NSEvent.removeMonitor(shortcutMonitor)
+            self.shortcutMonitor = nil
+        }
+    }
+
+    private func installShortcutMonitor() {
+        if let shortcutMonitor {
+            NSEvent.removeMonitor(shortcutMonitor)
+        }
+        let profile = WorkspaceShortcutRegistry.profile(
+            preferences: controller.surface.settings.keyboardShortcuts
+        )
+        shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard let shortcutEvent = QuillCodeDesktopShortcutEvent(event),
+                  let commandID = QuillCodeSecondaryShortcutResolver.commandID(
+                    for: shortcutEvent,
+                    profile: profile
+                  )
+            else { return event }
+            controller.runCommand(commandID: commandID)
+            return nil
+        }
+    }
+}
+
+private extension View {
+    func quillCodeDesktopCommandBindings(
+        controller: QuillCodeDesktopController
+    ) -> some View {
+        modifier(QuillCodeDesktopCommandBindings(controller: controller))
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopIssueReporterTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopIssueReporterTests.swift
@@ -43,6 +43,54 @@ final class QuillCodeDesktopIssueReporterTests: XCTestCase {
         )
         XCTAssertFalse(QuillCodeDesktopBuildMetadata.isCanonicalCommit("development"))
     }
+
+    func testUnexpectedExitReportContainsOnlyBoundedBuildIncidentContext() throws {
+        let current = QuillCodeDesktopBuildMetadata(
+            version: "0.1.0",
+            build: "698",
+            commit: String(repeating: "b", count: 40),
+            channel: "tester",
+            architecture: "arm64",
+            operatingSystem: "macOS 15.6.0"
+        )
+        let previous = QuillCodeDesktopBuildMetadata(
+            version: "0.1.0",
+            build: "697",
+            commit: String(repeating: "a", count: 40),
+            channel: "tester",
+            architecture: "arm64",
+            operatingSystem: "macOS 15.5.0"
+        )
+        let record = QuillCodeDesktopLaunchRecord(
+            processIdentifier: 123,
+            startedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            phase: .ready,
+            metadata: previous
+        )
+        let incident = try XCTUnwrap(
+            QuillCodeDesktopUnexpectedExit(
+                record: record,
+                now: record.startedAt.addingTimeInterval(10)
+            )
+        )
+
+        let url = try XCTUnwrap(
+            QuillCodeDesktopIssueReporter.issueURL(metadata: current, incident: incident)
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: try components.queryItems.orEmpty.map { item in
+            (item.name, try XCTUnwrap(item.value))
+        })
+        let body = try XCTUnwrap(query["body"])
+
+        XCTAssertEqual(query["title"], "[Crash] ")
+        XCTAssertTrue(body.contains("Ended unexpectedly while the app was running"), body)
+        XCTAssertTrue(body.contains("0.1.0 (697)"), body)
+        XCTAssertTrue(body.contains(previous.commit), body)
+        for forbidden in ["/Users/", "transcript", "API key:", "project path", "123"] {
+            XCTAssertFalse(body.contains(forbidden), body)
+        }
+    }
 }
 
 private extension Optional where Wrapped == [URLQueryItem] {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
@@ -1,0 +1,315 @@
+import AppKit
+import Foundation
+import XCTest
+import QuillCodeApp
+import QuillCodeCore
+import QuillCodePersistence
+import QuillCodeTools
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
+    private let referenceDate = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testReadyUnexpectedExitIsReportedAndGracefulRelaunchDoesNotRepeatIt() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let first = try fixture.store.beginLaunch(
+            metadata: metadata(build: "697"),
+            now: referenceDate,
+            processIdentifier: 10_001,
+            processIsRunning: { _ in false }
+        )
+        XCTAssertNil(first.unexpectedExit)
+        try fixture.store.markReady(launchID: first.currentRecord.launchID)
+
+        let second = try fixture.store.beginLaunch(
+            metadata: metadata(build: "698"),
+            now: referenceDate.addingTimeInterval(30),
+            processIdentifier: 10_002,
+            processIsRunning: { _ in false }
+        )
+        let incident = try XCTUnwrap(second.unexpectedExit)
+        XCTAssertEqual(incident.phase, .ready)
+        XCTAssertEqual(incident.metadata.build, "697")
+        XCTAssertTrue(incident.userMessage.contains("in-progress command may be incomplete"))
+
+        try fixture.store.finishLaunch(launchID: second.currentRecord.launchID)
+        let third = try fixture.store.beginLaunch(
+            metadata: metadata(build: "699"),
+            now: referenceDate.addingTimeInterval(60),
+            processIdentifier: 10_003,
+            processIsRunning: { _ in false }
+        )
+        XCTAssertNil(third.unexpectedExit)
+        try fixture.store.finishLaunch(launchID: third.currentRecord.launchID)
+    }
+
+    func testLivePriorProcessDoesNotProduceFalseCrashReport() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        _ = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate,
+            processIdentifier: 20_001,
+            processIsRunning: { _ in false }
+        )
+        let second = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate.addingTimeInterval(5),
+            processIdentifier: 20_002,
+            processIsRunning: { $0 == 20_001 }
+        )
+
+        XCTAssertNil(second.unexpectedExit)
+        try fixture.store.finishLaunch(launchID: second.currentRecord.launchID)
+
+        _ = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate.addingTimeInterval(10),
+            processIdentifier: 20_003,
+            processIsRunning: { _ in false }
+        )
+        let sameProcess = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate.addingTimeInterval(15),
+            processIdentifier: 20_003,
+            processIsRunning: { _ in false }
+        )
+        XCTAssertNil(sameProcess.unexpectedExit)
+        try fixture.store.finishLaunch(launchID: sameProcess.currentRecord.launchID)
+    }
+
+    func testOldOwnerCannotDeleteNewerLaunchMarker() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let first = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate,
+            processIdentifier: 30_001,
+            processIsRunning: { _ in false }
+        )
+        let second = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate.addingTimeInterval(5),
+            processIdentifier: 30_002,
+            processIsRunning: { _ in false }
+        )
+
+        try fixture.store.finishLaunch(launchID: first.currentRecord.launchID)
+        XCTAssertEqual(try fixture.store.currentRecord()?.launchID, second.currentRecord.launchID)
+        try fixture.store.finishLaunch(launchID: second.currentRecord.launchID)
+        XCTAssertNil(try fixture.store.currentRecord())
+    }
+
+    func testStaleAndUnsafeRecordsAreNotReported() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        _ = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate.addingTimeInterval(-QuillCodeDesktopUnexpectedExit.maximumIncidentAge - 1),
+            processIdentifier: 40_001,
+            processIsRunning: { _ in false }
+        )
+        let staleRelaunch = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate,
+            processIdentifier: 40_002,
+            processIsRunning: { _ in false }
+        )
+        XCTAssertNil(staleRelaunch.unexpectedExit)
+
+        try fixture.store.finishLaunch(launchID: staleRelaunch.currentRecord.launchID)
+        _ = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate.addingTimeInterval(
+                QuillCodeDesktopUnexpectedExit.maximumFutureClockSkew + 1
+            ),
+            processIdentifier: 40_010,
+            processIsRunning: { _ in false }
+        )
+        let futureRelaunch = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate,
+            processIdentifier: 40_011,
+            processIsRunning: { _ in false }
+        )
+        XCTAssertNil(futureRelaunch.unexpectedExit)
+        try fixture.store.finishLaunch(launchID: futureRelaunch.currentRecord.launchID)
+
+        let unsafeMetadata = QuillCodeDesktopBuildMetadata(
+            version: "/Users/private/project",
+            build: "697",
+            commit: String(repeating: "a", count: 40),
+            channel: "tester",
+            architecture: "arm64",
+            operatingSystem: "macOS 15.0"
+        )
+        _ = try fixture.store.beginLaunch(
+            metadata: unsafeMetadata,
+            now: referenceDate,
+            processIdentifier: 40_003,
+            processIsRunning: { _ in false }
+        )
+        let unsafeRelaunch = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate.addingTimeInterval(5),
+            processIdentifier: 40_004,
+            processIsRunning: { _ in false }
+        )
+        XCTAssertNil(unsafeRelaunch.unexpectedExit)
+        try fixture.store.finishLaunch(launchID: unsafeRelaunch.currentRecord.launchID)
+
+        let terminatingRecord = QuillCodeDesktopLaunchRecord(
+            processIdentifier: 40_005,
+            startedAt: referenceDate,
+            phase: .terminating,
+            metadata: metadata()
+        )
+        XCTAssertNil(
+            QuillCodeDesktopUnexpectedExit(
+                record: terminatingRecord,
+                now: referenceDate.addingTimeInterval(5)
+            )
+        )
+    }
+
+    func testSentinelUsesPrivateDirectoryAndFilePermissions() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let session = try fixture.store.beginLaunch(
+            metadata: metadata(),
+            now: referenceDate,
+            processIdentifier: 50_001,
+            processIsRunning: { _ in false }
+        )
+        let directoryPermissions = try permissions(
+            at: fixture.fileURL.deletingLastPathComponent()
+        )
+        let filePermissions = try permissions(at: fixture.fileURL)
+        let lockPermissions = try permissions(
+            at: fixture.fileURL.deletingPathExtension().appendingPathExtension("lock")
+        )
+
+        XCTAssertEqual(directoryPermissions, 0o700)
+        XCTAssertEqual(filePermissions, 0o600)
+        XCTAssertEqual(lockPermissions, 0o600)
+        try fixture.store.finishLaunch(launchID: session.currentRecord.launchID)
+    }
+
+    func testLifecycleControllerIsIdempotentAndClearsOnTerminationNotification() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let notificationCenter = NotificationCenter()
+        let lifecycle = QuillCodeDesktopLaunchLifecycleController(
+            store: fixture.store,
+            metadata: metadata(),
+            notificationCenter: notificationCenter,
+            now: { self.referenceDate },
+            processIdentifier: 60_001,
+            processIsRunning: { _ in false }
+        )
+
+        XCTAssertNil(lifecycle.startIfNeeded())
+        XCTAssertNil(lifecycle.startIfNeeded())
+        lifecycle.markReady()
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
+
+        notificationCenter.post(name: NSApplication.willTerminateNotification, object: nil)
+        XCTAssertNil(try fixture.store.currentRecord())
+    }
+
+    func testDesktopControllerRetainsLifecycleForFirstWindowConsumption() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let previous = try fixture.store.beginLaunch(
+            metadata: metadata(build: "697"),
+            now: referenceDate,
+            processIdentifier: 80_001,
+            processIsRunning: { _ in false }
+        )
+        try fixture.store.markReady(launchID: previous.currentRecord.launchID)
+        let lifecycle = QuillCodeDesktopLaunchLifecycleController(
+            store: fixture.store,
+            metadata: metadata(build: "698"),
+            notificationCenter: NotificationCenter(),
+            now: { self.referenceDate.addingTimeInterval(10) },
+            processIdentifier: 80_002,
+            processIsRunning: { _ in false }
+        )
+        _ = lifecycle.startIfNeeded()
+
+        let paths = QuillCodePaths(home: fixture.root.appendingPathComponent("state"))
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+        )
+        let controller = QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            browserLiveDOMCapturer: nil,
+            automationNotifier: LaunchLifecycleNoopNotifier(),
+            updateController: QuillCodeDesktopUpdateController(configuration: nil, installResultURL: nil),
+            installationLocationController: QuillCodeDesktopInstallationLocationController(
+                configuration: nil
+            ),
+            launchLifecycleController: lifecycle,
+            workspaceRoot: fixture.root
+        )
+
+        XCTAssertEqual(
+            controller.launchLifecycleController?.takeUnexpectedExit()?.metadata.build,
+            "697"
+        )
+        XCTAssertNil(controller.launchLifecycleController?.takeUnexpectedExit())
+        controller.launchLifecycleController?.markReady()
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
+        controller.startApplicationServices()
+        XCTAssertNil(controller.launchLifecycleController?.takeUnexpectedExit())
+        lifecycle.finishCurrentLaunch()
+        XCTAssertNil(try fixture.store.currentRecord())
+    }
+
+    private func metadata(build: String = "697") -> QuillCodeDesktopBuildMetadata {
+        QuillCodeDesktopBuildMetadata(
+            version: "0.1.0",
+            build: build,
+            commit: String(repeating: "a", count: 40),
+            channel: "tester",
+            architecture: "arm64",
+            operatingSystem: "macOS 15.0.0"
+        )
+    }
+
+    private func permissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).intValue & 0o777
+    }
+}
+
+private struct LaunchLifecycleNoopNotifier: QuillCodeAutomationNotifying {
+    func deliver(_ report: AutomationRunReport) {}
+}
+
+private struct Fixture {
+    let root: URL
+    let fileURL: URL
+    let store: QuillCodeDesktopLaunchStore
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        fileURL = root
+            .appendingPathComponent("runtime", isDirectory: true)
+            .appendingPathComponent("active-launch.json")
+        store = QuillCodeDesktopLaunchStore(fileURL: fileURL)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
@@ -9,12 +9,14 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         XCTAssertLessThanOrEqual(
             coreLineCount,
             240,
-            "The core desktop controller file should stay focused on published state, bootstrap, notifications, and refresh."
+            "The core desktop controller file should stay focused on published state, " +
+                "bootstrap, notifications, and refresh."
         )
         let extensionFileNames = [
             "QuillCodeDesktopController+Commands.swift",
             "QuillCodeDesktopController+ComposerAndPanes.swift",
             "QuillCodeDesktopController+Navigation.swift",
+            "QuillCodeDesktopController+Notifications.swift",
             "QuillCodeDesktopController+Settings.swift",
             "QuillCodeDesktopController+Terminal.swift",
             "QuillCodeDesktopController+Transcript.swift",
@@ -45,7 +47,9 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopControllerSourceText()
         let settingsCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopSettingsCoordinator.swift")
-        let computerUseCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopComputerUseCoordinator.swift")
+        let computerUseCoordinatorText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopComputerUseCoordinator.swift"
+        )
 
         Self.assertSource(text, contains: "QuillCodeDesktopSettingsCoordinator")
         Self.assertSource(text, contains: "MacSystemSettingsOpener")
@@ -164,7 +168,9 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
     func testDesktopControllerDelegatesWorkspaceActionMutations() throws {
         let text = try Self.desktopSourceText()
         let controllerText = try Self.desktopControllerSourceText()
-        let actionCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopWorkspaceActionCoordinator.swift")
+        let actionCoordinatorText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopWorkspaceActionCoordinator.swift"
+        )
         let sourceOpenerText = try Self.desktopSourceText(named: "QuillCodeDesktopSourceOpener.swift")
 
         Self.assertSource(text, contains: "QuillCodeDesktopWorkspaceActionCoordinator")
@@ -227,14 +233,20 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         Self.assertSource(controllerText, contains: "navigationCoordinator.addProject")
         Self.assertSource(navigationText, contains: "model.newChat()")
         Self.assertSource(navigationText, contains: "model.selectThread(id)")
-        Self.assertSource(navigationText, contains: "WorkspaceSidebarRowMutationExecutor.execute(mutation, model: model)")
+        Self.assertSource(
+            navigationText,
+            contains: "WorkspaceSidebarRowMutationExecutor.execute(mutation, model: model)"
+        )
         Self.assertSource(navigationText, contains: "model.renameThread(id, to: title)")
         Self.assertSource(navigationText, contains: "model.selectProject(id)")
         Self.assertSource(navigationText, contains: "model.renameProject(id, to: name)")
         Self.assertSource(navigationText, contains: "model.addProject(path: url)")
         Self.assertSource(controllerText, excludes: "_ = model.newChat()")
         Self.assertSource(controllerText, excludes: "model.selectThread(id)")
-        Self.assertSource(controllerText, excludes: "WorkspaceSidebarRowMutationExecutor.execute(mutation, model: model)")
+        Self.assertSource(
+            controllerText,
+            excludes: "WorkspaceSidebarRowMutationExecutor.execute(mutation, model: model)"
+        )
         Self.assertSource(controllerText, excludes: "model.renameThread(id, to: title)")
         Self.assertSource(controllerText, excludes: "model.selectProject(id)")
         Self.assertSource(controllerText, excludes: "model.renameProject(id, to: name)")
@@ -290,7 +302,10 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         Self.assertSource(coordinatorText, contains: "case .toggleActivity:")
         Self.assertSource(coordinatorText, contains: "case .toggleAutomations:")
         Self.assertSource(plannerText, contains: "WorkspaceCommandRoutingCatalog.canRunInWorkspaceModel")
-        Self.assertSource(controllerText, contains: "guard let action = QuillCodeDesktopCommandPlanner.action(for: command) else { return }")
+        Self.assertSource(
+            controllerText,
+            contains: "guard let action = QuillCodeDesktopCommandPlanner.action(for: command) else { return }"
+        )
         Self.assertSource(controllerText, contains: "commandCoordinator.run(action, performer: self)")
         Self.assertSource(controllerText, excludes: "switch command.id")
         Self.assertSource(controllerText, excludes: "switch action")

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -5,6 +5,7 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         let text = try Self.desktopSourceText()
         let commandsText = try Self.desktopSourceText(named: "DesktopCommands.swift")
         let appText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let rootViewText = try Self.desktopSourceText(named: "QuillCodeDesktopRootView.swift")
         let shortcutMonitorText = try Self.desktopSourceText(
             named: "QuillCodeDesktopShortcutMonitor.swift"
         )
@@ -60,9 +61,9 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         Self.assertSource(commandsText, contains: ".disabled(commandsByID[commandID]?.isEnabled != true)")
         Self.assertSource(commandsText, contains: "accessibilityIdentifier(\"quillcode-menu-command-\\(commandID)\")")
         Self.assertSource(appText, contains: "onCommand: { controller.runCommand(commandID: $0) }")
-        Self.assertSource(appText, contains: "controller.runCommand(commandID: commandID)")
+        Self.assertSource(rootViewText, contains: "controller.runCommand(commandID: commandID)")
         Self.assertSource(appText, excludes: "observeCommand()")
-        Self.assertSource(appText, contains: "QuillCodeSecondaryShortcutResolver.commandID")
+        Self.assertSource(rootViewText, contains: "QuillCodeSecondaryShortcutResolver.commandID")
         Self.assertSource(
             appText,
             contains: "Window(QuillCodeProduct.displayName, id: QuillCodeDesktopSceneID.mainWindow)"
@@ -85,5 +86,26 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
             "Disconnect All must not regress to a no-op button."
         )
         Self.assertSource(menuText, excludes: ".disabled(true)")
+    }
+
+    func testDesktopOwnsUnexpectedExitRecoveryAtTheApplicationBoundary() throws {
+        let appText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let rootViewText = try Self.desktopSourceText(named: "QuillCodeDesktopRootView.swift")
+        let lifecycleText = try Self.desktopSourceText(named: "QuillCodeDesktopLaunchLifecycle.swift")
+        let smokeText = try Self.desktopSourceText(named: "QuillCodeDesktopLaunchRecoverySmoke.swift")
+        let reporterText = try Self.desktopSourceText(named: "QuillCodeDesktopIssueReporter.swift")
+
+        Self.assertSource(appText, contains: "launchLifecycleController?.startIfNeeded()")
+        Self.assertSource(rootViewText, contains: "launchLifecycleController?.markReady()")
+        Self.assertSource(rootViewText, contains: "Quill Cowork closed unexpectedly")
+        Self.assertSource(rootViewText, contains: "controller.launchLifecycleController?.takeUnexpectedExit()")
+        Self.assertSource(rootViewText, contains: "QuillCodeDesktopIssueReporter.open(")
+        Self.assertSource(lifecycleText, contains: "flock(descriptor, LOCK_EX)")
+        Self.assertSource(lifecycleText, contains: "record.launchID == launchID")
+        Self.assertSource(lifecycleText, contains: "processIsRunning(record.processIdentifier)")
+        Self.assertSource(lifecycleText, contains: "NSApplication.willTerminateNotification")
+        Self.assertSource(reporterText, contains: "## Previous session")
+        Self.assertSource(appText, contains: "QuillCodeDesktopLaunchRecoverySmoke.runAndExit(request)")
+        Self.assertSource(smokeText, contains: "try verify(home: root.home)")
     }
 }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceReviewCardModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceReviewCardModelGateTests.swift
@@ -20,7 +20,7 @@ final class ParityWorkspaceReviewCardModelGateTests: QuillCodeParityTestCase {
         let workspaceViewText = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
         let approvalPlannerText = try Self.appSourceText(named: "WorkspaceApprovalActionPlanner.swift")
         let htmlRendererText = try Self.appSourceText(named: "WorkspaceHTMLToolCardRenderer.swift")
-        let desktopAppText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let desktopRootViewText = try Self.desktopSourceText(named: "QuillCodeDesktopRootView.swift")
         let desktopControllerText = try Self.desktopControllerSourceText()
         let desktopActionCoordinatorText = try Self.desktopSourceText(
             named: "QuillCodeDesktopWorkspaceActionCoordinator.swift"
@@ -81,7 +81,7 @@ final class ParityWorkspaceReviewCardModelGateTests: QuillCodeParityTestCase {
             "private func appendApprovalDecision",
             "approvalVerdict"
         ])
-        Self.assertSource(desktopAppText, contains: "controller.runToolCardAction")
+        Self.assertSource(desktopRootViewText, contains: "controller.runToolCardAction")
         Self.assertSource(desktopControllerText, contains: "workspaceActionCoordinator.runToolCardAction")
         Self.assertSource(desktopActionCoordinatorText, contains: "model.runToolCardAction")
     }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-10 Unexpected-Exit Recovery
+
+Overall grade after this slice: **A+ crash visibility, A+ privacy, A+ lifecycle ownership**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Crash visibility | A+ | Packaged launches register before workspace construction and transition to Ready only after the first native root view appears, so the next launch can distinguish startup and running failures. |
+| False-positive control | A+ | A prior live PID, same-process reentry, stale/future marker, unsafe metadata, and a graceful Terminating marker never become crash notices. |
+| Lifecycle safety | A+ | Marker mutations use one cross-process `flock`, atomic JSON replacement, launch-ID ownership checks, and a graceful-quit write-before-remove transition, so an older process cannot clear a newer launch. |
+| Privacy | A+ | The private 0700 directory and 0600 marker contain only schema, launch identity, PID, phase, time, and validated build/system metadata; no paths, prompts, transcripts, account data, or credentials are recorded. |
+| UX | A+ | The next successful launch presents one native alert with Continue and Report Issue actions, names potentially incomplete in-progress work honestly, and does not republish after dismissal. |
+| Supportability | A+ | Crash reports include bounded current/previous version, build, commit, channel, OS, architecture, start time, and phase without attaching files or private workspace state. |
+| Architecture | A+ | Process bootstrap, one-shot root-view presentation, launch persistence, reporting, and packaged smoke have focused owners; extracting the root view and notification routing keeps the core desktop controller at 230 lines. |
+
+Validation:
+
+- Final focused lifecycle, issue-reporting, application-service, controller-architecture, updater
+  parity, review-binding, and native hit-target/accessibility suite: 33 tests, 0 failures
+- Authoritative full Swift suite: 5,778 tests, 5 skipped, 0 failures
+- Native desktop executable smoke passed; packaged direct-executable, Launch Services, live-window,
+  Accessibility-frame, interaction, and recovery smokes passed
+- Dedicated packaged performance smoke passed 3/3 launches: 266.41 ms median launch-ready,
+  98.58 MiB initial RSS, 158.00 MiB after interaction, 162.59 MiB after repeated interaction,
+  4.59 MiB repeated growth, and zero repeated thread growth
+- Deterministic grader: every touched production and feature-specific test file scores 100/A+
+
 ## 2026-08-10 Bounded Live Terminal Backpressure
 
 Overall grade after this slice: **A+ memory ownership, A+ responsiveness, A+ crash resilience**.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -71,6 +71,19 @@ For a bug report, include the warning title, affected data labels, app version, 
 Do not include API keys, account details, filesystem paths, URLs, or raw private content. The
 in-app diagnostic is deliberately content-free and should report `Private content included: No`.
 
+## Tester Recovery: Unexpected Exit
+
+Packaged builds keep one private, content-free active-launch marker. A normal Quit or updater-driven
+termination clears the matching marker. If the process instead disappears during startup or while
+running, the next successful launch shows **Quill Cowork closed unexpectedly** and warns that an
+in-progress command may be incomplete. Choose **Continue** to return to the workspace or **Report
+Issue...** to open a prefilled crash report.
+
+The marker and report include only launch phase/time plus version, build, source commit, channel,
+architecture, and macOS version. They do not include project paths, filenames, prompts, transcripts,
+tool output, account details, or credentials. Live-process, stale, future-dated, unsafe, and graceful
+termination records are ignored to avoid false crash notices.
+
 ## Build Cadence
 
 The tester release is refreshed:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,6 +127,13 @@
 
 ## Latest Quality Pass
 
+- Packaged macOS launches now register an atomic, cross-process-locked, privacy-safe launch sentinel
+  before workspace construction, mark Ready only after the first native root view appears, and clear
+  only a matching launch on graceful termination. A fresh dead-process marker produces one native
+  recovery alert with Continue and a bounded Report Issue route; live PIDs, stale/future or unsafe
+  records, graceful Terminating state, development/smoke modes, and old-owner cleanup cannot create or
+  erase the wrong incident. The marker stores no project paths, prompts, transcripts, account data,
+  or credentials, and packaged smoke proves ready-state recovery followed by false-positive-free quit.
 - App-server Git inspection now includes Codex-compatible `gitDiffToRemote`: one bounded, binary,
   non-mutating diff from the current local upstream tip to committed-ahead, staged, unstaged, and
   untracked state, with ignored files excluded. Focused real-Git tests and the built JSONL smoke cover

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -7,6 +7,11 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 
 ## Unit Tests
 
+- Unexpected-exit recovery: early packaged launch registration, Starting-to-Ready transition,
+  graceful Terminating cleanup, dead-process detection, live-PID/same-process suppression, stale and
+  future timestamp rejection, unsafe metadata rejection, private directory/file permissions,
+  cross-process locking, old-owner cleanup refusal, idempotent service startup, one-shot dismissal,
+  content-free crash-report metadata, and packaged recovery-then-clean-relaunch smoke.
 - First-launch installation guidance: writable-copy suppression, already-installed suppression,
   read-only presentation, once-per-build dismissal, a new-build reminder, disabled smoke
   configuration, Applications-folder routing, fixed-size rendering, coordinated updater-sheet


### PR DESCRIPTION
## Summary
- add a private atomic launch ledger that distinguishes startup, ready, graceful termination, and unexpected exits
- present a one-shot native recovery alert with a privacy-safe crash report path
- split root-window and notification routing ownership to keep desktop architecture gates and A+ file grades intact

## Verification
- `swift test`: 5,778 tests, 5 skipped, 0 failures
- focused recovery/architecture/accessibility matrix: 33 tests, 0 failures
- packaged direct, Launch Services, live-window, Accessibility, and interaction smoke passed
- three-launch performance smoke: 266.41 ms launch-ready; 98.58 MiB initial, 158.00 MiB post-interaction, 162.59 MiB repeated RSS; zero repeated thread growth
- staged secret scan and `git diff --check` passed