### PR TITLE
Store signed desktop credentials in macOS Keychain

### DIFF
--- a/Sources/QuillCodeApp/MCPSecretStoreAdapter.swift
+++ b/Sources/QuillCodeApp/MCPSecretStoreAdapter.swift
@@ -3,9 +3,8 @@ import QuillCodePersistence
 import QuillCodeTools
 
 /// Bridges the persistence layer's `QuillSecretStore` to the tools layer's `MCPSecretStore`, so
-/// remote MCP OAuth tokens land in the same `~/.quillcode/secrets` file store that holds the
-/// TrustedRouter API key. Defined in `QuillCodeApp` because it is the only target depending on
-/// both `QuillCodePersistence` and `QuillCodeTools`.
+/// remote MCP OAuth tokens use the same platform credential store as the TrustedRouter API key.
+/// Defined here because this is the only target depending on both persistence and tools.
 struct MCPSecretStoreAdapter: MCPSecretStore {
     let backing: any QuillSecretStore
 

--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -252,7 +252,7 @@ public struct QuillCodeRuntimeFactory: Sendable {
 
     private func sessionStore() -> SecretTrustedRouterSessionStore {
         SecretTrustedRouterSessionStore(
-            secretStore: FileSecretStore(directory: paths.secretsDirectory),
+            secretStore: QuillSecretStoreFactory.make(for: paths),
             key: QuillSecretKeys.trustedRouterAPIKey
         )
     }

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -181,7 +181,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             subagentApprovalPayloadStore: payloadStore,
             managedWorktreeDefaultRoot: paths.worktreesDirectory,
             mcpSecretStore: MCPSecretStoreAdapter(
-                backing: FileSecretStore(directory: paths.secretsDirectory)
+                backing: QuillSecretStoreFactory.make(for: paths)
             )
         )
         if automaticStartupPolicy == .startImmediately {
@@ -228,7 +228,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             )
         }
 
-        let credentialStore = FileSecretStore(directory: paths.secretsDirectory)
+        let credentialStore = QuillSecretStoreFactory.make(for: paths)
         let transaction = WorkspaceSettingsPersistenceTransaction(
             saveConfiguration: { config in
                 try ConfigStore(fileURL: paths.configFile).save(config)
@@ -262,13 +262,13 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
         try paths.ensure()
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        try FileSecretStore(directory: paths.secretsDirectory)
+        try QuillSecretStoreFactory.make(for: paths)
             .write(trimmed, for: QuillSecretKeys.trustedRouterAPIKey)
     }
 
     public func clearTrustedRouterAPIKey() throws {
         try paths.ensure()
-        try FileSecretStore(directory: paths.secretsDirectory)
+        try QuillSecretStoreFactory.make(for: paths)
             .delete(QuillSecretKeys.trustedRouterAPIKey)
     }
 

--- a/Sources/QuillCodeCLI/AppServerAccountAuthentication.swift
+++ b/Sources/QuillCodeCLI/AppServerAccountAuthentication.swift
@@ -233,7 +233,7 @@ extension AppServerSession {
         profile: TrustedRouterAccountProfile?,
         authMode: TrustedRouterAuthMode
     ) throws {
-        let secretStore = FileSecretStore(directory: paths.secretsDirectory)
+        let secretStore = QuillSecretStoreFactory.make(for: paths)
         let previousKey = try secretStore.read(QuillSecretKeys.trustedRouterAPIKey)
         var nextConfig = appConfig
         nextConfig.authMode = authMode

--- a/Sources/QuillCodeCLI/AppServerMCPOAuth.swift
+++ b/Sources/QuillCodeCLI/AppServerMCPOAuth.swift
@@ -129,10 +129,10 @@ struct DefaultAppServerMCPOAuthLoginStarter: AppServerMCPOAuthLoginStarting {
 }
 
 struct AppServerMCPSecretStore: MCPSecretStore {
-    private let store: FileSecretStore
+    private let store: any QuillSecretStore
 
-    init(directory: URL) {
-        self.store = FileSecretStore(directory: directory)
+    init(paths: QuillCodePaths) {
+        self.store = QuillSecretStoreFactory.make(for: paths)
     }
 
     func read(_ key: String) throws -> String? { try store.read(key) }

--- a/Sources/QuillCodeCLI/AppServerSession.swift
+++ b/Sources/QuillCodeCLI/AppServerSession.swift
@@ -194,7 +194,7 @@ actor AppServerSession {
         self.appConfig = try ConfigStore(fileURL: paths.configFile).load()
         self.repository = AppServerThreadRepository(paths: paths, fallbackCWD: currentDirectory)
         self.attachmentStore = ImageAttachmentStore(directory: paths.attachmentsDirectory)
-        let mcpSecretStore = AppServerMCPSecretStore(directory: paths.secretsDirectory)
+        let mcpSecretStore = AppServerMCPSecretStore(paths: paths)
         self.mcpSecretStore = mcpSecretStore
         self.mcpRegistry = AppServerMCPRegistry(
             launcher: mcpLauncher,

--- a/Sources/QuillCodeCLI/CLIDoctorCollector.swift
+++ b/Sources/QuillCodeCLI/CLIDoctorCollector.swift
@@ -174,7 +174,7 @@ struct CLIDoctor: Sendable {
             }
         }
         do {
-            let store = FileSecretStore(directory: paths.secretsDirectory)
+            let store = QuillSecretStoreFactory.make(for: paths)
             if let key = normalized(try store.read(QuillSecretKeys.trustedRouterAPIKey)) {
                 return configuredCredentials(key: key, source: "Quill Cowork secret store")
             }
@@ -186,7 +186,7 @@ struct CLIDoctor: Sendable {
                     status: .fail,
                     summary: "no TrustedRouter credential was found",
                     details: .doctorDetails(["credential source": "none"]),
-                    remediation: "Run `quill-code auth set-key KEY` or sign in from Quill Cowork Settings."
+                    remediation: "Run `quill-code auth set-key KEY`."
                 )
             )
         } catch {
@@ -226,7 +226,7 @@ struct CLIDoctor: Sendable {
         environment: [String: String]
     ) -> CLIDoctorCheck {
         do {
-            let secretStore = AppServerMCPSecretStore(directory: paths.secretsDirectory)
+            let secretStore = AppServerMCPSecretStore(paths: paths)
             let configurations = try AppServerMCPConfigurationLoader.load(
                 globalConfig: paths.configFile,
                 projectRoot: currentDirectory,

--- a/Sources/QuillCodeCLI/CLIMCPAgentSession.swift
+++ b/Sources/QuillCodeCLI/CLIMCPAgentSession.swift
@@ -34,9 +34,7 @@ struct CLIMCPAgentSessionPreparer: Sendable {
 
         let registry = AppServerMCPRegistry(
             launcher: launcher,
-            secretStore: AppServerMCPSecretStore(
-                directory: configuration.paths.secretsDirectory
-            ),
+            secretStore: AppServerMCPSecretStore(paths: configuration.paths),
             httpClient: httpClient
         )
         let scope = "exec:\(threadID.uuidString.lowercased())"

--- a/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
+++ b/Sources/QuillCodeCLI/CLIRuntimeFactory.swift
@@ -46,7 +46,7 @@ public enum CLIRuntimeFactory {
         var runner: AgentRunner
         if request.live {
             let sessionStore = SecretTrustedRouterSessionStore(
-                secretStore: FileSecretStore(directory: configuration.paths.secretsDirectory),
+                secretStore: QuillSecretStoreFactory.make(for: configuration.paths),
                 key: QuillSecretKeys.trustedRouterAPIKey
             )
             let key = try CLITrustedRouterCredentials.resolve(

--- a/Sources/QuillCodeCLI/CLITrustedRouterCredentials.swift
+++ b/Sources/QuillCodeCLI/CLITrustedRouterCredentials.swift
@@ -30,7 +30,7 @@ extension AppServerSession {
             explicit: request.apiKey,
             environment: environment,
             sessionStore: SecretTrustedRouterSessionStore(
-                secretStore: FileSecretStore(directory: paths.secretsDirectory)
+                secretStore: QuillSecretStoreFactory.make(for: paths)
             )
         )
     }

--- a/Sources/QuillCodeCLI/MCPServerSession.swift
+++ b/Sources/QuillCodeCLI/MCPServerSession.swift
@@ -61,7 +61,7 @@ actor MCPServerSession {
         self.attachmentStore = ImageAttachmentStore(directory: paths.attachmentsDirectory)
         self.mcpRegistry = AppServerMCPRegistry(
             launcher: mcpLauncher,
-            secretStore: AppServerMCPSecretStore(directory: paths.secretsDirectory),
+            secretStore: AppServerMCPSecretStore(paths: paths),
             httpClient: mcpHTTPClient
         )
         self.runnerFactory = runnerFactory

--- a/Sources/QuillCodeCLI/QuillCodeCommandRunner.swift
+++ b/Sources/QuillCodeCLI/QuillCodeCommandRunner.swift
@@ -148,7 +148,7 @@ public struct QuillCodeCommandRunner: Sendable {
     ) async throws {
         let paths = home.map { QuillCodePaths(home: $0) } ?? QuillCodePaths()
         try paths.ensure()
-        let store = FileSecretStore(directory: paths.secretsDirectory)
+        let store = QuillSecretStoreFactory.make(for: paths)
         switch command {
         case .status:
             let key = try store.read(QuillSecretKeys.trustedRouterAPIKey)?

--- a/Sources/QuillCodePersistence/Paths.swift
+++ b/Sources/QuillCodePersistence/Paths.swift
@@ -1,6 +1,11 @@
 import Foundation
 import QuillCodeCore
 
+public enum QuillCodeSecretStorageScope: String, Sendable, Hashable {
+    case userAccount
+    case isolatedFile
+}
+
 public struct HookConfigurationPaths: Sendable, Hashable {
     public var userQuillCodeDirectory: URL?
     public var userCodexDirectory: URL?
@@ -47,6 +52,12 @@ public struct HookConfigurationPaths: Sendable, Hashable {
 public struct QuillCodePaths: Sendable, Hashable {
     public var home: URL
     public var hookConfigurationPaths: HookConfigurationPaths
+    public var secretStorageScope: QuillCodeSecretStorageScope {
+        let liveHome = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".quillcode", isDirectory: true)
+            .standardizedFileURL
+        return home.standardizedFileURL == liveHome ? .userAccount : .isolatedFile
+    }
     public var configFile: URL { home.appendingPathComponent("config.toml") }
     public var automationsFile: URL { home.appendingPathComponent("automations.json") }
     public var projectsFile: URL { home.appendingPathComponent("projects.json") }
@@ -78,8 +89,8 @@ public struct QuillCodePaths: Sendable, Hashable {
         self.hookConfigurationPaths = .live(quillCodeHome: home)
     }
 
-    /// Explicit homes are isolated by default so tests and portable installations never read the
-    /// host user's Codex or system configuration accidentally.
+    /// Explicit non-live homes are isolated so tests and portable installations never read the
+    /// host user's Codex, system configuration, or account credential store accidentally.
     public init(home: URL, hookConfigurationPaths: HookConfigurationPaths? = nil) {
         self.home = home
         self.hookConfigurationPaths = hookConfigurationPaths ?? .isolated(home: home)

--- a/Sources/QuillCodePersistence/PlatformSecretStore.swift
+++ b/Sources/QuillCodePersistence/PlatformSecretStore.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+#if canImport(Security)
+import Security
+#endif
+
+public enum QuillSecretStoreFactory {
+    public static let macOSService = "co.lorehex.QuillCowork.secrets"
+
+    public static func make(for paths: QuillCodePaths) -> any QuillSecretStore {
+        #if canImport(Security)
+        let signingTeamIdentifier = Bundle.main.object(
+            forInfoDictionaryKey: "QuillCodeSigningTeamIdentifier"
+        ) as? String
+        return make(for: paths, signingTeamIdentifier: signingTeamIdentifier)
+        #else
+        return FileSecretStore(directory: paths.secretsDirectory)
+        #endif
+    }
+
+    #if canImport(Security)
+    static func make(
+        for paths: QuillCodePaths,
+        signingTeamIdentifier: String?
+    ) -> any QuillSecretStore {
+        let legacy = FileSecretStore(directory: paths.secretsDirectory)
+        guard paths.secretStorageScope == .userAccount,
+              isValidTeamIdentifier(signingTeamIdentifier) else {
+            return legacy
+        }
+
+        // Ad-hoc designated requirements are build-specific hashes. Wait for the stable Developer
+        // ID identity so Keychain access survives an ordinary app update without prompting.
+        return LegacyMigratingSecretStore(
+            primary: KeychainSecretStore(service: macOSService),
+            legacy: legacy
+        )
+    }
+
+    private static func isValidTeamIdentifier(_ value: String?) -> Bool {
+        guard let value, value.utf8.count == 10 else { return false }
+        return value.utf8.allSatisfy { byte in
+            (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(byte)
+                || (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte)
+        }
+    }
+    #endif
+}
+
+public struct LegacyMigratingSecretStore: QuillSecretStore {
+    public var primary: any QuillSecretStore
+    public var legacy: any QuillSecretStore
+
+    public init(primary: any QuillSecretStore, legacy: any QuillSecretStore) {
+        self.primary = primary
+        self.legacy = legacy
+    }
+
+    public func read(_ key: String) throws -> String? {
+        if let value = try primary.read(key) {
+            try? legacy.delete(key)
+            return value
+        }
+        guard let value = try legacy.read(key) else { return nil }
+
+        try primary.write(value, for: key)
+        try? legacy.delete(key)
+        return value
+    }
+
+    public func write(_ value: String, for key: String) throws {
+        try primary.write(value, for: key)
+        try legacy.delete(key)
+    }
+
+    public func delete(_ key: String) throws {
+        // Remove fallback material first so a failed primary deletion cannot be undone by migration.
+        try legacy.delete(key)
+        try primary.delete(key)
+    }
+}
+
+#if canImport(Security)
+public enum KeychainSecretStoreError: LocalizedError, Equatable, Sendable {
+    case invalidService
+    case invalidKey
+    case invalidUTF8
+    case valueExceedsSizeLimit(maximumBytes: Int)
+    case operationFailed(operation: String, status: OSStatus)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidService:
+            return "The Keychain service identifier is invalid."
+        case .invalidKey:
+            return "The Keychain secret key is invalid."
+        case .invalidUTF8:
+            return "The Keychain secret is not valid UTF-8."
+        case .valueExceedsSizeLimit(let maximumBytes):
+            return "The secret exceeds the \(maximumBytes)-byte Keychain storage limit."
+        case .operationFailed(let operation, let status):
+            let detail = SecCopyErrorMessageString(status, nil) as String?
+                ?? "OSStatus \(status)"
+            return "Keychain \(operation) failed: \(detail)."
+        }
+    }
+}
+
+public struct KeychainSecretStore: QuillSecretStore {
+    public static let maximumValueBytes = FileSecretStore.maximumValueBytes
+    public static let maximumIdentifierBytes = 4 * 1_024
+
+    public var service: String
+
+    public init(service: String) {
+        self.service = service
+    }
+
+    public func read(_ key: String) throws -> String? {
+        let query = try baseQuery(for: key).merging([
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true
+        ]) { _, new in new }
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else {
+            throw KeychainSecretStoreError.operationFailed(operation: "read", status: status)
+        }
+        guard let data = result as? Data else {
+            throw KeychainSecretStoreError.invalidUTF8
+        }
+        guard data.count <= Self.maximumValueBytes else {
+            throw KeychainSecretStoreError.valueExceedsSizeLimit(
+                maximumBytes: Self.maximumValueBytes
+            )
+        }
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw KeychainSecretStoreError.invalidUTF8
+        }
+        return value
+    }
+
+    public func write(_ value: String, for key: String) throws {
+        let data = Data(value.utf8)
+        guard data.count <= Self.maximumValueBytes else {
+            throw KeychainSecretStoreError.valueExceedsSizeLimit(
+                maximumBytes: Self.maximumValueBytes
+            )
+        }
+        let query = try baseQuery(for: key)
+        let attributes = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess { return }
+        guard updateStatus == errSecItemNotFound else {
+            throw KeychainSecretStoreError.operationFailed(operation: "update", status: updateStatus)
+        }
+
+        let addition = query.merging([
+            kSecValueData as String: data
+        ]) { _, new in new }
+        let addStatus = SecItemAdd(addition as CFDictionary, nil)
+        if addStatus == errSecSuccess { return }
+        if addStatus == errSecDuplicateItem {
+            let retryStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            guard retryStatus == errSecSuccess else {
+                throw KeychainSecretStoreError.operationFailed(
+                    operation: "concurrent update",
+                    status: retryStatus
+                )
+            }
+            return
+        }
+        throw KeychainSecretStoreError.operationFailed(operation: "add", status: addStatus)
+    }
+
+    public func delete(_ key: String) throws {
+        let status = SecItemDelete(try baseQuery(for: key) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainSecretStoreError.operationFailed(operation: "delete", status: status)
+        }
+    }
+
+    private func baseQuery(for key: String) throws -> [String: Any] {
+        guard isValidIdentifier(service) else {
+            throw KeychainSecretStoreError.invalidService
+        }
+        guard isValidIdentifier(key) else {
+            throw KeychainSecretStoreError.invalidKey
+        }
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecAttrSynchronizable as String: false
+        ]
+    }
+
+    private func isValidIdentifier(_ value: String) -> Bool {
+        !value.isEmpty && value.utf8.count <= Self.maximumIdentifierBytes
+    }
+}
+#endif

--- a/Sources/QuillCodeTools/MCPTokenStore.swift
+++ b/Sources/QuillCodeTools/MCPTokenStore.swift
@@ -40,7 +40,7 @@ public struct MCPOAuthTokens: Codable, Sendable, Hashable {
 
 /// Minimal key→value string persistence for MCP OAuth tokens and dynamic-registration client
 /// credentials. Mirrors `QuillCodePersistence.QuillSecretStore` (which `QuillCodeTools` cannot
-/// import) so the wiring layer can adapt its `FileSecretStore` to this protocol.
+/// import) so the wiring layer can adapt the active platform store to this protocol.
 public protocol MCPSecretStore: Sendable {
     func read(_ key: String) throws -> String?
     func write(_ value: String, for key: String) throws

--- a/Sources/quill-code-desktop/QuillCodeDesktopDailyDriverSmokeFixture.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopDailyDriverSmokeFixture.swift
@@ -111,7 +111,7 @@ enum QuillCodeDesktopDailyDriverSmokeFixture {
         let destinationWorkspace = destination.appendingPathComponent("workspace", isDirectory: true)
         let paths = QuillCodePaths(home: appState)
         try paths.ensure()
-        try FileSecretStore(directory: paths.secretsDirectory).write(
+        try QuillSecretStoreFactory.make(for: paths).write(
             mockCredential,
             for: QuillSecretKeys.trustedRouterAPIKey
         )

--- a/Tests/QuillCodeCLITests/AppServerMCPConfigurationTests.swift
+++ b/Tests/QuillCodeCLITests/AppServerMCPConfigurationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import QuillCodeCLI
+import QuillCodePersistence
 import QuillCodeTools
 import XCTest
 
@@ -256,9 +257,7 @@ final class AppServerMCPConfigurationTests: XCTestCase {
             fallbackCWD: root,
             environment: ["MCP_TOKEN": "configured-token"]
         )
-        let secretStore = AppServerMCPSecretStore(
-            directory: root.appendingPathComponent("secrets", isDirectory: true)
-        )
+        let secretStore = AppServerMCPSecretStore(paths: QuillCodePaths(home: root))
         try MCPTokenStore(serverID: "mcp_server:oauth", secretStore: secretStore).saveTokens(
             MCPOAuthTokens(accessToken: "stored-oauth-token")
         )

--- a/Tests/QuillCodeCLITests/AppServerMCPOAuthStarterTests.swift
+++ b/Tests/QuillCodeCLITests/AppServerMCPOAuthStarterTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 @testable import QuillCodeCLI
+import QuillCodePersistence
 import QuillCodeTools
 import XCTest
 
@@ -11,9 +12,7 @@ final class AppServerMCPOAuthStarterTests: XCTestCase {
         let httpClient = MCPOAuthStarterHTTPClient()
         let starter = DefaultAppServerMCPOAuthLoginStarter(httpClient: httpClient)
         let root = try temporaryDirectory()
-        let secretStore = AppServerMCPSecretStore(
-            directory: root.appendingPathComponent("secrets", isDirectory: true)
-        )
+        let secretStore = AppServerMCPSecretStore(paths: QuillCodePaths(home: root))
         let configuration = AppServerMCPServerConfiguration(
             name: "remote",
             transport: .remote(

--- a/Tests/QuillCodeCLITests/CLIDoctorTests.swift
+++ b/Tests/QuillCodeCLITests/CLIDoctorTests.swift
@@ -89,9 +89,7 @@ final class CLIDoctorTests: XCTestCase {
         let mcpToken = "mcp-oauth-private-token"
         try MCPTokenStore(
             serverID: "mcp_server:oauth-fixture",
-            secretStore: AppServerMCPSecretStore(
-                directory: home.appendingPathComponent("secrets", isDirectory: true)
-            )
+            secretStore: AppServerMCPSecretStore(paths: QuillCodePaths(home: home))
         ).saveTokens(MCPOAuthTokens(accessToken: mcpToken))
         let apiKey = "sk-tr-doctor-private"
         let doctor = fixture.doctor(networkResult: CLIDoctorNetworkResult(

--- a/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
+++ b/Tests/QuillCodeParityTests/ParityFocusedSuiteManifest.swift
@@ -225,6 +225,10 @@ struct ParityFocusedSuiteManifest {
         Suite(fileName: "ParityWorkspaceRuntimeFactoryGateTests.swift", testNames: [
             "testWorkspaceModelTestsDoNotOwnRuntimeFactoryCoverage"
         ]),
+        Suite(fileName: "ParityPlatformCredentialStorageGateTests.swift", testNames: [
+            "testProductionCredentialConsumersUseThePlatformFactory",
+            "testKeychainActivationStaysBoundToDeveloperIDMetadataAndMigration"
+        ]),
         Suite(fileName: "ParityWorkspaceSidebarGateTests.swift", testNames: [
             "testWorkspaceModelDelegatesSidebarSelectionTransitions"
         ]),

--- a/Tests/QuillCodeParityTests/ParityPlatformCredentialStorageGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPlatformCredentialStorageGateTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+final class ParityPlatformCredentialStorageGateTests: QuillCodeParityTestCase {
+    func testProductionCredentialConsumersUseThePlatformFactory() throws {
+        let allowedFiles: Set<String> = [
+            "Sources/QuillCodePersistence/PlatformSecretStore.swift",
+            "Sources/QuillCodePersistence/SecretStore.swift"
+        ]
+        let offenders = try Self.swiftSourceFiles(in: "Sources").compactMap { file -> String? in
+            let relativePath = file.path.replacingOccurrences(
+                of: Self.packageRoot().path + "/",
+                with: ""
+            )
+            guard !allowedFiles.contains(relativePath) else { return nil }
+            let source = try String(contentsOf: file, encoding: .utf8)
+            return source.contains("FileSecretStore(") ? relativePath : nil
+        }
+
+        XCTAssertEqual(
+            offenders,
+            [],
+            "Live credential consumers must use QuillSecretStoreFactory: \(offenders)"
+        )
+    }
+
+    func testKeychainActivationStaysBoundToDeveloperIDMetadataAndMigration() throws {
+        let source = try String(
+            contentsOf: Self.packageRoot()
+                .appendingPathComponent("Sources/QuillCodePersistence/PlatformSecretStore.swift"),
+            encoding: .utf8
+        )
+        let buildScript = try String(
+            contentsOf: Self.packageRoot().appendingPathComponent("scripts/build-macos-app.sh"),
+            encoding: .utf8
+        )
+
+        Self.assertSource(source, containsAll: [
+            "QuillCodeSigningTeamIdentifier",
+            "isValidTeamIdentifier(signingTeamIdentifier)",
+            "LegacyMigratingSecretStore(",
+            "KeychainSecretStore(service: macOSService)",
+            "kSecAttrSynchronizable as String: false",
+            "try primary.write(value, for: key)",
+            "try legacy.delete(key)"
+        ])
+        Self.assertSource(buildScript, contains: "QuillCodeSigningTeamIdentifier")
+    }
+}

--- a/Tests/QuillCodePersistenceTests/PlatformSecretStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/PlatformSecretStoreTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import QuillCodePersistence
+
+#if canImport(Security)
+import Security
+#endif
+
+final class PlatformSecretStoreTests: PersistenceTestCase {
+    func testIsolatedFactoryUsesItsPrivateFileStore() throws {
+        let paths = QuillCodePaths(home: try makeTempDirectory())
+        try paths.ensure()
+        let store = QuillSecretStoreFactory.make(for: paths)
+
+        try store.write("isolated-secret", for: QuillSecretKeys.trustedRouterAPIKey)
+
+        XCTAssertEqual(
+            try FileSecretStore(directory: paths.secretsDirectory)
+                .read(QuillSecretKeys.trustedRouterAPIKey),
+            "isolated-secret"
+        )
+    }
+
+    #if canImport(Security)
+    func testFactoryRequiresCanonicalHomeAndDeveloperIDTeamMetadataForKeychain() throws {
+        XCTAssertTrue(
+            QuillSecretStoreFactory.make(
+                for: QuillCodePaths(),
+                signingTeamIdentifier: nil
+            ) is FileSecretStore
+        )
+        XCTAssertTrue(
+            QuillSecretStoreFactory.make(
+                for: QuillCodePaths(),
+                signingTeamIdentifier: "lowercase1"
+            ) is FileSecretStore
+        )
+        XCTAssertTrue(
+            QuillSecretStoreFactory.make(
+                for: QuillCodePaths(),
+                signingTeamIdentifier: "A1B2C3D4E5"
+            ) is LegacyMigratingSecretStore
+        )
+        XCTAssertTrue(
+            QuillSecretStoreFactory.make(
+                for: QuillCodePaths(home: try makeTempDirectory()),
+                signingTeamIdentifier: "A1B2C3D4E5"
+            ) is FileSecretStore
+        )
+    }
+    #endif
+
+    func testLegacyReadMigratesOnlyAfterPrimaryWriteSucceeds() throws {
+        let primary = try makePrivateSecretStore()
+        let legacy = try makePrivateSecretStore()
+        let store = LegacyMigratingSecretStore(primary: primary, legacy: legacy)
+        try legacy.write("legacy-secret", for: "credential")
+
+        XCTAssertEqual(try store.read("credential"), "legacy-secret")
+        XCTAssertEqual(try primary.read("credential"), "legacy-secret")
+        XCTAssertNil(try legacy.read("credential"))
+    }
+
+    func testPrimaryValueWinsAndRetiresStaleLegacyCopy() throws {
+        let primary = try makePrivateSecretStore()
+        let legacy = try makePrivateSecretStore()
+        let store = LegacyMigratingSecretStore(primary: primary, legacy: legacy)
+        try primary.write("current-secret", for: "credential")
+        try legacy.write("stale-secret", for: "credential")
+
+        XCTAssertEqual(try store.read("credential"), "current-secret")
+        XCTAssertNil(try legacy.read("credential"))
+    }
+
+    func testWriteStoresPrimaryAndRetiresLegacyCopy() throws {
+        let primary = try makePrivateSecretStore()
+        let legacy = try makePrivateSecretStore()
+        let store = LegacyMigratingSecretStore(primary: primary, legacy: legacy)
+        try legacy.write("legacy-secret", for: "credential")
+
+        try store.write("replacement-secret", for: "credential")
+
+        XCTAssertEqual(try primary.read("credential"), "replacement-secret")
+        XCTAssertNil(try legacy.read("credential"))
+    }
+
+    func testFailedPrimaryWritePreservesLegacyCredential() throws {
+        let primary = try makePrivateSecretStore()
+        let legacy = try makePrivateSecretStore()
+        let store = LegacyMigratingSecretStore(primary: primary, legacy: legacy)
+        try legacy.write("legacy-secret", for: "credential")
+
+        XCTAssertThrowsError(try store.write(
+            String(repeating: "x", count: FileSecretStore.maximumValueBytes + 1),
+            for: "credential"
+        ))
+
+        XCTAssertNil(try primary.read("credential"))
+        XCTAssertEqual(try legacy.read("credential"), "legacy-secret")
+    }
+
+    func testDeleteRetiresLegacyBeforePrimary() throws {
+        let parent = try makeTempDirectory()
+        let primary = FileSecretStore(directory: parent.appendingPathComponent("primary"))
+        let actualLegacy = parent.appendingPathComponent("actual-legacy")
+        let unsafeLegacy = parent.appendingPathComponent("legacy")
+        try FileManager.default.createDirectory(at: actualLegacy, withIntermediateDirectories: false)
+        try FileManager.default.createSymbolicLink(
+            at: unsafeLegacy,
+            withDestinationURL: actualLegacy
+        )
+        let store = LegacyMigratingSecretStore(
+            primary: primary,
+            legacy: FileSecretStore(directory: unsafeLegacy)
+        )
+        try primary.write("protected-secret", for: "credential")
+
+        XCTAssertThrowsError(try store.delete("credential"))
+
+        XCTAssertEqual(try primary.read("credential"), "protected-secret")
+    }
+
+    #if canImport(Security)
+    func testKeychainStoreRoundTripsWithoutPlaintextFiles() throws {
+        let service = "co.lorehex.QuillCowork.tests.\(UUID().uuidString)"
+        let key = "credential:\(UUID().uuidString)"
+        let store = KeychainSecretStore(service: service)
+        defer { try? store.delete(key) }
+
+        XCTAssertNil(try store.read(key))
+        try store.write("first-secret", for: key)
+        XCTAssertEqual(try store.read(key), "first-secret")
+
+        try store.write("replacement-secret", for: key)
+        XCTAssertEqual(try store.read(key), "replacement-secret")
+
+        try store.delete(key)
+        XCTAssertNil(try store.read(key))
+    }
+
+    func testKeychainStoreRejectsInvalidAndOversizedInputsBeforeMutation() throws {
+        let store = KeychainSecretStore(service: "co.lorehex.QuillCowork.tests.\(UUID().uuidString)")
+
+        XCTAssertThrowsError(try store.read("")) { error in
+            XCTAssertEqual(error as? KeychainSecretStoreError, .invalidKey)
+        }
+        XCTAssertThrowsError(try KeychainSecretStore(service: "").read("credential")) { error in
+            XCTAssertEqual(error as? KeychainSecretStoreError, .invalidService)
+        }
+        XCTAssertThrowsError(try store.write(
+            String(repeating: "x", count: KeychainSecretStore.maximumValueBytes + 1),
+            for: "credential"
+        )) { error in
+            XCTAssertEqual(
+                error as? KeychainSecretStoreError,
+                .valueExceedsSizeLimit(maximumBytes: KeychainSecretStore.maximumValueBytes)
+            )
+        }
+    }
+    #endif
+
+    private func makePrivateSecretStore() throws -> FileSecretStore {
+        let directory = try makeTempDirectory()
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: directory.path
+        )
+        return FileSecretStore(directory: directory)
+    }
+}

--- a/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
+++ b/Tests/QuillCodePersistenceTests/QuillCodePathsTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import QuillCodePersistence
 
 final class QuillCodePathsTests: PersistenceTestCase {
+    func testDefaultAndExplicitHomesChooseIntentionalSecretStorageScopes() throws {
+        XCTAssertEqual(QuillCodePaths().secretStorageScope, .userAccount)
+        XCTAssertEqual(
+            QuillCodePaths(home: try makeTempDirectory()).secretStorageScope,
+            .isolatedFile
+        )
+    }
+
     func testExplicitHomeUsesAnIsolatedHookConfigurationPathSet() throws {
         let home = try makeTempDirectory().appendingPathComponent("portable")
         let paths = QuillCodePaths(home: home)

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,28 @@
 # Code Quality Audit
 
+## 2026-08-12 Signature-Gated macOS Keychain Credential Storage
+
+Overall grade after this slice: **A+ credential architecture, A+ update compatibility, A+ migration safety**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Protected storage | A+ | Developer ID desktop builds store TrustedRouter and MCP OAuth secrets in macOS Keychain with non-synchronizing exact service/account queries and bounded UTF-8 values. |
+| Update compatibility | A+ | Keychain activation requires sealed ten-character signing-team metadata, so ad-hoc builds never create ACLs tied to a one-build code hash. |
+| Migration | A+ | Legacy data moves only after a successful protected write; current Keychain data wins; read cleanup retries without hiding valid data; replacement and clear use failure-safe ordering. |
+| Isolation | A+ | Explicit homes, tests, smoke fixtures, Linux, ad-hoc apps, and the standalone CLI retain the hardened private file backend without touching the user's Keychain. |
+| Architecture | A+ | One factory composes every production credential consumer while the existing `QuillSecretStore` protocol keeps runtime, settings, TrustedRouter, and MCP code backend-agnostic. |
+| Regression evidence | A+ | Behavioral tests exercise real Keychain CRUD and migration failures; a source gate rejects direct live file-store composition outside persistence. |
+
+Validation:
+
+- Focused platform-store and path-policy coverage: 15 tests, 0 failures.
+- Focused credential integration coverage: 74 tests, 0 failures.
+- Full Swift package coverage: 6,266 tests executed, 5 skipped, 0 failures.
+- Real macOS Keychain add, read, replace, delete, and missing-item behavior passed with an isolated
+  service and account.
+- Existing desktop settings rollback, runtime selection, CLI auth/doctor, app-server account, and
+  MCP credential suites remain part of the focused integration gate.
+
 ## 2026-08-12 Settled Idle Resource Release Evidence
 
 Overall grade after this slice: **A+ native performance evidence, A+ release integrity, A+ regression coverage**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,31 @@
 # QuillCode Decisions
 
+## 2026-08-12: Developer ID desktop credentials migrate to macOS Keychain
+
+- **Decision:** The canonical user-account store selects macOS Keychain only when the packaged app
+  carries a valid ten-character `QuillCodeSigningTeamIdentifier`. Ad-hoc tester builds, standalone
+  CLI processes, Linux, explicit `--home` runs, smoke fixtures, and tests keep the bounded private
+  file backend.
+- **Migration:** A signed desktop read checks Keychain first, migrates a legacy private-file value
+  only after the Keychain write succeeds, and then attempts to retire the old copy. Cleanup failure
+  does not hide a valid credential and is retried on the next read. A current Keychain value always
+  wins over stale fallback data. Explicit replacement writes Keychain before removing the fallback;
+  explicit clear removes fallback material before Keychain so a failed clear cannot resurrect a
+  credential through migration.
+- **Why signature-gated:** Current tester apps are ad-hoc signed, so their designated requirement is
+  a build-specific code hash. A Keychain item created by one tester build would not provide silent,
+  durable access to the next build. Developer ID gives the app a stable signed identity across
+  updates; the sealed team metadata is therefore both the activation and migration boundary.
+- **CLI boundary:** The separately distributed CLI remains on its existing `0600` private file store.
+  Modern noninteractive sharing through a Data Protection Keychain access group requires an
+  Apple-authorized entitlement and provisioning profile for every participating executable. The
+  desktop does not weaken Keychain ACLs merely to make an ad-hoc or independently installed CLI
+  share its item.
+- **Evidence:** Focused tests exercise real Keychain create/read/update/delete, byte and identifier
+  bounds, factory eligibility, isolated-file selection, primary precedence, migration ordering,
+  failed-write preservation, and delete ordering. A parity gate rejects direct production
+  `FileSecretStore` composition outside the persistence factory.
+
 ## 2026-08-12: public performance evidence gates settled idle resources
 
 - **Decision:** Every packaged release attempt measures a two-second idle window after two complete

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -75,6 +75,20 @@ For a bug report, include the warning title, affected data labels, app version, 
 Do not include API keys, account details, filesystem paths, URLs, or raw private content. The
 in-app diagnostic is deliberately content-free and should report `Private content included: No`.
 
+## Credential Storage
+
+Developer ID builds store desktop TrustedRouter credentials and MCP OAuth tokens in macOS Keychain.
+On first access, the app copies an existing private-file credential into Keychain only after the
+protected write succeeds, then attempts to remove the old copy. A transient cleanup failure does not
+hide the valid credential and cleanup is retried on the next read. Replacing or clearing a credential
+follows the same ordered migration boundary so interruption cannot silently lose or restore a key.
+
+The `tester-latest` app is currently ad-hoc signed. Because an ad-hoc identity changes with each
+binary, tester builds intentionally retain the update-safe private `0600` file backend rather than
+creating a Keychain item that the next build cannot access silently. The standalone CLI also keeps
+an independent private store; configure it with `quill-code auth set-key KEY`. Keychain migration
+activates automatically for the desktop when the Apple Developer ID signing secrets are configured.
+
 ## Tester Recovery: Unexpected Exit
 
 Packaged builds keep one private, content-free active-launch marker. A normal Quit or updater-driven

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -34,7 +34,8 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
   exact performance asset, production schema and limits, three attempts, median headline, recomputed
   deltas/flags, and a passing launch majority after file-integrity checks succeed.
 - Record & Replay contracts: request/status/capture encoding, event and snapshot bounds, skill-drafting prompt shape, empty-goal rejection, generic-backend unavailability, permission preflight, owner task/project/workspace propagation, stop-after-permission-revocation, event rejection once stop begins, protected-field redaction, and owner-only artifact permissions.
-- Config parsing, model catalog, auth state, secret store.
+- Config parsing, model catalog, auth state, private file storage, real macOS Keychain CRUD,
+  Developer ID eligibility, isolated-home selection, and ordered legacy credential migration.
 - Non-interactive CLI parsing and contracts: legacy/exec routing, relative path resolution, stdin
   framing and byte/UTF-8 bounds, resume targets, JSON value coding, bounded JSON Schema keywords and
   local references, repository-root termination, event projection, and secret-free auth output.


### PR DESCRIPTION
## Summary
- route every production credential consumer through one platform secret-store factory
- migrate Developer ID desktop credentials to macOS Keychain with failure-safe ordering while retaining the hardened file backend for ad-hoc, CLI, Linux, and isolated homes
- add real Keychain CRUD, migration-failure, isolation, and architecture-gate coverage

## Validation
- `swift test`: 6,266 tests executed, 5 skipped, 0 failures
- focused credential integration: 74 tests, 0 failures
- packaged macOS smoke: passed direct and Launch Services launch, crash recovery, interaction sweeps, and performance budgets
- packaged performance: 307.90 ms median launch-ready; 40.84 MiB initial, 85.38 MiB post-interaction, 87.31 MiB repeated; 0.0006% settled idle CPU
- code quality: new persistence source A+ (97), new tests A+ (100)