### PR TITLE
Bound browser session memory growth

### DIFF
--- a/Sources/QuillCodeApp/BrowserLiveDOMCapturing.swift
+++ b/Sources/QuillCodeApp/BrowserLiveDOMCapturing.swift
@@ -1,6 +1,14 @@
 import Foundation
 
 public struct BrowserLiveDOMSnapshot: Sendable, Hashable {
+    public static let maximumURLCharacters = 16_384
+    public static let maximumTitleCharacters = 512
+    public static let maximumVisibleTextCharacters = 12_000
+    public static let maximumOutlineCount = 48
+    public static let maximumOutlineCharacters = 512
+    public static let maximumHTMLCharacters = 512_000
+    public static let maximumViewportCharacters = 128
+
     public var finalURL: URL
     public var title: String?
     public var visibleText: String?
@@ -16,12 +24,37 @@ public struct BrowserLiveDOMSnapshot: Sendable, Hashable {
         html: String? = nil,
         viewportDescription: String? = nil
     ) {
-        self.finalURL = finalURL
-        self.title = title
-        self.visibleText = visibleText
-        self.outline = outline
-        self.html = html
-        self.viewportDescription = viewportDescription
+        self.finalURL = WorkspaceBrowserRetentionPolicy.boundedURL(finalURL)
+        self.title = title.map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: Self.maximumTitleCharacters
+            )
+        }
+        self.visibleText = visibleText.map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: Self.maximumVisibleTextCharacters
+            )
+        }
+        self.outline = outline.prefix(Self.maximumOutlineCount).map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: Self.maximumOutlineCharacters
+            )
+        }
+        self.html = html.map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: Self.maximumHTMLCharacters
+            )
+        }
+        self.viewportDescription = viewportDescription.map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: Self.maximumViewportCharacters
+            )
+        }
     }
 }
 

--- a/Sources/QuillCodeApp/BrowserSessionSyncSnapshot.swift
+++ b/Sources/QuillCodeApp/BrowserSessionSyncSnapshot.swift
@@ -8,8 +8,11 @@ public struct BrowserSessionTabSnapshot: Sendable, Hashable, Identifiable {
 
     public init(id: UUID, title: String, url: URL, isActive: Bool) {
         self.id = id
-        self.title = title
-        self.url = url
+        self.title = WorkspaceBrowserRetentionPolicy.bounded(
+            title,
+            maximumCharacters: BrowserLiveDOMSnapshot.maximumTitleCharacters
+        )
+        self.url = WorkspaceBrowserRetentionPolicy.boundedURL(url)
         self.isActive = isActive
     }
 }

--- a/Sources/QuillCodeApp/BrowserSessionUpdate.swift
+++ b/Sources/QuillCodeApp/BrowserSessionUpdate.swift
@@ -15,8 +15,11 @@ public struct BrowserSessionTabUpdate: Sendable, Hashable, Identifiable {
         liveDOMSnapshot: BrowserLiveDOMSnapshot? = nil
     ) {
         self.id = id
-        self.title = title
-        self.url = url
+        self.title = WorkspaceBrowserRetentionPolicy.bounded(
+            title,
+            maximumCharacters: BrowserLiveDOMSnapshot.maximumTitleCharacters
+        )
+        self.url = WorkspaceBrowserRetentionPolicy.boundedURL(url)
         self.isActive = isActive
         self.liveDOMSnapshot = liveDOMSnapshot
     }

--- a/Sources/QuillCodeApp/QuillCodeBrowserCommentState.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserCommentState.swift
@@ -8,8 +8,14 @@ public struct BrowserCommentState: Sendable, Hashable, Identifiable {
 
     public init(id: UUID = UUID(), url: String, text: String, createdAt: Date = Date()) {
         self.id = id
-        self.url = url
-        self.text = text
+        self.url = WorkspaceBrowserRetentionPolicy.bounded(
+            url,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumLocationCharacters
+        )
+        self.text = WorkspaceBrowserRetentionPolicy.bounded(
+            text,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumCommentCharacters
+        )
         self.createdAt = createdAt
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeBrowserPaneControls.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserPaneControls.swift
@@ -21,7 +21,11 @@ extension QuillCodeBrowserPaneView {
                     browserTabButton(tab)
                 }
 
-                browserNavigationButton(systemName: "plus", label: "New browser tab", isEnabled: true) {
+                browserNavigationButton(
+                    systemName: "plus",
+                    label: "New browser tab",
+                    isEnabled: browser.canCreateNewTab
+                ) {
                     onCommand("browser-tab-new")
                 }
 

--- a/Sources/QuillCodeApp/QuillCodeBrowserSnapshotState.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserSnapshotState.swift
@@ -16,11 +16,30 @@ public struct BrowserSnapshotState: Sendable, Hashable {
         outline: [String] = [],
         textSnippet: String? = nil
     ) {
-        self.sourceLabel = sourceLabel
+        self.sourceLabel = WorkspaceBrowserRetentionPolicy.bounded(
+            sourceLabel,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumSnapshotLabelCharacters
+        )
         self.inspectionDepth = inspectionDepth
-        self.summary = summary
-        self.details = details
-        self.outline = outline
-        self.textSnippet = textSnippet
+        self.summary = WorkspaceBrowserRetentionPolicy.bounded(
+            summary,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumSnapshotSummaryCharacters
+        )
+        self.details = WorkspaceBrowserRetentionPolicy.boundedLines(
+            details,
+            maximumCount: WorkspaceBrowserRetentionPolicy.maximumSnapshotDetailCount,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumSnapshotDetailCharacters
+        )
+        self.outline = WorkspaceBrowserRetentionPolicy.boundedLines(
+            outline,
+            maximumCount: WorkspaceBrowserRetentionPolicy.maximumSnapshotOutlineCount,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumSnapshotOutlineCharacters
+        )
+        self.textSnippet = textSnippet.map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumSnapshotTextCharacters
+            )
+        }
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeBrowserState.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserState.swift
@@ -33,6 +33,10 @@ public struct BrowserState: Sendable, Hashable {
         tabs.count > 1
     }
 
+    public var canCreateNewTab: Bool {
+        tabs.count < WorkspaceBrowserRetentionPolicy.maximumTabCount
+    }
+
     public init(
         isVisible: Bool = false,
         tabs: [BrowserTabState] = [],
@@ -48,7 +52,7 @@ public struct BrowserState: Sendable, Hashable {
     ) {
         self.isVisible = isVisible
         let selectedTabID = selectedTabID ?? tabs.first?.id ?? UUID()
-        self.tabs = tabs.isEmpty ? [
+        let initializedTabs = tabs.isEmpty ? [
             BrowserTabState(
                 id: selectedTabID,
                 addressDraft: addressDraft,
@@ -60,15 +64,39 @@ public struct BrowserState: Sendable, Hashable {
                 snapshot: snapshot,
                 comments: comments
             )
-        ] : tabs
-        self.selectedTabID = selectedTabID
-        self.addressDraft = addressDraft
-        self.currentURL = currentURL
-        self.history = history
-        self.historyIndex = historyIndex
-        self.title = title
-        self.status = status
-        self.snapshot = snapshot
-        self.comments = comments
+        ] : WorkspaceBrowserRetentionPolicy.normalizedTabs(
+            tabs,
+            selectedTabID: selectedTabID
+        )
+        self.tabs = initializedTabs
+        self.selectedTabID = initializedTabs.contains { $0.id == selectedTabID }
+            ? selectedTabID
+            : initializedTabs[0].id
+        self.addressDraft = WorkspaceBrowserRetentionPolicy.bounded(
+            addressDraft,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumLocationCharacters
+        )
+        self.currentURL = currentURL.map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumLocationCharacters
+            )
+        }
+        let retainedHistory = WorkspaceBrowserRetentionPolicy.normalizedHistory(
+            history,
+            selectedIndex: historyIndex
+        )
+        self.history = retainedHistory.entries
+        self.historyIndex = retainedHistory.selectedIndex
+        self.title = WorkspaceBrowserRetentionPolicy.bounded(
+            title,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumTabTitleCharacters
+        )
+        self.status = WorkspaceBrowserRetentionPolicy.bounded(
+            status,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumStatusCharacters
+        )
+        self.snapshot = snapshot.map(WorkspaceBrowserRetentionPolicy.normalizedSnapshot)
+        self.comments = WorkspaceBrowserRetentionPolicy.normalizedComments(comments)
     }
 }

--- a/Sources/QuillCodeApp/QuillCodeBrowserSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserSurface.swift
@@ -22,6 +22,10 @@ public struct BrowserSurface: Codable, Sendable, Hashable {
         !addressDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    public var canCreateNewTab: Bool {
+        tabs.count < WorkspaceBrowserRetentionPolicy.maximumTabCount
+    }
+
     public init(
         browser: BrowserState,
         emptyTitle: String = "Open a localhost, file, or web page inside \(QuillCodeProduct.displayName).",

--- a/Sources/QuillCodeApp/QuillCodeBrowserTabState.swift
+++ b/Sources/QuillCodeApp/QuillCodeBrowserTabState.swift
@@ -33,13 +33,31 @@ public struct BrowserTabState: Sendable, Hashable, Identifiable {
         comments: [BrowserCommentState] = []
     ) {
         self.id = id
-        self.addressDraft = addressDraft
-        self.currentURL = currentURL
-        self.history = history
-        self.historyIndex = historyIndex
-        self.title = title
-        self.status = status
-        self.snapshot = snapshot
-        self.comments = comments
+        self.addressDraft = WorkspaceBrowserRetentionPolicy.bounded(
+            addressDraft,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumLocationCharacters
+        )
+        self.currentURL = currentURL.map {
+            WorkspaceBrowserRetentionPolicy.bounded(
+                $0,
+                maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumLocationCharacters
+            )
+        }
+        let retainedHistory = WorkspaceBrowserRetentionPolicy.normalizedHistory(
+            history,
+            selectedIndex: historyIndex
+        )
+        self.history = retainedHistory.entries
+        self.historyIndex = retainedHistory.selectedIndex
+        self.title = WorkspaceBrowserRetentionPolicy.bounded(
+            title,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumTabTitleCharacters
+        )
+        self.status = WorkspaceBrowserRetentionPolicy.bounded(
+            status,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumStatusCharacters
+        )
+        self.snapshot = snapshot.map(WorkspaceBrowserRetentionPolicy.normalizedSnapshot)
+        self.comments = WorkspaceBrowserRetentionPolicy.normalizedComments(comments)
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceBrowserEngine.swift
+++ b/Sources/QuillCodeApp/WorkspaceBrowserEngine.swift
@@ -1,8 +1,13 @@
 import Foundation
 
 struct WorkspaceBrowserEngine {
-    static func newTab(state: inout BrowserState) -> UUID {
+    static func newTab(state: inout BrowserState) -> UUID? {
         storeSelectedTab(in: &state)
+        guard state.canCreateNewTab else {
+            state.status = WorkspaceBrowserRetentionPolicy.tabLimitStatus
+            storeSelectedTab(in: &state)
+            return nil
+        }
         let tab = BrowserTabState()
         state.tabs.append(tab)
         state.selectedTabID = tab.id
@@ -57,7 +62,9 @@ struct WorkspaceBrowserEngine {
         state.title = BrowserInspector.title(for: state.snapshot, fallbackURL: url)
         state.status = "Preview ready"
         if updateHistory {
-            appendHistory(url.absoluteString, state: &state)
+            if appendHistory(url.absoluteString, state: &state) {
+                state.status = "Preview ready; older browser history released."
+            }
         }
         storeSelectedTab(in: &state)
     }
@@ -128,7 +135,13 @@ struct WorkspaceBrowserEngine {
         storeSelectedTab(in: &state)
 
         var changed = false
+        var rejectedNewTab = false
         for tabUpdate in update.tabs {
+            if !state.tabs.contains(where: { $0.id == tabUpdate.id }),
+               !state.canCreateNewTab {
+                rejectedNewTab = true
+                continue
+            }
             changed = apply(tabUpdate, state: &state) || changed
         }
 
@@ -141,13 +154,22 @@ struct WorkspaceBrowserEngine {
 
         loadSelectedTab(into: &state)
         state.isVisible = true
+        if rejectedNewTab {
+            state.status = WorkspaceBrowserRetentionPolicy.tabLimitStatus
+            storeSelectedTab(in: &state)
+            changed = true
+        }
         return changed
     }
 
     static func markSnapshotFetchFailure(_ error: any Error, state: inout BrowserState) {
         if var snapshot = state.snapshot {
             let message = WorkspaceBrowserLocationResolver.snapshotFetchMessage(for: error)
-            snapshot.details.append("Snapshot fetch: \(message)")
+            snapshot.details = WorkspaceBrowserRetentionPolicy.replacingDiagnostic(
+                prefix: "Snapshot fetch: ",
+                message: message,
+                in: snapshot.details
+            )
             state.snapshot = snapshot
         }
         state.status = "Preview ready"
@@ -156,7 +178,11 @@ struct WorkspaceBrowserEngine {
 
     static func markLiveDOMCaptureFailure(_ error: any Error, state: inout BrowserState) {
         if var snapshot = state.snapshot {
-            snapshot.details.append("Live DOM capture: \(liveDOMCaptureMessage(for: error))")
+            snapshot.details = WorkspaceBrowserRetentionPolicy.replacingDiagnostic(
+                prefix: "Live DOM capture: ",
+                message: liveDOMCaptureMessage(for: error),
+                in: snapshot.details
+            )
             state.snapshot = snapshot
         }
         state.status = "Preview ready"
@@ -169,8 +195,27 @@ struct WorkspaceBrowserEngine {
         guard !trimmed.isEmpty, let url = state.currentURL else {
             return false
         }
-        state.comments.append(BrowserCommentState(url: url, text: trimmed))
-        state.status = "Comment added"
+        let shortenedComment = WorkspaceBrowserRetentionPolicy.exceedsMaximumCharacters(
+            trimmed,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumCommentCharacters
+        )
+        let boundedText = WorkspaceBrowserRetentionPolicy.bounded(
+            trimmed,
+            maximumCharacters: WorkspaceBrowserRetentionPolicy.maximumCommentCharacters
+        )
+        state.comments.append(BrowserCommentState(url: url, text: boundedText))
+        let releasedComment = state.comments.count > WorkspaceBrowserRetentionPolicy.maximumCommentCount
+        state.comments = WorkspaceBrowserRetentionPolicy.normalizedComments(state.comments)
+        switch (shortenedComment, releasedComment) {
+        case (true, true):
+            state.status = "Comment shortened; oldest browser comment released."
+        case (true, false):
+            state.status = "Comment shortened to 4,000 characters."
+        case (false, true):
+            state.status = "Comment added; oldest browser comment released."
+        case (false, false):
+            state.status = "Comment added"
+        }
         storeSelectedTab(in: &state)
         return true
     }
@@ -178,7 +223,7 @@ struct WorkspaceBrowserEngine {
     private static func storeSelectedTab(in state: inout BrowserState) {
         ensureSelectedTab(in: &state)
         guard let index = state.tabs.firstIndex(where: { $0.id == state.selectedTabID }) else { return }
-        state.tabs[index] = BrowserTabState(
+        let retained = BrowserTabState(
             id: state.selectedTabID,
             addressDraft: state.addressDraft,
             currentURL: state.currentURL,
@@ -189,6 +234,15 @@ struct WorkspaceBrowserEngine {
             snapshot: state.snapshot,
             comments: state.comments
         )
+        state.tabs[index] = retained
+        state.addressDraft = retained.addressDraft
+        state.currentURL = retained.currentURL
+        state.history = retained.history
+        state.historyIndex = retained.historyIndex
+        state.title = retained.title
+        state.status = retained.status
+        state.snapshot = retained.snapshot
+        state.comments = retained.comments
     }
 
     @discardableResult
@@ -203,13 +257,18 @@ struct WorkspaceBrowserEngine {
 
         var tab = state.tabs[index]
         var changed = false
+        var releasedHistory = false
         let displayURL = update.liveDOMSnapshot?.finalURL ?? update.url
         let urlString = displayURL.absoluteString
         if tab.currentURL != urlString {
             tab.currentURL = urlString
             tab.addressDraft = urlString
             tab.snapshot = snapshot(for: update, displayURL: displayURL)
-            appendHistory(urlString, history: &tab.history, historyIndex: &tab.historyIndex)
+            releasedHistory = appendHistory(
+                urlString,
+                history: &tab.history,
+                historyIndex: &tab.historyIndex
+            )
             changed = true
         } else if update.liveDOMSnapshot != nil {
             tab.snapshot = snapshot(for: update, displayURL: displayURL)
@@ -228,8 +287,10 @@ struct WorkspaceBrowserEngine {
         }
 
         if changed {
-            tab.status = "Synced from browser session"
-            state.tabs[index] = tab
+            tab.status = releasedHistory
+                ? "Synced from browser session; older history released."
+                : "Synced from browser session"
+            state.tabs[index] = WorkspaceBrowserRetentionPolicy.normalizedTab(tab)
         }
         return changed
     }
@@ -246,7 +307,9 @@ struct WorkspaceBrowserEngine {
 
     private static func loadSelectedTab(into state: inout BrowserState) {
         ensureSelectedTab(in: &state)
-        guard let tab = state.tabs.first(where: { $0.id == state.selectedTabID }) else { return }
+        guard let index = state.tabs.firstIndex(where: { $0.id == state.selectedTabID }) else { return }
+        let tab = WorkspaceBrowserRetentionPolicy.normalizedTab(state.tabs[index])
+        state.tabs[index] = tab
         state.addressDraft = tab.addressDraft
         state.currentURL = tab.currentURL
         state.history = tab.history
@@ -280,27 +343,30 @@ struct WorkspaceBrowserEngine {
         return true
     }
 
-    private static func appendHistory(_ url: String, state: inout BrowserState) {
+    @discardableResult
+    private static func appendHistory(_ url: String, state: inout BrowserState) -> Bool {
         appendHistory(url, history: &state.history, historyIndex: &state.historyIndex)
     }
 
-    private static func appendHistory(_ url: String, history: inout [String], historyIndex: inout Int?) {
+    @discardableResult
+    private static func appendHistory(
+        _ url: String,
+        history: inout [String],
+        historyIndex: inout Int?
+    ) -> Bool {
         if let historyIndex,
            history.indices.contains(historyIndex),
            history[historyIndex] == url {
-            return
+            return false
         }
-
-        let preservedHistory: ArraySlice<String>
-        if let historyIndex,
-           history.indices.contains(historyIndex) {
-            preservedHistory = history.prefix(through: historyIndex)
-        } else {
-            preservedHistory = []
-        }
-
-        history = Array(preservedHistory) + [url]
-        historyIndex = history.indices.last
+        let appended = WorkspaceBrowserRetentionPolicy.historyByAppending(
+            url,
+            to: history,
+            selectedIndex: historyIndex
+        )
+        history = appended.entries
+        historyIndex = appended.selectedIndex
+        return appended.didReleaseEntries
     }
 
     private static func replaceCurrentHistory(with url: String, state: inout BrowserState) {

--- a/Sources/QuillCodeApp/WorkspaceBrowserRetentionPolicy.swift
+++ b/Sources/QuillCodeApp/WorkspaceBrowserRetentionPolicy.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+enum WorkspaceBrowserRetentionPolicy {
+    static let maximumTabCount = 20
+    static let maximumHistoryEntryCount = 128
+    static let maximumCommentCount = 100
+    static let maximumCommentCharacters = 4_000
+    static let maximumLocationCharacters = 16_384
+    static let maximumTabTitleCharacters = 512
+    static let maximumStatusCharacters = 512
+    static let maximumSnapshotLabelCharacters = 256
+    static let maximumSnapshotSummaryCharacters = 2_000
+    static let maximumSnapshotDetailCount = 64
+    static let maximumSnapshotDetailCharacters = 1_024
+    static let maximumSnapshotOutlineCount = 48
+    static let maximumSnapshotOutlineCharacters = 1_024
+    static let maximumSnapshotTextCharacters = 12_000
+
+    static let tabLimitStatus = "20-tab limit reached; close a browser tab to open another."
+
+    static func normalizedTabs(
+        _ tabs: [BrowserTabState],
+        selectedTabID: UUID
+    ) -> [BrowserTabState] {
+        var retained = Array(tabs.prefix(maximumTabCount))
+        if !retained.contains(where: { $0.id == selectedTabID }),
+           let selected = tabs.first(where: { $0.id == selectedTabID }),
+           !retained.isEmpty {
+            retained[retained.count - 1] = selected
+        }
+        return retained.map(normalizedTab)
+    }
+
+    static func normalizedTab(_ tab: BrowserTabState) -> BrowserTabState {
+        var tab = tab
+        tab.addressDraft = bounded(
+            tab.addressDraft,
+            maximumCharacters: maximumLocationCharacters
+        )
+        tab.currentURL = tab.currentURL.map {
+            bounded($0, maximumCharacters: maximumLocationCharacters)
+        }
+        tab.title = bounded(tab.title, maximumCharacters: maximumTabTitleCharacters)
+        tab.status = bounded(tab.status, maximumCharacters: maximumStatusCharacters)
+        let history = normalizedHistory(tab.history, selectedIndex: tab.historyIndex)
+        tab.history = history.entries
+        tab.historyIndex = history.selectedIndex
+        tab.comments = normalizedComments(tab.comments)
+        tab.snapshot = tab.snapshot.map(normalizedSnapshot)
+        return tab
+    }
+
+    static func normalizedHistory(
+        _ entries: [String],
+        selectedIndex: Int?
+    ) -> (entries: [String], selectedIndex: Int?) {
+        guard !entries.isEmpty else { return ([], nil) }
+        let selected = selectedIndex.flatMap { entries.indices.contains($0) ? $0 : nil }
+            ?? entries.index(before: entries.endIndex)
+        guard entries.count > maximumHistoryEntryCount else {
+            return (
+                entries.map { bounded($0, maximumCharacters: maximumLocationCharacters) },
+                selected
+            )
+        }
+
+        let latestStart = entries.count - maximumHistoryEntryCount
+        let start = min(selected, latestStart)
+        let end = start + maximumHistoryEntryCount
+        let retained = entries[start..<end].map {
+            bounded($0, maximumCharacters: maximumLocationCharacters)
+        }
+        return (retained, selected - start)
+    }
+
+    static func historyByAppending(
+        _ url: String,
+        to entries: [String],
+        selectedIndex: Int?
+    ) -> (entries: [String], selectedIndex: Int, didReleaseEntries: Bool) {
+        let preserved: ArraySlice<String>
+        if let selectedIndex, entries.indices.contains(selectedIndex) {
+            preserved = entries.prefix(through: selectedIndex)
+        } else {
+            preserved = []
+        }
+        let appended = Array(preserved) + [
+            bounded(url, maximumCharacters: maximumLocationCharacters)
+        ]
+        let didReleaseEntries = appended.count > maximumHistoryEntryCount
+        let retained = Array(appended.suffix(maximumHistoryEntryCount))
+        return (retained, retained.index(before: retained.endIndex), didReleaseEntries)
+    }
+
+    static func normalizedComments(_ comments: [BrowserCommentState]) -> [BrowserCommentState] {
+        comments
+            .suffix(maximumCommentCount)
+            .map { comment in
+                var comment = comment
+                comment.url = bounded(
+                    comment.url,
+                    maximumCharacters: maximumLocationCharacters
+                )
+                comment.text = bounded(comment.text, maximumCharacters: maximumCommentCharacters)
+                return comment
+            }
+    }
+
+    static func normalizedSnapshot(_ snapshot: BrowserSnapshotState) -> BrowserSnapshotState {
+        var snapshot = snapshot
+        snapshot.sourceLabel = bounded(
+            snapshot.sourceLabel,
+            maximumCharacters: maximumSnapshotLabelCharacters
+        )
+        snapshot.summary = bounded(
+            snapshot.summary,
+            maximumCharacters: maximumSnapshotSummaryCharacters
+        )
+        snapshot.details = boundedLines(
+            snapshot.details,
+            maximumCount: maximumSnapshotDetailCount,
+            maximumCharacters: maximumSnapshotDetailCharacters
+        )
+        snapshot.outline = boundedLines(
+            snapshot.outline,
+            maximumCount: maximumSnapshotOutlineCount,
+            maximumCharacters: maximumSnapshotOutlineCharacters
+        )
+        snapshot.textSnippet = snapshot.textSnippet.map {
+            bounded($0, maximumCharacters: maximumSnapshotTextCharacters)
+        }
+        return snapshot
+    }
+
+    static func replacingDiagnostic(
+        prefix: String,
+        message: String,
+        in details: [String]
+    ) -> [String] {
+        let retained = details.filter { !$0.hasPrefix(prefix) }
+        return boundedLines(
+            retained + [prefix + message],
+            maximumCount: maximumSnapshotDetailCount,
+            maximumCharacters: maximumSnapshotDetailCharacters
+        )
+    }
+
+    static func bounded(_ text: String, maximumCharacters: Int) -> String {
+        guard let boundary = text.index(
+            text.startIndex,
+            offsetBy: maximumCharacters,
+            limitedBy: text.endIndex
+        ), boundary != text.endIndex else {
+            return text
+        }
+        return String(text[..<boundary])
+    }
+
+    static func boundedURL(_ url: URL) -> URL {
+        let absoluteString = url.absoluteString
+        guard exceedsMaximumCharacters(
+            absoluteString,
+            maximumCharacters: maximumLocationCharacters
+        ) else {
+            return url
+        }
+        let retained = bounded(
+            absoluteString,
+            maximumCharacters: maximumLocationCharacters
+        )
+        return URL(string: retained) ?? URL(string: "about:blank")!
+    }
+
+    static func exceedsMaximumCharacters(_ text: String, maximumCharacters: Int) -> Bool {
+        guard let boundary = text.index(
+            text.startIndex,
+            offsetBy: maximumCharacters,
+            limitedBy: text.endIndex
+        ) else {
+            return false
+        }
+        return boundary != text.endIndex
+    }
+
+    static func boundedLines(
+        _ lines: [String],
+        maximumCount: Int,
+        maximumCharacters: Int
+    ) -> [String] {
+        lines
+            .suffix(maximumCount)
+            .map { bounded($0, maximumCharacters: maximumCharacters) }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceBrowserWorkflow.swift
+++ b/Sources/QuillCodeApp/WorkspaceBrowserWorkflow.swift
@@ -208,7 +208,7 @@ enum WorkspaceBrowserWorkflow {
     }
 
     @discardableResult
-    static func newTab(browser: inout BrowserState) -> UUID {
+    static func newTab(browser: inout BrowserState) -> UUID? {
         WorkspaceBrowserEngine.newTab(state: &browser)
     }
 

--- a/Sources/QuillCodeApp/WorkspaceHTMLBrowserRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLBrowserRenderer.swift
@@ -87,7 +87,8 @@ enum WorkspaceHTMLBrowserRenderer {
               commandID: "browser-tab-new",
               hitTargetKind: .icon,
               classes: ["browser-tab-action"],
-              ariaLabel: "New browser tab"
+              ariaLabel: "New browser tab",
+              disabled: !browser.canCreateNewTab
           ))
           \(WorkspaceHTMLPrimitives.commandButton(
               "×",

--- a/Sources/QuillCodeApp/WorkspaceModelBrowserSession.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelBrowserSession.swift
@@ -20,7 +20,7 @@ extension QuillCodeWorkspaceModel {
     }
 
     @discardableResult
-    public func newBrowserTab() -> UUID {
+    public func newBrowserTab() -> UUID? {
         let tabID = mutateBrowserState { browser, _ in
             WorkspaceBrowserWorkflow.newTab(browser: &browser)
         }

--- a/Sources/quill-code-desktop/DesktopBrowserLiveDOMSnapshotExtractor.swift
+++ b/Sources/quill-code-desktop/DesktopBrowserLiveDOMSnapshotExtractor.swift
@@ -47,8 +47,8 @@ enum DesktopBrowserLiveDOMSnapshotExtractor {
       const limit = (value, max) => value.length > max ? value.slice(0, max) : value;
       const outline = [];
       const push = (label) => {
-        const text = compact(label);
-        if (text && outline.length < 48) outline.push(text);
+        const text = limit(compact(label), \#(BrowserLiveDOMSnapshot.maximumOutlineCharacters));
+        if (text && outline.length < \#(BrowserLiveDOMSnapshot.maximumOutlineCount)) outline.push(text);
       };
 
       document.querySelectorAll('h1,h2,h3,h4,h5,h6,a,button,input,textarea,select,form,img').forEach((element) => {
@@ -70,12 +70,18 @@ enum DesktopBrowserLiveDOMSnapshotExtractor {
 
       const html = document.documentElement ? document.documentElement.outerHTML : '';
       return JSON.stringify({
-        url: location.href,
-        title: document.title || '',
-        text: limit(compact(document.body ? document.body.innerText : ''), 12000),
+        url: limit(location.href, \#(BrowserLiveDOMSnapshot.maximumURLCharacters)),
+        title: limit(compact(document.title), \#(BrowserLiveDOMSnapshot.maximumTitleCharacters)),
+        text: limit(
+          compact(document.body ? document.body.innerText : ''),
+          \#(BrowserLiveDOMSnapshot.maximumVisibleTextCharacters)
+        ),
         outline: outline,
-        html: limit(html, 512000),
-        viewport: `${window.innerWidth}x${window.innerHeight} @${window.devicePixelRatio || 1}x`
+        html: limit(html, \#(BrowserLiveDOMSnapshot.maximumHTMLCharacters)),
+        viewport: limit(
+          `${window.innerWidth}x${window.innerHeight} @${window.devicePixelRatio || 1}x`,
+          \#(BrowserLiveDOMSnapshot.maximumViewportCharacters)
+        )
       });
     })()
     """#

--- a/Tests/QuillCodeAppTests/BrowserLiveDOMSnapshotBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/BrowserLiveDOMSnapshotBuilderTests.swift
@@ -56,4 +56,43 @@ final class BrowserLiveDOMSnapshotBuilderTests: XCTestCase {
         XCTAssertEqual(snapshot.outline, ["Main landmark"])
         XCTAssertEqual(snapshot.textSnippet, "Rendered copy")
     }
+
+    func testLiveDOMCaptureBoundsPageControlledPayloadBeforeStorage() throws {
+        let oversizedURL = try XCTUnwrap(URL(string: "https://example.com/?q=" + String(
+            repeating: "u",
+            count: BrowserLiveDOMSnapshot.maximumURLCharacters + 20
+        )))
+        let capture = BrowserLiveDOMSnapshot(
+            finalURL: oversizedURL,
+            title: String(repeating: "t", count: BrowserLiveDOMSnapshot.maximumTitleCharacters + 20),
+            visibleText: String(
+                repeating: "v",
+                count: BrowserLiveDOMSnapshot.maximumVisibleTextCharacters + 20
+            ),
+            outline: (0..<(BrowserLiveDOMSnapshot.maximumOutlineCount + 5)).map { index in
+                "\(index)-" + String(
+                    repeating: "o",
+                    count: BrowserLiveDOMSnapshot.maximumOutlineCharacters + 20
+                )
+            },
+            html: String(repeating: "h", count: BrowserLiveDOMSnapshot.maximumHTMLCharacters + 20),
+            viewportDescription: String(
+                repeating: "p",
+                count: BrowserLiveDOMSnapshot.maximumViewportCharacters + 20
+            )
+        )
+
+        XCTAssertEqual(capture.finalURL.absoluteString.count, BrowserLiveDOMSnapshot.maximumURLCharacters)
+        XCTAssertEqual(capture.title?.count, BrowserLiveDOMSnapshot.maximumTitleCharacters)
+        XCTAssertEqual(capture.visibleText?.count, BrowserLiveDOMSnapshot.maximumVisibleTextCharacters)
+        XCTAssertEqual(capture.outline.count, BrowserLiveDOMSnapshot.maximumOutlineCount)
+        XCTAssertTrue(capture.outline.allSatisfy {
+            $0.count == BrowserLiveDOMSnapshot.maximumOutlineCharacters
+        })
+        XCTAssertEqual(capture.html?.count, BrowserLiveDOMSnapshot.maximumHTMLCharacters)
+        XCTAssertEqual(
+            capture.viewportDescription?.count,
+            BrowserLiveDOMSnapshot.maximumViewportCharacters
+        )
+    }
 }

--- a/Tests/QuillCodeAppTests/BrowserSessionSyncSnapshotTests.swift
+++ b/Tests/QuillCodeAppTests/BrowserSessionSyncSnapshotTests.swift
@@ -10,8 +10,8 @@ final class BrowserSessionSyncSnapshotTests: XCTestCase {
             state: &browser,
             updateHistory: true
         )
-        let emptyTabID = WorkspaceBrowserEngine.newTab(state: &browser)
-        let secondTabID = WorkspaceBrowserEngine.newTab(state: &browser)
+        let emptyTabID = try XCTUnwrap(WorkspaceBrowserEngine.newTab(state: &browser))
+        let secondTabID = try XCTUnwrap(WorkspaceBrowserEngine.newTab(state: &browser))
         WorkspaceBrowserEngine.openPage(
             try XCTUnwrap(URL(string: "http://localhost:5173/dashboard")),
             state: &browser,

--- a/Tests/QuillCodeAppTests/QuillCodeBrowserSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeBrowserSurfaceTests.swift
@@ -9,6 +9,7 @@ final class QuillCodeBrowserSurfaceTests: XCTestCase {
         XCTAssertFalse(browser.canGoForward)
         XCTAssertFalse(browser.canReload)
         XCTAssertFalse(browser.canCloseSelectedTab)
+        XCTAssertTrue(browser.canCreateNewTab)
         XCTAssertEqual(browser.tabs.count, 1)
         XCTAssertEqual(browser.tabs.first?.id, browser.selectedTabID)
         XCTAssertEqual(browser.title, "Browser preview")
@@ -105,6 +106,7 @@ final class QuillCodeBrowserSurfaceTests: XCTestCase {
         XCTAssertEqual(surface.tabs.first?.title, "Docs")
         XCTAssertEqual(surface.tabs.first?.urlLabel, "example.com")
         XCTAssertFalse(surface.canCloseActiveTab)
+        XCTAssertTrue(surface.canCreateNewTab)
     }
 
     func testBrowserSurfaceMapsMultipleTabsIntoPresentationContract() {
@@ -134,5 +136,79 @@ final class QuillCodeBrowserSurfaceTests: XCTestCase {
         XCTAssertTrue(surface.canCloseActiveTab)
         XCTAssertEqual(surface.tabs[0].selectCommandID, "browser-tab-select:\(firstID.uuidString)")
         XCTAssertEqual(surface.tabs[1].closeCommandID, "browser-tab-close:\(secondID.uuidString)")
+    }
+
+    func testBrowserStateAndSurfaceRetainSelectedTabAtCapacity() throws {
+        let selectedID = UUID()
+        let tabs = (0..<(WorkspaceBrowserRetentionPolicy.maximumTabCount + 4)).map { index in
+            BrowserTabState(
+                id: index == WorkspaceBrowserRetentionPolicy.maximumTabCount + 3
+                    ? selectedID
+                    : UUID(),
+                title: "Tab \(index)"
+            )
+        }
+
+        let browser = BrowserState(tabs: tabs, selectedTabID: selectedID)
+        let surface = BrowserSurface(browser: browser)
+
+        XCTAssertEqual(browser.tabs.count, WorkspaceBrowserRetentionPolicy.maximumTabCount)
+        XCTAssertTrue(browser.tabs.contains { $0.id == selectedID })
+        XCTAssertEqual(browser.selectedTabID, selectedID)
+        XCTAssertFalse(browser.canCreateNewTab)
+        XCTAssertFalse(surface.canCreateNewTab)
+
+        let html = WorkspaceHTMLBrowserRenderer.render(
+            BrowserSurface(browser: BrowserState(isVisible: true, tabs: browser.tabs, selectedTabID: selectedID))
+        )
+        let buttonStart = try XCTUnwrap(
+            html.range(of: #"data-testid="browser-new-tab""#)?.lowerBound
+        )
+        let buttonEnd = try XCTUnwrap(html[buttonStart...].range(of: "</button>")?.upperBound)
+        XCTAssertTrue(html[buttonStart..<buttonEnd].contains(" disabled"))
+    }
+
+    func testSnapshotStateBoundsExternallyConstructedPresentationText() {
+        let snapshot = BrowserSnapshotState(
+            sourceLabel: String(
+                repeating: "s",
+                count: WorkspaceBrowserRetentionPolicy.maximumSnapshotLabelCharacters + 10
+            ),
+            summary: String(
+                repeating: "m",
+                count: WorkspaceBrowserRetentionPolicy.maximumSnapshotSummaryCharacters + 10
+            ),
+            details: (0..<(WorkspaceBrowserRetentionPolicy.maximumSnapshotDetailCount + 4)).map { _ in
+                String(
+                    repeating: "d",
+                    count: WorkspaceBrowserRetentionPolicy.maximumSnapshotDetailCharacters + 10
+                )
+            },
+            outline: (0..<(WorkspaceBrowserRetentionPolicy.maximumSnapshotOutlineCount + 4)).map { _ in
+                String(
+                    repeating: "o",
+                    count: WorkspaceBrowserRetentionPolicy.maximumSnapshotOutlineCharacters + 10
+                )
+            },
+            textSnippet: String(
+                repeating: "t",
+                count: WorkspaceBrowserRetentionPolicy.maximumSnapshotTextCharacters + 10
+            )
+        )
+
+        XCTAssertEqual(snapshot.sourceLabel.count, WorkspaceBrowserRetentionPolicy.maximumSnapshotLabelCharacters)
+        XCTAssertEqual(snapshot.summary.count, WorkspaceBrowserRetentionPolicy.maximumSnapshotSummaryCharacters)
+        XCTAssertEqual(snapshot.details.count, WorkspaceBrowserRetentionPolicy.maximumSnapshotDetailCount)
+        XCTAssertTrue(snapshot.details.allSatisfy {
+            $0.count == WorkspaceBrowserRetentionPolicy.maximumSnapshotDetailCharacters
+        })
+        XCTAssertEqual(snapshot.outline.count, WorkspaceBrowserRetentionPolicy.maximumSnapshotOutlineCount)
+        XCTAssertTrue(snapshot.outline.allSatisfy {
+            $0.count == WorkspaceBrowserRetentionPolicy.maximumSnapshotOutlineCharacters
+        })
+        XCTAssertEqual(
+            snapshot.textSnippet?.count,
+            WorkspaceBrowserRetentionPolicy.maximumSnapshotTextCharacters
+        )
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceBrowserEngineTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceBrowserEngineTests.swift
@@ -121,7 +121,7 @@ final class WorkspaceBrowserEngineTests: XCTestCase {
         var browser = BrowserState()
         let firstTabID = browser.selectedTabID
         WorkspaceBrowserEngine.openPage(try XCTUnwrap(URL(string: "https://example.com/docs")), state: &browser, updateHistory: true)
-        let secondTabID = WorkspaceBrowserEngine.newTab(state: &browser)
+        let secondTabID = try XCTUnwrap(WorkspaceBrowserEngine.newTab(state: &browser))
         WorkspaceBrowserEngine.openPage(try XCTUnwrap(URL(string: "https://trustedrouter.com")), state: &browser, updateHistory: true)
 
         let update = BrowserSessionUpdate(
@@ -249,7 +249,7 @@ final class WorkspaceBrowserEngineTests: XCTestCase {
         XCTAssertTrue(WorkspaceBrowserEngine.addComment("First tab note", state: &browser))
         let firstTabID = browser.selectedTabID
 
-        let secondTabID = WorkspaceBrowserEngine.newTab(state: &browser)
+        let secondTabID = try XCTUnwrap(WorkspaceBrowserEngine.newTab(state: &browser))
         XCTAssertEqual(browser.selectedTabID, secondTabID)
         XCTAssertNil(browser.currentURL)
         XCTAssertEqual(browser.status, "New tab")
@@ -273,7 +273,7 @@ final class WorkspaceBrowserEngineTests: XCTestCase {
         var browser = BrowserState()
         let firstTabID = browser.selectedTabID
         WorkspaceBrowserEngine.openPage(try XCTUnwrap(URL(string: "https://example.com")), state: &browser, updateHistory: true)
-        let secondTabID = WorkspaceBrowserEngine.newTab(state: &browser)
+        let secondTabID = try XCTUnwrap(WorkspaceBrowserEngine.newTab(state: &browser))
         WorkspaceBrowserEngine.openPage(try XCTUnwrap(URL(string: "https://trustedrouter.com")), state: &browser, updateHistory: true)
 
         XCTAssertTrue(WorkspaceBrowserEngine.closeTab(id: secondTabID, state: &browser))
@@ -283,4 +283,5 @@ final class WorkspaceBrowserEngineTests: XCTestCase {
         XCTAssertFalse(WorkspaceBrowserEngine.closeTab(id: firstTabID, state: &browser))
         XCTAssertEqual(browser.tabs.count, 1)
     }
+
 }

--- a/Tests/QuillCodeAppTests/WorkspaceBrowserRetentionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceBrowserRetentionTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import QuillCodeApp
+
+final class WorkspaceBrowserRetentionTests: XCTestCase {
+    func testImportedHistoryRetentionPreservesSelectedPageAndValidIndex() {
+        let entries = (0..<300).map { "https://example.com/page/\($0)" }
+
+        let early = WorkspaceBrowserRetentionPolicy.normalizedHistory(
+            entries,
+            selectedIndex: 20
+        )
+        XCTAssertEqual(early.entries.count, WorkspaceBrowserRetentionPolicy.maximumHistoryEntryCount)
+        XCTAssertEqual(early.entries.first, "https://example.com/page/20")
+        XCTAssertEqual(early.entries.last, "https://example.com/page/147")
+        XCTAssertEqual(early.selectedIndex, 0)
+
+        let later = WorkspaceBrowserRetentionPolicy.normalizedHistory(
+            entries,
+            selectedIndex: 220
+        )
+        XCTAssertEqual(later.entries.count, WorkspaceBrowserRetentionPolicy.maximumHistoryEntryCount)
+        XCTAssertEqual(later.entries.first, "https://example.com/page/172")
+        XCTAssertEqual(later.entries.last, "https://example.com/page/299")
+        XCTAssertEqual(later.selectedIndex, 48)
+        XCTAssertEqual(later.entries[later.selectedIndex ?? -1], "https://example.com/page/220")
+    }
+
+    func testLongNavigationRetainsNewestBoundedHistoryAndValidBackState() throws {
+        var browser = BrowserState()
+        let overflow = 37
+
+        for index in 0..<(WorkspaceBrowserRetentionPolicy.maximumHistoryEntryCount + overflow) {
+            WorkspaceBrowserEngine.openPage(
+                try XCTUnwrap(URL(string: "https://example.com/page/\(index)")),
+                state: &browser,
+                updateHistory: true
+            )
+        }
+
+        XCTAssertEqual(browser.history.count, WorkspaceBrowserRetentionPolicy.maximumHistoryEntryCount)
+        XCTAssertEqual(browser.history.first, "https://example.com/page/\(overflow)")
+        XCTAssertEqual(
+            browser.history.last,
+            "https://example.com/page/\(WorkspaceBrowserRetentionPolicy.maximumHistoryEntryCount + overflow - 1)"
+        )
+        XCTAssertEqual(browser.historyIndex, WorkspaceBrowserRetentionPolicy.maximumHistoryEntryCount - 1)
+        XCTAssertTrue(browser.canGoBack)
+        XCTAssertFalse(browser.canGoForward)
+        XCTAssertEqual(browser.status, "Preview ready; older browser history released.")
+
+        XCTAssertTrue(WorkspaceBrowserEngine.goBack(state: &browser))
+        XCTAssertEqual(
+            browser.currentURL,
+            "https://example.com/page/\(WorkspaceBrowserRetentionPolicy.maximumHistoryEntryCount + overflow - 2)"
+        )
+        XCTAssertTrue(browser.canGoForward)
+    }
+
+    func testLongCommentSessionRetainsNewestCommentsAndBoundsText() throws {
+        var browser = BrowserState()
+        WorkspaceBrowserEngine.openPage(
+            try XCTUnwrap(URL(string: "https://example.com/review")),
+            state: &browser,
+            updateHistory: true
+        )
+        let overflow = 13
+        for index in 0..<(WorkspaceBrowserRetentionPolicy.maximumCommentCount + overflow) {
+            XCTAssertTrue(WorkspaceBrowserEngine.addComment("Comment \(index)", state: &browser))
+        }
+
+        XCTAssertEqual(browser.comments.count, WorkspaceBrowserRetentionPolicy.maximumCommentCount)
+        XCTAssertEqual(browser.comments.first?.text, "Comment \(overflow)")
+        XCTAssertEqual(
+            browser.comments.last?.text,
+            "Comment \(WorkspaceBrowserRetentionPolicy.maximumCommentCount + overflow - 1)"
+        )
+        XCTAssertEqual(browser.status, "Comment added; oldest browser comment released.")
+
+        let oversized = String(
+            repeating: "x",
+            count: WorkspaceBrowserRetentionPolicy.maximumCommentCharacters + 100
+        )
+        XCTAssertTrue(WorkspaceBrowserEngine.addComment(oversized, state: &browser))
+        XCTAssertEqual(
+            browser.comments.last?.text.count,
+            WorkspaceBrowserRetentionPolicy.maximumCommentCharacters
+        )
+        XCTAssertEqual(browser.status, "Comment shortened; oldest browser comment released.")
+    }
+
+    func testRepeatedFailuresReplaceDiagnosticsInsteadOfGrowingSnapshot() throws {
+        var browser = BrowserState()
+        WorkspaceBrowserEngine.openPage(
+            try XCTUnwrap(URL(string: "https://example.com")),
+            state: &browser,
+            updateHistory: true
+        )
+
+        for status in 500..<700 {
+            WorkspaceBrowserEngine.markSnapshotFetchFailure(
+                BrowserPageFetchFailure.httpStatus(status),
+                state: &browser
+            )
+            WorkspaceBrowserEngine.markLiveDOMCaptureFailure(
+                BrowserLiveDOMCaptureFailure.transport("capture \(status)"),
+                state: &browser
+            )
+        }
+
+        let details = try XCTUnwrap(browser.snapshot?.details)
+        XCTAssertEqual(details.filter { $0.hasPrefix("Snapshot fetch: ") }.count, 1)
+        XCTAssertEqual(details.filter { $0.hasPrefix("Live DOM capture: ") }.count, 1)
+        XCTAssertTrue(details.contains("Snapshot fetch: The page returned HTTP 699."))
+        XCTAssertTrue(details.contains("Live DOM capture: capture 699"))
+        XCTAssertLessThanOrEqual(details.count, WorkspaceBrowserRetentionPolicy.maximumSnapshotDetailCount)
+    }
+
+    func testTabCapacityRejectsNewTabWithoutChangingSelectionAndRecoversAfterClose() throws {
+        var browser = BrowserState()
+        for _ in 1..<WorkspaceBrowserRetentionPolicy.maximumTabCount {
+            _ = try XCTUnwrap(WorkspaceBrowserEngine.newTab(state: &browser))
+        }
+        let selectedAtCapacity = browser.selectedTabID
+
+        XCTAssertEqual(browser.tabs.count, WorkspaceBrowserRetentionPolicy.maximumTabCount)
+        XCTAssertFalse(browser.canCreateNewTab)
+        XCTAssertNil(WorkspaceBrowserEngine.newTab(state: &browser))
+        XCTAssertEqual(browser.tabs.count, WorkspaceBrowserRetentionPolicy.maximumTabCount)
+        XCTAssertEqual(browser.selectedTabID, selectedAtCapacity)
+        XCTAssertEqual(browser.status, WorkspaceBrowserRetentionPolicy.tabLimitStatus)
+
+        XCTAssertTrue(WorkspaceBrowserEngine.closeTab(id: selectedAtCapacity, state: &browser))
+        XCTAssertTrue(browser.canCreateNewTab)
+        XCTAssertNotNil(WorkspaceBrowserEngine.newTab(state: &browser))
+        XCTAssertEqual(browser.tabs.count, WorkspaceBrowserRetentionPolicy.maximumTabCount)
+    }
+
+    func testSessionUpdateCannotInsertTabBeyondCapacityOrStealSelection() throws {
+        var browser = BrowserState()
+        for _ in 1..<WorkspaceBrowserRetentionPolicy.maximumTabCount {
+            _ = try XCTUnwrap(WorkspaceBrowserEngine.newTab(state: &browser))
+        }
+        let selectedAtCapacity = browser.selectedTabID
+        let rejectedTabID = UUID()
+
+        XCTAssertTrue(WorkspaceBrowserEngine.applySessionUpdate(
+            BrowserSessionUpdate(
+                tabs: [
+                    BrowserSessionTabUpdate(
+                        id: rejectedTabID,
+                        title: "Rejected",
+                        url: try XCTUnwrap(URL(string: "https://example.com/rejected")),
+                        isActive: true
+                    )
+                ],
+                activeTabID: rejectedTabID
+            ),
+            state: &browser
+        ))
+
+        XCTAssertEqual(browser.tabs.count, WorkspaceBrowserRetentionPolicy.maximumTabCount)
+        XCTAssertFalse(browser.tabs.contains { $0.id == rejectedTabID })
+        XCTAssertEqual(browser.selectedTabID, selectedAtCapacity)
+        XCTAssertEqual(browser.status, WorkspaceBrowserRetentionPolicy.tabLimitStatus)
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityBrowserSessionSyncGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityBrowserSessionSyncGateTests.swift
@@ -5,6 +5,7 @@ final class ParityBrowserSessionSyncGateTests: QuillCodeParityTestCase {
         let snapshotText = try Self.appSourceText(named: "BrowserSessionSyncSnapshot.swift")
         let updateText = try Self.appSourceText(named: "BrowserSessionUpdate.swift")
         let engineText = try Self.appSourceText(named: "WorkspaceBrowserEngine.swift")
+        let retentionPolicyText = try Self.appSourceText(named: "WorkspaceBrowserRetentionPolicy.swift")
         let workflowText = try Self.appSourceText(named: "WorkspaceBrowserWorkflow.swift")
         let browserModelText = try Self.appSourceText(named: "WorkspaceModelBrowserSession.swift")
         let presenterText = try Self.desktopSourceText(named: "DesktopBrowserSessionPresenter.swift")
@@ -14,6 +15,7 @@ final class ParityBrowserSessionSyncGateTests: QuillCodeParityTestCase {
         let controllerText = try Self.desktopControllerSourceText()
         let snapshotTests = try Self.appTestSourceText(named: "BrowserSessionSyncSnapshotTests.swift")
         let engineTests = try Self.appTestSourceText(named: "WorkspaceBrowserEngineTests.swift")
+        let retentionTests = try Self.appTestSourceText(named: "WorkspaceBrowserRetentionTests.swift")
         let integrationTests = try Self.appTestSourceText(named: "WorkspaceBrowserIntegrationTests.swift")
 
         for expected in [
@@ -36,6 +38,18 @@ final class ParityBrowserSessionSyncGateTests: QuillCodeParityTestCase {
         Self.assertSource(updateText, excludes: "WebKit")
         Self.assertSource(updateText, excludes: "AppKit")
         Self.assertSource(engineText, contains: "static func applySessionUpdate")
+        for expected in [
+            "static let maximumTabCount = 20",
+            "static let maximumHistoryEntryCount = 128",
+            "static let maximumCommentCount = 100",
+            "static func historyByAppending",
+            "static func replacingDiagnostic"
+        ] {
+            Self.assertSource(retentionPolicyText, contains: expected)
+        }
+        Self.assertSource(engineText, contains: "state.canCreateNewTab")
+        Self.assertSource(engineText, contains: "WorkspaceBrowserRetentionPolicy.normalizedComments")
+        Self.assertSource(engineText, contains: "WorkspaceBrowserRetentionPolicy.replacingDiagnostic")
         Self.assertSource(workflowText, contains: "WorkspaceBrowserEngine.applySessionUpdate")
         Self.assertSource(browserModelText, contains: "public func applyBrowserSessionUpdate")
         for expected in [
@@ -86,6 +100,14 @@ final class ParityBrowserSessionSyncGateTests: QuillCodeParityTestCase {
         Self.assertSource(
             engineTests,
             contains: "testSessionUpdateCanCarryRenderedLiveDOMFromVisibleBrowserSession"
+        )
+        Self.assertSource(
+            retentionTests,
+            contains: "testLongNavigationRetainsNewestBoundedHistoryAndValidBackState"
+        )
+        Self.assertSource(
+            retentionTests,
+            contains: "testSessionUpdateCannotInsertTabBeyondCapacityOrStealSelection"
         )
         Self.assertSource(integrationTests, contains: "testVisibleBrowserSessionUpdateRefreshesModelAndSurface")
         Self.assertSource(integrationTests, contains: "testVisibleBrowserSessionUpdateRefreshesRenderedSnapshotInSurface")

--- a/Tests/QuillCodeParityTests/ParityDesktopBrowserAdapterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopBrowserAdapterGateTests.swift
@@ -17,6 +17,22 @@ final class ParityDesktopBrowserAdapterGateTests: QuillCodeParityTestCase {
         Self.assertSource(capturerText, contains: "DesktopBrowserLiveDOMSnapshotExtractor.snapshot")
         Self.assertSource(extractorText, contains: "evaluateJavaScript")
         Self.assertSource(extractorText, contains: "BrowserLiveDOMSnapshot")
+        Self.assertSource(
+            extractorText,
+            contains: "BrowserLiveDOMSnapshot.maximumURLCharacters"
+        )
+        Self.assertSource(
+            extractorText,
+            contains: "BrowserLiveDOMSnapshot.maximumOutlineCharacters"
+        )
+        Self.assertSource(
+            extractorText,
+            contains: "BrowserLiveDOMSnapshot.maximumVisibleTextCharacters"
+        )
+        Self.assertSource(
+            extractorText,
+            contains: "BrowserLiveDOMSnapshot.maximumHTMLCharacters"
+        )
         Self.assertSource(capturerText, contains: "enum DesktopBrowserLiveDOMProfile")
         Self.assertSource(capturerText, contains: "case persistent")
         Self.assertSource(capturerText, contains: "case ephemeral")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -17360,3 +17360,26 @@ Validation:
 - Final physical-footprint evidence: 294.68 ms launch-ready, 41.00 MiB initial, 87.92 MiB post-interaction, 89.94 MiB repeated-interaction, and 2.02 MiB repeated growth
 - `python3 scripts/grade-code-quality.py --root .` (all touched modules A+)
 - `git diff --check`
+
+## 2026-08-11 Bounded Browser Session Residency
+
+Overall grade after this slice: **A+ memory architecture, A+ crash resilience, A+ packaged usability**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Memory architecture | A+ | Browser residency is bounded to 20 tabs, 128 history entries per tab, 100 comments per tab, and capped snapshot fields; oversized restores process only the retained history window instead of allocating normalized copies of every imported entry. |
+| WebKit boundary | A+ | Page-controlled URL, title, visible text, outline, HTML, and viewport payloads are capped in JavaScript before bridge transfer and normalized again in the model-owned snapshot contract. |
+| Long-session resilience | A+ | Repeated fetch and live-DOM failures replace their prior diagnostics, forward-history pruning remains valid, and rejected over-capacity session tabs cannot steal selection. |
+| Capacity UX | A+ | Native and HTML new-tab controls disable at capacity, tab creation fails without changing the active page, and concise statuses explain released history/comments or shortened comment text. |
+| Browser workflow | A+ | Packaged direct and Launch Services runs completed authenticated-form, CRM, and shared-sheet inspect/type/click/script analogues with matching rendered state. These are deterministic local analogues and do not claim external SaaS authentication coverage. |
+| Packaged performance | A+ | Three independent 100-chat launches passed: 306.25 ms median readiness, 41.09 MiB initial physical footprint, 85.97 MiB post-interaction, 88.58 MiB repeated-interaction, 2.61 MiB repeated growth, and eight repeated-interaction threads. |
+| Regression evidence | A+ | Scale tests cover retained-window index fidelity, long navigation, comment rollover, diagnostic replacement, tab capacity, external session insertion, DOM payload caps, and native/HTML parity. |
+
+Validation:
+
+- `swift test` (6,183 tests; 5 skipped; 0 failures)
+- `scripts/packaged-macos-smoke.sh` (SIGKILL draft recovery, direct and Launch Services rendering, live-window accessibility, browser workflows, computer-use contracts, and 100-chat interaction passed)
+- `scripts/packaged-macos-performance-smoke.sh` (3/3 launches within startup, physical-footprint, growth, and thread budgets)
+- Final three-launch physical-footprint evidence: 306.25 ms median launch-ready, 41.09 MiB initial, 85.97 MiB post-interaction, 88.58 MiB repeated-interaction, and 2.61 MiB repeated growth
+- `python3 scripts/grade-code-quality.py --root .` (all production modules A+)
+- `git diff --check`


### PR DESCRIPTION
## Summary
- bound browser tabs, history, comments, diagnostics, snapshots, and page-controlled WebKit payloads
- preserve selected-page history semantics while avoiding oversized restore allocations
- disable new-tab controls at capacity with clear native and HTML status UX
- add long-session, capacity, DOM-boundary, and parity regressions

## Validation
- swift test (6,183 tests; 5 skipped; 0 failures)
- scripts/packaged-macos-smoke.sh
- scripts/packaged-macos-performance-smoke.sh (3/3 within budget; 306.25 ms median, 41.09 MiB initial, 88.58 MiB repeated)
- python3 scripts/grade-code-quality.py --root . (all production modules A+)
- git diff --check