### PR TITLE
Harden credential persistence and upgrade polish

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTopBarIdentityView.swift
@@ -203,7 +203,7 @@ struct QuillCodeTopBarIdentityView: View {
                 }
             }
 
-            Text("QuillCode asks before the next paid model call after this task reaches the limit.")
+            Text("\(QuillCodeProduct.displayName) asks before the next paid model call after this task reaches the limit.")
                 .font(.caption)
                 .foregroundStyle(QuillCodePalette.muted)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/QuillCodePersistence/FileSecretStoreFileSystem.swift
+++ b/Sources/QuillCodePersistence/FileSecretStoreFileSystem.swift
@@ -1,0 +1,283 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Owns descriptor-relative secret I/O so an entry can never escape through a final-component link.
+enum FileSecretStoreFileSystem {
+    private static let directoryPermissions = mode_t(0o700)
+    private static let filePermissions = mode_t(0o600)
+    private static let readChunkBytes = 64 * 1_024
+
+    static func read(
+        directory: URL,
+        filename: String,
+        maximumBytes: Int
+    ) throws -> Data? {
+        guard maximumBytes >= 0 else {
+            throw BoundedFileDataError.invalidSizeLimit
+        }
+        guard let directoryDescriptor = try openDirectory(at: directory, createIfMissing: false) else {
+            return nil
+        }
+        defer { closeIgnoringErrors(directoryDescriptor) }
+
+        let descriptor = filename.withCString {
+            openat(directoryDescriptor, $0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard descriptor >= 0 else {
+            switch errno {
+            case ENOENT:
+                return nil
+            case ELOOP:
+                throw BoundedFileDataError.symbolicLink
+            default:
+                throw posixError()
+            }
+        }
+        defer { closeIgnoringErrors(descriptor) }
+
+        let metadata = try fileMetadata(descriptor)
+        try validateSecretEntry(metadata)
+        guard metadata.st_size >= 0,
+              UInt64(metadata.st_size) <= UInt64(maximumBytes)
+        else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+        }
+
+        var data = Data()
+        data.reserveCapacity(Int(metadata.st_size))
+        var buffer = [UInt8](repeating: 0, count: min(readChunkBytes, max(1, maximumBytes)))
+        while true {
+            let remaining = maximumBytes - data.count
+            let requested = remaining == 0 ? 1 : min(buffer.count, remaining)
+            let count = buffer.withUnsafeMutableBytes { bytes in
+                systemRead(descriptor, bytes.baseAddress, requested)
+            }
+            if count < 0, errno == EINTR {
+                continue
+            }
+            guard count >= 0 else {
+                throw posixError()
+            }
+            guard count > 0 else {
+                return data
+            }
+            guard count <= remaining else {
+                throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+            }
+            data.append(contentsOf: buffer.prefix(count))
+        }
+    }
+
+    static func write(_ data: Data, directory: URL, filename: String) throws {
+        guard let directoryDescriptor = try openDirectory(at: directory, createIfMissing: true) else {
+            throw FileSecretStoreError.unsafeDirectory
+        }
+        defer { closeIgnoringErrors(directoryDescriptor) }
+
+        let temporaryFilename = ".quill-secret-\(UUID().uuidString.lowercased()).tmp"
+        let descriptor = temporaryFilename.withCString {
+            openat(
+                directoryDescriptor,
+                $0,
+                O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+                filePermissions
+            )
+        }
+        guard descriptor >= 0 else {
+            throw posixError()
+        }
+        var temporaryEntryExists = true
+        defer {
+            closeIgnoringErrors(descriptor)
+            if temporaryEntryExists {
+                temporaryFilename.withCString {
+                    _ = unlinkat(directoryDescriptor, $0, 0)
+                }
+            }
+        }
+
+        guard fchmod(descriptor, filePermissions) == 0 else {
+            throw posixError()
+        }
+        try writeAll(data, to: descriptor)
+        guard fsync(descriptor) == 0 else {
+            throw posixError()
+        }
+
+        let renameResult = temporaryFilename.withCString { temporaryName in
+            filename.withCString { destinationName in
+                renameat(
+                    directoryDescriptor,
+                    temporaryName,
+                    directoryDescriptor,
+                    destinationName
+                )
+            }
+        }
+        guard renameResult == 0 else {
+            throw posixError()
+        }
+        temporaryEntryExists = false
+        try synchronize(directoryDescriptor)
+    }
+
+    static func delete(directory: URL, filename: String) throws {
+        guard let directoryDescriptor = try openDirectory(at: directory, createIfMissing: false) else {
+            return
+        }
+        defer { closeIgnoringErrors(directoryDescriptor) }
+
+        var metadata = stat()
+        let status = filename.withCString {
+            fstatat(directoryDescriptor, $0, &metadata, AT_SYMLINK_NOFOLLOW)
+        }
+        if status != 0 {
+            guard errno != ENOENT else { return }
+            throw posixError()
+        }
+        let type = metadata.st_mode & mode_t(S_IFMT)
+        guard type == mode_t(S_IFREG) || type == mode_t(S_IFLNK) else {
+            throw FileSecretStoreError.unsafeSecretEntry
+        }
+        guard filename.withCString({ unlinkat(directoryDescriptor, $0, 0) }) == 0 else {
+            if errno == ENOENT { return }
+            throw posixError()
+        }
+        try synchronize(directoryDescriptor)
+    }
+
+    private static func openDirectory(
+        at directory: URL,
+        createIfMissing: Bool
+    ) throws -> Int32? {
+        if createIfMissing {
+            let parent = directory.deletingLastPathComponent()
+            try FileManager.default.createDirectory(
+                at: parent,
+                withIntermediateDirectories: true
+            )
+            try PrivateDirectory.ensureExists(at: directory)
+        }
+
+        let descriptor = directory.path.withCString {
+            open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard descriptor >= 0 else {
+            if !createIfMissing, errno == ENOENT {
+                return nil
+            }
+            if errno == ELOOP || errno == ENOTDIR {
+                throw FileSecretStoreError.unsafeDirectory
+            }
+            throw posixError()
+        }
+
+        do {
+            var metadata = try fileMetadata(descriptor)
+            guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR),
+                  metadata.st_uid == geteuid()
+            else {
+                throw FileSecretStoreError.unsafeDirectory
+            }
+            if createIfMissing {
+                guard fchmod(descriptor, directoryPermissions) == 0 else {
+                    throw posixError()
+                }
+                metadata = try fileMetadata(descriptor)
+            }
+            guard metadata.st_mode & mode_t(0o077) == 0 else {
+                throw FileSecretStoreError.unsafeDirectory
+            }
+            return descriptor
+        } catch {
+            closeIgnoringErrors(descriptor)
+            throw error
+        }
+    }
+
+    private static func validateSecretEntry(_ metadata: stat) throws {
+        guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+            throw FileSecretStoreError.unsafeSecretEntry
+        }
+        // A concurrent atomic replacement can unlink this already-open inode before fstat, which
+        // safely produces link count zero. More than one link can expose the secret elsewhere.
+        guard metadata.st_uid == geteuid(), metadata.st_nlink <= 1 else {
+            throw FileSecretStoreError.unsafeSecretEntry
+        }
+        guard metadata.st_mode & mode_t(0o077) == 0 else {
+            throw FileSecretStoreError.unsafeSecretEntry
+        }
+    }
+
+    private static func fileMetadata(_ descriptor: Int32) throws -> stat {
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0 else {
+            throw posixError()
+        }
+        return metadata
+    }
+
+    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { bytes in
+            var offset = 0
+            while offset < bytes.count {
+                let count = systemWrite(
+                    descriptor,
+                    bytes.baseAddress?.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if count < 0, errno == EINTR {
+                    continue
+                }
+                guard count > 0 else {
+                    throw posixError()
+                }
+                offset += count
+            }
+        }
+    }
+
+    private static func synchronize(_ descriptor: Int32) throws {
+        guard fsync(descriptor) == 0 else {
+            throw posixError()
+        }
+    }
+
+    private static func closeIgnoringErrors(_ descriptor: Int32) {
+        guard descriptor >= 0 else { return }
+        _ = close(descriptor)
+    }
+
+    private static func posixError(_ code: Int32 = errno) -> NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(code))
+    }
+
+    private static func systemRead(
+        _ descriptor: Int32,
+        _ buffer: UnsafeMutableRawPointer?,
+        _ count: Int
+    ) -> Int {
+#if canImport(Darwin)
+        Darwin.read(descriptor, buffer, count)
+#else
+        Glibc.read(descriptor, buffer, count)
+#endif
+    }
+
+    private static func systemWrite(
+        _ descriptor: Int32,
+        _ buffer: UnsafeRawPointer?,
+        _ count: Int
+    ) -> Int {
+#if canImport(Darwin)
+        Darwin.write(descriptor, buffer, count)
+#else
+        Glibc.write(descriptor, buffer, count)
+#endif
+    }
+}

--- a/Sources/QuillCodePersistence/Paths.swift
+++ b/Sources/QuillCodePersistence/Paths.swift
@@ -103,7 +103,7 @@ public struct QuillCodePaths: Sendable, Hashable {
         try PrivateDirectory.ensureExists(at: memoriesDirectory)
         try FileManager.default.createDirectory(at: worktreeSnapshotsDirectory, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: worktreesDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: secretsDirectory, withIntermediateDirectories: true)
+        try PrivateDirectory.ensureExists(at: secretsDirectory)
         try FileManager.default.createDirectory(at: subagentSessionsDirectory, withIntermediateDirectories: true)
         try PrivateDirectory.ensureExists(at: pluginDataDirectory)
         try PrivateDirectory.ensureExists(at: importsDirectory)

--- a/Sources/QuillCodePersistence/SecretStore.swift
+++ b/Sources/QuillCodePersistence/SecretStore.swift
@@ -10,9 +10,28 @@ public protocol QuillSecretStore: Sendable {
     func delete(_ key: String) throws
 }
 
+public enum FileSecretStoreError: LocalizedError, Equatable, Sendable {
+    case invalidUTF8
+    case unsafeDirectory
+    case unsafeSecretEntry
+    case valueExceedsSizeLimit(maximumBytes: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidUTF8:
+            "The stored secret is not valid UTF-8."
+        case .unsafeDirectory:
+            "The secret-store directory is not a private directory owned by this user."
+        case .unsafeSecretEntry:
+            "The secret-store entry is not a private regular file owned by this user."
+        case .valueExceedsSizeLimit(let maximumBytes):
+            "The secret exceeds the \(maximumBytes)-byte storage limit."
+        }
+    }
+}
+
 public struct FileSecretStore: QuillSecretStore {
-    private static let directoryPermissions = 0o700
-    private static let filePermissions = 0o600
+    public static let maximumValueBytes = 1 * 1_024 * 1_024
 
     public var directory: URL
 
@@ -21,26 +40,41 @@ public struct FileSecretStore: QuillSecretStore {
     }
 
     public func read(_ key: String) throws -> String? {
-        let url = fileURL(for: key)
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-        return try String(contentsOf: url, encoding: .utf8)
+        guard let data = try FileSecretStoreFileSystem.read(
+            directory: directory,
+            filename: filename(for: key),
+            maximumBytes: Self.maximumValueBytes
+        ) else {
+            return nil
+        }
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw FileSecretStoreError.invalidUTF8
+        }
+        return value
     }
 
     public func write(_ value: String, for key: String) throws {
-        try prepareDirectory()
-        let url = fileURL(for: key)
-        try value.write(to: url, atomically: true, encoding: .utf8)
-        try protectFile(url)
+        let data = Data(value.utf8)
+        guard data.count <= Self.maximumValueBytes else {
+            throw FileSecretStoreError.valueExceedsSizeLimit(
+                maximumBytes: Self.maximumValueBytes
+            )
+        }
+        try FileSecretStoreFileSystem.write(
+            data,
+            directory: directory,
+            filename: filename(for: key)
+        )
     }
 
     public func delete(_ key: String) throws {
-        let url = fileURL(for: key)
-        if FileManager.default.fileExists(atPath: url.path) {
-            try FileManager.default.removeItem(at: url)
-        }
+        try FileSecretStoreFileSystem.delete(
+            directory: directory,
+            filename: filename(for: key)
+        )
     }
 
-    private func fileURL(for key: String) -> URL {
+    private func filename(for key: String) -> String {
         let safe = key.unicodeScalars.map { scalar -> Character in
             switch scalar {
             case "a"..."z", "A"..."Z", "0"..."9", ".", "_", "-":
@@ -50,25 +84,6 @@ public struct FileSecretStore: QuillSecretStore {
             }
         }
         let filename = String(safe).trimmingCharacters(in: CharacterSet(charactersIn: "."))
-        return directory.appendingPathComponent(filename.isEmpty ? "secret" : filename)
-    }
-
-    private func prepareDirectory() throws {
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: Self.directoryPermissions]
-        )
-        try FileManager.default.setAttributes(
-            [.posixPermissions: Self.directoryPermissions],
-            ofItemAtPath: directory.path
-        )
-    }
-
-    private func protectFile(_ url: URL) throws {
-        try FileManager.default.setAttributes(
-            [.posixPermissions: Self.filePermissions],
-            ofItemAtPath: url.path
-        )
+        return filename.isEmpty ? "secret" : filename
     }
 }

--- a/Sources/QuillCodePlatform/LoopbackHTTPCallbackServer.swift
+++ b/Sources/QuillCodePlatform/LoopbackHTTPCallbackServer.swift
@@ -280,7 +280,7 @@ public final class LoopbackHTTPCallbackServer: @unchecked Sendable {
         let body = """
         <!doctype html>
         <html lang="en">
-          <head><meta charset="utf-8"><title>QuillCode</title></head>
+          <head><meta charset="utf-8"><title>Quill Cowork</title></head>
           <body style="font-family: system-ui, sans-serif; padding: 40px;"><h1>\(escaped)</h1></body>
         </html>
         """

--- a/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceRoot.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopWorkspaceRoot.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 enum QuillCodeDesktopWorkspaceRootResolver {
-    static let fallbackDirectoryName = "QuillCode Workspace"
+    static let fallbackDirectoryName = "Quill Cowork Workspace"
+    private static let legacyFallbackDirectoryName = "QuillCode Workspace"
 
     static func resolve(
         currentDirectory: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath),
@@ -21,6 +22,15 @@ enum QuillCodeDesktopWorkspaceRootResolver {
         let fallback = home
             .appendingPathComponent("Documents", isDirectory: true)
             .appendingPathComponent(fallbackDirectoryName, isDirectory: true)
+        if existingDirectory(fallback, fileManager: fileManager) {
+            return fallback
+        }
+        let legacyFallback = home
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent(legacyFallbackDirectoryName, isDirectory: true)
+        if existingDirectory(legacyFallback, fileManager: fileManager) {
+            return legacyFallback
+        }
         do {
             try fileManager.createDirectory(at: fallback, withIntermediateDirectories: true)
             return fallback
@@ -30,5 +40,11 @@ enum QuillCodeDesktopWorkspaceRootResolver {
             try? fileManager.createDirectory(at: temporaryFallback, withIntermediateDirectories: true)
             return temporaryFallback
         }
+    }
+
+    private static func existingDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
     }
 }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
@@ -438,13 +438,22 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
     }
 
     func testDesktopWorkspaceRootResolverRejectsLaunchServicesRootAndHome() throws {
+        XCTAssertEqual(
+            QuillCodeDesktopWorkspaceRootResolver.fallbackDirectoryName,
+            "Quill Cowork Workspace"
+        )
         let temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("quillcode-workspace-root-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
         let home = temporaryDirectory.appendingPathComponent("home", isDirectory: true)
         let project = temporaryDirectory.appendingPathComponent("project", isDirectory: true)
+        let legacyHome = temporaryDirectory.appendingPathComponent("legacy-home", isDirectory: true)
+        let legacyFallback = legacyHome
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("QuillCode Workspace", isDirectory: true)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyFallback, withIntermediateDirectories: true)
 
         let rootFallback = QuillCodeDesktopWorkspaceRootResolver.resolve(
             currentDirectory: URL(fileURLWithPath: "/", isDirectory: true),
@@ -458,6 +467,10 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
             currentDirectory: project,
             userHome: home
         )
+        let preservedLegacyFallback = QuillCodeDesktopWorkspaceRootResolver.resolve(
+            currentDirectory: legacyHome,
+            userHome: legacyHome
+        )
         let expectedFallback = home
             .appendingPathComponent("Documents", isDirectory: true)
             .appendingPathComponent(QuillCodeDesktopWorkspaceRootResolver.fallbackDirectoryName, isDirectory: true)
@@ -465,6 +478,7 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
         XCTAssertEqual(rootFallback, expectedFallback)
         XCTAssertEqual(homeFallback, expectedFallback)
         XCTAssertEqual(explicitProject, project.standardizedFileURL)
+        XCTAssertEqual(preservedLegacyFallback, legacyFallback)
         XCTAssertTrue(FileManager.default.fileExists(atPath: expectedFallback.path))
     }
 

--- a/Tests/QuillCodePersistenceTests/FileSecretStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/FileSecretStoreTests.swift
@@ -12,6 +12,18 @@ final class FileSecretStoreTests: PersistenceTestCase {
         XCTAssertNil(try store.read("trustedrouter:key"))
     }
 
+    func testFileSecretStoreReadsExistingPlaintextEntry() throws {
+        let root = try makeTempDirectory()
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        let entry = root.appendingPathComponent("trustedrouter_api_key")
+        try Data("existing-secret".utf8).write(to: entry)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: entry.path)
+
+        let value = try FileSecretStore(directory: root).read(QuillSecretKeys.trustedRouterAPIKey)
+
+        XCTAssertEqual(value, "existing-secret")
+    }
+
     func testFileSecretStoreUsesPrivatePermissions() throws {
         let root = try makeTempDirectory()
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: root.path)
@@ -34,5 +46,174 @@ final class FileSecretStoreTests: PersistenceTestCase {
         let files = try FileManager.default.contentsOfDirectory(atPath: root.path)
         XCTAssertEqual(files, ["_trustedrouter_key_prod"])
         XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("trustedrouter").path))
+    }
+
+    func testFileSecretStoreRejectsOversizedWriteWithoutReplacingExistingSecret() throws {
+        let root = try makeTempDirectory()
+        let store = FileSecretStore(directory: root)
+        try store.write("existing", for: "trustedrouter:key")
+
+        XCTAssertThrowsError(
+            try store.write(
+                String(repeating: "x", count: FileSecretStore.maximumValueBytes + 1),
+                for: "trustedrouter:key"
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? FileSecretStoreError,
+                .valueExceedsSizeLimit(maximumBytes: FileSecretStore.maximumValueBytes)
+            )
+        }
+        XCTAssertEqual(try store.read("trustedrouter:key"), "existing")
+    }
+
+    func testFileSecretStoreRejectsOversizedReadBeforeLoadingPayload() throws {
+        let root = try makeTempDirectory()
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        let secret = root.appendingPathComponent("trustedrouter_key")
+        try Data(count: FileSecretStore.maximumValueBytes + 1).write(to: secret)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: secret.path)
+
+        XCTAssertThrowsError(try FileSecretStore(directory: root).read("trustedrouter:key")) { error in
+            XCTAssertEqual(
+                error as? BoundedFileDataError,
+                .exceedsSizeLimit(maximumBytes: FileSecretStore.maximumValueBytes)
+            )
+        }
+    }
+
+    func testFileSecretStoreRejectsSymbolicLinkReadAndAtomicallyReplacesLinkOnWrite() throws {
+        let parent = try makeTempDirectory()
+        let root = parent.appendingPathComponent("secrets", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        let target = parent.appendingPathComponent("outside-secret")
+        try Data("outside".utf8).write(to: target)
+        let link = root.appendingPathComponent("trustedrouter_key")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        let store = FileSecretStore(directory: root)
+
+        XCTAssertThrowsError(try store.read("trustedrouter:key"))
+        try store.write("replacement", for: "trustedrouter:key")
+
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "outside")
+        XCTAssertEqual(try link.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink, false)
+        XCTAssertEqual(try store.read("trustedrouter:key"), "replacement")
+    }
+
+    func testFileSecretStoreDeleteUnlinksSymbolicLinkWithoutTouchingTarget() throws {
+        let parent = try makeTempDirectory()
+        let root = parent.appendingPathComponent("secrets", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        let target = parent.appendingPathComponent("outside-secret")
+        try Data("outside".utf8).write(to: target)
+        let link = root.appendingPathComponent("trustedrouter_key")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        try FileSecretStore(directory: root).delete("trustedrouter:key")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: link.path))
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "outside")
+    }
+
+    func testFileSecretStoreRejectsHardLinkedReadAndRepairsEntryOnWrite() throws {
+        let parent = try makeTempDirectory()
+        let root = parent.appendingPathComponent("secrets", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        let target = parent.appendingPathComponent("outside-secret")
+        try Data("outside".utf8).write(to: target)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
+        let entry = root.appendingPathComponent("trustedrouter_key")
+        try FileManager.default.linkItem(at: target, to: entry)
+        let store = FileSecretStore(directory: root)
+
+        XCTAssertThrowsError(try store.read("trustedrouter:key")) { error in
+            XCTAssertEqual(error as? FileSecretStoreError, .unsafeSecretEntry)
+        }
+        try store.write("replacement", for: "trustedrouter:key")
+
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "outside")
+        XCTAssertEqual(try store.read("trustedrouter:key"), "replacement")
+    }
+
+    func testFileSecretStoreRejectsSymbolicLinkDirectory() throws {
+        let parent = try makeTempDirectory()
+        let target = parent.appendingPathComponent("target", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: false)
+        let link = parent.appendingPathComponent("secrets", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        let store = FileSecretStore(directory: link)
+
+        XCTAssertThrowsError(try store.write("secret", for: "trustedrouter:key"))
+        XCTAssertTrue(try FileManager.default.contentsOfDirectory(atPath: target.path).isEmpty)
+    }
+
+    func testFileSecretStoreRejectsInvalidUTF8() throws {
+        let root = try makeTempDirectory()
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        let secret = root.appendingPathComponent("trustedrouter_key")
+        try Data([0xFF]).write(to: secret)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: secret.path)
+
+        XCTAssertThrowsError(try FileSecretStore(directory: root).read("trustedrouter:key")) { error in
+            XCTAssertEqual(error as? FileSecretStoreError, .invalidUTF8)
+        }
+    }
+
+    func testFileSecretStoreAtomicReplacementLeavesOnlyCanonicalEntry() throws {
+        let root = try makeTempDirectory()
+        let store = FileSecretStore(directory: root)
+
+        for ordinal in 0..<100 {
+            try store.write("secret-\(ordinal)", for: "trustedrouter:key")
+        }
+
+        XCTAssertEqual(try store.read("trustedrouter:key"), "secret-99")
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(atPath: root.path),
+            ["trustedrouter_key"]
+        )
+    }
+
+    func testFileSecretStoreConcurrentReadersObserveOnlyCompleteValues() async throws {
+        let root = try makeTempDirectory()
+        let store = FileSecretStore(directory: root)
+        try store.write("secret-0", for: "trustedrouter:key")
+
+        let allValuesWereComplete = try await withThrowingTaskGroup(of: Bool.self) { group in
+            for ordinal in 1...100 {
+                group.addTask {
+                    try store.write("secret-\(ordinal)", for: "trustedrouter:key")
+                    return true
+                }
+                group.addTask {
+                    for _ in 0..<20 {
+                        guard let value = try store.read("trustedrouter:key"),
+                              value.hasPrefix("secret-"),
+                              let ordinal = Int(value.dropFirst("secret-".count)),
+                              (0...100).contains(ordinal)
+                        else {
+                            return false
+                        }
+                    }
+                    return true
+                }
+            }
+
+            var allValid = true
+            for try await result in group {
+                allValid = allValid && result
+            }
+            return allValid
+        }
+
+        XCTAssertTrue(allValuesWereComplete)
+        XCTAssertFalse(try XCTUnwrap(store.read("trustedrouter:key")).isEmpty)
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(atPath: root.path),
+            ["trustedrouter_key"]
+        )
     }
 }

--- a/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
+++ b/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
@@ -40,8 +40,27 @@ final class QuillCodePathsTests: PersistenceTestCase {
         }
         XCTAssertEqual(try posixPermissions(at: paths.composerDraftsDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.subagentApprovalPayloadsDirectory), 0o700)
+        XCTAssertEqual(try posixPermissions(at: paths.secretsDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.pluginDataDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.importsDirectory), 0o700)
+    }
+
+    func testEnsureRepairsLegacySecretsDirectoryPermissions() throws {
+        let home = try makeTempDirectory().appendingPathComponent(".quillcode")
+        let paths = QuillCodePaths(home: home)
+        try FileManager.default.createDirectory(
+            at: paths.secretsDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o755]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: paths.secretsDirectory.path
+        )
+
+        try paths.ensure()
+
+        XCTAssertEqual(try posixPermissions(at: paths.secretsDirectory), 0o700)
     }
 
     func testPluginDataDirectoriesAreStablePrivateAndWorkspaceScoped() throws {

--- a/Tests/QuillCodePlatformTests/LoopbackHTTPCallbackServerTests.swift
+++ b/Tests/QuillCodePlatformTests/LoopbackHTTPCallbackServerTests.swift
@@ -28,7 +28,9 @@ final class LoopbackHTTPCallbackServerTests: XCTestCase {
         let captured = try await wait.value
 
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
-        XCTAssertTrue(String(decoding: data, as: UTF8.self).contains("sign-in is complete"))
+        let page = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(page.contains("<title>Quill Cowork</title>"))
+        XCTAssertTrue(page.contains("sign-in is complete"))
         XCTAssertEqual(captured.path, "/oauth/callback")
         XCTAssertEqual(captured.query, "code=abc&state=expected")
         XCTAssertEqual(captured.port, server.callbackURL.port)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,32 @@
 # Code Quality Audit
 
+## 2026-08-11 Bounded Crash-Consistent Credential Persistence
+
+Overall grade after this slice: **A+ credential resilience, A+ bounded memory, A+ upgrade compatibility**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Crash consistency | A+ | Secret replacement writes a private exclusive temporary entry, synchronizes its bytes, atomically renames it, and synchronizes the owning directory. |
+| Memory bounds | A+ | Reads reject entries larger than 1 MiB before allocation and stream bounded chunks instead of mapping an attacker-sized credential file. |
+| Link safety | A+ | Descriptor-relative no-follow I/O rejects symbolic and multiple hard links; repair and deletion never mutate an external link target. |
+| Concurrency | A+ | Concurrent readers observe only complete old or new values while 100 writers replace the same canonical entry without leaving temporary files. |
+| Upgrade compatibility | A+ | Existing private plaintext credential entries remain readable, and startup repairs a legacy permissive secrets directory to mode `0700`. |
+| Product polish | A+ | Remaining customer-facing OAuth, usage-limit, and fresh fallback-workspace labels now consistently say Quill Cowork while existing legacy fallback folders remain usable. |
+
+Validation:
+
+- Focused credential, settings rollback, TrustedRouter startup, OAuth, path, and workspace-root
+  boundary: 39 tests, 0 failures.
+- Full Swift suite: 6,228 tests, 5 skipped, 0 failures.
+- Release packaged composer `SIGKILL` recovery, direct-executable, Launch Services, live-window,
+  Accessibility, native interaction, coworker, browser, computer-use, and 100-chat smokes passed.
+- Dedicated packaged performance gate: 3/3 launches within budget; 296.74 ms median launch-ready,
+  41.09 MiB initial footprint, 86.00 MiB after the first interaction sweep, and 85.45 MiB after the
+  repeated sweep.
+- `python3 scripts/grade-code-quality.py --root .`: changed production modules and every touched
+  production and focused test file grade A+.
+- Supplied live credential absent from source and diff; `git diff --check` passed.
+
 ## 2026-08-11 Stable Candidate Updater Proof Before Promotion
 
 Overall grade after this slice: **A+ release isolation, A+ relaunch resilience, A+ evidence quality**.


### PR DESCRIPTION
## Summary
- make shared credential reads bounded and no-follow, with durable atomic replacement and directory sync
- reject unsafe symlink/hardlink entries while preserving existing plaintext credentials and repairing legacy permissions
- finish remaining customer-facing Quill Cowork labels while preserving legacy fallback workspaces

## Verification
- `swift test`: 6,228 tests, 5 skipped, 0 failures
- packaged macOS crash recovery, direct launch, Launch Services, accessibility, interaction, browser, computer-use, and 100-chat daily-driver smokes passed
- three fresh packaged performance runs passed: 296.74 ms median launch-ready, 41.09 MiB initial, 86.00 MiB post-interaction, 85.45 MiB repeated
- code quality grader: changed modules and touched files A+
- `git diff --check`