### PR TITLE
Harden policy persistence under concurrency

### DIFF
--- a/Sources/QuillCodePersistence/Paths.swift
+++ b/Sources/QuillCodePersistence/Paths.swift
@@ -104,6 +104,8 @@ public struct QuillCodePaths: Sendable, Hashable {
         try FileManager.default.createDirectory(at: worktreeSnapshotsDirectory, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: worktreesDirectory, withIntermediateDirectories: true)
         try PrivateDirectory.ensureExists(at: secretsDirectory)
+        try PrivateDirectory.ensureExists(at: permissionsDirectory)
+        try PrivateDirectory.ensureExists(at: hookTrustDirectory)
         try FileManager.default.createDirectory(at: subagentSessionsDirectory, withIntermediateDirectories: true)
         try PrivateDirectory.ensureExists(at: pluginDataDirectory)
         try PrivateDirectory.ensureExists(at: importsDirectory)

--- a/Sources/QuillCodePersistence/PermissionRuleStore.swift
+++ b/Sources/QuillCodePersistence/PermissionRuleStore.swift
@@ -8,6 +8,7 @@ import QuillCodeSafety
 /// spelling of the same project path shares one rule table.
 public struct PermissionRuleFileStore: Sendable {
     public static let currentVersion = 1
+    public static let maximumBytes = 4 * 1_024 * 1_024
 
     public var directory: URL
 
@@ -23,12 +24,18 @@ public struct PermissionRuleFileStore: Sendable {
     /// newer-versioned file → empty table + diagnostics (the file itself is left untouched).
     public func load(forWorkspaceRoot root: URL) -> PermissionRuleLoadResult {
         let fileURL = fileURL(forWorkspaceRoot: root)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return PermissionRuleLoadResult()
-        }
         let data: Data
         do {
-            data = try Data(contentsOf: fileURL)
+            guard let stored = try PrivateFileStoreFileSystem.read(
+                directory: directory,
+                filename: fileURL.lastPathComponent,
+                maximumBytes: Self.maximumBytes,
+                requiresPrivateFilePermissions: false,
+                repairDirectoryPermissions: true
+            ) else {
+                return PermissionRuleLoadResult()
+            }
+            data = stored
         } catch {
             // The file exists but is unreadable: fail safe (degraded), do NOT report "no rules".
             return PermissionRuleLoadResult(degraded: true, diagnostics: [
@@ -45,11 +52,37 @@ public struct PermissionRuleFileStore: Sendable {
     @discardableResult
     public func append(_ rule: PermissionRule, forWorkspaceRoot root: URL) throws -> [String] {
         let fileURL = fileURL(forWorkspaceRoot: root)
+        return try PrivateFileStoreMutationCoordinator.withExclusiveLock(
+            directory: directory,
+            filename: fileURL.lastPathComponent
+        ) {
+            try appendUnlocked(rule, fileURL: fileURL)
+        }
+    }
+
+    public func save(_ table: PermissionRuleTable, forWorkspaceRoot root: URL) throws {
+        let fileURL = fileURL(forWorkspaceRoot: root)
+        try PrivateFileStoreMutationCoordinator.withExclusiveLock(
+            directory: directory,
+            filename: fileURL.lastPathComponent
+        ) {
+            try saveUnlocked(table, fileURL: fileURL)
+        }
+    }
+
+    private func appendUnlocked(
+        _ rule: PermissionRule,
+        fileURL: URL
+    ) throws -> [String] {
         var diagnostics: [String] = []
         var table = PermissionRuleTable()
 
-        if FileManager.default.fileExists(atPath: fileURL.path) {
-            let data = try Data(contentsOf: fileURL)
+        if let data = try PrivateFileStoreFileSystem.read(
+            directory: directory,
+            filename: fileURL.lastPathComponent,
+            maximumBytes: Self.maximumBytes,
+            requiresPrivateFilePermissions: false
+        ) {
             if let version = Self.decodedVersion(data), version > Self.currentVersion {
                 throw PermissionRuleStoreError.newerFileVersion(found: version, supported: Self.currentVersion)
             }
@@ -64,7 +97,11 @@ public struct PermissionRuleFileStore: Sendable {
             diagnostics = loaded.result.diagnostics
             if loaded.wasCorrupt {
                 let backupURL = Self.backupURL(for: fileURL)
-                try? FileManager.default.moveItem(at: fileURL, to: backupURL)
+                try PrivateFileStoreMutationCoordinator.moveAside(
+                    directory: directory,
+                    filename: fileURL.lastPathComponent,
+                    backupFilename: backupURL.lastPathComponent
+                )
                 diagnostics.append(
                     "Backed up the unreadable rules file to \(backupURL.lastPathComponent) and started a fresh one."
                 )
@@ -72,16 +109,23 @@ public struct PermissionRuleFileStore: Sendable {
         }
 
         table.append(rule)
-        try save(table, forWorkspaceRoot: root)
+        try saveUnlocked(table, fileURL: fileURL)
         return diagnostics
     }
 
-    public func save(_ table: PermissionRuleTable, forWorkspaceRoot root: URL) throws {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    private func saveUnlocked(_ table: PermissionRuleTable, fileURL: URL) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let payload = WirePayload(version: Self.currentVersion, rules: table.rules)
-        try encoder.encode(payload).write(to: fileURL(forWorkspaceRoot: root), options: .atomic)
+        let data = try encoder.encode(payload)
+        guard data.count <= Self.maximumBytes else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: Self.maximumBytes)
+        }
+        try PrivateFileStoreFileSystem.write(
+            data,
+            directory: directory,
+            filename: fileURL.lastPathComponent
+        )
     }
 
     // MARK: - Tolerant decoding
@@ -279,7 +323,7 @@ public struct PermissionRuleFileStore: Sendable {
         let stamp = ISO8601DateFormatter().string(from: Date())
             .replacingOccurrences(of: ":", with: "-")
         return fileURL.deletingPathExtension()
-            .appendingPathExtension("corrupt-\(stamp).json")
+            .appendingPathExtension("corrupt-\(stamp)-\(UUID().uuidString.lowercased()).json")
     }
 
 }

--- a/Sources/QuillCodePersistence/PrivateDirectory.swift
+++ b/Sources/QuillCodePersistence/PrivateDirectory.swift
@@ -3,17 +3,21 @@ import Foundation
 enum PrivateDirectory {
     static func ensureExists(at directory: URL) throws {
         let fileManager = FileManager.default
-        if fileManager.fileExists(atPath: directory.path) {
-            let values = try directory.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
-            guard values.isDirectory == true, values.isSymbolicLink != true else {
-                throw CocoaError(.fileWriteInvalidFileName)
+        if !fileManager.fileExists(atPath: directory.path) {
+            do {
+                try fileManager.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: false,
+                    attributes: [.posixPermissions: 0o700]
+                )
+            } catch {
+                // Another app task or process may have created it after the existence check.
+                guard fileManager.fileExists(atPath: directory.path) else { throw error }
             }
-        } else {
-            try fileManager.createDirectory(
-                at: directory,
-                withIntermediateDirectories: false,
-                attributes: [.posixPermissions: 0o700]
-            )
+        }
+        let values = try directory.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+        guard values.isDirectory == true, values.isSymbolicLink != true else {
+            throw CocoaError(.fileWriteInvalidFileName)
         }
         try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
     }

--- a/Sources/QuillCodePersistence/PrivateFileStoreFileSystem.swift
+++ b/Sources/QuillCodePersistence/PrivateFileStoreFileSystem.swift
@@ -6,8 +6,22 @@ import Darwin
 import Glibc
 #endif
 
-/// Owns descriptor-relative secret I/O so an entry can never escape through a final-component link.
-enum FileSecretStoreFileSystem {
+enum PrivateFileStoreFileSystemError: LocalizedError, Equatable, Sendable {
+    case unsafeDirectory
+    case unsafeEntry
+
+    var errorDescription: String? {
+        switch self {
+        case .unsafeDirectory:
+            "The private state directory is not owned by this user or has unsafe permissions."
+        case .unsafeEntry:
+            "The private state entry is not a private regular file owned by this user."
+        }
+    }
+}
+
+/// Owns descriptor-relative, bounded private-state reads and durable atomic writes.
+enum PrivateFileStoreFileSystem {
     private static let directoryPermissions = mode_t(0o700)
     private static let filePermissions = mode_t(0o600)
     private static let readChunkBytes = 64 * 1_024
@@ -15,12 +29,18 @@ enum FileSecretStoreFileSystem {
     static func read(
         directory: URL,
         filename: String,
-        maximumBytes: Int
+        maximumBytes: Int,
+        requiresPrivateFilePermissions: Bool = true,
+        repairDirectoryPermissions: Bool = false
     ) throws -> Data? {
         guard maximumBytes >= 0 else {
             throw BoundedFileDataError.invalidSizeLimit
         }
-        guard let directoryDescriptor = try openDirectory(at: directory, createIfMissing: false) else {
+        guard let directoryDescriptor = try openDirectory(
+            at: directory,
+            createIfMissing: false,
+            repairPermissions: repairDirectoryPermissions
+        ) else {
             return nil
         }
         defer { closeIgnoringErrors(directoryDescriptor) }
@@ -41,7 +61,7 @@ enum FileSecretStoreFileSystem {
         defer { closeIgnoringErrors(descriptor) }
 
         let metadata = try fileMetadata(descriptor)
-        try validateSecretEntry(metadata)
+        try validateEntry(metadata, requiresPrivatePermissions: requiresPrivateFilePermissions)
         guard metadata.st_size >= 0,
               UInt64(metadata.st_size) <= UInt64(maximumBytes)
         else {
@@ -75,11 +95,11 @@ enum FileSecretStoreFileSystem {
 
     static func write(_ data: Data, directory: URL, filename: String) throws {
         guard let directoryDescriptor = try openDirectory(at: directory, createIfMissing: true) else {
-            throw FileSecretStoreError.unsafeDirectory
+            throw PrivateFileStoreFileSystemError.unsafeDirectory
         }
         defer { closeIgnoringErrors(directoryDescriptor) }
 
-        let temporaryFilename = ".quill-secret-\(UUID().uuidString.lowercased()).tmp"
+        let temporaryFilename = ".quill-private-\(UUID().uuidString.lowercased()).tmp"
         let descriptor = temporaryFilename.withCString {
             openat(
                 directoryDescriptor,
@@ -142,7 +162,7 @@ enum FileSecretStoreFileSystem {
         }
         let type = metadata.st_mode & mode_t(S_IFMT)
         guard type == mode_t(S_IFREG) || type == mode_t(S_IFLNK) else {
-            throw FileSecretStoreError.unsafeSecretEntry
+            throw PrivateFileStoreFileSystemError.unsafeEntry
         }
         guard filename.withCString({ unlinkat(directoryDescriptor, $0, 0) }) == 0 else {
             if errno == ENOENT { return }
@@ -151,9 +171,10 @@ enum FileSecretStoreFileSystem {
         try synchronize(directoryDescriptor)
     }
 
-    private static func openDirectory(
+    static func openDirectory(
         at directory: URL,
-        createIfMissing: Bool
+        createIfMissing: Bool,
+        repairPermissions: Bool = false
     ) throws -> Int32? {
         if createIfMissing {
             let parent = directory.deletingLastPathComponent()
@@ -161,7 +182,11 @@ enum FileSecretStoreFileSystem {
                 at: parent,
                 withIntermediateDirectories: true
             )
-            try PrivateDirectory.ensureExists(at: directory)
+            do {
+                try PrivateDirectory.ensureExists(at: directory)
+            } catch let error as CocoaError where error.code == .fileWriteInvalidFileName {
+                throw PrivateFileStoreFileSystemError.unsafeDirectory
+            }
         }
 
         let descriptor = directory.path.withCString {
@@ -172,7 +197,7 @@ enum FileSecretStoreFileSystem {
                 return nil
             }
             if errno == ELOOP || errno == ENOTDIR {
-                throw FileSecretStoreError.unsafeDirectory
+                throw PrivateFileStoreFileSystemError.unsafeDirectory
             }
             throw posixError()
         }
@@ -182,16 +207,16 @@ enum FileSecretStoreFileSystem {
             guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR),
                   metadata.st_uid == geteuid()
             else {
-                throw FileSecretStoreError.unsafeDirectory
+                throw PrivateFileStoreFileSystemError.unsafeDirectory
             }
-            if createIfMissing {
+            if createIfMissing || repairPermissions {
                 guard fchmod(descriptor, directoryPermissions) == 0 else {
                     throw posixError()
                 }
                 metadata = try fileMetadata(descriptor)
             }
             guard metadata.st_mode & mode_t(0o077) == 0 else {
-                throw FileSecretStoreError.unsafeDirectory
+                throw PrivateFileStoreFileSystemError.unsafeDirectory
             }
             return descriptor
         } catch {
@@ -200,21 +225,24 @@ enum FileSecretStoreFileSystem {
         }
     }
 
-    private static func validateSecretEntry(_ metadata: stat) throws {
+    private static func validateEntry(
+        _ metadata: stat,
+        requiresPrivatePermissions: Bool
+    ) throws {
         guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
-            throw FileSecretStoreError.unsafeSecretEntry
+            throw PrivateFileStoreFileSystemError.unsafeEntry
         }
         // A concurrent atomic replacement can unlink this already-open inode before fstat, which
         // safely produces link count zero. More than one link can expose the secret elsewhere.
         guard metadata.st_uid == geteuid(), metadata.st_nlink <= 1 else {
-            throw FileSecretStoreError.unsafeSecretEntry
+            throw PrivateFileStoreFileSystemError.unsafeEntry
         }
-        guard metadata.st_mode & mode_t(0o077) == 0 else {
-            throw FileSecretStoreError.unsafeSecretEntry
+        guard !requiresPrivatePermissions || metadata.st_mode & mode_t(0o077) == 0 else {
+            throw PrivateFileStoreFileSystemError.unsafeEntry
         }
     }
 
-    private static func fileMetadata(_ descriptor: Int32) throws -> stat {
+    static func fileMetadata(_ descriptor: Int32) throws -> stat {
         var metadata = stat()
         guard fstat(descriptor, &metadata) == 0 else {
             throw posixError()
@@ -242,18 +270,18 @@ enum FileSecretStoreFileSystem {
         }
     }
 
-    private static func synchronize(_ descriptor: Int32) throws {
+    static func synchronize(_ descriptor: Int32) throws {
         guard fsync(descriptor) == 0 else {
             throw posixError()
         }
     }
 
-    private static func closeIgnoringErrors(_ descriptor: Int32) {
+    static func closeIgnoringErrors(_ descriptor: Int32) {
         guard descriptor >= 0 else { return }
         _ = close(descriptor)
     }
 
-    private static func posixError(_ code: Int32 = errno) -> NSError {
+    static func posixError(_ code: Int32 = errno) -> NSError {
         NSError(domain: NSPOSIXErrorDomain, code: Int(code))
     }
 

--- a/Sources/QuillCodePersistence/PrivateFileStoreMutationCoordinator.swift
+++ b/Sources/QuillCodePersistence/PrivateFileStoreMutationCoordinator.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// `flock` protects cooperating processes, but Darwin treats locks from sibling threads in the
+/// same process as one owner. Reference counting keeps only the currently active local locks.
+private final class PrivateFileStoreLocalLockRegistry: @unchecked Sendable {
+    static let shared = PrivateFileStoreLocalLockRegistry()
+
+    private final class Entry {
+        let lock = NSLock()
+        var referenceCount = 0
+    }
+
+    private let registryLock = NSLock()
+    private var entries: [String: Entry] = [:]
+
+    func withLock<Value>(for key: String, operation: () throws -> Value) rethrows -> Value {
+        registryLock.lock()
+        let entry: Entry
+        if let existing = entries[key] {
+            entry = existing
+        } else {
+            entry = Entry()
+            entries[key] = entry
+        }
+        entry.referenceCount += 1
+        registryLock.unlock()
+
+        entry.lock.lock()
+        defer {
+            entry.lock.unlock()
+            registryLock.lock()
+            entry.referenceCount -= 1
+            if entry.referenceCount == 0 {
+                entries.removeValue(forKey: key)
+            }
+            registryLock.unlock()
+        }
+        return try operation()
+    }
+}
+
+/// Serializes read-modify-write mutations across app tasks and cooperating processes.
+enum PrivateFileStoreMutationCoordinator {
+    private static let filePermissions = mode_t(0o600)
+
+    static func withExclusiveLock<Value>(
+        directory: URL,
+        filename: String,
+        operation: () throws -> Value
+    ) throws -> Value {
+        let lockIdentity = directory.resolvingSymlinksInPath().standardizedFileURL.path
+            + "\0" + filename
+        return try PrivateFileStoreLocalLockRegistry.shared.withLock(for: lockIdentity) {
+            try withProcessLock(directory: directory, filename: filename, operation: operation)
+        }
+    }
+
+    static func moveAside(
+        directory: URL,
+        filename: String,
+        backupFilename: String
+    ) throws {
+        guard let directoryDescriptor = try PrivateFileStoreFileSystem.openDirectory(
+            at: directory,
+            createIfMissing: false
+        ) else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(ENOENT))
+        }
+        defer { PrivateFileStoreFileSystem.closeIgnoringErrors(directoryDescriptor) }
+
+        var metadata = stat()
+        let sourceStatus = filename.withCString {
+            fstatat(directoryDescriptor, $0, &metadata, AT_SYMLINK_NOFOLLOW)
+        }
+        guard sourceStatus == 0 else {
+            throw PrivateFileStoreFileSystem.posixError()
+        }
+        guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+            throw PrivateFileStoreFileSystemError.unsafeEntry
+        }
+
+        let linkResult = filename.withCString { sourceName in
+            backupFilename.withCString { backupName in
+                linkat(directoryDescriptor, sourceName, directoryDescriptor, backupName, 0)
+            }
+        }
+        guard linkResult == 0 else {
+            throw PrivateFileStoreFileSystem.posixError()
+        }
+        do {
+            try PrivateFileStoreFileSystem.synchronize(directoryDescriptor)
+        } catch {
+            backupFilename.withCString { _ = unlinkat(directoryDescriptor, $0, 0) }
+            throw error
+        }
+        guard filename.withCString({ unlinkat(directoryDescriptor, $0, 0) }) == 0 else {
+            let error = PrivateFileStoreFileSystem.posixError()
+            backupFilename.withCString { _ = unlinkat(directoryDescriptor, $0, 0) }
+            throw error
+        }
+        // The backup is now the only durable owner of the bytes, so retain it on sync failure.
+        try PrivateFileStoreFileSystem.synchronize(directoryDescriptor)
+    }
+
+    private static func withProcessLock<Value>(
+        directory: URL,
+        filename: String,
+        operation: () throws -> Value
+    ) throws -> Value {
+        guard let directoryDescriptor = try PrivateFileStoreFileSystem.openDirectory(
+            at: directory,
+            createIfMissing: true
+        ) else {
+            throw PrivateFileStoreFileSystemError.unsafeDirectory
+        }
+        defer { PrivateFileStoreFileSystem.closeIgnoringErrors(directoryDescriptor) }
+
+        let lockFilename = ".\(filename).lock"
+        let descriptor = lockFilename.withCString {
+            openat(
+                directoryDescriptor,
+                $0,
+                O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                filePermissions
+            )
+        }
+        guard descriptor >= 0 else {
+            throw PrivateFileStoreFileSystem.posixError()
+        }
+        defer { PrivateFileStoreFileSystem.closeIgnoringErrors(descriptor) }
+
+        let metadata = try PrivateFileStoreFileSystem.fileMetadata(descriptor)
+        guard metadata.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG),
+              metadata.st_uid == geteuid(),
+              metadata.st_nlink <= 1
+        else {
+            throw PrivateFileStoreFileSystemError.unsafeEntry
+        }
+        guard fchmod(descriptor, filePermissions) == 0 else {
+            throw PrivateFileStoreFileSystem.posixError()
+        }
+        while flock(descriptor, LOCK_EX) != 0 {
+            guard errno == EINTR else { throw PrivateFileStoreFileSystem.posixError() }
+        }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try operation()
+    }
+}

--- a/Sources/QuillCodePersistence/ProjectHookTrustStore.swift
+++ b/Sources/QuillCodePersistence/ProjectHookTrustStore.swift
@@ -70,6 +70,7 @@ public enum ProjectHookTrustStoreError: LocalizedError, Sendable, Equatable {
 public struct ProjectHookTrustFileStore: Sendable {
     public static let currentVersion = 1
     public static let maxRecords = 256
+    public static let maximumBytes = 1 * 1_024 * 1_024
 
     public var directory: URL
 
@@ -83,11 +84,17 @@ public struct ProjectHookTrustFileStore: Sendable {
 
     public func load(forWorkspaceRoot root: URL) -> ProjectHookTrustLoadResult {
         let fileURL = fileURL(forWorkspaceRoot: root)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return .init() }
         do {
+            guard let data = try PrivateFileStoreFileSystem.read(
+                directory: directory,
+                filename: fileURL.lastPathComponent,
+                maximumBytes: Self.maximumBytes,
+                requiresPrivateFilePermissions: false,
+                repairDirectoryPermissions: true
+            ) else { return .init() }
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            let payload = try decoder.decode(WirePayload.self, from: Data(contentsOf: fileURL))
+            let payload = try decoder.decode(WirePayload.self, from: data)
             guard payload.version == Self.currentVersion else {
                 return .init(
                     degraded: true,
@@ -112,28 +119,51 @@ public struct ProjectHookTrustFileStore: Sendable {
         guard !hook.isManaged else {
             throw ProjectHookTrustStoreError.managedHook
         }
-        let existing = load(forWorkspaceRoot: workspaceRoot)
-        guard !existing.degraded else {
-            throw ProjectHookTrustStoreError.degradedFile
+        let fileURL = fileURL(forWorkspaceRoot: workspaceRoot)
+        try PrivateFileStoreMutationCoordinator.withExclusiveLock(
+            directory: directory,
+            filename: fileURL.lastPathComponent
+        ) {
+            let existing = load(forWorkspaceRoot: workspaceRoot)
+            guard !existing.degraded else {
+                throw ProjectHookTrustStoreError.degradedFile
+            }
+            var records = existing.records
+            records.removeAll { $0.hookID == hook.id }
+            records.append(ProjectHookTrustRecord(
+                hookID: hook.id,
+                definitionHash: hook.definitionHash,
+                decision: decision,
+                updatedAt: now
+            ))
+            try saveUnlocked(records, fileURL: fileURL)
         }
-        var records = existing.records
-        records.removeAll { $0.hookID == hook.id }
-        records.append(ProjectHookTrustRecord(
-            hookID: hook.id,
-            definitionHash: hook.definitionHash,
-            decision: decision,
-            updatedAt: now
-        ))
-        try save(records, forWorkspaceRoot: workspaceRoot)
     }
 
     public func save(_ records: [ProjectHookTrustRecord], forWorkspaceRoot root: URL) throws {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = fileURL(forWorkspaceRoot: root)
+        try PrivateFileStoreMutationCoordinator.withExclusiveLock(
+            directory: directory,
+            filename: fileURL.lastPathComponent
+        ) {
+            try saveUnlocked(records, fileURL: fileURL)
+        }
+    }
+
+    private func saveUnlocked(_ records: [ProjectHookTrustRecord], fileURL: URL) throws {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let payload = WirePayload(version: Self.currentVersion, records: Self.normalized(records))
-        try encoder.encode(payload).write(to: fileURL(forWorkspaceRoot: root), options: .atomic)
+        let data = try encoder.encode(payload)
+        guard data.count <= Self.maximumBytes else {
+            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: Self.maximumBytes)
+        }
+        try PrivateFileStoreFileSystem.write(
+            data,
+            directory: directory,
+            filename: fileURL.lastPathComponent
+        )
     }
 
     private struct WirePayload: Codable {

--- a/Sources/QuillCodePersistence/SecretStore.swift
+++ b/Sources/QuillCodePersistence/SecretStore.swift
@@ -40,12 +40,18 @@ public struct FileSecretStore: QuillSecretStore {
     }
 
     public func read(_ key: String) throws -> String? {
-        guard let data = try FileSecretStoreFileSystem.read(
-            directory: directory,
-            filename: filename(for: key),
-            maximumBytes: Self.maximumValueBytes
-        ) else {
-            return nil
+        let data: Data
+        do {
+            guard let stored = try PrivateFileStoreFileSystem.read(
+                directory: directory,
+                filename: filename(for: key),
+                maximumBytes: Self.maximumValueBytes
+            ) else {
+                return nil
+            }
+            data = stored
+        } catch {
+            throw mappedFileSystemError(error)
         }
         guard let value = String(data: data, encoding: .utf8) else {
             throw FileSecretStoreError.invalidUTF8
@@ -60,18 +66,26 @@ public struct FileSecretStore: QuillSecretStore {
                 maximumBytes: Self.maximumValueBytes
             )
         }
-        try FileSecretStoreFileSystem.write(
-            data,
-            directory: directory,
-            filename: filename(for: key)
-        )
+        do {
+            try PrivateFileStoreFileSystem.write(
+                data,
+                directory: directory,
+                filename: filename(for: key)
+            )
+        } catch {
+            throw mappedFileSystemError(error)
+        }
     }
 
     public func delete(_ key: String) throws {
-        try FileSecretStoreFileSystem.delete(
-            directory: directory,
-            filename: filename(for: key)
-        )
+        do {
+            try PrivateFileStoreFileSystem.delete(
+                directory: directory,
+                filename: filename(for: key)
+            )
+        } catch {
+            throw mappedFileSystemError(error)
+        }
     }
 
     private func filename(for key: String) -> String {
@@ -85,5 +99,15 @@ public struct FileSecretStore: QuillSecretStore {
         }
         let filename = String(safe).trimmingCharacters(in: CharacterSet(charactersIn: "."))
         return filename.isEmpty ? "secret" : filename
+    }
+
+    private func mappedFileSystemError(_ error: Error) -> Error {
+        guard let error = error as? PrivateFileStoreFileSystemError else { return error }
+        switch error {
+        case .unsafeDirectory:
+            return FileSecretStoreError.unsafeDirectory
+        case .unsafeEntry:
+            return FileSecretStoreError.unsafeSecretEntry
+        }
     }
 }

--- a/Tests/QuillCodePersistenceTests/PermissionRuleStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/PermissionRuleStoreTests.swift
@@ -123,9 +123,143 @@ final class PermissionRuleStoreTests: XCTestCase {
             at: fileURL.deletingLastPathComponent(),
             includingPropertiesForKeys: nil
         )
-        XCTAssertTrue(
-            siblings.contains { $0.lastPathComponent.contains("corrupt") },
-            "expected a corrupt-file backup, found \(siblings.map(\.lastPathComponent))"
+        let backups = siblings.filter { $0.lastPathComponent.contains("corrupt") }
+        XCTAssertEqual(backups.count, 1, "expected one corrupt-file backup")
+        XCTAssertEqual(try Data(contentsOf: XCTUnwrap(backups.first)), Data("garbage".utf8))
+    }
+
+    func testOversizedFileFailsClosedWithoutLoadingOrReplacingIt() throws {
+        let (store, root) = try makeStoreAndRoot()
+        let fileURL = store.fileURL(forWorkspaceRoot: root)
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: Data()))
+        let handle = try FileHandle(forWritingTo: fileURL)
+        try handle.truncate(atOffset: UInt64(PermissionRuleFileStore.maximumBytes + 1))
+        try handle.close()
+
+        let loaded = store.load(forWorkspaceRoot: root)
+
+        XCTAssertTrue(loaded.degraded)
+        XCTAssertTrue(loaded.table.isEmpty)
+        XCTAssertThrowsError(try store.append(
+            PermissionRule(action: "host.shell.run", resource: "swift test", decision: .allow),
+            forWorkspaceRoot: root
+        )) { error in
+            XCTAssertEqual(
+                error as? BoundedFileDataError,
+                .exceedsSizeLimit(maximumBytes: PermissionRuleFileStore.maximumBytes)
+            )
+        }
+        XCTAssertEqual(
+            try FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber,
+            NSNumber(value: PermissionRuleFileStore.maximumBytes + 1)
+        )
+    }
+
+    func testSymbolicLinkFailsClosedAndExplicitSaveRepairsWithoutTouchingTarget() throws {
+        let (store, root) = try makeStoreAndRoot()
+        let fileURL = store.fileURL(forWorkspaceRoot: root)
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let target = fileURL.deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("outside-rules.json")
+        let targetData = Data(#"{"version":1,"rules":[]}"#.utf8)
+        try targetData.write(to: target)
+        try FileManager.default.createSymbolicLink(at: fileURL, withDestinationURL: target)
+
+        XCTAssertTrue(store.load(forWorkspaceRoot: root).degraded)
+        XCTAssertThrowsError(try store.append(
+            PermissionRule(action: "host.shell.run", resource: "swift test", decision: .allow),
+            forWorkspaceRoot: root
+        )) { error in
+            XCTAssertEqual(error as? BoundedFileDataError, .symbolicLink)
+        }
+
+        let replacement = PermissionRule(
+            action: "host.git.push",
+            resource: "**",
+            decision: .deny
+        )
+        try store.save(PermissionRuleTable(rules: [replacement]), forWorkspaceRoot: root)
+
+        XCTAssertEqual(try Data(contentsOf: target), targetData)
+        XCTAssertEqual(store.load(forWorkspaceRoot: root).table.rules, [replacement])
+        XCTAssertFalse(try fileURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true)
+    }
+
+    func testSymbolicLinkDirectoryCannotInjectRules() throws {
+        let (store, root) = try makeStoreAndRoot()
+        let outsideDirectory = store.directory.deletingLastPathComponent()
+            .appendingPathComponent("outside-permissions", isDirectory: true)
+        try FileManager.default.createDirectory(at: outsideDirectory, withIntermediateDirectories: true)
+        let injectedStore = PermissionRuleFileStore(directory: outsideDirectory)
+        try injectedStore.save(
+            PermissionRuleTable(rules: [
+                PermissionRule(action: "host.shell.run", resource: "**", decision: .allow)
+            ]),
+            forWorkspaceRoot: root
+        )
+        try FileManager.default.createSymbolicLink(
+            at: store.directory,
+            withDestinationURL: outsideDirectory
+        )
+
+        let loaded = store.load(forWorkspaceRoot: root)
+
+        XCTAssertTrue(loaded.degraded)
+        XCTAssertTrue(loaded.table.isEmpty)
+        XCTAssertThrowsError(try store.append(
+            PermissionRule(action: "host.git.push", resource: "**", decision: .allow),
+            forWorkspaceRoot: root
+        )) { error in
+            XCTAssertEqual(error as? PrivateFileStoreFileSystemError, .unsafeDirectory)
+        }
+    }
+
+    func testConcurrentAppendsPreserveEveryRule() async throws {
+        let (store, root) = try makeStoreAndRoot()
+        let count = 100
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for index in 0..<count {
+                group.addTask {
+                    try store.append(
+                        PermissionRule(
+                            action: "host.shell.run",
+                            resource: "command-\(index)",
+                            match: .exact,
+                            decision: .allow
+                        ),
+                        forWorkspaceRoot: root
+                    )
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let resources = Set(store.load(forWorkspaceRoot: root).table.rules.map(\.resource))
+        XCTAssertEqual(resources, Set((0..<count).map { "command-\($0)" }))
+    }
+
+    func testWritesUsePrivateDurableStatePermissions() throws {
+        let (store, root) = try makeStoreAndRoot()
+        let fileURL = store.fileURL(forWorkspaceRoot: root)
+
+        try store.append(
+            PermissionRule(action: "host.shell.run", resource: "swift test", decision: .allow),
+            forWorkspaceRoot: root
+        )
+
+        XCTAssertEqual(try posixPermissions(at: store.directory), 0o700)
+        XCTAssertEqual(try posixPermissions(at: fileURL), 0o600)
+        XCTAssertEqual(
+            try posixPermissions(at: store.directory.appendingPathComponent(".\(fileURL.lastPathComponent).lock")),
+            0o600
         )
     }
 
@@ -342,5 +476,11 @@ final class PermissionRuleStoreTests: XCTestCase {
             .clarify,
             "an unknown-decision rule (possibly a deny) must force ask, not auto-approve"
         )
+    }
+
+    private func posixPermissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        return permissions.intValue & 0o777
     }
 }

--- a/Tests/QuillCodePersistenceTests/ProjectHookTrustStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/ProjectHookTrustStoreTests.swift
@@ -124,6 +124,133 @@ final class ProjectHookTrustStoreTests: XCTestCase {
         XCTAssertFalse(loaded.records.contains { $0.hookID == "invalid" })
     }
 
+    func testOversizedTrustFileFailsClosedWithoutReplacement() throws {
+        let setup = try makeSetup()
+        let fileURL = setup.store.fileURL(forWorkspaceRoot: setup.root)
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: Data()))
+        let handle = try FileHandle(forWritingTo: fileURL)
+        try handle.truncate(atOffset: UInt64(ProjectHookTrustFileStore.maximumBytes + 1))
+        try handle.close()
+
+        let loaded = setup.store.load(forWorkspaceRoot: setup.root)
+
+        XCTAssertTrue(loaded.degraded)
+        XCTAssertEqual(loaded.status(for: makeHook()), .reviewRequired)
+        XCTAssertThrowsError(
+            try setup.store.setDecision(.trusted, for: makeHook(), workspaceRoot: setup.root)
+        ) { error in
+            XCTAssertEqual(error as? ProjectHookTrustStoreError, .degradedFile)
+        }
+        XCTAssertEqual(
+            try FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber,
+            NSNumber(value: ProjectHookTrustFileStore.maximumBytes + 1)
+        )
+    }
+
+    func testSymbolicLinkFailsClosedAndExplicitSaveDoesNotTouchTarget() throws {
+        let setup = try makeSetup()
+        let fileURL = setup.store.fileURL(forWorkspaceRoot: setup.root)
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let target = setup.base.appendingPathComponent("outside-hook-trust.json")
+        let targetData = Data(#"{"version":1,"records":[]}"#.utf8)
+        try targetData.write(to: target)
+        try FileManager.default.createSymbolicLink(at: fileURL, withDestinationURL: target)
+
+        XCTAssertTrue(setup.store.load(forWorkspaceRoot: setup.root).degraded)
+        XCTAssertThrowsError(
+            try setup.store.setDecision(.trusted, for: makeHook(), workspaceRoot: setup.root)
+        ) { error in
+            XCTAssertEqual(error as? ProjectHookTrustStoreError, .degradedFile)
+        }
+
+        let record = ProjectHookTrustRecord(
+            hookID: "plugin_hook:replacement",
+            definitionHash: String(repeating: "b", count: 64),
+            decision: .disabled,
+            updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        try setup.store.save([record], forWorkspaceRoot: setup.root)
+
+        XCTAssertEqual(try Data(contentsOf: target), targetData)
+        XCTAssertEqual(setup.store.load(forWorkspaceRoot: setup.root).records, [record])
+        XCTAssertFalse(try fileURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true)
+    }
+
+    func testSymbolicLinkDirectoryCannotInjectTrust() throws {
+        let setup = try makeSetup()
+        let hook = makeHook()
+        let outsideDirectory = setup.base.appendingPathComponent("outside-trust", isDirectory: true)
+        let injectedStore = ProjectHookTrustFileStore(directory: outsideDirectory)
+        try injectedStore.setDecision(.trusted, for: hook, workspaceRoot: setup.root)
+        try FileManager.default.createSymbolicLink(
+            at: setup.store.directory,
+            withDestinationURL: outsideDirectory
+        )
+
+        let loaded = setup.store.load(forWorkspaceRoot: setup.root)
+
+        XCTAssertTrue(loaded.degraded)
+        XCTAssertEqual(loaded.status(for: hook), .reviewRequired)
+        XCTAssertThrowsError(
+            try setup.store.setDecision(.trusted, for: hook, workspaceRoot: setup.root)
+        ) { error in
+            XCTAssertEqual(error as? PrivateFileStoreFileSystemError, .unsafeDirectory)
+        }
+    }
+
+    func testConcurrentDecisionsPreserveEveryHook() async throws {
+        let setup = try makeSetup()
+        let store = setup.store
+        let root = setup.root
+        let count = 100
+        let hooks = (0..<count).map { index -> ProjectPluginHook in
+            var hook = makeHook(hash: String(format: "%064x", index + 1))
+            hook.id = "plugin_hook:concurrent.\(index)"
+            return hook
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for (index, hook) in hooks.enumerated() {
+                group.addTask {
+                    try store.setDecision(
+                        index.isMultiple(of: 2) ? .trusted : .disabled,
+                        for: hook,
+                        workspaceRoot: root,
+                        now: Date(timeIntervalSince1970: TimeInterval(index + 1))
+                    )
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let loaded = store.load(forWorkspaceRoot: root)
+        XCTAssertFalse(loaded.degraded)
+        XCTAssertEqual(Set(loaded.records.map(\.hookID)), Set(hooks.map(\.id)))
+    }
+
+    func testWritesUsePrivateDurableStatePermissions() throws {
+        let setup = try makeSetup()
+        let fileURL = setup.store.fileURL(forWorkspaceRoot: setup.root)
+
+        try setup.store.setDecision(.trusted, for: makeHook(), workspaceRoot: setup.root)
+
+        XCTAssertEqual(try posixPermissions(at: setup.store.directory), 0o700)
+        XCTAssertEqual(try posixPermissions(at: fileURL), 0o600)
+        XCTAssertEqual(
+            try posixPermissions(
+                at: setup.store.directory.appendingPathComponent(".\(fileURL.lastPathComponent).lock")
+            ),
+            0o600
+        )
+    }
+
     private func makeSetup() throws -> (base: URL, root: URL, store: ProjectHookTrustFileStore) {
         let base = FileManager.default.temporaryDirectory
             .appendingPathComponent("ProjectHookTrustStoreTests-\(UUID().uuidString)", isDirectory: true)
@@ -149,5 +276,11 @@ final class ProjectHookTrustStoreTests: XCTestCase {
             definitionHash: hash,
             supportStatus: .supported
         )
+    }
+
+    private func posixPermissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        return permissions.intValue & 0o777
     }
 }

--- a/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
+++ b/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
@@ -30,6 +30,8 @@ final class QuillCodePathsTests: PersistenceTestCase {
             paths.worktreeSnapshotsDirectory,
             paths.worktreesDirectory,
             paths.secretsDirectory,
+            paths.permissionsDirectory,
+            paths.hookTrustDirectory,
             paths.pluginDataDirectory,
             paths.subagentSessionsDirectory,
             paths.importsDirectory
@@ -41,6 +43,8 @@ final class QuillCodePathsTests: PersistenceTestCase {
         XCTAssertEqual(try posixPermissions(at: paths.composerDraftsDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.subagentApprovalPayloadsDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.secretsDirectory), 0o700)
+        XCTAssertEqual(try posixPermissions(at: paths.permissionsDirectory), 0o700)
+        XCTAssertEqual(try posixPermissions(at: paths.hookTrustDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.pluginDataDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: paths.importsDirectory), 0o700)
     }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,34 @@
 # Code Quality Audit
 
+## 2026-08-12 Bounded Crash-Consistent Policy Persistence
+
+Overall grade after this slice: **A+ policy resilience, A+ bounded memory, A+ concurrency safety**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Memory bounds | A+ | Permission rules reject payloads above 4 MiB and hook trust rejects payloads above 1 MiB before allocation; both use bounded descriptor-relative streaming reads. |
+| Concurrent correctness | A+ | Reference-counted local locks serialize sibling app tasks without retaining per-workspace locks, while private `flock` entries protect read-modify-write mutations across app and CLI processes. |
+| Crash consistency | A+ | Policy writes use private exclusive temporary files, file synchronization, atomic replacement, and directory synchronization; corrupt-rule backup failures now stop before replacement instead of silently losing the original. |
+| Fail-closed safety | A+ | File and directory symlinks, non-regular entries, foreign owners, and multiple hard links cannot inject allow or trust decisions; malformed and oversized state remains unchanged and degraded. |
+| Upgrade compatibility | A+ | Legacy user-owned policy files remain readable, policy directories are repaired to mode `0700`, and every new policy or lock entry is mode `0600`. |
+| Architecture | A+ | Bounded filesystem I/O and mutation coordination are focused components shared with credential persistence; every touched production and focused test file grades A+. |
+
+Validation:
+
+- Focused policy, hook-trust, credential, and path boundary: 52 tests, 0 failures.
+- Dependent permission reviewer, agent gate, workspace, and hook workflows: 66 tests, 1 expected
+  case-sensitive-volume skip, 0 failures.
+- Full Swift suite: 6,238 tests, 5 skipped, 0 failures.
+- Release packaged composer `SIGKILL` recovery, direct-executable, Launch Services, live-window,
+  Accessibility, native interaction, coworker, browser, computer-use, and 100-chat smokes passed.
+- Three fresh optimized packaged processes passed their performance budgets: 293.93 ms median
+  launch-ready, 40.91 MiB initial footprint, 85.13 MiB after interaction, and 84.33 MiB after the
+  repeated sweep, releasing 0.80 MiB with one fewer thread during repeated use.
+- The exact-commit arm64 DMG passed read-only mount, architecture, signature, move, relaunch,
+  first-window readiness, and cleanup checks.
+- `python3 scripts/grade-code-quality.py --root .`: every touched production and focused test file
+  grades A+; `git diff --check` passed and the supplied live credential is absent from source.
+
 ## 2026-08-11 Bounded Crash-Consistent Credential Persistence
 
 Overall grade after this slice: **A+ credential resilience, A+ bounded memory, A+ upgrade compatibility**.


### PR DESCRIPTION
## Summary
- bound permission-rule and hook-trust reads and reject unsafe link/path state
- serialize read-modify-write mutations across app tasks and processes with durable private writes
- preserve corrupt rule bytes and add concurrency, size, symlink, and permission regression coverage

## Verification
- 6,238 Swift tests, 5 skipped, 0 failures
- complete packaged desktop smoke including crash recovery, native UX, accessibility, browser, and computer use
- three-launch 100-chat gate: 293.93 ms median ready, 40.91 MiB initial, 85.13 MiB post-interaction, 84.33 MiB repeated
- arm64 DMG move-and-relaunch smoke passed
- all touched production and focused test files grade A+