### PR TITLE
Cache worktree environment surfaces

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -140,6 +140,9 @@ public final class QuillCodeWorkspaceModel {
     var projectContextRefreshInFlight: WorkspaceProjectContextRefreshRequest?
     var projectContextRefreshPending: WorkspaceProjectContextRefreshRequest?
     var projectMetadataLoader: @Sendable (URL, ProjectHookTrustFileStore?) -> WorkspaceProjectMetadata
+    /// Presentation-only cache populated by the same off-main project-context scan that owns
+    /// `.quillcode/config.toml`. Authoritative surface rebuilds must never perform project I/O.
+    var worktreeEnvironmentSurfacesByProjectID: [UUID: WorkspaceWorktreeEnvironmentSurface] = [:]
     /// In-memory front buffer for per-thread composer drafts during rapid thread switches.
     /// `ChatThread.composerDraft` is the cross-launch source of truth.
     public internal(set) var threadDrafts: [UUID: String] = [:]
@@ -382,11 +385,13 @@ public final class QuillCodeWorkspaceModel {
         refreshGlobalMemories()
         refreshGlobalHookConfiguration()
         let previousResolutions = instructionDiagnosticResolutions(for: id)
-        WorkspaceProjectContextRefresher.refreshLocalProjectMetadata(
+        if let metadata = WorkspaceProjectContextRefresher.refreshLocalProjectMetadata(
             projectID: id,
             projects: &root.projects,
             hookTrustStore: projectHookTrustStore
-        )
+        ), let id {
+            worktreeEnvironmentSurfacesByProjectID[id] = metadata.worktreeEnvironmentSurface
+        }
         let currentResolutions = instructionDiagnosticResolutions(for: id)
         if currentResolutions != previousResolutions {
             saveProjects()

--- a/Sources/QuillCodeApp/WorkspaceModelProjects.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelProjects.swift
@@ -14,15 +14,17 @@ extension QuillCodeWorkspaceModel {
     public func addProject(path: URL, name: String? = nil) -> UUID {
         let previousLocation = currentNavigationLocation
         let standardized = path.standardizedFileURL
+        let metadata = WorkspaceProjectMetadataLoader.loadLocal(
+            from: standardized,
+            hookTrustStore: projectHookTrustStore
+        )
         let result = WorkspaceProjectEngine.upsertLocalProject(
             path: standardized,
             name: name,
-            metadata: WorkspaceProjectMetadataLoader.loadLocal(
-                from: standardized,
-                hookTrustStore: projectHookTrustStore
-            ),
+            metadata: metadata,
             projects: &root.projects
         )
+        worktreeEnvironmentSurfacesByProjectID[result.projectID] = metadata.worktreeEnvironmentSurface
         root.selectedProjectID = result.projectID
         syncTerminalSessionToSelectedProject()
         refreshFileMentionIndex()
@@ -180,6 +182,8 @@ extension QuillCodeWorkspaceModel {
                 projects: &root.projects,
                 includeLocalExtensions: true
            ) {
+            worktreeEnvironmentSurfacesByProjectID[request.projectID] =
+                metadata.worktreeEnvironmentSurface
             if selectedThread?.projectID == request.projectID {
                 let refreshedContext = workspaceThreadContext(request.projectID)
                 mutateSelectedThread { thread in
@@ -400,6 +404,7 @@ extension QuillCodeWorkspaceModel {
         }
         root.projects = projects
         root.threads = threads
+        worktreeEnvironmentSurfacesByProjectID[id] = nil
         for threadID in result.changedThreadIDs {
             guard let thread = root.threads.first(where: { $0.id == threadID }) else { continue }
             threadPersistence.save(thread)

--- a/Sources/QuillCodeApp/WorkspaceProjectContextRefresher.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectContextRefresher.swift
@@ -4,28 +4,31 @@ import QuillCodePersistence
 import QuillCodeTools
 
 enum WorkspaceProjectContextRefresher {
+    @discardableResult
     static func refreshLocalProjectMetadata(
         projectID: UUID?,
         projects: inout [ProjectRef],
         hookTrustStore: ProjectHookTrustFileStore? = nil
-    ) {
+    ) -> WorkspaceProjectMetadata? {
         guard let projectID,
               let index = projects.firstIndex(where: { $0.id == projectID }),
               !projects[index].isRemote
         else {
-            return
+            return nil
         }
 
         let rootURL = URL(fileURLWithPath: projects[index].path)
+        let metadata = WorkspaceProjectMetadataLoader.loadLocal(
+            from: rootURL,
+            hookTrustStore: hookTrustStore
+        )
         applyMetadata(
-            WorkspaceProjectMetadataLoader.loadLocal(
-                from: rootURL,
-                hookTrustStore: hookTrustStore
-            ),
+            metadata,
             to: projectID,
             projects: &projects,
             source: .local
         )
+        return metadata
     }
 
     static func refreshRemoteProjectContext(

--- a/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
@@ -8,6 +8,7 @@ struct WorkspaceProjectMetadata: Equatable, Sendable {
     var pluginHooks: [ProjectPluginHook]
     var extensionManifests: [ProjectExtensionManifest]
     var memories: [MemoryNote]
+    var worktreeEnvironmentSurface: WorkspaceWorktreeEnvironmentSurface
 
     init(
         instructions: [ProjectInstruction],
@@ -15,7 +16,9 @@ struct WorkspaceProjectMetadata: Equatable, Sendable {
         runHooks: [ProjectRunHook],
         pluginHooks: [ProjectPluginHook] = [],
         extensionManifests: [ProjectExtensionManifest],
-        memories: [MemoryNote]
+        memories: [MemoryNote],
+        worktreeEnvironmentSurface: WorkspaceWorktreeEnvironmentSurface =
+            WorkspaceWorktreeEnvironmentSurface()
     ) {
         self.instructions = instructions
         self.localActions = localActions
@@ -23,6 +26,7 @@ struct WorkspaceProjectMetadata: Equatable, Sendable {
         self.pluginHooks = pluginHooks
         self.extensionManifests = extensionManifests
         self.memories = memories
+        self.worktreeEnvironmentSurface = worktreeEnvironmentSurface
     }
 
     static let empty = WorkspaceProjectMetadata(
@@ -31,7 +35,8 @@ struct WorkspaceProjectMetadata: Equatable, Sendable {
         runHooks: [],
         pluginHooks: [],
         extensionManifests: [],
-        memories: []
+        memories: [],
+        worktreeEnvironmentSurface: WorkspaceWorktreeEnvironmentSurface()
     )
 }
 

--- a/Sources/QuillCodeApp/WorkspaceProjectMetadataLoader.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectMetadataLoader.swift
@@ -51,7 +51,8 @@ enum WorkspaceProjectMetadataLoader {
                 + marketplaceManifests
                 + standardMarketplaceManifests
                 + bundledMarketplaceManifests,
-            memories: MemoryNoteLoader.loadProject(from: root)
+            memories: MemoryNoteLoader.loadProject(from: root),
+            worktreeEnvironmentSurface: configuration.worktreeEnvironmentSurface
         )
     }
 

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -218,11 +218,8 @@ public extension QuillCodeWorkspaceModel {
                 trustedRouterCredits: root.trustedRouterCredits,
                 managedWorktreeDefaultRoot: managedWorktreeDefaultRoot
             ),
-            worktreeEnvironments: selectedProject.flatMap { project in
-                guard !project.isRemote else { return nil }
-                return WorkspaceProjectConfigurationLoader
-                    .load(from: URL(fileURLWithPath: project.path))
-                    .worktreeEnvironmentSurface
+            worktreeEnvironments: selectedProject.flatMap {
+                worktreeEnvironmentSurfacesByProjectID[$0.id]
             } ?? WorkspaceWorktreeEnvironmentSurface(),
             runtimeIssue: progress.runtimeIssue,
             lastError: progress.lastError,

--- a/Tests/QuillCodeAppTests/WorkspaceProgressSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProgressSurfaceTests.swift
@@ -268,7 +268,7 @@ final class WorkspaceProgressSurfaceTests: XCTestCase {
         XCTAssertEqual(progress, model.surface())
     }
 
-    func testAgentProgressReusesFilesystemBackedWorktreeEnvironmentProjection() throws {
+    func testAgentProgressReusesCachedWorktreeEnvironmentProjection() throws {
         let root = try makeQuillCodeTestDirectory()
         let configurationDirectory = root.appendingPathComponent(".quillcode")
         let configurationURL = configurationDirectory.appendingPathComponent("config.toml")
@@ -293,6 +293,8 @@ final class WorkspaceProgressSurfaceTests: XCTestCase {
                 XCTAssertEqual(previousBuffer.baseAddress, progressBuffer.baseAddress)
             }
         }
+        XCTAssertEqual(model.surface().worktreeEnvironments.options.map(\.title), ["Development"])
+        XCTAssertTrue(model.refreshProjectContext(projectID))
         XCTAssertEqual(model.surface().worktreeEnvironments.options.map(\.title), ["Release"])
     }
 

--- a/Tests/QuillCodeAppTests/WorkspaceProjectIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProjectIntegrationTests.swift
@@ -233,6 +233,55 @@ final class WorkspaceProjectIntegrationTests: XCTestCase {
         XCTAssertTrue(didPublish)
     }
 
+    func testRestoredProjectWorktreeEnvironmentsLoadOffMainAndRemainCached() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let configurationDirectory = root.appendingPathComponent(".quillcode")
+        let configurationURL = configurationDirectory.appendingPathComponent("config.toml")
+        try FileManager.default.createDirectory(
+            at: configurationDirectory,
+            withIntermediateDirectories: true
+        )
+        try """
+        [worktree_setup]
+        default_environment = "development"
+
+        [local_environments.development]
+        title = "Development"
+        """.write(to: configurationURL, atomically: true, encoding: .utf8)
+        let projectID = UUID()
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            projects: [ProjectRef(id: projectID, name: "Restored", path: root.path)],
+            selectedProjectID: projectID
+        ))
+
+        XCTAssertTrue(model.surface().worktreeEnvironments.options.isEmpty)
+
+        model.scheduleSelectedProjectContextRefresh()
+        await model.waitForScheduledProjectContextRefresh()
+
+        XCTAssertEqual(
+            model.surface().worktreeEnvironments.options.map(\.title),
+            ["Development"]
+        )
+
+        try """
+        [worktree_setup]
+        default_environment = "release"
+
+        [local_environments.release]
+        title = "Release"
+        """.write(to: configurationURL, atomically: true, encoding: .utf8)
+        XCTAssertEqual(
+            model.surface().worktreeEnvironments.options.map(\.title),
+            ["Development"]
+        )
+
+        model.scheduleSelectedProjectContextRefresh()
+        await model.waitForScheduledProjectContextRefresh()
+
+        XCTAssertEqual(model.surface().worktreeEnvironments.options.map(\.title), ["Release"])
+    }
+
     func testRepeatedScheduledProjectContextRefreshCoalescesAnInFlightScan() async throws {
         let root = try makeQuillCodeTestDirectory()
         let projectID = UUID()

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,30 @@
 # Code Quality Audit
 
+## 2026-08-11 Cached Worktree Environment Projection
+
+Overall grade after this slice: **A+ launch isolation, A+ cache ownership, A+ stale-result safety**.
+
+- Removed synchronous `.quillcode/config.toml` reads from authoritative workspace surface builds.
+  Restored projects now publish the safe automatic setup default immediately, then receive named
+  worktree environments from the existing utility-priority project-context refresh after the first
+  window. Newly added and explicitly refreshed projects populate the same model-owned cache at once.
+- Cache entries are keyed by project identity, updated only after the project refresh generation is
+  accepted, and removed with the project. This keeps stale background scans from crossing project
+  selections while preventing slow, sleeping, or unavailable project volumes from stalling launch,
+  pane interaction, agent progress refreshes, or unrelated UI work.
+- Added integration coverage proving restored project environments load off the main actor, remain
+  stable across surface rebuilds, and change only after an explicit background refresh.
+
+Verification:
+
+- Focused cache contract: 3 tests, 0 failures; widened project/surface suites: 39 tests, 0 failures.
+- Full Swift suite: 5,862 tests, 5 skipped, 0 failures.
+- Release-mode packaged daily-driver smoke: 3/3 fresh launches within budget; 349.64 ms median
+  launch-ready, 103.38 MiB first-window RSS, 174.02 MiB settled after the first interaction sweep,
+  and 180.97 MiB after the repeated sweep (6.95 MiB repeated growth).
+- `python3 scripts/grade-code-quality.py --root .`: every module summary remains A+.
+- `git diff --check`: clean.
+
 ## 2026-08-11 Point-In-Time Environment Status Snapshots
 
 Overall grade after this slice: **A+ snapshot integrity, A+ event ordering, A+ release determinism**.


### PR DESCRIPTION
## Summary
- remove synchronous project config reads from authoritative workspace surface builds
- populate named worktree environments through the existing off-main project context refresh
- cache by project identity with stale-generation and project-removal safety

## Verification
- focused cache contract: 3 tests, 0 failures
- widened project/surface suites: 39 tests, 0 failures
- full Swift suite: 5,862 tests, 5 skipped, 0 failures
- packaged daily-driver performance: 3/3 launches; 349.64 ms median; 103.38 MiB initial; 180.97 MiB repeated
- every code-quality module summary A+
- git diff --check clean