### PR TITLE
Avoid full workspace rebuilds for pane toggles

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceActivitySurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceActivitySurface.swift
@@ -161,6 +161,12 @@ public struct WorkspaceActivitySurface: Codable, Sendable, Hashable {
         )
     }
 
+    public func settingVisibility(_ isVisible: Bool) -> Self {
+        var copy = self
+        copy.isVisible = isVisible
+        return copy
+    }
+
     private enum CodingKeys: String, CodingKey {
         case isVisible
         case title

--- a/Sources/QuillCodeApp/WorkspaceAutomationsSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceAutomationsSurface.swift
@@ -43,6 +43,12 @@ public struct WorkspaceAutomationsSurface: Codable, Sendable, Hashable {
         self.scheduleWorkspaceScheduleCommands = scheduleWorkspaceScheduleCommands
     }
 
+    public func settingVisibility(_ isVisible: Bool) -> Self {
+        var copy = self
+        copy.isVisible = isVisible
+        return copy
+    }
+
     private static func statusLabel(
         for automations: [QuillAutomation],
         configuredCount: Int,

--- a/Sources/QuillCodeApp/WorkspaceMemoriesSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceMemoriesSurface.swift
@@ -72,6 +72,12 @@ public struct WorkspaceMemoriesSurface: Codable, Sendable, Hashable {
             ?? "Add Markdown, text, or JSON notes under ~/.quillcode/memories or .quillcode/memories."
     }
 
+    public func settingVisibility(_ isVisible: Bool) -> Self {
+        var copy = self
+        copy.isVisible = isVisible
+        return copy
+    }
+
     private static func subtitle(
         for notes: [MemoryNote],
         conflicts: [MemoryConflictSurface],

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -112,6 +112,21 @@ public struct WorkspaceProgressSurfaceScope: OptionSet, Sendable, Hashable {
     public static let terminal = WorkspaceProgressSurfaceScope(rawValue: 1 << 1)
 }
 
+/// Identifies pane-only presentation changes that can reuse the current workspace projection.
+/// Opening or closing one of these panes must not rebuild the transcript, sidebar, or model catalog.
+public struct WorkspacePanePresentationScope: OptionSet, Sendable, Hashable {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let extensions = WorkspacePanePresentationScope(rawValue: 1 << 0)
+    public static let memories = WorkspacePanePresentationScope(rawValue: 1 << 1)
+    public static let activity = WorkspacePanePresentationScope(rawValue: 1 << 2)
+    public static let automations = WorkspacePanePresentationScope(rawValue: 1 << 3)
+}
+
 private struct WorkspaceAgentProgressSurface {
     var chrome: WorkspaceChromeSurface
     var topBar: TopBarSurface
@@ -246,6 +261,43 @@ public extension QuillCodeWorkspaceModel {
         return next
     }
 
+    /// Reprojects only pane presentation state after a visibility toggle. Pane contents are already
+    /// refreshed by their owning model mutations; Extensions is rebuilt because toggling it also
+    /// clears its focused kind and therefore changes its filtered item set.
+    func panePresentationSurface(
+        reusing surface: WorkspaceSurface,
+        scope: WorkspacePanePresentationScope
+    ) -> WorkspaceSurface {
+        guard !scope.isEmpty else { return surface }
+        var next = surface
+        if scope.contains(.extensions) {
+            next.extensions = extensionsSurface()
+        }
+        if scope.contains(.memories) {
+            next.memories = surface.memories.settingVisibility(memories.isVisible)
+        }
+        if scope.contains(.activity) {
+            next.activity = surface.activity.settingVisibility(activity.isVisible)
+        }
+        if scope.contains(.automations) {
+            next.automations = surface.automations.settingVisibility(automations.isVisible)
+        }
+        return next
+    }
+
+    private func extensionsSurface() -> WorkspaceExtensionsSurface {
+        WorkspaceExtensionsSurface(
+            isVisible: extensions.isVisible,
+            focusedKind: extensions.focusedKind,
+            manifests: selectedProject?.extensionManifests ?? [],
+            hooks: effectiveHookDefinitions(for: selectedProject),
+            mcpServerStatuses: extensions.mcpServerStatuses,
+            mcpServerProbeSummaries: extensions.mcpServerProbeSummaries,
+            workflowRecording: (computerUseBackend as? any WorkflowRecordingStatusProviding)?
+                .workflowRecordingStatusSnapshot
+        )
+    }
+
     private func agentProgressSurface(
         reusing previousTranscript: TranscriptSurface? = nil,
         transcriptRefresh: WorkspaceAgentTranscriptRefreshPlan = .rebuild
@@ -378,16 +430,7 @@ public extension QuillCodeWorkspaceModel {
                 : nil,
             review: review,
             browser: BrowserSurface(browser: browser),
-            extensions: WorkspaceExtensionsSurface(
-                isVisible: extensions.isVisible,
-                focusedKind: extensions.focusedKind,
-                manifests: selectedProject?.extensionManifests ?? [],
-                hooks: effectiveHookDefinitions(for: selectedProject),
-                mcpServerStatuses: extensions.mcpServerStatuses,
-                mcpServerProbeSummaries: extensions.mcpServerProbeSummaries,
-                workflowRecording: (computerUseBackend as? any WorkflowRecordingStatusProviding)?
-                    .workflowRecordingStatusSnapshot
-            ),
+            extensions: extensionsSurface(),
             memories: WorkspaceMemoriesSurface(
                 isVisible: memories.isVisible,
                 notes: activeSources.memories,

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+ComposerAndPanes.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+ComposerAndPanes.swift
@@ -101,23 +101,19 @@ extension QuillCodeDesktopController {
     }
 
     func toggleExtensions() {
-        paneCoordinator.toggleExtensions(on: model)
-        refresh()
+        paneCoordinator.toggleExtensions(on: model, surface: &surface)
     }
 
     func toggleMemories() {
-        paneCoordinator.toggleMemories(on: model)
-        refresh()
+        paneCoordinator.toggleMemories(on: model, surface: &surface)
     }
 
     func toggleActivity() {
-        paneCoordinator.toggleActivity(on: model)
-        refresh()
+        paneCoordinator.toggleActivity(on: model, surface: &surface)
     }
 
     func toggleAutomations() {
-        paneCoordinator.toggleAutomations(on: model)
-        refresh()
+        paneCoordinator.toggleAutomations(on: model, surface: &surface)
     }
 
     func openBrowserPreview() {

--- a/Sources/quill-code-desktop/QuillCodeDesktopPaneCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopPaneCoordinator.swift
@@ -11,20 +11,24 @@ struct QuillCodeDesktopPaneCoordinator {
         model.toggleBrowser()
     }
 
-    func toggleExtensions(on model: QuillCodeWorkspaceModel) {
+    func toggleExtensions(on model: QuillCodeWorkspaceModel, surface: inout WorkspaceSurface) {
         model.toggleExtensions()
+        surface = model.panePresentationSurface(reusing: surface, scope: .extensions)
     }
 
-    func toggleMemories(on model: QuillCodeWorkspaceModel) {
+    func toggleMemories(on model: QuillCodeWorkspaceModel, surface: inout WorkspaceSurface) {
         model.toggleMemories()
+        surface = model.panePresentationSurface(reusing: surface, scope: .memories)
     }
 
-    func toggleActivity(on model: QuillCodeWorkspaceModel) {
+    func toggleActivity(on model: QuillCodeWorkspaceModel, surface: inout WorkspaceSurface) {
         model.toggleActivity()
+        surface = model.panePresentationSurface(reusing: surface, scope: .activity)
     }
 
-    func toggleAutomations(on model: QuillCodeWorkspaceModel) {
+    func toggleAutomations(on model: QuillCodeWorkspaceModel, surface: inout WorkspaceSurface) {
         model.toggleAutomations()
+        surface = model.panePresentationSurface(reusing: surface, scope: .automations)
     }
 
     func addBrowserComment(_ comment: String, to model: QuillCodeWorkspaceModel) {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopPaneCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopPaneCoordinatorTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import QuillCodeApp
+@testable import quill_code_desktop
+
+@MainActor
+final class QuillCodeDesktopPaneCoordinatorTests: XCTestCase {
+    func testPaneTogglesReprojectOnlyTheirOwnedSurface() {
+        for pane in Pane.allCases {
+            assertNarrowProjection(for: pane)
+        }
+    }
+
+    private func assertNarrowProjection(
+        for pane: Pane,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let model = QuillCodeWorkspaceModel()
+        if pane == .extensions {
+            model.showExtensions(focusedOn: .skill)
+        }
+        var surface = model.surface()
+        surface.lastError = "pane projection sentinel"
+        surface.changedFilePaths.insert("sentinel/unrelated.txt")
+        let baseline = surface
+        let coordinator = QuillCodeDesktopPaneCoordinator()
+
+        switch pane {
+        case .extensions:
+            coordinator.toggleExtensions(on: model, surface: &surface)
+        case .memories:
+            coordinator.toggleMemories(on: model, surface: &surface)
+        case .activity:
+            coordinator.toggleActivity(on: model, surface: &surface)
+        case .automations:
+            coordinator.toggleAutomations(on: model, surface: &surface)
+        }
+
+        let authoritative = model.surface()
+        var expected = baseline
+        switch pane {
+        case .extensions:
+            expected.extensions = authoritative.extensions
+        case .memories:
+            expected.memories = authoritative.memories
+        case .activity:
+            expected.activity = authoritative.activity
+        case .automations:
+            expected.automations = authoritative.automations
+        }
+
+        XCTAssertEqual(surface, expected, "\(pane) changed an unrelated workspace surface", file: file, line: line)
+    }
+}
+
+private enum Pane: String, CaseIterable {
+    case extensions
+    case memories
+    case activity
+    case automations
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,21 @@
 # QuillCode Decisions
 
+## 2026-08-11: pane visibility changes reuse the current workspace projection
+
+- **Decision:** Opening or closing Automations, Extensions, Memories, or Activity updates only that
+  pane's presentation surface. The desktop no longer rebuilds the transcript, 100-chat navigation
+  projection, composer, model catalog, or filesystem-backed settings for a visibility-only change.
+  Extensions still reprojects its own contents because a normal toggle clears any focused extension
+  kind; the other panes retain their already-current content and change only visibility.
+- **Correctness boundary:** Model state remains authoritative. Each narrow projection is compared with
+  the corresponding field from a fresh full surface, while unrelated sentinel fields prove the
+  projection did not silently fall back to a full rebuild. Content-changing mutations continue to use
+  authoritative refreshes.
+- **Evidence:** The release-configured three-process `daily-driver-100-chats` gate passed 3/3 with a
+  354 ms median launch, 103.45 MiB initial RSS, 176.30 MiB after the first interaction sweep, and
+  182.11 MiB after the repeated sweep. The like-for-like single-process trace fell from 191.2 MB to
+  178.3 MB after the first sweep and from 198.7 MB to 187.3 MB after the repeated sweep.
+
 ## 2026-08-10: public performance measures a verified daily-driver workspace
 
 - **Decision:** Every packaged performance attempt first invokes the app's own fixture helper to


### PR DESCRIPTION
## Summary

- Reproject only the pane owned by Automations, Extensions, Memories, and Activity visibility toggles.
- Preserve the current transcript, navigation, composer, model catalog, settings, and unrelated presentation state.
- Add a regression test that compares each narrow projection with the authoritative full surface.

## Verification

- Full Swift suite: 5,856 tests, 5 expected skips, 0 failures.
- Complete packaged macOS smoke: first-run, Launch Services, accessibility, native interactions, forced-quit draft recovery, and 100-chat daily-driver performance passed.
- Packaged performance: 352.20 ms launch-ready, 103.66 MiB initial RSS, 173.78 MiB post-interaction, 181.61 MiB repeated.
- git diff --check and exact credential scan passed.