### PR TITLE
Add one universal Mac installer

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -144,6 +144,65 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  macos-universal:
+    needs: [release-policy, macos]
+    if: needs.release-policy.outputs.build-required == 'true'
+    runs-on: macos-15
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: quillcode-macos-downloads-*
+          path: ${{ runner.temp }}/thin-macos-downloads
+      - name: Set release channel
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "QUILLCODE_UPDATE_CHANNEL=stable" >> "$GITHUB_ENV"
+          else
+            echo "QUILLCODE_UPDATE_CHANNEL=tester" >> "$GITHUB_ENV"
+          fi
+      - name: Configure Apple distribution signing
+        env:
+          APPLE_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+        run: scripts/configure-macos-distribution-signing.sh
+      - name: Package universal macOS installer
+        run: |
+          mkdir -p "$RUNNER_TEMP/quillcode-macos-downloads-universal"
+          scripts/package-macos-universal-installer.sh \
+            --arm64-app-zip "$RUNNER_TEMP/thin-macos-downloads/quillcode-macos-downloads-arm64/Quill-Cowork-macOS-arm64.zip" \
+            --x86-64-app-zip "$RUNNER_TEMP/thin-macos-downloads/quillcode-macos-downloads-x86_64/Quill-Cowork-macOS-x86_64.zip" \
+            --output "$RUNNER_TEMP/quillcode-macos-downloads-universal/Quill-Cowork-macOS-universal.dmg"
+      - name: Remove temporary Apple signing material
+        if: always()
+        run: |
+          if [[ -n "${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}" && -f "$QUILLCODE_MACOS_SIGNING_KEYCHAIN" ]]; then
+            security delete-keychain "$QUILLCODE_MACOS_SIGNING_KEYCHAIN" || true
+          fi
+          if [[ -n "${QUILLCODE_MACOS_NOTARY_KEY_PATH:-}" && -f "$QUILLCODE_MACOS_NOTARY_KEY_PATH" ]]; then
+            rm -f "$QUILLCODE_MACOS_NOTARY_KEY_PATH"
+          fi
+          if [[ -n "${QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH:-}" && -f "$QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH" ]]; then
+            rm -f "$QUILLCODE_MACOS_SIGNING_CERTIFICATE_PATH"
+          fi
+      - name: Upload universal macOS installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: quillcode-macos-downloads-universal
+          path: ${{ runner.temp }}/quillcode-macos-downloads-universal/Quill-Cowork-macOS-universal.dmg
+          if-no-files-found: error
+          retention-days: 14
+
   linux:
     needs: release-policy
     if: needs.release-policy.outputs.build-required == 'true'
@@ -178,7 +237,7 @@ jobs:
           retention-days: 14
 
   publish:
-    needs: [macos, linux, capture-updater-source]
+    needs: [macos, macos-universal, linux, capture-updater-source]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -357,8 +416,16 @@ jobs:
             --pattern 'Quill-Cowork-macOS-${{ matrix.arch }}.zip' \
             --dir "$RUNNER_TEMP/public-updater"
           gh release download "$RELEASE_TAG" \
+            --pattern 'Quill-Cowork-macOS-universal.dmg' \
+            --dir "$RUNNER_TEMP/public-updater"
+          gh release download "$RELEASE_TAG" \
             --pattern "latest-${RELEASE_CHANNEL}-build.json" \
             --dir "$RUNNER_TEMP/public-updater"
+      - name: Verify universal installer launches natively
+        run: |
+          scripts/packaged-macos-relocation-smoke.sh \
+            --dmg "$RUNNER_TEMP/public-updater/Quill-Cowork-macOS-universal.dmg" \
+            --expected-architecture '${{ matrix.arch }}'
       - name: Verify public app updates and relaunches itself
         env:
           QUILLCODE_UPDATER_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/updater-smoke-artifacts

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **A 100% Swift coding agent and AI coworker for real project work.**
 
-[Download for Apple silicon](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg) · [Download for Intel](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-x86_64.dmg) · [Release notes and checksums](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest)
+[Download Quill Cowork for Mac](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg) · [Release notes and checksums](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest)
 
 ![Quill Cowork showing a code review with TrustedRouter billing limits expanded](docs/images/quill-cowork-desktop.png)
 
@@ -34,7 +34,7 @@ architecture.
 
 The current desktop build requires **macOS 14 or later** and supports Apple silicon and Intel Macs.
 
-1. Download the latest Quill Cowork disk image for [Apple silicon](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg) or [Intel](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-x86_64.dmg).
+1. [Download the latest Quill Cowork disk image](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg). The same installer runs natively on Apple silicon and Intel Macs.
 2. Open the disk image and drag **Quill Cowork.app** onto **Applications**, then eject it.
 3. For the current tester build, right-click the app and choose **Open** on first launch if macOS
    blocks it. Tester builds are ad-hoc code-signed but are not Apple-notarized yet.
@@ -74,6 +74,7 @@ extra network request.
 
 | Platform | Artifact | Status |
 | --- | --- | --- |
+| macOS universal | [Quill Cowork app](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg) | Recommended tester preview |
 | macOS arm64 | [Quill Cowork app](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg) | Tester preview |
 | macOS x86_64 | [Quill Cowork app](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-x86_64.dmg) | Tester preview |
 | macOS arm64 | [Quill Cowork CLI](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/quill-code-macOS-arm64.tar.gz) | Tester preview |

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -55,6 +55,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
                 to: temporaryDirectory.appendingPathComponent("quill-code-macOS-\(architecture).tar.gz")
             )
         }
+        try Data("universal mac installer".utf8).write(
+            to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-universal.dmg")
+        )
         try "product=Quill Cowork\nplatform=Linux\narch=x86_64\nversion=0.2.0\nbuild=123\n"
             .write(
                 to: temporaryDirectory.appendingPathComponent("BUILD_INFO-linux-x86_64.txt"),
@@ -129,9 +132,20 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             updaterAppAssets.compactMap { $0["name"] as? String },
             ["Quill-Cowork-macOS-arm64.zip", "Quill-Cowork-macOS-x86_64.zip"]
         )
+        let universalInstaller = try XCTUnwrap(
+            updater["macOSUniversalInstaller"] as? [String: Any]
+        )
+        XCTAssertEqual(universalInstaller["name"] as? String, "Quill-Cowork-macOS-universal.dmg")
+        XCTAssertEqual(universalInstaller["arch"] as? String, "universal")
 
         let assets = try XCTUnwrap(manifest["assets"] as? [[String: Any]])
-        XCTAssertEqual(assets.count, 14)
+        XCTAssertEqual(assets.count, 15)
+
+        let universalAsset = try asset(named: "Quill-Cowork-macOS-universal.dmg", in: assets)
+        XCTAssertEqual(universalAsset["kind"] as? String, "installer")
+        XCTAssertEqual(universalAsset["platform"] as? String, "macOS")
+        XCTAssertEqual(universalAsset["arch"] as? String, "universal")
+        XCTAssertEqual(universalAsset["install"] as? String, "dmg-app")
 
         let installerAsset = try asset(named: "Quill-Cowork-macOS-arm64.dmg", in: assets)
         XCTAssertEqual(installerAsset["kind"] as? String, "installer")
@@ -236,6 +250,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
                 to: temporaryDirectory.appendingPathComponent("quill-code-macOS-\(architecture).tar.gz")
             )
         }
+        try Data("stable universal installer".utf8).write(
+            to: temporaryDirectory.appendingPathComponent("Quill-Cowork-macOS-universal.dmg")
+        )
 
         let manifestURL = temporaryDirectory.appendingPathComponent("latest-stable-build.json")
         let script = Self.packageRoot()
@@ -313,6 +330,12 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "runner: macos-15",
             "runner: macos-15-intel",
             "name: quillcode-macos-downloads-${{ matrix.arch }}",
+            "macos-universal:",
+            "scripts/package-macos-universal-installer.sh",
+            "--arm64-app-zip",
+            "--x86-64-app-zip",
+            "Quill-Cowork-macOS-universal.dmg",
+            "name: quillcode-macos-downloads-universal",
             "name: quillcode-public-updater-smoke-${{ matrix.arch }}",
             "scripts/build-release-notes.py",
             "--build-info \"$RUNNER_TEMP/release-assets/BUILD_INFO.txt\"",
@@ -321,7 +344,7 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "--commit \"$GITHUB_SHA\"",
             "--output \"$RUNNER_TEMP/release-notes.md\"",
             "scripts/plan-download-publication.sh",
-            "needs: [macos, linux, capture-updater-source]",
+            "needs: [macos, macos-universal, linux, capture-updater-source]",
             "pattern: quillcode-*-downloads*",
             "published: ${{ steps.publication.outputs.publish-required }}",
             "if: steps.publication.outputs.publish-required == 'true'",
@@ -355,6 +378,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "needs.capture-updater-source.result == 'success'",
             "Download previous public updater source",
             "sourceAvailable raw",
+            "Verify universal installer launches natively",
+            "--expected-architecture '${{ matrix.arch }}'",
             "--source-manifest \"$CAPTURE_DIR/source-manifest.json\"",
             "verify-stable-promotion:",
             "needs: [promote-stable, verify-updater]",
@@ -425,7 +450,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "untouched previous public app",
             "synthetic one-build-behind fallback",
             "channel is `tester`",
-            "channel is `stable`"
+            "channel is `stable`",
+            "Quill-Cowork-macOS-universal.dmg"
         ])
         Self.assertSource(readme, contains: "machine-readable build manifest")
     }
@@ -446,6 +472,11 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         )
         let diskImageScript = try String(
             contentsOf: root.appendingPathComponent("scripts").appendingPathComponent("create-macos-disk-image.sh"),
+            encoding: .utf8
+        )
+        let universalInstallerScript = try String(
+            contentsOf: root.appendingPathComponent("scripts")
+                .appendingPathComponent("package-macos-universal-installer.sh"),
             encoding: .utf8
         )
 
@@ -501,6 +532,17 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "\"$CODESIGN_BIN\" --verify --deep --strict"
         ])
         Self.assertSource(diskImageScript, excludes: "-quiet")
+        Self.assertSource(universalInstallerScript, containsAll: [
+            "--arm64-app-zip",
+            "--x86-64-app-zip",
+            "lipo",
+            "-verify_arch arm64 x86_64",
+            "The arm64 and x86_64 app bundle inventories do not match.",
+            "codesign",
+            "notarytool submit",
+            "scripts/create-macos-disk-image.sh",
+            "scripts/packaged-macos-relocation-smoke.sh"
+        ])
         Self.assertSource(smokeScript, containsAll: [
             "assert_plist_value QuillCodeUpdateChannel tester",
             "assert_plist_value QuillCodeBuildCommit \"$EXPECTED_BUILD_COMMIT\"",

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -127,7 +127,7 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "scripts/capture-public-updater-source.py",
             "name: quillcode-prior-updater-sources",
             "pattern: quillcode-*-downloads*",
-            "needs: [macos, linux, capture-updater-source]",
+            "needs: [macos, macos-universal, linux, capture-updater-source]",
             "verify-updater:",
             "runner: macos-15",
             "runner: macos-15-intel",
@@ -140,6 +140,9 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
             "needs.verify-updater.result == 'success'",
             "sourceAvailable raw",
             "--source-manifest \"$CAPTURE_DIR/source-manifest.json\"",
+            "Quill-Cowork-macOS-universal.dmg",
+            "Verify universal installer launches natively",
+            "--expected-architecture '${{ matrix.arch }}'",
             "scripts/packaged-macos-updater-smoke.sh",
             "quillcode-public-updater-smoke-${{ matrix.arch }}"
         ])

--- a/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
@@ -12,6 +12,7 @@ final class ParityPublicDistributionGateTests: QuillCodeParityTestCase {
         Self.assertSource(
             readme,
             containsAll: [
+                "releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg",
                 "releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg",
                 "releases/download/tester-latest/Quill-Cowork-macOS-x86_64.dmg",
                 "releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip",

--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -364,6 +364,24 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         )
     }
 
+    func testVerifierRejectsUniversalInstallerMetadataDrift() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try mutateManifest(fixture) { manifest in
+            var updater = try XCTUnwrap(manifest["updater"] as? [String: Any])
+            updater.removeValue(forKey: "macOSUniversalInstaller")
+            manifest["updater"] = updater
+        }
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("universal installer must match the published universal DMG"),
+            result.output
+        )
+    }
+
     func testVerifierRejectsUnexpectedMacOSAppInstallMode() throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
@@ -490,6 +508,9 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 )
             }
         }
+        try Data("verified universal installer".utf8).write(
+            to: assetsURL.appendingPathComponent("Quill-Cowork-macOS-universal.dmg")
+        )
 
         var checksummedNames = try FileManager.default.contentsOfDirectory(
             atPath: assetsURL.path
@@ -517,6 +538,16 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
             )
         ]
         var appAssets: [[String: Any]] = []
+        let universalInstallerAsset = try manifestAsset(
+            named: "Quill-Cowork-macOS-universal.dmg",
+            kind: "installer",
+            platform: "macOS",
+            arch: "universal",
+            install: "dmg-app",
+            assetsURL: assetsURL,
+            releaseTag: releaseTag
+        )
+        manifestAssets.append(universalInstallerAsset)
         for architecture in architectures {
             manifestAssets.append(try manifestAsset(
                 named: "BUILD_INFO-macOS-\(architecture).txt",
@@ -602,6 +633,7 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
                 "codesign": codesign,
                 "signingTeamIdentifier": signingTeamIdentifier.map { $0 as Any } ?? NSNull(),
                 "notarized": notarized,
+                "macOSUniversalInstaller": universalInstallerAsset,
                 "macOSAppAsset": appAssets[0],
                 "macOSAppAssets": appAssets
             ],

--- a/Tests/QuillCodeParityTests/ParityReleaseNotesGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityReleaseNotesGateTests.swift
@@ -27,8 +27,10 @@ final class ParityReleaseNotesGateTests: QuillCodeParityTestCase {
             "docs/images/quill-cowork-desktop.png",
             "Tester version 0.1.0 (build 678)",
             "macOS 14.0 or later",
-            "Apple silicon (M-series)",
-            "Intel processor",
+            "Download Quill Cowork for Mac",
+            "Quill-Cowork-macOS-universal.dmg",
+            "One installer runs natively on Apple silicon and Intel Macs.",
+            "Architecture-specific installers",
             "Quill-Cowork-macOS-arm64.dmg",
             "Quill-Cowork-macOS-x86_64.dmg",
             "Drag **Quill Cowork.app** onto **Applications**",
@@ -68,6 +70,7 @@ final class ParityReleaseNotesGateTests: QuillCodeParityTestCase {
         let notes = try String(contentsOf: fixture.output, encoding: .utf8)
         Self.assertSource(notes, containsAll: [
             "Stable version 1.2.3 (build 678)",
+            "releases/download/v1.2.3/Quill-Cowork-macOS-universal.dmg",
             "releases/download/v1.2.3/Quill-Cowork-macOS-arm64.dmg",
             "releases/download/v1.2.3/Quill-Cowork-macOS-x86_64.dmg",
             "Developer ID signed, notarized by Apple, and stapled",

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -10,6 +10,8 @@ Send testers this moving prerelease link:
 
 Direct asset links for the current tester channel:
 
+- [Recommended Mac installer: `Quill-Cowork-macOS-universal.dmg`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg)
+  runs natively on Apple silicon and Intel.
 - [Apple silicon installer: `Quill-Cowork-macOS-arm64.dmg`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.dmg)
 - [Intel installer: `Quill-Cowork-macOS-x86_64.dmg`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-x86_64.dmg)
 - [Apple silicon updater archive: `Quill-Cowork-macOS-arm64.zip`](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip)
@@ -25,7 +27,7 @@ Direct asset links for the current tester channel:
 
 The GitHub release page is generated from the packaged app's validated
 `BUILD_INFO.txt`, not maintained as free-form workflow copy. It leads with a
-commit-pinned product screenshot, explicit Apple silicon and Intel installer
+commit-pinned product screenshot, one universal Mac installer, optional architecture-specific
 links, the minimum macOS version, installation and Gatekeeper steps, automatic
 update behavior, signing status, and exact source/build provenance. Secondary
 CLI, updater, checksum, manifest, and performance assets remain available in a
@@ -37,10 +39,12 @@ The build manifest is the app updater, website, and support script contract. It
 records the build channel, tag, commit, workflow run URL, version, build number,
 per-asset download URL, size, platform, architecture, and SHA-256 digest. It also
 includes an `updater` object with the feed URL, bundle identifier, minimum macOS
-version, signing/notarization status, and exact arm64 and x86_64 updater assets.
+version, signing/notarization status, the universal installer, and exact arm64
+and x86_64 updater assets.
 The legacy arm64 field remains present so already-installed tester builds continue
-to update. The DMG is the recommended human installation path; the ZIP remains the
-machine-verified updater payload so installation ergonomics cannot change update semantics.
+to update. The universal DMG is the recommended human installation path; the ZIP
+remains the machine-verified updater payload so installation ergonomics cannot
+change update semantics.
 Every macOS `BUILD_INFO` also records `symbolsStripped=true` and the exact uncompressed
 app-executable byte size. Release builds remove debug and local symbols before any ad-hoc or
 Developer ID signature is applied. Public verification compares the declared size with the Mach-O

--- a/scripts/build-download-manifest.py
+++ b/scripts/build-download-manifest.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 SCHEMA_VERSION = 1
 PRODUCT = "Quill Cowork"
 MACOS_ARCHITECTURES = ("arm64", "x86_64")
+MACOS_INSTALLER_ARCHITECTURES = ("universal", *MACOS_ARCHITECTURES)
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -150,6 +151,7 @@ def exact_macos_assets(
     *,
     kind: str,
     install: str,
+    architectures: tuple[str, ...] = MACOS_ARCHITECTURES,
 ) -> list[dict[str, object]]:
     assets_by_arch: dict[str, dict[str, object]] = {}
     for asset in assets:
@@ -163,16 +165,16 @@ def exact_macos_assets(
                 f"release macOS {kind} assets must use {install} installation"
             )
         architecture = str(asset.get("arch"))
-        if architecture not in MACOS_ARCHITECTURES or architecture in assets_by_arch:
+        if architecture not in architectures or architecture in assets_by_arch:
             raise SystemExit(
                 f"release must contain exactly one macOS {kind} for each architecture"
             )
         assets_by_arch[architecture] = asset
-    if set(assets_by_arch) != set(MACOS_ARCHITECTURES):
+    if set(assets_by_arch) != set(architectures):
         raise SystemExit(
             f"release must contain exactly one macOS {kind} for each architecture"
         )
-    return [assets_by_arch[architecture] for architecture in MACOS_ARCHITECTURES]
+    return [assets_by_arch[architecture] for architecture in architectures]
 
 
 def build_updater_metadata(
@@ -183,11 +185,13 @@ def build_updater_metadata(
     assets: list[dict[str, object]],
 ) -> dict[str, object]:
     app_assets = exact_macos_assets(assets, kind="app", install="zip-app")
-    for kind, install in (
-        ("installer", "dmg-app"),
-        ("performance", "json"),
-        ("cli", "tarball"),
-    ):
+    installer_assets = exact_macos_assets(
+        assets,
+        kind="installer",
+        install="dmg-app",
+        architectures=MACOS_INSTALLER_ARCHITECTURES,
+    )
+    for kind, install in (("performance", "json"), ("cli", "tarball")):
         exact_macos_assets(assets, kind=kind, install=install)
 
     build_info = build_infos["arm64"]
@@ -225,6 +229,7 @@ def build_updater_metadata(
         "codesign": build_info.get("codesign", "unknown"),
         "signingTeamIdentifier": signing_team,
         "notarized": build_info.get("notarized", "false").lower() == "true",
+        "macOSUniversalInstaller": installer_assets[0],
         "macOSAppAsset": app_assets[0],
         "macOSAppAssets": app_assets,
     }

--- a/scripts/build-release-notes.py
+++ b/scripts/build-release-notes.py
@@ -146,14 +146,20 @@ def build_release_notes(arguments: argparse.Namespace, values: dict[str, str]) -
         "docs/images/quill-cowork-desktop.png"
     )
 
+    universal_installer = markdown_link(
+        "Download Quill Cowork for Mac",
+        repo,
+        tag,
+        "Quill-Cowork-macOS-universal.dmg",
+    )
     arm_installer = markdown_link(
-        "Download for Apple silicon",
+        "Apple silicon installer",
         repo,
         tag,
         "Quill-Cowork-macOS-arm64.dmg",
     )
     intel_installer = markdown_link(
-        "Download for Intel",
+        "Intel installer",
         repo,
         tag,
         "Quill-Cowork-macOS-x86_64.dmg",
@@ -180,13 +186,11 @@ Native macOS coding agent and AI coworker for real project work.
 
 **{channel_label} version {version} (build {build})** | **macOS {minimum_system} or later**
 
-| Your Mac | Installer |
-| --- | --- |
-| Apple silicon (M-series) | **{arm_installer}** |
-| Intel processor | **{intel_installer}** |
+## Download
 
-Not sure which Mac you have? Open **Apple menu > About This Mac**. Choose Apple silicon when it
-shows **Chip**, or Intel when it shows **Processor**.
+**{universal_installer}**
+
+One installer runs natively on Apple silicon and Intel Macs.
 
 ## Install
 
@@ -206,8 +210,10 @@ against their declared size, SHA-256, app identity, architecture, source commit,
 activation is atomic, and the previous build is restored if the new build cannot finish launching.
 
 <details>
-<summary>CLI downloads, updater archives, checksums, and performance evidence</summary>
+<summary>Architecture-specific installers, CLI downloads, updater archives, checksums, and performance evidence</summary>
 
+- {arm_installer}
+- {intel_installer}
 - {markdown_link("Apple silicon updater archive", repo, tag, "Quill-Cowork-macOS-arm64.zip")}
 - {markdown_link("Intel updater archive", repo, tag, "Quill-Cowork-macOS-x86_64.zip")}
 - {markdown_link("Apple silicon macOS CLI", repo, tag, "quill-code-macOS-arm64.tar.gz")}

--- a/scripts/package-macos-universal-installer.sh
+++ b/scripts/package-macos-universal-installer.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s dotglob nullglob
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM="${QUILLCODE_UNIVERSAL_INSTALLER_PLATFORM:-$(uname -s)}"
+DITTO_BIN="${QUILLCODE_DITTO_BIN:-ditto}"
+LIPO_BIN="${QUILLCODE_LIPO_BIN:-lipo}"
+CODESIGN_BIN="${QUILLCODE_CODESIGN_BIN:-codesign}"
+SPCTL_BIN="${QUILLCODE_SPCTL_BIN:-spctl}"
+XCRUN_BIN="${QUILLCODE_XCRUN_BIN:-xcrun}"
+SIGNING_IDENTITY="${QUILLCODE_MACOS_SIGNING_IDENTITY:-}"
+SIGNING_TEAM_IDENTIFIER="${QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER:-}"
+SIGNING_KEYCHAIN="${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}"
+NOTARY_KEY_ID="${QUILLCODE_MACOS_NOTARY_KEY_ID:-}"
+NOTARY_ISSUER_ID="${QUILLCODE_MACOS_NOTARY_ISSUER_ID:-}"
+NOTARY_KEY_PATH="${QUILLCODE_MACOS_NOTARY_KEY_PATH:-}"
+UPDATE_CHANNEL="${QUILLCODE_UPDATE_CHANNEL:-tester}"
+MAXIMUM_ARCHIVE_BYTES=$((1024 * 1024 * 1024))
+APP_NAME="Quill Cowork.app"
+EXECUTABLE_RELATIVE_PATH="Contents/MacOS/Quill Cowork"
+
+usage() {
+  cat <<'USAGE'
+Usage: package-macos-universal-installer.sh \
+  --arm64-app-zip PATH --x86-64-app-zip PATH --output PATH
+USAGE
+}
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+ARM64_APP_ZIP=""
+X86_64_APP_ZIP=""
+OUTPUT_PATH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arm64-app-zip)
+      [[ $# -ge 2 ]] || fail "--arm64-app-zip requires a path." 2
+      ARM64_APP_ZIP="$2"
+      shift 2
+      ;;
+    --x86-64-app-zip)
+      [[ $# -ge 2 ]] || fail "--x86-64-app-zip requires a path." 2
+      X86_64_APP_ZIP="$2"
+      shift 2
+      ;;
+    --output)
+      [[ $# -ge 2 ]] || fail "--output requires a path." 2
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1" 2
+      ;;
+  esac
+done
+
+[[ "$PLATFORM" == "Darwin" ]] || fail "Universal macOS packaging must run on macOS." 2
+[[ -n "$ARM64_APP_ZIP" && -n "$X86_64_APP_ZIP" && -n "$OUTPUT_PATH" ]] || {
+  usage >&2
+  exit 2
+}
+[[ "$OUTPUT_PATH" == *.dmg ]] || fail "Universal installer output must end in .dmg." 2
+
+validate_archive() {
+  local archive="$1"
+  local label="$2"
+  [[ -f "$archive" && ! -L "$archive" ]] || fail "$label must be a regular ZIP archive: $archive" 2
+  local size
+  size="$(stat -f '%z' "$archive")"
+  [[ "$size" =~ ^[0-9]+$ && "$size" -gt 0 && "$size" -le "$MAXIMUM_ARCHIVE_BYTES" ]] || \
+    fail "$label has an invalid size: $size bytes" 2
+}
+
+validate_archive "$ARM64_APP_ZIP" "arm64 app archive"
+validate_archive "$X86_64_APP_ZIP" "x86_64 app archive"
+
+if [[ "$UPDATE_CHANNEL" == "stable" ]]; then
+  [[ -n "$SIGNING_IDENTITY" && -n "$SIGNING_TEAM_IDENTIFIER" ]] || \
+    fail "Stable universal installers require Developer ID signing." 2
+  [[ -n "$NOTARY_KEY_ID" && -n "$NOTARY_ISSUER_ID" && -n "$NOTARY_KEY_PATH" ]] || \
+    fail "Stable universal installers require App Store Connect notarization credentials." 2
+fi
+if [[ -n "$SIGNING_IDENTITY" && -z "$SIGNING_TEAM_IDENTIFIER" ]]; then
+  fail "QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER is required for Developer ID signing." 2
+fi
+
+OUTPUT_DIRECTORY="$(dirname "$OUTPUT_PATH")"
+mkdir -p "$OUTPUT_DIRECTORY"
+WORK_DIRECTORY="$(mktemp -d "$OUTPUT_DIRECTORY/.quill-cowork-universal.XXXXXX")"
+cleanup() {
+  rm -rf "$WORK_DIRECTORY"
+}
+trap cleanup EXIT
+
+ARM64_ROOT="$WORK_DIRECTORY/arm64"
+X86_64_ROOT="$WORK_DIRECTORY/x86_64"
+UNIVERSAL_ROOT="$WORK_DIRECTORY/universal"
+mkdir -p "$ARM64_ROOT" "$X86_64_ROOT" "$UNIVERSAL_ROOT"
+"$DITTO_BIN" -x -k "$ARM64_APP_ZIP" "$ARM64_ROOT"
+"$DITTO_BIN" -x -k "$X86_64_APP_ZIP" "$X86_64_ROOT"
+
+validate_app_bundle() {
+  local extraction_root="$1"
+  local expected_architecture="$2"
+  local app_bundle="$extraction_root/$APP_NAME"
+  local executable="$app_bundle/$EXECUTABLE_RELATIVE_PATH"
+  local entries=("$extraction_root"/*)
+
+  [[ ${#entries[@]} -eq 1 && "${entries[0]}" == "$app_bundle" && -d "$app_bundle" && ! -L "$app_bundle" ]] || \
+    fail "$expected_architecture archive must contain exactly one top-level $APP_NAME." 2
+  [[ -f "$app_bundle/Contents/Info.plist" && ! -L "$app_bundle/Contents/Info.plist" ]] || \
+    fail "$expected_architecture app has no regular Info.plist." 2
+  [[ -f "$executable" && -x "$executable" && ! -L "$executable" ]] || \
+    fail "$expected_architecture app has no executable Quill Cowork binary." 2
+  if find "$app_bundle" \( -type l -o \( ! -type d ! -type f \) \) -print -quit | grep -q .; then
+    fail "$expected_architecture app contains a symlink or special filesystem entry." 2
+  fi
+  while IFS= read -r -d '' path; do
+    [[ "$path" != *$'\n'* && "$path" != *$'\r'* ]] || \
+      fail "$expected_architecture app contains an unsafe path." 2
+  done < <(find "$app_bundle" -print0)
+  local architectures
+  architectures="$("$LIPO_BIN" -archs "$executable")"
+  [[ "$architectures" == "$expected_architecture" ]] || \
+    fail "$expected_architecture source app must contain exactly one $expected_architecture executable slice; found: $architectures" 2
+  "$CODESIGN_BIN" --verify --deep --strict --verbose=2 "$app_bundle"
+}
+
+validate_app_bundle "$ARM64_ROOT" "arm64"
+validate_app_bundle "$X86_64_ROOT" "x86_64"
+
+ARM64_APP="$ARM64_ROOT/$APP_NAME"
+X86_64_APP="$X86_64_ROOT/$APP_NAME"
+ARM64_INVENTORY="$WORK_DIRECTORY/arm64-inventory.txt"
+X86_64_INVENTORY="$WORK_DIRECTORY/x86_64-inventory.txt"
+
+bundle_inventory() {
+  local app_bundle="$1"
+  (
+    cd "$app_bundle"
+    find Contents \
+      -path 'Contents/_CodeSignature' -prune -o \
+      -path 'Contents/MacOS/Quill Cowork' -prune -o \
+      -print | LC_ALL=C sort
+  )
+}
+
+bundle_inventory "$ARM64_APP" > "$ARM64_INVENTORY"
+bundle_inventory "$X86_64_APP" > "$X86_64_INVENTORY"
+cmp -s "$ARM64_INVENTORY" "$X86_64_INVENTORY" || \
+  fail "The arm64 and x86_64 app bundle inventories do not match." 2
+
+while IFS= read -r relative_path; do
+  arm_path="$ARM64_APP/$relative_path"
+  intel_path="$X86_64_APP/$relative_path"
+  if [[ -d "$arm_path" ]]; then
+    [[ -d "$intel_path" ]] || fail "Bundle entry type differs: $relative_path" 2
+  else
+    [[ -f "$intel_path" ]] || fail "Bundle entry type differs: $relative_path" 2
+    cmp -s "$arm_path" "$intel_path" || \
+      fail "The arm64 and x86_64 app bundles differ at $relative_path." 2
+  fi
+done < "$ARM64_INVENTORY"
+
+UNIVERSAL_APP="$UNIVERSAL_ROOT/$APP_NAME"
+"$DITTO_BIN" "$ARM64_APP" "$UNIVERSAL_APP"
+rm -rf "$UNIVERSAL_APP/Contents/_CodeSignature"
+UNIVERSAL_EXECUTABLE="$UNIVERSAL_APP/$EXECUTABLE_RELATIVE_PATH"
+MERGED_EXECUTABLE="$WORK_DIRECTORY/Quill Cowork"
+"$LIPO_BIN" -create \
+  "$ARM64_APP/$EXECUTABLE_RELATIVE_PATH" \
+  "$X86_64_APP/$EXECUTABLE_RELATIVE_PATH" \
+  -output "$MERGED_EXECUTABLE"
+chmod 755 "$MERGED_EXECUTABLE"
+mv "$MERGED_EXECUTABLE" "$UNIVERSAL_EXECUTABLE"
+"$LIPO_BIN" "$UNIVERSAL_EXECUTABLE" -verify_arch arm64 x86_64
+
+if [[ -n "$SIGNING_IDENTITY" ]]; then
+  CODESIGN_ARGUMENTS=(
+    --force
+    --options runtime
+    --timestamp
+    --sign "$SIGNING_IDENTITY"
+  )
+  if [[ -n "$SIGNING_KEYCHAIN" ]]; then
+    CODESIGN_ARGUMENTS+=(--keychain "$SIGNING_KEYCHAIN")
+  fi
+  "$CODESIGN_BIN" "${CODESIGN_ARGUMENTS[@]}" "$UNIVERSAL_APP"
+else
+  "$CODESIGN_BIN" --force --deep --sign - "$UNIVERSAL_APP"
+fi
+"$CODESIGN_BIN" --verify --deep --strict --verbose=2 "$UNIVERSAL_APP"
+
+if [[ -n "$NOTARY_KEY_ID" || -n "$NOTARY_ISSUER_ID" || -n "$NOTARY_KEY_PATH" ]]; then
+  [[ -n "$NOTARY_KEY_ID" && -n "$NOTARY_ISSUER_ID" && -n "$NOTARY_KEY_PATH" ]] || \
+    fail "Universal installer notarization credentials must be configured together." 2
+  [[ -f "$NOTARY_KEY_PATH" && ! -L "$NOTARY_KEY_PATH" ]] || \
+    fail "Notarization private key does not exist: $NOTARY_KEY_PATH" 2
+  NOTARY_ARCHIVE="$WORK_DIRECTORY/notarization-submission.zip"
+  "$DITTO_BIN" -c -k --sequesterRsrc --keepParent "$UNIVERSAL_APP" "$NOTARY_ARCHIVE"
+  "$XCRUN_BIN" notarytool submit "$NOTARY_ARCHIVE" \
+    --key "$NOTARY_KEY_PATH" \
+    --key-id "$NOTARY_KEY_ID" \
+    --issuer "$NOTARY_ISSUER_ID" \
+    --wait
+  "$XCRUN_BIN" stapler staple "$UNIVERSAL_APP"
+  "$XCRUN_BIN" stapler validate "$UNIVERSAL_APP"
+  "$CODESIGN_BIN" --verify --deep --strict --verbose=2 "$UNIVERSAL_APP"
+  "$SPCTL_BIN" --assess --type execute --verbose=2 "$UNIVERSAL_APP"
+fi
+
+"$ROOT_DIR/scripts/create-macos-disk-image.sh" \
+  --app "$UNIVERSAL_APP" \
+  --output "$OUTPUT_PATH"
+"$ROOT_DIR/scripts/packaged-macos-relocation-smoke.sh" \
+  --dmg "$OUTPUT_PATH" \
+  --expected-architecture "$(uname -m)"
+
+printf 'Quill Cowork universal macOS installer: %s\n' "$OUTPUT_PATH"

--- a/scripts/release_verification_contract.py
+++ b/scripts/release_verification_contract.py
@@ -13,6 +13,7 @@ from urllib.parse import quote
 PRODUCT = "Quill Cowork"
 BUNDLE_IDENTIFIER = "co.lorehex.QuillCowork"
 MACOS_ARCHITECTURES = ("arm64", "x86_64")
+MACOS_INSTALLER_ARCHITECTURES = ("universal", *MACOS_ARCHITECTURES)
 MANIFEST_BYTE_LIMIT = 256 * 1024
 API_BYTE_LIMIT = 4 * 1024 * 1024
 MAXIMUM_ASSET_BYTES = 2 * 1024 * 1024 * 1024
@@ -117,6 +118,7 @@ def exact_macos_assets(
     *,
     kind: str,
     install: str,
+    architectures: tuple[str, ...] = MACOS_ARCHITECTURES,
 ) -> list[dict[str, Any]]:
     matching = [
         asset
@@ -131,16 +133,16 @@ def exact_macos_assets(
                 f"release macOS {kind} assets must use {install} installation"
             )
         architecture = asset["arch"]
-        if architecture not in MACOS_ARCHITECTURES or architecture in assets_by_arch:
+        if architecture not in architectures or architecture in assets_by_arch:
             raise VerificationError(
                 f"release must contain exactly one macOS {kind} for each architecture"
             )
         assets_by_arch[architecture] = asset
-    if set(assets_by_arch) != set(MACOS_ARCHITECTURES):
+    if set(assets_by_arch) != set(architectures):
         raise VerificationError(
             f"release must contain exactly one macOS {kind} for each architecture"
         )
-    return [assets_by_arch[architecture] for architecture in MACOS_ARCHITECTURES]
+    return [assets_by_arch[architecture] for architecture in architectures]
 
 
 def validate_manifest(
@@ -302,12 +304,18 @@ def validate_manifest(
     )
 
     app_assets = exact_macos_assets(assets, kind="app", install="zip-app")
-    for kind, install in (
-        ("installer", "dmg-app"),
-        ("performance", "json"),
-        ("cli", "tarball"),
-    ):
+    installer_assets = exact_macos_assets(
+        assets,
+        kind="installer",
+        install="dmg-app",
+        architectures=MACOS_INSTALLER_ARCHITECTURES,
+    )
+    for kind, install in (("performance", "json"), ("cli", "tarball")):
         exact_macos_assets(assets, kind=kind, install=install)
+    if updater.get("macOSUniversalInstaller") != installer_assets[0]:
+        raise VerificationError(
+            "updater universal installer must match the published universal DMG"
+        )
     if updater.get("macOSAppAsset") != app_assets[0]:
         raise VerificationError("legacy updater asset must be the arm64 app archive")
     if updater.get("macOSAppAssets") != app_assets:


### PR DESCRIPTION
## Summary
- assemble a native arm64 + x86_64 Quill Cowork app into one universal DMG
- keep thin updater payloads and performance evidence architecture-specific
- publish, hash, manifest, and verify the universal installer on both Mac architectures
- make the universal DMG the primary public download

## Verification
- swift test: 6,249 passed, 5 skipped, 0 failed
- focused release/distribution suite: 41 passed
- real public-build arm64 + x86_64 archives assembled into a universal DMG
- DMG checksum, mount, signature, relocation, launch, and relaunch smoke passed on arm64
- workflow YAML parsed; Python and shell syntax checks passed