### PR TITLE
Refresh Computer Use status on app activation

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopComputerUseCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComputerUseCoordinator.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import QuillCodeApp
 import QuillComputerUseKit
@@ -10,29 +11,48 @@ protocol QuillCodeDesktopComputerUseSettingsOpening {
 extension MacSystemSettingsOpener: QuillCodeDesktopComputerUseSettingsOpening {}
 
 @MainActor
-final class QuillCodeDesktopComputerUseCoordinator {
+final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     private var backend: any ComputerUseBackend
     private let systemSettingsOpener: any QuillCodeDesktopComputerUseSettingsOpening
-    /// Monotonic token so an in-flight foreground-app lookup that resolves late (e.g. the native
-    /// lookup spawned at install time) can't overwrite a newer one (the cua lookup after the swap).
+    private let applicationActivationNotificationCenter: NotificationCenter
+    private let applicationActivationNotification: Notification.Name
+    private var applicationActivationHandler: (@MainActor () -> Void)?
+    /// Monotonic token so an in-flight foreground-app lookup cannot overwrite a newer one after a
+    /// backend swap or rapid application activation sequence.
     private var foregroundRefreshGeneration = 0
 
     init(
         backend: any ComputerUseBackend = ComputerUseBackendFactory.platformDefault().backend(),
-        systemSettingsOpener: any QuillCodeDesktopComputerUseSettingsOpening = MacSystemSettingsOpener()
+        systemSettingsOpener: any QuillCodeDesktopComputerUseSettingsOpening = MacSystemSettingsOpener(),
+        applicationActivationNotificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        applicationActivationNotification: Notification.Name = NSWorkspace.didActivateApplicationNotification
     ) {
         self.backend = backend
         self.systemSettingsOpener = systemSettingsOpener
+        self.applicationActivationNotificationCenter = applicationActivationNotificationCenter
+        self.applicationActivationNotification = applicationActivationNotification
+        super.init()
     }
 
-    func install(
-        on model: QuillCodeWorkspaceModel,
-        refreshForegroundApplication: Bool = true
-    ) {
+    deinit {
+        applicationActivationNotificationCenter.removeObserver(self)
+    }
+
+    func install(on model: QuillCodeWorkspaceModel) {
         model.setComputerUseBackend(backend)
-        if refreshForegroundApplication {
-            scheduleForegroundApplicationRefresh(on: model)
-        }
+    }
+
+    func startApplicationActivationObservation(
+        onActivation: @escaping @MainActor () -> Void
+    ) {
+        guard applicationActivationHandler == nil else { return }
+        applicationActivationHandler = onActivation
+        applicationActivationNotificationCenter.addObserver(
+            self,
+            selector: #selector(applicationDidActivate),
+            name: applicationActivationNotification,
+            object: nil
+        )
     }
 
     /// Opt-in upgrade to the cua-driver backend (background computer use — no focus/cursor steal).
@@ -50,27 +70,34 @@ final class QuillCodeDesktopComputerUseCoordinator {
         model.setComputerUseBackend(cua) // also sets status
     }
 
-    func refreshForegroundApplication(on model: QuillCodeWorkspaceModel) async {
-        foregroundRefreshGeneration += 1
+    @discardableResult
+    func refreshForegroundApplication(on model: QuillCodeWorkspaceModel) async -> Bool {
+        guard !Task.isCancelled else { return false }
+        foregroundRefreshGeneration &+= 1
         let generation = foregroundRefreshGeneration
         guard let provider = backend as? any ComputerUseForegroundApplicationProviding else {
+            guard model.root.topBar.computerUseForegroundApplication != nil else { return false }
             model.setComputerUseForegroundApplication(nil)
-            return
+            return true
         }
         let application = await provider.foregroundApplication()
-        guard foregroundRefreshGeneration == generation else { return }
+        guard !Task.isCancelled, foregroundRefreshGeneration == generation else { return false }
+        guard model.root.topBar.computerUseForegroundApplication != application else { return false }
         model.setComputerUseForegroundApplication(application)
+        return true
     }
 
-    func refreshStatus(on model: QuillCodeWorkspaceModel) {
-        model.setComputerUseStatus(backend.status)
-        scheduleForegroundApplicationRefresh(on: model)
+    @discardableResult
+    func refreshStatus(on model: QuillCodeWorkspaceModel) -> Bool {
+        let status = backend.status
+        guard model.root.topBar.computerUseStatus != status else { return false }
+        model.setComputerUseStatus(status)
+        return true
     }
 
     @discardableResult
     func openSystemSettings(
-        _ destination: MacSystemSettingsOpener.Destination,
-        model: QuillCodeWorkspaceModel
+        _ destination: MacSystemSettingsOpener.Destination
     ) -> Bool {
         if let permissionRequester = backend as? any ComputerUsePermissionRequesting {
             switch destination {
@@ -81,13 +108,10 @@ final class QuillCodeDesktopComputerUseCoordinator {
             }
         }
         let didOpen = systemSettingsOpener.open(destination)
-        refreshStatus(on: model)
         return didOpen
     }
 
-    private func scheduleForegroundApplicationRefresh(on model: QuillCodeWorkspaceModel) {
-        Task { [weak self] in
-            await self?.refreshForegroundApplication(on: model)
-        }
+    @objc private func applicationDidActivate(_ notification: Notification) {
+        applicationActivationHandler?()
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+ComputerUse.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+ComputerUse.swift
@@ -1,0 +1,16 @@
+@MainActor
+extension QuillCodeDesktopController {
+    func scheduleComputerUseStatusRefresh() {
+        if computerUseCoordinator.refreshStatus(on: model) {
+            refresh()
+        }
+
+        let coordinator = computerUseCoordinator
+        let workspaceModel = model
+        tasks.replace(.computerUseForegroundRefresh) { [weak self] in
+            let changed = await coordinator.refreshForegroundApplication(on: workspaceModel)
+            guard !Task.isCancelled, changed else { return }
+            self?.refresh()
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Refresh.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Refresh.swift
@@ -15,9 +15,6 @@ extension QuillCodeDesktopController {
     }
 
     private func refreshNow(progressScope: WorkspaceProgressSurfaceScope?) {
-        if progressScope == nil || progressScope?.contains(.agent) == true {
-            computerUseCoordinator.refreshStatus(on: model)
-        }
         var nextSurface = surface
         var nextDraft = draft
         var nextTerminalDraft = terminalDraft

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Settings.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Settings.swift
@@ -65,7 +65,7 @@ extension QuillCodeDesktopController {
     }
 
     func openComputerUseSystemSettings(_ destination: MacSystemSettingsOpener.Destination) {
-        computerUseCoordinator.openSystemSettings(destination, model: model)
-        refresh()
+        computerUseCoordinator.openSystemSettings(destination)
+        scheduleComputerUseStatusRefresh()
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
@@ -53,11 +53,16 @@ extension QuillCodeDesktopController {
 
     private func startAutomaticWorkspaceServices() {
         model.startAutomaticStartupWork()
+        computerUseCoordinator.startApplicationActivationObservation { [weak self] in
+            self?.scheduleComputerUseStatusRefresh()
+        }
+        scheduleComputerUseStatusRefresh()
         let cuaCoordinator = computerUseCoordinator
         let cuaModel = model
         tasks.replace(.computerUseBackendResolution) {
             await cuaCoordinator.resolvePreferredBackend(on: cuaModel)
-            await cuaCoordinator.refreshForegroundApplication(on: cuaModel)
+        } onFinish: { [weak self] in
+            self?.scheduleComputerUseStatusRefresh()
         }
         model.scheduleSelectedProjectContextRefresh()
         // Bootstrap may finish a very small scan before its callback is installed. Starting one

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -68,6 +68,8 @@ final class QuillCodeDesktopController: ObservableObject {
 
     init(
         bootstrap: QuillCodeWorkspaceBootstrap = QuillCodeWorkspaceBootstrap(),
+        computerUseCoordinator: QuillCodeDesktopComputerUseCoordinator =
+            QuillCodeDesktopComputerUseCoordinator(),
         browserPageFetcher: any BrowserPageFetching = URLSessionBrowserPageFetcher(),
         browserLiveDOMCapturer: (any BrowserLiveDOMCapturing)? = DesktopBrowserLiveDOMCapturer(),
         browserSessionPresenter: any DesktopBrowserSessionPresenting = DesktopBrowserSessionPresenter(),
@@ -86,7 +88,7 @@ final class QuillCodeDesktopController: ObservableObject {
     ) {
         let launchWorkspaceRoot = workspaceRoot?.standardizedFileURL
         self.bootstrap = bootstrap
-        self.computerUseCoordinator = QuillCodeDesktopComputerUseCoordinator()
+        self.computerUseCoordinator = computerUseCoordinator
         self.activeWorkCoordinator = QuillCodeDesktopActiveWorkCoordinator()
         self.browserCoordinator = QuillCodeDesktopBrowserCoordinator(
             pageFetcher: browserPageFetcher,
@@ -135,10 +137,7 @@ final class QuillCodeDesktopController: ObservableObject {
         if let launchWorkspaceRoot {
             modelStateCoordinator.ensureDefaultProject(on: model, workspaceRoot: launchWorkspaceRoot)
         }
-        self.computerUseCoordinator.install(
-            on: model,
-            refreshForegroundApplication: false
-        )
+        self.computerUseCoordinator.install(on: model)
         // Ping the user when unattended work needs attention. The closure reads live config so
         // Settings toggles apply immediately without rebuilding the desktop controller.
         let workspaceModel = model

--- a/Sources/quill-code-desktop/QuillCodeDesktopTaskCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopTaskCoordinator.swift
@@ -9,6 +9,7 @@ final class QuillCodeDesktopTaskCoordinator {
         case terminal
         case browserPreview
         case computerUseBackendResolution
+        case computerUseForegroundRefresh
         case automationTicker
         case modelCatalogRefresh
         case modelCatalogRefreshTicker

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopComputerUseCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopComputerUseCoordinatorTests.swift
@@ -1,11 +1,13 @@
 import XCTest
 import QuillCodeApp
+import QuillCodeCore
+import QuillCodePersistence
 import QuillComputerUseKit
 @testable import quill_code_desktop
 
 @MainActor
 final class QuillCodeDesktopComputerUseCoordinatorTests: XCTestCase {
-    func testForegroundLookupCanWaitForTheStartupBoundary() async {
+    func testInstallAndStatusProjectionDoNotSpawnForegroundLookups() async {
         let application = ComputerUseApplication(
             name: "Terminal",
             bundleIdentifier: "com.apple.Terminal"
@@ -14,8 +16,12 @@ final class QuillCodeDesktopComputerUseCoordinatorTests: XCTestCase {
         let coordinator = QuillCodeDesktopComputerUseCoordinator(backend: backend)
         let model = QuillCodeWorkspaceModel()
 
-        coordinator.install(on: model, refreshForegroundApplication: false)
+        coordinator.install(on: model)
+        for _ in 0..<1_000 {
+            coordinator.refreshStatus(on: model)
+        }
         await Task.yield()
+        XCTAssertEqual(backend.statusReadCount, 1_001)
         XCTAssertEqual(backend.lookupCount, 0)
         XCTAssertNil(model.root.topBar.computerUseForegroundApplication)
 
@@ -25,6 +31,114 @@ final class QuillCodeDesktopComputerUseCoordinatorTests: XCTestCase {
         XCTAssertEqual(model.root.topBar.computerUseForegroundApplication, application)
     }
 
+    func testSurfaceProjectionNeverPollsComputerUseBackend() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let paths = QuillCodePaths(home: root.appendingPathComponent("state", isDirectory: true))
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+        )
+        let backend = ForegroundRecordingComputerUseBackend(
+            application: ComputerUseApplication(name: "Terminal")
+        )
+        let computerUseCoordinator = QuillCodeDesktopComputerUseCoordinator(backend: backend)
+        let controller = QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            computerUseCoordinator: computerUseCoordinator,
+            browserLiveDOMCapturer: nil,
+            automationNotifier: ComputerUseNoopNotifier(),
+            updateController: QuillCodeDesktopUpdateController(configuration: nil, installResultURL: nil),
+            installationLocationController: QuillCodeDesktopInstallationLocationController(
+                configuration: nil
+            ),
+            workspaceRoot: root
+        )
+        defer { controller.tasks.cancelAll() }
+
+        XCTAssertEqual(backend.statusReadCount, 1)
+        for _ in 0..<1_000 {
+            controller.refresh()
+        }
+
+        XCTAssertEqual(backend.statusReadCount, 1)
+        XCTAssertEqual(backend.lookupCount, 0)
+    }
+
+    func testApplicationActivationObservationIsIdempotent() {
+        let notificationCenter = NotificationCenter()
+        let activationNotification = Notification.Name("test-application-activated")
+        let coordinator = QuillCodeDesktopComputerUseCoordinator(
+            applicationActivationNotificationCenter: notificationCenter,
+            applicationActivationNotification: activationNotification
+        )
+        var activationCount = 0
+
+        coordinator.startApplicationActivationObservation {
+            activationCount += 1
+        }
+        coordinator.startApplicationActivationObservation {
+            XCTFail("A repeated installation must not replace the live activation handler.")
+        }
+        notificationCenter.post(name: activationNotification, object: nil)
+
+        XCTAssertEqual(activationCount, 1)
+    }
+
+    func testLateForegroundLookupCannotOverwriteNewerApplication() async {
+        let backend = ControlledForegroundComputerUseBackend()
+        let coordinator = QuillCodeDesktopComputerUseCoordinator(backend: backend)
+        let model = QuillCodeWorkspaceModel()
+        let oldApplication = ComputerUseApplication(
+            name: "Old App",
+            bundleIdentifier: "example.old"
+        )
+        let newApplication = ComputerUseApplication(
+            name: "New App",
+            bundleIdentifier: "example.new"
+        )
+
+        let oldLookup = Task { @MainActor in
+            await coordinator.refreshForegroundApplication(on: model)
+        }
+        await backend.waitForRequestCount(1)
+        let newLookup = Task { @MainActor in
+            await coordinator.refreshForegroundApplication(on: model)
+        }
+        await backend.waitForRequestCount(2)
+
+        await backend.resumeRequest(at: 1, with: newApplication)
+        let newChanged = await newLookup.value
+        await backend.resumeRequest(at: 0, with: oldApplication)
+        let oldChanged = await oldLookup.value
+
+        XCTAssertTrue(newChanged)
+        XCTAssertFalse(oldChanged)
+        XCTAssertEqual(model.root.topBar.computerUseForegroundApplication, newApplication)
+    }
+
+    func testCancelledForegroundLookupCannotMutateModel() async {
+        let backend = ControlledForegroundComputerUseBackend()
+        let coordinator = QuillCodeDesktopComputerUseCoordinator(backend: backend)
+        let model = QuillCodeWorkspaceModel()
+        let application = ComputerUseApplication(
+            name: "Cancelled App",
+            bundleIdentifier: "example.cancelled"
+        )
+
+        let lookup = Task { @MainActor in
+            await coordinator.refreshForegroundApplication(on: model)
+        }
+        await backend.waitForRequestCount(1)
+        lookup.cancel()
+        await backend.resumeRequest(at: 0, with: application)
+        let changed = await lookup.value
+
+        XCTAssertFalse(changed)
+        XCTAssertNil(model.root.topBar.computerUseForegroundApplication)
+    }
+
     func testOpenSystemSettingsRequestsPermissionForExactDestination() {
         let backend = PermissionRecordingComputerUseBackend()
         let opener = ComputerUseSettingsRecordingOpener()
@@ -32,14 +146,13 @@ final class QuillCodeDesktopComputerUseCoordinatorTests: XCTestCase {
             backend: backend,
             systemSettingsOpener: opener
         )
-        let model = QuillCodeWorkspaceModel()
 
-        XCTAssertTrue(coordinator.openSystemSettings(.screenRecording, model: model))
+        XCTAssertTrue(coordinator.openSystemSettings(.screenRecording))
         XCTAssertEqual(backend.screenRecordingRequestCount, 1)
         XCTAssertEqual(backend.accessibilityRequestCount, 0)
         XCTAssertEqual(opener.screenRecordingOpenCount, 1)
 
-        XCTAssertTrue(coordinator.openSystemSettings(.accessibility, model: model))
+        XCTAssertTrue(coordinator.openSystemSettings(.accessibility))
         XCTAssertEqual(backend.screenRecordingRequestCount, 1)
         XCTAssertEqual(backend.accessibilityRequestCount, 1)
         XCTAssertEqual(opener.accessibilityOpenCount, 1)
@@ -50,6 +163,7 @@ private final class ForegroundRecordingComputerUseBackend: @unchecked Sendable,
     ComputerUseBackend,
     ComputerUseForegroundApplicationProviding
 {
+    private(set) var statusReadCount = 0
     private(set) var lookupCount = 0
     let application: ComputerUseApplication
 
@@ -58,7 +172,8 @@ private final class ForegroundRecordingComputerUseBackend: @unchecked Sendable,
     }
 
     var status: ComputerUseStatus {
-        .permissionStatus(screenRecordingGranted: true, accessibilityGranted: true)
+        statusReadCount += 1
+        return .permissionStatus(screenRecordingGranted: true, accessibilityGranted: true)
     }
 
     func foregroundApplication() async -> ComputerUseApplication? {
@@ -75,6 +190,10 @@ private final class ForegroundRecordingComputerUseBackend: @unchecked Sendable,
     func scroll(dx: Int, dy: Int) async throws {}
     func moveCursor(x: Int, y: Int) async throws {}
     func pressKey(_ key: String) async throws {}
+}
+
+private struct ComputerUseNoopNotifier: QuillCodeAutomationNotifying {
+    func deliver(_ report: AutomationRunReport) {}
 }
 
 private final class PermissionRecordingComputerUseBackend: @unchecked Sendable,
@@ -96,6 +215,42 @@ private final class PermissionRecordingComputerUseBackend: @unchecked Sendable,
     func requestAccessibilityAccess() -> Bool {
         accessibilityRequestCount += 1
         return false
+    }
+
+    func screenshot() async throws -> ComputerScreenshot {
+        ComputerScreenshot(width: 1, height: 1, pngBase64: "")
+    }
+
+    func leftClick(x: Int, y: Int) async throws {}
+    func type(_ text: String) async throws {}
+    func scroll(dx: Int, dy: Int) async throws {}
+    func moveCursor(x: Int, y: Int) async throws {}
+    func pressKey(_ key: String) async throws {}
+}
+
+private actor ControlledForegroundComputerUseBackend: ComputerUseBackend,
+    ComputerUseForegroundApplicationProviding
+{
+    private var continuations: [CheckedContinuation<ComputerUseApplication?, Never>] = []
+
+    nonisolated var status: ComputerUseStatus {
+        .permissionStatus(screenRecordingGranted: true, accessibilityGranted: true)
+    }
+
+    func foregroundApplication() async -> ComputerUseApplication? {
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func waitForRequestCount(_ expectedCount: Int) async {
+        while continuations.count < expectedCount {
+            await Task.yield()
+        }
+    }
+
+    func resumeRequest(at index: Int, with application: ComputerUseApplication?) {
+        continuations[index].resume(returning: application)
     }
 
     func screenshot() async throws -> ComputerScreenshot {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
@@ -541,7 +541,7 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
         )
     }
 
-    func testComputerUseCoordinatorRefreshesForegroundApplication() async throws {
+    func testComputerUseCoordinatorRefreshesForegroundApplicationWhenRequested() async {
         let application = ComputerUseApplication(
             name: "Terminal",
             bundleIdentifier: "com.apple.Terminal"
@@ -551,10 +551,9 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
         let coordinator = QuillCodeDesktopComputerUseCoordinator(backend: backend)
 
         coordinator.install(on: model)
+        await coordinator.refreshForegroundApplication(on: model)
 
-        try await waitUntil(timeoutSeconds: 1) {
-            model.surface().settings.computerUseForegroundApplication == application
-        }
+        XCTAssertEqual(model.surface().settings.computerUseForegroundApplication, application)
     }
 
     func testWindowAccessibilityFrameSamplerRequiresPrimarySidebarActions() {

--- a/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
@@ -14,6 +14,7 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         )
         let extensionFileNames = [
             "QuillCodeDesktopController+Commands.swift",
+            "QuillCodeDesktopController+ComputerUse.swift",
             "QuillCodeDesktopController+ComposerAndPanes.swift",
             "QuillCodeDesktopController+Navigation.swift",
             "QuillCodeDesktopController+Notifications.swift",

--- a/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
@@ -10,6 +10,9 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
         let composerCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopComposerCoordinator.swift")
         let terminalCoordinatorText = try Self.desktopSourceText(named: "QuillCodeDesktopTerminalCoordinator.swift")
         let terminalControllerText = try Self.desktopSourceText(named: "QuillCodeDesktopController+Terminal.swift")
+        let computerUseControllerText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopController+ComputerUse.swift"
+        )
         let terminalSmokeText = try Self.desktopSourceText(named: "QuillCodeDesktopTerminalRetentionSmoke.swift")
         let smokeRunnerText = try Self.desktopSourceText(named: "QuillCodeDesktopSmokeRunner.swift")
         let desktopTaskText = try Self.desktopSourceText(named: "QuillCodeDesktopTaskCoordinator.swift")
@@ -51,6 +54,9 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
         Self.assertSource(terminalCoordinatorText, contains: "draft.trimmingCharacters(in: .whitespacesAndNewlines)")
         Self.assertSource(terminalCoordinatorText, contains: "model.setTerminalDraft(draft)")
         Self.assertSource(browserCoordinatorText, contains: "tasks.replace(.browserPreview")
+        Self.assertSource(desktopTaskText, contains: "case computerUseForegroundRefresh")
+        Self.assertSource(computerUseControllerText, contains: "tasks.replace(.computerUseForegroundRefresh)")
+        Self.assertSource(computerUseControllerText, contains: "guard !Task.isCancelled, changed else { return }")
         Self.assertSource(controllerText, contains: "QuillCodeDesktopAutomationCoordinator")
         Self.assertSource(controllerText, contains: "automationCoordinator.startTicker")
         Self.assertSource(automationCoordinatorText, contains: "tasks.replace(.automationTicker")
@@ -82,6 +88,7 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
 
         Self.assertSource(refreshText, contains: "modelStateCoordinator.refreshProgressState(")
         Self.assertSource(refreshText, contains: "progressRefreshScheduler.flush")
+        Self.assertSource(refreshText, excludes: "computerUseCoordinator")
         Self.assertSource(schedulerText, contains: "pendingScope.formUnion(scope)")
         Self.assertSource(composerText, contains: "scheduleProgressRefresh(.agent)")
         Self.assertSource(terminalText, contains: "scheduleProgressRefresh(.terminal)")

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -44,8 +44,8 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "automaticStartupPolicy: .deferUntilRequested",
             "model.startAutomaticStartupWork()",
             "tasks.replace(.computerUseBackendResolution)",
-            "refreshForegroundApplication: false",
-            "await cuaCoordinator.refreshForegroundApplication(on: cuaModel)",
+            "startApplicationActivationObservation",
+            "scheduleComputerUseStatusRefresh()",
             "installApprovalNotificationHandling()",
             "installationLocationController.startIfNeeded()",
             "updateController.startAutomaticChecks()"

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,24 @@
 # QuillCode Decisions
 
+## 2026-08-10: Computer Use status refresh is event-driven and task-owned
+
+- **Decision:** Workspace surface projection no longer polls Computer Use permissions or launches a
+  foreground-application query. Automatic startup performs one explicit refresh, and macOS
+  application-activation notifications request later refreshes only when the foreground app can
+  actually change. Returning from Computer Use system settings uses the same path.
+- **Bounded work:** Foreground queries occupy one replaceable desktop task slot. A newer activation
+  cancels the prior owner, generation checks reject late backend results, and cancellation is checked
+  before model mutation. Repeated surface refreshes therefore retain no lookup tasks or provider
+  subprocesses. Status and foreground values publish only when they changed.
+- **Recovery boundary:** Activation observation begins with automatic workspace services, so startup
+  recovery keeps this optional work paused. Native Computer Use remains installed for explicit user
+  actions, and resolving the optional CUA driver schedules a fresh status query after the backend swap.
+- **Evidence:** Coordinator tests prove 1,000 real controller surface projections perform zero
+  permission reads and foreground lookups beyond installation, activation observation installs once,
+  late results cannot replace newer applications, and canceled work cannot mutate the model. Desktop
+  task and progress-projection parity gates require cancellable ownership and reject Computer Use work
+  from the presentation path.
+
 ## 2026-08-10: startup failures reopen with automatic workspace work paused
 
 - **Decision:** Controller construction now loads and projects the usable workspace without starting


### PR DESCRIPTION
## Summary
- remove Computer Use permission polling and foreground-app process work from routine UI projection
- refresh on startup, app activation, settings return, and backend resolution through one replaceable task slot
- reject canceled and late foreground results and publish only changed values

## Verification
- 5,840 tests passed; 5 expected environment-gated skips
- release packaged macOS smoke passed, including direct launch, Launch Services, native interactions, accessibility, crash recovery, and coworker workflows
- 245.27 ms launch-ready; 90.55 MiB initial RSS; 4.23 MiB repeated-sweep growth; 0 repeated thread growth
- 1,000 real controller surface refreshes perform no Computer Use backend polls or lookups