### PR TITLE
Defer project bookmark restore past first window

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
@@ -1,7 +1,11 @@
+import Foundation
+import QuillCodeApp
+
 @MainActor
 struct QuillCodeDesktopStartupState {
     private(set) var automaticWorkspaceServicesArePaused: Bool
     private(set) var automaticWorkspaceServicesStarted = false
+    private(set) var postWindowApplicationServicesStarted = false
 
     init(mode: QuillCodeDesktopStartupMode) {
         self.automaticWorkspaceServicesArePaused = mode.pausesAutomaticWorkspaceServices
@@ -14,6 +18,12 @@ struct QuillCodeDesktopStartupState {
         return true
     }
 
+    mutating func startPostWindowApplicationServicesIfNeeded() -> Bool {
+        guard !postWindowApplicationServicesStarted else { return false }
+        postWindowApplicationServicesStarted = true
+        return true
+    }
+
     mutating func resumeAutomaticWorkspaceServices() -> Bool {
         automaticWorkspaceServicesArePaused = false
         return startAutomaticWorkspaceServicesIfAllowed()
@@ -22,6 +32,10 @@ struct QuillCodeDesktopStartupState {
 
 @MainActor
 extension QuillCodeDesktopController {
+    var postWindowApplicationServicesStarted: Bool {
+        automaticStartupState.postWindowApplicationServicesStarted
+    }
+
     var automaticWorkspaceServicesArePaused: Bool {
         automaticStartupState.automaticWorkspaceServicesArePaused
     }
@@ -33,6 +47,7 @@ extension QuillCodeDesktopController {
     /// Crosses the first-window startup boundary. A recovery launch remains in the `.starting`
     /// phase until the user either keeps automatic work paused or deliberately resumes it.
     func completeStartupIfAllowed() {
+        startPostWindowApplicationServicesIfNeeded()
         guard !automaticWorkspaceServicesArePaused else { return }
         if automaticStartupState.startAutomaticWorkspaceServicesIfAllowed() {
             startAutomaticWorkspaceServices()
@@ -41,14 +56,27 @@ extension QuillCodeDesktopController {
     }
 
     func continueWithAutomaticWorkspaceServicesPaused() {
+        startPostWindowApplicationServicesIfNeeded()
         launchLifecycleController?.markReady()
     }
 
     func resumeAutomaticWorkspaceServices() {
+        startPostWindowApplicationServicesIfNeeded()
         if automaticStartupState.resumeAutomaticWorkspaceServices() {
             startAutomaticWorkspaceServices()
         }
         launchLifecycleController?.markReady()
+    }
+
+    private func startPostWindowApplicationServicesIfNeeded() {
+        guard automaticStartupState.startPostWindowApplicationServicesIfNeeded() else { return }
+        projectAccessCoordinator.restoreAccess(for: model.root.projects)
+        ToolArtifactLocalPreviewAccess.configure(
+            projectRoots: model.root.projects
+                .filter { !$0.isRemote }
+                .map { URL(fileURLWithPath: $0.path) },
+            readableProjectRoots: projectAccessCoordinator.activeProjectURLs
+        )
     }
 
     private func startAutomaticWorkspaceServices() {

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -78,6 +78,8 @@ final class QuillCodeDesktopController: ObservableObject {
         sshRemoteProjectProbe: SSHRemoteProjectProbe = SSHRemoteProjectProbe(),
         composerDraftCheckpointCoordinator: QuillCodeDesktopComposerDraftCheckpointCoordinator =
             QuillCodeDesktopComposerDraftCheckpointCoordinator(),
+        projectAccessCoordinator: QuillCodeDesktopProjectAccessCoordinator =
+            QuillCodeDesktopProjectAccessCoordinator(),
         transcriptExportCoordinator: QuillCodeDesktopTranscriptExportCoordinator =
             QuillCodeDesktopTranscriptExportCoordinator(),
         updateController: QuillCodeDesktopUpdateController? = nil,
@@ -109,7 +111,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.composerDraftCheckpointCoordinator = composerDraftCheckpointCoordinator
         self.copyCoordinator = QuillCodeDesktopCopyCoordinator()
         self.projectImportCoordinator = QuillCodeDesktopProjectImportCoordinator()
-        self.projectAccessCoordinator = QuillCodeDesktopProjectAccessCoordinator()
+        self.projectAccessCoordinator = projectAccessCoordinator
         self.modelStateCoordinator = QuillCodeDesktopModelStateCoordinator()
         self.paneCoordinator = QuillCodeDesktopPaneCoordinator()
         self.workspaceActionCoordinator = QuillCodeDesktopWorkspaceActionCoordinator()
@@ -159,13 +161,6 @@ final class QuillCodeDesktopController: ObservableObject {
             // and read tools must stop with the session too.
             tasks.cancel(.codeReview(threadID))
         }
-        projectAccessCoordinator.restoreAccess(for: workspaceModel.root.projects)
-        ToolArtifactLocalPreviewAccess.configure(
-            projectRoots: workspaceModel.root.projects
-                .filter { !$0.isRemote }
-                .map { URL(fileURLWithPath: $0.path) },
-            readableProjectRoots: projectAccessCoordinator.activeProjectURLs
-        )
         let initialState = modelStateCoordinator.initialState(from: model)
         self.surface = initialState.surface
         self.draft = initialState.draft

--- a/Sources/quill-code-desktop/QuillCodeDesktopProjectAccessCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopProjectAccessCoordinator.swift
@@ -1,6 +1,14 @@
 import Foundation
 import QuillCodeCore
 
+@MainActor
+protocol QuillCodeDesktopProjectBookmarkPersisting: AnyObject {
+    func dictionary(forKey defaultName: String) -> [String: Any]?
+    func set(_ value: Any?, forKey defaultName: String)
+}
+
+extension UserDefaults: QuillCodeDesktopProjectBookmarkPersisting {}
+
 struct QuillCodeDesktopResolvedProjectBookmark {
     let url: URL
     let isStale: Bool
@@ -40,7 +48,7 @@ struct QuillCodeDesktopProjectBookmarkService {
 final class QuillCodeDesktopProjectAccessCoordinator {
     static let defaultStorageKey = "projectSecurityScopedBookmarks.v1"
 
-    private let defaults: UserDefaults
+    private let defaults: any QuillCodeDesktopProjectBookmarkPersisting
     private let storageKey: String
     private let service: QuillCodeDesktopProjectBookmarkService
     private var activeURLs: [String: URL] = [:]
@@ -50,7 +58,7 @@ final class QuillCodeDesktopProjectAccessCoordinator {
     }
 
     init(
-        defaults: UserDefaults = .standard,
+        defaults: any QuillCodeDesktopProjectBookmarkPersisting = UserDefaults.standard,
         storageKey: String = defaultStorageKey,
         service: QuillCodeDesktopProjectBookmarkService = .live
     ) {
@@ -81,6 +89,7 @@ final class QuillCodeDesktopProjectAccessCoordinator {
             URL(fileURLWithPath: project.path).standardizedFileURL.path
         })
         var bookmarks = storedBookmarks()
+        let originalBookmarks = bookmarks
 
         for path in activeURLs.keys where !localPaths.contains(path) {
             deactivate(path)
@@ -104,7 +113,9 @@ final class QuillCodeDesktopProjectAccessCoordinator {
                 bookmarks.removeValue(forKey: path)
             }
         }
-        saveBookmarks(bookmarks)
+        if bookmarks != originalBookmarks {
+            saveBookmarks(bookmarks)
+        }
     }
 
     func reconcileProjects(_ projects: [ProjectRef]) {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
@@ -139,6 +139,52 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
         XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
     }
 
+    func testProjectBookmarkRestoreWaitsForFirstWindowAndRunsOnceDuringRecovery() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let projectURL = fixture.root.appendingPathComponent("bookmarked-project", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+        let suiteName = "QuillCodeDesktopLaunchLifecycleTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let storageKey = "bookmarks"
+        defaults.set([projectURL.path: Data(projectURL.path.utf8)], forKey: storageKey)
+        let bookmarkSpy = LaunchLifecycleProjectBookmarkServiceSpy()
+        let projectAccessCoordinator = QuillCodeDesktopProjectAccessCoordinator(
+            defaults: defaults,
+            storageKey: storageKey,
+            service: bookmarkSpy.service
+        )
+        let paths = QuillCodePaths(home: fixture.root.appendingPathComponent("bookmark-state"))
+        try JSONProjectStore(fileURL: paths.projectsFile).save([
+            ProjectRef(name: "Bookmarked", path: projectURL.path)
+        ])
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+        )
+        let controller = QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            browserLiveDOMCapturer: nil,
+            automationNotifier: LaunchLifecycleNoopNotifier(),
+            projectAccessCoordinator: projectAccessCoordinator,
+            updateController: QuillCodeDesktopUpdateController(configuration: nil, installResultURL: nil),
+            installationLocationController: QuillCodeDesktopInstallationLocationController(configuration: nil),
+            startupMode: .recovery,
+            workspaceRoot: fixture.root
+        )
+
+        XCTAssertEqual(bookmarkSpy.resolvedPaths, [])
+
+        controller.completeStartupIfAllowed()
+        controller.completeStartupIfAllowed()
+
+        XCTAssertEqual(bookmarkSpy.resolvedPaths, [projectURL.path])
+        XCTAssertEqual(bookmarkSpy.startedPaths, [projectURL.path])
+        XCTAssertTrue(controller.postWindowApplicationServicesStarted)
+        XCTAssertFalse(controller.automaticWorkspaceServicesStarted)
+    }
+
     func testRecoveryStartupCanRemainPausedAndStillBecomeReady() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }
@@ -442,6 +488,31 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
     private func permissions(at url: URL) throws -> Int {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         return try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).intValue & 0o777
+    }
+}
+
+@MainActor
+private final class LaunchLifecycleProjectBookmarkServiceSpy {
+    private(set) var resolvedPaths: [String] = []
+    private(set) var startedPaths: [String] = []
+
+    var service: QuillCodeDesktopProjectBookmarkService {
+        QuillCodeDesktopProjectBookmarkService(
+            makeBookmark: { Data($0.path.utf8) },
+            resolveBookmark: { [weak self] data in
+                let path = String(decoding: data, as: UTF8.self)
+                self?.resolvedPaths.append(path)
+                return QuillCodeDesktopResolvedProjectBookmark(
+                    url: URL(fileURLWithPath: path),
+                    isStale: false
+                )
+            },
+            startAccessing: { [weak self] url in
+                self?.startedPaths.append(url.path)
+                return true
+            },
+            stopAccessing: { _ in }
+        )
     }
 }
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopProjectAccessCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopProjectAccessCoordinatorTests.swift
@@ -68,6 +68,27 @@ final class QuillCodeDesktopProjectAccessCoordinatorTests: XCTestCase {
         XCTAssertEqual(stored, [:])
     }
 
+    func testRestoreDoesNotRewriteUnchangedBookmarks() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanUp() }
+        let path = fixture.projectURL.path
+        let bookmark = Data(path.utf8)
+        let persistence = ProjectBookmarkPersistenceSpy(bookmarks: [path: bookmark])
+        let spy = ProjectBookmarkServiceSpy()
+        let coordinator = QuillCodeDesktopProjectAccessCoordinator(
+            defaults: persistence,
+            storageKey: fixture.storageKey,
+            service: spy.service
+        )
+
+        coordinator.restoreAccess(for: [ProjectRef(name: "Project", path: path)])
+
+        XCTAssertEqual(spy.resolvedPaths, [path])
+        XCTAssertEqual(spy.madeBookmarkPaths, [])
+        XCTAssertEqual(persistence.bookmarks, [path: bookmark])
+        XCTAssertEqual(persistence.writeCount, 0)
+    }
+
     private func makeFixture() throws -> ProjectAccessFixture {
         let suiteName = "QuillCodeDesktopProjectAccessCoordinatorTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -86,10 +107,30 @@ final class QuillCodeDesktopProjectAccessCoordinatorTests: XCTestCase {
 }
 
 @MainActor
+private final class ProjectBookmarkPersistenceSpy: QuillCodeDesktopProjectBookmarkPersisting {
+    var bookmarks: [String: Data]
+    private(set) var writeCount = 0
+
+    init(bookmarks: [String: Data]) {
+        self.bookmarks = bookmarks
+    }
+
+    func dictionary(forKey defaultName: String) -> [String: Any]? {
+        bookmarks
+    }
+
+    func set(_ value: Any?, forKey defaultName: String) {
+        writeCount += 1
+        bookmarks = value as? [String: Data] ?? [:]
+    }
+}
+
+@MainActor
 private final class ProjectBookmarkServiceSpy {
     var startedPaths: [String] = []
     var stoppedPaths: [String] = []
     var resolvedPaths: [String] = []
+    var madeBookmarkPaths: [String] = []
     private let isStale: Bool
     private let resolvedURLOverride: URL?
 
@@ -100,7 +141,10 @@ private final class ProjectBookmarkServiceSpy {
 
     var service: QuillCodeDesktopProjectBookmarkService {
         QuillCodeDesktopProjectBookmarkService(
-            makeBookmark: { Data($0.path.utf8) },
+            makeBookmark: { [weak self] url in
+                self?.madeBookmarkPaths.append(url.path)
+                return Data(url.path.utf8)
+            },
             resolveBookmark: { [weak self] data in
                 let path = String(decoding: data, as: UTF8.self)
                 self?.resolvedPaths.append(path)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # QuillCode Decisions
 
+## 2026-08-10: project bookmark restoration begins after the first window
+
+- **Decision:** Security-scoped project bookmarks are no longer read, resolved, activated, or
+  rewritten while the desktop controller is constructing its initial surface. The yielded
+  first-window startup boundary restores them once, then configures local artifact-preview access
+  before automatic project services begin.
+- **Persistence boundary:** Bookmark reconciliation writes `UserDefaults` only when it removes an
+  obsolete or invalid record or renews a stale bookmark. A healthy launch with unchanged bookmarks,
+  including the common empty-bookmark case, performs no preferences write.
+- **Recovery boundary:** Recovery startup restores explicit project access while leaving automatic
+  workspace work paused. All normal, paused, and resumed paths share one idempotent post-window gate.
+- **Evidence:** Focused coordinator tests inject bookmark persistence and prove unchanged state has
+  zero writes. Launch lifecycle coverage proves controller construction performs no bookmark
+  resolution and repeated first-window completion restores and activates access exactly once.
+
 ## 2026-08-10: Computer Use status refresh is event-driven and task-owned
 
 - **Decision:** Workspace surface projection no longer polls Computer Use permissions or launches a


### PR DESCRIPTION
## Summary
- move security-scoped bookmark restoration and artifact-preview access behind the existing first-window startup boundary
- avoid rewriting unchanged bookmark dictionaries to UserDefaults
- keep recovery startup paused while restoring explicit project access exactly once

## Verification
- 5,842 Swift tests, 5 expected skips, 0 failures
- focused launch/bookmark/parity tests after final state-machine cleanup: 27 passed
- three release native-window runs: 258 ms / 221 ms / 216 ms launch-ready, bounded repeated growth
- release packaged macOS smoke: direct executable, Launch Services, SIGKILL draft recovery, accessibility, and performance all passed
- packaged launch-ready 263 ms, 90.2 MiB initial RSS, 4.7 MiB repeated-sweep growth