### PR TITLE
Bound image preview memory usage

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactDocumentPreview.swift
@@ -1624,7 +1624,7 @@ struct QuillCodeArtifactDocumentPreview: View {
     @ViewBuilder
     private func appshotThumbnail(_ appshotPreview: ToolArtifactAppshotPreview) -> some View {
         if let screenshotURL = appshotPreview.screenshotURL.flatMap(URL.init(string:)) {
-            AsyncImage(url: screenshotURL) { phase in
+            QuillCodeBoundedAsyncImage(url: screenshotURL, maximumPixelSize: 256) { phase in
                 switch phase {
                 case .success(let image):
                     image

--- a/Sources/QuillCodeApp/QuillCodeArtifactImagePreview.swift
+++ b/Sources/QuillCodeApp/QuillCodeArtifactImagePreview.swift
@@ -23,7 +23,7 @@ struct QuillCodeArtifactImagePreview: View {
     @ViewBuilder
     private var imageContent: some View {
         if let url = previewURL {
-            AsyncImage(url: url) { phase in
+            QuillCodeBoundedAsyncImage(url: url, maximumPixelSize: 1_536) { phase in
                 switch phase {
                 case .success(let image):
                     image

--- a/Sources/QuillCodeApp/QuillCodeBoundedAsyncImage.swift
+++ b/Sources/QuillCodeApp/QuillCodeBoundedAsyncImage.swift
@@ -1,0 +1,369 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import QuillCodePlatformUI
+import SwiftUI
+
+struct QuillCodeDecodedThumbnail: @unchecked Sendable {
+    var image: CGImage
+    var pixelWidth: Int
+    var pixelHeight: Int
+}
+
+enum QuillCodeImageThumbnailError: Error {
+    case invalidSource
+    case sourceTooLarge
+    case unsupportedImage
+}
+
+enum QuillCodeImageThumbnailLoader {
+    static let maximumEncodedBytes = 32 * 1_024 * 1_024
+
+    static func load(
+        from url: URL,
+        maximumPixelSize: Int,
+        remoteSessionConfiguration: URLSessionConfiguration? = nil
+    ) async throws -> QuillCodeDecodedThumbnail {
+        let boundedPixelSize = max(1, maximumPixelSize)
+        if url.isFileURL {
+            return try await Task.detached(priority: .utility) {
+                try thumbnail(fromFile: url, maximumPixelSize: boundedPixelSize)
+            }.value
+        }
+        let encodedData: Data
+        switch url.scheme?.lowercased() {
+        case "data":
+            encodedData = try data(from: url)
+        case "https", "http":
+            encodedData = try await remoteData(
+                from: url,
+                sessionConfiguration: remoteSessionConfiguration
+            )
+        default:
+            throw QuillCodeImageThumbnailError.invalidSource
+        }
+        return try await Task.detached(priority: .utility) {
+            try thumbnail(from: encodedData, maximumPixelSize: boundedPixelSize)
+        }.value
+    }
+
+    static func thumbnail(
+        from data: Data,
+        maximumPixelSize: Int
+    ) throws -> QuillCodeDecodedThumbnail {
+        guard !data.isEmpty, data.count <= maximumEncodedBytes else {
+            throw QuillCodeImageThumbnailError.sourceTooLarge
+        }
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, options) else {
+            return try svgThumbnail(from: data, maximumPixelSize: maximumPixelSize)
+        }
+        do {
+            return try thumbnail(from: source, maximumPixelSize: maximumPixelSize)
+        } catch QuillCodeImageThumbnailError.unsupportedImage {
+            return try svgThumbnail(from: data, maximumPixelSize: maximumPixelSize)
+        }
+    }
+
+    static func thumbnail(
+        fromFile url: URL,
+        maximumPixelSize: Int
+    ) throws -> QuillCodeDecodedThumbnail {
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        let values = try resolvedURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard values.isRegularFile == true else {
+            throw QuillCodeImageThumbnailError.invalidSource
+        }
+        guard let fileSize = values.fileSize,
+              fileSize > 0,
+              fileSize <= maximumEncodedBytes
+        else {
+            throw QuillCodeImageThumbnailError.sourceTooLarge
+        }
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithURL(resolvedURL as CFURL, options) else {
+            let data = try Data(contentsOf: resolvedURL, options: .mappedIfSafe)
+            return try svgThumbnail(from: data, maximumPixelSize: maximumPixelSize)
+        }
+        do {
+            return try thumbnail(from: source, maximumPixelSize: maximumPixelSize)
+        } catch QuillCodeImageThumbnailError.unsupportedImage {
+            let data = try Data(contentsOf: resolvedURL, options: .mappedIfSafe)
+            return try svgThumbnail(from: data, maximumPixelSize: maximumPixelSize)
+        }
+    }
+
+    private static func thumbnail(
+        from source: CGImageSource,
+        maximumPixelSize: Int
+    ) throws -> QuillCodeDecodedThumbnail {
+        let boundedPixelSize = max(1, maximumPixelSize)
+        let options = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: boundedPixelSize,
+            kCGImageSourceShouldCacheImmediately: true,
+        ] as CFDictionary
+        guard CGImageSourceGetCount(source) > 0,
+              let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options)
+        else {
+            throw QuillCodeImageThumbnailError.unsupportedImage
+        }
+        return QuillCodeDecodedThumbnail(
+            image: image,
+            pixelWidth: image.width,
+            pixelHeight: image.height
+        )
+    }
+
+    private static func svgThumbnail(
+        from data: Data,
+        maximumPixelSize: Int
+    ) throws -> QuillCodeDecodedThumbnail {
+        let header = String(decoding: data.prefix(4_096), as: UTF8.self).lowercased()
+        guard !header.contains("\0"),
+              header.contains("<svg"),
+              let rasterized = QuillCodePlatformImageRasterizer.rasterizeVectorImage(
+                  from: data,
+                  maximumPixelSize: maximumPixelSize
+              )
+        else {
+            throw QuillCodeImageThumbnailError.unsupportedImage
+        }
+        return QuillCodeDecodedThumbnail(
+            image: rasterized,
+            pixelWidth: rasterized.width,
+            pixelHeight: rasterized.height
+        )
+    }
+
+    private static func data(from url: URL) throws -> Data {
+        let source = url.absoluteString
+        guard source.lowercased().hasPrefix("data:image/"),
+              let separator = source.firstIndex(of: ",")
+        else {
+            throw QuillCodeImageThumbnailError.invalidSource
+        }
+        let metadata = source[..<separator].lowercased()
+        let payload = source[source.index(after: separator)...]
+        if metadata.hasSuffix(";base64") {
+            let maximumBase64Characters = ((maximumEncodedBytes + 2) / 3) * 4
+            guard payload.utf8.count <= maximumBase64Characters,
+                  let data = Data(base64Encoded: String(payload)),
+                  data.count <= maximumEncodedBytes
+            else {
+                throw QuillCodeImageThumbnailError.sourceTooLarge
+            }
+            return data
+        }
+
+        guard payload.utf8.count <= maximumEncodedBytes * 3,
+              let decoded = String(payload).removingPercentEncoding,
+              let data = decoded.data(using: .utf8),
+              data.count <= maximumEncodedBytes
+        else {
+            throw QuillCodeImageThumbnailError.sourceTooLarge
+        }
+        return data
+    }
+
+    private static func remoteData(
+        from url: URL,
+        sessionConfiguration: URLSessionConfiguration?
+    ) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        request.setValue("image/*", forHTTPHeaderField: "Accept")
+        request.setValue("Quill-Cowork-Image-Preview/1", forHTTPHeaderField: "User-Agent")
+
+        let delegate = QuillCodeBoundedImageDataDelegate(maximumBytes: maximumEncodedBytes)
+        let delegateQueue = OperationQueue()
+        delegateQueue.name = "co.lorehex.QuillCowork.image-preview"
+        delegateQueue.qualityOfService = .utility
+        delegateQueue.maxConcurrentOperationCount = 1
+        let session = URLSession(
+            configuration: sessionConfiguration ?? makeRemoteSessionConfiguration(),
+            delegate: delegate,
+            delegateQueue: delegateQueue
+        )
+        defer { session.invalidateAndCancel() }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Data, any Error>) in
+                let task = session.dataTask(with: request)
+                if delegate.start(task: task, continuation: continuation) {
+                    task.resume()
+                }
+            }
+        } onCancel: {
+            delegate.cancel()
+        }
+    }
+
+    private static func makeRemoteSessionConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 60
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.waitsForConnectivity = true
+        return configuration
+    }
+}
+
+struct QuillCodeBoundedAsyncImage<Content: View>: View {
+    var url: URL?
+    var maximumPixelSize: Int
+    @ViewBuilder var content: (AsyncImagePhase) -> Content
+
+    @State private var phase: AsyncImagePhase = .empty
+
+    var body: some View {
+        content(phase)
+            .task(id: LoadRequest(url: url, maximumPixelSize: maximumPixelSize)) {
+                guard let url else {
+                    phase = .failure(QuillCodeImageThumbnailError.invalidSource)
+                    return
+                }
+                phase = .empty
+                do {
+                    let thumbnail = try await QuillCodeImageThumbnailLoader.load(
+                        from: url,
+                        maximumPixelSize: maximumPixelSize
+                    )
+                    try Task.checkCancellation()
+                    phase = .success(Image(
+                        decorative: thumbnail.image,
+                        scale: 1,
+                        orientation: .up
+                    ))
+                } catch is CancellationError {
+                    return
+                } catch {
+                    phase = .failure(error)
+                }
+            }
+    }
+
+    private struct LoadRequest: Hashable {
+        var url: URL?
+        var maximumPixelSize: Int
+    }
+}
+
+private final class QuillCodeBoundedImageDataDelegate: NSObject,
+    URLSessionDataDelegate,
+    @unchecked Sendable
+{
+    private let maximumBytes: Int
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Data, any Error>?
+    private var task: URLSessionDataTask?
+    private var receivedData = Data()
+    private var cancelRequested = false
+    private var isComplete = false
+
+    init(maximumBytes: Int) {
+        self.maximumBytes = maximumBytes
+    }
+
+    func start(
+        task: URLSessionDataTask,
+        continuation: CheckedContinuation<Data, any Error>
+    ) -> Bool {
+        lock.lock()
+        self.task = task
+        self.continuation = continuation
+        let shouldCancel = cancelRequested
+        lock.unlock()
+        if shouldCancel {
+            task.cancel()
+            complete(.failure(CancellationError()))
+            return false
+        }
+        return true
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelRequested = true
+        let task = task
+        let hasContinuation = continuation != nil
+        lock.unlock()
+        task?.cancel()
+        if hasContinuation {
+            complete(.failure(CancellationError()))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let response = response as? HTTPURLResponse,
+              response.statusCode == 200
+        else {
+            completionHandler(.cancel)
+            complete(.failure(QuillCodeImageThumbnailError.invalidSource))
+            return
+        }
+        guard response.expectedContentLength <= 0
+                || response.expectedContentLength <= Int64(maximumBytes)
+        else {
+            completionHandler(.cancel)
+            complete(.failure(QuillCodeImageThumbnailError.sourceTooLarge))
+            return
+        }
+        if response.expectedContentLength > 0 {
+            lock.lock()
+            receivedData.reserveCapacity(Int(response.expectedContentLength))
+            lock.unlock()
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        lock.lock()
+        guard !isComplete, data.count <= maximumBytes - receivedData.count else {
+            lock.unlock()
+            dataTask.cancel()
+            complete(.failure(QuillCodeImageThumbnailError.sourceTooLarge))
+            return
+        }
+        receivedData.append(data)
+        lock.unlock()
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        lock.lock()
+        let wasCancelled = cancelRequested
+        let data = receivedData
+        lock.unlock()
+        if wasCancelled {
+            complete(.failure(CancellationError()))
+        } else if error != nil {
+            complete(.failure(QuillCodeImageThumbnailError.invalidSource))
+        } else {
+            complete(.success(data))
+        }
+    }
+
+    private func complete(_ result: Result<Data, any Error>) {
+        lock.lock()
+        guard !isComplete, let continuation else {
+            lock.unlock()
+            return
+        }
+        isComplete = true
+        self.continuation = nil
+        task = nil
+        lock.unlock()
+        continuation.resume(with: result)
+    }
+}

--- a/Sources/QuillCodeApp/QuillCodeImageAttachmentViews.swift
+++ b/Sources/QuillCodeApp/QuillCodeImageAttachmentViews.swift
@@ -81,7 +81,10 @@ private struct QuillCodeAttachmentImage: View {
     var attachment: ImageAttachmentSurface
 
     var body: some View {
-        AsyncImage(url: URL(string: attachment.previewURL)) { phase in
+        QuillCodeBoundedAsyncImage(
+            url: URL(string: attachment.previewURL),
+            maximumPixelSize: 512
+        ) { phase in
             switch phase {
             case .success(let image):
                 image

--- a/Sources/QuillCodePlatformUI/QuillCodePlatformImageRasterizer.swift
+++ b/Sources/QuillCodePlatformUI/QuillCodePlatformImageRasterizer.swift
@@ -1,0 +1,43 @@
+import CoreGraphics
+import Foundation
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+public enum QuillCodePlatformImageRasterizer {
+    public static func rasterizeVectorImage(
+        from data: Data,
+        maximumPixelSize: Int
+    ) -> CGImage? {
+        #if canImport(AppKit)
+        guard let image = NSImage(data: data) else { return nil }
+        let intrinsicSize = image.size
+        guard intrinsicSize.width.isFinite,
+              intrinsicSize.height.isFinite,
+              intrinsicSize.width > 0,
+              intrinsicSize.height > 0
+        else {
+            return nil
+        }
+        let boundedPixelSize = CGFloat(max(1, maximumPixelSize))
+        let scale = min(1, boundedPixelSize / max(intrinsicSize.width, intrinsicSize.height))
+        let width = max(1, Int((intrinsicSize.width * scale).rounded()))
+        let height = max(1, Int((intrinsicSize.height * scale).rounded()))
+        var proposedRect = NSRect(x: 0, y: 0, width: width, height: height)
+        guard let rasterized = image.cgImage(
+            forProposedRect: &proposedRect,
+            context: nil,
+            hints: nil
+        ),
+              rasterized.width <= Int(boundedPixelSize),
+              rasterized.height <= Int(boundedPixelSize)
+        else {
+            return nil
+        }
+        return rasterized
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Tests/QuillCodeAppTests/QuillCodeImageThumbnailLoaderTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeImageThumbnailLoaderTests.swift
@@ -1,0 +1,235 @@
+#if canImport(AppKit) && canImport(CoreGraphics) && canImport(ImageIO)
+import AppKit
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+@testable import QuillCodeApp
+
+final class QuillCodeImageThumbnailLoaderTests: XCTestCase {
+    func testDownsamplesLargeBitmapWithinPixelBudget() throws {
+        let data = try png(width: 2_048, height: 1_024)
+
+        let thumbnail = try QuillCodeImageThumbnailLoader.thumbnail(
+            from: data,
+            maximumPixelSize: 256
+        )
+
+        XCTAssertEqual(thumbnail.pixelWidth, 256)
+        XCTAssertEqual(thumbnail.pixelHeight, 128)
+    }
+
+    func testDoesNotUpscaleSmallBitmap() throws {
+        let data = try png(width: 64, height: 32)
+
+        let thumbnail = try QuillCodeImageThumbnailLoader.thumbnail(
+            from: data,
+            maximumPixelSize: 512
+        )
+
+        XCTAssertEqual(thumbnail.pixelWidth, 64)
+        XCTAssertEqual(thumbnail.pixelHeight, 32)
+    }
+
+    func testRasterizesSVGWithinPixelBudget() throws {
+        let data = Data(
+            ##"<svg xmlns="http://www.w3.org/2000/svg" width="640" height="320"><rect width="640" height="320" fill="#2475b9"/></svg>"##.utf8
+        )
+
+        let thumbnail = try QuillCodeImageThumbnailLoader.thumbnail(
+            from: data,
+            maximumPixelSize: 160
+        )
+
+        XCTAssertEqual(thumbnail.pixelWidth, 160)
+        XCTAssertEqual(thumbnail.pixelHeight, 80)
+    }
+
+    func testLoadsBoundedDataImageOffMainPath() async throws {
+        let data = try png(width: 320, height: 160)
+        let url = try XCTUnwrap(URL(string: "data:image/png;base64,\(data.base64EncodedString())"))
+
+        let thumbnail = try await QuillCodeImageThumbnailLoader.load(
+            from: url,
+            maximumPixelSize: 80
+        )
+
+        XCTAssertEqual(thumbnail.pixelWidth, 80)
+        XCTAssertEqual(thumbnail.pixelHeight, 40)
+    }
+
+    func testStreamsAndDownsamplesRemoteImageWithinBounds() async throws {
+        let data = try png(width: 640, height: 320)
+        ImageThumbnailURLProtocol.state.configure(payload: data)
+        defer { ImageThumbnailURLProtocol.state.reset() }
+
+        let thumbnail = try await QuillCodeImageThumbnailLoader.load(
+            from: URL(string: "https://example.com/preview.png")!,
+            maximumPixelSize: 160,
+            remoteSessionConfiguration: ImageThumbnailURLProtocol.configuration()
+        )
+
+        XCTAssertEqual(thumbnail.pixelWidth, 160)
+        XCTAssertEqual(thumbnail.pixelHeight, 80)
+    }
+
+    func testRejectsOversizedRemoteResponseBeforeBodyDownload() async throws {
+        ImageThumbnailURLProtocol.state.configure(
+            payload: Data(),
+            declaredContentLength: QuillCodeImageThumbnailLoader.maximumEncodedBytes + 1
+        )
+        defer { ImageThumbnailURLProtocol.state.reset() }
+
+        do {
+            _ = try await QuillCodeImageThumbnailLoader.load(
+                from: URL(string: "https://example.com/oversized.png")!,
+                maximumPixelSize: 160,
+                remoteSessionConfiguration: ImageThumbnailURLProtocol.configuration()
+            )
+            XCTFail("Expected an oversized remote image to be rejected.")
+        } catch QuillCodeImageThumbnailError.sourceTooLarge {
+            XCTAssertEqual(ImageThumbnailURLProtocol.state.deliveredBytes, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRejectsOversizedLocalFileBeforeImageDecode() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "quill-cowork-thumbnail-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fileURL = directory.appendingPathComponent("oversized.png")
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: fileURL)
+        try handle.truncate(atOffset: UInt64(QuillCodeImageThumbnailLoader.maximumEncodedBytes + 1))
+        try handle.close()
+
+        XCTAssertThrowsError(
+            try QuillCodeImageThumbnailLoader.thumbnail(
+                fromFile: fileURL,
+                maximumPixelSize: 256
+            )
+        ) { error in
+            guard case QuillCodeImageThumbnailError.sourceTooLarge = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    private func png(width: Int, height: Int) throws -> Data {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.12, green: 0.46, blue: 0.72, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let image = try XCTUnwrap(context.makeImage())
+        let output = NSMutableData()
+        let destination = try XCTUnwrap(CGImageDestinationCreateWithData(
+            output,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ))
+        CGImageDestinationAddImage(destination, image, nil)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+        return output as Data
+    }
+}
+
+private final class ImageThumbnailURLProtocolState: @unchecked Sendable {
+    struct Fixture: Sendable {
+        var payload: Data
+        var declaredContentLength: Int
+    }
+
+    private let lock = NSLock()
+    private var fixture: Fixture?
+    private var deliveredByteCount = 0
+
+    var deliveredBytes: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return deliveredByteCount
+    }
+
+    func configure(payload: Data, declaredContentLength: Int? = nil) {
+        lock.lock()
+        fixture = Fixture(
+            payload: payload,
+            declaredContentLength: declaredContentLength ?? payload.count
+        )
+        deliveredByteCount = 0
+        lock.unlock()
+    }
+
+    func snapshot() -> Fixture? {
+        lock.lock()
+        defer { lock.unlock() }
+        return fixture
+    }
+
+    func recordDelivery(_ count: Int) {
+        lock.lock()
+        deliveredByteCount += count
+        lock.unlock()
+    }
+
+    func reset() {
+        lock.lock()
+        fixture = nil
+        deliveredByteCount = 0
+        lock.unlock()
+    }
+}
+
+private final class ImageThumbnailURLProtocol: URLProtocol, @unchecked Sendable {
+    static let state = ImageThumbnailURLProtocolState()
+
+    static func configuration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ImageThumbnailURLProtocol.self]
+        return configuration
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let fixture = Self.state.snapshot(),
+              let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: [
+                    "Content-Length": String(fixture.declaredContentLength),
+                    "Content-Type": "image/png",
+                ]
+              )
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        guard !fixture.payload.isEmpty else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        Self.state.recordDelivery(fixture.payload.count)
+        client?.urlProtocol(self, didLoad: fixture.payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+#endif

--- a/Tests/QuillCodeParityTests/ParityBoundedImagePreviewGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityBoundedImagePreviewGateTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+final class ParityBoundedImagePreviewGateTests: QuillCodeParityTestCase {
+    func testLocalImagePreviewSurfacesUseBoundedThumbnailDecoding() throws {
+        let loader = try Self.appSourceText(named: "QuillCodeBoundedAsyncImage.swift")
+        let artifact = try Self.appSourceText(named: "QuillCodeArtifactImagePreview.swift")
+        let attachments = try Self.appSourceText(named: "QuillCodeImageAttachmentViews.swift")
+        let documents = try Self.appSourceText(named: "QuillCodeArtifactDocumentPreview.swift")
+        let platformRasterizer = try Self.swiftSourceFiles(in: "Sources/QuillCodePlatformUI")
+            .first { $0.lastPathComponent == "QuillCodePlatformImageRasterizer.swift" }
+            .map { try String(contentsOf: $0, encoding: .utf8) }
+
+        Self.assertSource(loader, containsAll: [
+            "CGImageSourceCreateThumbnailAtIndex",
+            "kCGImageSourceThumbnailMaxPixelSize",
+            "kCGImageSourceShouldCacheImmediately",
+            "Task.detached(priority: .utility)",
+            "maximumEncodedBytes"
+        ])
+        Self.assertSource(loader, contains: "QuillCodePlatformImageRasterizer")
+        Self.assertSource(loader, excludes: "import AppKit")
+        Self.assertSource(try XCTUnwrap(platformRasterizer), containsAll: [
+            "import AppKit",
+            "NSImage(data: data)",
+            "maximumPixelSize"
+        ])
+        Self.assertSource(artifact, contains: "maximumPixelSize: 1_536")
+        Self.assertSource(attachments, contains: "maximumPixelSize: 512")
+        Self.assertSource(documents, contains: "maximumPixelSize: 256")
+        for source in [artifact, attachments, documents] {
+            Self.assertSource(source, contains: "QuillCodeBoundedAsyncImage")
+            XCTAssertFalse(source.split(separator: "\n").contains { line in
+                line.trimmingCharacters(in: .whitespaces).hasPrefix("AsyncImage(")
+            })
+        }
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -17383,3 +17383,27 @@ Validation:
 - Final three-launch physical-footprint evidence: 306.25 ms median launch-ready, 41.09 MiB initial, 85.97 MiB post-interaction, 88.58 MiB repeated-interaction, and 2.61 MiB repeated growth
 - `python3 scripts/grade-code-quality.py --root .` (all production modules A+)
 - `git diff --check`
+
+## 2026-08-11 Bounded Image Preview Residency
+
+Overall grade after this slice: **A+ memory architecture, A+ responsiveness, A+ packaged performance**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Decode residency | A+ | Artifact images, message attachments, composer attachments, and appshot thumbnails decode directly to bounded bitmap dimensions instead of retaining full-resolution display bitmaps. |
+| Main-thread responsiveness | A+ | Local, data-URL, remote, and SVG thumbnail decoding runs at utility priority outside the main actor; SwiftUI receives only the finished bounded image. |
+| Input safety | A+ | Local files and streamed HTTP responses share a 32 MiB encoded-source cap, oversized declared responses are rejected before body delivery, and remote requests use ephemeral no-cache sessions with explicit timeouts and cancellation. |
+| Format fidelity | A+ | ImageIO preserves bitmap orientation and aspect ratio without upscaling, while the AppKit platform adapter keeps bounded SVG rasterization available without leaking native APIs into the app module. |
+| Surface budgets | A+ | General artifact previews cap their longest edge at 1,536 pixels, attachment previews at 512 pixels, and compact appshot thumbnails at 256 pixels. |
+| Packaged compatibility | A+ | The release bundle passed SIGKILL draft recovery, direct and Launch Services rendering, live native interaction, Accessibility contracts, and screenshot validation. |
+| Packaged performance | A+ | Three independent 100-chat launches passed: 292.07 ms median readiness, 41.02 MiB initial physical footprint, 86.45 MiB post-interaction, 87.67 MiB repeated-interaction, 1.22 MiB repeated growth, and a repeated thread count that fell from eight to seven. |
+
+Validation:
+
+- Focused thumbnail and architecture suite (11 tests, 0 failures)
+- `swift test` (6,191 tests; 5 skipped; 0 failures)
+- `scripts/packaged-macos-smoke.sh` (SIGKILL draft recovery, direct and Launch Services rendering, live-window Accessibility, computer-use contracts, and 100-chat interaction passed)
+- `scripts/packaged-macos-performance-smoke.sh` (3/3 fresh launches within startup, physical-footprint, growth, and thread budgets)
+- Final three-launch physical-footprint evidence: 292.07 ms median launch-ready, 41.02 MiB initial, 86.45 MiB post-interaction, 87.67 MiB repeated-interaction, and 1.22 MiB repeated growth
+- `python3 scripts/grade-code-quality.py --root .` (all production modules A+)
+- `git diff --check`


### PR DESCRIPTION
Downsample local, data, and remote image previews off the main actor with strict encoded-source and pixel budgets. Preserve SVG previews behind the platform adapter, cover all production surfaces with regression gates, and record packaged crash/UI/performance evidence. Verification: 6,191 Swift tests passed; packaged macOS smoke passed; 3/3 fresh performance launches passed at 292.07 ms median readiness, 41.02 MiB initial footprint, and 1.22 MiB repeated growth; all production modules remain A+.