### PR TITLE
Bound JSON artifact preview parsing

### DIFF
--- a/Sources/QuillCodeApp/ToolArtifactAllureJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactAllureJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactAllureJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactAppshotPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactAppshotPreviewBuilder.swift
@@ -30,19 +30,10 @@ enum ToolArtifactAppshotPreviewBuilder {
 
     private static func appshotRoot(from fileURL: URL) -> [String: Any]? {
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-
-            let handle = try FileHandle(forReadingFrom: fileURL)
-            defer { try? handle.close() }
-            guard let data = try handle.read(upToCount: byteLimit + 1),
-                  !data.isEmpty,
-                  data.count <= byteLimit
-            else {
-                return nil
-            }
-
-            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            return try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            )?.root as? [String: Any]
         } catch {
             return nil
         }

--- a/Sources/QuillCodeApp/ToolArtifactBanditJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactBanditJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactBanditJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any],
                   let results = report["results"] as? [[String: Any]]
             else {

--- a/Sources/QuillCodeApp/ToolArtifactBenchmarkDotNetJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactBenchmarkDotNetJSONPreviewBuilder.swift
@@ -15,13 +15,12 @@ enum ToolArtifactBenchmarkDotNetJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactCargoAuditJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCargoAuditJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactCargoAuditJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(from: object, byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize))
         } catch {

--- a/Sources/QuillCodeApp/ToolArtifactCodeClimateJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCodeClimateJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactCodeClimateJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let issues = root as? [[String: Any]] else { return nil }
             return preview(
                 from: issues,

--- a/Sources/QuillCodeApp/ToolArtifactComposerLockfilePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactComposerLockfilePreviewBuilder.swift
@@ -10,17 +10,16 @@ enum ToolArtifactComposerLockfilePreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0),
-                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   isComposerLockfile(root)
             else {
                 return nil
             }
+            let fileSize = document.byteSize
             let preview = preview(
                 from: root,
                 byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)

--- a/Sources/QuillCodeApp/ToolArtifactCoveragePyPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCoveragePyPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactCoveragePyPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactCucumberJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCucumberJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactCucumberJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let features = root as? [[String: Any]] else { return nil }
             return preview(
                 from: features,

--- a/Sources/QuillCodeApp/ToolArtifactCycloneDXPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactCycloneDXPreviewBuilder.swift
@@ -12,17 +12,16 @@ enum ToolArtifactCycloneDXPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0),
-                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   stringValue(root["bomFormat"])?.lowercased() == "cyclonedx"
             else {
                 return nil
             }
+            let fileSize = document.byteSize
             let preview = preview(
                 from: root,
                 byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)

--- a/Sources/QuillCodeApp/ToolArtifactDenoLockPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactDenoLockPreviewBuilder.swift
@@ -10,17 +10,16 @@ enum ToolArtifactDenoLockPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0),
-                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   isDenoLockfile(root)
             else {
                 return nil
             }
+            let fileSize = document.byteSize
             let preview = preview(
                 from: root,
                 byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)

--- a/Sources/QuillCodeApp/ToolArtifactESLintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactESLintJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactESLintJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let results = root as? [[String: Any]] else { return nil }
             return preview(
                 from: results,

--- a/Sources/QuillCodeApp/ToolArtifactGolangCILintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactGolangCILintJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactGolangCILintJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any] else { return nil }
             return preview(
                 from: report,

--- a/Sources/QuillCodeApp/ToolArtifactHARPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactHARPreviewBuilder.swift
@@ -12,15 +12,12 @@ enum ToolArtifactHARPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
-            guard let preview = preview(from: root, fileSize: fileSize) else { return nil }
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let preview = preview(from: document.root, fileSize: document.byteSize)
+            else { return nil }
             return preview.hasDisplayContent ? preview : nil
         } catch {
             return nil

--- a/Sources/QuillCodeApp/ToolArtifactHyperfineJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactHyperfineJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactHyperfineJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactIstanbulPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactIstanbulPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactIstanbulPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactJSONDocumentReader.swift
+++ b/Sources/QuillCodeApp/ToolArtifactJSONDocumentReader.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+enum ToolArtifactJSONDocumentReader {
+    struct Document {
+        var root: Any
+        var byteSize: Int
+    }
+
+    struct Diagnostics: Equatable {
+        var fileReadCount: Int
+        var parseCount: Int
+        var cacheHitCount: Int
+    }
+
+    static func document(for fileURL: URL, byteLimit: Int) throws -> Document? {
+        guard byteLimit > 0 else { return nil }
+
+        var refreshedFileURL = fileURL.standardizedFileURL
+        refreshedFileURL.removeAllCachedResourceValues()
+        let resourceValues = try refreshedFileURL.resourceValues(forKeys: [
+            .contentModificationDateKey,
+            .fileResourceIdentifierKey,
+            .fileSizeKey,
+            .isRegularFileKey
+        ])
+        guard resourceValues.isRegularFile == true else { return nil }
+        let fileSize = max(resourceValues.fileSize ?? 0, 0)
+        guard fileSize > 0, fileSize <= byteLimit else { return nil }
+
+        let key = CacheKey(
+            path: refreshedFileURL.path,
+            fileSize: fileSize,
+            modificationDate: resourceValues.contentModificationDate,
+            resourceIdentifier: resourceValues.fileResourceIdentifier
+        )
+        return try cache.document(for: key, fileURL: refreshedFileURL, fileSize: fileSize)
+    }
+
+    static func diagnosticsForTesting() -> Diagnostics {
+        cache.diagnosticsSnapshot()
+    }
+
+    static func resetCacheForTesting() {
+        cache.reset()
+    }
+
+    private static func validatedDocument(from data: Data, byteSize: Int) -> (Document, Int)? {
+        guard !data.contains(0),
+              let root = try? JSONSerialization.jsonObject(with: data, options: [])
+        else { return nil }
+
+        var nodeCount = 0
+        guard validate(root, depth: 0, nodeCount: &nodeCount) else { return nil }
+        let estimatedCost = byteSize + (nodeCount * estimatedBytesPerNode)
+        return (Document(root: root, byteSize: byteSize), estimatedCost)
+    }
+
+    private static func validate(_ value: Any, depth: Int, nodeCount: inout Int) -> Bool {
+        guard depth <= maximumDepth, nodeCount < maximumNodeCount else { return false }
+        nodeCount += 1
+
+        if let dictionary = value as? [String: Any] {
+            for child in dictionary.values {
+                guard validate(child, depth: depth + 1, nodeCount: &nodeCount) else { return false }
+            }
+            return true
+        }
+        if let array = value as? [Any] {
+            for child in array {
+                guard validate(child, depth: depth + 1, nodeCount: &nodeCount) else { return false }
+            }
+            return true
+        }
+        return value is String || value is NSNumber || value is NSNull
+    }
+
+    private final class CacheKey: NSObject {
+        private let path: String
+        private let fileSize: Int
+        private let modificationTime: TimeInterval
+        private let resourceIdentifier: String
+
+        init(path: String, fileSize: Int, modificationDate: Date?, resourceIdentifier: Any?) {
+            self.path = path
+            self.fileSize = fileSize
+            self.modificationTime = modificationDate?.timeIntervalSinceReferenceDate ?? 0
+            self.resourceIdentifier = resourceIdentifier.map(String.init(describing:)) ?? ""
+        }
+
+        override var hash: Int {
+            var hasher = Hasher()
+            hasher.combine(path)
+            hasher.combine(fileSize)
+            hasher.combine(modificationTime)
+            hasher.combine(resourceIdentifier)
+            return hasher.finalize()
+        }
+
+        override func isEqual(_ object: Any?) -> Bool {
+            guard let other = object as? CacheKey else { return false }
+            return path == other.path
+                && fileSize == other.fileSize
+                && modificationTime == other.modificationTime
+                && resourceIdentifier == other.resourceIdentifier
+        }
+    }
+
+    private final class Cache: @unchecked Sendable {
+        private final class Box: NSObject {
+            let document: Document?
+
+            init(_ document: Document?) {
+                self.document = document
+            }
+        }
+
+        private let lock = NSLock()
+        private let storage: NSCache<CacheKey, Box>
+        private var diagnostics = Diagnostics(fileReadCount: 0, parseCount: 0, cacheHitCount: 0)
+
+        init() {
+            let storage = NSCache<CacheKey, Box>()
+            storage.countLimit = cacheEntryLimit
+            storage.totalCostLimit = cacheEstimatedByteLimit
+            self.storage = storage
+        }
+
+        func document(for key: CacheKey, fileURL: URL, fileSize: Int) throws -> Document? {
+            lock.lock()
+            defer { lock.unlock() }
+
+            if let cached = storage.object(forKey: key) {
+                diagnostics.cacheHitCount += 1
+                return cached.document
+            }
+
+            diagnostics.fileReadCount += 1
+            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+
+            diagnostics.parseCount += 1
+            let result = validatedDocument(from: data, byteSize: fileSize)
+            storage.setObject(Box(result?.0), forKey: key, cost: max(result?.1 ?? 1, 1))
+            return result?.0
+        }
+
+        func diagnosticsSnapshot() -> Diagnostics {
+            lock.lock()
+            defer { lock.unlock() }
+            return diagnostics
+        }
+
+        func reset() {
+            lock.lock()
+            defer { lock.unlock() }
+            storage.removeAllObjects()
+            diagnostics = Diagnostics(fileReadCount: 0, parseCount: 0, cacheHitCount: 0)
+        }
+    }
+
+    private static let cache = Cache()
+    private static let cacheEntryLimit = 4
+    private static let cacheEstimatedByteLimit = 4 * 1_024 * 1_024
+    private static let maximumDepth = 64
+    private static let maximumNodeCount = 16_384
+    private static let estimatedBytesPerNode = 64
+}

--- a/Sources/QuillCodeApp/ToolArtifactJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             let preview = preview(from: root, fileSize: fileSize)
             return preview.hasDisplayContent ? preview : nil
         } catch {

--- a/Sources/QuillCodeApp/ToolArtifactJestJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactJestJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactJestJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactMochaJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactMochaJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactMochaJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactMypyJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactMypyJSONPreviewBuilder.swift
@@ -12,6 +12,19 @@ enum ToolArtifactMypyJSONPreviewBuilder {
         }
 
         do {
+            if documentPreview.extensionLabel.lowercased() == "json" {
+                guard let document = try ToolArtifactJSONDocumentReader.document(
+                    for: fileURL,
+                    byteLimit: byteLimit
+                ),
+                      let diagnostics = document.root as? [[String: Any]]
+                else { return nil }
+                return preview(
+                    from: diagnostics,
+                    byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: document.byteSize)
+                )
+            }
+
             let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
             guard resourceValues.isRegularFile == true else { return nil }
             let fileSize = max(resourceValues.fileSize ?? 0, 0)

--- a/Sources/QuillCodeApp/ToolArtifactNPMAuditJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactNPMAuditJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactNPMAuditJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(from: object, byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize))
         } catch {

--- a/Sources/QuillCodeApp/ToolArtifactNPMLockfilePreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactNPMLockfilePreviewBuilder.swift
@@ -10,17 +10,16 @@ enum ToolArtifactNPMLockfilePreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0),
-                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   isNPMLockfile(root)
             else {
                 return nil
             }
+            let fileSize = document.byteSize
             let preview = preview(
                 from: root,
                 byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)

--- a/Sources/QuillCodeApp/ToolArtifactNotebookPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactNotebookPreviewBuilder.swift
@@ -10,13 +10,12 @@ enum ToolArtifactNotebookPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             return preview(from: root, fileSize: fileSize)
         } catch {
             return nil

--- a/Sources/QuillCodeApp/ToolArtifactPHPStanJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPHPStanJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactPHPStanJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any] else { return nil }
             return preview(
                 from: report,

--- a/Sources/QuillCodeApp/ToolArtifactPipAuditJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPipAuditJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactPipAuditJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             return preview(from: root, byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize))
         } catch {
             return nil

--- a/Sources/QuillCodeApp/ToolArtifactPipfileLockPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPipfileLockPreviewBuilder.swift
@@ -10,18 +10,15 @@ enum ToolArtifactPipfileLockPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let json = try JSONSerialization.jsonObject(with: data, options: [])
-            guard let root = json as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   root["_meta"] is [String: Any],
                   let preview = preview(
                     from: root,
-                    byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)
+                    byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: document.byteSize)
                   )
             else {
                 return nil

--- a/Sources/QuillCodeApp/ToolArtifactPlaywrightJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPlaywrightJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactPlaywrightJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactPsalmJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPsalmJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactPsalmJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any] else { return nil }
             return preview(
                 from: report,

--- a/Sources/QuillCodeApp/ToolArtifactPylintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPylintJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactPylintJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let messages = root as? [[String: Any]] else { return nil }
             return preview(
                 from: messages,

--- a/Sources/QuillCodeApp/ToolArtifactPyrightJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPyrightJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactPyrightJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any],
                   let diagnostics = report["generalDiagnostics"] as? [[String: Any]]
             else { return nil }

--- a/Sources/QuillCodeApp/ToolArtifactPytestJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactPytestJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactPytestJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let object = root as? [String: Any] else { return nil }
             return preview(
                 from: object,

--- a/Sources/QuillCodeApp/ToolArtifactRSpecJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactRSpecJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactRSpecJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any] else { return nil }
             return preview(
                 from: report,

--- a/Sources/QuillCodeApp/ToolArtifactRuboCopJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactRuboCopJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactRuboCopJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any] else { return nil }
             return preview(
                 from: report,

--- a/Sources/QuillCodeApp/ToolArtifactRuffJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactRuffJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactRuffJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let violations = root as? [[String: Any]] else { return nil }
             return preview(
                 from: violations,

--- a/Sources/QuillCodeApp/ToolArtifactSARIFPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSARIFPreviewBuilder.swift
@@ -10,17 +10,16 @@ enum ToolArtifactSARIFPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0),
-                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   let runs = root["runs"] as? [[String: Any]]
             else {
                 return nil
             }
+            let fileSize = document.byteSize
             let preview = preview(from: root, runs: runs, fileSize: fileSize)
             return preview.hasDisplayContent ? preview : nil
         } catch {

--- a/Sources/QuillCodeApp/ToolArtifactSPDXPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSPDXPreviewBuilder.swift
@@ -12,17 +12,16 @@ enum ToolArtifactSPDXPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0),
-                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   isSPDXDocument(root)
             else {
                 return nil
             }
+            let fileSize = document.byteSize
             let preview = preview(
                 from: root,
                 byteSizeLabel: ToolArtifactByteSizeFormatter.label(for: fileSize)

--- a/Sources/QuillCodeApp/ToolArtifactSemgrepJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSemgrepJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactSemgrepJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let report = root as? [String: Any],
                   let results = report["results"] as? [[String: Any]]
             else {

--- a/Sources/QuillCodeApp/ToolArtifactStylelintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactStylelintJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactStylelintJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let results = root as? [[String: Any]] else { return nil }
             return preview(
                 from: results,

--- a/Sources/QuillCodeApp/ToolArtifactSwiftLintJSONPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSwiftLintJSONPreviewBuilder.swift
@@ -12,13 +12,12 @@ enum ToolArtifactSwiftLintJSONPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0) else { return nil }
-            let root = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ) else { return nil }
+            let fileSize = document.byteSize
+            let root = document.root
             guard let violations = root as? [[String: Any]] else { return nil }
             return preview(
                 from: violations,

--- a/Sources/QuillCodeApp/ToolArtifactSwiftPMPackageResolvedPreviewBuilder.swift
+++ b/Sources/QuillCodeApp/ToolArtifactSwiftPMPackageResolvedPreviewBuilder.swift
@@ -13,17 +13,16 @@ enum ToolArtifactSwiftPMPackageResolvedPreviewBuilder {
         }
 
         do {
-            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-            guard resourceValues.isRegularFile == true else { return nil }
-            let fileSize = max(resourceValues.fileSize ?? 0, 0)
-            guard fileSize > 0, fileSize <= byteLimit else { return nil }
-            let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-            guard !data.contains(0),
-                  let root = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            guard let document = try ToolArtifactJSONDocumentReader.document(
+                for: fileURL,
+                byteLimit: byteLimit
+            ),
+                  let root = document.root as? [String: Any],
                   let pins = root["pins"] as? [[String: Any]]
             else {
                 return nil
             }
+            let fileSize = document.byteSize
             let preview = preview(
                 from: root,
                 pins: pins,

--- a/Tests/QuillCodeAppTests/ToolArtifactJSONDocumentReaderTests.swift
+++ b/Tests/QuillCodeAppTests/ToolArtifactJSONDocumentReaderTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import XCTest
+@testable import QuillCodeApp
+
+final class ToolArtifactJSONDocumentReaderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ToolArtifactJSONDocumentReader.resetCacheForTesting()
+    }
+
+    override func tearDown() {
+        ToolArtifactJSONDocumentReader.resetCacheForTesting()
+        super.tearDown()
+    }
+
+    func testPreviewBuildersShareOneFileReadAndParse() throws {
+        let fileURL = try fixtureFile(contents: """
+        [{"filePath":"/workspace/App.swift","messages":[{"ruleId":"no-debugger","severity":2}],"errorCount":1,"warningCount":0}]
+        """)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        let artifact = ToolArtifactState(value: fileURL.path)
+        XCTAssertNotNil(artifact.eslintJSONPreview)
+        XCTAssertNil(artifact.stylelintJSONPreview)
+        XCTAssertNil(artifact.jsonPreview)
+
+        let diagnostics = ToolArtifactJSONDocumentReader.diagnosticsForTesting()
+        XCTAssertEqual(diagnostics.fileReadCount, 1)
+        XCTAssertEqual(diagnostics.parseCount, 1)
+        XCTAssertGreaterThanOrEqual(diagnostics.cacheHitCount, 3)
+    }
+
+    func testMalformedDocumentIsNegativelyCached() throws {
+        let fileURL = try fixtureFile(contents: #"{"unfinished": true"#)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        let artifact = ToolArtifactState(value: fileURL.path)
+        XCTAssertNil(artifact.eslintJSONPreview)
+        XCTAssertNil(artifact.pytestJSONPreview)
+        XCTAssertNil(artifact.jsonPreview)
+
+        let diagnostics = ToolArtifactJSONDocumentReader.diagnosticsForTesting()
+        XCTAssertEqual(diagnostics.fileReadCount, 1)
+        XCTAssertEqual(diagnostics.parseCount, 1)
+        XCTAssertGreaterThanOrEqual(diagnostics.cacheHitCount, 2)
+    }
+
+    func testMetadataChangeInvalidatesSamePathAndSize() throws {
+        let fileURL = try fixtureFile(contents: #"{"a":1}"#)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        let first = try XCTUnwrap(ToolArtifactJSONDocumentReader.document(for: fileURL, byteLimit: 1_024))
+        XCTAssertEqual((first.root as? [String: Int])?["a"], 1)
+
+        try Data(#"{"b":2}"#.utf8).write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(2)],
+            ofItemAtPath: fileURL.path
+        )
+
+        let second = try XCTUnwrap(ToolArtifactJSONDocumentReader.document(for: fileURL, byteLimit: 1_024))
+        XCTAssertEqual((second.root as? [String: Int])?["b"], 2)
+        XCTAssertEqual(
+            ToolArtifactJSONDocumentReader.diagnosticsForTesting(),
+            .init(fileReadCount: 2, parseCount: 2, cacheHitCount: 0)
+        )
+    }
+
+    func testConcurrentRequestsCoalesceIntoOneParse() throws {
+        let fileURL = try fixtureFile(contents: #"{"value":42}"#)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        DispatchQueue.concurrentPerform(iterations: 32) { _ in
+            _ = try? ToolArtifactJSONDocumentReader.document(for: fileURL, byteLimit: 1_024)
+        }
+
+        XCTAssertEqual(
+            ToolArtifactJSONDocumentReader.diagnosticsForTesting(),
+            .init(fileReadCount: 1, parseCount: 1, cacheHitCount: 31)
+        )
+    }
+
+    func testStructurallyExplosiveDocumentIsRejectedAndNegativelyCached() throws {
+        let fileURL = try fixtureFile(contents: "[" + Array(repeating: "0", count: 16_384).joined(separator: ",") + "]")
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        XCTAssertNil(try ToolArtifactJSONDocumentReader.document(for: fileURL, byteLimit: 128 * 1_024))
+        XCTAssertNil(try ToolArtifactJSONDocumentReader.document(for: fileURL, byteLimit: 128 * 1_024))
+        XCTAssertEqual(
+            ToolArtifactJSONDocumentReader.diagnosticsForTesting(),
+            .init(fileReadCount: 1, parseCount: 1, cacheHitCount: 1)
+        )
+    }
+
+    func testCallerByteLimitIsEnforcedBeforeReadingOrCaching() throws {
+        let fileURL = try fixtureFile(contents: #"{"payload":"abcdefghijklmnopqrstuvwxyz"}"#)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        XCTAssertNil(try ToolArtifactJSONDocumentReader.document(for: fileURL, byteLimit: 8))
+        XCTAssertEqual(
+            ToolArtifactJSONDocumentReader.diagnosticsForTesting(),
+            .init(fileReadCount: 0, parseCount: 0, cacheHitCount: 0)
+        )
+        XCTAssertNotNil(try ToolArtifactJSONDocumentReader.document(for: fileURL, byteLimit: 1_024))
+        XCTAssertEqual(ToolArtifactJSONDocumentReader.diagnosticsForTesting().parseCount, 1)
+    }
+
+    private func fixtureFile(contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-cowork-json-preview-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("artifact.json")
+        try Data(contents.utf8).write(to: fileURL)
+        return fileURL
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityBoundedJSONPreviewParsingGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityBoundedJSONPreviewParsingGateTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+final class ParityBoundedJSONPreviewParsingGateTests: QuillCodeParityTestCase {
+    func testStructuredJSONPreviewsUseSharedBoundedDocumentReader() throws {
+        let reader = try Self.appSourceText(named: "ToolArtifactJSONDocumentReader.swift")
+        Self.assertSource(reader, containsAll: [
+            "NSCache<CacheKey, Box>",
+            "cacheEntryLimit = 4",
+            "cacheEstimatedByteLimit = 4 * 1_024 * 1_024",
+            "maximumDepth = 64",
+            "maximumNodeCount = 16_384",
+            ".contentModificationDateKey",
+            ".fileResourceIdentifierKey",
+            "private let lock = NSLock()"
+        ])
+
+        let directParserAllowlist: Set<String> = [
+            "ToolArtifactBunLockfilePreviewBuilder.swift",
+            "ToolArtifactCargoCompilerJSONLinesPreviewBuilder.swift",
+            "ToolArtifactGoTestJSONLinesPreviewBuilder.swift",
+            "ToolArtifactJSONLinesPreviewBuilder.swift",
+            "ToolArtifactMypyJSONPreviewBuilder.swift"
+        ]
+        var sharedReaderCount = 0
+
+        for fileURL in try Self.swiftSourceFiles(in: "Sources/QuillCodeApp")
+            where fileURL.lastPathComponent.hasPrefix("ToolArtifact")
+                && fileURL.lastPathComponent.hasSuffix("PreviewBuilder.swift")
+        {
+            let source = try String(contentsOf: fileURL, encoding: .utf8)
+            if source.contains("ToolArtifactJSONDocumentReader.document") {
+                sharedReaderCount += 1
+            }
+            if source.contains("JSONSerialization.jsonObject"),
+               !directParserAllowlist.contains(fileURL.lastPathComponent) {
+                XCTFail("\(fileURL.lastPathComponent) bypasses the shared bounded JSON reader")
+            }
+        }
+
+        XCTAssertGreaterThanOrEqual(sharedReaderCount, 39)
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -17433,3 +17433,26 @@ Validation:
 - Final three-launch physical-footprint evidence: 292.07 ms median launch-ready, 41.02 MiB initial, 86.45 MiB post-interaction, 87.67 MiB repeated-interaction, and 1.22 MiB repeated growth
 - `python3 scripts/grade-code-quality.py --root .` (all production modules A+)
 - `git diff --check`
+
+## 2026-08-11 Bounded JSON Artifact Parsing
+
+Overall grade after this slice: **A+ responsiveness, A+ memory architecture, A+ malformed-input resilience**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Parse ownership | A+ | Forty structured JSON preview builders now share one metadata-keyed document reader; one artifact projection no longer maps and parses the same bytes independently for each candidate format. |
+| Residency | A+ | Successful and invalid results use a purgeable four-entry cache capped at 4 MiB estimated decoded cost, with per-document byte and 16,384-node limits. |
+| Concurrency | A+ | Same-key requests coalesce under a synchronized read/parse boundary, so concurrent SwiftUI or parity projections perform one file read and one parse. |
+| Invalidation | A+ | Fresh file identity, size, and modification metadata form the key; same-path, same-size rewrites invalidate deterministically instead of serving stale preview data. |
+| Failure behavior | A+ | Malformed JSON is negatively cached, over-depth or over-node documents fail closed, caller byte limits run before I/O, and format-specific cards preserve their prior typed output. |
+| Regression evidence | A+ | Six focused cache tests cover reuse, malformed input, mutation, concurrency, structural limits, and byte limits; the architecture gate rejects new direct whole-document JSON parsers outside the explicit JSONL/JSONC adapters. |
+
+Validation:
+
+- Focused reader, architecture, and complete artifact-surface suite (105 tests, 0 failures)
+- `swift test` (6,206 tests; 5 skipped; 0 failures)
+- `scripts/packaged-macos-smoke.sh` (SIGKILL draft recovery, direct and Launch Services rendering, live native interaction, Accessibility, browser/computer-use contracts, and 100-chat interaction passed)
+- `scripts/packaged-macos-performance-smoke.sh` (3/3 fresh launches within startup, physical-footprint, growth, and thread budgets)
+- Final three-launch physical-footprint evidence: 305.24 ms median launch-ready, 41.17 MiB initial, 86.88 MiB post-interaction, 85.69 MiB repeated-interaction, and -1.19 MiB repeated growth
+- `python3 scripts/grade-code-quality.py --root .` (new production and test files A+; all production modules A+)
+- `git diff --check`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,12 @@
 
 ## Latest Quality Pass
 
+- Structured JSON artifact previews now share one metadata-keyed document reader instead of mapping
+  and parsing the same file independently for each candidate format. Successful and invalid parses
+  are purgeable and bounded to four entries / 4 MiB estimated residency; same-key concurrent reads
+  coalesce, file identity/size/mtime changes invalidate immediately, caller byte caps still apply
+  before I/O, and documents deeper than 64 levels or larger than 16,384 JSON nodes fail closed before
+  any format renderer walks them.
 - Model streaming now separates provider-token cadence from presentation cadence: visible answer
   drafts and bounded reasoning summaries publish at most every 50 milliseconds, with immediate first
   text and an exact final flush on success or provider failure. A shared 16 MiB UTF-8 action limit


### PR DESCRIPTION
## Summary
- share one metadata-keyed, purgeable JSON document cache across 40 artifact preview builders
- negatively cache malformed input and reject over-depth or over-node documents before format traversal
- cover reuse, invalidation, concurrency, byte limits, structural limits, and source architecture

## Validation
- focused artifact/cache suite: 105 tests passed
- full Swift suite: 6,206 tests passed, 5 skipped
- packaged macOS daily-driver smoke passed
- packaged performance: 3/3 passed; 305.24 ms median ready, 41.17 MiB initial, 85.69 MiB repeated
- all production modules A+; diff check clean