### PR TITLE
Bound artifact text preview residency

### DIFF
--- a/Sources/QuillCodeApp/ToolArtifactTextPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactTextPreviewBuilder.swift
@@ -30,8 +30,22 @@ enum ToolArtifactTextPreviewBuilder {
         else { return nil }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            let resourceValues = try fileURL.resourceValues(forKeys: [
+                .contentModificationDateKey,
+                .fileResourceIdentifierKey,
+                .fileSizeKey,
+                .isRegularFileKey
+            ])
             guard resourceValues.isRegularFile == true else { return nil }
+            let cacheKey = TextPreviewCacheKey(
+                path: fileURL.standardizedFileURL.path,
+                fileSize: resourceValues.fileSize ?? 0,
+                modificationDate: resourceValues.contentModificationDate,
+                resourceIdentifier: resourceValues.fileResourceIdentifier
+            )
+            if let cached = cache.value(for: cacheKey) {
+                return cached
+            }
 
             let handle = try FileHandle(forReadingFrom: fileURL)
             defer { try? handle.close() }
@@ -60,13 +74,15 @@ enum ToolArtifactTextPreviewBuilder {
                 text += "..."
             }
             guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-            return TextPreviewPayload(
+            let payload = TextPreviewPayload(
                 text: text,
                 typeLabel: typeLabel(for: fileURL),
                 lineCountLabel: lineCountLabel(for: text, wasTruncated: wasTruncated),
                 byteSizeLabel: resourceValues.fileSize.flatMap(ToolArtifactByteSizeFormatter.label),
                 wasTruncated: wasTruncated
             )
+            cache.insert(payload, for: cacheKey)
+            return payload
         } catch {
             return nil
         }
@@ -116,7 +132,77 @@ enum ToolArtifactTextPreviewBuilder {
         var lineCountLabel: String
         var byteSizeLabel: String?
         var wasTruncated: Bool
+
+        var estimatedByteCount: Int {
+            text.utf8.count
+                + typeLabel.utf8.count
+                + lineCountLabel.utf8.count
+                + (byteSizeLabel?.utf8.count ?? 0)
+        }
     }
+
+    private final class TextPreviewCacheKey: NSObject {
+        private let path: String
+        private let fileSize: Int
+        private let modificationTime: TimeInterval
+        private let resourceIdentifier: String
+
+        init(path: String, fileSize: Int, modificationDate: Date?, resourceIdentifier: Any?) {
+            self.path = path
+            self.fileSize = fileSize
+            self.modificationTime = modificationDate?.timeIntervalSinceReferenceDate ?? 0
+            self.resourceIdentifier = resourceIdentifier.map(String.init(describing:)) ?? ""
+        }
+
+        override var hash: Int {
+            var hasher = Hasher()
+            hasher.combine(path)
+            hasher.combine(fileSize)
+            hasher.combine(modificationTime)
+            hasher.combine(resourceIdentifier)
+            return hasher.finalize()
+        }
+
+        override func isEqual(_ object: Any?) -> Bool {
+            guard let other = object as? TextPreviewCacheKey else { return false }
+            return path == other.path
+                && fileSize == other.fileSize
+                && modificationTime == other.modificationTime
+                && resourceIdentifier == other.resourceIdentifier
+        }
+    }
+
+    private final class TextPreviewCache: @unchecked Sendable {
+        private final class Box: NSObject {
+            let payload: TextPreviewPayload
+
+            init(_ payload: TextPreviewPayload) {
+                self.payload = payload
+            }
+        }
+
+        private let storage: NSCache<TextPreviewCacheKey, Box>
+
+        init() {
+            let storage = NSCache<TextPreviewCacheKey, Box>()
+            storage.countLimit = ToolArtifactTextPreviewBuilder.cacheEntryLimit
+            storage.totalCostLimit = ToolArtifactTextPreviewBuilder.cacheByteLimit
+            self.storage = storage
+        }
+
+        func value(for key: TextPreviewCacheKey) -> TextPreviewPayload? {
+            storage.object(forKey: key)?.payload
+        }
+
+        func insert(_ payload: TextPreviewPayload, for key: TextPreviewCacheKey) {
+            storage.setObject(Box(payload), forKey: key, cost: payload.estimatedByteCount)
+        }
+
+    }
+
+    private static let cache = TextPreviewCache()
+    private static let cacheEntryLimit = 16
+    private static let cacheByteLimit = 128 * 1024
 
     private static let byteLimit = 6 * 1024
     private static let lineLimit = 80

--- a/Sources/QuillCodeApp/WorkspaceArtifactPreviewRetention.swift
+++ b/Sources/QuillCodeApp/WorkspaceArtifactPreviewRetention.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+enum WorkspaceArtifactPreviewRetention {
+    static let recentToolCardLimit = 12
+    static let artifactInspectionLimit = 48
+    static let textPreviewLimit = 8
+    static let textPreviewByteLimit = 64 * 1024
+
+    static func hydrate(_ cards: inout [ToolCardState]) {
+        for cardIndex in cards.indices {
+            for artifactIndex in cards[cardIndex].artifacts.indices {
+                cards[cardIndex].artifacts[artifactIndex].textPreview = nil
+            }
+        }
+
+        var hydratedCount = 0
+        var hydratedBytes = 0
+        var inspectedCount = 0
+        let firstRecentIndex = max(cards.count - recentToolCardLimit, 0)
+        guard firstRecentIndex < cards.count else { return }
+
+        for cardIndex in stride(from: cards.count - 1, through: firstRecentIndex, by: -1) {
+            for artifactIndex in cards[cardIndex].artifacts.indices {
+                guard inspectedCount < artifactInspectionLimit,
+                      hydratedCount < textPreviewLimit
+                else {
+                    break
+                }
+                inspectedCount += 1
+                guard let preview = ToolArtifactTextPreviewBuilder.textPreview(
+                          for: cards[cardIndex].artifacts[artifactIndex].value
+                      )
+                else {
+                    continue
+                }
+                let previewBytes = preview.utf8.count
+                guard previewBytes <= textPreviewByteLimit - hydratedBytes else {
+                    continue
+                }
+                cards[cardIndex].artifacts[artifactIndex].textPreview = preview
+                hydratedCount += 1
+                hydratedBytes += previewBytes
+            }
+            if inspectedCount == artifactInspectionLimit
+                || hydratedCount == textPreviewLimit
+                || hydratedBytes == textPreviewByteLimit {
+                break
+            }
+        }
+    }
+
+    static func hydrate(_ projection: inout WorkspaceTranscriptProjectionAccumulator) {
+        let timelineCardIndices = projection.timelineItems.indices.filter {
+            projection.timelineItems[$0].toolCard != nil
+        }
+        var timelineCards = timelineCardIndices.compactMap {
+            projection.timelineItems[$0].toolCard
+        }
+        hydrate(&timelineCards)
+
+        for (timelineIndex, card) in zip(timelineCardIndices, timelineCards) {
+            projection.timelineItems[timelineIndex] = .toolCard(card)
+        }
+        projection.synchronizeToolCardsFromTimeline()
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceToolCardEventReducer.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolCardEventReducer.swift
@@ -222,6 +222,19 @@ struct WorkspaceTranscriptProjectionAccumulator {
         toolCards[index] = card
         timelineItems[timelineIndex] = .toolCard(card)
     }
+
+    mutating func synchronizeToolCardsFromTimeline() {
+        for cardIndex in toolCards.indices {
+            guard timelineIndexByToolCardIndex.indices.contains(cardIndex) else { continue }
+            let timelineIndex = timelineIndexByToolCardIndex[cardIndex]
+            guard timelineItems.indices.contains(timelineIndex),
+                  let timelineCard = timelineItems[timelineIndex].toolCard
+            else {
+                continue
+            }
+            toolCards[cardIndex] = timelineCard
+        }
+    }
 }
 
 extension WorkspaceToolCardEventReducer where State == WorkspaceTranscriptProjectionAccumulator {

--- a/Sources/QuillCodeApp/WorkspaceToolCardProjection.swift
+++ b/Sources/QuillCodeApp/WorkspaceToolCardProjection.swift
@@ -263,9 +263,7 @@ enum WorkspaceToolCardProjection {
         }
         return result.artifacts
             .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            .map { value in
-                ToolArtifactState(value: value, textPreview: ToolArtifactTextPreviewBuilder.textPreview(for: value))
-            }
+            .map { ToolArtifactState(value: $0) }
     }
 
     private static func toolSubtitle(stateLabel: String, title: String, inputJSON: String?) -> String {

--- a/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTranscriptSurfaceBuilder.swift
@@ -44,7 +44,7 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
         for event in thread.events {
             reducer.apply(event)
         }
-
+        WorkspaceArtifactPreviewRetention.hydrate(&reducer.state)
         return reducer.state
     }
 
@@ -126,6 +126,7 @@ struct WorkspaceTranscriptSurfaceBuilder: Sendable, Hashable {
                 reducer.state.appendMessage(visibleMessages[visibleSurfaceIndex])
             }
         }
+        WorkspaceArtifactPreviewRetention.hydrate(&reducer.state)
         return WorkspaceTranscriptProjection(
             messages: visibleMessages,
             toolCards: reducer.state.toolCards,

--- a/Tests/QuillCodeAppTests/WorkspaceArtifactPreviewRetentionTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceArtifactPreviewRetentionTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceArtifactPreviewRetentionTests: XCTestCase {
+    func testRetentionKeepsOnlyNewestBoundedTextPreviews() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        var cards: [ToolCardState] = []
+        for index in 0..<14 {
+            let file = directory.appendingPathComponent("artifact-\(index).txt")
+            try "preview \(index)\n".write(to: file, atomically: true, encoding: .utf8)
+            cards.append(card(id: "card-\(index)", artifact: file.path, textPreview: "stale"))
+        }
+
+        WorkspaceArtifactPreviewRetention.hydrate(&cards)
+
+        let hydratedIndices = cards.indices.filter {
+            cards[$0].artifacts.first?.textPreview != nil
+        }
+        XCTAssertEqual(hydratedIndices, Array(6..<14))
+        XCTAssertEqual(
+            cards.flatMap(\.artifacts).compactMap(\.textPreview).count,
+            WorkspaceArtifactPreviewRetention.textPreviewLimit
+        )
+        XCTAssertLessThanOrEqual(
+            cards.flatMap(\.artifacts).compactMap(\.textPreview).reduce(0) { $0 + $1.utf8.count },
+            WorkspaceArtifactPreviewRetention.textPreviewByteLimit
+        )
+        XCTAssertTrue(cards.prefix(6).allSatisfy { $0.artifacts.first?.textPreview == nil })
+        XCTAssertEqual(cards.last?.artifacts.first?.textPreview, "preview 13\n")
+        XCTAssertEqual(cards.first?.artifacts.first?.value, directory.appendingPathComponent("artifact-0.txt").path)
+    }
+
+    func testProjectionHydratesTimelineAndToolCardsFromSameRecentBudget() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        var events: [ThreadEvent] = []
+        for index in 0..<10 {
+            let file = directory.appendingPathComponent("result-\(index).txt")
+            try "result \(index)\n".write(to: file, atomically: true, encoding: .utf8)
+            let call = ToolCall(
+                id: "call-\(index)",
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": file.path])
+            )
+            let result = ToolResult(ok: true, stdout: "read", artifacts: [file.path])
+            events.append(ThreadEvent(
+                kind: .toolQueued,
+                summary: "queued",
+                payloadJSON: try JSONHelpers.encodePretty(call)
+            ))
+            events.append(ThreadEvent(
+                kind: .toolCompleted,
+                summary: "completed",
+                payloadJSON: try JSONHelpers.encodePretty(result)
+            ))
+        }
+
+        let projection = WorkspaceTranscriptSurfaceBuilder(thread: ChatThread(events: events)).projection()
+        let timelineCards = projection.timelineItems.compactMap(\.toolCard)
+
+        XCTAssertEqual(projection.toolCards.count, 10)
+        XCTAssertEqual(timelineCards.count, 10)
+        XCTAssertTrue(projection.toolCards.prefix(2).allSatisfy { $0.artifacts.first?.textPreview == nil })
+        XCTAssertEqual(
+            projection.toolCards.suffix(8).compactMap { $0.artifacts.first?.textPreview }.count,
+            8
+        )
+        XCTAssertEqual(
+            projection.toolCards.map { $0.artifacts.first?.textPreview },
+            timelineCards.map { $0.artifacts.first?.textPreview }
+        )
+    }
+
+    func testRetentionBoundsArtifactInspectionWithinRecentCards() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        var artifacts = (0..<WorkspaceArtifactPreviewRetention.artifactInspectionLimit).map {
+            ToolArtifactState(value: directory.appendingPathComponent("opaque-\($0).bin").path)
+        }
+        let textFile = directory.appendingPathComponent("beyond-budget.txt")
+        try "should stay lazy\n".write(to: textFile, atomically: true, encoding: .utf8)
+        artifacts.append(ToolArtifactState(value: textFile.path, textPreview: "stale"))
+        var cards = [ToolCardState(
+            id: "many-artifacts",
+            title: ToolDefinition.fileRead.name,
+            subtitle: "Completed",
+            status: .done,
+            artifacts: artifacts
+        )]
+
+        WorkspaceArtifactPreviewRetention.hydrate(&cards)
+
+        XCTAssertEqual(cards[0].artifacts.count, artifacts.count)
+        XCTAssertNil(cards[0].artifacts.last?.textPreview)
+        XCTAssertEqual(cards[0].artifacts.last?.value, textFile.path)
+    }
+
+    func testProjectionSynchronizesDuplicateToolIDsByTimelinePosition() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        var events: [ThreadEvent] = []
+        for index in 0..<2 {
+            let file = directory.appendingPathComponent("duplicate-\(index).txt")
+            try "duplicate \(index)\n".write(to: file, atomically: true, encoding: .utf8)
+            let call = ToolCall(
+                id: "reused-id",
+                name: ToolDefinition.fileRead.name,
+                argumentsJSON: ToolArguments.json(["path": file.path])
+            )
+            let result = ToolResult(ok: true, stdout: "read", artifacts: [file.path])
+            events.append(ThreadEvent(
+                kind: .toolQueued,
+                summary: "queued",
+                payloadJSON: try JSONHelpers.encodePretty(call)
+            ))
+            events.append(ThreadEvent(
+                kind: .toolCompleted,
+                summary: "completed",
+                payloadJSON: try JSONHelpers.encodePretty(result)
+            ))
+        }
+
+        let projection = WorkspaceTranscriptSurfaceBuilder(thread: ChatThread(events: events)).projection()
+        let timelineCards = projection.timelineItems.compactMap(\.toolCard)
+
+        XCTAssertEqual(
+            projection.toolCards.map { $0.artifacts.first?.textPreview },
+            ["duplicate 0\n", "duplicate 1\n"]
+        )
+        XCTAssertEqual(
+            projection.toolCards.map { $0.artifacts.first?.textPreview },
+            timelineCards.map { $0.artifacts.first?.textPreview }
+        )
+    }
+
+    func testTextPreviewCacheInvalidatesWhenFileMetadataChanges() throws {
+        let directory = try makeQuillCodeTestDirectory()
+        let file = directory.appendingPathComponent("mutable.txt")
+        try "first\n".write(to: file, atomically: true, encoding: .utf8)
+        XCTAssertEqual(ToolArtifactTextPreviewBuilder.textPreview(for: file.path), "first\n")
+
+        try "other\n".write(to: file, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(5)],
+            ofItemAtPath: file.path
+        )
+        XCTAssertEqual(ToolArtifactTextPreviewBuilder.textPreview(for: file.path), "other\n")
+
+        try FileManager.default.removeItem(at: file)
+        XCTAssertNil(ToolArtifactTextPreviewBuilder.textPreview(for: file.path))
+    }
+
+    private func card(id: String, artifact: String, textPreview: String?) -> ToolCardState {
+        ToolCardState(
+            id: id,
+            title: ToolDefinition.fileRead.name,
+            subtitle: "Completed",
+            status: .done,
+            artifacts: [ToolArtifactState(value: artifact, textPreview: textPreview)]
+        )
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityBoundedArtifactPreviewResidencyGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityBoundedArtifactPreviewResidencyGateTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+final class ParityBoundedArtifactPreviewResidencyGateTests: QuillCodeParityTestCase {
+    func testTranscriptArtifactPreviewsUseRecentBoundedHydration() throws {
+        let projection = try Self.appSourceText(named: "WorkspaceToolCardProjection.swift")
+        let retention = try Self.appSourceText(named: "WorkspaceArtifactPreviewRetention.swift")
+        let transcript = try Self.appSourceText(named: "WorkspaceTranscriptSurfaceBuilder.swift")
+        let textPreview = try Self.appSourceText(named: "ToolArtifactTextPreviewBuilder.swift")
+
+        Self.assertSource(projection, excludes: "ToolArtifactTextPreviewBuilder.textPreview")
+        Self.assertSource(retention, containsAll: [
+            "recentToolCardLimit = 12",
+            "artifactInspectionLimit = 48",
+            "textPreviewLimit = 8",
+            "textPreviewByteLimit = 64 * 1024",
+            "static func hydrate"
+        ])
+        Self.assertSource(transcript, contains: "WorkspaceArtifactPreviewRetention.hydrate")
+        Self.assertSource(textPreview, containsAll: [
+            "NSCache<TextPreviewCacheKey, Box>",
+            "cacheEntryLimit = 16",
+            "cacheByteLimit = 128 * 1024",
+            ".contentModificationDateKey",
+            ".fileResourceIdentifierKey"
+        ])
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityWorkspaceToolCardModelGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceToolCardModelGateTests.swift
@@ -28,6 +28,7 @@ final class ParityWorkspaceToolCardModelGateTests: QuillCodeParityTestCase {
         let transcriptBuilderText = try Self.appSourceText(named: "WorkspaceTranscriptSurfaceBuilder.swift")
         let toolCardReducerText = try Self.appSourceText(named: "WorkspaceToolCardEventReducer.swift")
         let toolCardProjectionText = try Self.appSourceText(named: "WorkspaceToolCardProjection.swift")
+        let artifactPreviewRetentionText = try Self.appSourceText(named: "WorkspaceArtifactPreviewRetention.swift")
 
         Self.assertSource(toolCardSurfaceText, contains: "public struct ToolCardState")
         Self.assertSource(toolArtifactSurfaceText, containsAll: [
@@ -231,11 +232,16 @@ final class ParityWorkspaceToolCardModelGateTests: QuillCodeParityTestCase {
             "struct WorkspaceToolCardEventReducer",
             "WorkspaceToolCardProjection"
         ])
-        Self.assertSource(toolCardProjectionText, containsAll: [
-            "enum WorkspaceToolCardProjection",
+        Self.assertSource(toolCardProjectionText, contains: "enum WorkspaceToolCardProjection")
+        Self.assertSource(toolCardProjectionText, excludes: "ToolArtifactTextPreviewBuilder.textPreview")
+        Self.assertSource(artifactPreviewRetentionText, containsAll: [
+            "enum WorkspaceArtifactPreviewRetention",
             "ToolArtifactTextPreviewBuilder.textPreview"
         ])
-        Self.assertSource(transcriptBuilderText, contains: "WorkspaceToolCardEventReducer")
+        Self.assertSource(transcriptBuilderText, containsAll: [
+            "WorkspaceToolCardEventReducer",
+            "WorkspaceArtifactPreviewRetention.hydrate"
+        ])
         Self.assertSource(modelText, excludesAll: [
             "public struct ToolCardState",
             "public enum ToolCardStatus",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-11 Bounded Artifact Text Preview Residency
+
+Overall grade after this slice: **A+ memory architecture, A+ surface responsiveness, A+ data fidelity**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Projection architecture | A+ | Tool-event reduction remains filesystem-free; rich local text is hydrated only after the complete transcript shape is known. |
+| Residency | A+ | The newest 12 tool cards inspect at most 48 artifacts and retain at most eight previews or 64 KiB of text. |
+| Cache ownership | A+ | A purgeable 16-entry, 128 KiB cache reuses unchanged bounded reads without becoming a second transcript history. |
+| Freshness | A+ | Path, size, modification time, and resource identity invalidate changed content; deleted and unreadable files fail closed. |
+| Data fidelity | A+ | Every durable artifact reference, output, chip, type, and open action remains available after old inline text is released. |
+| Correlation safety | A+ | Timeline and card copies synchronize by reducer position, so reused malformed tool IDs cannot cross-contaminate previews. |
+| Regression evidence | A+ | Focused behavior, scale-bound, invalidation, duplicate-ID, transcript, and source-parity coverage is green. |
+
+Validation:
+
+- Focused artifact residency, transcript, and parity suite: 27 tests, 0 failures.
+- Full Swift suite: 6,197 tests, 5 skipped, 0 failures.
+- Release packaged direct-executable, Launch Services, composer `SIGKILL` recovery, live-window,
+  accessibility, native interaction, coworker, browser, computer-use, and 100-chat smokes passed.
+- Dedicated packaged performance gate: 3/3 launches within budget; 290.35 ms median launch-ready,
+  40.95 MiB initial footprint, 85.55 MiB after the first interaction sweep, and 85.24 MiB after the
+  repeated sweep (no retained repeated-interaction growth).
+- `python3 scripts/grade-code-quality.py --root .`: every production module summary remains A+.
+- `git diff --check`: clean.
+
 ## 2026-08-11 Cached Worktree Environment Projection
 
 Overall grade after this slice: **A+ launch isolation, A+ cache ownership, A+ stale-result safety**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,26 @@
 # QuillCode Decisions
 
+## 2026-08-11: rich artifact previews have a recent residency budget
+
+- **Decision:** Durable tool events retain every artifact reference, but transcript projection no
+  longer reads local artifact files while reducing each historical tool completion. After reduction,
+  only the newest 12 tool cards may be inspected for rich text; inspection stops after 48 artifacts,
+  eight successful previews, or 64 KiB of preview text.
+- **Cache boundary:** Unchanged text previews reuse a purgeable cache limited to 16 entries and
+  128 KiB. Cache identity includes the standardized path, file size, modification time, and resource
+  identifier. Changed, replaced, deleted, nonregular, unreadable, and no-longer-authorized files are
+  revalidated before cached content can be returned.
+- **Usability boundary:** Older cards keep their artifact chip, path or URL, type classification,
+  open action, and durable tool output; only their disposable inline text copy is released. Timeline
+  and tool-card projections receive the same hydrated values through the reducer's positional index,
+  including malformed histories that reuse a tool-call ID.
+- **Why:** Rebuilding the desktop surface reopened every historical text artifact and retained a
+  separate preview string for each card. Long coding sessions therefore paid filesystem and memory
+  costs for content that was usually far offscreen.
+- **Evidence:** Focused tests cover card, artifact-count, preview-count, byte, cache-invalidation, and
+  duplicate-ID boundaries. A source parity gate rejects eager preview reads in tool-event projection
+  and pins both cache limits.
+
 ## 2026-08-11: updater success waits for first-window readiness
 
 - **Decision:** Parsing the updater or relocation launch-handshake argument remains the first normal


### PR DESCRIPTION
Bounds transcript artifact hydration to recent cards, caps preview inspections/text residency, and adds a purgeable metadata-keyed cache while preserving durable artifact references. Verification: 6,197 Swift tests (5 skipped, 0 failures); packaged direct/Launch Services/crash-recovery/live-window/coworker/browser/computer-use smokes; 3/3 daily-driver launches at 290.35 ms median ready, 40.95 MiB initial, 85.55 MiB post-interaction, and 85.24 MiB repeated; all production module summaries A+; diff check clean.