### PR TITLE
Release offscreen Markdown render state

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeMessageMarkdown.swift
+++ b/Sources/QuillCodeApp/QuillCodeMessageMarkdown.swift
@@ -183,14 +183,16 @@ enum MessageMarkdownBlocks {
     }
 }
 
-/// Per-message parsed Markdown retained by SwiftUI for the lifetime of a lazy transcript row.
-/// Long assistant replies should be parsed when their text changes, not whenever scrolling asks the
-/// row for its body again.
+/// Per-message Markdown state owned by one lazy transcript row. Parsed blocks and inline styling are
+/// reused while visible, then released when the row leaves the viewport and rebuilt on demand.
 final class QuillCodeMessageMarkdownDocument: ObservableObject {
-    private var sourceText: String
+    private var sourceText: String?
     private var inlineCache: [String: AttributedString] = [:]
     private var plainInlineText: Set<String> = []
     private(set) var blocks: [MessageMarkdownBlocks.Block]
+    var retainedInlineEntryCount: Int {
+        inlineCache.count + plainInlineText.count
+    }
 
     init(text: String) {
         let displayText = MessageMarkdownBlocks.strippingReplacementCharacters(text)
@@ -203,9 +205,18 @@ final class QuillCodeMessageMarkdownDocument: ObservableObject {
         sourceText = text
         let displayText = MessageMarkdownBlocks.strippingReplacementCharacters(text)
         blocks = MessageMarkdownBlocks.parse(displayText)
-        inlineCache.removeAll(keepingCapacity: true)
-        plainInlineText.removeAll(keepingCapacity: true)
+        inlineCache.removeAll(keepingCapacity: false)
+        plainInlineText.removeAll(keepingCapacity: false)
         return blocks
+    }
+
+    /// Lazy transcript rows can keep their state object after leaving the viewport. Drop rendered
+    /// message copies until the row is visible again; the durable message text remains in its surface.
+    func releaseRenderedContent() {
+        sourceText = nil
+        blocks.removeAll(keepingCapacity: false)
+        inlineCache.removeAll(keepingCapacity: false)
+        plainInlineText.removeAll(keepingCapacity: false)
     }
 
     func inlineAttributed(for text: String) -> AttributedString? {
@@ -241,6 +252,7 @@ struct QuillCodeMessageMarkdownView: View {
                 blockView(block)
             }
         }
+        .onDisappear(perform: document.releaseRenderedContent)
     }
 
     @ViewBuilder

--- a/Tests/QuillCodeAppTests/MessageMarkdownBlocksTests.swift
+++ b/Tests/QuillCodeAppTests/MessageMarkdownBlocksTests.swift
@@ -155,5 +155,25 @@ final class MessageMarkdownBlocksTests: XCTestCase {
         XCTAssertEqual(first, second)
         XCTAssertNil(document.inlineAttributed(for: "Plain text"))
         XCTAssertNil(document.inlineAttributed(for: "Plain text"))
+        XCTAssertEqual(document.retainedInlineEntryCount, 2)
+    }
+
+    func testMarkdownDocumentReleasesAndRehydratesOffscreenRendering() throws {
+        let text = "## Result\n\nUse `swift test`."
+        let document = QuillCodeMessageMarkdownDocument(text: text)
+        _ = try XCTUnwrap(document.inlineAttributed(for: "Use `swift test`."))
+        XCTAssertFalse(document.blocks.isEmpty)
+        XCTAssertEqual(document.retainedInlineEntryCount, 1)
+
+        document.releaseRenderedContent()
+
+        XCTAssertTrue(document.blocks.isEmpty)
+        XCTAssertEqual(document.retainedInlineEntryCount, 0)
+        XCTAssertEqual(document.blocks(for: text), [
+            .heading(level: 2, text: "Result"),
+            .paragraph("Use `swift test`."),
+        ])
+        XCTAssertNotNil(document.inlineAttributed(for: "Use `swift test`."))
+        XCTAssertEqual(document.retainedInlineEntryCount, 1)
     }
 }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceTranscriptGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceTranscriptGateTests.swift
@@ -39,4 +39,21 @@ final class ParityWorkspaceTranscriptGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(broadSurfaceTests.contains("testContextBannerAppearsNearEstimatedLimit"), "WorkspaceSurfaceTests should not own context-banner threshold behavior.")
         XCTAssertFalse(broadSurfaceTests.contains("testContextBannerHiddenForShortThreadAndForkDisabledWithoutMessages"), "WorkspaceSurfaceTests should not own context-banner hidden-state behavior.")
     }
+
+    func testOffscreenAssistantMarkdownReleasesRenderedCopies() throws {
+        let markdownText = try Self.appSourceText(named: "QuillCodeMessageMarkdown.swift")
+        let markdownTests = try Self.appTestSourceText(named: "MessageMarkdownBlocksTests.swift")
+
+        Self.assertSource(markdownText, containsAll: [
+            "func releaseRenderedContent()",
+            "blocks.removeAll(keepingCapacity: false)",
+            "inlineCache.removeAll(keepingCapacity: false)",
+            "plainInlineText.removeAll(keepingCapacity: false)",
+            ".onDisappear(perform: document.releaseRenderedContent)",
+        ])
+        XCTAssertTrue(
+            markdownTests.contains("testMarkdownDocumentReleasesAndRehydratesOffscreenRendering"),
+            "Offscreen Markdown release must retain focused rehydration coverage."
+        )
+    }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,32 @@
 # Code Quality Audit
 
+## 2026-08-12 Offscreen Markdown Render Residency
+
+Overall grade after this slice: **A+ transcript memory, A+ rendering fidelity, A+ lifecycle safety**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Offscreen residency | A+ | Lazy transcript rows release parsed Markdown blocks, attributed inline text, plain-text projections, and their copied source string when they leave the viewport. |
+| Durable ownership | A+ | The transcript surface remains the single durable owner of message text; render state is disposable and cannot discard conversation history. |
+| Rehydration | A+ | A returning row rebuilds its blocks and inline styles from the canonical message text on demand, preserving headings, emphasis, links, and code presentation. |
+| Capacity release | A+ | Offscreen cleanup releases dictionary and array backing storage instead of keeping high-water allocations attached to retained row state. |
+| UI stability | A+ | Cleanup is tied to the existing lazy row lifecycle, requires no global cache or eviction coordinator, and leaves visible and streaming rows unchanged. |
+| Regression evidence | A+ | Behavioral tests prove release and exact-text rehydration, while parity coverage pins lifecycle wiring and non-retaining cleanup policy. |
+
+Validation:
+
+- Focused Markdown, transcript-parity, and rendered SwiftUI coverage: 22 tests, 0 failures.
+- Full Swift suite: 6,248 tests, 5 skipped, 0 failures.
+- Release packaged composer `SIGKILL` recovery, direct-executable, Launch Services, live-window,
+  Accessibility, native interaction, coworker, browser, computer-use, and 100-chat smokes passed.
+- Three fresh optimized packaged processes passed their performance budgets: 299.13 ms median
+  launch-ready, 40.70 MiB initial footprint, 85.00 MiB after interaction, and 87.05 MiB after the
+  repeated sweep.
+- The arm64 DMG passed checksum, read-only mount, architecture, signature, move, relaunch,
+  first-window readiness, and cleanup checks.
+- `python3 scripts/grade-code-quality.py --root .`: every production module and touched production
+  and focused test file grades A+; `git diff --check` passed.
+
 ## 2026-08-12 Bounded Crash-Consistent Policy Persistence
 
 Overall grade after this slice: **A+ policy resilience, A+ bounded memory, A+ concurrency safety**.


### PR DESCRIPTION
## Summary
- release parsed Markdown and inline render caches when lazy transcript rows leave the viewport
- rebuild exact rendering on demand from the canonical message surface
- add behavioral and source-parity regression coverage

## Verification
- 6,248 Swift tests, 5 skipped, 0 failures
- packaged direct, Launch Services, crash recovery, accessibility, browser/computer-use, and 100-chat smokes passed
- 3/3 performance launches: 299.13 ms median, 40.70 MiB initial, 87.05 MiB repeated footprint
- arm64 DMG checksum, mount, relocation, signature, relaunch, and readiness passed
- code quality A+; git diff check clean