### PR TITLE
Improve daily-driver performance and resilience

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeConnectBannerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeConnectBannerView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Keeps connection recovery visible without replacing a returning user's saved transcript.
+struct QuillCodeConnectBannerView: View {
+    var onSignIn: () -> Void
+    var onUseDeveloperKey: () -> Void
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 14) {
+                message
+                Spacer(minLength: 12)
+                actions
+            }
+            VStack(alignment: .leading, spacing: 12) {
+                message
+                actions
+            }
+        }
+        .padding(14)
+        .background(QuillCodePalette.panel2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(QuillCodePalette.yellow.opacity(0.48), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("TrustedRouter connection required")
+    }
+
+    private var message: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "person.crop.circle.badge.exclamationmark")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(QuillCodePalette.yellow)
+                .frame(width: 28, height: 28)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(TranscriptConnectPrompt.title)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(QuillCodePalette.text)
+                Text(TranscriptConnectPrompt.returningUserSubtitle)
+                    .font(.caption)
+                    .foregroundStyle(QuillCodePalette.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var actions: some View {
+        VStack(spacing: 8) {
+            Button("Sign in", action: onSignIn)
+                .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 240))
+                .quillCodeFormActionTarget(minWidth: 240)
+                .accessibilityIdentifier("quillcode-connect-sign-in")
+            Button(action: onUseDeveloperKey) {
+                Label(TranscriptConnectPrompt.developerKeyTitle, systemImage: "key.fill")
+            }
+            .buttonStyle(QuillCodeActionButtonStyle(.secondary, minWidth: 240))
+            .quillCodeFormActionTarget(minWidth: 240)
+            .accessibilityIdentifier("quillcode-connect-developer-key")
+            .help("Open Developer override settings")
+        }
+        .frame(width: 240)
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeSettingsView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSettingsView.swift
@@ -21,7 +21,9 @@ struct QuillCodeSettingsView: View {
             Divider().opacity(0.5)
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 14) {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    authenticationSection
+                    QuillCodeNotificationSettingsCard(settings: settings, draft: $draft)
                     generalSection
                     if let balance = settings.trustedRouterAccountBalance {
                         QuillCodeTrustedRouterCreditsSettingsCard(
@@ -30,7 +32,6 @@ struct QuillCodeSettingsView: View {
                             onCommand: onCommand
                         )
                     }
-                    QuillCodeNotificationSettingsCard(settings: settings, draft: $draft)
                     QuillCodeSpendLimitSettingsCard(settings: settings, draft: $draft)
                     QuillCodeManagedWorktreeSettingsCard(settings: settings, draft: $draft)
                     QuillCodeComputerUseSettingsCard(settings: settings, onCommand: onCommand)
@@ -48,8 +49,6 @@ struct QuillCodeSettingsView: View {
                     if let issue = settings.runtimeIssue {
                         QuillCodeRuntimeIssueView(issue: issue, showsDiagnostics: true)
                     }
-
-                    authenticationSection
                 }
                 .padding(20)
             }

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 import QuillCodeCore
 
 struct QuillCodeTranscriptView: View {
-    private static let reviewAnchorID = "quillcode-review-pane-anchor"
-
     var transcript: TranscriptSurface
     /// The currently selected thread, so the "N new turns" watermark is tracked per thread and a
     /// thread that grew in the background shows its pill on return. `nil` for the empty/no-thread
@@ -110,6 +108,14 @@ struct QuillCodeTranscriptView: View {
         return runtimeIssue == nil || runtimeIssueIsSetupRelated
     }
 
+    private var connectPlacement: TranscriptConnectPlacement {
+        TranscriptConnectPlacement.resolve(
+            hasPrompt: connectPrompt != nil,
+            requiresProjectSelection: requiresProjectSelection,
+            emptyStateVisible: isEmptyStateVisible
+        )
+    }
+
     private var runtimeIssueIsSetupRelated: Bool {
         switch runtimeIssue?.recovery?.reason {
         case .trustedRouterSignInRequired, .developerKeyMissing:
@@ -143,6 +149,16 @@ struct QuillCodeTranscriptView: View {
                 )
                 Divider()
             }
+            if connectPlacement == .banner {
+                QuillCodeConnectBannerView(
+                    onSignIn: onStartTrustedRouterSignIn,
+                    onUseDeveloperKey: onUseDeveloperKey
+                )
+                .frame(maxWidth: Self.contentColumnMaxWidth)
+                .padding(.horizontal, 22)
+                .padding(.top, 14)
+                .frame(maxWidth: .infinity)
+            }
             transcriptBody
         }
         .background(isConfidentialAppearance ? QuillCodePalette.Confidential.background : QuillCodePalette.background)
@@ -164,12 +180,22 @@ struct QuillCodeTranscriptView: View {
             // watermark) as it grows while the user watches.
             newTurnsStore.observe(threadID: threadID, transcript: transcript)
         }
+        .onChange(of: review.isVisible) { _, isVisible in
+            guard !isVisible else { return }
+            // Review is a focused viewport rather than a transcript row. Reopening the transcript
+            // therefore starts at its latest turn, matching the previous review-close behavior
+            // without laying out every intervening row during a top-to-bottom anchor jump.
+            isPinnedToBottom = true
+            scrollMetrics.resetContentOffsetBaseline()
+        }
     }
 
     @ViewBuilder
     private var transcriptBody: some View {
         Group {
-            if isEmptyStateVisible {
+            if review.isVisible {
+                reviewBody
+            } else if isEmptyStateVisible {
                 // Two spacers CENTER the hero in the transcript void — bottom-anchoring it against
                 // the composer left a large dead area above at tall windows.
                 Spacer(minLength: 0)
@@ -198,21 +224,6 @@ struct QuillCodeTranscriptView: View {
                                 )
                                 .frame(maxWidth: 760, alignment: .leading)
                             }
-                            if review.isVisible {
-                                QuillCodeReviewPaneView(
-                                    review: review,
-                                    onClose: onCloseReview,
-                                    onReviewScopeChange: onReviewScopeChange,
-                                    onReviewAction: onReviewAction,
-                                    onPullRequestReviewThreadAction: onPullRequestReviewThreadAction,
-                                    onPullRequestReviewThreadReply: onPullRequestReviewThreadReply,
-                                    onPullRequestReviewDraftChange: onPullRequestReviewDraftChange,
-                                    onCancelPullRequestReviewDraft: onCancelPullRequestReviewDraft,
-                                    onSubmitPullRequestReviewDraft: onSubmitPullRequestReviewDraft,
-                                    onAddReviewComment: onAddReviewComment
-                                )
-                                .id(Self.reviewAnchorID)
-                            }
                             timelineItems
                             if let thinking = transcript.thinking {
                                 QuillCodeThinkingView(thinking: thinking)
@@ -223,7 +234,7 @@ struct QuillCodeTranscriptView: View {
                         // Readable measure: cap the conversation column and center it, instead of
                         // letting text run edge-to-edge at wide windows (a ~1200pt line is unreadable
                         // and user bubbles end up a screen-width away from replies). Everything —
-                        // messages, tool cards, banners, the review pane — shares one column, so
+                        // messages, tool cards, and banners share one column, so
                         // alignment contexts (trailing user bubbles) pin to the column, not the pane.
                         .frame(maxWidth: Self.contentColumnMaxWidth)
                         .padding(22)
@@ -267,9 +278,6 @@ struct QuillCodeTranscriptView: View {
                     .overlay(alignment: .bottom) {
                         jumpToLatestOverlay(proxy)
                     }
-                    .onAppear {
-                        scrollForReviewVisibility(review.isVisible, proxy: proxy)
-                    }
                     .onChange(of: threadID) { _, _ in
                         // A different thread opens at ITS latest turn, never inheriting the previous
                         // thread's scroll-pin (codex review): otherwise switching away from a
@@ -278,7 +286,6 @@ struct QuillCodeTranscriptView: View {
                         // re-baselined instead of read as a giant scroll-up.
                         isPinnedToBottom = true
                         scrollMetrics.resetContentOffsetBaseline()
-                        scrollForReviewVisibility(review.isVisible, proxy: proxy)
                     }
                     .onChange(of: scrollContentSignature) { _, _ in
                         scrollToTranscriptEnd(proxy, id: scrollAnchorID)
@@ -298,13 +305,31 @@ struct QuillCodeTranscriptView: View {
                     .onChange(of: pendingJumpAnchorID) { _, id in
                         scrollToPendingJump(proxy, id: id)
                     }
-                    .onChange(of: review.isVisible) { _, isVisible in
-                        scrollForReviewVisibility(isVisible, proxy: proxy)
-                    }
                 }
             }
         }
         .background(isConfidentialAppearance ? QuillCodePalette.Confidential.background : QuillCodePalette.background)
+    }
+
+    private var reviewBody: some View {
+        ScrollView {
+            QuillCodeReviewPaneView(
+                review: review,
+                onClose: onCloseReview,
+                onReviewScopeChange: onReviewScopeChange,
+                onReviewAction: onReviewAction,
+                onPullRequestReviewThreadAction: onPullRequestReviewThreadAction,
+                onPullRequestReviewThreadReply: onPullRequestReviewThreadReply,
+                onPullRequestReviewDraftChange: onPullRequestReviewDraftChange,
+                onCancelPullRequestReviewDraft: onCancelPullRequestReviewDraft,
+                onSubmitPullRequestReviewDraft: onSubmitPullRequestReviewDraft,
+                onAddReviewComment: onAddReviewComment
+            )
+            .frame(maxWidth: Self.contentColumnMaxWidth)
+            .padding(22)
+            .frame(maxWidth: .infinity)
+        }
+        .accessibilityIdentifier("quillcode-review-viewport")
     }
 
     private var timelineItems: some View {
@@ -330,7 +355,7 @@ struct QuillCodeTranscriptView: View {
     private var emptyState: some View {
         if requiresProjectSelection {
             QuillCodeProjectSetupView(onOpenProject: onOpenProject)
-        } else if let connectPrompt {
+        } else if connectPlacement == .hero, let connectPrompt {
             // Not connected yet: the sign-in gate takes precedence over the starter cards (and even
             // confidential mode) — there is nothing to start until an account is connected.
             QuillCodeConnectView(
@@ -504,7 +529,7 @@ struct QuillCodeTranscriptView: View {
     }
 
     private func scrollToTranscriptEnd(_ proxy: ScrollViewProxy, id: String?, force: Bool = false) {
-        guard let id, !isFindPresented, !review.isVisible else { return }
+        guard let id, !isFindPresented else { return }
         // Only follow the stream when the reader is already at the bottom; `force` lets first-open and
         // the Jump-to-latest tap override. This is what stops a streamed chunk from yanking a
         // scrolled-up reader back down.
@@ -526,18 +551,6 @@ struct QuillCodeTranscriptView: View {
             transaction.disablesAnimations = true
             withTransaction(transaction) {
                 proxy.scrollTo(id, anchor: .bottom)
-            }
-        }
-    }
-
-    private func scrollForReviewVisibility(_ isVisible: Bool, proxy: ScrollViewProxy) {
-        DispatchQueue.main.async {
-            quillCodeWithAnimation(.easeOut(duration: 0.18), reduceMotion: reduceMotion) {
-                if isVisible {
-                    proxy.scrollTo(Self.reviewAnchorID, anchor: .top)
-                } else if let scrollAnchorID {
-                    proxy.scrollTo(scrollAnchorID, anchor: .bottom)
-                }
             }
         }
     }
@@ -592,13 +605,13 @@ struct QuillCodeTranscriptView: View {
         }
     }
 
-    /// Follow-scroll is suppressed (`scrollToTranscriptEnd` early-returns) while Find or the review pane
-    /// owns the scroll position. A chunk that grows past the threshold then will NOT auto-catch-up, so
+    /// Follow-scroll is suppressed (`scrollToTranscriptEnd` early-returns) while Find owns the scroll
+    /// position. A chunk that grows past the threshold then will NOT auto-catch-up, so
     /// the bottom-sentinel must un-pin (surface the Jump chip, honest state) rather than preserve a pin
     /// the viewport no longer reflects — otherwise closing Find strands the reader behind with no chip
     /// and the next chunk yanks them down.
     private var isFollowScrollSuppressed: Bool {
-        isFindPresented || review.isVisible
+        isFindPresented
     }
 
     /// Resolve the pin against a sentinel/viewport move that is NOT a user scroll (content growth,

--- a/Sources/QuillCodeApp/TranscriptConnectPrompt.swift
+++ b/Sources/QuillCodeApp/TranscriptConnectPrompt.swift
@@ -21,6 +21,8 @@ public struct TranscriptConnectPrompt: Equatable, Sendable {
     public static let browserSignInCaption = "Secure sign-in opens in your browser"
     public static let createAccountTitle = "Create a TrustedRouter account"
     public static let developerKeyTitle = "Use a developer key"
+    public static let returningUserSubtitle =
+        "Your saved chats are ready. Connect before starting or resuming model work."
     public static let defaultAccountURL = "https://trustedrouter.com"
     /// The three-beat "what happens next" reassurance under the button.
     public static let steps = ["Connect", "Choose a model", "Start a task"]
@@ -33,5 +35,20 @@ public struct TranscriptConnectPrompt: Equatable, Sendable {
     public static func make(hasStoredAPIKey: Bool) -> TranscriptConnectPrompt? {
         guard !hasStoredAPIKey else { return nil }
         return TranscriptConnectPrompt()
+    }
+}
+
+enum TranscriptConnectPlacement: Equatable {
+    case hidden
+    case hero
+    case banner
+
+    static func resolve(
+        hasPrompt: Bool,
+        requiresProjectSelection: Bool,
+        emptyStateVisible: Bool
+    ) -> Self {
+        guard hasPrompt, !requiresProjectSelection else { return .hidden }
+        return emptyStateVisible ? .hero : .banner
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceModelNavigationHistory.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelNavigationHistory.swift
@@ -40,21 +40,37 @@ extension QuillCodeWorkspaceModel {
         return false
     }
 
+    /// Restores the complete workspace location. A legacy/projectless chat can coexist with an
+    /// explicitly selected project, so thread and project are independent parts of the location.
+    @discardableResult
+    public func selectWorkspaceLocation(
+        _ location: WorkspaceNavigationLocation,
+        recordsNavigation: Bool = true
+    ) -> Bool {
+        let previousLocation = currentNavigationLocation
+        if let threadID = location.threadID,
+           let thread = root.threads.first(where: { $0.id == threadID }) {
+            let projectContextID = knownProjectID(location.projectID)
+                ?? knownProjectID(thread.projectID)
+            selectThread(
+                threadID,
+                projectContextID: projectContextID,
+                recordsNavigation: false
+            )
+        } else if let projectID = knownProjectID(location.projectID) {
+            selectProject(projectID, recordsNavigation: false)
+        } else {
+            pruneNavigationHistory()
+            return false
+        }
+        if recordsNavigation {
+            recordNavigationTransition(from: previousLocation)
+        }
+        return true
+    }
+
     @discardableResult
     private func applyNavigationLocation(_ location: WorkspaceNavigationLocation) -> Bool {
-        if let threadID = location.threadID,
-           root.threads.contains(where: { $0.id == threadID }) {
-            selectThread(threadID, recordsNavigation: false)
-            return true
-        }
-
-        if let projectID = location.projectID,
-           root.projects.contains(where: { $0.id == projectID }) {
-            selectProject(projectID, recordsNavigation: false)
-            return true
-        }
-
-        pruneNavigationHistory()
-        return false
+        selectWorkspaceLocation(location, recordsNavigation: false)
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
@@ -66,11 +66,24 @@ extension QuillCodeWorkspaceModel {
     }
 
     public func selectThread(_ id: UUID, recordsNavigation: Bool = true) {
+        guard let thread = root.threads.first(where: { $0.id == id }) else { return }
+        selectThread(
+            id,
+            projectContextID: thread.projectID,
+            recordsNavigation: recordsNavigation
+        )
+    }
+
+    func selectThread(
+        _ id: UUID,
+        projectContextID: UUID?,
+        recordsNavigation: Bool
+    ) {
         if id != root.selectedThreadID {
             _ = returnFromSideConversation()
             _ = discardConfidentialThreadOnExit()
         }
-        guard let thread = root.threads.first(where: { $0.id == id }) else { return }
+        guard root.threads.contains(where: { $0.id == id }) else { return }
         let previousLocation = currentNavigationLocation
         // The user is leaving the current thread: persist its morning-triage return watermark to its
         // current tail so background growth on it surfaces as "unseen" on return (cross-session).
@@ -79,7 +92,7 @@ extension QuillCodeWorkspaceModel {
             persistOutgoingReturnWatermark()
         }
         restoreComposerDraft(from: root.selectedThreadID, to: id)
-        selectThreadRecord(id, projectID: thread.projectID)
+        selectThreadRecord(id, projectID: projectContextID)
         if recordsNavigation {
             recordNavigationTransition(from: previousLocation)
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationContract.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationContract.swift
@@ -3,6 +3,7 @@ import Foundation
 
 struct QuillCodeDesktopWorkspaceThreadActivationState: Equatable {
     var selectedThreadID: UUID?
+    var selectedProjectID: UUID? = nil
     var threadIDs: Set<UUID>
 }
 
@@ -15,7 +16,9 @@ enum QuillCodeDesktopAccessibilityActivationState: Equatable, CustomStringConver
         case .flag(let value):
             return value.description
         case .workspaceThreads(let state):
-            return "selected=\(state.selectedThreadID?.uuidString ?? "none");count=\(state.threadIDs.count)"
+            return "selected=\(state.selectedThreadID?.uuidString ?? "none");"
+                + "project=\(state.selectedProjectID?.uuidString ?? "none");"
+                + "count=\(state.threadIDs.count)"
         }
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationSampler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationSampler.swift
@@ -203,6 +203,7 @@ enum QuillCodeDesktopAccessibilityActivationSampler {
         let sampledContracts = orderedActivationContracts(includesInitialSurface: includesInitialSurface)
 
         for contract in sampledContracts {
+            markStage("start", contractID: contract.contractID)
             contract.prepare?(controller)
             try? await Task.sleep(nanoseconds: 100_000_000)
             guard let probe = probesByID[contract.contractID] else {
@@ -214,6 +215,7 @@ enum QuillCodeDesktopAccessibilityActivationSampler {
                     "\(contract.contractID) did not resolve to an AXPress target; "
                         + unresolvedElementDiagnostic(probe, contentView: contentView)
                 )
+                markStage("unresolved", contractID: contract.contractID)
                 continue
             }
 
@@ -228,6 +230,7 @@ enum QuillCodeDesktopAccessibilityActivationSampler {
             if let issue = result.validationIssue {
                 validationIssues.append(issue)
             }
+            markStage("complete", contractID: contract.contractID)
         }
 
         let activatedIDs = checks.filter(\.ok).map(\.contractID).sorted()
@@ -331,7 +334,18 @@ enum QuillCodeDesktopAccessibilityActivationSampler {
         _ probe: QuillCodeNativeHitTargetProbe,
         contentView: NSView
     ) async -> QuillCodeDesktopAccessibilityElementSnapshot? {
-        await waitForResolvableElement(probe) {
+        let directCandidates = QuillCodeDesktopAccessibilityFrameSampler.candidateIdentifiers(for: probe)
+        let directElements = QuillCodeDesktopAccessibilityTree(
+            root: contentView,
+            matchingAnyIdentifier: directCandidates
+        ).elements
+        if let directElement = QuillCodeDesktopAccessibilityFrameSampler.resolveElementForActivation(
+            probe,
+            in: directElements
+        ) {
+            return directElement
+        }
+        return await waitForResolvableElement(probe) {
             QuillCodeDesktopAccessibilityTree(root: contentView).elements
         }
     }
@@ -375,6 +389,15 @@ enum QuillCodeDesktopAccessibilityActivationSampler {
 
     private static func axErrorDescription(_ error: AXError) -> String {
         error == .success ? "success" : String(describing: error)
+    }
+
+    private static func markStage(_ stage: String, contractID: String) {
+        let residentMemory = (try? QuillCodeDesktopProcessResourceSnapshot.capture())
+            .map { " rss=\($0.residentMemoryBytes) threads=\($0.threadCount)" }
+            ?? ""
+        FileHandle.standardError.write(
+            Data("quill-code-desktop AX activation \(stage): \(contractID)\(residentMemory)\n".utf8)
+        )
     }
 
     private static func waitForStateChange(

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityFrameSampler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityFrameSampler.swift
@@ -125,7 +125,13 @@ enum QuillCodeDesktopAccessibilityFrameSampler {
         contentView: NSView,
         nativeHitTargets: QuillCodeNativeHitTargetAuditReport
     ) -> QuillCodeDesktopAccessibilityFrameSampleReport {
-        let elements = QuillCodeDesktopAccessibilityTree(root: contentView).elements
+        let targetIdentifiers = Set(
+            nativeHitTargets.clickProbes.flatMap { candidateIdentifiers(for: $0) }
+        )
+        let elements = QuillCodeDesktopAccessibilityTree(
+            root: contentView,
+            matchingIdentifiers: targetIdentifiers
+        ).elements
         let samples = nativeHitTargets.clickProbes.compactMap { probe -> QuillCodeDesktopAccessibilityFrameSample? in
             guard let element = resolveElement(for: probe, in: elements),
                   let frame = element.frame
@@ -190,7 +196,7 @@ enum QuillCodeDesktopAccessibilityFrameSampler {
         _ probe: QuillCodeNativeHitTargetProbe,
         in elements: [QuillCodeDesktopAccessibilityElementSnapshot]
     ) -> QuillCodeDesktopAccessibilityElementSnapshot? {
-        if let primaryElement = largestElement(matching: identifiers(for: probe), in: elements) {
+        if let primaryElement = largestElement(matching: candidateIdentifiers(for: probe), in: elements) {
             return primaryElement
         }
         guard probe.selectorKind == .commandID else { return nil }
@@ -255,7 +261,7 @@ enum QuillCodeDesktopAccessibilityFrameSampler {
         return [baseTitle, "\(baseTitle)...", "\(baseTitle)…"]
     }
 
-    private static func identifiers(for probe: QuillCodeNativeHitTargetProbe) -> Set<String> {
+    static func candidateIdentifiers(for probe: QuillCodeNativeHitTargetProbe) -> Set<String> {
         switch probe.selectorKind {
         case .testID:
             return [probe.selector]

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityHierarchySettler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityHierarchySettler.swift
@@ -6,6 +6,11 @@ enum QuillCodeDesktopAccessibilityHierarchySettler {
     private static let sampleIntervalNanoseconds: UInt64 = 50_000_000
     private static let requiredStableComparisons = 6
     private static let maximumSamples = 30
+    private static let layoutSentinelIdentifiers: Set<String> = [
+        "quillcode-sidebar-command-new-chat",
+        "quillcode-sidebar-tools-button",
+        "quillcode-top-bar-overflow"
+    ]
 
     static func waitUntilStable(in contentView: NSView) async {
         var previousSignature: [String]?
@@ -15,7 +20,10 @@ enum QuillCodeDesktopAccessibilityHierarchySettler {
             try? await Task.sleep(nanoseconds: sampleIntervalNanoseconds)
             guard !Task.isCancelled else { return }
             let currentSignature = signature(
-                for: QuillCodeDesktopAccessibilityTree(root: contentView).elements
+                for: QuillCodeDesktopAccessibilityTree(
+                    root: contentView,
+                    matchingIdentifiers: layoutSentinelIdentifiers
+                ).elements
             )
             if currentSignature == previousSignature {
                 stableComparisonCount += 1

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityInteractionVerifier.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityInteractionVerifier.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ApplicationServices
 import Foundation
+import QuillCodeApp
 
 @MainActor
 enum QuillCodeDesktopAccessibilityInteractionVerifier {
@@ -73,6 +74,7 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
     ) -> QuillCodeDesktopAccessibilityActivationState {
         .workspaceThreads(QuillCodeDesktopWorkspaceThreadActivationState(
             selectedThreadID: controller.model.root.selectedThreadID,
+            selectedProjectID: controller.model.root.selectedProjectID,
             threadIDs: Set(controller.model.root.threads.map(\.id))
         ))
     }
@@ -110,11 +112,13 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
         for threadID in current.threadIDs.subtracting(baseline.threadIDs) {
             _ = controller.model.deleteThread(threadID)
         }
-        if let selectedThreadID = baseline.selectedThreadID,
-           controller.model.root.threads.contains(where: { $0.id == selectedThreadID })
-        {
-            controller.model.selectThread(selectedThreadID, recordsNavigation: false)
-        }
+        _ = controller.model.selectWorkspaceLocation(
+            WorkspaceNavigationLocation(
+                threadID: baseline.selectedThreadID,
+                projectID: baseline.selectedProjectID
+            ),
+            recordsNavigation: false
+        )
         controller.modelStateCoordinator.syncComposerDraft(from: controller.model, draft: &controller.draft)
         controller.refresh()
     }
@@ -469,7 +473,10 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
         _ identifier: String,
         in contentView: NSView
     ) -> QuillCodeDesktopAccessibilityElementSnapshot? {
-        QuillCodeDesktopAccessibilityTree(root: contentView).elements
+        QuillCodeDesktopAccessibilityTree(
+            root: contentView,
+            matchingIdentifiers: [identifier]
+        ).elements
             .first { $0.identifier == identifier }
     }
 
@@ -510,7 +517,10 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
         _ identifier: String,
         in contentView: NSView
     ) -> QuillCodeDesktopAccessibilityElementSnapshot? {
-        QuillCodeDesktopAccessibilityTree(root: contentView).elements
+        QuillCodeDesktopAccessibilityTree(
+            root: contentView,
+            matchingIdentifiers: [identifier]
+        ).elements
             .filter { $0.identifier == identifier }
             .max { $0.frameArea < $1.frameArea }
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityTree.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityTree.swift
@@ -97,6 +97,24 @@ struct QuillCodeDesktopAccessibilityTree {
         elements = collected
     }
 
+    init(root: NSView, matchingAnyIdentifier identifiers: Set<String>) {
+        _ = root
+        guard !identifiers.isEmpty else {
+            elements = []
+            return
+        }
+        var visited = Set<QuillCodeDesktopAccessibilityElementIdentity>()
+        var collected: [QuillCodeDesktopAccessibilityElementSnapshot] = []
+        let application = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
+        _ = Self.collect(
+            firstMatching: identifiers,
+            from: application,
+            into: &collected,
+            visited: &visited
+        )
+        elements = collected
+    }
+
     static func hitTest(at point: CGPoint) -> QuillCodeDesktopAccessibilityHitTestResult {
         let application = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
         var hitElement: AXUIElement?
@@ -173,6 +191,36 @@ struct QuillCodeDesktopAccessibilityTree {
                 matchingIdentifiers: identifiers,
                 into: &collected,
                 matchedIdentifiers: &matchedIdentifiers,
+                visited: &visited
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func collect(
+        firstMatching identifiers: Set<String>,
+        from element: AXUIElement,
+        into collected: inout [QuillCodeDesktopAccessibilityElementSnapshot],
+        visited: inout Set<QuillCodeDesktopAccessibilityElementIdentity>
+    ) -> Bool {
+        guard visited.insert(.init(element: element)).inserted else { return false }
+
+        let identifier = stringAttribute(kAXIdentifierAttribute, from: element)
+        if identifiers.contains(identifier),
+           let snapshot = snapshot(for: element, identifier: identifier),
+           snapshot.frameArea > 0
+        {
+            collected.append(snapshot)
+            return true
+        }
+
+        for child in children(of: element) {
+            if collect(
+                firstMatching: identifiers,
+                from: child,
+                into: &collected,
                 visited: &visited
             ) {
                 return true

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -17,6 +17,9 @@ struct QuillCodeDesktopApp: App {
         if let updateRequest = QuillCodeDesktopUpdateHelperRequest.parse(arguments: CommandLine.arguments) {
             Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
         }
+        if let seedRequest = QuillCodeDesktopDailyDriverSmokeSeedRequest(arguments: CommandLine.arguments) {
+            Darwin.exit(QuillCodeDesktopDailyDriverSmokeFixture.runAndReport(seedRequest))
+        }
 
         if let relocationSmokeRequest = QuillCodeDesktopRelocationSmokeRequest(
             arguments: CommandLine.arguments

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -189,12 +189,19 @@ final class QuillCodeDesktopController: ObservableObject {
     }
 
     /// Registers the Approve/Skip notification category and the delegate that routes a tapped action
-    /// back into the workspace. This can run before a window exists and remains idempotent.
+    /// back into the workspace. It remains idempotent across repeated post-window startup requests.
     private func installApprovalNotificationHandling() {
         guard approvalNotificationDelegate == nil else { return }
-        // Only the packaged product owns these categories. Bare executables and XCTest bundles must
-        // not replace the notification delegate of their host process.
-        guard Bundle.main.bundleIdentifier == updateController.configuration?.bundleIdentifier else {
+        let bundle = Bundle.main
+        // A SwiftPM executable can inherit the product bundle identifier without being backed by a
+        // Launch Services bundle. UserNotifications raises an Objective-C exception in that state,
+        // so identity and the canonical packaged layout must agree before touching the singleton.
+        guard QuillCodeDesktopPackagedProcessIdentity.ownsNotificationCenter(
+            bundleIdentifier: bundle.bundleIdentifier,
+            bundleURL: bundle.bundleURL,
+            executableURL: bundle.executableURL,
+            expectedBundleIdentifier: updateController.configuration?.bundleIdentifier
+        ) else {
             return
         }
         let delegate = QuillCodeApprovalNotificationDelegate(
@@ -209,4 +216,27 @@ final class QuillCodeDesktopController: ObservableObject {
         center.setNotificationCategories([QuillCodeApprovalNotification.category, QuillCodeRetryNotification.category])
     }
 
+}
+
+enum QuillCodeDesktopPackagedProcessIdentity {
+    static func ownsNotificationCenter(
+        bundleIdentifier: String?,
+        bundleURL: URL,
+        executableURL: URL?,
+        expectedBundleIdentifier: String?
+    ) -> Bool {
+        guard let expectedBundleIdentifier,
+              bundleIdentifier == expectedBundleIdentifier,
+              bundleURL.pathExtension.caseInsensitiveCompare("app") == .orderedSame,
+              let executableURL
+        else {
+            return false
+        }
+        let expectedExecutableDirectory = bundleURL
+            .appendingPathComponent("Contents/MacOS", isDirectory: true)
+            .standardizedFileURL
+        return executableURL
+            .deletingLastPathComponent()
+            .standardizedFileURL == expectedExecutableDirectory
+    }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopDailyDriverSmokeFixture.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopDailyDriverSmokeFixture.swift
@@ -1,0 +1,282 @@
+import Darwin
+import Foundation
+import QuillCodeApp
+import QuillCodeCore
+import QuillCodePersistence
+
+struct QuillCodeDesktopDailyDriverSmokeSeedRequest: Sendable {
+    var stateRootPath: String?
+
+    init?(arguments: [String]) {
+        guard arguments.contains("--seed-daily-driver-window-smoke") else {
+            return nil
+        }
+        stateRootPath = Self.value(after: "--window-smoke-state-root", in: arguments)
+    }
+
+    private static func value(after flag: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: flag) else { return nil }
+        let valueIndex = arguments.index(after: index)
+        guard valueIndex < arguments.endIndex else { return nil }
+        return arguments[valueIndex]
+    }
+}
+
+enum QuillCodeDesktopPerformanceWorkload: String, Equatable, Sendable {
+    case firstRunEmpty = "first-run-empty"
+    case dailyDriver100Chats = "daily-driver-100-chats"
+}
+
+enum QuillCodeDesktopDailyDriverSmokeFixtureError: LocalizedError, Equatable {
+    case missingStateRoot
+    case stateRootAlreadyExists
+    case unsupportedWorkload(String)
+    case invalidFixture(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingStateRoot:
+            "The daily-driver smoke seed requires --window-smoke-state-root."
+        case .stateRootAlreadyExists:
+            "The daily-driver smoke state root must not already exist."
+        case .unsupportedWorkload(let workload):
+            "The packaged performance workload is unsupported: \(workload)"
+        case .invalidFixture(let reason):
+            "The daily-driver smoke fixture is invalid: \(reason)"
+        }
+    }
+}
+
+enum QuillCodeDesktopDailyDriverSmokeFixture {
+    static let chatCount = 100
+    static let shortThreadTurnCount = 3
+    static let selectedThreadTurnCount = 100
+    static let markerFileName = "performance-workload.json"
+
+    private static let projectID = deterministicUUID(namespace: 0x1000_0000, value: 1)
+    private static let baseDate = Date(timeIntervalSince1970: 1_735_689_600)
+    private static let topics = [
+        "Release verification",
+        "Crash recovery",
+        "Launch performance",
+        "Memory profile",
+        "Navigation polish",
+        "Updater health",
+        "Workspace search",
+        "Review workflow",
+        "Plugin setup",
+        "Keyboard ergonomics"
+    ]
+
+    static func runAndReport(_ request: QuillCodeDesktopDailyDriverSmokeSeedRequest) -> Int32 {
+        do {
+            guard let stateRootPath = request.stateRootPath, !stateRootPath.isEmpty else {
+                throw QuillCodeDesktopDailyDriverSmokeFixtureError.missingStateRoot
+            }
+            let stateRoot = URL(fileURLWithPath: stateRootPath, isDirectory: true)
+            try seed(at: stateRoot)
+            FileHandle.standardOutput.write(
+                Data("Seeded \(QuillCodeDesktopPerformanceWorkload.dailyDriver100Chats.rawValue).\n".utf8)
+            )
+            return EXIT_SUCCESS
+        } catch {
+            FileHandle.standardError.write(Data("quill-code-desktop seed failed: \(error)\n".utf8))
+            return EXIT_FAILURE
+        }
+    }
+
+    static func seed(at stateRoot: URL) throws {
+        let destination = stateRoot.standardizedFileURL
+        guard !FileManager.default.fileExists(atPath: destination.path) else {
+            throw QuillCodeDesktopDailyDriverSmokeFixtureError.stateRootAlreadyExists
+        }
+
+        let parent = destination.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        let staging = parent.appendingPathComponent(
+            ".\(destination.lastPathComponent).seed-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        var committed = false
+        defer {
+            if !committed {
+                try? FileManager.default.removeItem(at: staging)
+            }
+        }
+
+        let appState = staging.appendingPathComponent("app-state", isDirectory: true)
+        let workspace = staging.appendingPathComponent("workspace", isDirectory: true)
+        let destinationWorkspace = destination.appendingPathComponent("workspace", isDirectory: true)
+        let paths = QuillCodePaths(home: appState)
+        try paths.ensure()
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+
+        let newestDate = baseDate.addingTimeInterval(TimeInterval(chatCount * 3_600))
+        let project = ProjectRef(
+            id: projectID,
+            name: "Quill Cowork Daily Driver",
+            path: destinationWorkspace.path,
+            lastOpenedAt: newestDate
+        )
+        try JSONProjectStore(fileURL: paths.projectsFile).save([project])
+
+        let threadStore = JSONThreadStore(directory: paths.threadsDirectory)
+        for ordinal in 1...chatCount {
+            try threadStore.save(makeThread(ordinal: ordinal))
+        }
+
+        let marker = Marker(
+            schemaVersion: 1,
+            workload: QuillCodeDesktopPerformanceWorkload.dailyDriver100Chats.rawValue,
+            projectCount: 1,
+            chatCount: chatCount,
+            shortThreadTurnCount: shortThreadTurnCount,
+            selectedThreadTurnCount: selectedThreadTurnCount
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(marker).write(
+            to: staging.appendingPathComponent(markerFileName),
+            options: .atomic
+        )
+
+        try FileManager.default.moveItem(at: staging, to: destination)
+        committed = true
+    }
+
+    @MainActor
+    static func validate(
+        workloadID: String,
+        controller: QuillCodeDesktopController,
+        workspaceRoot: QuillCodeDesktopWindowSmokeWorkspaceRoot
+    ) throws -> QuillCodeDesktopPerformanceWorkload {
+        guard let workload = QuillCodeDesktopPerformanceWorkload(rawValue: workloadID) else {
+            throw QuillCodeDesktopDailyDriverSmokeFixtureError.unsupportedWorkload(workloadID)
+        }
+        guard workload == .dailyDriver100Chats else {
+            return workload
+        }
+
+        let markerURL = workspaceRoot.root.appendingPathComponent(markerFileName)
+        let marker = try JSONDecoder().decode(Marker.self, from: Data(contentsOf: markerURL))
+        guard marker == Marker(
+            schemaVersion: 1,
+            workload: workload.rawValue,
+            projectCount: 1,
+            chatCount: chatCount,
+            shortThreadTurnCount: shortThreadTurnCount,
+            selectedThreadTurnCount: selectedThreadTurnCount
+        ) else {
+            throw QuillCodeDesktopDailyDriverSmokeFixtureError.invalidFixture("marker contract mismatch")
+        }
+
+        let root = controller.model.root
+        try require(root.projects.count == marker.projectCount, "loaded project count")
+        try require(root.threads.count == marker.chatCount, "loaded chat count")
+        try require(root.selectedProjectID == projectID, "selected project identity")
+        try require(
+            root.threads.allSatisfy({ $0.projectID == projectID }),
+            "project binding"
+        )
+        try require(
+            root.projects.first.map {
+                URL(fileURLWithPath: $0.path, isDirectory: true)
+                    .resolvingSymlinksInPath()
+                    .standardizedFileURL
+            } == workspaceRoot.workspace
+                .resolvingSymlinksInPath()
+                .standardizedFileURL,
+            "workspace path binding"
+        )
+        guard let selectedThread = root.threads.first(where: { $0.id == root.selectedThreadID }) else {
+            throw QuillCodeDesktopDailyDriverSmokeFixtureError.invalidFixture("selected chat missing")
+        }
+        try require(selectedThread.id == threadID(ordinal: chatCount), "selected chat identity")
+        try require(
+            selectedThread.messages.count == marker.selectedThreadTurnCount * 2,
+            "selected chat message count"
+        )
+        try require(
+            root.threads
+                .filter({ $0.id != selectedThread.id })
+                .allSatisfy({ $0.messages.count == marker.shortThreadTurnCount * 2 }),
+            "background chat message count"
+        )
+        return workload
+    }
+
+    private static func require(_ condition: Bool, _ invariant: String) throws {
+        guard condition else {
+            throw QuillCodeDesktopDailyDriverSmokeFixtureError.invalidFixture(invariant)
+        }
+    }
+
+    private static func makeThread(ordinal: Int) -> ChatThread {
+        let topic = topics[(ordinal - 1) % topics.count]
+        let createdAt = baseDate.addingTimeInterval(TimeInterval(ordinal * 3_600))
+        let turnCount = ordinal == chatCount ? selectedThreadTurnCount : shortThreadTurnCount
+        return ChatThread(
+            id: threadID(ordinal: ordinal),
+            title: "\(topic) \(String(format: "%03d", ordinal))",
+            projectID: projectID,
+            messages: makeMessages(
+                threadOrdinal: ordinal,
+                topic: topic,
+                turnCount: turnCount,
+                createdAt: createdAt
+            ),
+            isPinned: ordinal == chatCount,
+            createdAt: createdAt,
+            updatedAt: createdAt.addingTimeInterval(TimeInterval(turnCount * 120))
+        )
+    }
+
+    private static func makeMessages(
+        threadOrdinal: Int,
+        topic: String,
+        turnCount: Int,
+        createdAt: Date
+    ) -> [ChatMessage] {
+        (1...turnCount).flatMap { turn in
+            let userOrdinal = turn * 2 - 1
+            let assistantOrdinal = turn * 2
+            return [
+                ChatMessage(
+                    id: messageID(threadOrdinal: threadOrdinal, ordinal: userOrdinal),
+                    role: .user,
+                    content: "Review \(topic.lowercased()) for daily task \(threadOrdinal), turn \(turn). Identify the highest-impact next step and keep the response concise.",
+                    createdAt: createdAt.addingTimeInterval(TimeInterval(userOrdinal * 60))
+                ),
+                ChatMessage(
+                    id: messageID(threadOrdinal: threadOrdinal, ordinal: assistantOrdinal),
+                    role: .assistant,
+                    content: "Turn \(turn) is complete. The next \(topic.lowercased()) action is recorded with checks for speed, resilience, and usability.",
+                    createdAt: createdAt.addingTimeInterval(TimeInterval(assistantOrdinal * 60))
+                )
+            ]
+        }
+    }
+
+    private static func threadID(ordinal: Int) -> UUID {
+        deterministicUUID(namespace: 0x2000_0000, value: ordinal)
+    }
+
+    private static func messageID(threadOrdinal: Int, ordinal: Int) -> UUID {
+        deterministicUUID(namespace: 0x3000_0000 + UInt32(threadOrdinal), value: ordinal)
+    }
+
+    private static func deterministicUUID(namespace: UInt32, value: Int) -> UUID {
+        let namespaceHex = String(format: "%08X", namespace)
+        let valueHex = String(format: "%012llX", UInt64(value))
+        return UUID(uuidString: "\(namespaceHex)-0000-4000-8000-\(valueHex)")!
+    }
+
+    private struct Marker: Codable, Equatable {
+        var schemaVersion: Int
+        var workload: String
+        var projectCount: Int
+        var chatCount: Int
+        var shortThreadTurnCount: Int
+        var selectedThreadTurnCount: Int
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopPerformanceSnapshot.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopPerformanceSnapshot.swift
@@ -37,10 +37,12 @@ struct QuillCodeDesktopProcessResourceSnapshot: Equatable, Sendable {
 struct QuillCodeDesktopInitialPerformanceSnapshot: Equatable, Sendable {
     static let measurement = "initial-live-window"
 
+    var workload: QuillCodeDesktopPerformanceWorkload
     var launchReadyMilliseconds: Double
     var resources: QuillCodeDesktopProcessResourceSnapshot
 
     static func capture(
+        workload: QuillCodeDesktopPerformanceWorkload = .firstRunEmpty,
         launchStartedAtUptime: TimeInterval,
         nowUptime: TimeInterval = ProcessInfo.processInfo.systemUptime
     ) throws -> Self {
@@ -51,6 +53,7 @@ struct QuillCodeDesktopInitialPerformanceSnapshot: Equatable, Sendable {
         let milliseconds = (elapsed * 100_000).rounded() / 100
 
         return Self(
+            workload: workload,
             launchReadyMilliseconds: milliseconds,
             resources: try QuillCodeDesktopProcessResourceSnapshot.capture()
         )
@@ -60,6 +63,7 @@ struct QuillCodeDesktopInitialPerformanceSnapshot: Equatable, Sendable {
         firstSweepResources: QuillCodeDesktopProcessResourceSnapshot
     ) throws -> QuillCodeDesktopPerformanceSnapshot {
         QuillCodeDesktopPerformanceSnapshot(
+            workload: workload,
             launchReadyMilliseconds: launchReadyMilliseconds,
             initialResources: resources,
             postInteractionResources: firstSweepResources,
@@ -69,12 +73,13 @@ struct QuillCodeDesktopInitialPerformanceSnapshot: Equatable, Sendable {
 }
 
 struct QuillCodeDesktopPerformanceSnapshot: Equatable, Sendable {
-    static let schemaVersion = 3
+    static let schemaVersion = 4
     static let measurement = QuillCodeDesktopInitialPerformanceSnapshot.measurement
     static let postInteractionMeasurement = "settled-after-native-interaction-sweep"
     static let repeatedInteractionMeasurement = "settled-after-repeated-native-interaction-sweep"
     static let interactionSweepCount = 2
 
+    var workload: QuillCodeDesktopPerformanceWorkload = .firstRunEmpty
     var launchReadyMilliseconds: Double
     var initialResources: QuillCodeDesktopProcessResourceSnapshot
     var postInteractionResources: QuillCodeDesktopProcessResourceSnapshot
@@ -98,6 +103,7 @@ struct QuillCodeDesktopPerformanceSnapshot: Equatable, Sendable {
     var dictionary: [String: Any] {
         [
             "schemaVersion": Self.schemaVersion,
+            "workload": workload.rawValue,
             "measurement": Self.measurement,
             "launchReadyMilliseconds": launchReadyMilliseconds,
             "residentMemoryBytes": residentMemoryBytes,

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -36,6 +36,7 @@ struct QuillCodeDesktopWindowSmokeRequest: Sendable {
     var reportPath: String?
     var screenshotPath: String?
     var stateRootPath: String?
+    var performanceWorkloadID: String
 
     init?(arguments: [String]) {
         guard arguments.contains("--native-window-smoke") else {
@@ -45,6 +46,10 @@ struct QuillCodeDesktopWindowSmokeRequest: Sendable {
         self.reportPath = Self.value(after: "--window-smoke-report", in: arguments)
         self.screenshotPath = Self.value(after: "--window-smoke-screenshot", in: arguments)
         self.stateRootPath = Self.value(after: "--window-smoke-state-root", in: arguments)
+        self.performanceWorkloadID = Self.value(
+            after: "--window-smoke-performance-workload",
+            in: arguments
+        ) ?? QuillCodeDesktopPerformanceWorkload.firstRunEmpty.rawValue
     }
 
     private static func value(after flag: String, in arguments: [String]) -> String? {

--- a/Sources/quill-code-desktop/QuillCodeDesktopWindowSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWindowSmokeRunner.swift
@@ -57,7 +57,13 @@ enum QuillCodeDesktopWindowSmokeRunner {
         guard bounds.width >= 900, bounds.height >= 620 else {
             throw QuillCodeDesktopSmokeFailure.windowContentTooSmall(bounds.width, bounds.height)
         }
+        let workload = try QuillCodeDesktopDailyDriverSmokeFixture.validate(
+            workloadID: request.performanceWorkloadID,
+            controller: controller,
+            workspaceRoot: workspaceRoot
+        )
         let initialPerformance = try QuillCodeDesktopInitialPerformanceSnapshot.capture(
+            workload: workload,
             launchStartedAtUptime: QuillCodeDesktopLaunchClock.appEntryUptime
         )
         markStage("launch-window-ready")

--- a/Tests/QuillCodeAppTests/TranscriptConnectPromptTests.swift
+++ b/Tests/QuillCodeAppTests/TranscriptConnectPromptTests.swift
@@ -25,4 +25,42 @@ final class TranscriptConnectPromptTests: XCTestCase {
         XCTAssertFalse(TranscriptConnectPrompt.browserSignInCaption.contains("localhost"))
         XCTAssertEqual(TranscriptConnectPrompt.steps, ["Connect", "Choose a model", "Start a task"])
     }
+
+    func testConnectionPlacementUsesHeroOnlyForTheVisibleEmptyState() {
+        XCTAssertEqual(
+            TranscriptConnectPlacement.resolve(
+                hasPrompt: true,
+                requiresProjectSelection: false,
+                emptyStateVisible: true
+            ),
+            .hero
+        )
+        XCTAssertEqual(
+            TranscriptConnectPlacement.resolve(
+                hasPrompt: true,
+                requiresProjectSelection: false,
+                emptyStateVisible: false
+            ),
+            .banner
+        )
+    }
+
+    func testConnectionPlacementDefersToProjectSetupAndHidesWhenConnected() {
+        XCTAssertEqual(
+            TranscriptConnectPlacement.resolve(
+                hasPrompt: true,
+                requiresProjectSelection: true,
+                emptyStateVisible: true
+            ),
+            .hidden
+        )
+        XCTAssertEqual(
+            TranscriptConnectPlacement.resolve(
+                hasPrompt: false,
+                requiresProjectSelection: false,
+                emptyStateVisible: false
+            ),
+            .hidden
+        )
+    }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceNavigationHistoryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceNavigationHistoryTests.swift
@@ -84,6 +84,27 @@ final class WorkspaceNavigationHistoryTests: XCTestCase {
         XCTAssertEqual(model.root.selectedProjectID, secondProject.id)
     }
 
+    func testHistoryRestoresSelectedProjectAlongsideProjectlessThread() {
+        let project = ProjectRef(name: "Workspace", path: "/tmp/workspace")
+        let projectThread = ChatThread(title: "Project chat", projectID: project.id)
+        let projectlessThread = ChatThread(title: "Legacy global chat")
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            projects: [project],
+            selectedProjectID: project.id,
+            threads: [projectlessThread, projectThread],
+            selectedThreadID: projectlessThread.id
+        ))
+
+        model.selectThread(projectThread.id)
+        XCTAssertTrue(model.navigateBackInWorkspace())
+
+        XCTAssertEqual(model.root.selectedThreadID, projectlessThread.id)
+        XCTAssertEqual(model.root.selectedProjectID, project.id)
+        XCTAssertTrue(model.navigateForwardInWorkspace())
+        XCTAssertEqual(model.root.selectedThreadID, projectThread.id)
+        XCTAssertEqual(model.root.selectedProjectID, project.id)
+    }
+
     func testWorkspaceModelPrunesDeletedThreadFromHistory() {
         let firstThread = ChatThread(title: "First")
         let secondThread = ChatThread(title: "Second")

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopApplicationServicesTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopApplicationServicesTests.swift
@@ -7,6 +7,48 @@ import QuillCodeTools
 
 @MainActor
 final class QuillCodeDesktopApplicationServicesTests: XCTestCase {
+    func testNotificationOwnershipRequiresCanonicalPackagedApplicationLayout() {
+        let applicationURL = URL(
+            fileURLWithPath: "/Applications/Quill Cowork.app",
+            isDirectory: true
+        )
+        let executableURL = applicationURL
+            .appendingPathComponent("Contents/MacOS/Quill Cowork")
+
+        XCTAssertTrue(QuillCodeDesktopPackagedProcessIdentity.ownsNotificationCenter(
+            bundleIdentifier: "co.lorehex.QuillCowork",
+            bundleURL: applicationURL,
+            executableURL: executableURL,
+            expectedBundleIdentifier: "co.lorehex.QuillCowork"
+        ))
+        XCTAssertFalse(QuillCodeDesktopPackagedProcessIdentity.ownsNotificationCenter(
+            bundleIdentifier: "co.lorehex.QuillCowork",
+            bundleURL: URL(fileURLWithPath: "/tmp/.build/debug", isDirectory: true),
+            executableURL: URL(fileURLWithPath: "/tmp/.build/debug/Quill Cowork"),
+            expectedBundleIdentifier: "co.lorehex.QuillCowork"
+        ))
+    }
+
+    func testNotificationOwnershipRejectsMismatchedIdentityAndEscapedExecutable() {
+        let applicationURL = URL(
+            fileURLWithPath: "/Applications/Quill Cowork.app",
+            isDirectory: true
+        )
+
+        XCTAssertFalse(QuillCodeDesktopPackagedProcessIdentity.ownsNotificationCenter(
+            bundleIdentifier: "co.example.Lookalike",
+            bundleURL: applicationURL,
+            executableURL: applicationURL.appendingPathComponent("Contents/MacOS/Quill Cowork"),
+            expectedBundleIdentifier: "co.lorehex.QuillCowork"
+        ))
+        XCTAssertFalse(QuillCodeDesktopPackagedProcessIdentity.ownsNotificationCenter(
+            bundleIdentifier: "co.lorehex.QuillCowork",
+            bundleURL: applicationURL,
+            executableURL: URL(fileURLWithPath: "/tmp/Quill Cowork"),
+            expectedBundleIdentifier: "co.lorehex.QuillCowork"
+        ))
+    }
+
     func testApplicationServicesStartAtFirstWindowBoundaryAndRemainIdempotent() async throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import QuillCodePersistence
+import XCTest
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopDailyDriverSmokeFixtureTests: XCTestCase {
+    func testSeederCreatesDeterministicProjectScopedDailyDriverWorkspace() throws {
+        let parent = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let stateRoot = parent.appendingPathComponent("daily-driver", isDirectory: true)
+
+        try QuillCodeDesktopDailyDriverSmokeFixture.seed(at: stateRoot)
+
+        let paths = QuillCodePaths(home: stateRoot.appendingPathComponent("app-state"))
+        let projects = try JSONProjectStore(fileURL: paths.projectsFile).load()
+        let threads = try JSONThreadStore(directory: paths.threadsDirectory).list()
+        let selectedThread = try XCTUnwrap(threads.first)
+
+        XCTAssertEqual(projects.count, 1)
+        XCTAssertEqual(projects.first?.path, stateRoot.appendingPathComponent("workspace").path)
+        XCTAssertEqual(threads.count, QuillCodeDesktopDailyDriverSmokeFixture.chatCount)
+        XCTAssertEqual(Set(threads.map(\.id)).count, threads.count)
+        XCTAssertTrue(threads.allSatisfy { $0.projectID == projects.first?.id })
+        XCTAssertEqual(selectedThread.title, "Keyboard ergonomics 100")
+        XCTAssertTrue(selectedThread.isPinned)
+        XCTAssertEqual(
+            selectedThread.messages.count,
+            QuillCodeDesktopDailyDriverSmokeFixture.selectedThreadTurnCount * 2
+        )
+        XCTAssertTrue(
+            threads.dropFirst().allSatisfy {
+                $0.messages.count == QuillCodeDesktopDailyDriverSmokeFixture.shortThreadTurnCount * 2
+            }
+        )
+
+        let fixtureBytes = try FileManager.default.contentsOfDirectory(
+            at: paths.threadsDirectory,
+            includingPropertiesForKeys: [.fileSizeKey]
+        ).reduce(0) { total, url in
+            total + (try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0)
+        }
+        XCTAssertGreaterThan(fixtureBytes, 250_000)
+        XCTAssertLessThan(fixtureBytes, 2_000_000)
+
+        let request = try XCTUnwrap(QuillCodeDesktopWindowSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--native-window-smoke",
+            "--window-smoke-state-root",
+            stateRoot.path,
+            "--window-smoke-performance-workload",
+            QuillCodeDesktopPerformanceWorkload.dailyDriver100Chats.rawValue
+        ]))
+        let workspaceRoot = QuillCodeDesktopWindowSmokeWorkspaceRoot(request: request)
+        let controller = workspaceRoot.makeController()
+        XCTAssertEqual(
+            try QuillCodeDesktopDailyDriverSmokeFixture.validate(
+                workloadID: request.performanceWorkloadID,
+                controller: controller,
+                workspaceRoot: workspaceRoot
+            ),
+            .dailyDriver100Chats
+        )
+    }
+
+    func testSeederParsesRequiredStateRootAndRefusesExistingDestination() throws {
+        XCTAssertNil(QuillCodeDesktopDailyDriverSmokeSeedRequest(arguments: ["Quill Cowork"]))
+        let request = try XCTUnwrap(QuillCodeDesktopDailyDriverSmokeSeedRequest(arguments: [
+            "Quill Cowork",
+            "--seed-daily-driver-window-smoke",
+            "--window-smoke-state-root",
+            "/tmp/quill-daily-driver"
+        ]))
+        XCTAssertEqual(request.stateRootPath, "/tmp/quill-daily-driver")
+
+        let parent = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let stateRoot = parent.appendingPathComponent("daily-driver", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateRoot, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try QuillCodeDesktopDailyDriverSmokeFixture.seed(at: stateRoot)) { error in
+            XCTAssertEqual(
+                error as? QuillCodeDesktopDailyDriverSmokeFixtureError,
+                .stateRootAlreadyExists
+            )
+        }
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: stateRoot.path), [])
+    }
+
+    func testDailyDriverValidationRejectsTamperedMarker() throws {
+        let parent = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let stateRoot = parent.appendingPathComponent("daily-driver", isDirectory: true)
+        try QuillCodeDesktopDailyDriverSmokeFixture.seed(at: stateRoot)
+
+        let markerURL = stateRoot.appendingPathComponent(
+            QuillCodeDesktopDailyDriverSmokeFixture.markerFileName
+        )
+        var marker = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: markerURL)) as? [String: Any]
+        )
+        marker["chatCount"] = 99
+        try JSONSerialization.data(withJSONObject: marker, options: [.prettyPrinted, .sortedKeys])
+            .write(to: markerURL, options: .atomic)
+
+        let request = try XCTUnwrap(QuillCodeDesktopWindowSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--native-window-smoke",
+            "--window-smoke-state-root",
+            stateRoot.path,
+            "--window-smoke-performance-workload",
+            QuillCodeDesktopPerformanceWorkload.dailyDriver100Chats.rawValue
+        ]))
+        let workspaceRoot = QuillCodeDesktopWindowSmokeWorkspaceRoot(request: request)
+        let controller = workspaceRoot.makeController()
+
+        XCTAssertThrowsError(
+            try QuillCodeDesktopDailyDriverSmokeFixture.validate(
+                workloadID: request.performanceWorkloadID,
+                controller: controller,
+                workspaceRoot: workspaceRoot
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? QuillCodeDesktopDailyDriverSmokeFixtureError,
+                .invalidFixture("marker contract mismatch")
+            )
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-daily-driver-fixture-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
@@ -255,12 +255,15 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
             "--window-smoke-screenshot",
             "/tmp/quillcode-window.png",
             "--window-smoke-state-root",
-            "/tmp/quillcode-window-state"
+            "/tmp/quillcode-window-state",
+            "--window-smoke-performance-workload",
+            "daily-driver-100-chats"
         ])
 
         XCTAssertEqual(request?.reportPath, "/tmp/quillcode-window-report.json")
         XCTAssertEqual(request?.screenshotPath, "/tmp/quillcode-window.png")
         XCTAssertEqual(request?.stateRootPath, "/tmp/quillcode-window-state")
+        XCTAssertEqual(request?.performanceWorkloadID, "daily-driver-100-chats")
         XCTAssertNil(QuillCodeDesktopWindowSmokeRequest(arguments: ["QuillCode"]))
     }
 
@@ -507,6 +510,7 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
         XCTAssertTrue(json.contains(#""surface""#))
         XCTAssertTrue(json.contains(#""composerCanSend" : false"#))
         XCTAssertTrue(json.contains(#""measurement" : "initial-live-window""#))
+        XCTAssertTrue(json.contains(#""workload" : "first-run-empty""#))
         XCTAssertTrue(json.contains(#""postInteractionMeasurement" : "settled-after-native-interaction-sweep""#))
         XCTAssertTrue(json.contains(
             #""repeatedInteractionMeasurement" : "settled-after-repeated-native-interaction-sweep""#

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -40,10 +40,23 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(windowSmokeText.contains("QuillCodeDesktopSmokePixelStats"))
         XCTAssertTrue(windowSmokeText.contains("window.title == QuillCodeProduct.displayName"))
         XCTAssertTrue(packagedSmoke.contains("wait_for_smoke_process"))
+        XCTAssertTrue(
+            packagedSmoke.contains(
+                #"APP_CONFIGURATION="${QUILLCODE_PACKAGED_MACOS_SMOKE_CONFIGURATION:-release}""#
+            )
+        )
+        XCTAssertTrue(packagedSmoke.contains(#"--configuration "$APP_CONFIGURATION""#))
         XCTAssertTrue(packagedSmoke.contains("--native-window-smoke"))
         XCTAssertTrue(packagedSmoke.contains("--window-smoke-report \"$WINDOW_REPORT_PATH\""))
         XCTAssertTrue(packagedSmoke.contains("--window-smoke-screenshot \"$WINDOW_SCREENSHOT_PATH\""))
         XCTAssertTrue(packagedSmoke.contains("--window-smoke-state-root \"$WINDOW_STATE_ROOT\""))
+        XCTAssertTrue(packagedSmoke.contains("--seed-daily-driver-window-smoke"))
+        XCTAssertTrue(
+            packagedSmoke.contains(#"--window-smoke-performance-workload "daily-driver-100-chats""#)
+        )
+        XCTAssertTrue(packagedSmoke.contains("performance-window-report.json"))
+        XCTAssertTrue(packagedSmoke.contains("performance-window.png"))
+        XCTAssertTrue(packagedSmoke.contains("\"$PERFORMANCE_WINDOW_REPORT_PATH\""))
         XCTAssertFalse(packagedSmoke.contains("HOME=\"$SMOKE_ROOT/home\""))
         XCTAssertTrue(packagedSmoke.contains("window-report.json"))
         XCTAssertTrue(packagedSmoke.contains("window.png"))
@@ -79,6 +92,8 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         XCTAssertTrue(packagedSmoke.contains("browser_workflow_manifest=packaged-browser-workflow.json"))
         XCTAssertTrue(packagedSmoke.contains("computer_use_manifest=packaged-computer-use.json"))
         XCTAssertTrue(packagedSmoke.contains("computer_use_action_manifest=packaged-computer-use-action.json"))
+        XCTAssertTrue(packagedSmoke.contains("performance_window_report=performance-window-report.json"))
+        XCTAssertTrue(packagedSmoke.contains("performance_window_screenshot=performance-window.png"))
         XCTAssertTrue(packagedSmoke.contains(" scheduled-coworker \\"))
         XCTAssertTrue(packagedSmoke.contains(" multi-file-artifact \\"))
         XCTAssertTrue(packagedSmoke.contains(" one-turn-coworker \\"))

--- a/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
@@ -7,6 +7,18 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
         let app = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
         let runner = try Self.desktopSourceText(named: "QuillCodeDesktopWindowSmokeRunner.swift")
         let support = try Self.desktopSourceText(named: "QuillCodeDesktopSmokeSupport.swift")
+        let activationSampler = try Self.desktopSourceText(
+            named: "QuillCodeDesktopAccessibilityActivationSampler.swift"
+        )
+        let interactionVerifier = try Self.desktopSourceText(
+            named: "QuillCodeDesktopAccessibilityInteractionVerifier.swift"
+        )
+        let hierarchySettler = try Self.desktopSourceText(
+            named: "QuillCodeDesktopAccessibilityHierarchySettler.swift"
+        )
+        let frameSampler = try Self.desktopSourceText(
+            named: "QuillCodeDesktopAccessibilityFrameSampler.swift"
+        )
         let packagedSmoke = try Self.scriptText(named: "packaged-macos-smoke.sh")
         let performanceSmoke = try Self.scriptText(named: "packaged-macos-performance-smoke.sh")
         let packageDownloads = try Self.scriptText(named: "package-macos-downloads.sh")
@@ -58,14 +70,37 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
         XCTAssertLessThan(performanceIndex, screenshotIndex)
         XCTAssertLessThan(interactionIndex, completedPerformanceIndex)
         Self.assertSource(support, contains: #""performance": performance.dictionary"#)
+        Self.assertSource(activationSampler, containsAll: [
+            "candidateIdentifiers(for: probe)",
+            "matchingAnyIdentifier: directCandidates",
+            #"markStage("start", contractID: contract.contractID)"#,
+            #"markStage("complete", contractID: contract.contractID)"#,
+            "QuillCodeDesktopProcessResourceSnapshot.capture()"
+        ])
+        Self.assertSource(interactionVerifier, contains: "matchingIdentifiers: [identifier]")
+        Self.assertSource(hierarchySettler, containsAll: [
+            "layoutSentinelIdentifiers",
+            "matchingIdentifiers: layoutSentinelIdentifiers"
+        ])
+        Self.assertSource(frameSampler, containsAll: [
+            "targetIdentifiers",
+            "matchingIdentifiers: targetIdentifiers"
+        ])
 
         Self.assertSource(packagedSmoke, containsAll: [
             "packaged-performance.json",
+            #"QUILLCODE_PACKAGED_MACOS_SMOKE_CONFIGURATION:-release"#,
+            #"--configuration "$APP_CONFIGURATION""#,
+            "--seed-daily-driver-window-smoke",
+            #"--window-smoke-performance-workload "daily-driver-100-chats""#,
+            "performance-window-report.json",
             "native-click-probe-contracts.py\" performance",
             "performance_manifest=packaged-performance.json"
         ])
         Self.assertSource(performanceSmoke, containsAll: [
             "--native-window-smoke",
+            "--seed-daily-driver-window-smoke",
+            #"--window-smoke-performance-workload "daily-driver-100-chats""#,
             "PERFORMANCE_ATTEMPT_COUNT=3",
             #"REPORT_PATHS+=("$REPORT_PATH")"#,
             "--max-launch-ready-milliseconds",
@@ -122,7 +157,8 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
         let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(manifest["ok"] as? Bool, true)
         XCTAssertEqual(manifest["withinBudget"] as? Bool, true)
-        XCTAssertEqual(manifest["schemaVersion"] as? Int, 3)
+        XCTAssertEqual(manifest["schemaVersion"] as? Int, 4)
+        XCTAssertEqual(manifest["workload"] as? String, "daily-driver-100-chats")
         XCTAssertEqual(manifest["measurement"] as? String, "initial-live-window")
         XCTAssertEqual(
             manifest["postInteractionMeasurement"] as? String,
@@ -436,6 +472,30 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.manifest.path))
     }
 
+    func testPerformanceValidatorRejectsMislabeledWorkload() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let reportData = try Data(contentsOf: fixture.report)
+        var report = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: reportData) as? [String: Any]
+        )
+        var performance = try XCTUnwrap(report["performance"] as? [String: Any])
+        performance["workload"] = "first-run-empty"
+        report["performance"] = performance
+        try JSONSerialization.data(withJSONObject: report, options: [.prettyPrinted])
+            .write(to: fixture.report, options: .atomic)
+
+        let result = try runValidator(
+            reports: [fixture.report],
+            manifest: fixture.manifest,
+            maximumLaunchMilliseconds: 3_000,
+            maximumResidentBytes: 128 * 1_024 * 1_024
+        )
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.output.contains("unexpected packaged performance workload"), result.output)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.manifest.path))
+    }
+
     private func makeFixture() throws -> (root: URL, report: URL, manifest: URL) {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("quillcode-performance-gate-(UUID().uuidString)")
@@ -460,7 +520,8 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
             "ok": true,
             "appName": "Quill Cowork",
             "performance": [
-                "schemaVersion": 3,
+                "schemaVersion": 4,
+                "workload": "daily-driver-100-chats",
                 "measurement": "initial-live-window",
                 "launchReadyMilliseconds": launchReadyMilliseconds,
                 "residentMemoryBytes": residentMemoryBytes,

--- a/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
@@ -41,6 +41,7 @@ final class ParityPublicDistributionGateTests: QuillCodeParityTestCase {
 
     func testFirstRunConnectSurfaceHidesDeveloperCallbackDetails() throws {
         let connectView = try Self.appSourceText(named: "QuillCodeConnectView.swift")
+        let connectBannerView = try Self.appSourceText(named: "QuillCodeConnectBannerView.swift")
         let connectPrompt = try Self.appSourceText(named: "TranscriptConnectPrompt.swift")
         let settingsView = try Self.appSourceText(named: "QuillCodeSettingsView.swift")
         let workspaceView = try Self.appSourceText(named: "WorkspaceSwiftUIView.swift")
@@ -52,12 +53,41 @@ final class ParityPublicDistributionGateTests: QuillCodeParityTestCase {
             "quillcode-connect-developer-key",
             "onUseDeveloperKey"
         ])
+        Self.assertSource(connectBannerView, containsAll: [
+            "TranscriptConnectPrompt.returningUserSubtitle",
+            "quillcode-connect-sign-in",
+            "quillcode-connect-developer-key"
+        ])
+        Self.assertSource(connectPrompt, contains: "case banner")
         Self.assertSource(connectPrompt, excludes: "var signInURL")
         Self.assertSource(settingsView, contains: "Text(settings.signInURL)")
+        Self.assertSource(settingsView, containsAll: [
+            "LazyVStack(alignment: .leading, spacing: 14)",
+            "authenticationSection",
+            "QuillCodeNotificationSettingsCard"
+        ])
+        let authenticationIndex = try XCTUnwrap(settingsView.range(of: "authenticationSection")).lowerBound
+        let notificationIndex = try XCTUnwrap(
+            settingsView.range(of: "QuillCodeNotificationSettingsCard")
+        ).lowerBound
+        XCTAssertLessThan(authenticationIndex, notificationIndex)
         Self.assertSource(workspaceView, containsAll: [
             "onUseDeveloperKey: presentDeveloperKeySettings",
             "settingsAuthModeOverride = .developerOverride"
         ])
         Self.assertSource(workspaceSheets, contains: "authModeOverride: settingsAuthModeOverride")
+    }
+
+    func testNotificationServicesRequireCanonicalPackagedProcessIdentity() throws {
+        let controller = try Self.desktopSourceText(named: "QuillCodeDesktopController.swift")
+
+        Self.assertSource(controller, containsAll: [
+            "QuillCodeDesktopPackagedProcessIdentity.ownsNotificationCenter(",
+            #"pathExtension.caseInsensitiveCompare("app")"#,
+            #"appendingPathComponent("Contents/MacOS", isDirectory: true)"#
+        ])
+        Self.assertSource(controller, excludesAll: [
+            "guard bundle.bundleIdentifier == updateController.configuration?.bundleIdentifier else"
+        ])
     }
 }

--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -110,6 +110,21 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         )
     }
 
+    func testVerifierRejectsPerformanceWorkloadDriftAfterIntegrityChecksPass() throws {
+        let fixture = try makeFixture { evidence in
+            evidence["workload"] = "first-run-empty"
+        }
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("performance evidence workload is invalid"),
+            result.output
+        )
+    }
+
     func testVerifierRejectsForgedPerformanceDeltaAfterIntegrityChecksPass() throws {
         let fixture = try makeFixture { evidence in
             var attempts = try XCTUnwrap(evidence["attempts"] as? [[String: Any]])
@@ -666,9 +681,10 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         ]
         let selectedAttempt = attempts[1]
         var evidence: [String: Any] = [
-            "schemaVersion": 3,
+            "schemaVersion": 4,
             "ok": true,
             "product": "Quill Cowork",
+            "workload": "daily-driver-100-chats",
             "measurement": "initial-live-window",
             "postInteractionMeasurement": "settled-after-native-interaction-sweep",
             "repeatedInteractionMeasurement": "settled-after-repeated-native-interaction-sweep",

--- a/Tests/QuillCodeParityTests/ParityWorkspaceReviewSurfaceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceReviewSurfaceGateTests.swift
@@ -229,13 +229,15 @@ final class ParityWorkspaceReviewSurfaceGateTests: QuillCodeParityTestCase {
         Self.assertSource(mainPaneText, contains: "onCloseReview: { runCommand(id: \"toggle-review-panel\") }")
     }
 
-    func testNativeReviewOpeningBringsThePaneIntoViewWithoutTailScrollCompetition() throws {
+    func testNativeReviewUsesAFocusedViewportWithoutMaterializingTheTranscriptTail() throws {
         let transcriptText = try Self.appSourceText(named: "QuillCodeTranscriptView.swift")
 
-        Self.assertSource(transcriptText, contains: ".id(Self.reviewAnchorID)")
+        Self.assertSource(transcriptText, contains: "if review.isVisible")
+        Self.assertSource(transcriptText, contains: "reviewBody")
+        Self.assertSource(transcriptText, contains: "accessibilityIdentifier(\"quillcode-review-viewport\")")
         Self.assertSource(transcriptText, contains: ".onChange(of: review.isVisible)")
-        Self.assertSource(transcriptText, contains: "proxy.scrollTo(Self.reviewAnchorID, anchor: .top)")
-        Self.assertSource(transcriptText, contains: "!review.isVisible")
+        XCTAssertFalse(transcriptText.contains("reviewAnchorID"))
+        XCTAssertFalse(transcriptText.contains("scrollForReviewVisibility"))
     }
 
 }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,25 @@
 # QuillCode Decisions
 
+## 2026-08-10: public performance measures a verified daily-driver workspace
+
+- **Decision:** Every packaged performance attempt first invokes the app's own fixture helper to
+  atomically create one project, 100 saved chats, and a 200-message selected transcript. The timed
+  process loads that state normally and validates the marker, project binding, chat count, selected
+  chat, and message counts before capturing launch or resource evidence.
+- **Evidence contract:** Version-4 performance evidence identifies the workload as
+  `daily-driver-100-chats`. Raw window reports and the public architecture-specific manifests must
+  agree on that exact identity; an empty, malformed, mislabeled, or partially seeded workspace fails
+  closed. Seeding runs in a separate process so fixture creation is outside launch timing.
+- **Coverage boundary:** The full packaged smoke keeps its first-run empty-state window for onboarding,
+  Accessibility frames, and Computer Use proof, then starts a second, separately seeded daily-driver
+  window for its performance manifest. It packages an optimized release executable by default (with
+  an explicit diagnostic override), so production budgets never judge debug-code memory behavior.
+  Published speed and memory numbers therefore represent a returning user's restored workspace
+  without surrendering first-run coverage.
+- **Why:** Empty-state launch evidence could remain green while persistence loading, transcript
+  restoration, navigation context, or reconnect UX regressed for established users. Distribution
+  claims should measure the state people keep after adopting the product.
+
 ## 2026-08-10: process-owned application services begin after the first window
 
 - **Decision:** Normal desktop launch no longer registers notification categories, inspects the

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -174,10 +174,13 @@ code, manifest-only checks, and unit-level updater tests cannot prove.
 
 The release-configured macOS app must also open a real native window within three
 seconds and remain below 256 MiB of resident memory at that initial-window
-boundary. Release packaging measures three fresh processes with isolated state,
-requires at least two launches to meet the time budget, and requires every memory
-sample to meet its budget. The median-launch attempt, every attempt, thread
-counts, and enforced budgets ship as both architecture-specific `PERFORMANCE.json` assets.
+boundary. Each attempt atomically seeds and verifies one project with 100 saved
+chats and a 200-message active transcript before timing the real packaged launch.
+Release packaging measures three fresh processes with isolated state, requires at
+least two launches to meet the time budget, and requires every memory sample to
+meet its budget. The workload identity, median-launch attempt, every attempt,
+thread counts, and enforced budgets ship as both architecture-specific
+`PERFORMANCE.json` assets.
 
 Each process then completes the packaged native interaction sweep twice, including
 reversible navigation, sheet, search, model-picker, and text-entry checks. The gate

--- a/scripts/native_click_probe_contracts/performance.py
+++ b/scripts/native_click_probe_contracts/performance.py
@@ -19,6 +19,7 @@ from performance_evidence_contract import (
     INTERACTION_SWEEP_COUNT,
     PERFORMANCE_PRODUCT,
     PERFORMANCE_SCHEMA_VERSION,
+    PERFORMANCE_WORKLOAD,
     POST_INTERACTION_MEASUREMENT,
     REPEATED_INTERACTION_MEASUREMENT,
 )
@@ -91,6 +92,10 @@ def _load_attempt(report_path: Path) -> PerformanceAttempt:
     require(
         performance.get("schemaVersion") == PERFORMANCE_SCHEMA_VERSION,
         "unsupported performance evidence schema",
+    )
+    require(
+        performance.get("workload") == PERFORMANCE_WORKLOAD,
+        "unexpected packaged performance workload",
     )
     require(
         performance.get("measurement") == INITIAL_MEASUREMENT,
@@ -324,6 +329,7 @@ def write_performance_manifest(
         "schemaVersion": PERFORMANCE_SCHEMA_VERSION,
         "ok": True,
         "product": PERFORMANCE_PRODUCT,
+        "workload": PERFORMANCE_WORKLOAD,
         "measurement": INITIAL_MEASUREMENT,
         "postInteractionMeasurement": POST_INTERACTION_MEASUREMENT,
         "launchReadyMilliseconds": launch_ready,

--- a/scripts/packaged-macos-performance-smoke.sh
+++ b/scripts/packaged-macos-performance-smoke.sh
@@ -88,10 +88,15 @@ for ((attempt = 1; attempt <= PERFORMANCE_ATTEMPT_COUNT; attempt += 1)); do
   STATE_ROOT="$SMOKE_ROOT/window-state-$attempt"
   echo "==> Packaged performance attempt $attempt/$PERFORMANCE_ATTEMPT_COUNT"
   "$APP_EXECUTABLE" \
+    --seed-daily-driver-window-smoke \
+    --window-smoke-state-root "$STATE_ROOT" \
+    >/dev/null
+  "$APP_EXECUTABLE" \
     --native-window-smoke \
     --window-smoke-report "$REPORT_PATH" \
     --window-smoke-screenshot "$SCREENSHOT_PATH" \
     --window-smoke-state-root "$STATE_ROOT" \
+    --window-smoke-performance-workload "daily-driver-100-chats" \
     >/dev/null &
   SMOKE_PID="$!"
 

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/quillcode-packaged-macos-smoke.XXXXXX")"
 APP_OUTPUT_DIR="$SMOKE_ROOT/app"
+APP_CONFIGURATION="${QUILLCODE_PACKAGED_MACOS_SMOKE_CONFIGURATION:-release}"
 DIRECT_SMOKE_ARTIFACT_DIR="$SMOKE_ROOT/direct-executable"
 LAUNCH_SERVICES_SMOKE_ARTIFACT_DIR="$SMOKE_ROOT/launch-services"
 CLICK_PROBE_MANIFEST="$SMOKE_ROOT/packaged-click-probes.json"
@@ -16,6 +17,9 @@ BROWSER_WORKFLOW_MANIFEST="$SMOKE_ROOT/packaged-browser-workflow.json"
 COMPUTER_USE_MANIFEST="$SMOKE_ROOT/packaged-computer-use.json"
 COMPUTER_USE_ACTION_MANIFEST="$SMOKE_ROOT/packaged-computer-use-action.json"
 PERFORMANCE_MANIFEST="$SMOKE_ROOT/packaged-performance.json"
+PERFORMANCE_WINDOW_REPORT_PATH="$SMOKE_ROOT/performance-window-report.json"
+PERFORMANCE_WINDOW_SCREENSHOT_PATH="$SMOKE_ROOT/performance-window.png"
+PERFORMANCE_WINDOW_STATE_ROOT="$SMOKE_ROOT/performance-window-state"
 COMPOSER_DRAFT_CRASH_STATE_ROOT="$SMOKE_ROOT/composer-draft-crash-state"
 COMPOSER_DRAFT_CRASH_WRITE_LOG="$SMOKE_ROOT/composer-draft-crash-write.log"
 COMPOSER_DRAFT_CRASH_VERIFY_LOG="$SMOKE_ROOT/composer-draft-crash-verify.log"
@@ -72,6 +76,12 @@ cleanup() {
     if [[ -e "$PERFORMANCE_MANIFEST" ]]; then
       cp "$PERFORMANCE_MANIFEST" "$ARTIFACT_DIR/packaged-performance.json"
     fi
+    if [[ -e "$PERFORMANCE_WINDOW_REPORT_PATH" ]]; then
+      cp "$PERFORMANCE_WINDOW_REPORT_PATH" "$ARTIFACT_DIR/performance-window-report.json"
+    fi
+    if [[ -e "$PERFORMANCE_WINDOW_SCREENSHOT_PATH" ]]; then
+      cp "$PERFORMANCE_WINDOW_SCREENSHOT_PATH" "$ARTIFACT_DIR/performance-window.png"
+    fi
     if [[ -e "$COMPOSER_DRAFT_CRASH_WRITE_LOG" ]]; then
       cp "$COMPOSER_DRAFT_CRASH_WRITE_LOG" "$ARTIFACT_DIR/composer-draft-crash-write.log"
     fi
@@ -103,6 +113,8 @@ cleanup() {
       printf 'computer_use_manifest=packaged-computer-use.json\n'
       printf 'computer_use_action_manifest=packaged-computer-use-action.json\n'
       printf 'performance_manifest=packaged-performance.json\n'
+      printf 'performance_window_report=performance-window-report.json\n'
+      printf 'performance_window_screenshot=performance-window.png\n'
       printf 'composer_draft_crash_write=composer-draft-crash-write.log\n'
       printf 'composer_draft_crash_verify=composer-draft-crash-verify.log\n'
       printf 'window_smoke=window-report.json\n'
@@ -128,7 +140,11 @@ fi
 cd "$ROOT_DIR"
 
 echo "==> Building packaged macOS app"
-APP_BUNDLE="$("$ROOT_DIR/scripts/build-macos-app.sh" --output "$APP_OUTPUT_DIR")"
+APP_BUNDLE="$(
+  "$ROOT_DIR/scripts/build-macos-app.sh" \
+    --output "$APP_OUTPUT_DIR" \
+    --configuration "$APP_CONFIGURATION"
+)"
 INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
 APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/Quill Cowork"
 EXPECTED_BUILD_COMMIT="$(git rev-parse HEAD)"
@@ -297,8 +313,42 @@ fi
   --click-probe-manifest "$CLICK_PROBE_MANIFEST" \
   --manifest "$ACCESSIBILITY_FRAMES_MANIFEST"
 
+echo "==> Running packaged macOS app daily-driver performance window smoke"
+"$APP_EXECUTABLE" \
+  --seed-daily-driver-window-smoke \
+  --window-smoke-state-root "$PERFORMANCE_WINDOW_STATE_ROOT" \
+  >/dev/null
+(
+  "$APP_EXECUTABLE" \
+    --native-window-smoke \
+    --window-smoke-report "$PERFORMANCE_WINDOW_REPORT_PATH" \
+    --window-smoke-screenshot "$PERFORMANCE_WINDOW_SCREENSHOT_PATH" \
+    --window-smoke-state-root "$PERFORMANCE_WINDOW_STATE_ROOT" \
+    --window-smoke-performance-workload "daily-driver-100-chats" \
+    >/dev/null
+) &
+PERFORMANCE_WINDOW_SMOKE_PID="$!"
+if ! wait_for_smoke_process \
+  "$PERFORMANCE_WINDOW_SMOKE_PID" \
+  "$WINDOW_SMOKE_TIMEOUT_SECONDS" \
+  "Packaged app daily-driver performance window smoke"
+then
+  cat "$PERFORMANCE_WINDOW_REPORT_PATH" >&2 2>/dev/null || true
+  exit 1
+fi
+
+if [[ ! -s "$PERFORMANCE_WINDOW_REPORT_PATH" ]]; then
+  echo "Packaged app daily-driver performance smoke did not write a JSON report" >&2
+  exit 1
+fi
+if [[ ! -s "$PERFORMANCE_WINDOW_SCREENSHOT_PATH" ]]; then
+  echo "Packaged app daily-driver performance smoke did not write a screenshot" >&2
+  cat "$PERFORMANCE_WINDOW_REPORT_PATH" >&2 || true
+  exit 1
+fi
+
 "$ROOT_DIR/scripts/native-click-probe-contracts.py" performance \
-  "$WINDOW_REPORT_PATH" \
+  "$PERFORMANCE_WINDOW_REPORT_PATH" \
   --manifest "$PERFORMANCE_MANIFEST"
 
 "$ROOT_DIR/scripts/native-click-probe-contracts.py" computer-use \

--- a/scripts/performance_evidence_contract.py
+++ b/scripts/performance_evidence_contract.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 
-PERFORMANCE_SCHEMA_VERSION = 3
+PERFORMANCE_SCHEMA_VERSION = 4
 PERFORMANCE_PRODUCT = "Quill Cowork"
+PERFORMANCE_WORKLOAD = "daily-driver-100-chats"
 INITIAL_MEASUREMENT = "initial-live-window"
 POST_INTERACTION_MEASUREMENT = "settled-after-native-interaction-sweep"
 REPEATED_INTERACTION_MEASUREMENT = (

--- a/scripts/release_verification_performance.py
+++ b/scripts/release_verification_performance.py
@@ -11,6 +11,7 @@ from performance_evidence_contract import (
     INTERACTION_SWEEP_COUNT,
     PERFORMANCE_PRODUCT,
     PERFORMANCE_SCHEMA_VERSION,
+    PERFORMANCE_WORKLOAD,
     POST_INTERACTION_MEASUREMENT,
     RELEASE_ATTEMPT_COUNT,
     REPEATED_INTERACTION_MEASUREMENT,
@@ -64,6 +65,7 @@ TOP_LEVEL_KEYS = frozenset(
         "threadCount",
         "threadGrowth",
         "withinBudget",
+        "workload",
     }
 )
 
@@ -93,6 +95,7 @@ def validate_performance_evidence(evidence: dict[str, Any]) -> None:
         "schemaVersion": PERFORMANCE_SCHEMA_VERSION,
         "ok": True,
         "product": PERFORMANCE_PRODUCT,
+        "workload": PERFORMANCE_WORKLOAD,
         "measurement": INITIAL_MEASUREMENT,
         "postInteractionMeasurement": POST_INTERACTION_MEASUREMENT,
         "repeatedInteractionMeasurement": REPEATED_INTERACTION_MEASUREMENT,


### PR DESCRIPTION
## Summary

- keep returning users' saved transcript visible behind a compact TrustedRouter reconnect banner
- restore thread and project navigation atomically and guard notification services to packaged app identity
- add a verified 100-chat daily-driver performance workload and reduce Review and Accessibility retained memory

## Verification

- `swift test` (5,855 tests, 5 expected skips)
- optimized packaged performance smoke (3/3 launches within budget)
- complete packaged macOS smoke, including first-run, SIGKILL recovery, Launch Services, Accessibility, and daily-driver window

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing UI was checked for keyboard, accessibility, compact-window, and failure states.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release, updater, dependency, or workflow changes include their contract-level verification.
