### PR TITLE
Defer Computer Use permission probes past first window

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -351,8 +351,15 @@ public final class QuillCodeWorkspaceModel {
         changedFilePathsProjectID == root.selectedProjectID ? changedFilePaths : []
     }
 
-    public func setComputerUseBackend(_ backend: any ComputerUseBackend) {
+    /// Installs the executable backend without synchronously querying operating-system permission
+    /// state. Desktop startup uses this boundary so TCC and screen-capture preflights can run in its
+    /// cancellable post-window refresh task while Computer Use actions are available immediately.
+    public func installComputerUseBackend(_ backend: any ComputerUseBackend) {
         computerUseBackend = backend
+    }
+
+    public func setComputerUseBackend(_ backend: any ComputerUseBackend) {
+        installComputerUseBackend(backend)
         setComputerUseStatus(backend.status)
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopComputerUseCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComputerUseCoordinator.swift
@@ -17,6 +17,8 @@ final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     private let applicationActivationNotificationCenter: NotificationCenter
     private let applicationActivationNotification: Notification.Name
     private var applicationActivationHandler: (@MainActor () -> Void)?
+    /// Invalidates a permission preflight when a newer refresh or backend replacement wins.
+    private var statusRefreshGeneration = 0
     /// Monotonic token so an in-flight foreground-app lookup cannot overwrite a newer one after a
     /// backend swap or rapid application activation sequence.
     private var foregroundRefreshGeneration = 0
@@ -39,7 +41,7 @@ final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     }
 
     func install(on model: QuillCodeWorkspaceModel) {
-        model.setComputerUseBackend(backend)
+        model.installComputerUseBackend(backend)
     }
 
     func startApplicationActivationObservation(
@@ -63,11 +65,14 @@ final class QuillCodeDesktopComputerUseCoordinator: NSObject {
         on model: QuillCodeWorkspaceModel,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         locator: CuaDriverLocator = CuaDriverLocator()
-    ) async {
-        guard ComputerUseBackendFactory.cuaDriverPreferred(environment: environment) else { return }
-        guard let cua = await locator.makeBackendIfAvailable(environment: environment) else { return }
+    ) async -> Bool {
+        guard ComputerUseBackendFactory.cuaDriverPreferred(environment: environment) else { return false }
+        guard let cua = await locator.makeBackendIfAvailable(environment: environment) else { return false }
+        statusRefreshGeneration &+= 1
+        foregroundRefreshGeneration &+= 1
         backend = cua
-        model.setComputerUseBackend(cua) // also sets status
+        model.installComputerUseBackend(cua)
+        return true
     }
 
     @discardableResult
@@ -88,8 +93,16 @@ final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     }
 
     @discardableResult
-    func refreshStatus(on model: QuillCodeWorkspaceModel) -> Bool {
-        let status = backend.status
+    func refreshStatus(on model: QuillCodeWorkspaceModel) async -> Bool {
+        guard !Task.isCancelled else { return false }
+        statusRefreshGeneration &+= 1
+        let generation = statusRefreshGeneration
+        let backend = backend
+        let statusTask = Task.detached(priority: .utility) {
+            backend.status
+        }
+        let status = await statusTask.value
+        guard !Task.isCancelled, statusRefreshGeneration == generation else { return false }
         guard model.root.topBar.computerUseStatus != status else { return false }
         model.setComputerUseStatus(status)
         return true

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Commands.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Commands.swift
@@ -68,7 +68,7 @@ extension QuillCodeDesktopController {
 
 extension QuillCodeDesktopController: QuillCodeDesktopCommandPerforming {
     func refreshComputerUseStatus() {
-        refresh()
+        scheduleComputerUseStatusRefresh()
     }
 
     func refreshTrustedRouterCredits() {

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+ComputerUse.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+ComputerUse.swift
@@ -1,10 +1,16 @@
 @MainActor
 extension QuillCodeDesktopController {
     func scheduleComputerUseStatusRefresh() {
-        if computerUseCoordinator.refreshStatus(on: model) {
-            refresh()
+        let coordinator = computerUseCoordinator
+        let workspaceModel = model
+        tasks.replace(.computerUseStatusRefresh) { [weak self] in
+            let changed = await coordinator.refreshStatus(on: workspaceModel)
+            guard !Task.isCancelled, changed else { return }
+            self?.refresh()
         }
+    }
 
+    func scheduleComputerUseForegroundApplicationRefresh() {
         let coordinator = computerUseCoordinator
         let workspaceModel = model
         tasks.replace(.computerUseForegroundRefresh) { [weak self] in

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
@@ -77,20 +77,23 @@ extension QuillCodeDesktopController {
                 .map { URL(fileURLWithPath: $0.path) },
             readableProjectRoots: projectAccessCoordinator.activeProjectURLs
         )
+        scheduleComputerUseStatusRefresh()
     }
 
     private func startAutomaticWorkspaceServices() {
         model.startAutomaticStartupWork()
         computerUseCoordinator.startApplicationActivationObservation { [weak self] in
             self?.scheduleComputerUseStatusRefresh()
+            self?.scheduleComputerUseForegroundApplicationRefresh()
         }
-        scheduleComputerUseStatusRefresh()
+        scheduleComputerUseForegroundApplicationRefresh()
         let cuaCoordinator = computerUseCoordinator
         let cuaModel = model
-        tasks.replace(.computerUseBackendResolution) {
-            await cuaCoordinator.resolvePreferredBackend(on: cuaModel)
-        } onFinish: { [weak self] in
+        tasks.replace(.computerUseBackendResolution) { [weak self] in
+            guard await cuaCoordinator.resolvePreferredBackend(on: cuaModel) else { return }
+            guard !Task.isCancelled else { return }
             self?.scheduleComputerUseStatusRefresh()
+            self?.scheduleComputerUseForegroundApplicationRefresh()
         }
         model.scheduleSelectedProjectContextRefresh()
         // Bootstrap may finish a very small scan before its callback is installed. Starting one

--- a/Sources/quill-code-desktop/QuillCodeDesktopTaskCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopTaskCoordinator.swift
@@ -9,6 +9,7 @@ final class QuillCodeDesktopTaskCoordinator {
         case terminal
         case browserPreview
         case computerUseBackendResolution
+        case computerUseStatusRefresh
         case computerUseForegroundRefresh
         case automationTicker
         case modelCatalogRefresh

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopComputerUseCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopComputerUseCoordinatorTests.swift
@@ -7,7 +7,7 @@ import QuillComputerUseKit
 
 @MainActor
 final class QuillCodeDesktopComputerUseCoordinatorTests: XCTestCase {
-    func testInstallAndStatusProjectionDoNotSpawnForegroundLookups() async {
+    func testInstallDefersStatusProbeAndStatusProjectionDoesNotSpawnForegroundLookups() async {
         let application = ComputerUseApplication(
             name: "Terminal",
             bundleIdentifier: "com.apple.Terminal"
@@ -17,11 +17,12 @@ final class QuillCodeDesktopComputerUseCoordinatorTests: XCTestCase {
         let model = QuillCodeWorkspaceModel()
 
         coordinator.install(on: model)
+        XCTAssertEqual(backend.statusReadCount, 0)
         for _ in 0..<1_000 {
-            coordinator.refreshStatus(on: model)
+            await coordinator.refreshStatus(on: model)
         }
         await Task.yield()
-        XCTAssertEqual(backend.statusReadCount, 1_001)
+        XCTAssertEqual(backend.statusReadCount, 1_000)
         XCTAssertEqual(backend.lookupCount, 0)
         XCTAssertNil(model.root.topBar.computerUseForegroundApplication)
 
@@ -57,13 +58,33 @@ final class QuillCodeDesktopComputerUseCoordinatorTests: XCTestCase {
         )
         defer { controller.tasks.cancelAll() }
 
-        XCTAssertEqual(backend.statusReadCount, 1)
+        XCTAssertEqual(backend.statusReadCount, 0)
         for _ in 0..<1_000 {
             controller.refresh()
         }
 
-        XCTAssertEqual(backend.statusReadCount, 1)
+        XCTAssertEqual(backend.statusReadCount, 0)
         XCTAssertEqual(backend.lookupCount, 0)
+    }
+
+    func testCancelledStatusProbeCannotMutateModel() async {
+        let backend = BlockingStatusComputerUseBackend()
+        let coordinator = QuillCodeDesktopComputerUseCoordinator(backend: backend)
+        let model = QuillCodeWorkspaceModel()
+
+        coordinator.install(on: model)
+        let refresh = Task { @MainActor in
+            await coordinator.refreshStatus(on: model)
+        }
+        await backend.waitForStatusRead()
+        refresh.cancel()
+        backend.resumeStatusRead(
+            with: .permissionStatus(screenRecordingGranted: true, accessibilityGranted: true)
+        )
+
+        let changed = await refresh.value
+        XCTAssertFalse(changed)
+        XCTAssertFalse(model.root.topBar.computerUseStatus.available)
     }
 
     func testApplicationActivationObservationIsIdempotent() {
@@ -215,6 +236,47 @@ private final class PermissionRecordingComputerUseBackend: @unchecked Sendable,
     func requestAccessibilityAccess() -> Bool {
         accessibilityRequestCount += 1
         return false
+    }
+
+    func screenshot() async throws -> ComputerScreenshot {
+        ComputerScreenshot(width: 1, height: 1, pngBase64: "")
+    }
+
+    func leftClick(x: Int, y: Int) async throws {}
+    func type(_ text: String) async throws {}
+    func scroll(dx: Int, dy: Int) async throws {}
+    func moveCursor(x: Int, y: Int) async throws {}
+    func pressKey(_ key: String) async throws {}
+}
+
+private final class BlockingStatusComputerUseBackend: @unchecked Sendable, ComputerUseBackend {
+    private let lock = NSLock()
+    private let statusReadCanFinish = DispatchSemaphore(value: 0)
+    private var statusReadHasStarted = false
+    private var resolvedStatus = ComputerUseStatus.permissionStatus(
+        screenRecordingGranted: false,
+        accessibilityGranted: false
+    )
+
+    var status: ComputerUseStatus {
+        lock.withLock {
+            statusReadHasStarted = true
+        }
+        statusReadCanFinish.wait()
+        return lock.withLock { resolvedStatus }
+    }
+
+    func waitForStatusRead() async {
+        while !lock.withLock({ statusReadHasStarted }) {
+            await Task.yield()
+        }
+    }
+
+    func resumeStatusRead(with status: ComputerUseStatus) {
+        lock.withLock {
+            resolvedStatus = status
+        }
+        statusReadCanFinish.signal()
     }
 
     func screenshot() async throws -> ComputerScreenshot {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
@@ -5,6 +5,7 @@ import QuillCodeApp
 import QuillCodeCore
 import QuillCodePersistence
 import QuillCodeTools
+import QuillComputerUseKit
 @testable import quill_code_desktop
 
 @MainActor
@@ -137,6 +138,37 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
         XCTAssertTrue(controller.automaticWorkspaceServicesStarted)
         XCTAssertTrue(controller.tasks.isRunning(.automationTicker))
         XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
+    }
+
+    func testRecoveryStartupRefreshesComputerUseStatusAfterWindowWhileBackgroundWorkStaysPaused() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let lifecycle = makeLifecycle(fixture: fixture, processIdentifier: 13_101)
+        XCTAssertNil(lifecycle.startIfNeeded())
+        let controller = makeController(
+            fixture: fixture,
+            lifecycle: lifecycle,
+            startupMode: .recovery,
+            computerUseCoordinator: QuillCodeDesktopComputerUseCoordinator(
+                backend: StubComputerUseBackend()
+            )
+        )
+        defer {
+            controller.tasks.cancelAll()
+            lifecycle.finishCurrentLaunch()
+        }
+
+        XCTAssertFalse(controller.model.root.topBar.computerUseStatus.available)
+        controller.completeStartupIfAllowed()
+
+        for _ in 0..<100 where !controller.model.root.topBar.computerUseStatus.available {
+            await Task.yield()
+        }
+        XCTAssertTrue(controller.model.root.topBar.computerUseStatus.available)
+        XCTAssertTrue(controller.automaticWorkspaceServicesArePaused)
+        XCTAssertFalse(controller.automaticWorkspaceServicesStarted)
+        XCTAssertFalse(controller.tasks.isRunning(.computerUseForegroundRefresh))
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .starting)
     }
 
     func testProjectBookmarkRestoreWaitsForFirstWindowAndRunsOnceDuringRecovery() throws {
@@ -464,7 +496,9 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
     private func makeController(
         fixture: Fixture,
         lifecycle: QuillCodeDesktopLaunchLifecycleController,
-        startupMode: QuillCodeDesktopStartupMode
+        startupMode: QuillCodeDesktopStartupMode,
+        computerUseCoordinator: QuillCodeDesktopComputerUseCoordinator =
+            QuillCodeDesktopComputerUseCoordinator()
     ) -> QuillCodeDesktopController {
         let paths = QuillCodePaths(home: fixture.root.appendingPathComponent("state"))
         let runtimeFactory = QuillCodeRuntimeFactory(
@@ -473,6 +507,7 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
         )
         return QuillCodeDesktopController(
             bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            computerUseCoordinator: computerUseCoordinator,
             browserLiveDOMCapturer: nil,
             automationNotifier: LaunchLifecycleNoopNotifier(),
             updateController: QuillCodeDesktopUpdateController(configuration: nil, installResultURL: nil),

--- a/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
@@ -52,6 +52,9 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         let computerUseCoordinatorText = try Self.desktopSourceText(
             named: "QuillCodeDesktopComputerUseCoordinator.swift"
         )
+        let computerUseControllerText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopController+ComputerUse.swift"
+        )
 
         Self.assertSource(text, contains: "QuillCodeDesktopSettingsCoordinator")
         Self.assertSource(text, contains: "MacSystemSettingsOpener")
@@ -69,10 +72,15 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         Self.assertSource(settingsCoordinatorText, contains: "model.applySettings")
         Self.assertSource(settingsCoordinatorText, contains: "model.applyRuntime")
         Self.assertSource(controllerText, contains: "computerUseCoordinator.openSystemSettings")
-        Self.assertSource(controllerText, contains: "computerUseCoordinator.refreshStatus")
+        Self.assertSource(computerUseControllerText, contains: "coordinator.refreshStatus")
+        Self.assertSource(computerUseControllerText, contains: "coordinator.refreshForegroundApplication")
+        Self.assertSource(controllerText, contains: "func refreshComputerUseStatus()")
+        Self.assertSource(controllerText, contains: "scheduleComputerUseStatusRefresh()")
         Self.assertSource(computerUseCoordinatorText, contains: "ComputerUseBackendFactory.platformDefault")
-        Self.assertSource(computerUseCoordinatorText, contains: "model.setComputerUseBackend")
+        Self.assertSource(computerUseCoordinatorText, contains: "model.installComputerUseBackend")
+        Self.assertSource(computerUseCoordinatorText, contains: "Task.detached(priority: .utility)")
         Self.assertSource(computerUseCoordinatorText, contains: "model.setComputerUseStatus")
+        Self.assertSource(computerUseCoordinatorText, excludes: "model.setComputerUseBackend")
         Self.assertSource(computerUseCoordinatorText, contains: "ComputerUseForegroundApplicationProviding")
         Self.assertSource(computerUseCoordinatorText, contains: "model.setComputerUseForegroundApplication")
         Self.assertSource(computerUseCoordinatorText, contains: "systemSettingsOpener.open")

--- a/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopTaskCoordinationGateTests.swift
@@ -54,9 +54,16 @@ final class ParityDesktopTaskCoordinationGateTests: QuillCodeParityTestCase {
         Self.assertSource(terminalCoordinatorText, contains: "draft.trimmingCharacters(in: .whitespacesAndNewlines)")
         Self.assertSource(terminalCoordinatorText, contains: "model.setTerminalDraft(draft)")
         Self.assertSource(browserCoordinatorText, contains: "tasks.replace(.browserPreview")
-        Self.assertSource(desktopTaskText, contains: "case computerUseForegroundRefresh")
-        Self.assertSource(computerUseControllerText, contains: "tasks.replace(.computerUseForegroundRefresh)")
-        Self.assertSource(computerUseControllerText, contains: "guard !Task.isCancelled, changed else { return }")
+        Self.assertSource(desktopTaskText, containsAll: [
+            "case computerUseStatusRefresh",
+            "case computerUseForegroundRefresh",
+        ])
+        Self.assertSource(computerUseControllerText, containsAll: [
+            "tasks.replace(.computerUseStatusRefresh)",
+            "let changed = await coordinator.refreshStatus",
+            "tasks.replace(.computerUseForegroundRefresh)",
+            "let changed = await coordinator.refreshForegroundApplication",
+        ])
         Self.assertSource(controllerText, contains: "QuillCodeDesktopAutomationCoordinator")
         Self.assertSource(controllerText, contains: "automationCoordinator.startTicker")
         Self.assertSource(automationCoordinatorText, contains: "tasks.replace(.automationTicker")

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,23 @@
 # QuillCode Decisions
 
+## 2026-08-10: Computer Use permission probes begin after the first window
+
+- **Decision:** Installing the native Computer Use backend no longer reads its status. The desktop
+  keeps the backend available immediately, then queries Screen Recording and Accessibility trust in
+  the existing cancellable post-window refresh task. The synchronous operating-system preflights
+  run at utility priority instead of occupying the main actor during first-window construction.
+- **Lifecycle boundary:** Status refreshes are generation-bound. Cancellation or a later backend
+  replacement prevents an obsolete preflight result from mutating the model. Permission and
+  foreground-app refreshes use distinct replaceable task slots: recovery startup refreshes
+  permission state while automatic foreground observation remains paused, and rapid application
+  activations retain only the latest result of each kind. Optional CUA discovery requests another
+  pair of refreshes only when it actually replaces the backend.
+- **Evidence:** Coordinator tests prove controller construction and repeated surface projection read
+  no backend status, an explicit refresh does not spawn foreground lookup work, and a cancelled
+  preflight cannot update the model. Launch coverage proves recovery mode refreshes permission state
+  without starting automatic workspace or foreground work. Desktop parity pins side-effect-free
+  installation, explicit command routing, and the utility-priority refresh boundary.
+
 ## 2026-08-10: project bookmark restoration begins after the first window
 
 - **Decision:** Security-scoped project bookmarks are no longer read, resolved, activated, or


### PR DESCRIPTION
Defers synchronous macOS Screen Recording and Accessibility trust probes until the first window is available, moves them to a generation-bound utility task, preserves status refresh in recovery mode, separates foreground lookup ownership, and makes the explicit refresh command perform a real probe. Verification: 5,844 tests with 5 expected skips and 0 failures; focused lifecycle/parity coverage green; release build green; exact release packaged smoke green at 242.16 ms launch-ready, 90.36 MiB initial RSS, and 4.17 MiB repeated-sweep growth, including direct launch, Launch Services, SIGKILL recovery, rendering, and 10 native accessibility activations.