### PR TITLE
Harden stable promotion and updater relaunch

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -306,60 +306,14 @@ jobs:
           fi
           scripts/verify-published-release.py "${VERIFY_ARGUMENTS[@]}"
 
-  quarantine-stable-candidate:
-    needs: [publish, verify-published]
-    if: >-
-      ${{
-        always() &&
-        github.ref_type == 'tag' &&
-        startsWith(github.ref_name, 'v') &&
-        needs.publish.result == 'success' &&
-        needs.verify-published.result != 'success'
-      }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Return failed stable candidate to draft
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release edit "$GITHUB_REF_NAME" --draft --latest=false --repo "$GITHUB_REPOSITORY"
-
-  promote-stable:
-    needs: [publish, verify-published]
-    if: >-
-      ${{
-        github.ref_type == 'tag' &&
-        startsWith(github.ref_name, 'v') &&
-        needs.publish.result == 'success' &&
-        needs.verify-published.result == 'success'
-      }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Promote verified stable candidate
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh release edit "$GITHUB_REF_NAME"
-          --draft=false
-          --prerelease=false
-          --latest
-          --repo "$GITHUB_REPOSITORY"
-
   verify-updater:
-    needs: [publish, verify-published, promote-stable, capture-updater-source]
+    needs: [publish, verify-published, capture-updater-source]
     if: >-
       ${{
         always() &&
         needs.publish.result == 'success' &&
         needs.verify-published.result == 'success' &&
-        needs.capture-updater-source.result == 'success' &&
-        (
-          !(github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) ||
-          needs.promote-stable.result == 'success'
-        )
+        needs.capture-updater-source.result == 'success'
       }}
     strategy:
       fail-fast: false
@@ -436,6 +390,52 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  quarantine-stable-candidate:
+    needs: [publish, verify-published, verify-updater]
+    if: >-
+      ${{
+        always() &&
+        github.ref_type == 'tag' &&
+        startsWith(github.ref_name, 'v') &&
+        needs.publish.result == 'success' &&
+        (
+          needs.verify-published.result != 'success' ||
+          needs.verify-updater.result != 'success'
+        )
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Return failed stable candidate to draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft --latest=false --repo "$GITHUB_REPOSITORY"
+
+  promote-stable:
+    needs: [publish, verify-published, verify-updater]
+    if: >-
+      ${{
+        github.ref_type == 'tag' &&
+        startsWith(github.ref_name, 'v') &&
+        needs.publish.result == 'success' &&
+        needs.verify-published.result == 'success' &&
+        needs.verify-updater.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Promote verified stable candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release edit "$GITHUB_REF_NAME"
+          --draft=false
+          --prerelease=false
+          --latest
+          --repo "$GITHUB_REPOSITORY"
+
   verify-stable-promotion:
     needs: [promote-stable, verify-updater]
     if: >-
@@ -464,7 +464,7 @@ jobs:
             --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
   quarantine-promoted-stable:
-    needs: [publish, promote-stable, verify-updater, verify-stable-promotion]
+    needs: [publish, promote-stable, verify-stable-promotion]
     if: >-
       ${{
         always() &&
@@ -472,10 +472,7 @@ jobs:
         startsWith(github.ref_name, 'v') &&
         needs.publish.result == 'success' &&
         needs.promote-stable.result == 'success' &&
-        (
-          needs.verify-updater.result != 'success' ||
-          needs.verify-stable-promotion.result != 'success'
-        )
+        needs.verify-stable-promotion.result != 'success'
       }}
     runs-on: ubuntu-latest
     permissions:

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateApplicationLauncher.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateApplicationLauncher.swift
@@ -1,0 +1,119 @@
+import AppKit
+import Dispatch
+import Foundation
+
+struct QuillCodeDesktopLaunchedApplication {
+    let processIdentifier: Int32
+    let isRunning: () -> Bool
+}
+
+enum QuillCodeDesktopUpdateApplicationLaunchMode: Equatable, Sendable {
+    case launchServices
+    case directProcess
+}
+
+enum QuillCodeDesktopUpdateApplicationLauncher {
+    static func launch(
+        _ applicationURL: URL,
+        handshakeURL: URL?,
+        mode: QuillCodeDesktopUpdateApplicationLaunchMode,
+        timeout: TimeInterval
+    ) throws -> QuillCodeDesktopLaunchedApplication {
+        guard let bundle = Bundle(url: applicationURL),
+              let executableURL = bundle.executableURL,
+              FileManager.default.isExecutableFile(atPath: executableURL.path)
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed("the app executable is missing")
+        }
+        let arguments = handshakeURL.map {
+            [QuillCodeDesktopUpdateLaunchHandshake.argument, $0.path]
+        } ?? []
+        switch mode {
+        case .launchServices:
+            return try launchWithWorkspace(
+                applicationURL,
+                arguments: arguments,
+                timeout: timeout
+            )
+        case .directProcess:
+            return try launchDirectly(executableURL, arguments: arguments)
+        }
+    }
+
+    private static func launchWithWorkspace(
+        _ applicationURL: URL,
+        arguments: [String],
+        timeout: TimeInterval
+    ) throws -> QuillCodeDesktopLaunchedApplication {
+        guard timeout.isFinite, timeout > 0 else {
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the updated app launch timeout is invalid"
+            )
+        }
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        configuration.addsToRecentItems = false
+        configuration.createsNewApplicationInstance = true
+        configuration.allowsRunningApplicationSubstitution = false
+        configuration.arguments = arguments
+        configuration.environment = ProcessInfo.processInfo.environment
+
+        let completion = QuillCodeDesktopWorkspaceLaunchCompletion()
+        let semaphore = DispatchSemaphore(value: 0)
+        NSWorkspace.shared.openApplication(
+            at: applicationURL,
+            configuration: configuration
+        ) { application, _ in
+            completion.resolve(application)
+            semaphore.signal()
+        }
+        guard semaphore.wait(timeout: .now() + timeout) == .success,
+              let application = completion.application
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the updated app could not be opened by Launch Services"
+            )
+        }
+        return QuillCodeDesktopLaunchedApplication(
+            processIdentifier: application.processIdentifier,
+            isRunning: { !application.isTerminated }
+        )
+    }
+
+    private static func launchDirectly(
+        _ executableURL: URL,
+        arguments: [String]
+    ) throws -> QuillCodeDesktopLaunchedApplication {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        do {
+            try process.run()
+        } catch {
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the updated app could not be launched"
+            )
+        }
+        return QuillCodeDesktopLaunchedApplication(
+            processIdentifier: process.processIdentifier,
+            isRunning: { process.isRunning }
+        )
+    }
+}
+
+private final class QuillCodeDesktopWorkspaceLaunchCompletion: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resolvedApplication: NSRunningApplication?
+
+    var application: NSRunningApplication? {
+        lock.lock()
+        defer { lock.unlock() }
+        return resolvedApplication
+    }
+
+    func resolve(_ application: NSRunningApplication?) {
+        lock.lock()
+        resolvedApplication = application
+        lock.unlock()
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
@@ -19,7 +19,7 @@ enum QuillCodeDesktopUpdateHelper {
             try validateStaging(request, environment: environment)
             didValidate = true
             try validateActivation(request)
-            guard waitForProcessToExit(
+            guard QuillCodeDesktopUpdateProcessMonitor.waitForExit(
                 request.parentProcessID,
                 timeout: environment.parentExitTimeout
             ) else {
@@ -134,31 +134,33 @@ enum QuillCodeDesktopUpdateHelper {
         let fileManager = FileManager.default
         try activate(request)
 
-        let launchedProcess: Process
+        let launchedProcess: QuillCodeDesktopLaunchedApplication
         do {
-            launchedProcess = try launch(
+            launchedProcess = try QuillCodeDesktopUpdateApplicationLauncher.launch(
                 request.destinationApplicationURL,
-                handshakeURL: request.handshakeURL
+                handshakeURL: request.handshakeURL,
+                mode: environment.applicationLaunchMode,
+                timeout: environment.launchHandshakeTimeout
             )
         } catch {
-            try rollback(request)
+            try rollback(request, environment: environment)
             throw recoveredFailure("could not be launched", request: request)
         }
 
-        guard waitForFile(
+        guard QuillCodeDesktopUpdateProcessMonitor.waitForFile(
             request.handshakeURL,
             timeout: environment.launchHandshakeTimeout
         ) else {
-            terminateProcess(launchedProcess.processIdentifier)
-            try rollback(request)
+            QuillCodeDesktopUpdateProcessMonitor.terminate(launchedProcess.processIdentifier)
+            try rollback(request, environment: environment)
             throw recoveredFailure("did not finish launching", request: request)
         }
-        guard remainsRunning(
+        guard QuillCodeDesktopUpdateProcessMonitor.remainsRunning(
             launchedProcess,
             for: environment.launchStabilityDuration
         ) else {
-            terminateProcess(launchedProcess.processIdentifier)
-            try rollback(request)
+            QuillCodeDesktopUpdateProcessMonitor.terminate(launchedProcess.processIdentifier)
+            try rollback(request, environment: environment)
             throw recoveredFailure("stopped during startup", request: request)
         }
 
@@ -188,7 +190,10 @@ enum QuillCodeDesktopUpdateHelper {
         try? FileManager.default.removeItem(at: workspace)
     }
 
-    private static func rollback(_ request: QuillCodeDesktopUpdateHelperRequest) throws {
+    private static func rollback(
+        _ request: QuillCodeDesktopUpdateHelperRequest,
+        environment: QuillCodeDesktopUpdateHelperEnvironment
+    ) throws {
         let fileManager = FileManager.default
         switch request.activationMode {
         case .replaceExisting:
@@ -203,7 +208,12 @@ enum QuillCodeDesktopUpdateHelper {
                 request.destinationApplicationURL,
                 request.incomingApplicationURL
             )
-            _ = try launch(request.destinationApplicationURL, handshakeURL: nil)
+            _ = try QuillCodeDesktopUpdateApplicationLauncher.launch(
+                request.destinationApplicationURL,
+                handshakeURL: nil,
+                mode: environment.applicationLaunchMode,
+                timeout: environment.launchHandshakeTimeout
+            )
             try? fileManager.removeItem(at: request.incomingApplicationURL)
         case .installNew:
             guard fileManager.fileExists(atPath: request.destinationApplicationURL.path),
@@ -222,7 +232,12 @@ enum QuillCodeDesktopUpdateHelper {
                 )
             }
             try fileManager.removeItem(at: request.destinationApplicationURL)
-            _ = try launch(rollbackApplicationURL, handshakeURL: nil)
+            _ = try QuillCodeDesktopUpdateApplicationLauncher.launch(
+                rollbackApplicationURL,
+                handshakeURL: nil,
+                mode: environment.applicationLaunchMode,
+                timeout: environment.launchHandshakeTimeout
+            )
         }
         try? fileManager.removeItem(at: request.handshakeURL)
     }
@@ -286,31 +301,6 @@ enum QuillCodeDesktopUpdateHelper {
         }
     }
 
-    private static func launch(
-        _ applicationURL: URL,
-        handshakeURL: URL?
-    ) throws -> Process {
-        guard let bundle = Bundle(url: applicationURL),
-              let executableURL = bundle.executableURL,
-              FileManager.default.isExecutableFile(atPath: executableURL.path)
-        else {
-            throw QuillCodeDesktopUpdateError.installationFailed("the app executable is missing")
-        }
-        var arguments: [String] = []
-        if let handshakeURL {
-            arguments = [QuillCodeDesktopUpdateLaunchHandshake.argument, handshakeURL.path]
-        }
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = arguments
-        do {
-            try process.run()
-        } catch {
-            throw QuillCodeDesktopUpdateError.installationFailed("the updated app could not be launched")
-        }
-        return process
-    }
-
     private static func bundleMatches(
         _ url: URL,
         identifier: String,
@@ -343,43 +333,6 @@ enum QuillCodeDesktopUpdateHelper {
         return true
     }
 
-    private static func waitForProcessToExit(_ processID: Int32, timeout: TimeInterval) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if kill(processID, 0) == -1 && errno == ESRCH { return true }
-            usleep(100_000)
-        }
-        return kill(processID, 0) == -1 && errno == ESRCH
-    }
-
-    private static func waitForFile(_ url: URL, timeout: TimeInterval) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if FileManager.default.fileExists(atPath: url.path) { return true }
-            usleep(100_000)
-        }
-        return FileManager.default.fileExists(atPath: url.path)
-    }
-
-    private static func remainsRunning(_ process: Process, for duration: TimeInterval) -> Bool {
-        guard process.isRunning else { return false }
-        guard duration.isFinite, duration > 0 else { return true }
-        let deadline = Date().addingTimeInterval(duration)
-        while Date() < deadline {
-            usleep(100_000)
-            guard process.isRunning else { return false }
-        }
-        return process.isRunning
-    }
-
-    private static func terminateProcess(_ processID: Int32) {
-        guard processID > 1 else { return }
-        _ = kill(processID, SIGTERM)
-        guard !waitForProcessToExit(processID, timeout: 3) else { return }
-        _ = kill(processID, SIGKILL)
-        _ = waitForProcessToExit(processID, timeout: 2)
-    }
-
     private static func writeResult(
         _ result: QuillCodeDesktopUpdateInstallResult,
         to url: URL,
@@ -401,6 +354,7 @@ struct QuillCodeDesktopUpdateHelperEnvironment: Sendable {
     var parentExitTimeout: TimeInterval
     var launchHandshakeTimeout: TimeInterval
     var launchStabilityDuration: TimeInterval
+    var applicationLaunchMode: QuillCodeDesktopUpdateApplicationLaunchMode = .directProcess
 
     static func production() throws -> Self {
         Self(
@@ -408,7 +362,8 @@ struct QuillCodeDesktopUpdateHelperEnvironment: Sendable {
             resultURL: try QuillCodeDesktopUpdatePaths.installResultURL(),
             parentExitTimeout: 30,
             launchHandshakeTimeout: 45,
-            launchStabilityDuration: 3
+            launchStabilityDuration: 3,
+            applicationLaunchMode: .launchServices
         )
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateProcessMonitor.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateProcessMonitor.swift
@@ -1,0 +1,44 @@
+import Darwin
+import Foundation
+
+enum QuillCodeDesktopUpdateProcessMonitor {
+    static func waitForExit(_ processID: Int32, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if kill(processID, 0) == -1 && errno == ESRCH { return true }
+            usleep(100_000)
+        }
+        return kill(processID, 0) == -1 && errno == ESRCH
+    }
+
+    static func waitForFile(_ url: URL, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            usleep(100_000)
+        }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    static func remainsRunning(
+        _ process: QuillCodeDesktopLaunchedApplication,
+        for duration: TimeInterval
+    ) -> Bool {
+        guard process.isRunning() else { return false }
+        guard duration.isFinite, duration > 0 else { return true }
+        let deadline = Date().addingTimeInterval(duration)
+        while Date() < deadline {
+            usleep(100_000)
+            guard process.isRunning() else { return false }
+        }
+        return process.isRunning()
+    }
+
+    static func terminate(_ processID: Int32) {
+        guard processID > 1 else { return }
+        _ = kill(processID, SIGTERM)
+        guard !waitForExit(processID, timeout: 3) else { return }
+        _ = kill(processID, SIGKILL)
+        _ = waitForExit(processID, timeout: 2)
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdaterSmokeRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdaterSmokeRunner.swift
@@ -5,17 +5,79 @@ struct QuillCodeDesktopUpdaterSmokeRequest: Equatable, Sendable {
     static let modeArgument = "--native-updater-smoke"
 
     var reportURL: URL
+    var manifestURL: URL
 
     init?(arguments: [String]) {
         guard arguments.contains(Self.modeArgument),
-              let flagIndex = arguments.firstIndex(of: "--updater-smoke-report"),
+              let reportURL = Self.absoluteFileURL(
+                  after: "--updater-smoke-report",
+                  arguments: arguments
+              ),
+              let manifestURL = Self.absoluteFileURL(
+                  after: "--updater-smoke-manifest",
+                  arguments: arguments
+              )
+        else {
+            return nil
+        }
+        self.reportURL = reportURL
+        self.manifestURL = manifestURL
+    }
+
+    private static func absoluteFileURL(after flag: String, arguments: [String]) -> URL? {
+        let flagIndices = arguments.indices.filter { arguments[$0] == flag }
+        guard flagIndices.count == 1,
+              let flagIndex = flagIndices.first,
               arguments.indices.contains(flagIndex + 1)
         else {
             return nil
         }
         let value = arguments[flagIndex + 1]
-        guard value.hasPrefix("/"), !value.isEmpty else { return nil }
-        reportURL = URL(fileURLWithPath: value).standardizedFileURL
+        guard value.hasPrefix("/"), value != "/" else { return nil }
+        return URL(fileURLWithPath: value).standardizedFileURL
+    }
+}
+
+struct QuillCodeDesktopUpdaterSmokeManifestLoader: QuillCodeDesktopUpdateManifestLoading, Sendable {
+    var manifestURL: URL
+
+    func loadManifest(from _: URL, byteLimit: Int) async throws -> Data {
+        guard manifestURL.isFileURL,
+              byteLimit > 0,
+              byteLimit < Int.max
+        else {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
+
+        do {
+            let values = try manifestURL.resourceValues(forKeys: [
+                .fileSizeKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+            ])
+            guard values.isRegularFile == true,
+                  values.isSymbolicLink != true
+            else {
+                throw QuillCodeDesktopUpdateError.invalidResponse
+            }
+            guard let fileSize = values.fileSize,
+                  fileSize <= byteLimit
+            else {
+                throw QuillCodeDesktopUpdateError.manifestTooLarge
+            }
+
+            let handle = try FileHandle(forReadingFrom: manifestURL)
+            defer { try? handle.close() }
+            let data = try handle.read(upToCount: byteLimit + 1) ?? Data()
+            guard data.count <= byteLimit else {
+                throw QuillCodeDesktopUpdateError.manifestTooLarge
+            }
+            return data
+        } catch let error as QuillCodeDesktopUpdateError {
+            throw error
+        } catch {
+            throw QuillCodeDesktopUpdateError.invalidResponse
+        }
     }
 }
 
@@ -31,13 +93,10 @@ struct QuillCodeDesktopUpdaterSmokeReport: Codable, Equatable, Sendable {
 
 @MainActor
 enum QuillCodeDesktopUpdaterSmokeRunner {
-    static let feedPropagationAttemptLimit = 6
-    private static let feedPropagationRetryDelayNanoseconds: UInt64 = 2_000_000_000
-
     static func runAndExit(_ request: QuillCodeDesktopUpdaterSmokeRequest) async -> Never {
         let report: QuillCodeDesktopUpdaterSmokeReport
         do {
-            report = try await stageLatestUpdate()
+            report = try await stageLatestUpdate(manifestURL: request.manifestURL)
         } catch {
             report = QuillCodeDesktopUpdaterSmokeReport(
                 ok: false,
@@ -65,11 +124,17 @@ enum QuillCodeDesktopUpdaterSmokeRunner {
         Darwin.exit(exitCode)
     }
 
-    private static func stageLatestUpdate() async throws -> QuillCodeDesktopUpdaterSmokeReport {
+    private static func stageLatestUpdate(manifestURL: URL) async throws -> QuillCodeDesktopUpdaterSmokeReport {
         guard let configuration = QuillCodeDesktopUpdateConfiguration.bundled() else {
             throw QuillCodeDesktopUpdateError.updatesUnavailable
         }
-        let release = try await waitForAvailableUpdate(configuration: configuration)
+        let checker = QuillCodeDesktopUpdateChecker(
+            loader: QuillCodeDesktopUpdaterSmokeManifestLoader(manifestURL: manifestURL)
+        )
+        let release = try await candidateUpdate(
+            configuration: configuration,
+            checker: checker
+        )
         let prepared = try await QuillCodeDesktopUpdatePreparer().prepare(
             release: release,
             configuration: configuration
@@ -89,24 +154,16 @@ enum QuillCodeDesktopUpdaterSmokeRunner {
         )
     }
 
-    static func waitForAvailableUpdate(
+    static func candidateUpdate(
         configuration: QuillCodeDesktopUpdateConfiguration,
-        checker: any QuillCodeDesktopUpdateChecking = QuillCodeDesktopUpdateChecker(),
-        retryDelay: @escaping @Sendable () async throws -> Void = {
-            try await Task.sleep(nanoseconds: feedPropagationRetryDelayNanoseconds)
-        }
+        checker: any QuillCodeDesktopUpdateChecking
     ) async throws -> QuillCodeDesktopUpdateRelease {
-        for attempt in 1...feedPropagationAttemptLimit {
-            let result = try await checker.check(configuration: configuration)
-            if case .updateAvailable(let release) = result {
-                return release
-            }
-            if attempt < feedPropagationAttemptLimit {
-                try await retryDelay()
-            }
+        let result = try await checker.check(configuration: configuration)
+        if case .updateAvailable(let release) = result {
+            return release
         }
         throw QuillCodeDesktopUpdateError.installationFailed(
-            "the published update feed did not advance beyond the smoke fixture after bounded retries"
+            "the verified candidate manifest did not advance beyond the smoke fixture"
         )
     }
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateApplicationLauncherTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateApplicationLauncherTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopUpdateApplicationLauncherTests: XCTestCase {
+    func testProductionHelperRelaunchesThroughLaunchServices() throws {
+        XCTAssertEqual(
+            try QuillCodeDesktopUpdateHelperEnvironment.production().applicationLaunchMode,
+            .launchServices
+        )
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdaterSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdaterSmokeTests.swift
@@ -2,22 +2,105 @@ import XCTest
 @testable import quill_code_desktop
 
 final class QuillCodeDesktopUpdaterSmokeTests: XCTestCase {
-    func testRequestRequiresModeAndAbsoluteReportPath() throws {
+    func testRequestRequiresModeAndAbsoluteReportAndManifestPaths() throws {
         let request = try XCTUnwrap(QuillCodeDesktopUpdaterSmokeRequest(arguments: [
             "Quill Cowork",
             "--native-updater-smoke",
             "--updater-smoke-report",
             "/tmp/updater-smoke.json",
+            "--updater-smoke-manifest",
+            "/tmp/latest-candidate-build.json",
         ]))
 
         XCTAssertEqual(request.reportURL.path, "/tmp/updater-smoke.json")
+        XCTAssertEqual(request.manifestURL.path, "/tmp/latest-candidate-build.json")
         XCTAssertNil(QuillCodeDesktopUpdaterSmokeRequest(arguments: ["Quill Cowork"]))
         XCTAssertNil(QuillCodeDesktopUpdaterSmokeRequest(arguments: [
             "Quill Cowork",
             "--native-updater-smoke",
             "--updater-smoke-report",
             "relative.json",
+            "--updater-smoke-manifest",
+            "/tmp/latest-candidate-build.json",
         ]))
+        XCTAssertNil(QuillCodeDesktopUpdaterSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--native-updater-smoke",
+            "--updater-smoke-report",
+            "/tmp/updater-smoke.json",
+            "--updater-smoke-manifest",
+            "relative.json",
+        ]))
+    }
+
+    func testRequestRejectsMissingOrAmbiguousManifestFixture() {
+        XCTAssertNil(QuillCodeDesktopUpdaterSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--native-updater-smoke",
+            "--updater-smoke-report",
+            "/tmp/updater-smoke.json",
+        ]))
+        XCTAssertNil(QuillCodeDesktopUpdaterSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--native-updater-smoke",
+            "--updater-smoke-report",
+            "/tmp/updater-smoke.json",
+            "--updater-smoke-manifest",
+            "/tmp/first.json",
+            "--updater-smoke-manifest",
+            "/tmp/second.json",
+        ]))
+    }
+
+    func testFixtureManifestLoaderReadsOnlyBoundedRegularFiles() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-updater-smoke-loader")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let fixture = root.appendingPathComponent("manifest.json")
+        let payload = Data(#"{"build":"731"}"#.utf8)
+        try payload.write(to: fixture)
+        let loader = QuillCodeDesktopUpdaterSmokeManifestLoader(manifestURL: fixture)
+
+        let loaded = try await loader.loadManifest(
+            from: URL(string: "https://example.com/ignored.json")!,
+            byteLimit: payload.count
+        )
+
+        XCTAssertEqual(loaded, payload)
+    }
+
+    func testFixtureManifestLoaderRejectsOversizedSymlinkAndMissingInputs() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-updater-smoke-loader")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let fixture = root.appendingPathComponent("manifest.json")
+        try Data("candidate".utf8).write(to: fixture)
+        let symlink = root.appendingPathComponent("manifest-link.json")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: fixture)
+
+        await assertLoaderError(
+            QuillCodeDesktopUpdaterSmokeManifestLoader(manifestURL: fixture),
+            byteLimit: 4,
+            expected: .manifestTooLarge
+        )
+        await assertLoaderError(
+            QuillCodeDesktopUpdaterSmokeManifestLoader(manifestURL: symlink),
+            byteLimit: 32,
+            expected: .invalidResponse
+        )
+        await assertLoaderError(
+            QuillCodeDesktopUpdaterSmokeManifestLoader(
+                manifestURL: root.appendingPathComponent("missing.json")
+            ),
+            byteLimit: 32,
+            expected: .invalidResponse
+        )
     }
 
     func testReportEncodesReleaseProvenance() throws {
@@ -39,55 +122,43 @@ final class QuillCodeDesktopUpdaterSmokeTests: XCTestCase {
     }
 
     @MainActor
-    func testAvailableUpdateRetriesAStalePublishedFeed() async throws {
+    func testCandidateUpdateReturnsAnAvailableRelease() async throws {
         let release = makeRelease()
-        let checker = UpdaterSmokeCheckerStub(results: [
-            .upToDate(latestVersion: "0.1.0", latestBuild: "680"),
-            .upToDate(latestVersion: "0.1.0", latestBuild: "680"),
-            .updateAvailable(release),
-        ])
-        let delay = UpdaterSmokeRetryDelaySpy()
+        let checker = UpdaterSmokeCheckerStub(result: .updateAvailable(release))
 
-        let result = try await QuillCodeDesktopUpdaterSmokeRunner.waitForAvailableUpdate(
+        let result = try await QuillCodeDesktopUpdaterSmokeRunner.candidateUpdate(
             configuration: makeConfiguration(),
-            checker: checker,
-            retryDelay: { await delay.record() }
+            checker: checker
         )
 
         XCTAssertEqual(result, release)
         let checkCallCount = await checker.callCount
-        let delayCallCount = await delay.callCount
-        XCTAssertEqual(checkCallCount, 3)
-        XCTAssertEqual(delayCallCount, 2)
+        XCTAssertEqual(checkCallCount, 1)
     }
 
     @MainActor
-    func testAvailableUpdateFailsAfterBoundedStaleFeedRetries() async throws {
-        let checker = UpdaterSmokeCheckerStub(results: [
-            .upToDate(latestVersion: "0.1.0", latestBuild: "680"),
-        ])
-        let delay = UpdaterSmokeRetryDelaySpy()
+    func testCandidateUpdateRejectsANonadvancingFixtureWithoutRetrying() async throws {
+        let checker = UpdaterSmokeCheckerStub(
+            result: .upToDate(latestVersion: "0.1.0", latestBuild: "680")
+        )
 
         do {
-            _ = try await QuillCodeDesktopUpdaterSmokeRunner.waitForAvailableUpdate(
+            _ = try await QuillCodeDesktopUpdaterSmokeRunner.candidateUpdate(
                 configuration: makeConfiguration(),
-                checker: checker,
-                retryDelay: { await delay.record() }
+                checker: checker
             )
-            XCTFail("Expected a stale feed to fail after bounded retries")
+            XCTFail("Expected a nonadvancing candidate fixture to fail")
         } catch {
             XCTAssertEqual(
                 error as? QuillCodeDesktopUpdateError,
                 .installationFailed(
-                    "the published update feed did not advance beyond the smoke fixture after bounded retries"
+                    "the verified candidate manifest did not advance beyond the smoke fixture"
                 )
             )
         }
 
         let checkCallCount = await checker.callCount
-        let delayCallCount = await delay.callCount
-        XCTAssertEqual(checkCallCount, QuillCodeDesktopUpdaterSmokeRunner.feedPropagationAttemptLimit)
-        XCTAssertEqual(delayCallCount, QuillCodeDesktopUpdaterSmokeRunner.feedPropagationAttemptLimit - 1)
+        XCTAssertEqual(checkCallCount, 1)
     }
 
     private func makeConfiguration() -> QuillCodeDesktopUpdateConfiguration {
@@ -103,6 +174,22 @@ final class QuillCodeDesktopUpdaterSmokeTests: XCTestCase {
             applicationURL: URL(fileURLWithPath: "/Applications/Quill Cowork.app"),
             expectedSigningTeamIdentifier: nil
         )
+    }
+
+    private func assertLoaderError(
+        _ loader: QuillCodeDesktopUpdaterSmokeManifestLoader,
+        byteLimit: Int,
+        expected: QuillCodeDesktopUpdateError
+    ) async {
+        do {
+            _ = try await loader.loadManifest(
+                from: URL(string: "https://example.com/ignored.json")!,
+                byteLimit: byteLimit
+            )
+            XCTFail("Expected fixture loader to fail with \(expected)")
+        } catch {
+            XCTAssertEqual(error as? QuillCodeDesktopUpdateError, expected)
+        }
     }
 
     private func makeRelease() -> QuillCodeDesktopUpdateRelease {
@@ -129,31 +216,17 @@ final class QuillCodeDesktopUpdaterSmokeTests: XCTestCase {
 }
 
 private actor UpdaterSmokeCheckerStub: QuillCodeDesktopUpdateChecking {
-    private var results: [QuillCodeDesktopUpdateCheckResult]
+    private let result: QuillCodeDesktopUpdateCheckResult
     private(set) var callCount = 0
 
-    init(results: [QuillCodeDesktopUpdateCheckResult]) {
-        self.results = results
+    init(result: QuillCodeDesktopUpdateCheckResult) {
+        self.result = result
     }
 
     func check(
         configuration: QuillCodeDesktopUpdateConfiguration
     ) async throws -> QuillCodeDesktopUpdateCheckResult {
         callCount += 1
-        guard let result = results.first else {
-            throw QuillCodeDesktopUpdateError.invalidResponse
-        }
-        if results.count > 1 {
-            results.removeFirst()
-        }
         return result
-    }
-}
-
-private actor UpdaterSmokeRetryDelaySpy {
-    private(set) var callCount = 0
-
-    func record() {
-        callCount += 1
     }
 }

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -346,10 +346,12 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "quarantine-stable-candidate:",
             "Return failed stable candidate to draft",
             "needs.verify-published.result != 'success'",
+            "needs.verify-updater.result != 'success'",
             "promote-stable:",
             "Promote verified stable candidate",
             "--prerelease=false",
-            "needs: [publish, verify-published, promote-stable, capture-updater-source]",
+            "needs: [publish, verify-published, capture-updater-source]",
+            "needs: [publish, verify-published, verify-updater]",
             "needs.capture-updater-source.result == 'success'",
             "Download previous public updater source",
             "sourceAvailable raw",
@@ -359,7 +361,6 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "Verify promoted stable release",
             "quarantine-promoted-stable:",
             "Return failed promoted stable release to draft",
-            "needs.verify-updater.result != 'success'",
             "needs.verify-stable-promotion.result != 'success'",
             "--draft --latest=false"
         ])
@@ -391,9 +392,10 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertLessThan(sourceCaptureIndex.lowerBound, publishIndex.lowerBound)
         XCTAssertLessThan(publishIndex.lowerBound, publicVerificationIndex.lowerBound)
         XCTAssertLessThan(freshnessIndex.lowerBound, releaseMutationIndex.lowerBound)
-        XCTAssertLessThan(publicVerificationIndex.lowerBound, promotionIndex.lowerBound)
-        XCTAssertLessThan(promotionIndex.lowerBound, updaterIndex.lowerBound)
+        XCTAssertLessThan(publicVerificationIndex.lowerBound, updaterIndex.lowerBound)
+        XCTAssertLessThan(updaterIndex.lowerBound, promotionIndex.lowerBound)
         XCTAssertLessThan(updaterIndex.lowerBound, finalVerificationIndex.lowerBound)
+        XCTAssertLessThan(promotionIndex.lowerBound, finalVerificationIndex.lowerBound)
     }
 
     func testDownloadDocsExposeStableManifestLink() throws {

--- a/Tests/QuillCodeParityTests/ParityPackagedRelocationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedRelocationGateTests.swift
@@ -10,6 +10,9 @@ final class ParityPackagedRelocationGateTests: QuillCodeParityTestCase {
             named: "QuillCodeDesktopApplicationRelocator.swift"
         )
         let helper = try Self.desktopSourceText(named: "QuillCodeDesktopUpdateHelper.swift")
+        let launcher = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateApplicationLauncher.swift"
+        )
         let runner = try Self.desktopSourceText(
             named: "QuillCodeDesktopRelocationSmokeRunner.swift"
         )
@@ -38,7 +41,14 @@ final class ParityPackagedRelocationGateTests: QuillCodeParityTestCase {
             "UInt32(RENAME_EXCL)",
             ".isSymbolicLinkKey",
             "try fileManager.removeItem(at: request.destinationApplicationURL)",
-            "_ = try launch(rollbackApplicationURL, handshakeURL: nil)"
+            "QuillCodeDesktopUpdateApplicationLauncher.launch(",
+            "rollbackApplicationURL,",
+            "mode: environment.applicationLaunchMode"
+        ])
+        Self.assertSource(launcher, containsAll: [
+            "NSWorkspace.shared.openApplication(",
+            "configuration.createsNewApplicationInstance = true",
+            "configuration.allowsRunningApplicationSubstitution = false"
         ])
         Self.assertSource(runner, containsAll: [
             "--native-relocation-smoke",

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -10,6 +10,12 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         let updateSupport = try Self.desktopSourceText(
             named: "QuillCodeDesktopUpdateSupport.swift"
         )
+        let helper = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateHelper.swift"
+        )
+        let launcher = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateApplicationLauncher.swift"
+        )
         let bootstrap = try Self.appSourceText(named: "WorkspaceBootstrap.swift")
         let runner = try Self.desktopSourceText(named: "QuillCodeDesktopUpdaterSmokeRunner.swift")
         let script = try Self.scriptText(named: "packaged-macos-updater-smoke.sh")
@@ -69,11 +75,29 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "try Task.checkCancellation()",
             "guard self.generation == generation else { return }"
         ])
+        Self.assertSource(helper, containsAll: [
+            "QuillCodeDesktopUpdateApplicationLauncher.launch(",
+            "applicationLaunchMode: .launchServices"
+        ])
+        Self.assertSource(launcher, containsAll: [
+            "NSWorkspace.shared.openApplication(",
+            "configuration.activates = true",
+            "configuration.createsNewApplicationInstance = true",
+            "configuration.allowsRunningApplicationSubstitution = false",
+            "configuration.arguments = arguments",
+            "configuration.environment = ProcessInfo.processInfo.environment",
+            "processIdentifier: application.processIdentifier",
+            "isRunning: { !application.isTerminated }"
+        ])
         Self.assertSource(runner, containsAll: [
-            "waitForAvailableUpdate(configuration: configuration)",
-            "feedPropagationAttemptLimit = 6",
-            "if case .updateAvailable(let release) = result",
-            "try await retryDelay()",
+            "--updater-smoke-manifest",
+            "QuillCodeDesktopUpdaterSmokeManifestLoader",
+            "values.isRegularFile == true",
+            "values.isSymbolicLink != true",
+            "read(upToCount: byteLimit + 1)",
+            "loader: QuillCodeDesktopUpdaterSmokeManifestLoader(manifestURL: manifestURL)",
+            "candidateUpdate(",
+            "the verified candidate manifest did not advance beyond the smoke fixture",
             "QuillCodeDesktopUpdatePreparer().prepare",
             "QuillCodeDesktopUpdateInstaller().stageAndLaunch",
             "targetCommit: release.commit"
@@ -81,9 +105,12 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         Self.assertSource(script, containsAll: [
             "--native-updater-smoke",
             "--updater-smoke-report",
+            "--updater-smoke-manifest \"$MANIFEST_PATH\"",
             "--source-manifest",
             "SOURCE_MODE=\"previous-public-build\"",
             "SOURCE_MODE=\"synthetic-first-release\"",
+            "install-result.json",
+            "install-helper.log",
             "Previous public app metadata disagrees with its captured manifest.",
             "codesign --verify --deep --strict",
             "CFBundleVersion $SOURCE_BUILD",
@@ -107,13 +134,21 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "runs-on: ${{ matrix.runner }}",
             "arch: arm64",
             "arch: x86_64",
-            "needs: [publish, verify-published, promote-stable, capture-updater-source]",
+            "needs: [publish, verify-published, capture-updater-source]",
             "needs.capture-updater-source.result == 'success'",
-            "needs.promote-stable.result == 'success'",
+            "needs: [publish, verify-published, verify-updater]",
+            "needs.verify-updater.result == 'success'",
             "sourceAvailable raw",
             "--source-manifest \"$CAPTURE_DIR/source-manifest.json\"",
             "scripts/packaged-macos-updater-smoke.sh",
             "quillcode-public-updater-smoke-${{ matrix.arch }}"
         ])
+        let updaterIndex = try XCTUnwrap(workflow.range(of: "  verify-updater:"))
+        let promotionIndex = try XCTUnwrap(workflow.range(of: "  promote-stable:"))
+        XCTAssertLessThan(
+            updaterIndex.lowerBound,
+            promotionIndex.lowerBound,
+            "stable candidates must prove updater activation before becoming latest stable"
+        )
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,33 @@
 # Code Quality Audit
 
+## 2026-08-11 Stable Candidate Updater Proof Before Promotion
+
+Overall grade after this slice: **A+ release isolation, A+ relaunch resilience, A+ evidence quality**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Promotion ordering | A+ | A stable candidate remains non-latest until public inventory checks and native updater/relaunch gates pass on Apple Silicon and Intel. |
+| Failure isolation | A+ | Candidate or updater failure drafts only the candidate; the prior stable feed stays unchanged. Post-promotion quarantine is reserved for final latest-feed identity failure. |
+| Candidate fidelity | A+ | Updater smoke consumes the candidate's bounded regular manifest file through the ordinary checker and validator while preserving the production channel, repository, signature, team, asset, SHA-256, and app validation contracts. |
+| Relaunch correctness | A+ | Production activation and rollback reopen the exact app bundle through Launch Services, disable running-app substitution, preserve arguments and environment, and wait for real first-window readiness. |
+| Architecture | A+ | Transaction ownership, application launch, and PID/file/stability monitoring live in focused components; deterministic fixture launches remain explicit test-only policy. |
+| Failure evidence | A+ | Smoke artifacts retain bounded stage, source, install-result, and detached-helper evidence for both candidate and updater failures. |
+
+Validation:
+
+- Focused updater, relocation, candidate-manifest, and release-order boundary: 49 tests, 0 failures.
+- Full Swift suite: 6,217 tests, 5 skipped, 0 failures.
+- Real packaged synthetic-first-release update: public build 729 to 730, exact commit
+  `947324195a579190ae4735ebcc59115aec58bc6b`, successful first-window handshake and cleanup.
+- Release packaged composer `SIGKILL` recovery, direct-executable, Launch Services, live-window,
+  Accessibility, native interaction, browser, computer-use, and 100-chat daily-driver smokes passed.
+- Dedicated packaged performance gate: 3/3 launches within budget; 299.16 ms median launch-ready,
+  40.63 MiB initial footprint, 91.67 MiB after the first interaction sweep, and 93.05 MiB after the
+  repeated sweep.
+- `python3 scripts/grade-code-quality.py --root .`: every production module and every touched
+  production, script, and focused test file grades A+.
+- Workflow YAML parse, shell syntax validation, and `git diff --check` passed.
+
 ## 2026-08-11 Idempotent Tester Publication Recovery
 
 Overall grade after this slice: **A+ transaction safety, A+ outage resilience, A+ failure evidence**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -21,6 +21,22 @@
   duplicate-ID boundaries. A source parity gate rejects eager preview reads in tool-event projection
   and pins both cache limits.
 
+## 2026-08-11: updater activation uses Launch Services
+
+- **Decision:** The production update helper opens both the replacement app and any restored rollback
+  app through `NSWorkspace`. It pins the exact bundle path, requests a new foreground instance,
+  rejects running-application substitution, forwards the launch-handshake arguments and inherited
+  environment, and bounds the asynchronous open request with the existing handshake timeout.
+- **Test boundary:** Fixture helpers retain a direct-process launch mode so unit tests can execute
+  deterministic shell-backed app bundles and inject launch, handshake, and stability failures. The
+  production environment selects Launch Services explicitly, and packaged updater smoke proves that
+  mode against a signed `.app` and its real SwiftUI first-window readiness boundary.
+- **Why:** Directly spawning the executable can leave a healthy AppKit process without the normal
+  application-open event that materializes SwiftUI's primary `Window`. A daily-driver 729-to-730
+  update reproduced that state: staging and signature validation passed, but no window or readiness
+  acknowledgement appeared and the helper correctly rolled back. The same update completed after
+  the helper adopted the system application-launch path.
+
 ## 2026-08-11: updater success waits for first-window readiness
 
 - **Decision:** Parsing the updater or relocation launch-handshake argument remains the first normal
@@ -4620,3 +4636,18 @@
   `ParityTransactionalTesterPublicationTests` cover transient reads, pre- and post-mutation upload
   failures, conflicting bytes, bounded exhaustion, PATCH/tag retries, deletion response loss,
   permanent failures, exact rollback, and tag-last success ordering.
+
+## 2026-08-11: stable candidates prove native updates before promotion
+
+- **Decision:** A versioned stable release remains a non-latest prerelease candidate through public
+  asset verification and updater/relaunch smoke on native arm64 and Intel runners. Promotion to
+  latest stable requires both updater matrix entries to pass.
+- **Why:** Promoting before updater validation briefly exposed an unproven release through
+  `releases/latest` and the moving stable feed. Drafting it after a failure restored the prior feed,
+  but could not eliminate that avoidable exposure window.
+- **Recovery boundary:** Candidate verification or updater failure returns only the new candidate to
+  draft while the previous stable release and feed remain untouched. Post-promotion verification is
+  now limited to proving GitHub's latest-release and moving-feed views; a failure still drafts the
+  new release so GitHub falls back to the previous stable version.
+- **Evidence:** `download-builds.yml`, `ParityDownloadBuildsGateTests`,
+  `ParityPackagedUpdaterGateTests`, and the stable publication contract in `docs/DOWNLOADS.md`.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -284,7 +284,9 @@ version/build/commit identity, retain the expected native architecture, and pass
 strict recursive code-signature check.
 
 Installation stages the verified app beside the running bundle, then uses a
-detached helper for the final rename and relaunch. The new app must complete a
+detached helper for the final rename. It opens that exact bundle through Launch
+Services as a new foreground instance, with running-app substitution disabled.
+The new app must complete a
 launch handshake within 45 seconds and remain running for a three-second startup
 observation window. If either check fails, the helper restores and reopens the
 previous bundle. The one-shot install result is read only when it is a regular,
@@ -362,17 +364,19 @@ or already published. It creates the stable release as a draft, uploads every
 asset, and exposes it first as a non-latest prerelease candidate. The public
 consumer verifier must accept the candidate's exact inventory, hashes, bundle
 metadata, CPU architectures, performance evidence, signing identity, and
-notarization declaration before GitHub promotes it to the stable latest feed.
-Both native updater runners then install and relaunch through that live feed.
-A final verifier requires GitHub's `releases/latest` API object to identify the
-same release and requires the moving `latest-stable-build.json` bytes to match
-the versioned manifest exactly.
+notarization declaration. Both native updater runners then install the previous
+stable app, consume the candidate's versioned manifest, and prove update,
+activation, relaunch, and launch stability while the candidate remains
+non-latest. Only after both architectures pass does GitHub promote the candidate
+to the stable latest feed. A final verifier requires GitHub's `releases/latest`
+API object to identify the same release and requires the moving
+`latest-stable-build.json` bytes to match the versioned manifest exactly.
 
-If candidate verification fails, the workflow returns the new release to draft
-without changing the previous stable feed. If either native updater gate or the
-final feed verification fails after promotion, the workflow also returns the new
-release to draft so GitHub falls back to the previous stable feed. Inspect and
-delete that failed draft before retrying; an existing stable release is never
+If candidate verification or either native updater gate fails, the workflow
+returns the new release to draft without changing the previous stable feed. If
+the final feed verification fails after promotion, the workflow also returns the
+new release to draft so GitHub falls back to the previous stable feed. Inspect
+and delete that failed draft before retrying; an existing stable release is never
 edited or clobbered automatically. Treat a versioned release as announced only
 after the complete **Download Builds** run is green.
 Pre-existing stable releases remain untouched throughout this recovery flow.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,11 @@
 
 ## Latest Quality Pass
 
+- Stable releases now remain non-latest prerelease candidates until public asset verification and
+  real update, activation, relaunch, and launch-stability checks pass on native Apple Silicon and
+  Intel runners. Candidate or updater failure drafts only the new release without changing the
+  previous stable feed; promotion happens afterward, followed by a focused latest-feed identity
+  check.
 - Tester publication now absorbs bounded transient GitHub and network failures without weakening its
   atomic release contract. Release reads and idempotent PATCH/tag operations retry recognized TLS,
   DNS, timeout, rate-limit, and 5xx diagnostics with capped exponential backoff. Candidate uploads

--- a/scripts/packaged-macos-updater-smoke.sh
+++ b/scripts/packaged-macos-updater-smoke.sh
@@ -14,6 +14,8 @@ UPDATED_PID=""
 
 cleanup() {
   local status=$?
+  local install_result_path
+  local -a helper_log_candidates
   set +e
   if [[ -n "$UPDATED_PID" ]]; then
     kill "$UPDATED_PID" 2>/dev/null || true
@@ -25,6 +27,15 @@ cleanup() {
     [[ -f "$LOG_PATH" ]] && cp "$LOG_PATH" "$ARTIFACT_DIR/updater.log"
     [[ -n "$SOURCE_MANIFEST_PATH" && -f "$SOURCE_MANIFEST_PATH" ]] &&
       cp "$SOURCE_MANIFEST_PATH" "$ARTIFACT_DIR/source-manifest.json"
+    install_result_path="$SMOKE_ROOT/home/Library/Application Support/co.lorehex.QuillCowork/UpdateResult.json"
+    [[ -f "$install_result_path" ]] &&
+      cp "$install_result_path" "$ARTIFACT_DIR/install-result.json"
+    helper_log_candidates=(
+      "$SMOKE_ROOT"/home/Library/Caches/co.lorehex.QuillCowork/Updates/*/install-*.log
+    )
+    if [[ ${#helper_log_candidates[@]} -eq 1 && -f "${helper_log_candidates[0]}" ]]; then
+      cp "${helper_log_candidates[0]}" "$ARTIFACT_DIR/install-helper.log"
+    fi
     printf 'status=%s\nsource_mode=%s\n' \
       "$status" "${SOURCE_MODE:-unknown}" > "$ARTIFACT_DIR/manifest.txt"
   fi
@@ -61,6 +72,10 @@ fi
 if [[ ! -f "$APP_ZIP" || ! -f "$MANIFEST_PATH" ||
       ( -n "$SOURCE_MANIFEST_PATH" && ! -f "$SOURCE_MANIFEST_PATH" ) ]]; then
   echo "Usage: packaged-macos-updater-smoke.sh --app-zip APP_ZIP --manifest TARGET_JSON [--source-manifest SOURCE_JSON]" >&2
+  exit 2
+fi
+if [[ "$MANIFEST_PATH" != /* ]]; then
+  echo "Packaged updater smoke requires an absolute candidate manifest path." >&2
   exit 2
 fi
 
@@ -133,6 +148,7 @@ CFFIXED_USER_HOME="$SMOKE_ROOT/home" HOME="$SMOKE_ROOT/home" \
   "$APP_EXECUTABLE" \
     --native-updater-smoke \
     --updater-smoke-report "$REPORT_PATH" \
+    --updater-smoke-manifest "$MANIFEST_PATH" \
     >"$LOG_PATH" 2>&1 &
 SMOKE_PID="$!"
 


### PR DESCRIPTION
## Summary

- verify stable candidates with native arm64 and Intel updater runs before latest-feed promotion
- validate the exact candidate manifest through the production checker and retain bounded helper evidence
- relaunch updated and restored apps through exact-path Launch Services activation

## Validation

- 6,217 Swift tests, 5 skipped, 0 failures
- packaged macOS crash-recovery, render, live-window, Accessibility, browser, and computer-use smoke
- real packaged updater 729 -> 730
- 3/3 packaged performance launches within latency, memory, growth, and thread budgets
- all touched files and production modules grade A+