### PR TITLE
Add crash-safe composer draft checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ not attach project paths, transcripts, or credentials. After an unexpected exit,
 launch identifies whether the prior session ended during startup or while running, warns that active
 command work may be incomplete, and offers the same privacy-safe report path.
 
+Unsent composer text is checkpointed after a brief typing pause and immediately when the app becomes
+inactive or quits. Quill Cowork restores that text after an unexpected exit without rewriting the
+potentially large chat transcript on every keystroke. Checkpoints are private, bounded, and scoped to
+one chat; confidential-chat text is never written to them.
+
 Choosing **Remind Me Tomorrow** defers only that exact update for 24 hours, including across app
 restarts. A newer build appears on the normal check cadence, and **Check for Updates...** always
 overrides the reminder. The app reopens its already-verified update state at the deadline without an

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -42,6 +42,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             unreadableDataKinds.append(.configuration)
         }
         let threadStore = JSONThreadStore(directory: paths.threadsDirectory)
+        let composerDraftStore = ComposerDraftCheckpointStore(directory: paths.composerDraftsDirectory)
         let projectStore = JSONProjectStore(fileURL: paths.projectsFile)
         let automationStore = JSONAutomationStore(fileURL: paths.automationsFile)
         let sidebarSavedSearchStore = JSONSidebarSavedSearchStore(fileURL: paths.sidebarSavedSearchesFile)
@@ -135,6 +136,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             runner: runtime.runner,
             contextSummaryGenerator: runtime.contextSummaryGenerator,
             threadStore: threadStore,
+            composerDraftStore: composerDraftStore,
             startupLoadIssue: WorkspaceStartupLoadIssue(
                 loadedThreadCount: threads.count,
                 threadLoadIssue: WorkspaceThreadLoadIssue(listing: threadListing),

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -174,6 +174,7 @@ public final class QuillCodeWorkspaceModel {
         runner: AgentRunner = AgentRunner(),
         contextSummaryGenerator: any WorkspaceContextSummaryGenerating = DeterministicWorkspaceContextSummaryGenerator(),
         threadStore: JSONThreadStore? = nil,
+        composerDraftStore: ComposerDraftCheckpointStore? = nil,
         threadLoadIssue: WorkspaceThreadLoadIssue? = nil,
         startupLoadIssue: WorkspaceStartupLoadIssue? = nil,
         projectStore: JSONProjectStore? = nil,
@@ -227,6 +228,7 @@ public final class QuillCodeWorkspaceModel {
         self.threadPersistenceIssueTracker = threadPersistenceIssueTracker
         self.threadPersistence = WorkspaceThreadPersistence(
             store: threadStore,
+            composerDraftStore: composerDraftStore,
             issueTracker: threadPersistenceIssueTracker
         )
         let registryPersistenceIssueTracker = WorkspaceRegistryPersistenceIssueTracker()

--- a/Sources/QuillCodeApp/WorkspaceModelComposerDraftPersistence.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposerDraftPersistence.swift
@@ -4,9 +4,19 @@ import QuillCodeCore
 @MainActor
 extension QuillCodeWorkspaceModel {
     func restorePersistedSelectedComposerDraftIfNeeded() {
-        guard let selectedThreadID = root.selectedThreadID else { return }
+        guard let selectedThreadID = root.selectedThreadID else {
+            if composer.draft.isEmpty {
+                composer.draft = threadPersistence.pendingComposerDraft() ?? ""
+            }
+            return
+        }
+        threadPersistence.deletePendingComposerDraft()
+        let persistedDraft = persistedComposerDraft(for: selectedThreadID)
+        if let index = root.threads.firstIndex(where: { $0.id == selectedThreadID }) {
+            root.threads[index].composerDraft = Self.normalizedComposerDraft(persistedDraft)
+        }
         if composer.draft.isEmpty {
-            composer.draft = persistedComposerDraft(for: selectedThreadID) ?? ""
+            composer.draft = persistedDraft ?? ""
         }
         if composer.attachments.isEmpty {
             composer.attachments = persistedComposerAttachments(for: selectedThreadID)
@@ -14,8 +24,27 @@ extension QuillCodeWorkspaceModel {
     }
 
     func persistCurrentComposerDraft() {
-        guard let selectedThreadID = root.selectedThreadID else { return }
+        guard let selectedThreadID = root.selectedThreadID else {
+            threadPersistence.savePendingComposerDraft(Self.normalizedComposerDraft(composer.draft))
+            return
+        }
         persistComposerDraft(composer.draft, for: selectedThreadID)
+    }
+
+    /// Keeps model projections aligned with the live desktop binding without touching disk. The
+    /// desktop follows this with a debounced checkpoint, while navigation can still synchronously
+    /// persist before changing the owner.
+    public func updateLiveComposerDraft(_ draft: String, ownerThreadID: UUID?) {
+        guard ownerThreadID == root.selectedThreadID else { return }
+        composer.draft = draft
+    }
+
+    /// Applies a debounced desktop checkpoint to the owner that was selected when typing occurred.
+    /// Capturing that identity prevents a delayed write from bleeding text into a newly selected chat.
+    public func checkpointComposerDraft(_ draft: String, ownerThreadID: UUID?) {
+        guard ownerThreadID == root.selectedThreadID else { return }
+        composer.draft = draft
+        persistCurrentComposerDraft()
     }
 
     func clearComposerDraft(for threadID: UUID?) {
@@ -28,7 +57,8 @@ extension QuillCodeWorkspaceModel {
     }
 
     func persistedComposerDraft(for threadID: UUID) -> String? {
-        root.threads.first { $0.id == threadID }?.composerDraft
+        guard let thread = root.threads.first(where: { $0.id == threadID }) else { return nil }
+        return threadPersistence.composerDraft(for: thread)
     }
 
     func persistedComposerAttachments(for threadID: UUID) -> [ChatAttachment] {
@@ -43,7 +73,7 @@ extension QuillCodeWorkspaceModel {
             return
         }
         root.threads[index].composerDraft = normalized
-        threadPersistence.save(root.threads[index])
+        threadPersistence.saveComposerDraft(in: root.threads[index])
     }
 
     static func normalizedComposerDraft(_ draft: String?) -> String? {

--- a/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
@@ -120,6 +120,7 @@ extension QuillCodeWorkspaceModel {
             _ = discardConfidentialThreadOnExit()
         }
         let previousLocation = currentNavigationLocation
+        let isClaimingPendingComposer = root.selectedThreadID == nil
         // Leaving the current thread for a newly created one (New Chat / fork / compact): persist its
         // return watermark, mirroring the harness's newChat() → markTranscriptSeen.
         if let outgoing = root.selectedThreadID, outgoing != thread.id {
@@ -127,6 +128,9 @@ extension QuillCodeWorkspaceModel {
         }
         clearSidebarSelection()
         restoreComposerDraft(from: root.selectedThreadID, to: thread.id)
+        if isClaimingPendingComposer {
+            threadPersistence.deletePendingComposerDraft()
+        }
         root.threads.insert(thread, at: 0)
         sessionStartHookCoordinator.registerCreatedThread(thread.id, source: sessionStartSource)
         selectThreadRecord(thread.id, projectID: selectedProjectID)

--- a/Sources/QuillCodeApp/WorkspaceThreadPersistence.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadPersistence.swift
@@ -4,15 +4,18 @@ import QuillCodePersistence
 
 struct WorkspaceThreadPersistence {
     let store: JSONThreadStore?
+    let composerDraftStore: ComposerDraftCheckpointStore?
     let now: @Sendable () -> Date
     let issueTracker: WorkspaceThreadPersistenceIssueTracker
 
     init(
         store: JSONThreadStore?,
+        composerDraftStore: ComposerDraftCheckpointStore? = nil,
         now: @escaping @Sendable () -> Date = Date.init,
         issueTracker: WorkspaceThreadPersistenceIssueTracker = WorkspaceThreadPersistenceIssueTracker()
     ) {
         self.store = store
+        self.composerDraftStore = composerDraftStore
         self.now = now
         self.issueTracker = issueTracker
     }
@@ -45,13 +48,76 @@ struct WorkspaceThreadPersistence {
     }
 
     func delete(_ id: UUID) {
-        guard let store else { return }
         do {
-            try store.delete(id)
+            try store?.delete(id)
+            try composerDraftStore?.delete(for: id)
             issueTracker.recordSuccess(for: id)
         } catch {
             issueTracker.recordFailure(for: id)
         }
+    }
+
+    func composerDraft(for thread: ChatThread) -> String? {
+        guard !thread.runtimeContext.isEphemeral, let composerDraftStore else {
+            return thread.composerDraft
+        }
+        do {
+            guard let checkpoint = try composerDraftStore.load(for: thread.id) else {
+                return thread.composerDraft
+            }
+            return checkpoint.draft
+        } catch {
+            issueTracker.recordFailure(for: thread.id)
+            return thread.composerDraft
+        }
+    }
+
+    func saveComposerDraft(in thread: ChatThread) {
+        guard !thread.runtimeContext.isEphemeral else { return }
+        guard let composerDraftStore else {
+            save(thread)
+            return
+        }
+        do {
+            if let store, !store.contains(thread.id) {
+                try store.save(thread)
+            }
+            try composerDraftStore.save(thread.composerDraft, for: thread.id)
+            issueTracker.recordSuccess(for: thread.id)
+        } catch {
+            // The established full-thread store remains a durable fallback when the lightweight
+            // checkpoint path is unavailable or the draft exceeds its deliberately small bound.
+            let removedStaleCheckpoint: Bool
+            do {
+                try composerDraftStore.delete(for: thread.id)
+                removedStaleCheckpoint = true
+            } catch {
+                removedStaleCheckpoint = false
+            }
+            do {
+                guard let store else { throw CocoaError(.fileNoSuchFile) }
+                try store.save(thread)
+                if removedStaleCheckpoint {
+                    issueTracker.recordSuccess(for: thread.id)
+                } else {
+                    issueTracker.recordFailure(for: thread.id)
+                }
+            } catch {
+                issueTracker.recordFailure(for: thread.id)
+            }
+        }
+    }
+
+    func pendingComposerDraft() -> String? {
+        try? composerDraftStore?.load(for: nil)?.draft
+    }
+
+    func savePendingComposerDraft(_ draft: String?) {
+        try? composerDraftStore?.save(draft, for: nil)
+    }
+
+    func deletePendingComposerDraft() {
+        try? composerDraftStore?.delete(for: nil)
     }
 
     @discardableResult

--- a/Sources/QuillCodePersistence/ComposerDraftCheckpointStore.swift
+++ b/Sources/QuillCodePersistence/ComposerDraftCheckpointStore.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+public struct ComposerDraftCheckpoint: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public var schemaVersion: Int
+    public var threadID: UUID?
+    public var draft: String?
+
+    public init(threadID: UUID?, draft: String?) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.threadID = threadID
+        self.draft = Self.normalized(draft)
+    }
+
+    fileprivate var isValid: Bool {
+        schemaVersion == Self.currentSchemaVersion
+            && draft.map { $0.utf8.count <= ComposerDraftCheckpointStore.maximumDraftBytes } != false
+    }
+
+    private static func normalized(_ draft: String?) -> String? {
+        guard let draft,
+              !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return draft
+    }
+}
+
+public enum ComposerDraftCheckpointStoreError: LocalizedError, Equatable, Sendable {
+    case draftExceedsSizeLimit(maximumBytes: Int)
+    case recordExceedsSizeLimit(maximumBytes: Int)
+    case invalidRecord
+
+    public var errorDescription: String? {
+        switch self {
+        case .draftExceedsSizeLimit(let maximumBytes):
+            "The composer draft exceeds the \(maximumBytes)-byte checkpoint limit."
+        case .recordExceedsSizeLimit(let maximumBytes):
+            "The composer draft checkpoint exceeds the \(maximumBytes)-byte storage limit."
+        case .invalidRecord:
+            "The composer draft checkpoint is invalid."
+        }
+    }
+}
+
+/// Stores only the current unsent text, separately from the potentially large thread transcript.
+/// Per-owner files keep a typing checkpoint bounded and make one chat's draft independent of every
+/// other chat. A nil draft is a durable tombstone so older thread snapshots cannot resurrect text.
+public struct ComposerDraftCheckpointStore: Sendable {
+    public static let maximumDraftBytes = 1 * 1_024 * 1_024
+    public static let maximumRecordBytes = maximumDraftBytes * 6 + 4_096
+    private static let filePermissions = 0o600
+
+    public var directory: URL
+
+    public init(directory: URL) {
+        self.directory = directory.standardizedFileURL
+    }
+
+    public func save(_ draft: String?, for threadID: UUID?) throws {
+        let checkpoint = ComposerDraftCheckpoint(threadID: threadID, draft: draft)
+        guard checkpoint.draft.map({ $0.utf8.count <= Self.maximumDraftBytes }) != false else {
+            throw ComposerDraftCheckpointStoreError.draftExceedsSizeLimit(
+                maximumBytes: Self.maximumDraftBytes
+            )
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(checkpoint)
+        guard data.count <= Self.maximumRecordBytes else {
+            throw ComposerDraftCheckpointStoreError.recordExceedsSizeLimit(
+                maximumBytes: Self.maximumRecordBytes
+            )
+        }
+
+        try PrivateDirectory.ensureExists(at: directory)
+        let destination = fileURL(for: threadID)
+        try data.write(to: destination, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: Self.filePermissions],
+            ofItemAtPath: destination.path
+        )
+    }
+
+    public func load(for threadID: UUID?) throws -> ComposerDraftCheckpoint? {
+        guard let data = try BoundedFileDataReader.readIfPresent(
+            from: fileURL(for: threadID),
+            maximumBytes: Self.maximumRecordBytes
+        ) else {
+            return nil
+        }
+        let checkpoint = try JSONDecoder().decode(ComposerDraftCheckpoint.self, from: data)
+        guard checkpoint.isValid, checkpoint.threadID == threadID else {
+            throw ComposerDraftCheckpointStoreError.invalidRecord
+        }
+        return checkpoint
+    }
+
+    public func delete(for threadID: UUID?) throws {
+        let destination = fileURL(for: threadID)
+        guard FileManager.default.fileExists(atPath: destination.path) else { return }
+        try FileManager.default.removeItem(at: destination)
+    }
+
+    private func fileURL(for threadID: UUID?) -> URL {
+        let name = threadID.map { "thread-\($0.uuidString.lowercased())" } ?? "pending"
+        return directory.appendingPathComponent(name).appendingPathExtension("json")
+    }
+}

--- a/Sources/QuillCodePersistence/Paths.swift
+++ b/Sources/QuillCodePersistence/Paths.swift
@@ -52,6 +52,7 @@ public struct QuillCodePaths: Sendable, Hashable {
     public var projectsFile: URL { home.appendingPathComponent("projects.json") }
     public var sidebarSavedSearchesFile: URL { home.appendingPathComponent("sidebar-saved-searches.json") }
     public var threadsDirectory: URL { home.appendingPathComponent("threads") }
+    public var composerDraftsDirectory: URL { home.appendingPathComponent("composer-drafts") }
     public var subagentThreadsDirectory: URL { home.appendingPathComponent("subagent-threads") }
     public var subagentApprovalPayloadsDirectory: URL { home.appendingPathComponent("subagent-approval-payloads") }
     public var attachmentsDirectory: URL { home.appendingPathComponent("attachments") }
@@ -87,6 +88,7 @@ public struct QuillCodePaths: Sendable, Hashable {
     public func ensure() throws {
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: threadsDirectory, withIntermediateDirectories: true)
+        try PrivateDirectory.ensureExists(at: composerDraftsDirectory)
         try FileManager.default.createDirectory(at: subagentThreadsDirectory, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(
             at: subagentApprovalPayloadsDirectory,

--- a/Sources/QuillCodePersistence/ThreadStore.swift
+++ b/Sources/QuillCodePersistence/ThreadStore.swift
@@ -105,6 +105,16 @@ public struct JSONThreadStore: Sendable {
         try FileManager.default.removeItem(at: url)
     }
 
+    public func contains(_ id: UUID) -> Bool {
+        guard let values = try? fileURL(for: id).resourceValues(forKeys: [
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+        ]) else {
+            return false
+        }
+        return values.isRegularFile == true && values.isSymbolicLink != true
+    }
+
     public func list() throws -> [ChatThread] {
         listing().threads
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -72,6 +72,20 @@ struct QuillCodeDesktopApp: App {
             return
         }
 
+        if let request = QuillCodeDesktopComposerDraftCrashSmokeRequest(arguments: CommandLine.arguments) {
+            let workspaceRoot = QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot(request: request)
+            let controller = workspaceRoot.makeController()
+            _controller = StateObject(wrappedValue: controller)
+            Task { @MainActor in
+                await QuillCodeDesktopComposerDraftCrashSmoke.runAndExit(
+                    request,
+                    controller: controller,
+                    workspaceRoot: workspaceRoot
+                )
+            }
+            return
+        }
+
         if let windowRequest = QuillCodeDesktopWindowSmokeRequest(arguments: CommandLine.arguments) {
             let workspaceRoot = QuillCodeDesktopWindowSmokeWorkspaceRoot(request: windowRequest)
             let controller = workspaceRoot.makeController()

--- a/Sources/quill-code-desktop/QuillCodeDesktopComposerCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComposerCoordinator.swift
@@ -22,6 +22,7 @@ struct QuillCodeDesktopComposerCoordinator {
         }
 
         draft = ""
+        model.setDraft("")
         let root = model.activeWorkspaceRoot ?? fallbackWorkspaceRoot
         guard model.runBrowserSessionSlashCommand(slashTarget.target, originalPrompt: prompt, workspaceRoot: root) else {
             refresh()
@@ -54,6 +55,7 @@ struct QuillCodeDesktopComposerCoordinator {
         if WorkspaceConfidentialSlash.isConfidentialCommand(prompt) {
             if model.composer.attachments.isEmpty {
                 draft = ""
+                model.setDraft("")
                 model.newConfidentialChat()
             } else {
                 model.setLastError("Remove the attached image to start a confidential chat: attachments aren't available in confidential chats.")
@@ -68,6 +70,7 @@ struct QuillCodeDesktopComposerCoordinator {
         if model.composer.attachments.isEmpty,
            let sideSlash = WorkspaceSideConversationSlash.parse(prompt) {
             draft = ""
+            model.setDraft("")
             guard let sideThreadID = model.startSideConversation(prompt: sideSlash.prompt) else {
                 refresh()
                 return
@@ -95,6 +98,7 @@ struct QuillCodeDesktopComposerCoordinator {
         if tasks.isSendRunning(threadID: selectedThreadID) || model.isAgentRunActive(for: selectedThreadID) {
             model.enqueueFollowUp(prompt)
             draft = ""
+            model.setDraft("")
             refresh()
             return
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopComposerDraftCheckpointCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComposerDraftCheckpointCoordinator.swift
@@ -1,0 +1,101 @@
+import AppKit
+import Foundation
+import QuillCodeApp
+
+/// Debounces live typing into the lightweight composer checkpoint store. The pending request owns
+/// the selected thread identity from the keystroke boundary, so delayed work cannot cross chats.
+@MainActor
+final class QuillCodeDesktopComposerDraftCheckpointCoordinator: NSObject {
+    static let defaultDelayNanoseconds: UInt64 = 350_000_000
+
+    private struct Request: Equatable {
+        var draft: String
+        var ownerThreadID: UUID?
+    }
+
+    private let delayNanoseconds: UInt64
+    private let notificationCenter: NotificationCenter
+    private var pendingRequest: Request?
+    private var pendingTask: Task<Void, Never>?
+    private var generation: UInt64 = 0
+    private weak var lifecycleModel: QuillCodeWorkspaceModel?
+
+    init(
+        delayNanoseconds: UInt64 = defaultDelayNanoseconds,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.delayNanoseconds = delayNanoseconds
+        self.notificationCenter = notificationCenter
+        super.init()
+    }
+
+    deinit {
+        pendingTask?.cancel()
+        notificationCenter.removeObserver(self)
+    }
+
+    var hasPendingCheckpoint: Bool {
+        pendingRequest != nil
+    }
+
+    func schedule(draft: String, model: QuillCodeWorkspaceModel) {
+        guard model.composer.draft != draft else {
+            cancelPending()
+            return
+        }
+        pendingRequest = Request(
+            draft: draft,
+            ownerThreadID: model.selectedThread?.id
+        )
+        generation &+= 1
+        let scheduledGeneration = generation
+        pendingTask?.cancel()
+        let delayNanoseconds = delayNanoseconds
+        pendingTask = Task { @MainActor [weak self, weak model] in
+            do {
+                try await Task.sleep(nanoseconds: delayNanoseconds)
+            } catch {
+                return
+            }
+            guard let self, let model, generation == scheduledGeneration else { return }
+            flush(on: model)
+        }
+    }
+
+    func flush(on model: QuillCodeWorkspaceModel) {
+        generation &+= 1
+        pendingTask?.cancel()
+        pendingTask = nil
+        guard let request = pendingRequest else { return }
+        pendingRequest = nil
+        model.checkpointComposerDraft(
+            request.draft,
+            ownerThreadID: request.ownerThreadID
+        )
+    }
+
+    func startLifecycleFlushes(model: QuillCodeWorkspaceModel) {
+        guard lifecycleModel == nil else { return }
+        lifecycleModel = model
+        for name in [NSApplication.didResignActiveNotification, NSApplication.willTerminateNotification] {
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(flushForApplicationLifecycle),
+                name: name,
+                object: nil
+            )
+        }
+    }
+
+    @objc private func flushForApplicationLifecycle(_ notification: Notification) {
+        guard let lifecycleModel else { return }
+        flush(on: lifecycleModel)
+    }
+
+    private func cancelPending() {
+        generation &+= 1
+        pendingRequest = nil
+        pendingTask?.cancel()
+        pendingTask = nil
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopComposerDraftCrashSmoke.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComposerDraftCrashSmoke.swift
@@ -1,0 +1,109 @@
+import Darwin
+import Foundation
+import QuillCodePersistence
+
+@MainActor
+enum QuillCodeDesktopComposerDraftCrashSmoke {
+    private static let expectedDraft = "Packaged crash recovery keeps this unsent text."
+
+    static func runAndExit(
+        _ request: QuillCodeDesktopComposerDraftCrashSmokeRequest,
+        controller: QuillCodeDesktopController,
+        workspaceRoot: QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot
+    ) async {
+        do {
+            switch request.phase {
+            case "write":
+                try await checkpointAndCrash(controller: controller, workspaceRoot: workspaceRoot)
+            case "verify":
+                try verifyAndClean(controller: controller, workspaceRoot: workspaceRoot)
+                exit(0)
+            default:
+                throw Failure.invalidPhase(request.phase)
+            }
+        } catch {
+            FileHandle.standardError.write(
+                Data("quill-code-desktop composer draft crash smoke failed: \(error)\n".utf8)
+            )
+            exit(1)
+        }
+    }
+
+    private static func checkpointAndCrash(
+        controller: QuillCodeDesktopController,
+        workspaceRoot: QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot
+    ) async throws {
+        let threadID = controller.model.newChat()
+        controller.refresh()
+        controller.draft = expectedDraft
+
+        let store = ComposerDraftCheckpointStore(
+            directory: QuillCodePaths(home: workspaceRoot.appState).composerDraftsDirectory
+        )
+        for _ in 0..<200 {
+            if try store.load(for: threadID)?.draft == expectedDraft {
+                FileHandle.standardOutput.write(Data("composer draft checkpointed before SIGKILL\n".utf8))
+                FileHandle.standardOutput.synchronizeFile()
+                guard Darwin.kill(getpid(), SIGKILL) == 0 else {
+                    throw Failure.couldNotTerminate
+                }
+                throw Failure.couldNotTerminate
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        throw Failure.checkpointTimedOut
+    }
+
+    private static func verifyAndClean(
+        controller: QuillCodeDesktopController,
+        workspaceRoot: QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot
+    ) throws {
+        guard let threadID = controller.model.selectedThread?.id else {
+            throw Failure.missingRecoveredThread
+        }
+        guard controller.model.composer.draft == expectedDraft else {
+            throw Failure.draftMismatch(controller.model.composer.draft)
+        }
+
+        let store = ComposerDraftCheckpointStore(
+            directory: QuillCodePaths(home: workspaceRoot.appState).composerDraftsDirectory
+        )
+        guard try store.load(for: threadID)?.draft == expectedDraft else {
+            throw Failure.missingCheckpoint
+        }
+        controller.model.setDraft("")
+        guard try store.load(for: threadID)?.draft == nil else {
+            throw Failure.tombstoneWasNotWritten
+        }
+        FileHandle.standardOutput.write(Data("composer draft recovered after SIGKILL\n".utf8))
+    }
+
+    private enum Failure: LocalizedError {
+        case checkpointTimedOut
+        case couldNotTerminate
+        case draftMismatch(String)
+        case invalidPhase(String)
+        case missingCheckpoint
+        case missingRecoveredThread
+        case tombstoneWasNotWritten
+
+        var errorDescription: String? {
+            switch self {
+            case .checkpointTimedOut:
+                "The live composer draft was not checkpointed before the deadline."
+            case .couldNotTerminate:
+                "The writer process could not terminate itself with SIGKILL."
+            case .draftMismatch(let draft):
+                "The relaunched composer restored an unexpected draft: \(draft)"
+            case .invalidPhase(let phase):
+                "The composer draft crash smoke phase is invalid: \(phase)"
+            case .missingCheckpoint:
+                "The relaunched app could not read the expected composer checkpoint."
+            case .missingRecoveredThread:
+                "The relaunched app did not restore the checkpoint owner."
+            case .tombstoneWasNotWritten:
+                "Clearing the recovered draft did not write a durable tombstone."
+            }
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+ComposerAndPanes.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+ComposerAndPanes.swift
@@ -4,6 +4,9 @@ import QuillCodeApp
 @MainActor
 extension QuillCodeDesktopController {
     func send() {
+        composerDraftCheckpointCoordinator.flush(on: model)
+        isComposerDraftBindingSideEffectsSuppressed = true
+        defer { isComposerDraftBindingSideEffectsSuppressed = false }
         if composerCoordinator.openBrowserSessionFromSlashIfNeeded(
             draft: &draft,
             model: model,
@@ -26,6 +29,9 @@ extension QuillCodeDesktopController {
     }
 
     func retryLastTurn() {
+        composerDraftCheckpointCoordinator.flush(on: model)
+        isComposerDraftBindingSideEffectsSuppressed = true
+        defer { isComposerDraftBindingSideEffectsSuppressed = false }
         composerCoordinator.retryLastTurn(
             draft: &draft,
             model: model,

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -8,7 +8,14 @@ import QuillCodeTools
 @MainActor
 final class QuillCodeDesktopController: ObservableObject {
     @Published var surface: WorkspaceSurface
-    @Published var draft: String
+    @Published var draft: String {
+        didSet {
+            guard !isComposerDraftBindingSideEffectsSuppressed else { return }
+            let ownerThreadID = model.selectedThread?.id
+            composerDraftCheckpointCoordinator.schedule(draft: draft, model: model)
+            model.updateLiveComposerDraft(draft, ownerThreadID: ownerThreadID)
+        }
+    }
     @Published var terminalDraft: String
     @Published var browserAddressDraft: String
     @Published var isCommandPalettePresented = false
@@ -38,6 +45,8 @@ final class QuillCodeDesktopController: ObservableObject {
     let sshHostDiscovery: SSHHostDiscovery
     let sshRemoteProjectProbe: SSHRemoteProjectProbe
     let composerCoordinator: QuillCodeDesktopComposerCoordinator
+    let composerDraftCheckpointCoordinator: QuillCodeDesktopComposerDraftCheckpointCoordinator
+    var isComposerDraftBindingSideEffectsSuppressed = false
     let copyCoordinator: QuillCodeDesktopCopyCoordinator
     let projectImportCoordinator: QuillCodeDesktopProjectImportCoordinator
     let projectAccessCoordinator: QuillCodeDesktopProjectAccessCoordinator
@@ -64,6 +73,8 @@ final class QuillCodeDesktopController: ObservableObject {
         automationNotifier: any QuillCodeAutomationNotifying = DesktopAutomationNotifierFactory.platformDefault(),
         sshHostDiscovery: SSHHostDiscovery = SSHHostDiscovery(),
         sshRemoteProjectProbe: SSHRemoteProjectProbe = SSHRemoteProjectProbe(),
+        composerDraftCheckpointCoordinator: QuillCodeDesktopComposerDraftCheckpointCoordinator =
+            QuillCodeDesktopComposerDraftCheckpointCoordinator(),
         transcriptExportCoordinator: QuillCodeDesktopTranscriptExportCoordinator =
             QuillCodeDesktopTranscriptExportCoordinator(),
         updateController: QuillCodeDesktopUpdateController? = nil,
@@ -91,6 +102,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.sshHostDiscovery = sshHostDiscovery
         self.sshRemoteProjectProbe = sshRemoteProjectProbe
         self.composerCoordinator = QuillCodeDesktopComposerCoordinator()
+        self.composerDraftCheckpointCoordinator = composerDraftCheckpointCoordinator
         self.copyCoordinator = QuillCodeDesktopCopyCoordinator()
         self.projectImportCoordinator = QuillCodeDesktopProjectImportCoordinator()
         self.projectAccessCoordinator = QuillCodeDesktopProjectAccessCoordinator()
@@ -201,6 +213,7 @@ final class QuillCodeDesktopController: ObservableObject {
     /// Starts services that belong to the application process rather than any SwiftUI scene. The
     /// ordinary app entry point calls this once; the owned controllers keep repeat calls idempotent.
     func startApplicationServices() {
+        composerDraftCheckpointCoordinator.startLifecycleFlushes(model: model)
         installApprovalNotificationHandling()
         installationLocationController.startIfNeeded()
         updateController.startAutomaticChecks()

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -55,6 +55,65 @@ struct QuillCodeDesktopWindowSmokeRequest: Sendable {
     }
 }
 
+struct QuillCodeDesktopComposerDraftCrashSmokeRequest: Sendable {
+    var phase: String
+    var stateRootPath: String?
+
+    init?(arguments: [String]) {
+        guard arguments.contains("--composer-draft-crash-smoke") else {
+            return nil
+        }
+
+        self.phase = Self.value(after: "--composer-draft-crash-phase", in: arguments) ?? ""
+        self.stateRootPath = Self.value(after: "--composer-draft-crash-state-root", in: arguments)
+    }
+
+    private static func value(after flag: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: flag) else { return nil }
+        let valueIndex = arguments.index(after: index)
+        guard valueIndex < arguments.endIndex else { return nil }
+        return arguments[valueIndex]
+    }
+}
+
+struct QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot: Sendable, Hashable {
+    var root: URL
+    var appState: URL
+    var workspace: URL
+
+    init(request: QuillCodeDesktopComposerDraftCrashSmokeRequest) {
+        if let stateRootPath = request.stateRootPath, !stateRootPath.isEmpty {
+            root = URL(fileURLWithPath: stateRootPath, isDirectory: true)
+        } else {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("quillcode-composer-crash-\(UUID().uuidString)", isDirectory: true)
+        }
+        appState = root.appendingPathComponent("app-state", isDirectory: true)
+        workspace = root.appendingPathComponent("workspace", isDirectory: true)
+    }
+
+    @MainActor
+    func makeController() -> QuillCodeDesktopController {
+        let paths = QuillCodePaths(home: appState)
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+        )
+        return QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            browserLiveDOMCapturer: nil,
+            updateController: QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            ),
+            installationLocationController: QuillCodeDesktopInstallationLocationController(
+                configuration: nil
+            ),
+            workspaceRoot: workspace
+        )
+    }
+}
+
 struct QuillCodeDesktopWindowSmokeWorkspaceRoot: Sendable, Hashable {
     var root: URL
     var appState: URL

--- a/Tests/QuillCodeAppTests/WorkspaceComposerDraftIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerDraftIntegrationTests.swift
@@ -118,6 +118,142 @@ final class WorkspaceComposerDraftIntegrationTests: XCTestCase {
         XCTAssertEqual(second.composer.draft, "continue the partial plan")
     }
 
+    func testLightweightCheckpointRestoresWithoutRewritingTranscript() throws {
+        let root = try makeTempDirectory()
+        let threadStore = JSONThreadStore(directory: root.appendingPathComponent("threads"))
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let thread = ChatThread(title: "Checkpointed draft")
+        try threadStore.save(thread)
+        let first = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id),
+            threadStore: threadStore,
+            composerDraftStore: checkpointStore
+        )
+
+        first.setDraft("continue after a crash")
+
+        XCTAssertNil(try threadStore.load(thread.id).composerDraft)
+        XCTAssertEqual(try checkpointStore.load(for: thread.id)?.draft, "continue after a crash")
+        let second = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                threads: try threadStore.list(),
+                selectedThreadID: thread.id
+            ),
+            threadStore: threadStore,
+            composerDraftStore: checkpointStore
+        )
+        XCTAssertEqual(second.composer.draft, "continue after a crash")
+        XCTAssertEqual(second.root.threads.first?.composerDraft, "continue after a crash")
+    }
+
+    func testCheckpointTombstonePreventsStaleThreadDraftFromResurrecting() throws {
+        let root = try makeTempDirectory()
+        let threadStore = JSONThreadStore(directory: root.appendingPathComponent("threads"))
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let thread = ChatThread(title: "Stale snapshot", composerDraft: "already sent")
+        try threadStore.save(thread)
+        try checkpointStore.save(nil, for: thread.id)
+
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id),
+            threadStore: threadStore,
+            composerDraftStore: checkpointStore
+        )
+
+        XCTAssertEqual(model.composer.draft, "")
+        XCTAssertNil(model.root.threads.first?.composerDraft)
+    }
+
+    func testPendingFirstMessageRestoresAndMovesToCreatedThread() throws {
+        let root = try makeTempDirectory()
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        try checkpointStore.save("first unsent message", for: nil)
+        let model = QuillCodeWorkspaceModel(composerDraftStore: checkpointStore)
+
+        XCTAssertEqual(model.composer.draft, "first unsent message")
+        let threadID = try XCTUnwrap(model.prepareComposerSubmissionThread())
+
+        XCTAssertEqual(model.composer.draft, "first unsent message")
+        XCTAssertEqual(try checkpointStore.load(for: threadID)?.draft, "first unsent message")
+        XCTAssertNil(try checkpointStore.load(for: nil))
+    }
+
+    func testConfidentialDraftNeverCreatesCheckpoint() throws {
+        let root = try makeTempDirectory()
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let model = QuillCodeWorkspaceModel(composerDraftStore: checkpointStore)
+        let threadID = model.newConfidentialChat()
+
+        model.setDraft("private unsent text")
+
+        XCTAssertEqual(model.composer.draft, "private unsent text")
+        XCTAssertNil(try checkpointStore.load(for: threadID))
+        XCTAssertNil(try checkpointStore.load(for: nil))
+    }
+
+    func testOversizedCheckpointFallsBackWithoutLeavingStaleDraft() throws {
+        let root = try makeTempDirectory()
+        let threadStore = JSONThreadStore(directory: root.appendingPathComponent("threads"))
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let thread = ChatThread(title: "Large draft")
+        try threadStore.save(thread)
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id),
+            threadStore: threadStore,
+            composerDraftStore: checkpointStore
+        )
+        model.setDraft("old checkpoint")
+        let oversized = String(
+            repeating: "x",
+            count: ComposerDraftCheckpointStore.maximumDraftBytes + 1
+        )
+
+        model.setDraft(oversized)
+
+        XCTAssertNil(try checkpointStore.load(for: thread.id))
+        XCTAssertEqual(try threadStore.load(thread.id).composerDraft, oversized)
+        let reloaded = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                threads: try threadStore.list(),
+                selectedThreadID: thread.id
+            ),
+            threadStore: threadStore,
+            composerDraftStore: checkpointStore
+        )
+        XCTAssertEqual(reloaded.composer.draft, oversized)
+    }
+
+    func testDeletingThreadRemovesItsCheckpoint() throws {
+        let root = try makeTempDirectory()
+        let threadStore = JSONThreadStore(directory: root.appendingPathComponent("threads"))
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let thread = ChatThread(title: "Delete checkpoint")
+        try threadStore.save(thread)
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id),
+            threadStore: threadStore,
+            composerDraftStore: checkpointStore
+        )
+        model.setDraft("remove with chat")
+
+        XCTAssertTrue(model.deleteThread(thread.id))
+
+        XCTAssertNil(try checkpointStore.load(for: thread.id))
+        XCTAssertFalse(threadStore.contains(thread.id))
+    }
+
     func testSentDraftIsClearedFromPersistentThread() async throws {
         let root = try makeQuillCodeTestDirectory()
         let store = try JSONThreadStore(directory: makeTempDirectory())

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopComposerDraftCheckpointCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopComposerDraftCheckpointCoordinatorTests.swift
@@ -1,0 +1,161 @@
+import AppKit
+import Foundation
+import XCTest
+import QuillCodeApp
+import QuillCodeCore
+import QuillCodePersistence
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopComposerDraftCheckpointCoordinatorTests: XCTestCase {
+    func testControllerDebouncesTypingAndRelaunchRestoresLatestDraft() async throws {
+        let root = try makeTempDirectory()
+        let paths = QuillCodePaths(home: root)
+        let coordinator = QuillCodeDesktopComposerDraftCheckpointCoordinator(
+            delayNanoseconds: 1_000_000
+        )
+        let controller = QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(
+                paths: paths,
+                runtimeFactory: QuillCodeRuntimeFactory(
+                    paths: paths,
+                    environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+                )
+            ),
+            browserLiveDOMCapturer: nil,
+            composerDraftCheckpointCoordinator: coordinator,
+            updateController: QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            ),
+            workspaceRoot: root
+        )
+        let threadID = controller.model.newChat()
+        controller.refresh()
+
+        for index in 0..<1_000 {
+            controller.draft = "draft \(index)"
+        }
+        await waitUntil { !coordinator.hasPendingCheckpoint }
+
+        let threadStore = JSONThreadStore(directory: paths.threadsDirectory)
+        XCTAssertTrue(threadStore.contains(threadID), "the first checkpoint must make a new chat durable")
+        let baselineThreadDraft = try threadStore.load(threadID).composerDraft
+        XCTAssertEqual(
+            try ComposerDraftCheckpointStore(directory: paths.composerDraftsDirectory)
+                .load(for: threadID)?.draft,
+            "draft 999"
+        )
+
+        controller.draft = "latest after another burst"
+        await waitUntil { !coordinator.hasPendingCheckpoint }
+
+        XCTAssertEqual(
+            try threadStore.load(threadID).composerDraft,
+            baselineThreadDraft,
+            "later typing should not rewrite the full transcript snapshot"
+        )
+        let reloaded = try QuillCodeWorkspaceBootstrap(
+            paths: paths,
+            runtimeFactory: QuillCodeRuntimeFactory(
+                paths: paths,
+                environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+            )
+        ).makeModel()
+        XCTAssertEqual(reloaded.selectedThread?.id, threadID)
+        XCTAssertEqual(reloaded.composer.draft, "latest after another burst")
+    }
+
+    func testDelayedCheckpointCannotBleedAcrossThreadSelection() throws {
+        let root = try makeTempDirectory()
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let first = ChatThread(title: "First")
+        let second = ChatThread(title: "Second")
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                threads: [first, second],
+                selectedThreadID: first.id
+            ),
+            composerDraftStore: checkpointStore
+        )
+        let coordinator = QuillCodeDesktopComposerDraftCheckpointCoordinator(
+            delayNanoseconds: 5_000_000_000
+        )
+
+        coordinator.schedule(draft: "belongs to first", model: model)
+        model.selectThread(second.id)
+        coordinator.flush(on: model)
+
+        XCTAssertEqual(model.selectedThread?.id, second.id)
+        XCTAssertEqual(model.composer.draft, "")
+        XCTAssertNotEqual(try checkpointStore.load(for: first.id)?.draft, "belongs to first")
+        XCTAssertNil(try checkpointStore.load(for: second.id))
+    }
+
+    func testConfidentialTypingNeverWritesCheckpoint() throws {
+        let root = try makeTempDirectory()
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let model = QuillCodeWorkspaceModel(composerDraftStore: checkpointStore)
+        let threadID = model.newConfidentialChat()
+        let coordinator = QuillCodeDesktopComposerDraftCheckpointCoordinator(
+            delayNanoseconds: 5_000_000_000
+        )
+
+        coordinator.schedule(draft: "private live draft", model: model)
+        coordinator.flush(on: model)
+
+        XCTAssertEqual(model.composer.draft, "private live draft")
+        XCTAssertNil(try checkpointStore.load(for: threadID))
+        XCTAssertNil(try checkpointStore.load(for: nil))
+    }
+
+    func testAppDeactivationFlushesPendingCheckpointImmediately() async throws {
+        let root = try makeTempDirectory()
+        let threadStore = JSONThreadStore(directory: root.appendingPathComponent("threads"))
+        let checkpointStore = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts")
+        )
+        let thread = ChatThread(title: "Lifecycle flush")
+        try threadStore.save(thread)
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(threads: [thread], selectedThreadID: thread.id),
+            threadStore: threadStore,
+            composerDraftStore: checkpointStore
+        )
+        let notificationCenter = NotificationCenter()
+        let coordinator = QuillCodeDesktopComposerDraftCheckpointCoordinator(
+            delayNanoseconds: 5_000_000_000,
+            notificationCenter: notificationCenter
+        )
+        coordinator.startLifecycleFlushes(model: model)
+        coordinator.schedule(draft: "flush before leaving", model: model)
+
+        notificationCenter.post(name: NSApplication.didResignActiveNotification, object: nil)
+        await waitUntil { !coordinator.hasPendingCheckpoint }
+
+        XCTAssertEqual(try checkpointStore.load(for: thread.id)?.draft, "flush before leaving")
+    }
+
+    private func waitUntil(
+        _ condition: @escaping @MainActor () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0..<1_000 where !condition() {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTAssertTrue(condition(), "condition did not become true", file: file, line: line)
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("QuillCodeComposerCheckpointTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -108,4 +108,55 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         Self.assertSource(appText, contains: "QuillCodeDesktopLaunchRecoverySmoke.runAndExit(request)")
         Self.assertSource(smokeText, contains: "try verify(home: root.home)")
     }
+
+    func testDesktopCrashRecoveryCheckpointsLiveComposerDrafts() throws {
+        let controllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+        let coordinatorText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopComposerDraftCheckpointCoordinator.swift"
+        )
+        let modelText = try Self.appSourceText(named: "WorkspaceModelComposerDraftPersistence.swift")
+        let persistenceText = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("Sources/QuillCodePersistence/ComposerDraftCheckpointStore.swift"),
+            encoding: .utf8
+        )
+        let downloadsText = try Self.docsText(named: "DOWNLOADS.md")
+        let crashSmokeText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopComposerDraftCrashSmoke.swift"
+        )
+        let appText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let packagedSmokeText = try Self.scriptText(named: "packaged-macos-smoke.sh")
+
+        Self.assertSource(controllerText, contains: "composerDraftCheckpointCoordinator.schedule")
+        Self.assertSource(controllerText, contains: "model.updateLiveComposerDraft")
+        Self.assertSource(controllerText, contains: "isComposerDraftBindingSideEffectsSuppressed")
+        let composerActionsText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopController+ComposerAndPanes.swift"
+        )
+        Self.assertSource(composerActionsText, contains: "composerDraftCheckpointCoordinator.flush")
+        Self.assertSource(
+            composerActionsText,
+            contains: "isComposerDraftBindingSideEffectsSuppressed = true"
+        )
+        Self.assertSource(coordinatorText, contains: "defaultDelayNanoseconds: UInt64 = 350_000_000")
+        Self.assertSource(coordinatorText, contains: "ownerThreadID: model.selectedThread?.id")
+        Self.assertSource(coordinatorText, contains: "NSApplication.didResignActiveNotification")
+        Self.assertSource(coordinatorText, contains: "NSApplication.willTerminateNotification")
+        Self.assertSource(modelText, contains: "ownerThreadID == root.selectedThreadID")
+        Self.assertSource(modelText, contains: "threadPersistence.saveComposerDraft")
+        Self.assertSource(persistenceText, contains: "maximumDraftBytes = 1 * 1_024 * 1_024")
+        Self.assertSource(persistenceText, contains: "BoundedFileDataReader.readIfPresent")
+        Self.assertSource(persistenceText, contains: "filePermissions = 0o600")
+        Self.assertSource(downloadsText, contains: "Confidential and side-conversation drafts remain memory-only")
+        Self.assertSource(crashSmokeText, contains: "Darwin.kill(getpid(), SIGKILL)")
+        Self.assertSource(crashSmokeText, contains: "controller.model.composer.draft == expectedDraft")
+        Self.assertSource(crashSmokeText, contains: "controller.model.setDraft(\"\")")
+        Self.assertSource(
+            appText,
+            contains: "QuillCodeDesktopComposerDraftCrashSmoke.runAndExit"
+        )
+        Self.assertSource(packagedSmokeText, contains: "--composer-draft-crash-phase write")
+        Self.assertSource(packagedSmokeText, contains: "--composer-draft-crash-phase verify")
+        Self.assertSource(packagedSmokeText, contains: "COMPOSER_DRAFT_CRASH_STATUS\" -ne 137")
+    }
 }

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -16,7 +16,8 @@ struct ParityFocusedSuiteManifest {
             "testTerminalRendererBehaviorTestsCoverScrollAndAlternateScreenParity"
         ]),
         Suite(fileName: "ParityDesktopGateTests.swift", testNames: [
-            "testDesktopDefinesNativeMenuBarWidgetAndUnifiedCommandRouting"
+            "testDesktopDefinesNativeMenuBarWidgetAndUnifiedCommandRouting",
+            "testDesktopCrashRecoveryCheckpointsLiveComposerDrafts"
         ]),
         Suite(fileName: "ParityTopBarPresentationGateTests.swift", testNames: [
             "testTopBarViewsDelegateStatusPresentationSemantics",

--- a/Tests/QuillCodePersistenceTests/ComposerDraftCheckpointStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/ComposerDraftCheckpointStoreTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import XCTest
+@testable import QuillCodePersistence
+
+final class ComposerDraftCheckpointStoreTests: PersistenceTestCase {
+    func testRoundTripsDraftAndDurableTombstoneWithPrivatePermissions() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("composer-drafts", isDirectory: true)
+        let store = ComposerDraftCheckpointStore(directory: directory)
+        let threadID = UUID()
+
+        try store.save("half-written plan", for: threadID)
+
+        XCTAssertEqual(
+            try store.load(for: threadID),
+            ComposerDraftCheckpoint(threadID: threadID, draft: "half-written plan")
+        )
+        XCTAssertEqual(try posixPermissions(at: directory), 0o700)
+        XCTAssertEqual(try posixPermissions(at: checkpointURL(directory: directory, threadID: threadID)), 0o600)
+
+        try store.save(" \n ", for: threadID)
+        let tombstone = try XCTUnwrap(store.load(for: threadID))
+        XCTAssertNil(tombstone.draft)
+    }
+
+    func testThreadAndPendingCheckpointsRemainIndependent() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts", isDirectory: true)
+        )
+        let firstID = UUID()
+        let secondID = UUID()
+
+        try store.save("pending first message", for: nil)
+        try store.save("first", for: firstID)
+        try store.save("second", for: secondID)
+
+        XCTAssertEqual(try store.load(for: nil)?.draft, "pending first message")
+        XCTAssertEqual(try store.load(for: firstID)?.draft, "first")
+        XCTAssertEqual(try store.load(for: secondID)?.draft, "second")
+
+        try store.delete(for: firstID)
+        XCTAssertNil(try store.load(for: firstID))
+        XCTAssertEqual(try store.load(for: secondID)?.draft, "second")
+    }
+
+    func testRejectsOversizedDraftWithoutReplacingPreviousCheckpoint() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = ComposerDraftCheckpointStore(
+            directory: root.appendingPathComponent("composer-drafts", isDirectory: true)
+        )
+        let threadID = UUID()
+        try store.save("known good", for: threadID)
+
+        XCTAssertThrowsError(try store.save(
+            String(repeating: "x", count: ComposerDraftCheckpointStore.maximumDraftBytes + 1),
+            for: threadID
+        )) { error in
+            XCTAssertEqual(
+                error as? ComposerDraftCheckpointStoreError,
+                .draftExceedsSizeLimit(maximumBytes: ComposerDraftCheckpointStore.maximumDraftBytes)
+            )
+        }
+        XCTAssertEqual(try store.load(for: threadID)?.draft, "known good")
+    }
+
+    func testRejectsMismatchedAndSymlinkedRecords() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("composer-drafts", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let store = ComposerDraftCheckpointStore(directory: directory)
+        let requestedID = UUID()
+        let destination = checkpointURL(directory: directory, threadID: requestedID)
+        let encoder = JSONEncoder()
+        try encoder.encode(ComposerDraftCheckpoint(
+            threadID: UUID(),
+            draft: "wrong owner"
+        )).write(to: destination)
+
+        XCTAssertThrowsError(try store.load(for: requestedID)) { error in
+            XCTAssertEqual(error as? ComposerDraftCheckpointStoreError, .invalidRecord)
+        }
+
+        try FileManager.default.removeItem(at: destination)
+        let target = root.appendingPathComponent("target.json")
+        try Data("{}".utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(at: destination, withDestinationURL: target)
+        XCTAssertThrowsError(try store.load(for: requestedID)) { error in
+            XCTAssertEqual(error as? BoundedFileDataError, .symbolicLink)
+        }
+    }
+
+    private func checkpointURL(directory: URL, threadID: UUID) -> URL {
+        directory
+            .appendingPathComponent("thread-\(threadID.uuidString.lowercased())")
+            .appendingPathExtension("json")
+    }
+}

--- a/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
+++ b/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
@@ -22,6 +22,7 @@ final class QuillCodePathsTests: PersistenceTestCase {
 
         for directory in [
             paths.threadsDirectory,
+            paths.composerDraftsDirectory,
             paths.subagentThreadsDirectory,
             paths.subagentApprovalPayloadsDirectory,
             paths.attachmentsDirectory,
@@ -37,6 +38,7 @@ final class QuillCodePathsTests: PersistenceTestCase {
             XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
             XCTAssertTrue(isDirectory.boolValue)
         }
+        XCTAssertEqual(try posixPermissions(at: paths.composerDraftsDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.subagentApprovalPayloadsDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.pluginDataDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.importsDirectory), 0o700)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-10 Crash-Safe Composer Draft Checkpoints
+
+Overall grade after this slice: **A+ crash recovery, A+ persistence boundaries, A+ typing-path cost**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Crash recovery | A+ | Unsent text survives abrupt exits after a short debounce, with immediate deactivate/quit flushes and pending-first-message recovery. |
+| Ownership safety | A+ | Every delayed write is bound to its original chat identity and cannot cross a rapid selection change. |
+| Persistence architecture | A+ | Small private sidecars avoid serializing large transcripts while typing; tombstones, one-time new-chat baselines, and full-thread fallback keep recovery authoritative. |
+| Privacy and bounds | A+ | One-MiB draft bounds, bounded no-follow reads, owner/schema checks, `0700`/`0600` permissions, and runtime-context guards keep confidential/side text memory-only. |
+| Runtime behavior | A+ | Live model synchronization prevents unrelated background refreshes from erasing text during the debounce window. |
+| Regression evidence | A+ | Focused store, model lifecycle, desktop debounce, lifecycle notification, fallback, deletion, relaunch, and parity tests cover the complete boundary. |
+
+Validation:
+
+- Focused checkpoint, lifecycle, path, and desktop parity boundary: 29 tests, 0 failures
+- Authoritative full Swift suite: 5,804 tests, 5 skipped, 0 failures
+- Packaged writer terminated by `SIGKILL` (status 137); a fresh packaged process restored the exact
+  unsent text and persisted a tombstone after clearing it
+- Packaged direct-executable, Launch Services, live-window, accessibility, interaction, screenshot,
+  and Computer Use smokes passed
+- Packaged performance: 277.41 ms median launch-ready, 98.62 MiB initial, 155.12 MiB
+  post-interaction, and 159.81 MiB repeated-interaction memory
+- `python3 scripts/grade-code-quality.py --root .`
+- `git diff --check`
+
 ## 2026-08-10 Durable Update Reminders
 
 Overall grade after this slice: **A+ interruption UX, A+ update freshness, A+ bounded persistence**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,27 @@
 # QuillCode Decisions
 
+## 2026-08-10: live composer drafts checkpoint outside large transcripts
+
+- **Decision:** The desktop synchronizes its live composer binding into model memory immediately, then
+  debounces durable writes for 350 milliseconds. App deactivation and termination flush pending work.
+  Every delayed request retains its original optional thread identity and is ignored if selection has
+  changed before it runs.
+- **Persistence:** Standard drafts use private `0600` per-thread records beneath a `0700` directory.
+  Records are schema-checked, owner-checked, symlink-safe on read, and bounded to one MiB of draft text.
+  A nil draft is a tombstone, so a stale full-thread snapshot cannot resurrect sent or cleared text.
+  The first checkpoint makes an unsaved new chat durable; later typing does not serialize its transcript.
+- **Recovery:** A pending first message without a thread owner has a separate checkpoint and transfers
+  to the created chat. Oversized or unavailable sidecar storage removes stale checkpoint authority and
+  falls back to the established atomic full-thread save. Deleting a chat removes both stores.
+- **Privacy:** Confidential and side-conversation drafts remain memory-only. The same runtime-context
+  guard that excludes their transcripts also excludes checkpoint files.
+- **Evidence:** `ComposerDraftCheckpointStoreTests`,
+  `WorkspaceComposerDraftIntegrationTests`,
+  `QuillCodeDesktopComposerDraftCheckpointCoordinatorTests`, and
+  `ParityDesktopGateTests/testDesktopCrashRecoveryCheckpointsLiveComposerDrafts` cover storage bounds,
+  permissions, malformed/symlink rejection, burst coalescing, lifecycle flushes, relaunch, tombstones,
+  fallback, cleanup, selection races, and confidential-session exclusion.
+
 ## 2026-08-09: releases update from the untouched previous public app
 
 - **Decision:** Download Builds captures the current public manifest and matching arm64 and x86_64

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -84,6 +84,14 @@ architecture, and macOS version. They do not include project paths, filenames, p
 tool output, account details, or credentials. Live-process, stale, future-dated, unsafe, and graceful
 termination records are ignored to avoid false crash notices.
 
+Ordinary composer typing uses a private per-chat checkpoint after a 350-millisecond quiet interval.
+Leaving Quill Cowork or quitting flushes pending text immediately. The checkpoint is a bounded small
+record rather than a rewrite of the chat transcript, so long conversations do not turn autosave into
+typing or memory pressure. A delayed checkpoint carries the chat identity from the keystroke boundary
+and is rejected after a selection change, while a durable tombstone prevents sent or cleared text from
+returning after relaunch. A first message without a chat owner has its own pending record and moves to
+the created chat on send. Confidential and side-conversation drafts remain memory-only.
+
 ## Build Cadence
 
 The tester release is refreshed:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -128,6 +128,12 @@
 
 ## Latest Quality Pass
 
+- Unsent composer text now uses a private, owner-bound, size-limited checkpoint after a short typing
+  debounce, with immediate app-deactivation and quit flushes. The live model updates synchronously so
+  unrelated background surface refreshes cannot erase typing during that delay. New chats gain one
+  durable baseline before sidecar-only updates; relaunch restores pending first messages and per-chat
+  drafts, tombstones prevent sent text from returning, oversized records fall back to the established
+  full-thread snapshot, and confidential/side drafts never reach disk.
 - Packaged macOS launches now register an atomic, cross-process-locked, privacy-safe launch sentinel
   before workspace construction, mark Ready only after the first native root view appears, and clear
   only a matching launch on graceful termination. A fresh dead-process marker produces one native

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -16,6 +16,9 @@ BROWSER_WORKFLOW_MANIFEST="$SMOKE_ROOT/packaged-browser-workflow.json"
 COMPUTER_USE_MANIFEST="$SMOKE_ROOT/packaged-computer-use.json"
 COMPUTER_USE_ACTION_MANIFEST="$SMOKE_ROOT/packaged-computer-use-action.json"
 PERFORMANCE_MANIFEST="$SMOKE_ROOT/packaged-performance.json"
+COMPOSER_DRAFT_CRASH_STATE_ROOT="$SMOKE_ROOT/composer-draft-crash-state"
+COMPOSER_DRAFT_CRASH_WRITE_LOG="$SMOKE_ROOT/composer-draft-crash-write.log"
+COMPOSER_DRAFT_CRASH_VERIFY_LOG="$SMOKE_ROOT/composer-draft-crash-verify.log"
 WINDOW_REPORT_PATH="$SMOKE_ROOT/window-report.json"
 WINDOW_SCREENSHOT_PATH="$SMOKE_ROOT/window.png"
 WINDOW_STATE_ROOT="$SMOKE_ROOT/window-state"
@@ -69,6 +72,12 @@ cleanup() {
     if [[ -e "$PERFORMANCE_MANIFEST" ]]; then
       cp "$PERFORMANCE_MANIFEST" "$ARTIFACT_DIR/packaged-performance.json"
     fi
+    if [[ -e "$COMPOSER_DRAFT_CRASH_WRITE_LOG" ]]; then
+      cp "$COMPOSER_DRAFT_CRASH_WRITE_LOG" "$ARTIFACT_DIR/composer-draft-crash-write.log"
+    fi
+    if [[ -e "$COMPOSER_DRAFT_CRASH_VERIFY_LOG" ]]; then
+      cp "$COMPOSER_DRAFT_CRASH_VERIFY_LOG" "$ARTIFACT_DIR/composer-draft-crash-verify.log"
+    fi
     if [[ -e "$WINDOW_REPORT_PATH" ]]; then
       cp "$WINDOW_REPORT_PATH" "$ARTIFACT_DIR/window-report.json"
     fi
@@ -94,6 +103,8 @@ cleanup() {
       printf 'computer_use_manifest=packaged-computer-use.json\n'
       printf 'computer_use_action_manifest=packaged-computer-use-action.json\n'
       printf 'performance_manifest=packaged-performance.json\n'
+      printf 'composer_draft_crash_write=composer-draft-crash-write.log\n'
+      printf 'composer_draft_crash_verify=composer-draft-crash-verify.log\n'
       printf 'window_smoke=window-report.json\n'
       printf 'window_screenshot=window.png\n'
     } > "$ARTIFACT_DIR/manifest.txt"
@@ -175,6 +186,43 @@ assert_plist_value QuillCodeUpdateChannel tester
 assert_plist_value QuillCodeUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
 assert_plist_value QuillCodeStableUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json
 assert_plist_value QuillCodeTesterUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
+
+echo "==> Running packaged composer draft SIGKILL recovery smoke"
+"$APP_EXECUTABLE" \
+  --composer-draft-crash-smoke \
+  --composer-draft-crash-phase write \
+  --composer-draft-crash-state-root "$COMPOSER_DRAFT_CRASH_STATE_ROOT" \
+  >"$COMPOSER_DRAFT_CRASH_WRITE_LOG" 2>&1 &
+COMPOSER_DRAFT_CRASH_PID="$!"
+set +e
+wait_for_smoke_process \
+  "$COMPOSER_DRAFT_CRASH_PID" \
+  15 \
+  "Packaged composer draft SIGKILL writer"
+COMPOSER_DRAFT_CRASH_STATUS="$?"
+set -e
+if [[ "$COMPOSER_DRAFT_CRASH_STATUS" -ne 137 ]]; then
+  echo "Packaged composer draft writer expected SIGKILL status 137 but found $COMPOSER_DRAFT_CRASH_STATUS." >&2
+  cat "$COMPOSER_DRAFT_CRASH_WRITE_LOG" >&2
+  exit 1
+fi
+
+(
+  "$APP_EXECUTABLE" \
+    --composer-draft-crash-smoke \
+    --composer-draft-crash-phase verify \
+    --composer-draft-crash-state-root "$COMPOSER_DRAFT_CRASH_STATE_ROOT" \
+    >"$COMPOSER_DRAFT_CRASH_VERIFY_LOG" 2>&1
+) &
+COMPOSER_DRAFT_VERIFY_PID="$!"
+if ! wait_for_smoke_process \
+  "$COMPOSER_DRAFT_VERIFY_PID" \
+  15 \
+  "Packaged composer draft recovery verifier"
+then
+  cat "$COMPOSER_DRAFT_CRASH_VERIFY_LOG" >&2
+  exit 1
+fi
 
 QUILLCODE_DESKTOP_EXECUTABLE="$APP_EXECUTABLE" \
 QUILLCODE_NATIVE_DESKTOP_SMOKE_LABEL="packaged macOS app" \


### PR DESCRIPTION
## Summary
- checkpoint live unsent composer text through bounded private per-chat sidecars
- debounce typing while flushing navigation, deactivation, termination, send, retry, and local command boundaries safely
- add packaged SIGKILL/relaunch recovery proof plus lifecycle, privacy, fallback, and race coverage

## Verification
- swift test: 5,804 tests, 5 skipped, 0 failures
- focused desktop controller/checkpoint cluster: 36 tests, 0 failures
- packaged macOS smoke: SIGKILL recovery, direct executable, Launch Services, accessibility, interactions, screenshots, and Computer Use passed
- packaged performance: 277.41 ms median ready; 98.62 MiB initial; 155.12 MiB post-interaction; 159.81 MiB repeated
- code quality audit: all module averages A+
- git diff --check