### PR TITLE
Serialize updater recovery and relaunch cleanup

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopComposerDraftCheckpointCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComposerDraftCheckpointCoordinator.swift
@@ -77,7 +77,11 @@ final class QuillCodeDesktopComposerDraftCheckpointCoordinator: NSObject {
     func startLifecycleFlushes(model: QuillCodeWorkspaceModel) {
         guard lifecycleModel == nil else { return }
         lifecycleModel = model
-        for name in [NSApplication.didResignActiveNotification, NSApplication.willTerminateNotification] {
+        for name in [
+            NSApplication.didResignActiveNotification,
+            NSApplication.willTerminateNotification,
+            .quillCodeDesktopWillTerminateForRelaunch,
+        ] {
             notificationCenter.addObserver(
                 self,
                 selector: #selector(flushForApplicationLifecycle),

--- a/Sources/quill-code-desktop/QuillCodeDesktopLaunchLifecycle.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopLaunchLifecycle.swift
@@ -296,12 +296,17 @@ final class QuillCodeDesktopLaunchLifecycleController: NSObject {
             )
             currentLaunchID = session.currentRecord.launchID
             unexpectedExit = session.unexpectedExit
-            notificationCenter.addObserver(
-                self,
-                selector: #selector(applicationWillTerminate),
-                name: NSApplication.willTerminateNotification,
-                object: nil
-            )
+            for name in [
+                NSApplication.willTerminateNotification,
+                .quillCodeDesktopWillTerminateForRelaunch,
+            ] {
+                notificationCenter.addObserver(
+                    self,
+                    selector: #selector(applicationWillTerminate),
+                    name: name,
+                    object: nil
+                )
+            }
         } catch {
             currentLaunchID = nil
             unexpectedExit = nil

--- a/Sources/quill-code-desktop/QuillCodeDesktopSystemApplication.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSystemApplication.swift
@@ -1,5 +1,12 @@
 import AppKit
 import Darwin
+import Foundation
+
+extension Notification.Name {
+    static let quillCodeDesktopWillTerminateForRelaunch = Notification.Name(
+        "QuillCodeDesktopWillTerminateForRelaunch"
+    )
+}
 
 @MainActor
 enum QuillCodeDesktopSystemApplication {
@@ -14,7 +21,12 @@ enum QuillCodeDesktopSystemApplication {
     static func terminateForUpdate() {
         // SwiftUI can defer or decline a normal termination while a sheet-driven async action still
         // owns the scene. The detached updater helper cannot proceed until this process is gone, so
-        // retain a short, bounded fallback after first allowing normal app shutdown to complete.
+        // synchronously finish durable lifecycle work, then retain a short, bounded fallback after
+        // first allowing normal app shutdown to complete.
+        NotificationCenter.default.post(
+            name: .quillCodeDesktopWillTerminateForRelaunch,
+            object: nil
+        )
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             Darwin.exit(EXIT_SUCCESS)
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -151,6 +151,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             isPresented = true
             return
         }
+        let recoveryTask = cancelRecoveryAndTakeTask()
         let generation = beginNewOperation()
         state = .downloading(release)
         preparationProgress = .downloading(receivedBytes: 0, totalBytes: release.asset.sizeBytes)
@@ -158,6 +159,11 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             guard let self else { return }
             defer { self.finishOperation(generation: generation) }
             do {
+                if let recoveryTask {
+                    await recoveryTask.value
+                }
+                try Task.checkCancellation()
+                guard self.generation == generation else { return }
                 let prepared = try await self.prepareUpdate(
                     release: release,
                     configuration: configuration,
@@ -322,6 +328,13 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         preparationProgress = nil
         generation = UUID()
         return generation
+    }
+
+    private func cancelRecoveryAndTakeTask() -> Task<Void, Never>? {
+        let task = recoveryTask
+        recoveryTask = nil
+        task?.cancel()
+        return task
     }
 
     private func prepareUpdate(

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopComposerDraftCheckpointCoordinatorTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopComposerDraftCheckpointCoordinatorTests.swift
@@ -113,7 +113,7 @@ final class QuillCodeDesktopComposerDraftCheckpointCoordinatorTests: XCTestCase 
         XCTAssertNil(try checkpointStore.load(for: nil))
     }
 
-    func testAppDeactivationFlushesPendingCheckpointImmediately() async throws {
+    func testApplicationLifecycleNotificationsFlushPendingCheckpointImmediately() async throws {
         let root = try makeTempDirectory()
         let threadStore = JSONThreadStore(directory: root.appendingPathComponent("threads"))
         let checkpointStore = ComposerDraftCheckpointStore(
@@ -138,6 +138,15 @@ final class QuillCodeDesktopComposerDraftCheckpointCoordinatorTests: XCTestCase 
         await waitUntil { !coordinator.hasPendingCheckpoint }
 
         XCTAssertEqual(try checkpointStore.load(for: thread.id)?.draft, "flush before leaving")
+
+        coordinator.schedule(draft: "flush before relaunch", model: model)
+        notificationCenter.post(
+            name: .quillCodeDesktopWillTerminateForRelaunch,
+            object: nil
+        )
+        await waitUntil { !coordinator.hasPendingCheckpoint }
+
+        XCTAssertEqual(try checkpointStore.load(for: thread.id)?.draft, "flush before relaunch")
     }
 
     private func waitUntil(

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
@@ -418,6 +418,30 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
         XCTAssertNil(try fixture.store.currentRecord())
     }
 
+    func testLifecycleControllerClearsBeforeForcedRelaunchTermination() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let notificationCenter = NotificationCenter()
+        let lifecycle = QuillCodeDesktopLaunchLifecycleController(
+            store: fixture.store,
+            metadata: metadata(),
+            notificationCenter: notificationCenter,
+            now: { self.referenceDate },
+            processIdentifier: 60_002,
+            processIsRunning: { _ in false }
+        )
+
+        XCTAssertNil(lifecycle.startIfNeeded())
+        lifecycle.markReady()
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
+
+        notificationCenter.post(
+            name: .quillCodeDesktopWillTerminateForRelaunch,
+            object: nil
+        )
+        XCTAssertNil(try fixture.store.currentRecord())
+    }
+
     func testDesktopControllerRetainsLifecycleForFirstWindowConsumption() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -113,6 +113,51 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         XCTAssertEqual(recoveryCallCount, 1)
     }
 
+    func testUpdateWaitsForStartupRecoveryToFinishBeforePreparing() async throws {
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let recovery = GatedUpdateRecovery()
+        let preparer = UpdatePreparerSpy(release: release)
+        let installer = UpdateInstallerSpy()
+        var terminationCount = 0
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            checker: UpdateCheckerSpy(result: .updateAvailable(release)),
+            preparer: preparer,
+            installer: installer,
+            installationInspector: UpdateInstallationInspectorStub(.available),
+            recovery: recovery,
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(initialDelay: 60),
+            installResultURL: temporaryInstallResultURL(),
+            terminateApplication: { terminationCount += 1 }
+        )
+
+        controller.startAutomaticChecks()
+        try await waitUntil { await recovery.callCount == 1 }
+        controller.checkForUpdates()
+        try await waitUntil { controller.state == .updateAvailable(release) }
+
+        controller.updateAndRelaunch()
+        try await waitUntil {
+            if case .downloading = controller.state { return true }
+            return false
+        }
+        try await waitUntil { await recovery.observedCancellation }
+        let blockedPrepareCallCount = await preparer.callCount
+        let blockedInstallCallCount = await installer.callCount
+        XCTAssertEqual(blockedPrepareCallCount, 0)
+        XCTAssertEqual(blockedInstallCallCount, 0)
+
+        await recovery.finish()
+        try await waitUntil { terminationCount == 1 }
+        let recoveryObservedCancellation = await recovery.observedCancellation
+        let prepareCallCount = await preparer.callCount
+        let installCallCount = await installer.callCount
+        XCTAssertTrue(recoveryObservedCancellation)
+        XCTAssertEqual(prepareCallCount, 1)
+        XCTAssertEqual(installCallCount, 1)
+    }
+
     func testBackgroundFailureStaysQuietButManualFailureIsVisible() async throws {
         let checker = UpdateCheckerSpy(error: .invalidResponse)
         let controller = QuillCodeDesktopUpdateController(
@@ -695,5 +740,27 @@ private actor UpdateRecoverySpy: QuillCodeDesktopUpdateRecovering {
 
     func recoverInterruptedUpdate(configuration: QuillCodeDesktopUpdateConfiguration) async {
         callCount += 1
+    }
+}
+
+private actor GatedUpdateRecovery: QuillCodeDesktopUpdateRecovering {
+    private(set) var callCount = 0
+    private(set) var observedCancellation = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func recoverInterruptedUpdate(configuration: QuillCodeDesktopUpdateConfiguration) async {
+        callCount += 1
+        while !Task.isCancelled {
+            await Task.yield()
+        }
+        observedCancellation = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finish() {
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -92,6 +92,9 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         let appText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
         let rootViewText = try Self.desktopSourceText(named: "QuillCodeDesktopRootView.swift")
         let lifecycleText = try Self.desktopSourceText(named: "QuillCodeDesktopLaunchLifecycle.swift")
+        let systemApplicationText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopSystemApplication.swift"
+        )
         let smokeText = try Self.desktopSourceText(named: "QuillCodeDesktopLaunchRecoverySmoke.swift")
         let reporterText = try Self.desktopSourceText(named: "QuillCodeDesktopIssueReporter.swift")
 
@@ -109,6 +112,15 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         Self.assertSource(lifecycleText, contains: "record.launchID == launchID")
         Self.assertSource(lifecycleText, contains: "processIsRunning(record.processIdentifier)")
         Self.assertSource(lifecycleText, contains: "NSApplication.willTerminateNotification")
+        Self.assertSource(
+            lifecycleText,
+            contains: ".quillCodeDesktopWillTerminateForRelaunch"
+        )
+        Self.assertSource(systemApplicationText, containsAll: [
+            "NotificationCenter.default.post(",
+            "name: .quillCodeDesktopWillTerminateForRelaunch",
+            "Darwin.exit(EXIT_SUCCESS)"
+        ])
         Self.assertSource(lifecycleText, contains: "var requiresRecoveryStartup: Bool")
         Self.assertSource(reporterText, contains: "## Previous session")
         Self.assertSource(appText, contains: "QuillCodeDesktopLaunchRecoverySmoke.runAndExit(request)")
@@ -148,6 +160,10 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         Self.assertSource(coordinatorText, contains: "ownerThreadID: model.selectedThread?.id")
         Self.assertSource(coordinatorText, contains: "NSApplication.didResignActiveNotification")
         Self.assertSource(coordinatorText, contains: "NSApplication.willTerminateNotification")
+        Self.assertSource(
+            coordinatorText,
+            contains: ".quillCodeDesktopWillTerminateForRelaunch"
+        )
         Self.assertSource(modelText, contains: "ownerThreadID == root.selectedThreadID")
         Self.assertSource(modelText, contains: "threadPersistence.saveComposerDraft")
         Self.assertSource(persistenceText, contains: "maximumDraftBytes = 1 * 1_024 * 1_024")

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -4,6 +4,9 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
     func testPublishedBuildMustUpdateAndRelaunchItself() throws {
         let app = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
         let controller = try Self.desktopControllerSourceText()
+        let updateController = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateController.swift"
+        )
         let bootstrap = try Self.appSourceText(named: "WorkspaceBootstrap.swift")
         let runner = try Self.desktopSourceText(named: "QuillCodeDesktopUpdaterSmokeRunner.swift")
         let script = try Self.scriptText(named: "packaged-macos-updater-smoke.sh")
@@ -44,6 +47,12 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             2
         )
         Self.assertSource(bootstrap, contains: "automaticStartupPolicy == .startImmediately")
+        Self.assertSource(updateController, containsAll: [
+            "let recoveryTask = cancelRecoveryAndTakeTask()",
+            "await recoveryTask.value",
+            "try Task.checkCancellation()",
+            "guard self.generation == generation else { return }"
+        ])
         Self.assertSource(runner, containsAll: [
             "waitForAvailableUpdate(configuration: configuration)",
             "feedPropagationAttemptLimit = 6",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,29 @@
 # Code Quality Audit
 
+## 2026-08-11 Serialized Update Recovery And Durable Relaunch
+
+Overall grade after this slice: **A+ update isolation, A+ relaunch durability, A+ crash classification**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Update isolation | A+ | A fresh update cancels and fully joins startup orphan recovery before download, staging, or helper launch can begin. |
+| Relaunch durability | A+ | Update and relocation exits synchronously flush pending composer text and finish the active launch before AppKit termination or the bounded forced fallback. |
+| Cancellation safety | A+ | Recovery completion is followed by cancellation and generation checks, so a superseded foreground operation cannot resume into preparation. |
+| Crash classification | A+ | A successful forced updater exit cannot leave a stale ready marker and surface a false unexpected-exit warning after relaunch. |
+| Regression evidence | A+ | Deterministic actor-gated tests cover recovery serialization; lifecycle, composer, and source-parity gates pin forced-relaunch cleanup. |
+
+Validation:
+
+- `swift test --filter 'QuillCodeDesktopUpdateControllerTests|QuillCodeDesktopLaunchLifecycleTests|QuillCodeDesktopComposerDraftCheckpointCoordinatorTests|ParityPackagedUpdaterGateTests|ParityDesktopGateTests'`
+- Broader updater, relocation, installation, and smoke boundary: 26 tests, 0 failures
+- `swift test --disable-sandbox` (5,858 tests; 5 skipped; 0 failures)
+- Packaged release direct-executable, Launch Services, composer `SIGKILL` recovery, live-window,
+  Accessibility, and two interaction-sweep smokes passed
+- Optimized packaged daily-driver performance: 347.97 ms median launch-ready, 103.67 MiB initial,
+  179.12 MiB post-interaction, and 186.89 MiB repeated-interaction memory
+- `python3 scripts/grade-code-quality.py --root .` (all module summaries A+)
+- `git diff --check`
+
 ## 2026-08-11 Graceful Termination And Accurate Crash Recovery
 
 Overall grade after this slice: **A+ crash classification, A+ lifecycle integrity, A+ release enforcement**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # QuillCode Decisions
 
+## 2026-08-11: updater relaunches serialize cleanup and durable exit work
+
+- **Decision:** A foreground update cancels and joins the one-shot interrupted-update recovery task
+  before downloading or staging a fresh app. Relaunch termination synchronously broadcasts a private
+  lifecycle boundary before asking AppKit to quit or using its bounded forced-exit fallback.
+- **Why:** Startup recovery removes orphaned `.update-<uuid>.app` bundles beside the installed app. If
+  its delayed scan overlapped a new install, it could delete that installer's live staging bundle.
+  AppKit may also defer sheet-driven termination long enough to reach the fallback, which otherwise
+  bypasses the normal launch-marker and pending-draft cleanup notifications.
+- **Correctness boundary:** Cancellation alone is insufficient because recovery may already be in a
+  detached filesystem scan. The update awaits complete recovery termination, then rechecks operation
+  cancellation and generation before preparation. Relaunch cleanup is synchronous and idempotent;
+  the later AppKit notification may safely repeat it.
+- **Evidence:** Controller coverage blocks recovery behind a deterministic gate and proves neither
+  preparation nor installation begins until cancelled recovery exits. Lifecycle and composer tests
+  prove the relaunch boundary removes the active-launch marker and flushes pending draft text.
+
 ## 2026-08-11: packaged launches require graceful termination
 
 - **Decision:** Packaged Quill Cowork apps explicitly disable macOS sudden termination. Automatic

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -74,9 +74,11 @@ in-app diagnostic is deliberately content-free and should report `Private conten
 ## Tester Recovery: Unexpected Exit
 
 Packaged builds keep one private, content-free active-launch marker. A normal Quit or updater-driven
-termination clears the matching marker. If the process disappears after it was ready, the next
-launch shows **Quill Cowork closed unexpectedly** and warns that an in-progress command may be
-incomplete. Choose **Continue** to return to the workspace or **Report Issue...** to open a prefilled
+termination clears the matching marker. Update and Move & Relaunch exits synchronously flush pending
+composer text and clear that marker before their bounded termination fallback. If the process
+disappears after it was ready, the next launch shows **Quill Cowork closed unexpectedly** and warns
+that an in-progress command may be incomplete. Choose **Continue** to return to the workspace or
+**Report Issue...** to open a prefilled
 crash report.
 
 Packaged apps require graceful macOS termination rather than opting into sudden process death. This
@@ -242,6 +244,10 @@ downloads on demand, and verifies
 the exact size, SHA-256 digest, app identity, version, embedded source commit,
 architecture, and macOS code signature before installation. The detached helper
 checks that same commit again immediately before the atomic swap.
+
+Startup recovery waits two minutes before removing abandoned updater staging apps. Starting a fresh
+foreground update cancels and fully joins that recovery first, so cleanup can never remove the new
+installer's live staging bundle.
 
 Signing metadata is also a payload requirement, not only a feed label. Ad-hoc
 updates must contain an actual ad-hoc signature with no team. A Developer ID


### PR DESCRIPTION
## Summary
- cancel and join startup orphan recovery before a foreground update can download or stage a fresh app
- flush pending composer text and finish the active launch before updater or relocation forced-exit fallback
- add deterministic concurrency, lifecycle, draft, parity, and distribution documentation coverage

## Verification
- focused updater/lifecycle/draft/parity: 41 tests, 0 failures
- broader updater/relocation boundary: 26 tests, 0 failures
- full Swift suite: 5,858 tests, 5 expected skips, 0 failures
- packaged release smoke: direct executable, Launch Services, composer SIGKILL recovery, live window, Accessibility, and two interaction sweeps
- daily-driver performance: 347.97 ms launch-ready; 103.67 MiB initial; 179.12 MiB first sweep; 186.89 MiB repeated sweep
- all quality-grader module summaries A+
- git diff --check