### PR TITLE
Bound streaming progress work

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ inactive or quits. Quill Cowork restores that text after an unexpected exit with
 potentially large chat transcript on every keystroke. Checkpoints are private, bounded, and scoped to
 one chat; confidential-chat text is never written to them.
 
+Live model output is also bounded and projected to the interface at display cadence instead of once
+per provider token. The first useful text remains immediate, the exact final draft is preserved across
+success and connection failure, and an oversized response offers a direct model-switch recovery path.
+
 Choosing **Remind Me Tomorrow** defers only that exact update for 24 hours, including across app
 restarts. A newer build appears on the normal check cadence, and **Check for Updates...** always
 overrides the reminder. The app reopens its already-verified update state at the deadline without an

--- a/Sources/QuillCodeAgent/AgentActionStreaming.swift
+++ b/Sources/QuillCodeAgent/AgentActionStreaming.swift
@@ -8,10 +8,20 @@ public enum AgentTextStreamEvent: Sendable, Hashable {
 }
 
 public enum AgentActionStreamCollector {
+    /// A model action is one JSON object, not an artifact transport. Keep enough room for large
+    /// patches while preventing an unbounded or malformed provider stream from exhausting the app.
+    public static let maximumActionUTF8Bytes = 16 * 1_024 * 1_024
+
     public static func collectText(from stream: AsyncThrowingStream<String, Error>) async throws -> String {
         var text = ""
+        var receivedBytes = 0
         for try await chunk in stream {
             try Task.checkCancellation()
+            receivedBytes = try checkedByteCount(
+                current: receivedBytes,
+                adding: chunk.utf8.count,
+                maximum: maximumActionUTF8Bytes
+            )
             text.append(chunk)
         }
         return text
@@ -45,37 +55,89 @@ public enum AgentActionStreamCollector {
         onUsage: ((ModelTokenUsage) async -> Void)?,
         onReasoning: ((String) async -> Void)? = nil
     ) async throws -> AgentAction {
+        try await collect(
+            from: stream,
+            emptyError: emptyError(),
+            onVisibleAssistantText: onVisibleAssistantText,
+            onUsage: onUsage,
+            onReasoning: onReasoning,
+            maximumActionUTF8Bytes: maximumActionUTF8Bytes,
+            previewIntervalNanoseconds: AgentStreamingProgressCadence.minimumIntervalNanoseconds,
+            nowNanoseconds: { DispatchTime.now().uptimeNanoseconds }
+        )
+    }
+
+    /// Internal deterministic seam for limit/cadence coverage. Production callers use the public
+    /// overload above so every provider shares one response budget and one presentation cadence.
+    static func collect(
+        from stream: AsyncThrowingStream<AgentTextStreamEvent, Error>,
+        emptyError: @autoclosure () -> any Error,
+        onVisibleAssistantText: ((String) async -> Void)?,
+        onUsage: ((ModelTokenUsage) async -> Void)?,
+        onReasoning: ((String) async -> Void)?,
+        maximumActionUTF8Bytes: Int,
+        previewIntervalNanoseconds: UInt64,
+        nowNanoseconds: @escaping () -> UInt64
+    ) async throws -> AgentAction {
+        precondition(maximumActionUTF8Bytes > 0)
         var rawActionText = ""
-        var lastVisibleText = ""
+        var receivedBytes = 0
+        var preview = AgentVisibleAssistantPreviewCadence(
+            minimumIntervalNanoseconds: previewIntervalNanoseconds
+        )
         var lastReasoningText = ""
-        for try await event in stream {
-            try Task.checkCancellation()
-            switch event {
-            case .text(let chunk):
-                rawActionText.append(chunk)
-                guard let visibleText = AgentActionStreamPreview.visibleAssistantText(from: rawActionText),
-                      !visibleText.isEmpty,
-                      !AgentPromisedWorkGuard.shouldSuppressStreamingPreview(for: visibleText),
-                      visibleText != lastVisibleText
-                else {
-                    continue
+
+        do {
+            for try await event in stream {
+                try Task.checkCancellation()
+                switch event {
+                case .text(let chunk):
+                    receivedBytes = try checkedByteCount(
+                        current: receivedBytes,
+                        adding: chunk.utf8.count,
+                        maximum: maximumActionUTF8Bytes
+                    )
+                    rawActionText.append(chunk)
+                    if let visibleText = preview.nextPreview(
+                        from: rawActionText,
+                        nowNanoseconds: nowNanoseconds()
+                    ) {
+                        await onVisibleAssistantText?(visibleText)
+                    }
+                case .reasoning(let fragment):
+                    // Preserve boundary whitespace: several providers emit reasoning one token at a
+                    // time, and trimming here would join words in the accumulated presentation.
+                    guard !fragment.isEmpty, fragment != lastReasoningText else {
+                        continue
+                    }
+                    lastReasoningText = fragment
+                    await onReasoning?(fragment)
+                case .usage(let usage):
+                    await onUsage?(usage)
                 }
-                lastVisibleText = visibleText
-                await onVisibleAssistantText?(visibleText)
-            case .reasoning(let fragment):
-                // Preserve boundary whitespace: several providers emit reasoning one token at a
-                // time, and trimming here would join words in the accumulated presentation.
-                guard !fragment.isEmpty, fragment != lastReasoningText else {
-                    continue
-                }
-                lastReasoningText = fragment
-                await onReasoning?(fragment)
-            case .usage(let usage):
-                await onUsage?(usage)
             }
+        } catch {
+            if let visibleText = preview.finalPreview(from: rawActionText) {
+                await onVisibleAssistantText?(visibleText)
+            }
+            throw error
         }
 
+        if let visibleText = preview.finalPreview(from: rawActionText) {
+            await onVisibleAssistantText?(visibleText)
+        }
         return try parseAction(from: rawActionText, emptyError: emptyError())
+    }
+
+    private static func checkedByteCount(
+        current: Int,
+        adding additional: Int,
+        maximum: Int
+    ) throws -> Int {
+        guard additional <= maximum - current else {
+            throw AgentError.streamingActionTooLarge(maximumBytes: maximum)
+        }
+        return current + additional
     }
 
     static func parseAction(from text: String, emptyError: @autoclosure () -> any Error) throws -> AgentAction {
@@ -107,10 +169,18 @@ extension AsyncThrowingStream where Element == String, Failure == Error {
 
 public enum AgentActionStreamPreview {
     public static func visibleAssistantText(from rawActionText: String) -> String? {
-        guard partialJSONStringValue(for: "type", in: rawActionText) == "say" else {
+        guard streamedActionType(from: rawActionText) == "say" else {
             return nil
         }
-        return partialJSONStringValue(for: "text", in: rawActionText)
+        return visibleAssistantTextForKnownSayAction(from: rawActionText)
+    }
+
+    static func streamedActionType(from rawActionText: String) -> String? {
+        partialJSONStringValue(for: "type", in: rawActionText)
+    }
+
+    static func visibleAssistantTextForKnownSayAction(from rawActionText: String) -> String? {
+        partialJSONStringValue(for: "text", in: rawActionText)
     }
 
     private static func partialJSONStringValue(for key: String, in text: String) -> String? {

--- a/Sources/QuillCodeAgent/AgentStreamingProgressCadence.swift
+++ b/Sources/QuillCodeAgent/AgentStreamingProgressCadence.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Keeps provider token cadence separate from presentation cadence. The desktop projects progress
+/// every 50 ms; rebuilding a growing answer and a full thread more often only creates quadratic
+/// parsing/copying work that cannot become visible. The first usable text remains immediate and the
+/// terminal path always forces the newest preview through.
+struct AgentVisibleAssistantPreviewCadence {
+    private let minimumIntervalNanoseconds: UInt64
+    private var actionType: String?
+    private var lastInspectionNanoseconds: UInt64?
+    private var lastPublishedText = ""
+
+    init(minimumIntervalNanoseconds: UInt64) {
+        self.minimumIntervalNanoseconds = minimumIntervalNanoseconds
+    }
+
+    mutating func nextPreview(from rawActionText: String, nowNanoseconds: UInt64) -> String? {
+        if actionType == nil {
+            actionType = AgentActionStreamPreview.streamedActionType(from: rawActionText)
+        }
+        guard actionType == "say" else { return nil }
+        if let lastInspectionNanoseconds,
+           nowNanoseconds >= lastInspectionNanoseconds,
+           nowNanoseconds - lastInspectionNanoseconds < minimumIntervalNanoseconds {
+            return nil
+        }
+        return inspect(rawActionText, nowNanoseconds: nowNanoseconds)
+    }
+
+    mutating func finalPreview(from rawActionText: String) -> String? {
+        if actionType == nil {
+            actionType = AgentActionStreamPreview.streamedActionType(from: rawActionText)
+        }
+        guard actionType == "say" else { return nil }
+        return inspect(rawActionText, nowNanoseconds: nil)
+    }
+
+    private mutating func inspect(
+        _ rawActionText: String,
+        nowNanoseconds: UInt64?
+    ) -> String? {
+        guard let visibleText = AgentActionStreamPreview
+            .visibleAssistantTextForKnownSayAction(from: rawActionText),
+              !visibleText.isEmpty
+        else {
+            return nil
+        }
+        if let nowNanoseconds {
+            lastInspectionNanoseconds = nowNanoseconds
+        }
+        guard visibleText != lastPublishedText,
+              !AgentPromisedWorkGuard.shouldSuppressStreamingPreview(for: visibleText)
+        else {
+            return nil
+        }
+        lastPublishedText = visibleText
+        return visibleText
+    }
+}
+
+enum AgentStreamingProgressCadence {
+    static let minimumIntervalNanoseconds: UInt64 = 50_000_000
+}

--- a/Sources/QuillCodeAgent/AgentTypes.swift
+++ b/Sources/QuillCodeAgent/AgentTypes.swift
@@ -30,9 +30,10 @@ public enum AgentError: Error, CustomStringConvertible {
     case emptyStreamingResponse
     case promisedWorkWithoutToolAction
     case tooManyToolSteps(Int)
+    case missingNamedDeliverable(String)
     // Appended last: never insert enum cases mid-list — discriminants shift and stale incremental
     // builds misread persisted values.
-    case missingNamedDeliverable(String)
+    case streamingActionTooLarge(maximumBytes: Int)
 
     public var description: String {
         switch self {
@@ -44,6 +45,12 @@ public enum AgentError: Error, CustomStringConvertible {
             return "The agent reached the tool-step limit (\(limit)) before returning a final answer."
         case .missingNamedDeliverable(let path):
             return "The run ended without creating the task-required file \(path)."
+        case .streamingActionTooLarge(let maximumBytes):
+            let mebibyte = 1_024 * 1_024
+            let limit = maximumBytes >= mebibyte && maximumBytes.isMultiple(of: mebibyte)
+                ? "\(maximumBytes / mebibyte) MiB"
+                : "\(maximumBytes) bytes"
+            return "The model response exceeded the \(limit) action safety limit."
         }
     }
 }

--- a/Sources/QuillCodeAgent/AgentUsageStreamActionCollector.swift
+++ b/Sources/QuillCodeAgent/AgentUsageStreamActionCollector.swift
@@ -26,12 +26,19 @@ extension AgentRunner {
                 },
                 onReasoning: { fragment in
                     sawReasoning = true
-                    guard let summary = reasoning.append(fragment) else { return }
+                    guard let summary = reasoning.appendThrottled(
+                        fragment,
+                        nowNanoseconds: DispatchTime.now().uptimeNanoseconds
+                    ) else { return }
                     publishReasoningSummary(summary, in: &draftThread)
                     await onProgress?(draftThread)
                 }
             )
 
+            if let summary = reasoning.finalPendingSummary() {
+                publishReasoningSummary(summary, in: &draftThread)
+                await onProgress?(draftThread)
+            }
             thread = draftThread
             if let latestUsage {
                 thread.events.append(ModelTokenUsageEvent.event(usage: latestUsage, modelID: thread.model))
@@ -43,6 +50,10 @@ extension AgentRunner {
             // Failed completions still cost tokens and may have published visible reasoning. Commit
             // both to the durable thread before classifying the failure so the spend fuse and UI
             // never lose accounting for corrective attempts.
+            if let summary = reasoning.finalPendingSummary() {
+                publishReasoningSummary(summary, in: &draftThread)
+                await onProgress?(draftThread)
+            }
             thread = draftThread
             if let latestUsage {
                 thread.events.append(ModelTokenUsageEvent.event(usage: latestUsage, modelID: thread.model))
@@ -66,8 +77,34 @@ struct AgentReasoningStreamAccumulator {
 
     private(set) var text = ""
     private var lastPublishedText = ""
+    private var lastPublishedNanoseconds: UInt64?
 
     mutating func append(_ fragment: String) -> String? {
+        guard let presentation = appendFragment(fragment) else { return nil }
+        lastPublishedText = presentation
+        return presentation
+    }
+
+    mutating func appendThrottled(_ fragment: String, nowNanoseconds: UInt64) -> String? {
+        guard let presentation = appendFragment(fragment) else { return nil }
+        if let lastPublishedNanoseconds,
+           nowNanoseconds >= lastPublishedNanoseconds,
+           nowNanoseconds - lastPublishedNanoseconds < AgentStreamingProgressCadence.minimumIntervalNanoseconds {
+            return nil
+        }
+        self.lastPublishedNanoseconds = nowNanoseconds
+        lastPublishedText = presentation
+        return presentation
+    }
+
+    mutating func finalPendingSummary() -> String? {
+        let presentation = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !presentation.isEmpty, presentation != lastPublishedText else { return nil }
+        lastPublishedText = presentation
+        return presentation
+    }
+
+    private mutating func appendFragment(_ fragment: String) -> String? {
         guard !fragment.isEmpty else { return nil }
 
         if fragment.count > Self.maximumCharacters {
@@ -83,7 +120,6 @@ struct AgentReasoningStreamAccumulator {
 
         let presentation = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !presentation.isEmpty, presentation != lastPublishedText else { return nil }
-        lastPublishedText = presentation
         return presentation
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceRuntimeIssueBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceRuntimeIssueBuilder.swift
@@ -147,6 +147,17 @@ struct WorkspaceRuntimeIssueBuilder: Sendable, Hashable {
                 recovery: .retry(reason: .emptyResponse)
             )
         }
+        if normalized.contains("model response exceeded") &&
+            normalized.contains("action safety limit") {
+            return RuntimeIssueSurface(
+                severity: .warning,
+                title: "Model response was too large",
+                message: "The selected model exceeded Quill Cowork's safe response limit. " +
+                    "Retry with a narrower request or switch models.",
+                actionLabel: "Switch model",
+                recovery: .modelPicker(reason: .malformedModelAction)
+            )
+        }
         if normalized.contains("valid quillcode action json") || normalized.contains("empty argument object") {
             return RuntimeIssueSurface(
                 severity: .warning,

--- a/Tests/QuillCodeAgentTests/TrustedRouterStreamingActionTests.swift
+++ b/Tests/QuillCodeAgentTests/TrustedRouterStreamingActionTests.swift
@@ -46,6 +46,78 @@ final class TrustedRouterStreamingActionTests: XCTestCase {
         XCTAssertEqual(action, .say("hello"))
     }
 
+    func testCollectActionCoalescesRapidVisibleDraftsAndFlushesFinalText() async throws {
+        let finalText = String(repeating: "x", count: 4_096)
+        let events = [AgentTextStreamEvent.text(#"{"type":"say","text":""#)]
+            + finalText.map { .text(String($0)) }
+            + [.text(#""}"#)]
+        var drafts: [String] = []
+
+        let action = try await AgentActionStreamCollector.collect(
+            from: eventStream(events),
+            emptyError: AgentError.emptyStreamingResponse,
+            onVisibleAssistantText: { drafts.append($0) },
+            onUsage: nil,
+            onReasoning: nil,
+            maximumActionUTF8Bytes: 32 * 1_024,
+            previewIntervalNanoseconds: 50_000_000,
+            nowNanoseconds: { 1 }
+        )
+
+        XCTAssertEqual(action, .say(finalText))
+        XCTAssertEqual(drafts.count, 2)
+        XCTAssertEqual(drafts.first, "x")
+        XCTAssertEqual(drafts.last, finalText)
+    }
+
+    func testCollectActionFlushesLatestSafePreviewBeforeStreamFailure() async {
+        var drafts: [String] = []
+        let brokenStream = AsyncThrowingStream<AgentTextStreamEvent, Error> { continuation in
+            continuation.yield(.text(#"{"type":"say","text":""#))
+            continuation.yield(.text("hel"))
+            continuation.yield(.text("lo"))
+            continuation.finish(throwing: StreamingProbeError.disconnected)
+        }
+
+        do {
+            _ = try await AgentActionStreamCollector.collect(
+                from: brokenStream,
+                emptyError: AgentError.emptyStreamingResponse,
+                onVisibleAssistantText: { drafts.append($0) },
+                onUsage: nil,
+                onReasoning: nil,
+                maximumActionUTF8Bytes: 1_024,
+                previewIntervalNanoseconds: 50_000_000,
+                nowNanoseconds: { 1 }
+            )
+            XCTFail("Expected the provider stream failure")
+        } catch StreamingProbeError.disconnected {
+            XCTAssertEqual(drafts, ["hel", "hello"])
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testCollectActionRejectsResponseBeyondUTF8ByteBudget() async {
+        do {
+            _ = try await AgentActionStreamCollector.collect(
+                from: eventStream([.text(String(repeating: "x", count: 33))]),
+                emptyError: AgentError.emptyStreamingResponse,
+                onVisibleAssistantText: nil,
+                onUsage: nil,
+                onReasoning: nil,
+                maximumActionUTF8Bytes: 32,
+                previewIntervalNanoseconds: 50_000_000,
+                nowNanoseconds: { 1 }
+            )
+            XCTFail("Expected the response budget to reject the stream")
+        } catch let AgentError.streamingActionTooLarge(maximumBytes) {
+            XCTAssertEqual(maximumBytes, 32)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     func testCollectActionPublishesReasoningSummariesSeparatelyFromText() async throws {
         var reasoning: [String] = []
         let action = try await AgentActionStreamCollector.collect(
@@ -92,6 +164,16 @@ final class TrustedRouterStreamingActionTests: XCTestCase {
         XCTAssertEqual(accumulator.text, "First second")
     }
 
+    func testReasoningAccumulatorCoalescesRapidProgressAndFlushesFinalSummary() {
+        var accumulator = AgentReasoningStreamAccumulator()
+
+        XCTAssertEqual(accumulator.appendThrottled("First", nowNanoseconds: 1), "First")
+        XCTAssertNil(accumulator.appendThrottled(" second", nowNanoseconds: 2))
+        XCTAssertNil(accumulator.appendThrottled(" third", nowNanoseconds: 3))
+        XCTAssertEqual(accumulator.finalPendingSummary(), "First second third")
+        XCTAssertNil(accumulator.finalPendingSummary())
+    }
+
     func testStreamingPreviewExposesOnlySayText() {
         XCTAssertEqual(
             AgentActionStreamPreview.visibleAssistantText(from: #"{"type":"say","text":"hello\nwor"#),
@@ -118,4 +200,8 @@ final class TrustedRouterStreamingActionTests: XCTestCase {
             continuation.finish()
         }
     }
+}
+
+private enum StreamingProbeError: Error {
+    case disconnected
 }

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueBuilderTests.swift
@@ -138,6 +138,22 @@ final class WorkspaceRuntimeIssueBuilderTests: XCTestCase {
         XCTAssertTrue(issue?.message.contains(TrustedRouterDefaults.prometheusModelDisplayName) == true)
     }
 
+    func testOversizedResponseOffersFocusedModelRecovery() {
+        let issue = WorkspaceRuntimeIssueBuilder.issue(
+            from: "The model response exceeded the 16 MiB action safety limit.",
+            config: AppConfig()
+        )
+
+        XCTAssertEqual(issue?.severity, .warning)
+        XCTAssertEqual(issue?.title, "Model response was too large")
+        XCTAssertEqual(issue?.actionLabel, "Switch model")
+        XCTAssertEqual(issue?.recovery, RuntimeRecoveryTelemetry(
+            route: .modelPicker,
+            reason: .malformedModelAction
+        ))
+        XCTAssertTrue(issue?.message.contains("narrower request") == true)
+    }
+
     func testRejectedKeyIssueUsesSettingsRecoveryTelemetry() {
         let issue = WorkspaceRuntimeIssueBuilder.issue(
             from: "HTTP 401 invalid api key",

--- a/Tests/QuillCodeParityTests/ParityAgentStreamingGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAgentStreamingGateTests.swift
@@ -5,6 +5,7 @@ final class ParityAgentStreamingGateTests: QuillCodeParityTestCase {
         let agentText = try Self.agentSourceText(named: "Agent.swift")
         let actionResolverText = try Self.agentSourceText(named: "AgentActionResolver.swift")
         let streamingText = try Self.agentSourceText(named: "AgentActionStreaming.swift")
+        let cadenceText = try Self.agentSourceText(named: "AgentStreamingProgressCadence.swift")
         let textRunnerText = try Self.agentSourceText(named: "AgentTextStreamActionRunner.swift")
         let usageRunnerText = try Self.agentSourceText(named: "AgentUsageStreamActionRunner.swift")
         let rawCollectorText = try Self.agentSourceText(named: "AgentRawTextStreamActionCollector.swift")
@@ -16,7 +17,18 @@ final class ParityAgentStreamingGateTests: QuillCodeParityTestCase {
             "public enum AgentActionStreamCollector",
             "public enum AgentActionStreamPreview",
             "var rawActionText",
-            "AgentActionStreamPreview.visibleAssistantText"
+            "maximumActionUTF8Bytes",
+            "streamingActionTooLarge"
+        ])
+        Self.assertSource(streamingText, containsAll: [
+            "AgentVisibleAssistantPreviewCadence",
+            "AgentStreamingProgressCadence.minimumIntervalNanoseconds"
+        ])
+        Self.assertSource(cadenceText, containsAll: [
+            "struct AgentVisibleAssistantPreviewCadence",
+            "enum AgentStreamingProgressCadence",
+            "minimumIntervalNanoseconds: UInt64 = 50_000_000",
+            "finalPreview"
         ])
         Self.assertSource(actionResolverText, containsAll: [
             "nextTextStreamingAction",
@@ -27,6 +39,10 @@ final class ParityAgentStreamingGateTests: QuillCodeParityTestCase {
         Self.assertSource(rawCollectorText, contains: "AgentActionStreamCollector.collect")
         Self.assertSource(textCollectorText, contains: "AgentActionStreamCollector.collect")
         Self.assertSource(usageCollectorText, contains: "AgentActionStreamCollector.collect")
+        Self.assertSource(usageCollectorText, containsAll: [
+            "appendThrottled",
+            "finalPendingSummary"
+        ])
         Self.assertSource(draftPublisherText, containsAll: [
             "publishAssistantDraft",
             "publishReasoningSummary"

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -26,6 +26,31 @@ Validation:
 - `python3 scripts/grade-code-quality.py --root .`
 - `git diff --check`
 
+## 2026-08-10 Bounded Streaming Presentation Cadence
+
+Overall grade after this slice: **A+ bounded streaming, A+ progress efficiency, A+ failure recovery**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Response bounds | A+ | Every streamed action shares a 16 MiB UTF-8 limit, checked before append with a typed error and focused desktop recovery. |
+| Presentation efficiency | A+ | Visible drafts and bounded reasoning summaries publish at the existing 50 ms desktop cadence instead of rebuilding growing JSON and thread snapshots for every provider token. |
+| Per-action work | A+ | Once a stream is classified as a tool action, preview parsing stops; answer streams retain immediate first text and a forced exact terminal preview. |
+| Failure semantics | A+ | The latest safe answer and reasoning summary flush before a stream error propagates, while usage remains committed through the existing failure path. |
+| Architecture | A+ | Cadence policy lives in a focused agent type and is shared by answer and reasoning projection without coupling provider transport to SwiftUI. |
+| Regression evidence | A+ | Deterministic tests reduce 4,096 rapid fragments to two draft callbacks and cover success/error flushing, UTF-8 overflow, reasoning coalescing, recovery UX, and parity ownership. |
+
+Validation:
+
+- `swift test --filter 'TrustedRouterStreamingActionTests|AgentStreamingTests|WorkspaceRuntimeIssueBuilderTests|ParityAgentStreamingGateTests'` (35 tests, 0 failures)
+- `swift test --filter 'AgentMalformedActionRecoveryTests|AgentPromisedWorkGuardTests|AgentStreamingTests|RetryingLLMClientTests|ParityAgentStreamingGateTests|ParityTrustedRouterActionParsingGateTests'` (77 tests, 0 failures)
+- Full Swift suite: 5,809 tests, 5 skipped, 0 failures
+- Packaged direct-executable, Launch Services, SIGKILL draft recovery, live-window, Accessibility,
+  and two-pass interaction smokes passed
+- Packaged performance passed 3/3 fresh processes: 272.59 ms median launch-ready, 98.80 MiB
+  initial RSS, 158.42 MiB after interaction, and 163.12 MiB after repeated interaction
+- `python3 scripts/grade-code-quality.py --root .`
+- `git diff --check`
+
 ## 2026-08-10 Durable Update Reminders
 
 Overall grade after this slice: **A+ interruption UX, A+ update freshness, A+ bounded persistence**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # QuillCode Decisions
 
+## 2026-08-10: model streams publish at presentation cadence
+
+- **Decision:** Provider token cadence is no longer desktop presentation cadence. Visible assistant
+  drafts and reasoning summaries publish at most every 50 milliseconds while preserving an immediate
+  first update and an exact final flush on both successful and failed streams.
+- **Memory and CPU boundary:** A streamed action is limited to 16 MiB of UTF-8. The collector stops
+  before appending an over-limit chunk, and non-`say` actions stop repeated preview parsing as soon as
+  their action type is known. This bounds retained response data and removes provider-token-driven
+  parsing and full-thread copying that cannot become visible.
+- **Recovery:** An over-limit response becomes a focused warning with narrower-request guidance and a
+  direct model-picker action. Usage and the latest bounded reasoning summary remain committed on
+  failure, and the newest safe visible draft is not discarded when a provider disconnects.
+- **Evidence:** `TrustedRouterStreamingActionTests` deterministically reduces a 4,096-fragment answer
+  to two draft publications under one cadence window, verifies success and failure final flushes, and
+  rejects UTF-8 overflow. `WorkspaceRuntimeIssueBuilderTests` and `ParityAgentStreamingGateTests`
+  protect the recovery surface, shared cadence, final-flush ownership, and response limit.
+
 ## 2026-08-10: live composer drafts checkpoint outside large transcripts
 
 - **Decision:** The desktop synchronizes its live composer binding into model memory immediately, then

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -128,6 +128,11 @@
 
 ## Latest Quality Pass
 
+- Model streaming now separates provider-token cadence from presentation cadence: visible answer
+  drafts and bounded reasoning summaries publish at most every 50 milliseconds, with immediate first
+  text and an exact final flush on success or provider failure. A shared 16 MiB UTF-8 action limit
+  prevents malformed or runaway streams from exhausting the desktop, non-answer tool JSON stops
+  repeated preview parsing after classification, and an overflow opens focused model-switch recovery.
 - Unsent composer text now uses a private, owner-bound, size-limited checkpoint after a short typing
   debounce, with immediate app-deactivation and quit flushes. The live model updates synchronously so
   unrelated background surface refreshes cannot erase typing during that delay. New chats gain one


### PR DESCRIPTION
## Summary
- cap streamed model actions at 16 MiB and surface focused model recovery
- coalesce visible answer and reasoning progress at the desktop presentation cadence
- preserve exact terminal previews on success and provider failure

## Verification
- swift test: 5,809 tests, 5 skipped, 0 failures
- packaged macOS direct, Launch Services, SIGKILL recovery, Accessibility, and interaction smokes passed
- packaged performance: 3/3 fresh launches, 272.59 ms median, 98.80 MiB initial, 163.12 MiB repeated
- deterministic code-quality grader: all modules A+
- git diff --check