### PR TITLE
Optimize desktop progress surface refreshes

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -98,9 +98,145 @@ public struct WorkspaceSurface: Codable, Sendable, Hashable {
     }
 }
 
+/// Identifies the model regions that can change during a coalesced progress update.
+/// Full refreshes remain authoritative; these scopes only avoid rebuilding unrelated,
+/// potentially filesystem-backed presentation state between progress callbacks.
+public struct WorkspaceProgressSurfaceScope: OptionSet, Sendable, Hashable {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let agent = WorkspaceProgressSurfaceScope(rawValue: 1 << 0)
+    public static let terminal = WorkspaceProgressSurfaceScope(rawValue: 1 << 1)
+}
+
+private struct WorkspaceAgentProgressSurface {
+    var chrome: WorkspaceChromeSurface
+    var topBar: TopBarSurface
+    var projects: ProjectListSurface
+    var sidebar: SidebarSurface
+    var transcript: TranscriptSurface
+    var contextBanner: ContextBannerSurface?
+    var sideConversation: SideConversationSurface?
+    var isConfidential: Bool
+    var codeReviewRequest: WorkspaceCodeReviewRequest?
+    var autoReviewDenials: AutoReviewDenialsSurface?
+    var review: WorkspaceReviewSurface
+    var browser: BrowserSurface
+    var extensions: WorkspaceExtensionsSurface
+    var memories: WorkspaceMemoriesSurface
+    var activity: WorkspaceActivitySurface
+    var composer: ComposerSurface
+    var fileMentionIndex: WorkspaceFileIndex
+    var changedFilePaths: Set<String>
+    var commands: [WorkspaceCommandSurface]
+    var runtimeIssue: RuntimeIssueSurface?
+    var lastError: String?
+    var attentionDigest: AttentionDigestSurface?
+
+    func apply(to surface: inout WorkspaceSurface) {
+        surface.chrome = chrome
+        surface.topBar = topBar
+        surface.projects = projects
+        surface.sidebar = sidebar
+        surface.transcript = transcript
+        surface.contextBanner = contextBanner
+        surface.sideConversation = sideConversation
+        surface.isConfidential = isConfidential
+        surface.codeReviewRequest = codeReviewRequest
+        surface.autoReviewDenials = autoReviewDenials
+        surface.review = review
+        surface.browser = browser
+        surface.extensions = extensions
+        surface.memories = memories
+        surface.activity = activity
+        surface.composer = composer
+        surface.fileMentionIndex = fileMentionIndex
+        surface.changedFilePaths = changedFilePaths
+        surface.commands = commands
+        surface.runtimeIssue = runtimeIssue
+        surface.lastError = lastError
+        surface.attentionDigest = attentionDigest
+    }
+}
+
 @MainActor
 public extension QuillCodeWorkspaceModel {
     func surface() -> WorkspaceSurface {
+        let progress = agentProgressSurface()
+        return WorkspaceSurface(
+            chrome: progress.chrome,
+            topBar: progress.topBar,
+            projects: progress.projects,
+            sidebar: progress.sidebar,
+            transcript: progress.transcript,
+            contextBanner: progress.contextBanner,
+            sideConversation: progress.sideConversation,
+            isConfidential: progress.isConfidential,
+            codeReviewRequest: progress.codeReviewRequest,
+            autoReviewDenials: progress.autoReviewDenials,
+            review: progress.review,
+            terminal: terminalSurface(),
+            browser: progress.browser,
+            extensions: progress.extensions,
+            memories: progress.memories,
+            activity: progress.activity,
+            automations: WorkspaceAutomationsSurfaceBuilder(
+                isVisible: automations.isVisible,
+                automations: automations.items,
+                hasSelectedThread: selectedThread != nil,
+                hasSelectedProject: selectedProject != nil
+            ).surface(),
+            composer: progress.composer,
+            fileMentionIndex: progress.fileMentionIndex,
+            changedFilePaths: progress.changedFilePaths,
+            commands: progress.commands,
+            settings: WorkspaceSettingsSurface(
+                config: root.config,
+                hasStoredAPIKey: root.trustedRouterAPIKeyConfigured,
+                runtimeIssue: progress.runtimeIssue,
+                computerUseRuntime: ComputerUseSettingsRuntime(topBarState: root.topBar),
+                modelCatalogStatus: root.modelCatalogStatus,
+                modelProviderHealthSummary: ModelProviderHealthSummary.summarize(root.modelCatalog),
+                trustedRouterCredits: root.trustedRouterCredits,
+                managedWorktreeDefaultRoot: managedWorktreeDefaultRoot
+            ),
+            worktreeEnvironments: selectedProject.flatMap { project in
+                guard !project.isRemote else { return nil }
+                return WorkspaceProjectConfigurationLoader
+                    .load(from: URL(fileURLWithPath: project.path))
+                    .worktreeEnvironmentSurface
+            } ?? WorkspaceWorktreeEnvironmentSurface(),
+            runtimeIssue: progress.runtimeIssue,
+            lastError: progress.lastError,
+            attentionDigest: progress.attentionDigest
+        )
+    }
+
+    /// Reprojects only state that the named progress producers are allowed to mutate.
+    /// The returned value preserves all other value-semantic storage from `surface`.
+    func progressSurface(
+        reusing surface: WorkspaceSurface,
+        scope: WorkspaceProgressSurfaceScope
+    ) -> WorkspaceSurface {
+        guard !scope.isEmpty else { return surface }
+        var next = surface
+        if scope.contains(.agent) {
+            agentProgressSurface().apply(to: &next)
+        }
+        if scope.contains(.terminal) {
+            next.terminal = terminalSurface()
+            if !scope.contains(.agent) {
+                next.commands = commandSurfaceBuilder().commands
+                applyTerminalStatus(to: &next)
+            }
+        }
+        return next
+    }
+
+    private func agentProgressSurface() -> WorkspaceAgentProgressSurface {
         let thread = selectedThread
         let topBarState = root.topBar
         let runtimeIssue = runtimeIssueSurface()
@@ -183,7 +319,7 @@ public extension QuillCodeWorkspaceModel {
             pullRequestReviewDraft: pullRequestReviewDraft
         ).surface()
         review.isPresented = chrome.reviewPresentation.resolves(hasContent: review.hasContent)
-        return WorkspaceSurface(
+        return WorkspaceAgentProgressSurface(
             chrome: WorkspaceChromeSurface(state: chrome, reviewHasContent: review.hasContent),
             topBar: topBar,
             projects: navigation.projects,
@@ -214,10 +350,6 @@ public extension QuillCodeWorkspaceModel {
                 )
                 : nil,
             review: review,
-            terminal: TerminalSurface(
-                terminal: terminal,
-                cwd: terminalCurrentDirectoryURL
-            ),
             browser: BrowserSurface(browser: browser),
             extensions: WorkspaceExtensionsSurface(
                 isVisible: extensions.isVisible,
@@ -248,12 +380,6 @@ public extension QuillCodeWorkspaceModel {
                 collapsedSectionIDs: activity.collapsedSectionIDs,
                 dismissedInstructionDiagnosticIDs: dismissedInstructionDiagnosticIDs
             ),
-            automations: WorkspaceAutomationsSurfaceBuilder(
-                isVisible: automations.isVisible,
-                automations: automations.items,
-                hasSelectedThread: thread != nil,
-                hasSelectedProject: selectedProject != nil
-            ).surface(),
             composer: ComposerSurface(
                 composer: composer,
                 fileMentionIndex: fileMentionIndex,
@@ -269,26 +395,26 @@ public extension QuillCodeWorkspaceModel {
             fileMentionIndex: fileMentionIndex,
             changedFilePaths: activeChangedFilePaths,
             commands: commandSurfaceBuilder().commands,
-            settings: WorkspaceSettingsSurface(
-                config: root.config,
-                hasStoredAPIKey: root.trustedRouterAPIKeyConfigured,
-                runtimeIssue: runtimeIssue,
-                computerUseRuntime: ComputerUseSettingsRuntime(topBarState: topBarState),
-                modelCatalogStatus: root.modelCatalogStatus,
-                modelProviderHealthSummary: ModelProviderHealthSummary.summarize(root.modelCatalog),
-                trustedRouterCredits: root.trustedRouterCredits,
-                managedWorktreeDefaultRoot: managedWorktreeDefaultRoot
-            ),
-            worktreeEnvironments: selectedProject.flatMap { project in
-                guard !project.isRemote else { return nil }
-                return WorkspaceProjectConfigurationLoader
-                    .load(from: URL(fileURLWithPath: project.path))
-                    .worktreeEnvironmentSurface
-            } ?? WorkspaceWorktreeEnvironmentSurface(),
             runtimeIssue: runtimeIssue,
             lastError: lastError,
             attentionDigest: attentionDigestSurface()
         )
+    }
+
+    private func terminalSurface() -> TerminalSurface {
+        TerminalSurface(terminal: terminal, cwd: terminalCurrentDirectoryURL)
+    }
+
+    private func applyTerminalStatus(to surface: inout WorkspaceSurface) {
+        let runtimeIssue = runtimeIssueSurface()
+        surface.topBar.agentStatus = root.topBar.agentStatus
+        surface.topBar.runtimeIssueLabel = runtimeIssue?.title
+        surface.topBar.runtimeIssueSeverity = runtimeIssue?.severity
+        surface.topBar.branchStatusLabel = WorkspaceTopBarSurfaceBuilder.branchStatusLabel(
+            for: root.topBar.branchStatus
+        )
+        surface.runtimeIssue = runtimeIssue
+        surface.lastError = lastError
     }
 
     /// The morning-triage return digest for the currently opened digest thread (issue #877), or nil when

--- a/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeCore
+import QuillCodeTools
 
 struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
     var topBarState: TopBarState
@@ -84,10 +85,7 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
             worktreeStatusDetail: worktreeStatus?.detail,
             worktreeStatusIsWarning: worktreeStatus?.isWarning ?? false,
             pullRequest: thread?.pullRequest,
-            branchStatusLabel: topBarState.branchStatus.flatMap { status in
-                let label = status.compactLabel
-                return label.isEmpty ? nil : label
-            },
+            branchStatusLabel: Self.branchStatusLabel(for: topBarState.branchStatus),
             usageStatusLabel: spendStatus == nil ? usageStatusLabel : nil,
             tokenBudget: tokenBudget,
             accountBalance: accountBalance,
@@ -98,6 +96,13 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
             canNavigateBack: canNavigateBack,
             canNavigateForward: canNavigateForward
         )
+    }
+
+    static func branchStatusLabel(for status: GitBranchStatus?) -> String? {
+        status.flatMap { value in
+            let label = value.compactLabel
+            return label.isEmpty ? nil : label
+        }
     }
 
     private struct WorktreeStatus: Sendable, Hashable {

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+ComposerAndPanes.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+ComposerAndPanes.swift
@@ -23,7 +23,7 @@ extension QuillCodeDesktopController {
             fallbackWorkspaceRoot: workspaceRoot,
             tasks: tasks,
             refresh: { [weak self] in self?.refresh() },
-            progressRefresh: { [weak self] in self?.scheduleProgressRefresh() },
+            progressRefresh: { [weak self] in self?.scheduleProgressRefresh(.agent) },
             onSlotFree: { [weak self] in self?.recoverSelectedThreadDrain() }
         )
     }
@@ -38,7 +38,7 @@ extension QuillCodeDesktopController {
             fallbackWorkspaceRoot: workspaceRoot,
             tasks: tasks,
             refresh: { [weak self] in self?.refresh() },
-            progressRefresh: { [weak self] in self?.scheduleProgressRefresh() },
+            progressRefresh: { [weak self] in self?.scheduleProgressRefresh(.agent) },
             onSlotFree: { [weak self] in self?.recoverSelectedThreadDrain() }
         )
     }
@@ -49,7 +49,7 @@ extension QuillCodeDesktopController {
             fallbackWorkspaceRoot: workspaceRoot,
             tasks: tasks,
             refresh: { [weak self] in self?.refresh() },
-            progressRefresh: { [weak self] in self?.scheduleProgressRefresh() },
+            progressRefresh: { [weak self] in self?.scheduleProgressRefresh(.agent) },
             onSlotFree: { [weak self] in self?.recoverSelectedThreadDrain() }
         )
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Refresh.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Refresh.swift
@@ -4,30 +4,45 @@ import QuillCodeApp
 extension QuillCodeDesktopController {
     func refresh() {
         progressRefreshScheduler.flush { [weak self] in
-            self?.refreshNow()
+            self?.refreshNow(progressScope: nil)
         }
     }
 
-    func scheduleProgressRefresh() {
-        progressRefreshScheduler.schedule { [weak self] in
-            self?.refreshNow()
+    func scheduleProgressRefresh(_ scope: WorkspaceProgressSurfaceScope) {
+        progressRefreshScheduler.schedule(scope) { [weak self] coalescedScope in
+            self?.refreshNow(progressScope: coalescedScope)
         }
     }
 
-    private func refreshNow() {
-        computerUseCoordinator.refreshStatus(on: model)
+    private func refreshNow(progressScope: WorkspaceProgressSurfaceScope?) {
+        if progressScope == nil || progressScope?.contains(.agent) == true {
+            computerUseCoordinator.refreshStatus(on: model)
+        }
         var nextSurface = surface
         var nextDraft = draft
         var nextTerminalDraft = terminalDraft
         var nextBrowserAddressDraft = browserAddressDraft
-        modelStateCoordinator.refreshState(
-            from: model,
-            surface: &nextSurface,
-            draft: &nextDraft,
-            terminalDraft: &nextTerminalDraft,
-            browserAddressDraft: &nextBrowserAddressDraft,
-            isComposerTaskRunning: tasks.isSendRunning(threadID: model.selectedThread?.id)
-        )
+        let isComposerTaskRunning = tasks.isSendRunning(threadID: model.selectedThread?.id)
+        if let progressScope {
+            modelStateCoordinator.refreshProgressState(
+                from: model,
+                scope: progressScope,
+                surface: &nextSurface,
+                draft: &nextDraft,
+                terminalDraft: &nextTerminalDraft,
+                browserAddressDraft: &nextBrowserAddressDraft,
+                isComposerTaskRunning: isComposerTaskRunning
+            )
+        } else {
+            modelStateCoordinator.refreshState(
+                from: model,
+                surface: &nextSurface,
+                draft: &nextDraft,
+                terminalDraft: &nextTerminalDraft,
+                browserAddressDraft: &nextBrowserAddressDraft,
+                isComposerTaskRunning: isComposerTaskRunning
+            )
+        }
         if nextSurface != surface {
             surface = nextSurface
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+RunRetry.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+RunRetry.swift
@@ -28,7 +28,7 @@ extension QuillCodeDesktopController {
                 threadID: threadID,
                 workspaceRoot: runRoot,
                 onStarted: { [weak self] in self?.refresh() },
-                onProgressUpdated: { [weak self] in self?.scheduleProgressRefresh() }
+                onProgressUpdated: { [weak self] in self?.scheduleProgressRefresh(.agent) }
             )
         } onFinish: { [weak self] in
             self?.refresh()

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Terminal.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Terminal.swift
@@ -9,7 +9,7 @@ extension QuillCodeDesktopController {
             model: model,
             fallbackWorkspaceRoot: workspaceRoot,
             tasks: tasks,
-            progressRefresh: { [weak self] in self?.scheduleProgressRefresh() },
+            progressRefresh: { [weak self] in self?.scheduleProgressRefresh(.terminal) },
             refresh: { [weak self] in self?.refresh() }
         )
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+WorkspaceActions.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+WorkspaceActions.swift
@@ -28,7 +28,7 @@ extension QuillCodeDesktopController {
             await model.runCodeReview(
                 request,
                 workspaceRoot: root,
-                onProgressUpdated: { [weak self] in self?.scheduleProgressRefresh() }
+                onProgressUpdated: { [weak self] in self?.scheduleProgressRefresh(.agent) }
             )
         } onFinish: { [weak self] in
             guard let self else { return }

--- a/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
@@ -34,10 +34,65 @@ struct QuillCodeDesktopModelStateCoordinator {
         isComposerTaskRunning: Bool = false
     ) {
         let nextState = initialState(from: model)
+        reconcile(
+            nextState,
+            from: model,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft,
+            updatesComposer: true,
+            updatesTerminal: true,
+            updatesBrowser: true,
+            isComposerTaskRunning: isComposerTaskRunning
+        )
+    }
+
+    func refreshProgressState(
+        from model: QuillCodeWorkspaceModel,
+        scope: WorkspaceProgressSurfaceScope,
+        surface: inout WorkspaceSurface,
+        draft: inout String,
+        terminalDraft: inout String,
+        browserAddressDraft: inout String,
+        isComposerTaskRunning: Bool = false
+    ) {
+        let nextState = QuillCodeDesktopModelState(
+            surface: model.progressSurface(reusing: surface, scope: scope),
+            draft: model.composer.draft,
+            terminalDraft: model.terminal.draft,
+            browserAddressDraft: model.browser.addressDraft
+        )
+        reconcile(
+            nextState,
+            from: model,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft,
+            updatesComposer: scope.contains(.agent),
+            updatesTerminal: scope.contains(.terminal),
+            updatesBrowser: scope.contains(.agent),
+            isComposerTaskRunning: isComposerTaskRunning
+        )
+    }
+
+    private func reconcile(
+        _ nextState: QuillCodeDesktopModelState,
+        from model: QuillCodeWorkspaceModel,
+        surface: inout WorkspaceSurface,
+        draft: inout String,
+        terminalDraft: inout String,
+        browserAddressDraft: inout String,
+        updatesComposer: Bool,
+        updatesTerminal: Bool,
+        updatesBrowser: Bool,
+        isComposerTaskRunning: Bool
+    ) {
         let isComposerBusy = model.composer.isSending || isComposerTaskRunning
         surface = nextState.surface
 
-        if draft != nextState.draft, !isComposerBusy {
+        if updatesComposer, draft != nextState.draft, !isComposerBusy {
             draft = nextState.draft
         }
         // Rebuild from the LOCAL draft so slash/@-mention suggestions reflect live typing, but
@@ -49,25 +104,27 @@ struct QuillCodeDesktopModelStateCoordinator {
         // — otherwise both vanish on every controller-triggered refresh), and supportsPersonality
         // (drives whether personality slash suggestions appear; defaulting it true after a refresh
         // would surface `/personality` on models that don't support it).
-        surface.composer = ComposerSurface(
-            composer: ComposerState(
-                draft: draft,
-                attachments: model.composer.attachments,
-                isSending: isComposerBusy,
-                placeholder: nextState.surface.composer.placeholder,
-                focusToken: model.composer.focusToken
-            ),
-            fileMentionIndex: model.fileMentionIndex,
-            changedFilePaths: nextState.surface.changedFilePaths,
-            sentMessageHistory: nextState.surface.composer.sentMessageHistory,
-            planProgress: nextState.surface.composer.planProgress,
-            followUpQueue: model.selectedThread?.followUpQueue ?? [],
-            supportsPersonality: nextState.surface.composer.supportsPersonality
-        )
-        if terminalDraft != nextState.terminalDraft, !model.terminal.isRunning {
+        if updatesComposer {
+            surface.composer = ComposerSurface(
+                composer: ComposerState(
+                    draft: draft,
+                    attachments: model.composer.attachments,
+                    isSending: isComposerBusy,
+                    placeholder: nextState.surface.composer.placeholder,
+                    focusToken: model.composer.focusToken
+                ),
+                fileMentionIndex: model.fileMentionIndex,
+                changedFilePaths: nextState.surface.changedFilePaths,
+                sentMessageHistory: nextState.surface.composer.sentMessageHistory,
+                planProgress: nextState.surface.composer.planProgress,
+                followUpQueue: model.selectedThread?.followUpQueue ?? [],
+                supportsPersonality: nextState.surface.composer.supportsPersonality
+            )
+        }
+        if updatesTerminal, terminalDraft != nextState.terminalDraft, !model.terminal.isRunning {
             terminalDraft = nextState.terminalDraft
         }
-        if browserAddressDraft != nextState.browserAddressDraft {
+        if updatesBrowser, browserAddressDraft != nextState.browserAddressDraft {
             browserAddressDraft = nextState.browserAddressDraft
         }
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopProgressRefreshScheduler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopProgressRefreshScheduler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QuillCodeApp
 
 /// Coalesces high-frequency model progress into a responsive, bounded presentation cadence.
 /// Authoritative workspace state is updated before this scheduler is called; only the expensive
@@ -8,7 +9,8 @@ final class QuillCodeDesktopProgressRefreshScheduler {
     static let defaultDelayNanoseconds: UInt64 = 50_000_000
 
     private let delayNanoseconds: UInt64
-    private var pendingAction: (() -> Void)?
+    private var pendingScope: WorkspaceProgressSurfaceScope = []
+    private var pendingAction: ((WorkspaceProgressSurfaceScope) -> Void)?
     private var pendingTask: Task<Void, Never>?
     private var generation: UInt64 = 0
 
@@ -24,7 +26,12 @@ final class QuillCodeDesktopProgressRefreshScheduler {
         pendingTask != nil
     }
 
-    func schedule(_ action: @escaping @MainActor () -> Void) {
+    func schedule(
+        _ scope: WorkspaceProgressSurfaceScope,
+        action: @escaping @MainActor (WorkspaceProgressSurfaceScope) -> Void
+    ) {
+        guard !scope.isEmpty else { return }
+        pendingScope.formUnion(scope)
         pendingAction = action
         guard pendingTask == nil else { return }
 
@@ -50,6 +57,7 @@ final class QuillCodeDesktopProgressRefreshScheduler {
 
     func cancel() {
         generation &+= 1
+        pendingScope = []
         pendingAction = nil
         pendingTask?.cancel()
         pendingTask = nil
@@ -57,14 +65,17 @@ final class QuillCodeDesktopProgressRefreshScheduler {
 
     private func runIfCurrent(_ scheduledGeneration: UInt64) {
         guard generation == scheduledGeneration else { return }
+        let scope = pendingScope
         let action = pendingAction
+        pendingScope = []
         pendingAction = nil
         pendingTask = nil
-        action?()
+        action?(scope)
     }
 
     private func clearIfCurrent(_ scheduledGeneration: UInt64) {
         guard generation == scheduledGeneration else { return }
+        pendingScope = []
         pendingAction = nil
         pendingTask = nil
     }

--- a/Tests/QuillCodeAppTests/WorkspaceProgressSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProgressSurfaceTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceProgressSurfaceTests: XCTestCase {
+    func testAgentProgressMatchesAuthoritativeSurfaceForFiftyThousandEventHistory() {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let eventCount = 50_000
+        var events: [ThreadEvent] = []
+        var messages: [ChatMessage] = []
+        events.reserveCapacity(eventCount)
+        messages.reserveCapacity(eventCount / 10)
+
+        for index in 0..<eventCount {
+            events.append(ThreadEvent(
+                kind: .notice,
+                createdAt: timestamp,
+                summary: "Progress record \(index)"
+            ))
+            if index.isMultiple(of: 10) {
+                messages.append(ChatMessage(
+                    role: index.isMultiple(of: 20) ? .user : .assistant,
+                    content: "Daily-driving turn \(index)",
+                    createdAt: timestamp
+                ))
+            }
+        }
+
+        let thread = ChatThread(
+            title: "Long-running task",
+            messages: messages,
+            events: events
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        let previous = model.surface()
+
+        model.root.threads[0].messages.append(ChatMessage(
+            role: .assistant,
+            content: "Fresh streamed answer",
+            createdAt: timestamp
+        ))
+        model.root.threads[0].events.append(ThreadEvent(
+            kind: .notice,
+            createdAt: timestamp,
+            summary: "Fresh streamed progress"
+        ))
+
+        let progress = model.progressSurface(reusing: previous, scope: .agent)
+        let authoritative = model.surface()
+
+        XCTAssertEqual(progress, authoritative)
+        XCTAssertEqual(progress.transcript.messages.last?.text, "Fresh streamed answer")
+        XCTAssertEqual(progress.settings, previous.settings)
+        XCTAssertEqual(progress.automations, previous.automations)
+        XCTAssertEqual(progress.worktreeEnvironments, previous.worktreeEnvironments)
+        XCTAssertEqual(progress.terminal, previous.terminal)
+    }
+
+    func testTerminalProgressUpdatesTerminalAndStatusWithoutRebuildingAgentHistory() {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let thread = ChatThread(
+            title: "Terminal task",
+            messages: (0..<10_000).map { index in
+                ChatMessage(
+                    role: index.isMultiple(of: 2) ? .user : .assistant,
+                    content: "Turn \(index)",
+                    createdAt: timestamp
+                )
+            }
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        let previous = model.surface()
+        model.terminal = TerminalState(
+            isVisible: true,
+            isRunning: true,
+            entries: [TerminalCommandState(
+                command: "swift test",
+                stdout: "Building...",
+                stderr: "",
+                exitCode: nil,
+                ok: true,
+                status: .running,
+                createdAt: timestamp
+            )]
+        )
+        model.root.topBar.agentStatus = TopBarAgentStatusLabel.running
+
+        let progress = model.progressSurface(reusing: previous, scope: .terminal)
+        let authoritative = model.surface()
+
+        XCTAssertEqual(progress.terminal, authoritative.terminal)
+        XCTAssertEqual(progress.commands, authoritative.commands)
+        XCTAssertEqual(progress.topBar.agentStatus, authoritative.topBar.agentStatus)
+        XCTAssertEqual(progress.topBar.runtimeIssueLabel, authoritative.topBar.runtimeIssueLabel)
+        XCTAssertEqual(progress.topBar.runtimeIssueSeverity, authoritative.topBar.runtimeIssueSeverity)
+        XCTAssertEqual(progress.topBar.branchStatusLabel, authoritative.topBar.branchStatusLabel)
+        XCTAssertEqual(progress.runtimeIssue, authoritative.runtimeIssue)
+        XCTAssertEqual(progress.lastError, authoritative.lastError)
+        XCTAssertEqual(progress.terminal.entries.last?.stdout, "Building...")
+        XCTAssertEqual(progress.transcript, previous.transcript)
+        XCTAssertEqual(progress.settings, previous.settings)
+        XCTAssertEqual(progress.automations, previous.automations)
+        XCTAssertEqual(progress.worktreeEnvironments, previous.worktreeEnvironments)
+    }
+
+    func testAgentProgressReusesFilesystemBackedWorktreeEnvironmentProjection() throws {
+        let root = try makeQuillCodeTestDirectory()
+        let configurationDirectory = root.appendingPathComponent(".quillcode")
+        let configurationURL = configurationDirectory.appendingPathComponent("config.toml")
+        try FileManager.default.createDirectory(
+            at: configurationDirectory,
+            withIntermediateDirectories: true
+        )
+        try writeEnvironment(named: "development", title: "Development", to: configurationURL)
+
+        let model = QuillCodeWorkspaceModel()
+        let projectID = model.addProject(path: root, name: "Scoped refresh")
+        model.selectProject(projectID)
+        let previous = model.surface()
+        XCTAssertEqual(previous.worktreeEnvironments.options.map(\.title), ["Development"])
+
+        try writeEnvironment(named: "release", title: "Release", to: configurationURL)
+        let progress = model.progressSurface(reusing: previous, scope: .agent)
+
+        XCTAssertEqual(progress.worktreeEnvironments, previous.worktreeEnvironments)
+        previous.worktreeEnvironments.options.withUnsafeBufferPointer { previousBuffer in
+            progress.worktreeEnvironments.options.withUnsafeBufferPointer { progressBuffer in
+                XCTAssertEqual(previousBuffer.baseAddress, progressBuffer.baseAddress)
+            }
+        }
+        XCTAssertEqual(model.surface().worktreeEnvironments.options.map(\.title), ["Release"])
+    }
+
+    func testEmptyProgressScopeReturnsSurfaceUnchanged() {
+        let model = QuillCodeWorkspaceModel()
+        let previous = model.surface()
+
+        XCTAssertEqual(model.progressSurface(reusing: previous, scope: []), previous)
+    }
+
+    private func writeEnvironment(named name: String, title: String, to url: URL) throws {
+        try """
+        [worktree_setup]
+        default_environment = "\(name)"
+
+        [local_environments.\(name)]
+        title = "\(title)"
+        """.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -923,8 +923,8 @@ final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
     }
 
     /// Structural guard against the whole "native refresh drops a composer field" bug class the
-    /// focus-composer review surfaced: `refreshState` is the ONLY place that rebuilds a sub-surface
-    /// (the composer); everything else is copied verbatim. So with the local draft matching the
+    /// focus-composer review surfaced: the model-state coordinator owns every local-draft composer
+    /// rebuild. So with the local draft matching the
     /// model's, the rebuilt composer must EQUAL `model.surface().composer` exactly — any field a
     /// future rebuild forgets to carry (focusToken, sentMessageHistory, …) trips this immediately.
     /// (Compares the composer, not the whole surface, because the sidebar carries relative-time

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopProgressModelStateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopProgressModelStateTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopProgressModelStateTests: XCTestCase {
+    func testAgentProgressKeepsLiveComposerAndTerminalDraftOwnership() {
+        let thread = ChatThread(messages: [ChatMessage(role: .user, content: "Start")])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        var surface = model.surface()
+        var draft = "half-typed message"
+        var terminalDraft = "half-typed command"
+        var browserAddressDraft = "https://old.example"
+        model.root.threads[0].messages.append(ChatMessage(role: .assistant, content: "Streaming"))
+        model.setBrowserAddressDraft("https://new.example")
+
+        QuillCodeDesktopModelStateCoordinator().refreshProgressState(
+            from: model,
+            scope: .agent,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft,
+            isComposerTaskRunning: true
+        )
+
+        XCTAssertEqual(draft, "half-typed message")
+        XCTAssertEqual(surface.composer.draft, "half-typed message")
+        XCTAssertEqual(surface.transcript.messages.last?.text, "Streaming")
+        XCTAssertEqual(terminalDraft, "half-typed command")
+        XCTAssertEqual(browserAddressDraft, "https://new.example")
+    }
+
+    func testTerminalProgressDoesNotTouchComposerOrBrowserDrafts() {
+        let thread = ChatThread(messages: [ChatMessage(role: .user, content: "Start")])
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        let previousComposer = model.surface().composer
+        var surface = model.surface()
+        var draft = "local composer"
+        var terminalDraft = "local terminal"
+        var browserAddressDraft = "https://local.example"
+        model.setDraft("new model composer")
+        model.setBrowserAddressDraft("https://model.example")
+        model.terminal = TerminalState(
+            isVisible: true,
+            draft: "",
+            isRunning: true,
+            entries: [TerminalCommandState(
+                command: "make test",
+                stdout: "running",
+                stderr: "",
+                exitCode: nil,
+                ok: true,
+                status: .running
+            )]
+        )
+
+        QuillCodeDesktopModelStateCoordinator().refreshProgressState(
+            from: model,
+            scope: .terminal,
+            surface: &surface,
+            draft: &draft,
+            terminalDraft: &terminalDraft,
+            browserAddressDraft: &browserAddressDraft
+        )
+
+        XCTAssertEqual(surface.composer, previousComposer)
+        XCTAssertEqual(draft, "local composer")
+        XCTAssertEqual(terminalDraft, "local terminal")
+        XCTAssertEqual(browserAddressDraft, "https://local.example")
+        XCTAssertEqual(surface.terminal.entries.last?.stdout, "running")
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopProgressRefreshSchedulerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopProgressRefreshSchedulerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import QuillCodeApp
 @testable import quill_code_desktop
 
 @MainActor
@@ -10,7 +11,7 @@ final class QuillCodeDesktopProgressRefreshSchedulerTests: XCTestCase {
         var refreshCount = 0
 
         for _ in 0..<10_000 {
-            scheduler.schedule { refreshCount += 1 }
+            scheduler.schedule(.agent) { _ in refreshCount += 1 }
         }
 
         XCTAssertTrue(scheduler.hasPendingRefresh)
@@ -26,8 +27,8 @@ final class QuillCodeDesktopProgressRefreshSchedulerTests: XCTestCase {
         var firstCount = 0
         var latestCount = 0
 
-        scheduler.schedule { firstCount += 1 }
-        scheduler.schedule {
+        scheduler.schedule(.agent) { _ in firstCount += 1 }
+        scheduler.schedule(.agent) { _ in
             latestCount += 1
             refreshed.fulfill()
         }
@@ -42,7 +43,7 @@ final class QuillCodeDesktopProgressRefreshSchedulerTests: XCTestCase {
         let scheduler = QuillCodeDesktopProgressRefreshScheduler(delayNanoseconds: 1_000_000)
         var refreshCount = 0
 
-        scheduler.schedule { refreshCount += 1 }
+        scheduler.schedule(.agent) { _ in refreshCount += 1 }
         scheduler.cancel()
         try await Task.sleep(nanoseconds: 10_000_000)
 
@@ -58,9 +59,33 @@ final class QuillCodeDesktopProgressRefreshSchedulerTests: XCTestCase {
                 delayNanoseconds: 5_000_000_000
             )
             retainedScheduler = scheduler
-            scheduler.schedule {}
+            scheduler.schedule(.agent) { _ in }
         }
 
         XCTAssertNil(retainedScheduler)
+    }
+
+    func testCadenceBoundaryUnionsIndependentProgressScopes() async throws {
+        let scheduler = QuillCodeDesktopProgressRefreshScheduler(delayNanoseconds: 1_000_000)
+        let refreshed = expectation(description: "coalesced refresh")
+        var receivedScope: WorkspaceProgressSurfaceScope = []
+
+        scheduler.schedule(.agent) { _ in XCTFail("latest action should replace this closure") }
+        scheduler.schedule(.terminal) { scope in
+            receivedScope = scope
+            refreshed.fulfill()
+        }
+
+        await fulfillment(of: [refreshed], timeout: 1)
+        XCTAssertTrue(receivedScope.contains(.agent))
+        XCTAssertTrue(receivedScope.contains(.terminal))
+    }
+
+    func testEmptyScopeDoesNotScheduleRefresh() {
+        let scheduler = QuillCodeDesktopProgressRefreshScheduler()
+
+        scheduler.schedule([]) { _ in XCTFail("empty scopes must not run") }
+
+        XCTAssertFalse(scheduler.hasPendingRefresh)
     }
 }

--- a/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
@@ -43,7 +43,7 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
         Self.assertSource(controllerText, contains: "terminalCoordinator.recallPreviousCommand")
         Self.assertSource(terminalCoordinatorText, contains: "tasks.startIfIdle(.terminal")
         Self.assertSource(terminalCoordinatorText, contains: "onStateChange: progressRefresh")
-        Self.assertSource(terminalControllerText, contains: "self?.scheduleProgressRefresh()")
+        Self.assertSource(terminalControllerText, contains: "self?.scheduleProgressRefresh(.terminal)")
         Self.assertSource(smokeRunnerText, contains: "QuillCodeDesktopTerminalRetentionSmoke.verify")
         Self.assertSource(terminalSmokeText, contains: "entry.stdout.contains(\"output truncated\")")
         Self.assertSource(terminalSmokeText, contains: "outputByteCount < maximumPublishedOutputBytes")
@@ -68,6 +68,34 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
         Self.assertSource(controllerText, excludes: "tasks.cancel([.send, .terminal, .browserPreview])")
         Self.assertSource(controllerText, excludes: "model.cancelActiveWork()")
         Self.assertSource(controllerText, excludes: "model.disconnectAll()")
+    }
+
+    func testDesktopProgressRefreshScopesOwnTheirProjectionBoundaries() throws {
+        let refreshText = try Self.desktopSourceText(named: "QuillCodeDesktopController+Refresh.swift")
+        let schedulerText = try Self.desktopSourceText(named: "QuillCodeDesktopProgressRefreshScheduler.swift")
+        let composerText = try Self.desktopSourceText(named: "QuillCodeDesktopController+ComposerAndPanes.swift")
+        let terminalText = try Self.desktopSourceText(named: "QuillCodeDesktopController+Terminal.swift")
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+
+        Self.assertSource(refreshText, contains: "modelStateCoordinator.refreshProgressState(")
+        Self.assertSource(refreshText, contains: "progressRefreshScheduler.flush")
+        Self.assertSource(schedulerText, contains: "pendingScope.formUnion(scope)")
+        Self.assertSource(composerText, contains: "scheduleProgressRefresh(.agent)")
+        Self.assertSource(terminalText, contains: "scheduleProgressRefresh(.terminal)")
+        Self.assertSource(surfaceText, contains: "func progressSurface(")
+        Self.assertSource(surfaceText, contains: "agentProgressSurface().apply(to: &next)")
+        Self.assertSource(surfaceText, contains: "next.terminal = terminalSurface()")
+
+        let progressImplementation = try XCTUnwrap(
+            surfaceText.components(separatedBy: "func progressSurface(").dropFirst().first
+        ).components(separatedBy: "private func agentProgressSurface()").first ?? ""
+        XCTAssertFalse(progressImplementation.contains("surface()"))
+        XCTAssertFalse(progressImplementation.contains("WorkspaceProjectConfigurationLoader"))
+
+        let agentImplementation = try XCTUnwrap(
+            surfaceText.components(separatedBy: "private func agentProgressSurface()").dropFirst().first
+        ).components(separatedBy: "private func terminalSurface()").first ?? ""
+        XCTAssertFalse(agentImplementation.contains("WorkspaceProjectConfigurationLoader"))
     }
 
 }


### PR DESCRIPTION
## Summary
- scope high-frequency desktop refreshes to agent and terminal-owned presentation state
- coalesce simultaneous progress producers without rebuilding filesystem-backed or unrelated surfaces
- preserve local draft ownership while work is streaming
- add long-history equivalence, storage-reuse, no-disk-reprojection, and scheduler gates

## Validation
- `swift test`: 5,822 tests passed, 5 skipped
- optimized packaged macOS smoke: passed direct executable, Launch Services, crash recovery, live-window, accessibility, and interaction contracts
- median launch-ready: 270.51 ms
- resident memory: 90.94 MiB initial, 147.94 MiB post interaction, 152.03 MiB after repeated interaction
- 50,000-event projection equivalence test passed