### PR TITLE
Optimize transcript projection during agent progress

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceAgentProgressThreadReconciler.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentProgressThreadReconciler.swift
@@ -1,21 +1,54 @@
+import Foundation
 import QuillCodeCore
 
 /// Applies presentation-cadence agent snapshots without making the model retain the producer's
 /// large transcript buffers. Agent histories normally append or update their current tail; the
 /// identified-array reconciliation also handles truncation and structural replacement exactly.
+struct WorkspaceAgentProgressThreadMutation: Sendable, Hashable {
+    enum MessageMutation: Sendable, Hashable {
+        case unchanged
+        case replacedAssistantTail(messageID: UUID)
+        case appendedAssistantTail(messageID: UUID)
+        case rebuild
+    }
+
+    var threadID: UUID
+    var messageMutation: MessageMutation
+    var eventsAffectTranscript: Bool
+    var contextAffectsTranscript: Bool
+}
+
 enum WorkspaceAgentProgressThreadReconciler {
-    static func reconcile(_ snapshot: ChatThread, into live: inout ChatThread) {
+    static func reconcile(
+        _ snapshot: ChatThread,
+        into live: inout ChatThread
+    ) -> WorkspaceAgentProgressThreadMutation {
         precondition(snapshot.id == live.id)
 
+        let contextAffectsTranscript = live.projectID != snapshot.projectID
+        let previousLastMessage = live.messages.last
         live.title = snapshot.title
         live.projectID = snapshot.projectID
         live.mode = snapshot.mode
         live.model = snapshot.model
         live.personality = snapshot.personality
-        reconcile(snapshot.messages, into: &live.messages)
-        reconcile(snapshot.modelContextItems, into: &live.modelContextItems)
-        reconcile(snapshot.events, into: &live.events)
-        reconcile(snapshot.subagentRuns, into: &live.subagentRuns)
+        let messageSummary = reconcile(snapshot.messages, into: &live.messages)
+        _ = reconcile(snapshot.modelContextItems, into: &live.modelContextItems)
+        var tailHasPersistedMessageEvent = false
+        let eventSummary = reconcile(
+            snapshot.events,
+            into: &live.events,
+            changeAffectsTranscript: { previous, next in
+                previous.kind.affectsTranscriptProjection || next.kind.affectsTranscriptProjection
+            },
+            inspectSnapshotElement: { event in
+                guard event.kind == .message else { return }
+                tailHasPersistedMessageEvent = tailHasPersistedMessageEvent
+                    || event.summary == previousLastMessage?.content
+                    || event.summary == snapshot.messages.last?.content
+            }
+        )
+        _ = reconcile(snapshot.subagentRuns, into: &live.subagentRuns)
         live.isPinned = snapshot.isPinned
         live.isArchived = snapshot.isArchived
         live.createdAt = snapshot.createdAt
@@ -28,32 +61,120 @@ enum WorkspaceAgentProgressThreadReconciler {
 
         // instructions, memories, goal, drafts, attachments, and the follow-up queue are owned by
         // the live workspace model and may change after the agent captured its send-start snapshot.
+        let messageMutation = messageMutation(
+            from: messageSummary,
+            previousLastMessage: previousLastMessage,
+            messages: snapshot.messages
+        )
+        let persistedTailEventRequiresRebuild: Bool
+        switch messageMutation {
+        case .replacedAssistantTail, .appendedAssistantTail:
+            persistedTailEventRequiresRebuild = tailHasPersistedMessageEvent
+        case .unchanged, .rebuild:
+            persistedTailEventRequiresRebuild = false
+        }
+        return WorkspaceAgentProgressThreadMutation(
+            threadID: snapshot.id,
+            messageMutation: messageMutation,
+            eventsAffectTranscript: eventSummary.affectsTranscript || persistedTailEventRequiresRebuild,
+            contextAffectsTranscript: contextAffectsTranscript
+        )
+    }
+
+    private struct ArrayMutationSummary {
+        var previousCount: Int
+        var currentCount: Int
+        var changedCount = 0
+        var onlyChangedIndex: Int?
+        var didReplaceStructure = false
+        var affectsTranscript = false
     }
 
     private static func reconcile<Element>(
         _ snapshot: [Element],
-        into live: inout [Element]
-    ) where Element: Identifiable & Equatable, Element.ID: Equatable {
+        into live: inout [Element],
+        changeAffectsTranscript: (Element, Element) -> Bool = { _, _ in false },
+        inspectSnapshotElement: (Element) -> Void = { _ in }
+    ) -> ArrayMutationSummary where Element: Identifiable & Equatable, Element.ID: Equatable {
+        let previousCount = live.count
+        var summary = ArrayMutationSummary(previousCount: previousCount, currentCount: snapshot.count)
         let overlapCount = min(live.count, snapshot.count)
         for index in 0..<overlapCount {
+            inspectSnapshotElement(snapshot[index])
             guard live[index].id == snapshot[index].id else {
+                summary.didReplaceStructure = true
+                summary.affectsTranscript = true
                 replaceDetached(&live, with: snapshot)
-                return
+                return summary
             }
             if live[index] != snapshot[index] {
+                summary.changedCount += 1
+                summary.onlyChangedIndex = summary.changedCount == 1 ? index : nil
+                summary.affectsTranscript = summary.affectsTranscript
+                    || changeAffectsTranscript(live[index], snapshot[index])
                 live[index] = snapshot[index]
             }
         }
 
         if snapshot.count > live.count {
+            for element in snapshot[live.count...] {
+                inspectSnapshotElement(element)
+                summary.affectsTranscript = summary.affectsTranscript
+                    || changeAffectsTranscript(element, element)
+            }
             live.append(contentsOf: snapshot[live.count...])
         } else if snapshot.count < live.count {
+            for element in live[snapshot.count...] {
+                summary.affectsTranscript = summary.affectsTranscript
+                    || changeAffectsTranscript(element, element)
+            }
             live.removeLast(live.count - snapshot.count)
         }
+        return summary
+    }
+
+    private static func messageMutation(
+        from summary: ArrayMutationSummary,
+        previousLastMessage: ChatMessage?,
+        messages: [ChatMessage]
+    ) -> WorkspaceAgentProgressThreadMutation.MessageMutation {
+        guard !summary.didReplaceStructure else { return .rebuild }
+        if summary.previousCount == summary.currentCount {
+            guard summary.changedCount > 0 else { return .unchanged }
+            guard summary.changedCount == 1,
+                  summary.onlyChangedIndex == messages.indices.last,
+                  let last = messages.last,
+                  previousLastMessage?.role == .assistant,
+                  last.role == .assistant
+            else {
+                return .rebuild
+            }
+            return .replacedAssistantTail(messageID: last.id)
+        }
+        guard summary.changedCount == 0,
+              summary.currentCount == summary.previousCount + 1,
+              let last = messages.last,
+              last.role == .assistant
+        else {
+            return .rebuild
+        }
+        return .appendedAssistantTail(messageID: last.id)
     }
 
     private static func replaceDetached<Element>(_ live: inout [Element], with snapshot: [Element]) {
         live.removeAll(keepingCapacity: true)
         live.append(contentsOf: snapshot)
+    }
+}
+
+private extension ThreadEventKind {
+    var affectsTranscriptProjection: Bool {
+        switch self {
+        case .message, .toolQueued, .toolRunning, .toolProgress, .toolCompleted, .toolFailed,
+             .approvalRequested, .approvalDecided:
+            return true
+        case .messageFeedback, .reviewComment, .notice:
+            return false
+        }
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceAgentTranscriptRefreshTracker.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentTranscriptRefreshTracker.swift
@@ -1,0 +1,141 @@
+import Foundation
+import QuillCodeCore
+
+enum WorkspaceAgentTranscriptRefreshPlan: Sendable, Hashable {
+    case reuse(selectedThreadID: UUID?)
+    case replaceAssistantTail(threadID: UUID, messageID: UUID)
+    case appendAssistantTail(threadID: UUID, messageID: UUID)
+    case rebuild
+
+    func combined(with next: Self) -> Self {
+        switch (self, next) {
+        case (.rebuild, _), (_, .rebuild):
+            return .rebuild
+        case let (.reuse(previousID), .reuse(nextID)):
+            return previousID == nextID ? self : .rebuild
+        case let (.reuse(selectedID), .replaceAssistantTail(threadID, _)),
+             let (.reuse(selectedID), .appendAssistantTail(threadID, _)):
+            return selectedID == threadID ? next : .rebuild
+        case let (.replaceAssistantTail(threadID, _), .reuse(selectedID)),
+             let (.appendAssistantTail(threadID, _), .reuse(selectedID)):
+            return selectedID == threadID ? self : .rebuild
+        case let (
+            .replaceAssistantTail(previousThreadID, previousMessageID),
+            .replaceAssistantTail(nextThreadID, nextMessageID)
+        ):
+            return previousThreadID == nextThreadID && previousMessageID == nextMessageID
+                ? self
+                : .rebuild
+        case let (
+            .appendAssistantTail(previousThreadID, previousMessageID),
+            .replaceAssistantTail(nextThreadID, nextMessageID)
+        ):
+            return previousThreadID == nextThreadID && previousMessageID == nextMessageID
+                ? self
+                : .rebuild
+        case (.replaceAssistantTail, .appendAssistantTail),
+             (.appendAssistantTail, .appendAssistantTail):
+            return .rebuild
+        }
+    }
+
+    func updatingTranscript(
+        _ previous: TranscriptSurface,
+        for thread: ChatThread?
+    ) -> TranscriptSurface? {
+        switch self {
+        case .rebuild:
+            return nil
+        case .reuse(let selectedThreadID):
+            guard thread?.id == selectedThreadID else { return nil }
+            return previous
+        case .replaceAssistantTail(let threadID, let messageID):
+            guard let message = thread?.messages.last,
+                  thread?.id == threadID,
+                  message.id == messageID,
+                  message.role == .assistant,
+                  previous.messages.last?.id == messageID,
+                  previous.timelineItems.last?.message?.id == messageID
+            else {
+                return nil
+            }
+            let messageSurface = MessageSurface(message: message)
+            var next = previous
+            next.messages[next.messages.index(before: next.messages.endIndex)] = messageSurface
+            next.timelineItems[next.timelineItems.index(before: next.timelineItems.endIndex)] = .message(messageSurface)
+            return next
+        case .appendAssistantTail(let threadID, let messageID):
+            guard let message = thread?.messages.last,
+                  thread?.id == threadID,
+                  message.id == messageID,
+                  message.role == .assistant,
+                  previous.messages.last?.id != messageID
+            else {
+                return nil
+            }
+            let messageSurface = MessageSurface(message: message)
+            var next = previous
+            next.messages.append(messageSurface)
+            next.timelineItems.append(.message(messageSurface))
+            return next
+        }
+    }
+}
+
+struct WorkspaceAgentTranscriptRefreshTracker: Sendable, Hashable {
+    private struct PublishedSelection: Sendable, Hashable {
+        var threadID: UUID?
+    }
+
+    private var publishedSelection: PublishedSelection?
+    private var pendingPlan: WorkspaceAgentTranscriptRefreshPlan?
+
+    mutating func didPublishAuthoritativeSurface(selectedThreadID: UUID?) {
+        publishedSelection = PublishedSelection(threadID: selectedThreadID)
+        pendingPlan = nil
+    }
+
+    mutating func record(
+        _ mutation: WorkspaceAgentProgressThreadMutation,
+        selectedThreadID: UUID?
+    ) {
+        guard let publishedSelection,
+              publishedSelection.threadID == selectedThreadID
+        else {
+            pendingPlan = .rebuild
+            return
+        }
+
+        let next: WorkspaceAgentTranscriptRefreshPlan
+        if mutation.threadID != selectedThreadID {
+            next = .reuse(selectedThreadID: selectedThreadID)
+        } else if mutation.eventsAffectTranscript || mutation.contextAffectsTranscript {
+            next = .rebuild
+        } else {
+            switch mutation.messageMutation {
+            case .unchanged:
+                next = .reuse(selectedThreadID: selectedThreadID)
+            case .replacedAssistantTail(let messageID):
+                next = .replaceAssistantTail(threadID: mutation.threadID, messageID: messageID)
+            case .appendedAssistantTail(let messageID):
+                next = .appendAssistantTail(threadID: mutation.threadID, messageID: messageID)
+            case .rebuild:
+                next = .rebuild
+            }
+        }
+        pendingPlan = pendingPlan.map { $0.combined(with: next) } ?? next
+    }
+
+    mutating func consume(selectedThreadID: UUID?) -> WorkspaceAgentTranscriptRefreshPlan {
+        defer {
+            publishedSelection = PublishedSelection(threadID: selectedThreadID)
+            pendingPlan = nil
+        }
+        guard let publishedSelection,
+              publishedSelection.threadID == selectedThreadID
+        else {
+            return .rebuild
+        }
+        return pendingPlan ?? .rebuild
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -39,6 +39,9 @@ public final class QuillCodeWorkspaceModel {
     /// registry lets diagnostics distinguish a genuine finish from a budget or safety stop after
     /// the running entry has been removed.
     var completedAgentRunStopReasons: [UUID: AgentRunStopReason] = [:]
+    /// One-shot structural hints for the next coalesced agent refresh. This deliberately stores no
+    /// transcript arrays, so publishing progress cannot retain a producer's large history buffers.
+    var agentTranscriptRefreshTracker = WorkspaceAgentTranscriptRefreshTracker()
     public private(set) var lastError: String?
     let startupLoadIssue: WorkspaceStartupLoadIssue?
 

--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -381,7 +381,8 @@ extension QuillCodeWorkspaceModel {
             expectedThreadID: expectedThreadID,
             composer: composer
         ) else { return }
-        updateThreadFromAgentProgress(progress.thread)
+        guard let mutation = updateThreadFromAgentProgress(progress.thread) else { return }
+        agentTranscriptRefreshTracker.record(mutation, selectedThreadID: root.selectedThreadID)
         updateAgentRun(threadID: expectedThreadID, status: progress.agentStatus)
     }
 

--- a/Sources/QuillCodeApp/WorkspaceModelThreadMutation.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadMutation.swift
@@ -98,10 +98,10 @@ extension QuillCodeWorkspaceModel {
         }
     }
 
-    func updateThreadFromAgentProgress(_ thread: ChatThread) {
+    func updateThreadFromAgentProgress(_ thread: ChatThread) -> WorkspaceAgentProgressThreadMutation? {
         if thread.runtimeContext.isEphemeral,
            !root.threads.contains(where: { $0.id == thread.id }) {
-            return
+            return nil
         }
         let result = WorkspaceThreadLifecycleEngine.applyAgentRunProgressThreadUpdate(
             thread,
@@ -110,12 +110,13 @@ extension QuillCodeWorkspaceModel {
             selectedThreadID: root.selectedThreadID,
             selectedProjectID: root.selectedProjectID
         )
-        root.selectedThreadID = result.selectedThreadID
-        root.selectedProjectID = result.selectedProjectID
-        if result.didSelectUpdatedThread {
+        root.selectedThreadID = result.lifecycle.selectedThreadID
+        root.selectedProjectID = result.lifecycle.selectedProjectID
+        if result.lifecycle.didSelectUpdatedThread {
             syncTerminalSessionToSelectedProject()
             touchProject(root.selectedProjectID)
             saveProjects()
         }
+        return result.mutation
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -166,7 +166,7 @@ private struct WorkspaceAgentProgressSurface {
 public extension QuillCodeWorkspaceModel {
     func surface() -> WorkspaceSurface {
         let progress = agentProgressSurface()
-        return WorkspaceSurface(
+        let surface = WorkspaceSurface(
             chrome: progress.chrome,
             topBar: progress.topBar,
             projects: progress.projects,
@@ -213,6 +213,10 @@ public extension QuillCodeWorkspaceModel {
             lastError: progress.lastError,
             attentionDigest: progress.attentionDigest
         )
+        agentTranscriptRefreshTracker.didPublishAuthoritativeSurface(
+            selectedThreadID: root.selectedThreadID
+        )
+        return surface
     }
 
     /// Reprojects only state that the named progress producers are allowed to mutate.
@@ -224,7 +228,13 @@ public extension QuillCodeWorkspaceModel {
         guard !scope.isEmpty else { return surface }
         var next = surface
         if scope.contains(.agent) {
-            agentProgressSurface().apply(to: &next)
+            let transcriptRefresh = agentTranscriptRefreshTracker.consume(
+                selectedThreadID: root.selectedThreadID
+            )
+            agentProgressSurface(
+                reusing: surface.transcript,
+                transcriptRefresh: transcriptRefresh
+            ).apply(to: &next)
         }
         if scope.contains(.terminal) {
             next.terminal = terminalSurface()
@@ -236,26 +246,52 @@ public extension QuillCodeWorkspaceModel {
         return next
     }
 
-    private func agentProgressSurface() -> WorkspaceAgentProgressSurface {
+    private func agentProgressSurface(
+        reusing previousTranscript: TranscriptSurface? = nil,
+        transcriptRefresh: WorkspaceAgentTranscriptRefreshPlan = .rebuild
+    ) -> WorkspaceAgentProgressSurface {
         let thread = selectedThread
         let topBarState = root.topBar
         let runtimeIssue = runtimeIssueSurface()
-        let transcriptProjection = thread.map {
-            WorkspaceTranscriptSurfaceBuilder(
-                thread: $0,
-                allowsRevert: selectedProject?.isRemote != true
-            ).projection()
-        } ?? .empty
         let executionContextBuilder = WorkspaceExecutionContextSurfaceBuilder(
             selectedProject: selectedProject,
             projects: root.projects
         )
-        let toolCards = thread.map {
-            executionContextBuilder.enrichToolCards(transcriptProjection.toolCards, for: $0)
-        } ?? []
-        let timelineItems = thread.map {
-            executionContextBuilder.enrichTimelineItems(transcriptProjection.timelineItems, for: $0)
-        } ?? []
+        let transcript: TranscriptSurface
+        if var incrementalTranscript = previousTranscript.flatMap({
+            transcriptRefresh.updatingTranscript($0, for: thread)
+        }) {
+            incrementalTranscript.thinking = WorkspaceTranscriptThinkingSurfaceBuilder(
+                thread: thread,
+                composer: composer,
+                agentStatus: topBarState.agentStatus
+            ).surface()
+            transcript = incrementalTranscript
+        } else {
+            let transcriptProjection = thread.map {
+                WorkspaceTranscriptSurfaceBuilder(
+                    thread: $0,
+                    allowsRevert: selectedProject?.isRemote != true
+                ).projection()
+            } ?? .empty
+            let toolCards = thread.map {
+                executionContextBuilder.enrichToolCards(transcriptProjection.toolCards, for: $0)
+            } ?? []
+            let timelineItems = thread.map {
+                executionContextBuilder.enrichTimelineItems(transcriptProjection.timelineItems, for: $0)
+            } ?? []
+            transcript = TranscriptSurface(
+                messages: transcriptProjection.messages,
+                toolCards: toolCards,
+                timelineItems: thread == nil ? nil : timelineItems,
+                thinking: WorkspaceTranscriptThinkingSurfaceBuilder(
+                    thread: thread,
+                    composer: composer,
+                    agentStatus: topBarState.agentStatus
+                ).surface()
+            )
+        }
+        let toolCards = transcript.toolCards
         let activeSources = WorkspaceContextResolver(
             projects: root.projects,
             globalMemories: root.globalMemories,
@@ -324,16 +360,7 @@ public extension QuillCodeWorkspaceModel {
             topBar: topBar,
             projects: navigation.projects,
             sidebar: navigation.sidebar,
-            transcript: TranscriptSurface(
-                messages: transcriptProjection.messages,
-                toolCards: toolCards,
-                timelineItems: thread == nil ? nil : timelineItems,
-                thinking: WorkspaceTranscriptThinkingSurfaceBuilder(
-                    thread: thread,
-                    composer: composer,
-                    agentStatus: topBarState.agentStatus
-                ).surface()
-            ),
+            transcript: transcript,
             contextBanner: WorkspaceContextBannerBuilder(
                 thread: thread,
                 selectedModelID: topBarState.model,

--- a/Sources/QuillCodeApp/WorkspaceThreadLifecycleEngine.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadLifecycleEngine.swift
@@ -35,6 +35,11 @@ struct WorkspaceThreadLifecycleEngine {
         var didSelectUpdatedThread: Bool
     }
 
+    struct AgentRunProgressThreadUpdateResult: Sendable, Hashable {
+        var lifecycle: AgentRunThreadUpdateResult
+        var mutation: WorkspaceAgentProgressThreadMutation
+    }
+
     static func renameThread(
         _ id: UUID,
         to title: String,
@@ -233,18 +238,28 @@ struct WorkspaceThreadLifecycleEngine {
         projects: [ProjectRef],
         selectedThreadID: UUID?,
         selectedProjectID: UUID?
-    ) -> AgentRunThreadUpdateResult {
+    ) -> AgentRunProgressThreadUpdateResult {
+        let mutation: WorkspaceAgentProgressThreadMutation
         if let index = threads.firstIndex(where: { $0.id == thread.id }) {
-            WorkspaceAgentProgressThreadReconciler.reconcile(thread, into: &threads[index])
+            mutation = WorkspaceAgentProgressThreadReconciler.reconcile(thread, into: &threads[index])
         } else {
             threads.insert(thread, at: 0)
+            mutation = WorkspaceAgentProgressThreadMutation(
+                threadID: thread.id,
+                messageMutation: .rebuild,
+                eventsAffectTranscript: true,
+                contextAffectsTranscript: true
+            )
         }
-        return agentRunThreadUpdateResult(
-            for: thread,
-            threads: threads,
-            projects: projects,
-            selectedThreadID: selectedThreadID,
-            selectedProjectID: selectedProjectID
+        return AgentRunProgressThreadUpdateResult(
+            lifecycle: agentRunThreadUpdateResult(
+                for: thread,
+                threads: threads,
+                projects: projects,
+                selectedThreadID: selectedThreadID,
+                selectedProjectID: selectedProjectID
+            ),
+            mutation: mutation
         )
     }
 

--- a/Tests/QuillCodeAppTests/WorkspaceAgentTranscriptRefreshTrackerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentTranscriptRefreshTrackerTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceAgentTranscriptRefreshTrackerTests: XCTestCase {
+    func testReconcilerClassifiesAssistantAndReasoningTailUpdatesAsIncremental() {
+        let assistant = ChatMessage(role: .assistant, content: "Draft")
+        let notice = ThreadEvent(kind: .notice, summary: "Thinking: one")
+        var live = ChatThread(messages: [assistant], events: [notice])
+        var snapshot = live
+        snapshot.messages[0].content = "Draft continued"
+        snapshot.events[0].summary = "Thinking: two"
+
+        let mutation = WorkspaceAgentProgressThreadReconciler.reconcile(snapshot, into: &live)
+
+        XCTAssertEqual(mutation.messageMutation, .replacedAssistantTail(messageID: assistant.id))
+        XCTAssertFalse(mutation.eventsAffectTranscript)
+        XCTAssertFalse(mutation.contextAffectsTranscript)
+        XCTAssertEqual(live, snapshot)
+    }
+
+    func testReconcilerForcesRebuildWhenAssistantTailHasPersistedMessageEvent() {
+        let assistant = ChatMessage(role: .assistant, content: "Finished")
+        var live = ChatThread(
+            messages: [assistant],
+            events: [ThreadEvent(kind: .message, summary: assistant.content)]
+        )
+        var snapshot = live
+        snapshot.messages[0].content = "Changed after persistence"
+
+        let mutation = WorkspaceAgentProgressThreadReconciler.reconcile(snapshot, into: &live)
+
+        XCTAssertEqual(mutation.messageMutation, .replacedAssistantTail(messageID: assistant.id))
+        XCTAssertTrue(mutation.eventsAffectTranscript)
+    }
+
+    func testReconcilerForcesRebuildForToolLifecycleChanges() {
+        var live = ChatThread(
+            messages: [ChatMessage(role: .user, content: "Run")],
+            events: [ThreadEvent(kind: .toolQueued, summary: "queued")]
+        )
+        var snapshot = live
+        snapshot.events.append(ThreadEvent(kind: .toolRunning, summary: "running"))
+
+        let mutation = WorkspaceAgentProgressThreadReconciler.reconcile(snapshot, into: &live)
+
+        XCTAssertEqual(mutation.messageMutation, .unchanged)
+        XCTAssertTrue(mutation.eventsAffectTranscript)
+    }
+
+    func testCoalescedAppendThenReplaceRetainsSingleTailPatch() {
+        let threadID = UUID()
+        let messageID = UUID()
+        let append = WorkspaceAgentTranscriptRefreshPlan.appendAssistantTail(
+            threadID: threadID,
+            messageID: messageID
+        )
+        let replace = WorkspaceAgentTranscriptRefreshPlan.replaceAssistantTail(
+            threadID: threadID,
+            messageID: messageID
+        )
+
+        XCTAssertEqual(append.combined(with: replace), append)
+        XCTAssertEqual(replace.combined(with: append), .rebuild)
+    }
+
+    func testTrackerFallsBackWithoutAnAuthoritativePublishedBaseline() {
+        let threadID = UUID()
+        var tracker = WorkspaceAgentTranscriptRefreshTracker()
+        tracker.record(
+            WorkspaceAgentProgressThreadMutation(
+                threadID: threadID,
+                messageMutation: .unchanged,
+                eventsAffectTranscript: false,
+                contextAffectsTranscript: false
+            ),
+            selectedThreadID: threadID
+        )
+
+        XCTAssertEqual(tracker.consume(selectedThreadID: threadID), .rebuild)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
@@ -519,7 +519,7 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
         let producerMessageStorage = storageAddress(of: snapshot.messages)
         let producerEventStorage = storageAddress(of: snapshot.events)
 
-        WorkspaceAgentProgressThreadReconciler.reconcile(snapshot, into: &live)
+        let mutation = WorkspaceAgentProgressThreadReconciler.reconcile(snapshot, into: &live)
 
         XCTAssertEqual(live.messages, snapshot.messages)
         XCTAssertEqual(live.events, snapshot.events)
@@ -531,6 +531,8 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
         XCTAssertEqual(live.composerDraft, "A newer draft")
         XCTAssertEqual(live.composerAttachments.map(\.id), [liveAttachment.id])
         XCTAssertEqual(live.followUpQueue.map(\.text), ["Then run tests"])
+        XCTAssertEqual(mutation.messageMutation, .rebuild)
+        XCTAssertTrue(mutation.eventsAffectTranscript)
     }
 
     func testCancelledComposerRunRecordsNoticeOnOriginalThread() async throws {

--- a/Tests/QuillCodeAppTests/WorkspaceProgressSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProgressSurfaceTests.swift
@@ -111,6 +111,163 @@ final class WorkspaceProgressSurfaceTests: XCTestCase {
         XCTAssertEqual(progress.worktreeEnvironments, previous.worktreeEnvironments)
     }
 
+    func testTrackedAssistantTailProgressSkipsLongHistoryTranscriptProjection() throws {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        var events = [ThreadEvent(
+            kind: .toolQueued,
+            createdAt: timestamp,
+            summary: "queued"
+        )]
+        events.reserveCapacity(50_000)
+        for index in 1..<50_000 {
+            events.append(ThreadEvent(
+                kind: .notice,
+                createdAt: timestamp,
+                summary: "Progress record \(index)"
+            ))
+        }
+        let assistant = ChatMessage(
+            role: .assistant,
+            content: "Initial streamed answer",
+            createdAt: timestamp
+        )
+        let thread = ChatThread(
+            title: "Long streaming task",
+            messages: [ChatMessage(role: .user, content: "Proceed", createdAt: timestamp), assistant],
+            events: events
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        model.beginAgentRun(
+            threadID: thread.id,
+            lifecycle: WorkspaceComposerSendLifecycle.started(from: model.composer)
+        )
+        let previous = model.surface()
+        XCTAssertEqual(previous.transcript.toolCards.count, 1)
+
+        var snapshot = try XCTUnwrap(model.selectedThread)
+        snapshot.messages[snapshot.messages.index(before: snapshot.messages.endIndex)].content = "Fresh streamed answer"
+        snapshot.events[snapshot.events.index(before: snapshot.events.endIndex)].summary = "Thinking: validating"
+        model.applyAgentProgress(snapshot, expectedThreadID: thread.id)
+
+        let progress = model.progressSurface(reusing: previous, scope: .agent)
+        XCTAssertEqual(progress.transcript.messages.last?.text, "Fresh streamed answer")
+        XCTAssertEqual(
+            storageAddress(of: progress.transcript.toolCards),
+            storageAddress(of: previous.transcript.toolCards),
+            "assistant streaming should retain the already-reduced tool-card buffer"
+        )
+        XCTAssertEqual(progress, model.surface())
+    }
+
+    func testBackgroundAgentProgressReusesSelectedLongTranscript() throws {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let selected = ChatThread(
+            title: "Foreground history",
+            messages: (0..<10_000).map { index in
+                ChatMessage(
+                    role: index.isMultiple(of: 2) ? .user : .assistant,
+                    content: "Turn \(index)",
+                    createdAt: timestamp
+                )
+            },
+            events: [ThreadEvent(kind: .toolQueued, createdAt: timestamp, summary: "queued")]
+        )
+        let background = ChatThread(
+            title: "Background run",
+            messages: [ChatMessage(role: .user, content: "Keep working", createdAt: timestamp)]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [selected, background],
+            selectedThreadID: selected.id
+        ))
+        model.beginAgentRun(
+            threadID: background.id,
+            lifecycle: WorkspaceComposerSendLifecycle.started(from: model.composer)
+        )
+        let previous = model.surface()
+
+        var snapshot = try XCTUnwrap(model.root.threads.first { $0.id == background.id })
+        snapshot.messages.append(ChatMessage(
+            role: .assistant,
+            content: "Background result",
+            createdAt: timestamp
+        ))
+        model.applyAgentProgress(snapshot, expectedThreadID: background.id)
+
+        let progress = model.progressSurface(reusing: previous, scope: .agent)
+        XCTAssertEqual(
+            storageAddress(of: progress.transcript.messages),
+            storageAddress(of: previous.transcript.messages)
+        )
+        XCTAssertEqual(
+            storageAddress(of: progress.transcript.toolCards),
+            storageAddress(of: previous.transcript.toolCards)
+        )
+        XCTAssertEqual(
+            storageAddress(of: progress.transcript.timelineItems),
+            storageAddress(of: previous.transcript.timelineItems)
+        )
+        XCTAssertEqual(progress, model.surface())
+    }
+
+    func testToolLifecycleProgressFallsBackToAuthoritativeTranscriptProjection() throws {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let thread = ChatThread(
+            messages: [ChatMessage(role: .user, content: "Run it", createdAt: timestamp)],
+            events: [ThreadEvent(kind: .toolQueued, createdAt: timestamp, summary: "queued")]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        model.beginAgentRun(
+            threadID: thread.id,
+            lifecycle: WorkspaceComposerSendLifecycle.started(from: model.composer)
+        )
+        let previous = model.surface()
+
+        var snapshot = try XCTUnwrap(model.selectedThread)
+        snapshot.events.append(ThreadEvent(kind: .toolRunning, createdAt: timestamp, summary: "running"))
+        model.applyAgentProgress(snapshot, expectedThreadID: thread.id)
+
+        let progress = model.progressSurface(reusing: previous, scope: .agent)
+        XCTAssertEqual(progress.transcript.toolCards.last?.status, .running)
+        XCTAssertNotEqual(
+            storageAddress(of: progress.transcript.toolCards),
+            storageAddress(of: previous.transcript.toolCards)
+        )
+        XCTAssertEqual(progress, model.surface())
+    }
+
+    func testCoalescedAssistantAppendAndTailUpdateMatchesAuthoritativeSurface() throws {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let thread = ChatThread(
+            messages: [ChatMessage(role: .user, content: "Stream", createdAt: timestamp)]
+        )
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+        model.beginAgentRun(
+            threadID: thread.id,
+            lifecycle: WorkspaceComposerSendLifecycle.started(from: model.composer)
+        )
+        let previous = model.surface()
+
+        var snapshot = try XCTUnwrap(model.selectedThread)
+        snapshot.messages.append(ChatMessage(role: .assistant, content: "First", createdAt: timestamp))
+        model.applyAgentProgress(snapshot, expectedThreadID: thread.id)
+        snapshot.messages[snapshot.messages.index(before: snapshot.messages.endIndex)].content = "First complete chunk"
+        model.applyAgentProgress(snapshot, expectedThreadID: thread.id)
+
+        let progress = model.progressSurface(reusing: previous, scope: .agent)
+        XCTAssertEqual(progress.transcript.messages.map(\.text), ["Stream", "First complete chunk"])
+        XCTAssertEqual(progress, model.surface())
+    }
+
     func testAgentProgressReusesFilesystemBackedWorktreeEnvironmentProjection() throws {
         let root = try makeQuillCodeTestDirectory()
         let configurationDirectory = root.appendingPathComponent(".quillcode")
@@ -154,5 +311,11 @@ final class WorkspaceProgressSurfaceTests: XCTestCase {
         [local_environments.\(name)]
         title = "\(title)"
         """.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func storageAddress<Element>(of values: [Element]) -> UInt {
+        values.withUnsafeBufferPointer { buffer in
+            UInt(bitPattern: buffer.baseAddress)
+        }
     }
 }

--- a/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
@@ -76,6 +76,9 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
         let composerText = try Self.desktopSourceText(named: "QuillCodeDesktopController+ComposerAndPanes.swift")
         let terminalText = try Self.desktopSourceText(named: "QuillCodeDesktopController+Terminal.swift")
         let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+        let transcriptTrackerText = try Self.appSourceText(
+            named: "WorkspaceAgentTranscriptRefreshTracker.swift"
+        )
 
         Self.assertSource(refreshText, contains: "modelStateCoordinator.refreshProgressState(")
         Self.assertSource(refreshText, contains: "progressRefreshScheduler.flush")
@@ -83,17 +86,22 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
         Self.assertSource(composerText, contains: "scheduleProgressRefresh(.agent)")
         Self.assertSource(terminalText, contains: "scheduleProgressRefresh(.terminal)")
         Self.assertSource(surfaceText, contains: "func progressSurface(")
-        Self.assertSource(surfaceText, contains: "agentProgressSurface().apply(to: &next)")
+        Self.assertSource(surfaceText, contains: "agentTranscriptRefreshTracker.consume(")
+        Self.assertSource(surfaceText, contains: "reusing: surface.transcript")
+        Self.assertSource(surfaceText, contains: "transcriptRefresh.updatingTranscript")
         Self.assertSource(surfaceText, contains: "next.terminal = terminalSurface()")
+        Self.assertSource(transcriptTrackerText, contains: "private var pendingPlan")
+        Self.assertSource(transcriptTrackerText, excludes: "[ChatMessage]")
+        Self.assertSource(transcriptTrackerText, excludes: "[ThreadEvent]")
 
         let progressImplementation = try XCTUnwrap(
             surfaceText.components(separatedBy: "func progressSurface(").dropFirst().first
-        ).components(separatedBy: "private func agentProgressSurface()").first ?? ""
+        ).components(separatedBy: "private func agentProgressSurface(").first ?? ""
         XCTAssertFalse(progressImplementation.contains("surface()"))
         XCTAssertFalse(progressImplementation.contains("WorkspaceProjectConfigurationLoader"))
 
         let agentImplementation = try XCTUnwrap(
-            surfaceText.components(separatedBy: "private func agentProgressSurface()").dropFirst().first
+            surfaceText.components(separatedBy: "private func agentProgressSurface(").dropFirst().first
         ).components(separatedBy: "private func terminalSurface()").first ?? ""
         XCTAssertFalse(agentImplementation.contains("WorkspaceProjectConfigurationLoader"))
     }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,25 @@
 # QuillCode Decisions
 
+## 2026-08-10: agent transcript progress projects only proven tail changes
+
+- **Decision:** Reconciliation classifies each presentation-cadence snapshot as transcript
+  unchanged, one assistant-tail replacement, one assistant-tail append, or full rebuild. It also
+  marks message/tool/approval events and execution-context changes as projection-relevant. The next
+  coalesced agent refresh may reuse the selected transcript or patch that one tail only when the
+  model has an authoritative published baseline and every accumulated mutation remains compatible.
+- **Correctness boundary:** Hints are consumed once. A missing or changed baseline, changed message
+  identity or role, persisted message-event ambiguity, tool lifecycle mutation, structural history
+  change, project-context change, or incompatible coalesced sequence falls back to the complete
+  transcript projector. The incremental result is regression-tested against the authoritative
+  surface, including 50,000-event selected histories and 10,000-message background histories.
+- **Memory boundary:** The tracker retains only enum cases and UUIDs, never messages, events, tool
+  cards, timelines, or producer snapshots. Assistant streaming therefore reuses the already-reduced
+  tool-card buffer, and background progress reuses every selected transcript buffer, without
+  reintroducing copy-on-write coupling between the producer and workspace model.
+- **Evidence:** `WorkspaceAgentTranscriptRefreshTrackerTests`, `WorkspaceProgressSurfaceTests`,
+  `ParityDesktopTaskCoordinationGateTests`, the complete 5,831-test Swift suite, and release-packaged
+  native smoke with launch, resident-memory, repeated-interaction, and Accessibility budgets.
+
 ## 2026-08-10: agent progress keeps producer and model histories independently owned
 
 - **Decision:** Presentation-cadence progress reconciles identified message, context, event, and


### PR DESCRIPTION
## Summary
- classify coalesced agent mutations and incrementally patch only proven assistant-tail changes
- reuse the selected transcript wholesale for background-agent progress
- preserve authoritative full-projection fallbacks for structural, tool, approval, event, selection, and context changes
- retain only enum/UUID hints so progress tracking cannot pin producer transcript buffers

## Validation
- `swift test`: 5,831 tests passed, 5 skipped, 0 failures
- focused transcript/progress/parity run: 15 tests passed
- release packaged macOS smoke passed direct, Launch Services, live-window, Accessibility, interaction, crash-recovery, and budget checks
- packaged median launch-ready: 247.88 ms
- packaged initial RSS: 90.67 MiB
- packaged repeated-interaction RSS: 153.16 MiB with 4.77 MiB growth