### PR TITLE
Require graceful packaged app termination

### DIFF
--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -460,6 +460,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "QuillCodeSigningTeamIdentifier",
             #"${QUILLCODE_MACOS_ADHOC_CODESIGN:-1}"#
         ])
+        Self.assertSource(buildScript, contains: """
+          <key>NSSupportsSuddenTermination</key>
+          <false/>
+        """)
         Self.assertSource(packageScript, containsAll: [
             "bundleIdentifier=$BUNDLE_ID",
             "minimumSystemVersion=$MINIMUM_SYSTEM_VERSION",
@@ -498,6 +502,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         Self.assertSource(smokeScript, containsAll: [
             "assert_plist_value QuillCodeUpdateChannel tester",
             "assert_plist_value QuillCodeBuildCommit \"$EXPECTED_BUILD_COMMIT\"",
+            "assert_plist_value NSSupportsSuddenTermination false",
             "assert_plist_value QuillCodeUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json",
             "assert_plist_value QuillCodeStableUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json",
             "assert_plist_value QuillCodeTesterUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json"

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,23 @@
 # Code Quality Audit
 
+## 2026-08-11 Graceful Termination And Accurate Crash Recovery
+
+Overall grade after this slice: **A+ crash classification, A+ lifecycle integrity, A+ release enforcement**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Crash classification | A+ | Normal logout, shutdown, automatic termination, and explicit Quit must pass through AppKit termination and clear the matching active-launch record instead of looking like a crash. |
+| Lifecycle integrity | A+ | The packaged capability now matches the launch store's existing write-before-remove graceful boundary and leaves genuine `SIGKILL` and process-loss detection intact. |
+| Recovery UX | A+ | Ordinary system termination cannot trigger a false unexpected-exit warning or pause automatic workspace services on the next launch. |
+| Release enforcement | A+ | Packaged smoke validates the generated Boolean value, while source parity pins both generation and artifact verification. |
+
+Validation:
+
+- `swift test --filter ParityDownloadBuildsGateTests/testMacOSDownloadPackagingEmbedsUpdaterMetadata`
+- Built release `Info.plist` inspection
+- `bash -n scripts/build-macos-app.sh scripts/packaged-macos-smoke.sh`
+- `git diff --check`
+
 ## 2026-08-10 Independently Owned Agent Progress Histories
 
 Overall grade after this slice: **A+ progress ownership, A+ memory scaling, A+ structural recovery**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,18 @@
 # QuillCode Decisions
 
+## 2026-08-11: packaged launches require graceful termination
+
+- **Decision:** Packaged Quill Cowork apps explicitly disable macOS sudden termination. Automatic
+  termination support remains unchanged, but every operating-system termination must cross AppKit's
+  normal `willTerminate` boundary before the process exits.
+- **Why:** The active-launch record is intentionally removed only at that graceful boundary. Apple
+  documents that sudden termination skips `willTerminate`; advertising it made an ordinary fast
+  logout or shutdown indistinguishable from a crash and could show a false unexpected-exit warning or
+  pause automatic workspace services on the next launch.
+- **Release boundary:** Packaged smoke reads the built `Info.plist` and fails unless
+  `NSSupportsSuddenTermination` is false. Source parity separately pins both the generated plist entry
+  and the artifact assertion so future packaging changes cannot silently reintroduce the mismatch.
+
 ## 2026-08-11: pane visibility changes reuse the current workspace projection
 
 - **Decision:** Opening or closing Automations, Extensions, Memories, or Activity updates only that

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -79,6 +79,10 @@ launch shows **Quill Cowork closed unexpectedly** and warns that an in-progress 
 incomplete. Choose **Continue** to return to the workspace or **Report Issue...** to open a prefilled
 crash report.
 
+Packaged apps require graceful macOS termination rather than opting into sudden process death. This
+ensures normal logout, shutdown, automatic termination, and explicit Quit cross the same marker-clearing
+boundary; macOS cannot skip that cleanup and make an ordinary system action look like a crash.
+
 If the process disappears before reaching its first-window startup boundary, the next launch opens
 the saved workspace in recovery mode. Managed-worktree retention, pull-request reconciliation,
 project indexing, due automations, account refreshes, and optional Computer Use driver discovery stay

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -132,7 +132,7 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
   <key>NSSupportsAutomaticTermination</key>
   <true/>
   <key>NSSupportsSuddenTermination</key>
-  <true/>
+  <false/>
   <key>QuillCodeUpdateChannel</key>
   <string>$UPDATE_CHANNEL</string>
   <key>QuillCodeUpdateManifestURL</key>

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -198,6 +198,7 @@ assert_plist_value CFBundlePackageType APPL
 assert_plist_value QuillCodeBuildCommit "$EXPECTED_BUILD_COMMIT"
 assert_plist_value LSApplicationCategoryType public.app-category.developer-tools
 assert_plist_value NSPrincipalClass NSApplication
+assert_plist_value NSSupportsSuddenTermination false
 assert_plist_value QuillCodeUpdateChannel tester
 assert_plist_value QuillCodeUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/latest-tester-build.json
 assert_plist_value QuillCodeStableUpdateManifestURL https://github.com/Lore-Hex/QuillCode/releases/latest/download/latest-stable-build.json


### PR DESCRIPTION
## Summary
- disable macOS sudden termination in packaged Quill Cowork builds
- prevent normal logout or shutdown from being misclassified as an unexpected exit
- enforce the generated Info.plist value in packaging smoke and parity tests

## Validation
- swift test: 5,856 tests, 5 expected skips, 0 failures
- deterministic code quality grader: passed with A+ module summaries
- focused lifecycle and packaging tests: 20 passed
- release app built, codesign verified, and NSSupportsSuddenTermination inspected as false
- shell syntax and git diff checks passed