### PR TITLE
Defer historical archived chat payloads

### DIFF
--- a/Sources/QuillCodeApp/AppState.swift
+++ b/Sources/QuillCodeApp/AppState.swift
@@ -5,7 +5,7 @@ import QuillCodeTools
 import QuillComputerUseKit
 
 public struct SidebarItem: Sendable, Hashable, Identifiable {
-    static let maximumSearchTextCharacters = 8_000
+    static let maximumSearchTextCharacters = ThreadSearchTextBuilder.maximumCharacters
 
     public var id: UUID
     public var title: String
@@ -22,7 +22,8 @@ public struct SidebarItem: Sendable, Hashable, Identifiable {
         self.title = thread.title
         self.subtitle = thread.model
         self.updatedAt = thread.updatedAt
-        self.searchText = Self.boundedSearchText(from: thread.messages)
+        self.searchText = thread.payloadResidency.deferredSearchText
+            ?? ThreadSearchTextBuilder.build(from: thread.messages)
         self.isPinned = thread.isPinned
         self.isArchived = thread.isArchived
         self.worktree = thread.worktree.map { binding in
@@ -42,27 +43,6 @@ public struct SidebarItem: Sendable, Hashable, Identifiable {
         self.pullRequest = thread.pullRequest
     }
 
-    private static func boundedSearchText(from messages: [ChatMessage]) -> String {
-        var text = ""
-        text.reserveCapacity(maximumSearchTextCharacters)
-        var remainingCharacters = maximumSearchTextCharacters
-        var hasIncludedMessage = false
-
-        for message in messages where message.role == .user || message.role == .assistant {
-            guard remainingCharacters > 0 else { break }
-            if hasIncludedMessage {
-                text.append("\n")
-                remainingCharacters -= 1
-                guard remainingCharacters > 0 else { break }
-            }
-
-            let prefix = message.content.prefix(remainingCharacters)
-            text.append(contentsOf: prefix)
-            remainingCharacters -= prefix.count
-            hasIncludedMessage = true
-        }
-        return text
-    }
 }
 
 public struct TopBarState: Sendable, Hashable {

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -13,17 +13,20 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
     public var runtimeFactory: QuillCodeRuntimeFactory
     public var modelCatalogFetcher: ModelCatalogFetcher?
     public var accountCreditsFetcher: AccountCreditsFetcher?
+    public var now: @Sendable () -> Date
 
     public init(
         paths: QuillCodePaths = QuillCodePaths(),
         runtimeFactory: QuillCodeRuntimeFactory? = nil,
         modelCatalogFetcher: ModelCatalogFetcher? = nil,
-        accountCreditsFetcher: AccountCreditsFetcher? = nil
+        accountCreditsFetcher: AccountCreditsFetcher? = nil,
+        now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.paths = paths
         self.runtimeFactory = runtimeFactory ?? QuillCodeRuntimeFactory(paths: paths)
         self.modelCatalogFetcher = modelCatalogFetcher
         self.accountCreditsFetcher = accountCreditsFetcher
+        self.now = now
     }
 
     @MainActor
@@ -57,7 +60,14 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
         }
         let childStore = SubagentThreadStore(directory: paths.subagentThreadsDirectory)
         let payloadStore = SubagentApprovalPayloadStore(directory: paths.subagentApprovalPayloadsDirectory)
-        let threadListing = threadStore.listing()
+        let currentDate = now()
+        let archiveDeferralCutoff = Calendar.current.dateInterval(
+            of: .month,
+            for: currentDate
+        )?.start ?? currentDate
+        let threadListing = threadStore.bootstrapListing(
+            deferArchivedBefore: archiveDeferralCutoff
+        )
         let reconciliation = WorkspaceSubagentRelaunchReconciler.reconcile(
             threadListing.threads,
             childStore: childStore,

--- a/Sources/QuillCodeApp/WorkspaceModelAutomationRuns.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelAutomationRuns.swift
@@ -79,6 +79,7 @@ extension QuillCodeWorkspaceModel {
         now: Date
     ) -> AutomationRunReport? {
         guard let threadID = automation.threadID,
+              hydrateThreadPayload(threadID),
               let source = root.threads.first(where: { $0.id == threadID })
         else {
             return reportMissingAutomationDependency(

--- a/Sources/QuillCodeApp/WorkspaceModelImageAttachments.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelImageAttachments.swift
@@ -108,7 +108,10 @@ extension QuillCodeWorkspaceModel {
 
     func removeManagedImagesIfUnreferenced(_ candidates: [ChatAttachment]) {
         guard let imageAttachmentStore, !candidates.isEmpty else { return }
-        let referencedIDs = Set(root.threads.flatMap(Self.allImageAttachments).map(\.id))
+        let referencedIDs = Set(root.threads.flatMap { thread in
+            Self.allImageAttachments(in: thread).map(\.id)
+                + Array(thread.payloadResidency.deferredSummary?.attachmentIDs ?? [])
+        })
         for attachment in candidates where !referencedIDs.contains(attachment.id) {
             try? imageAttachmentStore.remove(attachment)
         }

--- a/Sources/QuillCodeApp/WorkspaceModelManagedWorktreeSnapshots.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelManagedWorktreeSnapshots.swift
@@ -42,7 +42,8 @@ extension QuillCodeWorkspaceModel {
         threadID: UUID,
         reason: ManagedWorktreeRemovalReason
     ) -> Bool {
-        guard let store = worktreeSnapshotStore,
+        guard hydrateThreadPayload(threadID),
+              let store = worktreeSnapshotStore,
               let threadIndex = root.threads.firstIndex(where: { $0.id == threadID }),
               !root.threads[threadIndex].isPinned,
               !agentRuns.isRunning(threadID),
@@ -97,7 +98,8 @@ extension QuillCodeWorkspaceModel {
             setLastError("Stop this task before restoring its worktree.")
             return false
         }
-        guard let store = worktreeSnapshotStore,
+        guard hydrateThreadPayload(threadID),
+              let store = worktreeSnapshotStore,
               let threadIndex = root.threads.firstIndex(where: { $0.id == threadID }),
               var binding = root.threads[threadIndex].worktree,
               let reference = binding.snapshot,

--- a/Sources/QuillCodeApp/WorkspaceModelSidebar.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelSidebar.swift
@@ -108,9 +108,14 @@ extension QuillCodeWorkspaceModel {
 
     @discardableResult
     public func performSidebarBulkAction(_ kind: SidebarBulkActionKind) -> Bool {
+        let selectedThreadIDs = selectedSidebarThreadIDs()
         if kind == .delete,
-           selectedSidebarThreadIDs().contains(where: { agentRuns.isRunning($0) }) {
+           selectedThreadIDs.contains(where: { agentRuns.isRunning($0) }) {
             setLastError("Stop running chats before deleting them.")
+            return false
+        }
+        if kind == .delete || kind == .unarchive,
+           !hydrateThreadPayloads(selectedThreadIDs) {
             return false
         }
         guard let plan = WorkspaceSidebarBulkActionPlanner.plan(

--- a/Sources/QuillCodeApp/WorkspaceModelThreadLifecycleActions.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadLifecycleActions.swift
@@ -74,6 +74,7 @@ extension QuillCodeWorkspaceModel {
 
     @discardableResult
     public func unarchiveThread(_ id: UUID) -> Bool {
+        guard hydrateThreadPayload(id) else { return false }
         return applyNavigationLifecycleChange {
             guard let result = updateThreadLifecycle({
                 WorkspaceThreadLifecycleEngine.unarchiveThread(id, threads: &$0)
@@ -100,6 +101,7 @@ extension QuillCodeWorkspaceModel {
             setLastError("Stop this chat before deleting it.")
             return false
         }
+        guard hydrateThreadPayload(id) else { return false }
         // Typed /delete bypasses the discard-on-exit helper; keep the ephemeral spend receipt so a
         // deleted confidential session's usage still counts against the period limits, and clear the
         // workspace-scoped error so a private run's failure doesn't render as a runtime-issue card
@@ -141,6 +143,7 @@ extension QuillCodeWorkspaceModel {
             setLastError("Stop this chat before clearing it.")
             return false
         }
+        guard hydrateThreadPayload(id) else { return false }
         let originalThread = root.threads.first(where: { $0.id == id })
         // /clear wipes the transcript (and its usage events); keep the ephemeral spend receipt first.
         if let originalThread {

--- a/Sources/QuillCodeApp/WorkspaceModelThreadMutation.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadMutation.swift
@@ -45,6 +45,19 @@ extension QuillCodeWorkspaceModel {
     }
 
     @discardableResult
+    func hydrateThreadPayload(_ id: UUID) -> Bool {
+        threadPersistence.hydrate(id, threads: &root.threads) != nil
+    }
+
+    @discardableResult
+    func hydrateThreadPayloads<S: Sequence>(_ ids: S) -> Bool where S.Element == UUID {
+        for id in ids where !hydrateThreadPayload(id) {
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
     func mutateThread(_ id: UUID, _ update: (inout ChatThread) -> Void) -> Int? {
         guard let index = threadPersistence.mutate(id, threads: &root.threads, update: update) else {
             return nil

--- a/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
@@ -83,7 +83,7 @@ extension QuillCodeWorkspaceModel {
             _ = returnFromSideConversation()
             _ = discardConfidentialThreadOnExit()
         }
-        guard root.threads.contains(where: { $0.id == id }) else { return }
+        guard hydrateThreadPayload(id) else { return }
         let previousLocation = currentNavigationLocation
         // The user is leaving the current thread: persist its morning-triage return watermark to its
         // current tail so background growth on it surfaces as "unseen" on return (cross-session).

--- a/Sources/QuillCodeApp/WorkspaceModelThreads.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreads.swift
@@ -86,6 +86,7 @@ extension QuillCodeWorkspaceModel {
 
     @discardableResult
     public func duplicateThread(_ id: UUID) -> UUID? {
+        guard hydrateThreadPayload(id) else { return nil }
         guard let source = root.threads.first(where: { $0.id == id }) else { return nil }
         guard !refuseDurableContinuation(of: source, action: "duplicate") else { return nil }
         let projectID = knownProjectID(source.projectID)

--- a/Sources/QuillCodeApp/WorkspaceThreadPersistence.swift
+++ b/Sources/QuillCodeApp/WorkspaceThreadPersistence.swift
@@ -121,14 +121,31 @@ struct WorkspaceThreadPersistence {
     }
 
     @discardableResult
+    func hydrate(_ id: UUID, threads: inout [ChatThread]) -> Int? {
+        guard let index = threads.firstIndex(where: { $0.id == id }) else {
+            return nil
+        }
+        guard !threads[index].payloadResidency.isLoaded else { return index }
+        guard let store else {
+            issueTracker.recordFailure(for: id)
+            return nil
+        }
+        do {
+            threads[index] = try store.materialize(threads[index])
+            return index
+        } catch {
+            issueTracker.recordFailure(for: id)
+            return nil
+        }
+    }
+
+    @discardableResult
     func mutate(
         _ id: UUID,
         threads: inout [ChatThread],
         update: (inout ChatThread) -> Void
     ) -> Int? {
-        guard let index = threads.firstIndex(where: { $0.id == id }) else {
-            return nil
-        }
+        guard let index = hydrate(id, threads: &threads) else { return nil }
         update(&threads[index])
         threads[index].updatedAt = now()
         save(threads[index])

--- a/Sources/QuillCodeCore/AgentImportModels.swift
+++ b/Sources/QuillCodeCore/AgentImportModels.swift
@@ -227,6 +227,6 @@ public struct AgentImportThreadProvenance: Codable, Sendable, Hashable {
             else { continue }
             return provenance
         }
-        return nil
+        return thread.payloadResidency.deferredSummary?.agentImportProvenance
     }
 }

--- a/Sources/QuillCodeCore/AttentionModel.swift
+++ b/Sources/QuillCodeCore/AttentionModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// One row in the Attention section: a thread that needs morning triage.
-public struct AttentionItem: Sendable, Hashable, Identifiable {
+public struct AttentionItem: Codable, Sendable, Hashable, Identifiable {
     public var threadID: UUID
     public var title: String
     public var verdict: TriageVerdict
@@ -94,6 +94,11 @@ public struct AttentionModel: Sendable, Hashable {
         selectedThreadID: UUID? = nil
     ) -> AttentionModel {
         let items: [AttentionItem] = threads.compactMap { thread in
+            if var item = thread.payloadResidency.deferredSummary?.attentionItem {
+                item.title = thread.title
+                item.updatedAt = thread.updatedAt
+                return item
+            }
             guard let stamp = TriageStamp.derive(from: thread), stamp.verdict.needsAttention else {
                 return nil
             }

--- a/Sources/QuillCodeCore/ChatThread.swift
+++ b/Sources/QuillCodeCore/ChatThread.swift
@@ -44,6 +44,9 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
     public var forkParentThreadID: UUID?
     /// The turn (a `TurnRevertPlan.turnMessageID`) a decision-point fork branched at. nil otherwise.
     public var forkAnchorTurnMessageID: UUID?
+    /// Runtime-only transcript ownership. Old archived chats may retain only a bounded summary until
+    /// selected or mutated; this state is deliberately omitted from Codable.
+    public var payloadResidency: ThreadPayloadResidency
     /// Session-only behavior such as a transient side conversation. This field is deliberately
     /// omitted from Codable; decoded threads are always standard durable conversations.
     public var runtimeContext: ThreadRuntimeContext
@@ -73,6 +76,7 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
         pullRequest: PullRequestLink? = nil,
         forkParentThreadID: UUID? = nil,
         forkAnchorTurnMessageID: UUID? = nil,
+        payloadResidency: ThreadPayloadResidency = .loaded,
         runtimeContext: ThreadRuntimeContext = .standard
     ) {
         self.id = id
@@ -99,6 +103,7 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
         self.pullRequest = pullRequest
         self.forkParentThreadID = forkParentThreadID
         self.forkAnchorTurnMessageID = forkAnchorTurnMessageID
+        self.payloadResidency = payloadResidency
         self.runtimeContext = runtimeContext
     }
 
@@ -166,6 +171,7 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
         self.pullRequest = try container.decodeIfPresent(PullRequestLink.self, forKey: .pullRequest)
         self.forkParentThreadID = try container.decodeIfPresent(UUID.self, forKey: .forkParentThreadID)
         self.forkAnchorTurnMessageID = try container.decodeIfPresent(UUID.self, forKey: .forkAnchorTurnMessageID)
+        self.payloadResidency = .loaded
         self.runtimeContext = .standard
     }
 

--- a/Sources/QuillCodeCore/ThreadPayloadResidency.swift
+++ b/Sources/QuillCodeCore/ThreadPayloadResidency.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public struct DeferredThreadPayloadSummary: Sendable, Hashable {
+    public var searchText: String
+    public var attachmentIDs: Set<UUID>
+    public var agentImportProvenance: AgentImportThreadProvenance?
+    public var attentionItem: AttentionItem?
+
+    public init(
+        searchText: String,
+        attachmentIDs: Set<UUID> = [],
+        agentImportProvenance: AgentImportThreadProvenance? = nil,
+        attentionItem: AttentionItem? = nil
+    ) {
+        self.searchText = searchText
+        self.attachmentIDs = attachmentIDs
+        self.agentImportProvenance = agentImportProvenance
+        self.attentionItem = attentionItem
+    }
+}
+
+/// Runtime-only ownership for a persisted chat's potentially large transcript payload.
+/// Deferred summaries keep navigation metadata and bounded search text in memory; persistence
+/// hydrates the authoritative chat before transcript access or mutation.
+public enum ThreadPayloadResidency: Sendable, Hashable {
+    case loaded
+    case deferred(DeferredThreadPayloadSummary)
+
+    public var isLoaded: Bool {
+        if case .loaded = self { return true }
+        return false
+    }
+
+    public var deferredSearchText: String? {
+        deferredSummary?.searchText
+    }
+
+    public var deferredSummary: DeferredThreadPayloadSummary? {
+        guard case .deferred(let summary) = self else { return nil }
+        return summary
+    }
+}

--- a/Sources/QuillCodeCore/ThreadSearchTextBuilder.swift
+++ b/Sources/QuillCodeCore/ThreadSearchTextBuilder.swift
@@ -1,0 +1,30 @@
+public enum ThreadSearchTextBuilder {
+    public static let maximumCharacters = 8_000
+
+    public static func build(
+        from messages: [ChatMessage],
+        maximumCharacters: Int = maximumCharacters
+    ) -> String {
+        guard maximumCharacters > 0 else { return "" }
+
+        var text = ""
+        text.reserveCapacity(maximumCharacters)
+        var remainingCharacters = maximumCharacters
+        var hasIncludedMessage = false
+
+        for message in messages where message.role == .user || message.role == .assistant {
+            guard remainingCharacters > 0 else { break }
+            if hasIncludedMessage {
+                text.append("\n")
+                remainingCharacters -= 1
+                guard remainingCharacters > 0 else { break }
+            }
+
+            let prefix = message.content.prefix(remainingCharacters)
+            text.append(contentsOf: prefix)
+            remainingCharacters -= prefix.count
+            hasIncludedMessage = true
+        }
+        return text
+    }
+}

--- a/Sources/QuillCodePersistence/ArchivedThreadSummaryIndex.swift
+++ b/Sources/QuillCodePersistence/ArchivedThreadSummaryIndex.swift
@@ -1,0 +1,241 @@
+import Foundation
+import QuillCodeCore
+
+struct ArchivedThreadSummaryIndex: Codable, Hashable {
+    static let schemaVersion = 1
+    static let maximumBytes = 64 * 1_024 * 1_024
+    static let maximumEntries = 5_000
+    static let maximumAttachmentIDsPerThread = 10_000
+
+    var schemaVersion: Int
+    var entries: [String: Entry]
+
+    struct Entry: Codable, Hashable {
+        var fingerprint: ThreadFileFingerprint
+        var id: UUID
+        var title: String
+        var projectID: UUID?
+        var mode: AgentMode
+        var model: String
+        var personality: QuillCodePersonality
+        var goal: ThreadGoal?
+        var isPinned: Bool
+        var createdAt: Date
+        var updatedAt: Date
+        var worktree: WorktreeBinding?
+        var pullRequest: PullRequestLink?
+        var forkParentThreadID: UUID?
+        var forkAnchorTurnMessageID: UUID?
+        var searchText: String
+        var attachmentIDs: [UUID]
+        var agentImportProvenance: AgentImportThreadProvenance?
+        var attentionItem: AttentionItem?
+
+        init?(thread: ChatThread, fileURL: URL, fingerprint: ThreadFileFingerprint) {
+            let loadedAttachmentIDs = Set(
+                (
+                    thread.composerAttachments
+                        + thread.followUpQueue.flatMap(\.attachments)
+                        + thread.messages.flatMap(\.attachments)
+                ).map(\.id)
+            )
+            let attachmentIDs = thread.payloadResidency.deferredSummary?.attachmentIDs
+                ?? loadedAttachmentIDs
+            guard thread.isArchived,
+                  thread.subagentRuns.isEmpty,
+                  attachmentIDs.count <= ArchivedThreadSummaryIndex.maximumAttachmentIDsPerThread,
+                  fileURL.lastPathComponent == "\(thread.id.uuidString).json"
+            else { return nil }
+
+            self.fingerprint = fingerprint
+            self.id = thread.id
+            self.title = thread.title
+            self.projectID = thread.projectID
+            self.mode = thread.mode
+            self.model = thread.model
+            self.personality = thread.personality
+            self.goal = thread.goal
+            self.isPinned = thread.isPinned
+            self.createdAt = thread.createdAt
+            self.updatedAt = thread.updatedAt
+            self.worktree = thread.worktree
+            self.pullRequest = thread.pullRequest
+            self.forkParentThreadID = thread.forkParentThreadID
+            self.forkAnchorTurnMessageID = thread.forkAnchorTurnMessageID
+            self.searchText = thread.payloadResidency.deferredSearchText
+                ?? ThreadSearchTextBuilder.build(from: thread.messages)
+            self.attachmentIDs = attachmentIDs.sorted { $0.uuidString < $1.uuidString }
+            self.agentImportProvenance = AgentImportThreadProvenance.value(in: thread)
+            self.attentionItem = AttentionModel.build(from: [thread]).items.first
+        }
+
+        func matches(fileURL: URL, fingerprint currentFingerprint: ThreadFileFingerprint) -> Bool {
+            fileURL.lastPathComponent == "\(id.uuidString).json"
+                && fingerprint == currentFingerprint
+                && searchText.count <= ThreadSearchTextBuilder.maximumCharacters
+        }
+
+        func deferredThread() -> ChatThread {
+            ChatThread(
+                id: id,
+                title: title,
+                projectID: projectID,
+                mode: mode,
+                model: model,
+                personality: personality,
+                goal: goal,
+                isPinned: isPinned,
+                isArchived: true,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                worktree: worktree,
+                pullRequest: pullRequest,
+                forkParentThreadID: forkParentThreadID,
+                forkAnchorTurnMessageID: forkAnchorTurnMessageID,
+                payloadResidency: .deferred(DeferredThreadPayloadSummary(
+                    searchText: searchText,
+                    attachmentIDs: Set(attachmentIDs),
+                    agentImportProvenance: agentImportProvenance,
+                    attentionItem: attentionItem
+                ))
+            )
+        }
+    }
+}
+
+struct ThreadFileFingerprint: Codable, Hashable {
+    var size: Int
+    var modificationDate: Date
+
+    static func read(from fileURL: URL) -> ThreadFileFingerprint? {
+        guard let values = try? fileURL.resourceValues(forKeys: [
+            .fileSizeKey,
+            .contentModificationDateKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+        ]),
+        values.isRegularFile == true,
+        values.isSymbolicLink != true,
+        let size = values.fileSize,
+        size >= 0,
+        let modificationDate = values.contentModificationDate
+        else { return nil }
+
+        return ThreadFileFingerprint(size: size, modificationDate: modificationDate)
+    }
+}
+
+enum ArchivedThreadSummaryIndexStore {
+    private static let fileName = ".archived-thread-summary-index-v1"
+
+    static func load(from directory: URL) -> ArchivedThreadSummaryIndex? {
+        let fileURL = indexURL(in: directory)
+        let data: Data
+        do {
+            guard let loaded = try BoundedFileDataReader.readIfPresent(
+                from: fileURL,
+                maximumBytes: ArchivedThreadSummaryIndex.maximumBytes
+            ) else { return nil }
+            data = loaded
+        } catch {
+            return nil
+        }
+        guard let index = try? JSONDecoder().decode(ArchivedThreadSummaryIndex.self, from: data),
+        index.schemaVersion == ArchivedThreadSummaryIndex.schemaVersion,
+        index.entries.count <= ArchivedThreadSummaryIndex.maximumEntries,
+        index.entries.allSatisfy({ key, entry in
+            key == entry.id.uuidString
+                && entry.searchText.count <= ThreadSearchTextBuilder.maximumCharacters
+                && entry.attachmentIDs.count
+                    <= ArchivedThreadSummaryIndex.maximumAttachmentIDsPerThread
+        })
+        else { return nil }
+        return index
+    }
+
+    static func save(
+        entries: [String: ArchivedThreadSummaryIndex.Entry],
+        to directory: URL
+    ) {
+        let fileURL = indexURL(in: directory)
+        guard !entries.isEmpty else {
+            try? FileManager.default.removeItem(at: fileURL)
+            return
+        }
+
+        let boundedEntries = bounded(entries)
+        let index = ArchivedThreadSummaryIndex(
+            schemaVersion: ArchivedThreadSummaryIndex.schemaVersion,
+            entries: boundedEntries
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(index),
+              data.count <= ArchivedThreadSummaryIndex.maximumBytes
+        else { return }
+
+        do {
+            try data.write(to: fileURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+        } catch {
+            // This index is a disposable optimization. Authoritative chat files remain untouched.
+        }
+    }
+
+    static func remove(from directory: URL) {
+        try? FileManager.default.removeItem(at: indexURL(in: directory))
+    }
+
+    static func bounded(
+        _ entries: [String: ArchivedThreadSummaryIndex.Entry]
+    ) -> [String: ArchivedThreadSummaryIndex.Entry] {
+        let retainedEntries = entries.values
+            .sorted { $0.updatedAt > $1.updatedAt }
+            .prefix(ArchivedThreadSummaryIndex.maximumEntries)
+        return Dictionary(uniqueKeysWithValues: retainedEntries.map { ($0.id.uuidString, $0) })
+    }
+
+    private static func indexURL(in directory: URL) -> URL {
+        directory.appendingPathComponent(fileName, isDirectory: false)
+    }
+}
+
+enum DeferredThreadPayloadMerger {
+    static func merge(summary: ChatThread, into persisted: ChatThread) throws -> ChatThread {
+        guard !summary.payloadResidency.isLoaded else { return summary }
+        guard summary.id == persisted.id,
+              summary.instructions.isEmpty,
+              summary.memories.isEmpty,
+              summary.messages.isEmpty,
+              summary.modelContextItems.isEmpty,
+              summary.events.isEmpty,
+              summary.composerDraft == nil,
+              summary.composerAttachments.isEmpty,
+              summary.followUpQueue.isEmpty
+        else {
+            throw JSONThreadStoreError.deferredPayloadMutation
+        }
+
+        var merged = persisted
+        merged.title = summary.title
+        merged.projectID = summary.projectID
+        merged.mode = summary.mode
+        merged.model = summary.model
+        merged.personality = summary.personality
+        merged.subagentRuns = summary.subagentRuns
+        merged.goal = summary.goal
+        merged.isPinned = summary.isPinned
+        merged.isArchived = summary.isArchived
+        merged.createdAt = summary.createdAt
+        merged.updatedAt = summary.updatedAt
+        merged.worktree = summary.worktree
+        merged.pullRequest = summary.pullRequest
+        merged.forkParentThreadID = summary.forkParentThreadID
+        merged.forkAnchorTurnMessageID = summary.forkAnchorTurnMessageID
+        merged.payloadResidency = .loaded
+        return merged
+    }
+}

--- a/Sources/QuillCodePersistence/ThreadStore.swift
+++ b/Sources/QuillCodePersistence/ThreadStore.swift
@@ -26,11 +26,15 @@ public struct ThreadListing: Sendable {
     public var unreadable: [URL]
     public var issues: [ThreadFileIssue]
     public var directoryReadFailed: Bool
+    public var deferredThreadCount: Int
+    public var summaryCacheHitCount: Int
 
     public init(
         threads: [ChatThread],
         unreadable: [URL],
-        directoryReadFailed: Bool = false
+        directoryReadFailed: Bool = false,
+        deferredThreadCount: Int = 0,
+        summaryCacheHitCount: Int = 0
     ) {
         self.threads = threads
         self.unreadable = unreadable
@@ -38,17 +42,23 @@ public struct ThreadListing: Sendable {
             ThreadFileIssue(fileURL: $0, reason: .unreadable)
         }
         self.directoryReadFailed = directoryReadFailed
+        self.deferredThreadCount = deferredThreadCount
+        self.summaryCacheHitCount = summaryCacheHitCount
     }
 
     public init(
         threads: [ChatThread],
         issues: [ThreadFileIssue],
-        directoryReadFailed: Bool = false
+        directoryReadFailed: Bool = false,
+        deferredThreadCount: Int = 0,
+        summaryCacheHitCount: Int = 0
     ) {
         self.threads = threads
         self.unreadable = issues.map(\.fileURL)
         self.issues = issues
         self.directoryReadFailed = directoryReadFailed
+        self.deferredThreadCount = deferredThreadCount
+        self.summaryCacheHitCount = summaryCacheHitCount
     }
 }
 
@@ -56,6 +66,7 @@ public enum JSONThreadStoreError: LocalizedError, Equatable, Sendable {
     case notRegularFile
     case symbolicLink
     case exceedsSizeLimit(maximumBytes: Int)
+    case deferredPayloadMutation
 
     public var errorDescription: String? {
         switch self {
@@ -65,6 +76,8 @@ public enum JSONThreadStoreError: LocalizedError, Equatable, Sendable {
             "The saved chat path is a symbolic link."
         case .exceedsSizeLimit(let maximumBytes):
             "The saved chat exceeds the \(maximumBytes)-byte loading limit."
+        case .deferredPayloadMutation:
+            "The archived chat must be loaded before changing transcript content."
         }
     }
 }
@@ -79,6 +92,7 @@ public struct JSONThreadStore: Sendable {
     }
 
     public func save(_ thread: ChatThread) throws {
+        let thread = try materialize(thread)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -90,6 +104,12 @@ public struct JSONThreadStore: Sendable {
             )
         }
         try data.write(to: fileURL(for: thread.id), options: .atomic)
+        if thread.isArchived {
+            // The summary index contains bounded transcript excerpts. Any archived rewrite may have
+            // cleared or replaced that content, so discard all derived entries instead of retaining
+            // stale text until the next bootstrap fingerprint pass.
+            ArchivedThreadSummaryIndexStore.remove(from: directory)
+        }
     }
 
     public func load(_ id: UUID) throws -> ChatThread {
@@ -101,6 +121,7 @@ public struct JSONThreadStore: Sendable {
 
     public func delete(_ id: UUID) throws {
         let url = fileURL(for: id)
+        ArchivedThreadSummaryIndexStore.remove(from: directory)
         guard FileManager.default.fileExists(atPath: url.path) else { return }
         try FileManager.default.removeItem(at: url)
     }
@@ -119,6 +140,89 @@ public struct JSONThreadStore: Sendable {
         listing().threads
     }
 
+    /// Startup-oriented listing that keeps old archived transcript payloads on disk. The summary
+    /// index is validated against each authoritative file's size and modification date; a miss or
+    /// damaged index falls back to the normal bounded decode for that one file.
+    public func bootstrapListing(deferArchivedBefore cutoff: Date) -> ThreadListing {
+        guard FileManager.default.fileExists(atPath: directory.path) else {
+            return ThreadListing(threads: [], issues: [])
+        }
+        guard let urls = threadFileURLs() else {
+            return ThreadListing(threads: [], issues: [], directoryReadFailed: true)
+        }
+
+        let cachedIndex = ArchivedThreadSummaryIndexStore.load(from: directory)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        var threads: [ChatThread] = []
+        var issues: [ThreadFileIssue] = []
+        var nextEntries: [String: ArchivedThreadSummaryIndex.Entry] = [:]
+        var deferredThreadCount = 0
+        var summaryCacheHitCount = 0
+
+        for url in urls {
+            let fingerprint = ThreadFileFingerprint.read(from: url)
+            let cachedEntry: ArchivedThreadSummaryIndex.Entry?
+            if let id = UUID(uuidString: url.deletingPathExtension().lastPathComponent),
+               let entry = cachedIndex?.entries[id.uuidString],
+               let fingerprint,
+               entry.matches(fileURL: url, fingerprint: fingerprint) {
+                cachedEntry = entry
+            } else {
+                cachedEntry = nil
+            }
+            if let cachedEntry, cachedEntry.updatedAt < cutoff {
+                threads.append(cachedEntry.deferredThread())
+                nextEntries[cachedEntry.id.uuidString] = cachedEntry
+                deferredThreadCount += 1
+                summaryCacheHitCount += 1
+                continue
+            }
+
+            do {
+                let data = try Self.boundedData(contentsOf: url)
+                let decoded = try decoder.decode(ChatThread.self, from: data)
+                let compacted = ThreadEventLogCompactor.compact(decoded)
+                var currentFingerprint = fingerprint
+                if compacted.events.count != decoded.events.count {
+                    if (try? save(compacted)) != nil {
+                        currentFingerprint = ThreadFileFingerprint.read(from: url)
+                    }
+                }
+
+                if let currentFingerprint,
+                   let entry = ArchivedThreadSummaryIndex.Entry(
+                       thread: compacted,
+                       fileURL: url,
+                       fingerprint: currentFingerprint
+                   ),
+                   entry.updatedAt < cutoff {
+                    nextEntries[entry.id.uuidString] = entry
+                    threads.append(entry.deferredThread())
+                    deferredThreadCount += 1
+                    continue
+                }
+                threads.append(compacted)
+            } catch let error as JSONThreadStoreError {
+                issues.append(ThreadFileIssue(fileURL: url, reason: Self.issueReason(for: error)))
+            } catch {
+                issues.append(ThreadFileIssue(fileURL: url, reason: .unreadable))
+            }
+        }
+
+        threads.sort { $0.updatedAt > $1.updatedAt }
+        let boundedEntries = ArchivedThreadSummaryIndexStore.bounded(nextEntries)
+        if cachedIndex?.entries != boundedEntries {
+            ArchivedThreadSummaryIndexStore.save(entries: boundedEntries, to: directory)
+        }
+        return ThreadListing(
+            threads: threads,
+            issues: issues,
+            deferredThreadCount: deferredThreadCount,
+            summaryCacheHitCount: summaryCacheHitCount
+        )
+    }
+
     /// Best-effort listing that self-heals around damage: a single truncated (crash-mid-write),
     /// hand-edited, or schema-skewed thread file must NOT empty the entire sidebar — every healthy
     /// conversation still loads and the unreadable files are reported separately. `load(_:)` stays
@@ -127,16 +231,7 @@ public struct JSONThreadStore: Sendable {
         guard FileManager.default.fileExists(atPath: directory.path) else {
             return ThreadListing(threads: [], issues: [])
         }
-        guard let urls = try? FileManager.default.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [
-                .fileSizeKey,
-                .isRegularFileKey,
-                .isSymbolicLinkKey,
-            ]
-        ).filter({ $0.pathExtension == "json" }).sorted(by: {
-            $0.lastPathComponent < $1.lastPathComponent
-        }) else {
+        guard let urls = threadFileURLs() else {
             return ThreadListing(threads: [], issues: [], directoryReadFailed: true)
         }
         let decoder = JSONDecoder()
@@ -194,7 +289,28 @@ public struct JSONThreadStore: Sendable {
             .symbolicLink
         case .exceedsSizeLimit:
             .exceedsSizeLimit
+        case .deferredPayloadMutation:
+            .unreadable
         }
+    }
+
+    public func materialize(_ thread: ChatThread) throws -> ChatThread {
+        guard !thread.payloadResidency.isLoaded else { return thread }
+        return try DeferredThreadPayloadMerger.merge(summary: thread, into: load(thread.id))
+    }
+
+    private func threadFileURLs() -> [URL]? {
+        try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [
+                .fileSizeKey,
+                .contentModificationDateKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+            ]
+        ).filter({ $0.pathExtension == "json" }).sorted(by: {
+            $0.lastPathComponent < $1.lastPathComponent
+        })
     }
 
     private func fileURL(for id: UUID) -> URL {

--- a/Sources/quill-code-desktop/QuillCodeDesktopDailyDriverSmokeFixture.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopDailyDriverSmokeFixture.swift
@@ -49,6 +49,7 @@ enum QuillCodeDesktopDailyDriverSmokeFixtureError: LocalizedError, Equatable {
 
 enum QuillCodeDesktopDailyDriverSmokeFixture {
     static let chatCount = 100
+    static let archivedChatCount = 80
     static let shortThreadTurnCount = 3
     static let selectedThreadTurnCount = 100
     static let markerFileName = "performance-workload.json"
@@ -129,12 +130,16 @@ enum QuillCodeDesktopDailyDriverSmokeFixture {
         for ordinal in 1...chatCount {
             try threadStore.save(makeThread(ordinal: ordinal))
         }
+        // Performance smoke represents an established daily-driver workspace. Prime the disposable
+        // archive index outside the measured launch so the packaged app exercises its warm-start path.
+        _ = threadStore.bootstrapListing(deferArchivedBefore: .distantFuture)
 
         let marker = Marker(
-            schemaVersion: 1,
+            schemaVersion: 2,
             workload: QuillCodeDesktopPerformanceWorkload.dailyDriver100Chats.rawValue,
             projectCount: 1,
             chatCount: chatCount,
+            archivedChatCount: archivedChatCount,
             shortThreadTurnCount: shortThreadTurnCount,
             selectedThreadTurnCount: selectedThreadTurnCount
         )
@@ -165,10 +170,11 @@ enum QuillCodeDesktopDailyDriverSmokeFixture {
         let markerURL = workspaceRoot.root.appendingPathComponent(markerFileName)
         let marker = try JSONDecoder().decode(Marker.self, from: Data(contentsOf: markerURL))
         guard marker == Marker(
-            schemaVersion: 1,
+            schemaVersion: 2,
             workload: workload.rawValue,
             projectCount: 1,
             chatCount: chatCount,
+            archivedChatCount: archivedChatCount,
             shortThreadTurnCount: shortThreadTurnCount,
             selectedThreadTurnCount: selectedThreadTurnCount
         ) else {
@@ -203,10 +209,20 @@ enum QuillCodeDesktopDailyDriverSmokeFixture {
             "selected chat message count"
         )
         try require(
+            root.threads.filter(\.isArchived).count == marker.archivedChatCount,
+            "archived chat count"
+        )
+        try require(
             root.threads
-                .filter({ $0.id != selectedThread.id })
+                .filter(\.isArchived)
+                .allSatisfy({ !$0.payloadResidency.isLoaded && $0.messages.isEmpty }),
+            "archived chat payload residency"
+        )
+        try require(
+            root.threads
+                .filter({ !$0.isArchived && $0.id != selectedThread.id })
                 .allSatisfy({ $0.messages.count == marker.shortThreadTurnCount * 2 }),
-            "background chat message count"
+            "active background chat message count"
         )
         return workload
     }
@@ -232,6 +248,7 @@ enum QuillCodeDesktopDailyDriverSmokeFixture {
                 createdAt: createdAt
             ),
             isPinned: ordinal == chatCount,
+            isArchived: ordinal <= archivedChatCount,
             createdAt: createdAt,
             updatedAt: createdAt.addingTimeInterval(TimeInterval(turnCount * 120))
         )
@@ -282,6 +299,7 @@ enum QuillCodeDesktopDailyDriverSmokeFixture {
         var workload: String
         var projectCount: Int
         var chatCount: Int
+        var archivedChatCount: Int
         var shortThreadTurnCount: Int
         var selectedThreadTurnCount: Int
     }

--- a/Tests/QuillCodeAppTests/WorkspaceArchivedThreadHydrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceArchivedThreadHydrationTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+import QuillCodeCore
+import QuillCodePersistence
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceArchivedThreadHydrationTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_786_435_200) // 2026-08-11 UTC
+
+    func testBootstrapDefersOnlyHistoricalArchiveAndHydratesItOnSelection() throws {
+        let paths = QuillCodePaths(home: try makeTempDirectory())
+        try paths.ensure()
+        let project = ProjectRef(name: "Quill Cowork", path: paths.home.path)
+        try JSONProjectStore(fileURL: paths.projectsFile).save([project])
+        let store = JSONThreadStore(directory: paths.threadsDirectory)
+        let oldDate = Date(timeIntervalSince1970: 1_751_328_000)
+        let currentMonthDate = now.addingTimeInterval(-24 * 60 * 60)
+        var historical = ChatThread(
+            title: "Historical crash investigation",
+            projectID: project.id,
+            messages: [
+                ChatMessage(role: .user, content: "why did launch fail"),
+                ChatMessage(role: .assistant, content: "the prior build rolled back safely")
+            ],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        historical.events = [ThreadEvent(kind: .notice, summary: "Exact archived event")]
+        let provenance = AgentImportThreadProvenance(source: .claudeCode, sourceID: "session-42")
+        let provenancePayload = try JSONEncoder().encode([
+            AgentImportThreadProvenance.payloadKey: provenance
+        ])
+        historical.events.append(ThreadEvent(
+            kind: .notice,
+            summary: "Imported from Claude Code",
+            payloadJSON: String(decoding: provenancePayload, as: UTF8.self)
+        ))
+        historical.events.append(try XCTUnwrap(RunIntegrityRecord.event(for: RunIntegrityReport(
+            verdict: .red,
+            reasons: [RunIntegrityReason(
+                rule: .standingTestFailure,
+                detail: "release verification failed"
+            )]
+        ))))
+        let recentArchive = ChatThread(
+            title: "August usage receipt",
+            projectID: project.id,
+            messages: [ChatMessage(role: .assistant, content: "keep current month resident")],
+            isArchived: true,
+            createdAt: currentMonthDate,
+            updatedAt: currentMonthDate
+        )
+        let active = ChatThread(
+            title: "Current release",
+            projectID: project.id,
+            messages: [ChatMessage(role: .user, content: "publish")],
+            createdAt: now,
+            updatedAt: now
+        )
+        try store.save(historical)
+        try store.save(recentArchive)
+        try store.save(active)
+
+        let model = try makeBootstrap(paths: paths).makeModel(
+            automaticStartupPolicy: .deferUntilRequested
+        )
+
+        XCTAssertEqual(model.root.selectedThreadID, active.id)
+        XCTAssertTrue(try XCTUnwrap(model.root.threads.first { $0.id == active.id }).payloadResidency.isLoaded)
+        XCTAssertTrue(
+            try XCTUnwrap(model.root.threads.first { $0.id == recentArchive.id })
+                .payloadResidency.isLoaded
+        )
+        let deferred = try XCTUnwrap(model.root.threads.first { $0.id == historical.id })
+        XCTAssertFalse(deferred.payloadResidency.isLoaded)
+        XCTAssertTrue(deferred.messages.isEmpty)
+        XCTAssertEqual(
+            model.root.allSidebarItems.first { $0.id == historical.id }?.searchText,
+            "why did launch fail\nthe prior build rolled back safely"
+        )
+        XCTAssertEqual(AgentImportThreadProvenance.value(in: deferred), provenance)
+        let attentionItem = try XCTUnwrap(model.attentionModel.items.first { $0.threadID == historical.id })
+        XCTAssertEqual(attentionItem.verdict, .red)
+        XCTAssertEqual(attentionItem.title, historical.title)
+
+        model.selectThread(historical.id)
+
+        XCTAssertEqual(model.root.selectedThreadID, historical.id)
+        let selected = try XCTUnwrap(model.selectedThread)
+        XCTAssertTrue(selected.payloadResidency.isLoaded)
+        XCTAssertEqual(selected.messages.map(\.id), historical.messages.map(\.id))
+        XCTAssertEqual(selected.messages.map(\.content), historical.messages.map(\.content))
+        XCTAssertEqual(selected.events.map(\.id), historical.events.map(\.id))
+        XCTAssertEqual(selected.events.map(\.summary), historical.events.map(\.summary))
+    }
+
+    func testDuplicateAndUnarchiveHydrateHistoricalPayloadBeforeMutation() throws {
+        let paths = QuillCodePaths(home: try makeTempDirectory())
+        try paths.ensure()
+        let oldDate = Date(timeIntervalSince1970: 1_751_328_000)
+        var historical = ChatThread(
+            title: "Archived task",
+            messages: [ChatMessage(role: .user, content: "preserve the complete transcript")],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        historical.events = [ThreadEvent(kind: .notice, summary: "Preserved lifecycle")]
+        let store = JSONThreadStore(directory: paths.threadsDirectory)
+        try store.save(historical)
+
+        let duplicateModel = try makeBootstrap(paths: paths).makeModel(
+            automaticStartupPolicy: .deferUntilRequested
+        )
+        let duplicateID = try XCTUnwrap(duplicateModel.duplicateThread(historical.id))
+        let duplicate = try XCTUnwrap(duplicateModel.root.threads.first { $0.id == duplicateID })
+        XCTAssertEqual(duplicate.messages.map(\.id), historical.messages.map(\.id))
+        XCTAssertEqual(duplicate.messages.map(\.content), historical.messages.map(\.content))
+        XCTAssertEqual(
+            duplicate.events.prefix(historical.events.count).map(\.summary),
+            historical.events.map(\.summary)
+        )
+        XCTAssertTrue(duplicate.events.last?.summary.hasPrefix("Duplicated from") == true)
+
+        let unarchiveModel = try makeBootstrap(paths: paths).makeModel(
+            automaticStartupPolicy: .deferUntilRequested
+        )
+        XCTAssertTrue(unarchiveModel.unarchiveThread(historical.id))
+        let restored = try XCTUnwrap(unarchiveModel.selectedThread)
+        XCTAssertEqual(restored.id, historical.id)
+        XCTAssertFalse(restored.isArchived)
+        XCTAssertEqual(restored.messages.map(\.id), historical.messages.map(\.id))
+        XCTAssertEqual(restored.messages.map(\.content), historical.messages.map(\.content))
+        XCTAssertEqual(restored.events.map(\.id), historical.events.map(\.id))
+        XCTAssertEqual(restored.events.map(\.summary), historical.events.map(\.summary))
+        let persisted = try store.load(historical.id)
+        XCTAssertEqual(persisted.messages.map(\.id), historical.messages.map(\.id))
+        XCTAssertEqual(persisted.messages.map(\.content), historical.messages.map(\.content))
+    }
+
+    func testHistoricalFollowUpAutomationHydratesSourceContext() throws {
+        let paths = QuillCodePaths(home: try makeTempDirectory())
+        try paths.ensure()
+        let oldDate = Date(timeIntervalSince1970: 1_751_328_000)
+        let historical = ChatThread(
+            title: "Archived follow-up source",
+            messages: [
+                ChatMessage(role: .user, content: "investigate the crash"),
+                ChatMessage(role: .assistant, content: "rollback was healthy")
+            ],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        try JSONThreadStore(directory: paths.threadsDirectory).save(historical)
+        let automation = QuillAutomation(
+            title: "Follow up archived task",
+            detail: "Resume the original context.",
+            kind: .threadFollowUp,
+            scheduleKind: .heartbeat,
+            scheduleDescription: "Now",
+            threadID: historical.id,
+            createdAt: oldDate,
+            updatedAt: oldDate,
+            nextRunAt: now
+        )
+        try JSONAutomationStore(fileURL: paths.automationsFile).save([automation])
+        let model = try makeBootstrap(paths: paths).makeModel(
+            automaticStartupPolicy: .deferUntilRequested
+        )
+        XCTAssertFalse(try XCTUnwrap(model.root.threads.first).payloadResidency.isLoaded)
+
+        let followUpID = try XCTUnwrap(model.runAutomation(id: automation.id))
+        let followUp = try XCTUnwrap(model.root.threads.first { $0.id == followUpID })
+
+        XCTAssertEqual(followUp.messages.map(\.content), historical.messages.map(\.content))
+        XCTAssertTrue(
+            try XCTUnwrap(model.root.threads.first { $0.id == historical.id })
+                .payloadResidency.isLoaded
+        )
+    }
+
+    func testDeletingSharedAttachmentKeepsFileWhileDeferredArchiveReferencesIt() throws {
+        let paths = QuillCodePaths(home: try makeTempDirectory())
+        try paths.ensure()
+        let imageStore = ImageAttachmentStore(directory: paths.attachmentsDirectory)
+        let activeID = UUID()
+        let attachment = try imageStore.importImage(
+            data: Self.onePixelPNG,
+            displayName: "shared.png",
+            threadID: activeID
+        )
+        let oldDate = Date(timeIntervalSince1970: 1_751_328_000)
+        let historical = ChatThread(
+            title: "Archived duplicate",
+            messages: [ChatMessage(role: .user, content: "keep image", attachments: [attachment])],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        let active = ChatThread(
+            id: activeID,
+            title: "Current duplicate",
+            messages: [ChatMessage(role: .user, content: "same image", attachments: [attachment])],
+            createdAt: now,
+            updatedAt: now
+        )
+        let store = JSONThreadStore(directory: paths.threadsDirectory)
+        try store.save(historical)
+        try store.save(active)
+        let model = try makeBootstrap(paths: paths).makeModel(
+            automaticStartupPolicy: .deferUntilRequested
+        )
+        let deferred = try XCTUnwrap(model.root.threads.first { $0.id == historical.id })
+        XCTAssertEqual(
+            deferred.payloadResidency.deferredSummary?.attachmentIDs,
+            Set([attachment.id])
+        )
+
+        XCTAssertTrue(model.deleteThread(active.id))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: attachment.localURL.path))
+        XCTAssertTrue(model.deleteThread(historical.id))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: attachment.localURL.path))
+    }
+
+    private func makeBootstrap(paths: QuillCodePaths) -> QuillCodeWorkspaceBootstrap {
+        QuillCodeWorkspaceBootstrap(paths: paths, now: { [now] in now })
+    }
+
+    private static let onePixelPNG = Data(base64Encoded:
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )!
+}

--- a/Tests/QuillCodeAppTests/WorkspaceManagedWorktreeRetentionIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceManagedWorktreeRetentionIntegrationTests.swift
@@ -50,6 +50,39 @@ final class WorkspaceManagedWorktreeRetentionIntegrationTests: XCTestCase {
         XCTAssertNotNil(model.root.threads.first { $0.id == oldest.id }?.worktree?.snapshot)
         XCTAssertTrue(FileManager.default.fileExists(atPath: newest.worktree?.path ?? ""))
     }
+
+    func testEnforcementHydratesDeferredArchiveBeforeRecordingSnapshot() throws {
+        let fixture = try RetentionFixture(count: 2, retentionLimit: 1)
+        defer { fixture.remove() }
+        var archived = try XCTUnwrap(fixture.threads.first)
+        archived.isArchived = true
+        archived.messages = [ChatMessage(role: .user, content: "preserve archived context")]
+        try fixture.threadStore.save(archived)
+        let cutoff = Date(timeIntervalSince1970: 10_000)
+        let bootstrapped = fixture.threadStore.bootstrapListing(
+            deferArchivedBefore: cutoff
+        ).threads
+        XCTAssertFalse(
+            try XCTUnwrap(bootstrapped.first { $0.id == archived.id })
+                .payloadResidency.isLoaded
+        )
+        let model = fixture.model(
+            threads: bootstrapped,
+            selectedThreadID: fixture.threads.last?.id
+        )
+
+        XCTAssertEqual(model.enforceManagedWorktreeRetention(), 1)
+
+        let retained = try XCTUnwrap(model.root.threads.first { $0.id == archived.id })
+        XCTAssertTrue(retained.payloadResidency.isLoaded)
+        XCTAssertEqual(retained.messages.map(\.content), ["preserve archived context"])
+        XCTAssertNotNil(retained.worktree?.snapshot)
+        let persisted = try fixture.threadStore.load(archived.id)
+        XCTAssertEqual(persisted.messages.map(\.content), ["preserve archived context"])
+        XCTAssertTrue(
+            persisted.events.contains { $0.summary.contains("worktree") }
+        )
+    }
 }
 
 private final class RetentionFixture {
@@ -121,13 +154,16 @@ private final class RetentionFixture {
     }
 
     @MainActor
-    func model(selectedThreadID: UUID?) -> QuillCodeWorkspaceModel {
+    func model(
+        threads: [ChatThread]? = nil,
+        selectedThreadID: UUID?
+    ) -> QuillCodeWorkspaceModel {
         QuillCodeWorkspaceModel(
             root: QuillCodeRootState(
                 config: AppConfig(managedWorktrees: settings),
                 projects: [project],
                 selectedProjectID: project.id,
-                threads: threads,
+                threads: threads ?? self.threads,
                 selectedThreadID: selectedThreadID
             ),
             threadStore: threadStore,

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
@@ -28,6 +28,10 @@ final class QuillCodeDesktopDailyDriverSmokeFixtureTests: XCTestCase {
         XCTAssertEqual(threads.count, QuillCodeDesktopDailyDriverSmokeFixture.chatCount)
         XCTAssertEqual(Set(threads.map(\.id)).count, threads.count)
         XCTAssertTrue(threads.allSatisfy { $0.projectID == projects.first?.id })
+        XCTAssertEqual(
+            threads.filter(\.isArchived).count,
+            QuillCodeDesktopDailyDriverSmokeFixture.archivedChatCount
+        )
         XCTAssertEqual(selectedThread.title, "Keyboard ergonomics 100")
         XCTAssertTrue(selectedThread.isPinned)
         XCTAssertEqual(
@@ -65,6 +69,15 @@ final class QuillCodeDesktopDailyDriverSmokeFixtureTests: XCTestCase {
                 includesInitialSurface: true,
                 controller: controller
             ).contains("onboarding.developer-key")
+        )
+        XCTAssertEqual(
+            controller.model.root.threads.filter(\.isArchived).count,
+            QuillCodeDesktopDailyDriverSmokeFixture.archivedChatCount
+        )
+        XCTAssertTrue(
+            controller.model.root.threads.filter(\.isArchived).allSatisfy {
+                !$0.payloadResidency.isLoaded && $0.messages.isEmpty
+            }
         )
         XCTAssertEqual(
             try QuillCodeDesktopDailyDriverSmokeFixture.validate(

--- a/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
@@ -270,6 +270,247 @@ final class JSONThreadStoreTests: PersistenceTestCase {
         XCTAssertTrue(listing.directoryReadFailed)
     }
 
+    func testBootstrapListingDefersOldArchivedPayloadAndUsesValidatedWarmIndex() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let oldDate = Date(timeIntervalSince1970: 1_600_000_000)
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000)
+        var archived = ChatThread(
+            title: "Archived release investigation",
+            messages: [
+                ChatMessage(role: .user, content: "find the launch regression"),
+                ChatMessage(role: .assistant, content: "the cache was rebuilding synchronously")
+            ],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        archived.events = [ThreadEvent(kind: .notice, summary: "Preserved event")]
+        let active = ChatThread(
+            title: "Current work",
+            messages: [ChatMessage(role: .user, content: "ship it")],
+            updatedAt: cutoff.addingTimeInterval(100)
+        )
+        try store.save(archived)
+        try store.save(active)
+
+        let cold = store.bootstrapListing(deferArchivedBefore: cutoff)
+
+        XCTAssertEqual(cold.deferredThreadCount, 1)
+        XCTAssertEqual(cold.summaryCacheHitCount, 0)
+        let coldArchive = try XCTUnwrap(cold.threads.first { $0.id == archived.id })
+        XCTAssertFalse(coldArchive.payloadResidency.isLoaded)
+        XCTAssertTrue(coldArchive.messages.isEmpty)
+        XCTAssertTrue(coldArchive.events.isEmpty)
+        XCTAssertEqual(
+            coldArchive.payloadResidency.deferredSearchText,
+            "find the launch regression\nthe cache was rebuilding synchronously"
+        )
+        XCTAssertTrue(try XCTUnwrap(cold.threads.first { $0.id == active.id }).payloadResidency.isLoaded)
+
+        let warm = store.bootstrapListing(deferArchivedBefore: cutoff)
+
+        XCTAssertEqual(warm.deferredThreadCount, 1)
+        XCTAssertEqual(warm.summaryCacheHitCount, 1)
+        let fullyListed = try XCTUnwrap(try store.list().first { $0.id == archived.id })
+        XCTAssertEqual(fullyListed.messages.map(\.id), archived.messages.map(\.id))
+        XCTAssertEqual(fullyListed.messages.map(\.role), archived.messages.map(\.role))
+        XCTAssertEqual(fullyListed.messages.map(\.content), archived.messages.map(\.content))
+        XCTAssertEqual(try store.load(archived.id).events.map(\.summary), archived.events.map(\.summary))
+    }
+
+    func testBootstrapListingInvalidatesChangedArchivedSummary() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let oldDate = Date(timeIntervalSince1970: 1_600_000_000)
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000)
+        var archived = ChatThread(
+            title: "Before",
+            messages: [ChatMessage(role: .user, content: "original search")],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        try store.save(archived)
+        _ = store.bootstrapListing(deferArchivedBefore: cutoff)
+        XCTAssertEqual(
+            store.bootstrapListing(deferArchivedBefore: cutoff).summaryCacheHitCount,
+            1
+        )
+
+        archived.title = "After"
+        archived.messages.append(ChatMessage(role: .assistant, content: "updated search"))
+        try store.save(archived)
+        let refreshed = store.bootstrapListing(deferArchivedBefore: cutoff)
+
+        XCTAssertEqual(refreshed.summaryCacheHitCount, 0)
+        let summary = try XCTUnwrap(refreshed.threads.first)
+        XCTAssertEqual(summary.title, "After")
+        XCTAssertEqual(summary.payloadResidency.deferredSearchText, "original search\nupdated search")
+    }
+
+    func testBootstrapListingIgnoresCorruptIndexAndRebuildsItPrivately() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let oldDate = Date(timeIntervalSince1970: 1_600_000_000)
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000)
+        let archived = ChatThread(
+            title: "Recoverable archive",
+            messages: [ChatMessage(role: .user, content: "recover exact search")],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        try store.save(archived)
+        _ = store.bootstrapListing(deferArchivedBefore: cutoff)
+        let indexURL = directory.appendingPathComponent(".archived-thread-summary-index-v1")
+        try Data("not an index".utf8).write(to: indexURL, options: .atomic)
+
+        let recovered = store.bootstrapListing(deferArchivedBefore: cutoff)
+
+        XCTAssertEqual(recovered.deferredThreadCount, 1)
+        XCTAssertEqual(recovered.summaryCacheHitCount, 0)
+        XCTAssertEqual(
+            recovered.threads.first?.payloadResidency.deferredSearchText,
+            "recover exact search"
+        )
+        XCTAssertEqual(
+            try FileManager.default.attributesOfItem(atPath: indexURL.path)[.posixPermissions] as? Int,
+            0o600
+        )
+        XCTAssertEqual(
+            store.bootstrapListing(deferArchivedBefore: cutoff).summaryCacheHitCount,
+            1
+        )
+    }
+
+    func testArchivedRewritePurgesDerivedTranscriptExcerpts() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let oldDate = Date(timeIntervalSince1970: 1_600_000_000)
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000)
+        var archived = ChatThread(
+            title: "Sensitive archive",
+            messages: [ChatMessage(role: .user, content: "remove this excerpt")],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        try store.save(archived)
+        _ = store.bootstrapListing(deferArchivedBefore: cutoff)
+        let indexURL = directory.appendingPathComponent(".archived-thread-summary-index-v1")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: indexURL.path))
+
+        archived.messages = []
+        archived.updatedAt = oldDate.addingTimeInterval(1)
+        try store.save(archived)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: indexURL.path))
+        XCTAssertTrue(try store.load(archived.id).messages.isEmpty)
+    }
+
+    func testWarmBootstrapKeepsLargeArchiveSetAsBoundedSummaries() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let oldDate = Date(timeIntervalSince1970: 1_600_000_000)
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000)
+        let threadCount = 200
+        for index in 0..<threadCount {
+            try store.save(ChatThread(
+                title: "Archive \(index)",
+                messages: [
+                    ChatMessage(role: .user, content: "request \(index) " + String(repeating: "x", count: 4_096)),
+                    ChatMessage(role: .assistant, content: "answer \(index) " + String(repeating: "y", count: 4_096))
+                ],
+                isArchived: true,
+                createdAt: oldDate,
+                updatedAt: oldDate.addingTimeInterval(TimeInterval(index))
+            ))
+        }
+
+        let cold = store.bootstrapListing(deferArchivedBefore: cutoff)
+        let warm = store.bootstrapListing(deferArchivedBefore: cutoff)
+
+        XCTAssertEqual(cold.deferredThreadCount, threadCount)
+        XCTAssertEqual(cold.summaryCacheHitCount, 0)
+        XCTAssertEqual(warm.deferredThreadCount, threadCount)
+        XCTAssertEqual(warm.summaryCacheHitCount, threadCount)
+        XCTAssertTrue(warm.threads.allSatisfy {
+            !$0.payloadResidency.isLoaded && $0.messages.isEmpty && $0.events.isEmpty
+        })
+        XCTAssertEqual(try store.list().count, threadCount)
+    }
+
+    func testSavingDeferredMetadataPreservesAuthoritativePayload() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let oldDate = Date(timeIntervalSince1970: 1_600_000_000)
+        var archived = ChatThread(
+            title: "Before",
+            messages: [ChatMessage(role: .user, content: "retain me")],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate,
+            instructions: [ProjectInstruction(
+                path: "/workspace/AGENTS.md",
+                title: "AGENTS.md",
+                content: "Be exact",
+                byteCount: 8
+            )]
+        )
+        archived.events = [ThreadEvent(kind: .notice, summary: "Keep this too")]
+        archived.followUpQueue = [FollowUpItem(text: "and this", createdAt: oldDate)]
+        try store.save(archived)
+        var summary = try XCTUnwrap(
+            store.bootstrapListing(
+                deferArchivedBefore: Date(timeIntervalSince1970: 1_700_000_000)
+            ).threads.first
+        )
+        XCTAssertFalse(summary.payloadResidency.isLoaded)
+
+        summary.title = "After"
+        summary.isPinned = true
+        summary.updatedAt = oldDate.addingTimeInterval(60)
+        try store.save(summary)
+
+        let persisted = try store.load(archived.id)
+        XCTAssertEqual(persisted.title, "After")
+        XCTAssertTrue(persisted.isPinned)
+        XCTAssertEqual(persisted.messages.map(\.id), archived.messages.map(\.id))
+        XCTAssertEqual(persisted.messages.map(\.content), archived.messages.map(\.content))
+        XCTAssertEqual(persisted.events.map(\.id), archived.events.map(\.id))
+        XCTAssertEqual(persisted.events.map(\.summary), archived.events.map(\.summary))
+        XCTAssertEqual(persisted.instructions, archived.instructions)
+        XCTAssertEqual(persisted.followUpQueue, archived.followUpQueue)
+        XCTAssertTrue(persisted.payloadResidency.isLoaded)
+    }
+
+    func testSavingDeferredTranscriptMutationFailsWithoutChangingFile() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let oldDate = Date(timeIntervalSince1970: 1_600_000_000)
+        let archived = ChatThread(
+            messages: [ChatMessage(role: .user, content: "authoritative")],
+            isArchived: true,
+            createdAt: oldDate,
+            updatedAt: oldDate
+        )
+        try store.save(archived)
+        var summary = try XCTUnwrap(
+            store.bootstrapListing(
+                deferArchivedBefore: Date(timeIntervalSince1970: 1_700_000_000)
+            ).threads.first
+        )
+        summary.messages.append(ChatMessage(role: .assistant, content: "unsafe partial edit"))
+
+        XCTAssertThrowsError(try store.save(summary)) { error in
+            XCTAssertEqual(error as? JSONThreadStoreError, .deferredPayloadMutation)
+        }
+        let persisted = try store.load(archived.id)
+        XCTAssertEqual(persisted.messages.map(\.id), archived.messages.map(\.id))
+        XCTAssertEqual(persisted.messages.map(\.content), archived.messages.map(\.content))
+    }
+
     func testListToleratesSchemaIncompatibleFile() throws {
         // A .json that is valid JSON but missing required ChatThread keys is skipped, not fatal.
         let directory = try makeTempDirectory()

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -17338,3 +17338,25 @@ Validation:
 - `scripts/app-server-smoke.sh`
 - `python3 scripts/grade-code-quality.py --root .`
 - `git diff --check`
+
+## 2026-08-11 Historical Archive Payload Residency
+
+Overall grade after this slice: **A+ memory architecture, A+ data safety, A+ packaged performance**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Memory architecture | A+ | Bootstrap retains current-period archives but replaces older transcripts with bounded runtime summaries, avoiding historical message and event residency during ordinary use. |
+| Cache safety | A+ | The disposable summary index is schema- and fingerprint-validated, size-bounded, atomically written with mode `0600`, and ignored when corrupt, stale, oversized, symlinked, or nonregular. |
+| Data integrity | A+ | Selection and mutation hydrate canonical JSON first; metadata-only saves merge against authoritative payloads, while attempted deferred transcript mutation fails closed. |
+| Behavioral fidelity | A+ | Deferred summaries preserve the existing bounded search projection, attachment references, agent-import provenance, and Attention rows without changing ordinary CLI or app-server listing semantics. |
+| Lifecycle coverage | A+ | Selection, duplication, unarchive, automation follow-up, worktree retention/restoration, attachment cleanup, archived rewrites, and deletion honor deferred residency. |
+| Packaged performance | A+ | The final 100-chat run reached readiness in 294.68 ms with a 41.00 MiB initial physical footprint, 89.94 MiB after the repeated interaction sweep, 2.02 MiB repeated growth, and a thread count that fell from seven to six. |
+| Regression evidence | A+ | Cold and warm cache paths, invalidation, corruption recovery, 200-archive scale, data-loss rejection, current-month policy, search, provenance, Attention, hydration, and packaged fixture behavior are covered. |
+
+Validation:
+
+- `swift test` (6,174 tests; 5 skipped; 0 failures)
+- `scripts/packaged-macos-smoke.sh` (SIGKILL draft recovery, direct and Launch Services rendering, Accessibility, computer-use contracts, and repeated 100-chat interaction passed)
+- Final physical-footprint evidence: 294.68 ms launch-ready, 41.00 MiB initial, 87.92 MiB post-interaction, 89.94 MiB repeated-interaction, and 2.02 MiB repeated growth
+- `python3 scripts/grade-code-quality.py --root .` (all touched modules A+)
+- `git diff --check`


### PR DESCRIPTION
## Summary
- keep historical archived transcripts out of steady-state memory behind a validated, bounded summary index
- hydrate canonical thread JSON before selection or mutation, and preserve authoritative transcript payloads across metadata saves
- retain search, attachment, import provenance, Attention, automation, and managed-worktree behavior while exercising 80 deferred archives in the 100-chat packaged fixture

## Verification
- `swift test` (6,174 tests; 5 skipped; 0 failures)
- focused persistence, hydration, worktree, and packaged-fixture suite (37 tests; 0 failures)
- full packaged macOS smoke: SIGKILL recovery, direct and Launch Services rendering, accessibility, computer-use contracts, and repeated daily-driver interaction
- 294.68 ms launch-ready; 41.00 MiB initial physical footprint; 89.94 MiB repeated-interaction footprint; 2.02 MiB repeated growth; thread count 7 -> 6
- `python3 scripts/grade-code-quality.py --root .` (all touched modules A+)
- `git diff --check`