### PR TITLE
Harden tester publication retries

### DIFF
--- a/Tests/QuillCodeParityTests/ParityTransactionalTesterPublicationTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTransactionalTesterPublicationTests.swift
@@ -89,6 +89,99 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
         )
     }
 
+    func testTransientReleaseReadRetriesBeforeAnyMutation() throws {
+        let result = try runPublisher(failure: "get-release-transient")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let operations = try XCTUnwrap(result.state["operations"] as? [String])
+        XCTAssertEqual(operations.filter { $0 == "failure:get-release-transient" }.count, 1)
+        XCTAssertEqual(operations.first, "failure:get-release-transient")
+        XCTAssertEqual(result.state["tag"] as? String, newCommit)
+    }
+
+    func testTemporaryReleaseNotFoundDuringCandidateUploadRetriesSafely() throws {
+        let result = try runPublisher(failure: "upload-release-not-found")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let operations = try XCTUnwrap(result.state["operations"] as? [String])
+        XCTAssertEqual(operations.filter { $0 == "failure:upload-release-not-found" }.count, 1)
+        XCTAssertEqual(operations.filter { $0.hasPrefix("upload:") }.count, 3)
+        XCTAssertEqual(
+            try assetNames(in: release(from: result.state)),
+            ["Quill-Cowork-macOS-arm64.zip", "latest-tester-build.json", "new-evidence.json"]
+        )
+    }
+
+    func testLostCandidateUploadResponseAcceptsOnlyExactRetainedAsset() throws {
+        let result = try runPublisher(failure: "upload-transient-after-mutation")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let operations = try XCTUnwrap(result.state["operations"] as? [String])
+        XCTAssertEqual(
+            operations.filter { $0 == "failure:upload-transient-after-mutation" }.count,
+            1
+        )
+        XCTAssertEqual(operations.filter { $0.hasPrefix("upload:") }.count, 3)
+        XCTAssertEqual(
+            try assetNames(in: release(from: result.state)),
+            ["Quill-Cowork-macOS-arm64.zip", "latest-tester-build.json", "new-evidence.json"]
+        )
+    }
+
+    func testLostUploadResponseWithConflictingRemoteAssetRestoresPreviousRelease() throws {
+        let result = try runPublisher(failure: "upload-transient-after-conflicting-mutation")
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.output.contains("conflicting metadata"), result.output)
+        XCTAssertTrue(result.output.contains("Restored the previous tester release"), result.output)
+        XCTAssertEqual(result.state["tag"] as? String, oldCommit)
+        XCTAssertEqual(
+            try assetNames(in: release(from: result.state)),
+            ["Quill-Cowork-macOS-arm64.zip", "latest-tester-build.json", "obsolete.txt"]
+        )
+    }
+
+    func testPersistentTransientReleaseFailureExhaustsBoundedRetriesWithoutMutation() throws {
+        let result = try runPublisher(
+            failure: "get-release-transient",
+            failureCount: 5
+        )
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        let operations = try XCTUnwrap(result.state["operations"] as? [String])
+        XCTAssertEqual(operations.count, 5)
+        XCTAssertTrue(operations.allSatisfy { $0 == "failure:get-release-transient" })
+        XCTAssertEqual(result.state["tag"] as? String, oldCommit)
+    }
+
+    func testTransientIdempotentRemoteMutationsRetry() throws {
+        for failure in ["patch-asset-transient", "patch-release-transient", "push-tag-transient"] {
+            let result = try runPublisher(failure: failure)
+
+            XCTAssertEqual(result.exitCode, 0, "\(failure): \(result.output)")
+            let operations = try XCTUnwrap(result.state["operations"] as? [String])
+            XCTAssertEqual(
+                operations.filter { $0 == "failure:\(failure)" }.count,
+                1,
+                failure
+            )
+            XCTAssertEqual(result.state["tag"] as? String, newCommit, failure)
+        }
+    }
+
+    func testLostDeleteResponseRecognizesCompletedCleanup() throws {
+        let result = try runPublisher(failure: "delete-asset-after-mutation")
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        let operations = try XCTUnwrap(result.state["operations"] as? [String])
+        XCTAssertEqual(operations.filter { $0 == "failure:delete-asset-after-mutation" }.count, 1)
+        XCTAssertEqual(operations.filter { $0.hasPrefix("delete:") }.count, 3)
+        XCTAssertEqual(
+            try assetNames(in: release(from: result.state)),
+            ["Quill-Cowork-macOS-arm64.zip", "latest-tester-build.json", "new-evidence.json"]
+        )
+    }
+
     func testUnsafeInputsFailBeforeGitHubMutation() throws {
         let result = try runPublisher(commit: "short")
 
@@ -106,6 +199,7 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
 
     private func runPublisher(
         failure: String? = nil,
+        failureCount: Int = 1,
         commit: String? = nil
     ) throws -> PublisherResult {
         let root = FileManager.default.temporaryDirectory
@@ -135,7 +229,7 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
             "localTag": oldCommit,
             "nextAssetID": 100,
             "operations": [],
-            "failures": failure.map { [$0: 1] } ?? [:],
+            "failures": failure.map { [$0: failureCount] } ?? [:],
             "release": [
                 "id": 77,
                 "tag_name": "tester-latest",
@@ -254,6 +348,15 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
                 print("injected failure: " + point, file=sys.stderr)
                 raise SystemExit(42)
 
+        def fail_with_diagnostic_if_requested(state, point, diagnostic):
+            remaining = state.get("failures", {}).get(point, 0)
+            if remaining > 0:
+                state["failures"][point] = remaining - 1
+                record(state, "failure:" + point)
+                save(state)
+                print(diagnostic, file=sys.stderr)
+                raise SystemExit(42)
+
         def asset_by_id(state, identifier):
             for asset in state["release"]["assets"]:
                 if asset["id"] == identifier:
@@ -267,6 +370,11 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
             method = args[args.index("--method") + 1]
             endpoint = next(value for value in args if value.startswith("repos/"))
             if method == "GET" and "/releases/tags/" in endpoint:
+                fail_with_diagnostic_if_requested(
+                    state,
+                    "get-release-transient",
+                    "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+                )
                 record(state, "get-release")
                 save(state)
                 print(json.dumps(state["release"], sort_keys=True))
@@ -274,6 +382,11 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
             if "/releases/assets/" in endpoint:
                 identifier = int(endpoint.rsplit("/", 1)[1])
                 if method == "PATCH":
+                    fail_with_diagnostic_if_requested(
+                        state,
+                        "patch-asset-transient",
+                        "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+                    )
                     fail_if_requested(state, "patch-asset")
                     requested = args[args.index("-f") + 1]
                     name = requested.split("=", 1)[1]
@@ -292,8 +405,18 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
                         if value["id"] != identifier
                     ]
                     save(state)
+                    fail_with_diagnostic_if_requested(
+                        state,
+                        "delete-asset-after-mutation",
+                        "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+                    )
                     raise SystemExit(0)
             if method == "PATCH" and "/releases/" in endpoint:
+                fail_with_diagnostic_if_requested(
+                    state,
+                    "patch-release-transient",
+                    "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+                )
                 fail_if_requested(state, "patch-release")
                 payload_path = Path(args[args.index("--input") + 1])
                 payload = json.loads(payload_path.read_text())
@@ -304,6 +427,11 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
                 print(json.dumps(state["release"], sort_keys=True))
                 raise SystemExit(0)
         if args[:2] == ["release", "upload"]:
+            fail_with_diagnostic_if_requested(
+                state,
+                "upload-release-not-found",
+                "release not found"
+            )
             fail_if_requested(state, "upload")
             path = Path(args[3])
             data = path.read_bytes()
@@ -314,10 +442,25 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
                 "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
                 "state": "uploaded"
             }
+            if state.get("failures", {}).get(
+                "upload-transient-after-conflicting-mutation",
+                0
+            ) > 0:
+                asset["digest"] = "sha256:conflicting-remote-content"
             state["nextAssetID"] += 1
             state["release"]["assets"].append(asset)
             record(state, "upload:" + path.name)
             save(state)
+            fail_with_diagnostic_if_requested(
+                state,
+                "upload-transient-after-conflicting-mutation",
+                "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+            )
+            fail_with_diagnostic_if_requested(
+                state,
+                "upload-transient-after-mutation",
+                "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+            )
             raise SystemExit(0)
         print("unexpected gh invocation: " + " ".join(args), file=sys.stderr)
         raise SystemExit(49)
@@ -351,6 +494,18 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
                 print("injected failure: " + point, file=sys.stderr)
                 raise SystemExit(42)
 
+        def fail_transient_if_requested(state, point):
+            remaining = state.get("failures", {}).get(point, 0)
+            if remaining > 0:
+                state["failures"][point] = remaining - 1
+                state["operations"].append("failure:" + point)
+                save(state)
+                print(
+                    "tls: failed to verify certificate: x509: certificate signed by unknown authority",
+                    file=sys.stderr
+                )
+                raise SystemExit(42)
+
         args = sys.argv[1:]
         state = load()
         if args[:1] == ["config"]:
@@ -374,6 +529,7 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
                 state["operations"].append("delete-tag")
                 save(state)
                 raise SystemExit(0)
+            fail_transient_if_requested(state, "push-tag-transient")
             fail_if_requested(state, "push-tag")
             state["tag"] = state["localTag"]
             state["operations"].append("push-tag:" + state["tag"])

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,32 @@
 # Code Quality Audit
 
+## 2026-08-11 Idempotent Tester Publication Recovery
+
+Overall grade after this slice: **A+ transaction safety, A+ outage resilience, A+ failure evidence**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Retry ownership | A+ | One publication remote owns bounded transient classification, capped exponential backoff, and idempotent remote commands. |
+| Upload ambiguity | A+ | A failed upload response succeeds only when a fresh release probe finds the exact expected name, uploaded state, size, and SHA-256 digest. |
+| Failure isolation | A+ | Permanent diagnostics still fail immediately; temporary `release not found` retries only while the canonical release is independently readable. |
+| Rollback safety | A+ | Conflicting retained bytes fail closed, candidate aliases are removed, canonical assets and metadata are restored, and the prior tag is verified. |
+| Boundedness | A+ | Persistent transient failures stop after five attempts with retry delays capped at 30 seconds; tests use zero delay without changing production policy. |
+| Recovery evidence | A+ | Fault injection covers failures before mutation, after remote mutation but before response, mismatched retained bytes, idempotent PATCH/tag retry, and lost DELETE responses. |
+
+Validation:
+
+- Transactional publication fault suite: 11 tests, 0 failures.
+- Complete download-build, exact-main CI, release-policy, freshness, manifest, and publication
+  parity boundary: 36 tests, 0 failures.
+- Full Swift suite: 6,213 tests, 5 skipped, 0 failures.
+- Release packaged composer `SIGKILL` recovery, direct-executable, Launch Services, native
+  Accessibility interaction, and 100-chat daily-driver smokes passed.
+- Packaged performance gate: 295.45 ms median launch-ready, 41.28 MiB initial footprint,
+  85.75 MiB after the first interaction sweep, and 88.45 MiB after the repeated sweep.
+- Python bytecode compilation for the complete tester-publication package passed.
+- `python3 scripts/grade-code-quality.py --root .`: every module summary remains A+.
+- `git diff --check`: clean.
+
 ## 2026-08-11 Bounded Artifact Text Preview Residency
 
 Overall grade after this slice: **A+ memory architecture, A+ surface responsiveness, A+ data fidelity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4598,3 +4598,25 @@
   `ParityBenchmarkCompatibilityEvalsTests`. The 2026-08-07 exact-model live run passed TAU3 banking
   6/6 and BFCL 8/8 with all 24 bounded paid invocations successful; the redacted local manifest is
   `.build/quillcode-validation/benchmark-compat/live-r1/manifest.json`.
+
+## 2026-08-11: tester publication retries are idempotent and state-probed
+
+- **Incident:** Tester build 729 packaged successfully on every platform, but its first publish job
+  received `release not found` while uploading a candidate and then a transient GitHub API TLS
+  certificate error while checking rollback. The transaction preserved the complete prior public
+  build, and a failed-job retry published and verified 729 successfully.
+- **Decision:** Read-only and idempotent GitHub publication operations retry only recognized TLS,
+  DNS, connection, timeout, rate-limit, and 5xx failures, using five attempts and capped exponential
+  backoff. Permanent policy, validation, and malformed-response failures remain immediate.
+- **Upload boundary:** A candidate upload never retries blindly after an ambiguous response. The
+  publisher first reads the live release and accepts the operation only when the exact transaction
+  alias exists in uploaded state with the expected byte count and SHA-256 digest. Conflicting remote
+  content fails closed into the existing verified rollback. A temporary `release not found` result
+  retries only when that probe independently confirms the canonical release still exists.
+- **Cleanup boundary:** Asset deletion is idempotent. A retry that observes the asset already absent
+  treats the original deletion as complete, preventing a lost success response from turning a
+  correct committed release into a false failure.
+- **Evidence:** `tester_publication/remote.py`, `publisher.py`, `initial.py`, and
+  `ParityTransactionalTesterPublicationTests` cover transient reads, pre- and post-mutation upload
+  failures, conflicting bytes, bounded exhaustion, PATCH/tag retries, deletion response loss,
+  permanent failures, exact rollback, and tag-last success ordering.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,14 @@
 
 ## Latest Quality Pass
 
+- Tester publication now absorbs bounded transient GitHub and network failures without weakening its
+  atomic release contract. Release reads and idempotent PATCH/tag operations retry recognized TLS,
+  DNS, timeout, rate-limit, and 5xx diagnostics with capped exponential backoff. Candidate uploads
+  probe the live release after every failed response: an exact uploaded size and SHA-256 completes
+  the operation, conflicting bytes fail closed into rollback, and the observed temporary
+  `release not found` response retries only after the canonical release is independently visible.
+  Cleanup deletion is idempotent across lost responses, and persistent outages stop after five
+  attempts without beginning a mutation.
 - Structured JSON artifact previews now share one metadata-keyed document reader instead of mapping
   and parsing the same file independently for each candidate format. Successful and invalid parses
   are purgeable and bounded to four entries / 4 MiB estimated residency; same-key concurrent reads

--- a/scripts/tester_publication/initial.py
+++ b/scripts/tester_publication/initial.py
@@ -46,16 +46,11 @@ def publish_initial_release(
         )
         created_release = True
         for name in ordered_asset_names(assets):
-            run_command(
-                [
-                    "gh",
-                    "release",
-                    "upload",
-                    TAG,
-                    str(assets[name].path),
-                    "--repo",
-                    remote.repository,
-                ]
+            asset = assets[name]
+            remote.upload_asset(
+                str(asset.path),
+                expected_size=asset.size,
+                expected_digest=asset.digest,
             )
         run_command(
             [

--- a/scripts/tester_publication/publisher.py
+++ b/scripts/tester_publication/publisher.py
@@ -20,7 +20,7 @@ from tester_publication.contracts import (
     validate_release_metadata,
 )
 from tester_publication.initial import publish_initial_release
-from tester_publication.remote import PublicationRemote, run_command
+from tester_publication.remote import PublicationRemote
 
 
 class TesterReleasePublisher:
@@ -115,16 +115,10 @@ class TesterReleasePublisher:
                 raise PublicationError(f"Transaction asset name is too long: {candidate_name}")
             candidate_path = staging_directory / candidate_name
             shutil.copyfile(local.path, candidate_path)
-            run_command(
-                [
-                    "gh",
-                    "release",
-                    "upload",
-                    TAG,
-                    str(candidate_path),
-                    "--repo",
-                    self.remote.repository,
-                ]
+            self.remote.upload_asset(
+                str(candidate_path),
+                expected_size=local.size,
+                expected_digest=local.digest,
             )
 
         staged_release = self.remote.get_release()

--- a/scripts/tester_publication/remote.py
+++ b/scripts/tester_publication/remote.py
@@ -16,6 +16,34 @@ from tester_publication.contracts import (
 )
 
 
+REMOTE_ATTEMPTS = 5
+MAX_RETRY_DELAY_SECONDS = 30.0
+TRANSIENT_REMOTE_DIAGNOSTICS = (
+    "certificate signed by unknown authority",
+    "certificate is not valid",
+    "connection refused",
+    "connection reset",
+    "could not resolve host",
+    "gateway timeout",
+    "http 429",
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+    "i/o timeout",
+    "network is unreachable",
+    "remote end hung up",
+    "secondary rate limit",
+    "service unavailable",
+    "server error",
+    "temporary failure",
+    "timed out",
+    "tls:",
+    "unexpected eof",
+    "x509:",
+)
+
+
 @dataclass(frozen=True)
 class CommandResult:
     exit_code: int
@@ -37,9 +65,23 @@ def command_result(arguments: list[str]) -> CommandResult:
 def run_command(arguments: list[str]) -> str:
     result = command_result(arguments)
     if result.exit_code != 0:
-        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
-        raise PublicationError(f"Command failed ({' '.join(arguments)}): {detail}")
+        raise command_error(arguments, result)
     return result.stdout
+
+
+def command_error(arguments: list[str], result: CommandResult) -> PublicationError:
+    detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+    return PublicationError(f"Command failed ({' '.join(arguments)}): {detail}")
+
+
+def is_transient_remote_failure(result: CommandResult) -> bool:
+    diagnostic = f"{result.stderr}\n{result.stdout}".lower()
+    return any(fragment in diagnostic for fragment in TRANSIENT_REMOTE_DIAGNOSTICS)
+
+
+def is_not_found(result: CommandResult) -> bool:
+    diagnostic = f"{result.stderr}\n{result.stdout}".lower()
+    return "http 404" in diagnostic or "not found" in diagnostic
 
 
 class PublicationRemote:
@@ -56,17 +98,94 @@ class PublicationRemote:
     def asset_endpoint(self, identifier: int) -> str:
         return f"repos/{self.repository}/releases/assets/{identifier}"
 
+    def wait_before_retry(self, attempt: int) -> None:
+        delay = min(
+            self.retry_delay_seconds * (2**attempt),
+            MAX_RETRY_DELAY_SECONDS,
+        )
+        if delay > 0:
+            time.sleep(delay)
+
+    def run_idempotent_remote_command(
+        self,
+        arguments: list[str],
+        *,
+        missing_ok: bool = False,
+    ) -> str:
+        for attempt in range(REMOTE_ATTEMPTS):
+            result = command_result(arguments)
+            if result.exit_code == 0:
+                return result.stdout
+            if missing_ok and is_not_found(result):
+                return ""
+            if attempt + 1 == REMOTE_ATTEMPTS or not is_transient_remote_failure(result):
+                raise command_error(arguments, result)
+            self.wait_before_retry(attempt)
+        raise AssertionError("Remote retry loop must return or raise.")
+
     def get_release(self, *, missing_ok: bool = False) -> ReleaseSnapshot | None:
-        result = command_result(["gh", "api", "--method", "GET", self.release_endpoint()])
-        if result.exit_code == 0:
-            return decode_release(result.stdout)
-        if missing_ok and ("HTTP 404" in result.stderr or "Not Found" in result.stderr):
-            return None
-        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
-        raise PublicationError(f"Could not read {TAG}: {detail}")
+        arguments = ["gh", "api", "--method", "GET", self.release_endpoint()]
+        for attempt in range(REMOTE_ATTEMPTS):
+            result = command_result(arguments)
+            if result.exit_code == 0:
+                return decode_release(result.stdout)
+            if missing_ok and is_not_found(result):
+                return None
+            if attempt + 1 == REMOTE_ATTEMPTS or not is_transient_remote_failure(result):
+                detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+                raise PublicationError(f"Could not read {TAG}: {detail}")
+            self.wait_before_retry(attempt)
+        raise AssertionError("Release retry loop must return or raise.")
+
+    def upload_asset(self, path: str, expected_size: int, expected_digest: str) -> None:
+        arguments = [
+            "gh",
+            "release",
+            "upload",
+            TAG,
+            path,
+            "--repo",
+            self.repository,
+        ]
+        expected_name = path.rsplit("/", 1)[-1]
+        for attempt in range(REMOTE_ATTEMPTS):
+            result = command_result(arguments)
+            if result.exit_code == 0:
+                return
+
+            probe_error: PublicationError | None = None
+            release: ReleaseSnapshot | None = None
+            try:
+                release = self.get_release()
+            except PublicationError as error:
+                probe_error = error
+            if release is not None:
+                remote = release.assets.get(expected_name)
+                if remote is not None:
+                    if (
+                        remote.state == "uploaded"
+                        and remote.size == expected_size
+                        and remote.digest == expected_digest
+                    ):
+                        return
+                    raise PublicationError(
+                        f"GitHub retained conflicting metadata for staged asset {expected_name}."
+                    )
+
+            diagnostic = f"{result.stderr}\n{result.stdout}".lower()
+            release_temporarily_missing = release is not None and "release not found" in diagnostic
+            retryable = is_transient_remote_failure(result) or release_temporarily_missing
+            if attempt + 1 < REMOTE_ATTEMPTS and retryable:
+                self.wait_before_retry(attempt)
+                continue
+            error = command_error(arguments, result)
+            if probe_error is not None:
+                raise PublicationError(f"{error} | Upload state probe failed: {probe_error}")
+            raise error
+        raise AssertionError("Upload retry loop must return or raise.")
 
     def remote_tag_commit(self, *, missing_ok: bool = False) -> str | None:
-        output = run_command(
+        output = self.run_idempotent_remote_command(
             ["git", "ls-remote", "--refs", "origin", f"refs/tags/{TAG}"]
         )
         rows = [line.split() for line in output.splitlines() if line.strip()]
@@ -92,14 +211,19 @@ class PublicationRemote:
 
     def force_remote_tag(self, commit: str) -> None:
         run_command(["git", "tag", "-f", TAG, commit])
-        run_command(["git", "push", "origin", f"refs/tags/{TAG}", "--force"])
+        self.run_idempotent_remote_command(
+            ["git", "push", "origin", f"refs/tags/{TAG}", "--force"]
+        )
 
     def delete_remote_tag(self) -> None:
-        run_command(["git", "push", "origin", f":refs/tags/{TAG}"])
+        self.run_idempotent_remote_command(
+            ["git", "push", "origin", f":refs/tags/{TAG}"],
+            missing_ok=True,
+        )
         command_result(["git", "tag", "-d", TAG])
 
     def rename_asset(self, identifier: int, name: str) -> None:
-        run_command(
+        self.run_idempotent_remote_command(
             [
                 "gh",
                 "api",
@@ -112,19 +236,15 @@ class PublicationRemote:
         )
 
     def delete_asset(self, identifier: int) -> None:
-        last_error: PublicationError | None = None
-        for attempt in range(3):
-            try:
-                run_command(
-                    ["gh", "api", "--method", "DELETE", self.asset_endpoint(identifier)]
-                )
+        arguments = ["gh", "api", "--method", "DELETE", self.asset_endpoint(identifier)]
+        for attempt in range(REMOTE_ATTEMPTS):
+            result = command_result(arguments)
+            if result.exit_code == 0 or is_not_found(result):
                 return
-            except PublicationError as error:
-                last_error = error
-                if attempt < 2:
-                    time.sleep(self.retry_delay_seconds)
-        assert last_error is not None
-        raise last_error
+            if attempt + 1 == REMOTE_ATTEMPTS:
+                raise command_error(arguments, result)
+            self.wait_before_retry(attempt)
+        raise AssertionError("Delete retry loop must return or raise.")
 
     def patch_release(self, snapshot: ReleaseSnapshot, payload: dict[str, Any]) -> None:
         with tempfile.NamedTemporaryFile(
@@ -132,7 +252,7 @@ class PublicationRemote:
         ) as handle:
             json.dump(payload, handle, ensure_ascii=True)
             handle.flush()
-            run_command(
+            self.run_idempotent_remote_command(
                 [
                     "gh",
                     "api",


### PR DESCRIPTION
## Summary
- retry recognized transient GitHub/network failures with bounded capped backoff
- resolve failed upload ambiguity by probing exact remote size and SHA-256 before retry or acceptance
- keep conflicting content and permanent errors fail-closed through verified rollback
- make remote deletion idempotent after lost success responses

## Incident
Tester build 729 packaged successfully but its first publish attempt received a temporary release-not-found result followed by a GitHub API TLS certificate failure during rollback inspection. The prior public release remained intact and a failed-job retry completed publication. These tests reproduce both diagnostics and response-loss boundaries deterministically.

## Validation
- 11 transactional publication fault tests
- 36 complete download/release parity tests
- 6,213 full Swift tests; 5 skipped; 0 failures
- packaged macOS launch, recovery, native interaction, 100-chat, and performance smoke
- 295.45 ms ready; 41.28 MiB initial; 85.75 MiB first sweep; 88.45 MiB repeated
- touched implementation and test files: 100/A+
- Python bytecode compilation and git diff checks