### PR TITLE
Defer application services past first window

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -134,7 +134,6 @@ struct QuillCodeDesktopApp: App {
             startupMode: QuillCodeDesktopStartupMode(unexpectedExit: unexpectedExit),
             workspaceRoot: QuillCodeDesktopWorkspaceRootResolver.resolve()
         )
-        controller.startApplicationServices()
         _controller = StateObject(wrappedValue: controller)
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
@@ -70,6 +70,7 @@ extension QuillCodeDesktopController {
 
     private func startPostWindowApplicationServicesIfNeeded() {
         guard automaticStartupState.startPostWindowApplicationServicesIfNeeded() else { return }
+        startApplicationServicesAfterFirstWindow()
         projectAccessCoordinator.restoreAccess(for: model.root.projects)
         ToolArtifactLocalPreviewAccess.configure(
             projectRoots: model.root.projects

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -179,9 +179,9 @@ final class QuillCodeDesktopController: ObservableObject {
         installVisibleBrowserToolOverride(on: model)
     }
 
-    /// Starts services that belong to the application process rather than any SwiftUI scene. The
-    /// ordinary app entry point calls this once; the owned controllers keep repeat calls idempotent.
-    func startApplicationServices() {
+    /// Starts process-owned services after SwiftUI has yielded through the first-window boundary.
+    /// The owned controllers keep repeat calls idempotent for recovery and repeated scene tasks.
+    func startApplicationServicesAfterFirstWindow() {
         composerDraftCheckpointCoordinator.startLifecycleFlushes(model: model)
         installApprovalNotificationHandling()
         installationLocationController.startIfNeeded()

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopApplicationServicesTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopApplicationServicesTests.swift
@@ -7,7 +7,7 @@ import QuillCodeTools
 
 @MainActor
 final class QuillCodeDesktopApplicationServicesTests: XCTestCase {
-    func testApplicationServicesStartWithoutAWindowAndRemainIdempotent() async throws {
+    func testApplicationServicesStartAtFirstWindowBoundaryAndRemainIdempotent() async throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let paths = QuillCodePaths(home: root.appendingPathComponent("state", isDirectory: true))
@@ -47,13 +47,21 @@ final class QuillCodeDesktopApplicationServicesTests: XCTestCase {
             automationNotifier: ApplicationServiceNoopNotifier(),
             updateController: updateController,
             installationLocationController: installationController,
+            startupMode: .recovery,
             workspaceRoot: root
         )
 
-        controller.startApplicationServices()
-        controller.startApplicationServices()
+        XCTAssertFalse(installationController.isPresented)
+        XCTAssertFalse(controller.postWindowApplicationServicesStarted)
+        let preWindowRecoveryCallCount = await recovery.callCount
+        XCTAssertEqual(preWindowRecoveryCallCount, 0)
+
+        controller.completeStartupIfAllowed()
+        controller.completeStartupIfAllowed()
 
         XCTAssertTrue(installationController.isPresented)
+        XCTAssertTrue(controller.postWindowApplicationServicesStarted)
+        XCTAssertFalse(controller.automaticWorkspaceServicesStarted)
         try await waitUntil { await recovery.callCount == 1 }
         let checkerCallCount = await checker.callCount
         XCTAssertEqual(checkerCallCount, 0)

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
@@ -462,7 +462,7 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
         XCTAssertNil(controller.launchLifecycleController?.takeUnexpectedExit())
         controller.launchLifecycleController?.markReady()
         XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
-        controller.startApplicationServices()
+        controller.completeStartupIfAllowed()
         XCTAssertNil(controller.launchLifecycleController?.takeUnexpectedExit())
         lifecycle.finishCurrentLaunch()
         XCTAssertNil(try fixture.store.currentRecord())

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -12,7 +12,6 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         Self.assertSource(app, containsAll: [
             "_ = QuillCodeDesktopLaunchClock.appEntryUptime",
             "QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()",
-            "controller.startApplicationServices()",
             "QuillCodeDesktopUpdaterSmokeRequest",
             "QuillCodeDesktopUpdaterSmokeRunner.runAndExit"
         ])
@@ -23,24 +22,14 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         let helperRange = try XCTUnwrap(app.range(of: "QuillCodeDesktopUpdateHelperRequest.parse"))
         XCTAssertLessThan(entryRange.lowerBound, handshakeRange.lowerBound)
         XCTAssertLessThan(handshakeRange.lowerBound, helperRange.lowerBound)
-        XCTAssertEqual(app.components(separatedBy: "controller.startApplicationServices()").count - 1, 1)
-        let normalControllerRange = try XCTUnwrap(app.range(
-            of: "workspaceRoot: QuillCodeDesktopWorkspaceRootResolver.resolve()",
-            options: .backwards
-        ))
-        let normalLaunchSuffix = app[normalControllerRange.upperBound...]
-        let serviceRange = try XCTUnwrap(
-            normalLaunchSuffix.range(of: "controller.startApplicationServices()")
-        )
-        let ownershipRange = try XCTUnwrap(
-            normalLaunchSuffix.range(of: "_controller = StateObject(wrappedValue: controller)")
-        )
-        XCTAssertLessThan(serviceRange.lowerBound, ownershipRange.lowerBound)
+        XCTAssertFalse(app.contains("startApplicationServicesAfterFirstWindow"))
         XCTAssertFalse(app.contains("controller.updateController.startAutomaticChecks()"))
         XCTAssertFalse(app.contains("controller.installationLocationController.startIfNeeded()"))
         Self.assertSource(controller, containsAll: [
-            "func startApplicationServices()",
+            "func startApplicationServicesAfterFirstWindow()",
             "func completeStartupIfAllowed()",
+            "guard automaticStartupState.startPostWindowApplicationServicesIfNeeded() else { return }",
+            "startApplicationServicesAfterFirstWindow()",
             "automaticStartupPolicy: .deferUntilRequested",
             "model.startAutomaticStartupWork()",
             "tasks.replace(.computerUseBackendResolution)",
@@ -50,6 +39,10 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "installationLocationController.startIfNeeded()",
             "updateController.startAutomaticChecks()"
         ])
+        XCTAssertEqual(
+            controller.components(separatedBy: "startApplicationServicesAfterFirstWindow()").count - 1,
+            2
+        )
         Self.assertSource(bootstrap, contains: "automaticStartupPolicy == .startImmediately")
         Self.assertSource(runner, containsAll: [
             "waitForAvailableUpdate(configuration: configuration)",

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # QuillCode Decisions
 
+## 2026-08-10: process-owned application services begin after the first window
+
+- **Decision:** Normal desktop launch no longer registers notification categories, inspects the
+  installed app location, recovers an interrupted update, or schedules automatic update checks from
+  `App.init`. The yielded first-window startup gate starts that same idempotent service bundle once,
+  before optional workspace automation begins.
+- **Availability boundary:** Draft lifecycle flushes, approval notifications, installation recovery,
+  and updates still start in both normal and recovery launches. Recovery mode pauses only automatic
+  workspace services; it does not withhold distribution or durability services after the saved
+  workspace is visible.
+- **Evidence:** Application-service tests prove controller construction performs none of this work,
+  the first-window boundary starts it once, and repeated boundary completion cannot duplicate updater
+  recovery. Desktop parity rejects an application-services call from `App.init` and pins ownership to
+  the post-window gate.
+
 ## 2026-08-10: Computer Use permission probes begin after the first window
 
 - **Decision:** Installing the native Computer Use backend no longer reads its status. The desktop


### PR DESCRIPTION
## Summary
- start notification, installation, and updater services from the yielded first-window boundary instead of App.init
- preserve distribution and durability services during recovery-mode startup while optional workspace work remains paused
- pin the lifecycle boundary with focused tests, updater parity, and an architecture decision

## Verification
- swift test: 5,844 tests, 5 expected skips, 0 failures
- focused application-service, launch-lifecycle, and updater parity tests
- release package: 240.60 ms median launch-ready, 90.34 MiB initial RSS, 154.19 MiB after repeated interaction
- release packaged smoke: direct launch, Launch Services, SIGKILL draft recovery, accessibility, browser, Computer Use, visual frame, and resource checks passed
- DMG verification and Move & Relaunch smoke passed