### PR TITLE
Require first-window updater readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ remain available as manual fallbacks and verified auto-update payloads.
 Quill Cowork checks for updates automatically and also provides **Check for Updates...** in the app
 menu. Downloads are size- and SHA-256-verified, the app identity and code signature are checked before
 installation, the packaged source commit must match the public manifest, activation is atomic, and
-the previous build is restored if the new build cannot finish launching. Use **Report an Issue...**
+the previous build is restored if the new build cannot render its first workspace window and remain
+stable. Use **Report an Issue...**
 in the app menu to open a prefilled GitHub report with bounded build and system information; it does
 not attach project paths, transcripts, or credentials. After an unexpected exit, the next successful
 launch identifies whether the prior session ended during startup or while running, warns that active

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -13,7 +13,7 @@ struct QuillCodeDesktopApp: App {
 
     init() {
         _ = QuillCodeDesktopLaunchClock.appEntryUptime
-        QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()
+        let updateLaunchHandshake = QuillCodeDesktopUpdateLaunchHandshake()
         if let updateRequest = QuillCodeDesktopUpdateHelperRequest.parse(arguments: CommandLine.arguments) {
             Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
         }
@@ -134,6 +134,7 @@ struct QuillCodeDesktopApp: App {
         let controller = QuillCodeDesktopController(
             updateController: updateController,
             launchLifecycleController: launchLifecycleController,
+            updateLaunchHandshake: updateLaunchHandshake,
             startupMode: QuillCodeDesktopStartupMode(unexpectedExit: unexpectedExit),
             workspaceRoot: QuillCodeDesktopWorkspaceRootResolver.resolve()
         )

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Startup.swift
@@ -52,12 +52,12 @@ extension QuillCodeDesktopController {
         if automaticStartupState.startAutomaticWorkspaceServicesIfAllowed() {
             startAutomaticWorkspaceServices()
         }
-        launchLifecycleController?.markReady()
+        markLaunchReady()
     }
 
     func continueWithAutomaticWorkspaceServicesPaused() {
         startPostWindowApplicationServicesIfNeeded()
-        launchLifecycleController?.markReady()
+        markLaunchReady()
     }
 
     func resumeAutomaticWorkspaceServices() {
@@ -65,7 +65,15 @@ extension QuillCodeDesktopController {
         if automaticStartupState.resumeAutomaticWorkspaceServices() {
             startAutomaticWorkspaceServices()
         }
+        markLaunchReady()
+    }
+
+    private func markLaunchReady() {
         launchLifecycleController?.markReady()
+        guard let updateLaunchHandshake,
+              updateLaunchHandshake.acknowledge()
+        else { return }
+        self.updateLaunchHandshake = nil
     }
 
     private func startPostWindowApplicationServicesIfNeeded() {

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -60,6 +60,7 @@ final class QuillCodeDesktopController: ObservableObject {
     let updateController: QuillCodeDesktopUpdateController
     let installationLocationController: QuillCodeDesktopInstallationLocationController
     let launchLifecycleController: QuillCodeDesktopLaunchLifecycleController?
+    var updateLaunchHandshake: QuillCodeDesktopUpdateLaunchHandshake?
     let tasks = QuillCodeDesktopTaskCoordinator()
     let progressRefreshScheduler = QuillCodeDesktopProgressRefreshScheduler()
     var automaticStartupState: QuillCodeDesktopStartupState
@@ -85,6 +86,7 @@ final class QuillCodeDesktopController: ObservableObject {
         updateController: QuillCodeDesktopUpdateController? = nil,
         installationLocationController: QuillCodeDesktopInstallationLocationController? = nil,
         launchLifecycleController: QuillCodeDesktopLaunchLifecycleController? = nil,
+        updateLaunchHandshake: QuillCodeDesktopUpdateLaunchHandshake? = nil,
         startupMode: QuillCodeDesktopStartupMode = .normal,
         workspaceRoot: URL? = nil
     ) {
@@ -123,6 +125,7 @@ final class QuillCodeDesktopController: ObservableObject {
         self.installationLocationController = installationLocationController
             ?? QuillCodeDesktopInstallationLocationController()
         self.launchLifecycleController = launchLifecycleController
+        self.updateLaunchHandshake = updateLaunchHandshake
         self.automaticStartupState = QuillCodeDesktopStartupState(mode: startupMode)
         do {
             self.model = try bootstrap.makeModel(automaticStartupPolicy: .deferUntilRequested)

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
@@ -1,17 +1,45 @@
 import Foundation
 
-enum QuillCodeDesktopUpdateLaunchHandshake {
+struct QuillCodeDesktopUpdateLaunchHandshake: Equatable, Sendable {
     static let argument = "--quillcode-update-handshake"
 
-    static func acknowledgeIfRequested(arguments: [String] = CommandLine.arguments) {
-        guard let index = arguments.firstIndex(of: argument),
+    private let url: URL
+    private let cacheRoot: URL
+
+    init?(arguments: [String] = CommandLine.arguments) {
+        guard let cacheRoot = try? QuillCodeDesktopUpdatePaths.cacheRoot() else {
+            return nil
+        }
+        self.init(arguments: arguments, cacheRoot: cacheRoot)
+    }
+
+    init?(arguments: [String], cacheRoot: URL) {
+        guard let index = arguments.firstIndex(of: Self.argument),
               arguments.indices.contains(index + 1)
         else {
-            return
+            return nil
         }
         let url = URL(fileURLWithPath: arguments[index + 1]).standardizedFileURL
-        guard isAllowed(url) else { return }
-        try? Data("ready\n".utf8).write(to: url, options: [.atomic, .completeFileProtection])
+        let cacheRoot = cacheRoot.standardizedFileURL
+        guard Self.isAllowed(url, cacheRoot: cacheRoot) else { return nil }
+        self.url = url
+        self.cacheRoot = cacheRoot
+    }
+
+    /// Acknowledges only after the desktop root has crossed its first-window-ready boundary.
+    /// The updater keeps the previous app available until this write and its stability wait pass.
+    @discardableResult
+    func acknowledge() -> Bool {
+        guard Self.isAllowed(url, cacheRoot: cacheRoot) else { return false }
+        do {
+            try Data("ready\n".utf8).write(
+                to: url,
+                options: [.atomic, .completeFileProtection]
+            )
+            return true
+        } catch {
+            return false
+        }
     }
 
     static func isAllowed(_ url: URL) -> Bool {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchLifecycleTests.swift
@@ -111,6 +111,104 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
         XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
     }
 
+    func testUpdateHandshakeWaitsForFirstWindowReadiness() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let handshake = try makeUpdateHandshake(fixture: fixture, suffix: "normal")
+        let lifecycle = makeLifecycle(fixture: fixture, processIdentifier: 12_101)
+        XCTAssertNil(lifecycle.startIfNeeded())
+        let controller = makeController(
+            fixture: fixture,
+            lifecycle: lifecycle,
+            updateLaunchHandshake: handshake,
+            startupMode: .normal
+        )
+        defer {
+            controller.tasks.cancelAll()
+            lifecycle.finishCurrentLaunch()
+        }
+        let handshakeURL = fixture.updateCacheRoot
+            .appendingPathComponent("workspace", isDirectory: true)
+            .appendingPathComponent("launch-normal.ack")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: handshakeURL.path))
+
+        controller.completeStartupIfAllowed()
+
+        XCTAssertEqual(try String(contentsOf: handshakeURL, encoding: .utf8), "ready\n")
+        XCTAssertNil(controller.updateLaunchHandshake)
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
+    }
+
+    func testRecoveryUpdateHandshakeWaitsForExplicitReadyChoice() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let handshake = try makeUpdateHandshake(fixture: fixture, suffix: "recovery")
+        let lifecycle = makeLifecycle(fixture: fixture, processIdentifier: 12_102)
+        XCTAssertNil(lifecycle.startIfNeeded())
+        let controller = makeController(
+            fixture: fixture,
+            lifecycle: lifecycle,
+            updateLaunchHandshake: handshake,
+            startupMode: .recovery
+        )
+        defer {
+            controller.tasks.cancelAll()
+            lifecycle.finishCurrentLaunch()
+        }
+        let handshakeURL = fixture.updateCacheRoot
+            .appendingPathComponent("workspace", isDirectory: true)
+            .appendingPathComponent("launch-recovery.ack")
+
+        controller.completeStartupIfAllowed()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: handshakeURL.path))
+        XCTAssertNotNil(controller.updateLaunchHandshake)
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .starting)
+
+        controller.continueWithAutomaticWorkspaceServicesPaused()
+
+        XCTAssertEqual(try String(contentsOf: handshakeURL, encoding: .utf8), "ready\n")
+        XCTAssertNil(controller.updateLaunchHandshake)
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
+    }
+
+    func testFailedUpdateHandshakeRemainsPendingForReadinessRetry() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let handshake = try makeUpdateHandshake(fixture: fixture, suffix: "retry")
+        let lifecycle = makeLifecycle(fixture: fixture, processIdentifier: 12_103)
+        XCTAssertNil(lifecycle.startIfNeeded())
+        let controller = makeController(
+            fixture: fixture,
+            lifecycle: lifecycle,
+            updateLaunchHandshake: handshake,
+            startupMode: .normal
+        )
+        defer {
+            controller.tasks.cancelAll()
+            lifecycle.finishCurrentLaunch()
+        }
+        let workspace = fixture.updateCacheRoot.appendingPathComponent(
+            "workspace",
+            isDirectory: true
+        )
+        let handshakeURL = workspace.appendingPathComponent("launch-retry.ack")
+        try FileManager.default.removeItem(at: workspace)
+
+        controller.completeStartupIfAllowed()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: handshakeURL.path))
+        XCTAssertNotNil(controller.updateLaunchHandshake)
+        XCTAssertEqual(try fixture.store.currentRecord()?.phase, .ready)
+
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        controller.completeStartupIfAllowed()
+
+        XCTAssertEqual(try String(contentsOf: handshakeURL, encoding: .utf8), "ready\n")
+        XCTAssertNil(controller.updateLaunchHandshake)
+    }
+
     func testRecoveryStartupKeepsServicesPausedUntilUserResumes() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }
@@ -520,6 +618,7 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
     private func makeController(
         fixture: Fixture,
         lifecycle: QuillCodeDesktopLaunchLifecycleController,
+        updateLaunchHandshake: QuillCodeDesktopUpdateLaunchHandshake? = nil,
         startupMode: QuillCodeDesktopStartupMode,
         computerUseCoordinator: QuillCodeDesktopComputerUseCoordinator =
             QuillCodeDesktopComputerUseCoordinator()
@@ -539,9 +638,33 @@ final class QuillCodeDesktopLaunchLifecycleTests: XCTestCase {
                 configuration: nil
             ),
             launchLifecycleController: lifecycle,
+            updateLaunchHandshake: updateLaunchHandshake,
             startupMode: startupMode,
             workspaceRoot: fixture.root
         )
+    }
+
+    private func makeUpdateHandshake(
+        fixture: Fixture,
+        suffix: String
+    ) throws -> QuillCodeDesktopUpdateLaunchHandshake {
+        let workspace = fixture.updateCacheRoot.appendingPathComponent(
+            "workspace",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: workspace,
+            withIntermediateDirectories: true
+        )
+        let handshakeURL = workspace.appendingPathComponent("launch-\(suffix).ack")
+        return try XCTUnwrap(QuillCodeDesktopUpdateLaunchHandshake(
+            arguments: [
+                "Quill Cowork",
+                QuillCodeDesktopUpdateLaunchHandshake.argument,
+                handshakeURL.path,
+            ],
+            cacheRoot: fixture.updateCacheRoot
+        ))
     }
 
     private func permissions(at url: URL) throws -> Int {
@@ -583,6 +706,10 @@ private struct Fixture {
     let root: URL
     let fileURL: URL
     let store: QuillCodeDesktopLaunchStore
+
+    var updateCacheRoot: URL {
+        root.appendingPathComponent("updates", isDirectory: true)
+    }
 
     init() throws {
         root = FileManager.default.temporaryDirectory

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -7,6 +7,9 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         let updateController = try Self.desktopSourceText(
             named: "QuillCodeDesktopUpdateController.swift"
         )
+        let updateSupport = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateSupport.swift"
+        )
         let bootstrap = try Self.appSourceText(named: "WorkspaceBootstrap.swift")
         let runner = try Self.desktopSourceText(named: "QuillCodeDesktopUpdaterSmokeRunner.swift")
         let script = try Self.scriptText(named: "packaged-macos-updater-smoke.sh")
@@ -14,11 +17,13 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
 
         Self.assertSource(app, containsAll: [
             "_ = QuillCodeDesktopLaunchClock.appEntryUptime",
-            "QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()",
+            "let updateLaunchHandshake = QuillCodeDesktopUpdateLaunchHandshake()",
+            "updateLaunchHandshake: updateLaunchHandshake",
             "QuillCodeDesktopUpdaterSmokeRequest",
             "QuillCodeDesktopUpdaterSmokeRunner.runAndExit"
         ])
-        let handshake = "QuillCodeDesktopUpdateLaunchHandshake.acknowledgeIfRequested()"
+        XCTAssertFalse(app.contains(".acknowledge()"))
+        let handshake = "let updateLaunchHandshake = QuillCodeDesktopUpdateLaunchHandshake()"
         XCTAssertEqual(app.components(separatedBy: handshake).count - 1, 1)
         let entryRange = try XCTUnwrap(app.range(of: "_ = QuillCodeDesktopLaunchClock.appEntryUptime"))
         let handshakeRange = try XCTUnwrap(app.range(of: handshake))
@@ -35,6 +40,9 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "startApplicationServicesAfterFirstWindow()",
             "automaticStartupPolicy: .deferUntilRequested",
             "model.startAutomaticStartupWork()",
+            "private func markLaunchReady()",
+            "updateLaunchHandshake.acknowledge()",
+            "self.updateLaunchHandshake = nil",
             "tasks.replace(.computerUseBackendResolution)",
             "startApplicationActivationObservation",
             "scheduleComputerUseStatusRefresh()",
@@ -46,6 +54,14 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             controller.components(separatedBy: "startApplicationServicesAfterFirstWindow()").count - 1,
             2
         )
+        XCTAssertEqual(controller.components(separatedBy: "markLaunchReady()").count - 1, 4)
+        Self.assertSource(updateSupport, containsAll: [
+            "struct QuillCodeDesktopUpdateLaunchHandshake: Equatable, Sendable",
+            "init?(arguments: [String] = CommandLine.arguments)",
+            "func acknowledge() -> Bool",
+            "Self.isAllowed(url, cacheRoot: cacheRoot)",
+            "Data(\"ready\\n\".utf8).write"
+        ])
         Self.assertSource(bootstrap, contains: "automaticStartupPolicy == .startImmediately")
         Self.assertSource(updateController, containsAll: [
             "let recoveryTask = cancelRecoveryAndTakeTask()",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-11 First-Window Update Activation Handshake
+
+Overall grade after this slice: **A+ rollback safety, A+ readiness ownership, A+ recovery behavior**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Rollback safety | A+ | The helper cannot accept a replacement merely because its executable entered and remained alive; acknowledgement waits for the native workspace's first-window-ready transition. |
+| Readiness ownership | A+ | Crash classification and update/relocation activation now share one controller transition instead of maintaining separate definitions of a successful launch. |
+| Recovery behavior | A+ | A recovery-mode replacement keeps its acknowledgement pending until the user explicitly chooses paused or resumed background work. |
+| Failure semantics | A+ | The one-shot request clears only after an atomic acknowledgement write succeeds, so transient write failure remains retryable and preserves helper rollback. |
+| Regression evidence | A+ | Focused lifecycle tests pin normal and recovery timing; source parity prevents process-entry acknowledgement from returning. |
+
+Validation:
+
+- Focused launch-lifecycle, updater, and relocation boundary: 19 tests, 0 failures
+- Broader updater, installation, relocation, and publication boundary: 77 tests, 0 failures
+- `swift test --disable-sandbox` (5,861 tests; 5 skipped; 0 failures)
+- Packaged release direct-executable, Launch Services, composer `SIGKILL` recovery, live-window,
+  Accessibility, native interaction, and DMG Move & Relaunch smokes passed
+- Optimized packaged performance: 359.99 ms median launch-ready, 103.52 MiB initial, 180.44 MiB
+  post-interaction, and 187.23 MiB repeated-interaction memory across 3/3 passing processes
+- The post-publication workflow remains the authoritative previous-public-build updater gate on
+  both Apple silicon and Intel because unpublished builds cannot advance the GitHub-only feed
+- `python3 scripts/grade-code-quality.py --root .` (all module summaries A+)
+- `git diff --check`
+
 ## 2026-08-11 Serialized Update Recovery And Durable Relaunch
 
 Overall grade after this slice: **A+ update isolation, A+ relaunch durability, A+ crash classification**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,24 @@
 # QuillCode Decisions
 
+## 2026-08-11: updater success waits for first-window readiness
+
+- **Decision:** Parsing the updater or relocation launch-handshake argument remains the first normal
+  process step, but parsing performs no filesystem mutation. The desktop controller writes the
+  acknowledgement only from the same first-window-ready transition that marks launch lifecycle
+  state ready.
+- **Why:** Process entry proves only that dyld reached the executable. An app can still hang while
+  loading persistence or constructing its first SwiftUI workspace and remain alive beyond the
+  helper's stability interval. A process-entry acknowledgement could therefore discard the
+  known-good rollback bundle before the replacement was usable.
+- **Recovery behavior:** A normal launch acknowledges after post-window services are installed. A
+  recovery-mode launch keeps both the crash marker and update acknowledgement pending until the user
+  explicitly keeps background work paused or resumes it. Failed acknowledgement writes remain
+  retryable and never clear the controller's one-shot request.
+- **Evidence:** Lifecycle tests prove normal readiness creates the acknowledgement and recovery
+  startup does not create it prematurely. The packaged updater parity gate requires parsing to stay
+  mutation-free in the app entry point and requires acknowledgement to remain owned by the shared
+  ready transition. Native public updater smoke then exercises that boundary on both architectures.
+
 ## 2026-08-11: updater relaunches serialize cleanup and durable exit work
 
 - **Decision:** A foreground update cancels and joins the one-shot interrupted-update recovery task

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -172,7 +172,11 @@ After publication, each native runner launches that untouched previous public ap
 against the newly live feed. The gate requires the app
 to stream, verify, unpack, validate, atomically replace, and relaunch itself; it
 then checks the exact source and target metadata, activated version and source
-commit, code signature, launch handshake, and staging cleanup. A channel with no
+commit, code signature, first-window-ready launch handshake, post-handshake process
+stability, and staging cleanup. The acknowledgement is parsed at process entry but
+is not written until the native workspace crosses the same ready boundary used for
+unexpected-exit classification, so a replacement that hangs during bootstrap keeps
+the previous build available for rollback. A channel with no
 previous release uses an explicitly recorded synthetic one-build-behind fallback;
 once a public source exists, metadata rewriting and re-signing are not allowed.
 This catches cross-version compatibility failures that a self-update of newly built


### PR DESCRIPTION
## Summary
- defer update and Move & Relaunch acknowledgement until the first native workspace window is ready
- keep recovery launches pending until the user explicitly chooses paused or resumed background work
- retain failed acknowledgement writes for retry and pin the contract with lifecycle and source-parity tests

## Verification
- focused updater/lifecycle/relocation boundary: 19 tests, 0 failures
- broader updater/publication boundary: 77 tests, 0 failures
- full Swift suite: 5,861 tests, 5 skipped, 0 failures
- packaged direct launch, Launch Services, SIGKILL recovery, live Accessibility/interaction, performance, DMG relocation and relaunch smokes
- packaged performance: 359.99 ms median launch-ready; 103.52 MiB initial, 180.44 MiB post-interaction, 187.23 MiB repeated
- all code-quality module summaries A+
- git diff --check