### PR TITLE
Harden Keychain activation with signer attestation

### DIFF
--- a/Sources/QuillCodePersistence/PlatformSecretStore.swift
+++ b/Sources/QuillCodePersistence/PlatformSecretStore.swift
@@ -12,7 +12,15 @@ public enum QuillSecretStoreFactory {
         let signingTeamIdentifier = Bundle.main.object(
             forInfoDictionaryKey: "QuillCodeSigningTeamIdentifier"
         ) as? String
-        return make(for: paths, signingTeamIdentifier: signingTeamIdentifier)
+        guard paths.secretStorageScope == .userAccount,
+              isValidTeamIdentifier(signingTeamIdentifier) else {
+            return FileSecretStore(directory: paths.secretsDirectory)
+        }
+        return make(
+            for: paths,
+            signingTeamIdentifier: signingTeamIdentifier,
+            runtimeSigningTeamIdentifier: MacOSCodeSigningIdentity.currentTeamIdentifier
+        )
         #else
         return FileSecretStore(directory: paths.secretsDirectory)
         #endif
@@ -21,16 +29,18 @@ public enum QuillSecretStoreFactory {
     #if canImport(Security)
     static func make(
         for paths: QuillCodePaths,
-        signingTeamIdentifier: String?
+        signingTeamIdentifier: String?,
+        runtimeSigningTeamIdentifier: String?
     ) -> any QuillSecretStore {
         let legacy = FileSecretStore(directory: paths.secretsDirectory)
         guard paths.secretStorageScope == .userAccount,
-              isValidTeamIdentifier(signingTeamIdentifier) else {
+              isValidTeamIdentifier(signingTeamIdentifier),
+              runtimeSigningTeamIdentifier == signingTeamIdentifier else {
             return legacy
         }
 
-        // Ad-hoc designated requirements are build-specific hashes. Wait for the stable Developer
-        // ID identity so Keychain access survives an ordinary app update without prompting.
+        // Require the sealed metadata to agree with the running signature. Ad-hoc designated
+        // requirements are build-specific hashes and do not provide a durable Keychain identity.
         return LegacyMigratingSecretStore(
             primary: KeychainSecretStore(service: macOSService),
             legacy: legacy
@@ -46,6 +56,35 @@ public enum QuillSecretStoreFactory {
     }
     #endif
 }
+
+#if canImport(Security)
+enum MacOSCodeSigningIdentity {
+    static let currentTeamIdentifier = loadCurrentTeamIdentifier()
+
+    private static func loadCurrentTeamIdentifier() -> String? {
+        var code: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(), &code) == errSecSuccess,
+              let code,
+              SecCodeCheckValidity(code, SecCSFlags(), nil) == errSecSuccess else {
+            return nil
+        }
+
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode) == errSecSuccess,
+              let staticCode else {
+            return nil
+        }
+
+        var information: CFDictionary?
+        let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+        guard SecCodeCopySigningInformation(staticCode, flags, &information) == errSecSuccess,
+              let values = information as? [String: Any] else {
+            return nil
+        }
+        return values[kSecCodeInfoTeamIdentifier as String] as? String
+    }
+}
+#endif
 
 public struct LegacyMigratingSecretStore: QuillSecretStore {
     public var primary: any QuillSecretStore

--- a/Tests/QuillCodeParityTests/ParityPlatformCredentialStorageGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPlatformCredentialStorageGateTests.swift
@@ -37,6 +37,11 @@ final class ParityPlatformCredentialStorageGateTests: QuillCodeParityTestCase {
         Self.assertSource(source, containsAll: [
             "QuillCodeSigningTeamIdentifier",
             "isValidTeamIdentifier(signingTeamIdentifier)",
+            "static let currentTeamIdentifier = loadCurrentTeamIdentifier()",
+            "SecCodeCheckValidity",
+            "SecCodeCopyStaticCode",
+            "SecCodeCopySigningInformation",
+            "runtimeSigningTeamIdentifier == signingTeamIdentifier",
             "LegacyMigratingSecretStore(",
             "KeychainSecretStore(service: macOSService)",
             "kSecAttrSynchronizable as String: false",

--- a/Tests/QuillCodePersistenceTests/PlatformSecretStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/PlatformSecretStoreTests.swift
@@ -21,31 +21,61 @@ final class PlatformSecretStoreTests: PersistenceTestCase {
     }
 
     #if canImport(Security)
-    func testFactoryRequiresCanonicalHomeAndDeveloperIDTeamMetadataForKeychain() throws {
+    func testFactoryRequiresCanonicalHomeAndMatchingDeveloperIDSignatureForKeychain() throws {
         XCTAssertTrue(
             QuillSecretStoreFactory.make(
                 for: QuillCodePaths(),
-                signingTeamIdentifier: nil
+                signingTeamIdentifier: nil,
+                runtimeSigningTeamIdentifier: nil
             ) is FileSecretStore
         )
         XCTAssertTrue(
             QuillSecretStoreFactory.make(
                 for: QuillCodePaths(),
-                signingTeamIdentifier: "lowercase1"
+                signingTeamIdentifier: "lowercase1",
+                runtimeSigningTeamIdentifier: "lowercase1"
             ) is FileSecretStore
         )
         XCTAssertTrue(
             QuillSecretStoreFactory.make(
                 for: QuillCodePaths(),
-                signingTeamIdentifier: "A1B2C3D4E5"
+                signingTeamIdentifier: "A1B2C3D4E5",
+                runtimeSigningTeamIdentifier: nil
+            ) is FileSecretStore
+        )
+        XCTAssertTrue(
+            QuillSecretStoreFactory.make(
+                for: QuillCodePaths(),
+                signingTeamIdentifier: "A1B2C3D4E5",
+                runtimeSigningTeamIdentifier: "OTHER12345"
+            ) is FileSecretStore
+        )
+        XCTAssertTrue(
+            QuillSecretStoreFactory.make(
+                for: QuillCodePaths(),
+                signingTeamIdentifier: "A1B2C3D4E5",
+                runtimeSigningTeamIdentifier: "A1B2C3D4E5"
             ) is LegacyMigratingSecretStore
         )
         XCTAssertTrue(
             QuillSecretStoreFactory.make(
                 for: QuillCodePaths(home: try makeTempDirectory()),
-                signingTeamIdentifier: "A1B2C3D4E5"
+                signingTeamIdentifier: "A1B2C3D4E5",
+                runtimeSigningTeamIdentifier: "A1B2C3D4E5"
             ) is FileSecretStore
         )
+    }
+
+    func testRuntimeSigningIdentityReturnsOnlyADeveloperTeamIdentifier() {
+        let teamIdentifier = MacOSCodeSigningIdentity.currentTeamIdentifier
+
+        if let teamIdentifier {
+            XCTAssertEqual(teamIdentifier.utf8.count, 10)
+            XCTAssertTrue(teamIdentifier.utf8.allSatisfy { byte in
+                (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(byte)
+                    || (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte)
+            })
+        }
     }
     #endif
 

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,25 +1,33 @@
 # Code Quality Audit
 
-## 2026-08-12 Signature-Gated macOS Keychain Credential Storage
+## 2026-08-12 Runtime-Attested macOS Keychain Credential Storage
 
 Overall grade after this slice: **A+ credential architecture, A+ update compatibility, A+ migration safety**.
 
 | Area | Grade | Notes |
 | --- | --- | --- |
 | Protected storage | A+ | Developer ID desktop builds store TrustedRouter and MCP OAuth secrets in macOS Keychain with non-synchronizing exact service/account queries and bounded UTF-8 values. |
-| Update compatibility | A+ | Keychain activation requires sealed ten-character signing-team metadata, so ad-hoc builds never create ACLs tied to a one-build code hash. |
+| Update compatibility | A+ | Keychain activation requires sealed ten-character signing-team metadata to match the running macOS signature, so ad-hoc or mispackaged builds never create ACLs tied to an unstable identity. |
 | Migration | A+ | Legacy data moves only after a successful protected write; current Keychain data wins; read cleanup retries without hiding valid data; replacement and clear use failure-safe ordering. |
 | Isolation | A+ | Explicit homes, tests, smoke fixtures, Linux, ad-hoc apps, and the standalone CLI retain the hardened private file backend without touching the user's Keychain. |
 | Architecture | A+ | One factory composes every production credential consumer while the existing `QuillSecretStore` protocol keeps runtime, settings, TrustedRouter, and MCP code backend-agnostic. |
-| Regression evidence | A+ | Behavioral tests exercise real Keychain CRUD and migration failures; a source gate rejects direct live file-store composition outside persistence. |
+| Regression evidence | A+ | Behavioral tests exercise real Keychain CRUD, runtime signer eligibility, and migration failures; a source gate rejects direct live file-store composition and pins signature attestation. |
 
 Validation:
 
-- Focused platform-store and path-policy coverage: 15 tests, 0 failures.
-- Focused credential integration coverage: 74 tests, 0 failures.
-- Full Swift package coverage: 6,266 tests executed, 5 skipped, 0 failures.
+- Focused platform-store and path-policy coverage: 16 tests, 0 failures, including matching,
+  missing, malformed, and mismatched runtime signing identities.
+- Focused credential integration coverage: 96 tests, 0 failures.
+- Full Swift package coverage: 6,267 tests executed, 5 skipped, 0 failures.
 - Real macOS Keychain add, read, replace, delete, and missing-item behavior passed with an isolated
   service and account.
+- The packaged release app passed direct-executable, Launch Services, crash-draft recovery,
+  live-window, Accessibility-frame, repeated-interaction, and settled-idle smoke. Release evidence
+  measured 289.56 ms median launch-ready, 40.88 MiB initial physical footprint, 85.25 MiB after the
+  first interaction sweep, 87.55 MiB after repetition, and 0.0006% settled idle CPU.
+- The ad-hoc package carried no signing-team metadata, proving the tester path returns before runtime
+  signer attestation. The deterministic quality grader scored `PlatformSecretStore.swift` A+ 97,
+  both changed test files A+ 100, and the persistence source module A+ 99.
 - Existing desktop settings rollback, runtime selection, CLI auth/doctor, app-server account, and
   MCP credential suites remain part of the focused integration gate.
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3,9 +3,10 @@
 ## 2026-08-12: Developer ID desktop credentials migrate to macOS Keychain
 
 - **Decision:** The canonical user-account store selects macOS Keychain only when the packaged app
-  carries a valid ten-character `QuillCodeSigningTeamIdentifier`. Ad-hoc tester builds, standalone
-  CLI processes, Linux, explicit `--home` runs, smoke fixtures, and tests keep the bounded private
-  file backend.
+  carries a valid ten-character `QuillCodeSigningTeamIdentifier`, the running process passes macOS
+  signature validation, and its signature reports the same team. Missing, invalid, malformed, or
+  mismatched identity data fails closed. Ad-hoc tester builds, standalone CLI processes, Linux,
+  explicit `--home` runs, smoke fixtures, and tests keep the bounded private file backend.
 - **Migration:** A signed desktop read checks Keychain first, migrates a legacy private-file value
   only after the Keychain write succeeds, and then attempts to retire the old copy. Cleanup failure
   does not hide a valid credential and is retried on the next read. A current Keychain value always
@@ -15,16 +16,20 @@
 - **Why signature-gated:** Current tester apps are ad-hoc signed, so their designated requirement is
   a build-specific code hash. A Keychain item created by one tester build would not provide silent,
   durable access to the next build. Developer ID gives the app a stable signed identity across
-  updates; the sealed team metadata is therefore both the activation and migration boundary.
+  updates. Sealed metadata and independent runtime signature attestation must agree before that
+  stable identity becomes the activation and migration boundary.
 - **CLI boundary:** The separately distributed CLI remains on its existing `0600` private file store.
   Modern noninteractive sharing through a Data Protection Keychain access group requires an
   Apple-authorized entitlement and provisioning profile for every participating executable. The
   desktop does not weaken Keychain ACLs merely to make an ad-hoc or independently installed CLI
   share its item.
 - **Evidence:** Focused tests exercise real Keychain create/read/update/delete, byte and identifier
-  bounds, factory eligibility, isolated-file selection, primary precedence, migration ordering,
-  failed-write preservation, and delete ordering. A parity gate rejects direct production
-  `FileSecretStore` composition outside the persistence factory.
+  bounds, factory eligibility, missing and mismatched runtime identities, isolated-file selection,
+  primary precedence, migration ordering, failed-write preservation, and delete ordering. A parity
+  gate rejects direct production `FileSecretStore` composition outside the persistence factory and
+  pins the runtime signature check. The immutable validated runtime identity is initialized once per
+  process, and ineligible ad-hoc or isolated stores return before initializing it, so multiple
+  credential consumers do not add Security-framework work to the normal tester startup path.
 
 ## 2026-08-12: public performance evidence gates settled idle resources
 

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -78,6 +78,9 @@ in-app diagnostic is deliberately content-free and should report `Private conten
 ## Credential Storage
 
 Developer ID builds store desktop TrustedRouter credentials and MCP OAuth tokens in macOS Keychain.
+Before enabling Keychain or migrating data, the app independently validates its running macOS code
+signature and requires its team identifier to match the sealed packaging metadata. Missing,
+invalid, or mismatched identity data keeps the hardened private-file backend active.
 On first access, the app copies an existing private-file credential into Keychain only after the
 protected write succeeds, then attempts to remove the old copy. A transient cleanup failure does not
 hide the valid credential and cleanup is retried on the next read. Replacing or clearing a credential
@@ -87,7 +90,8 @@ The `tester-latest` app is currently ad-hoc signed. Because an ad-hoc identity c
 binary, tester builds intentionally retain the update-safe private `0600` file backend rather than
 creating a Keychain item that the next build cannot access silently. The standalone CLI also keeps
 an independent private store; configure it with `quill-code auth set-key KEY`. Keychain migration
-activates automatically for the desktop when the Apple Developer ID signing secrets are configured.
+activates automatically for the desktop when the Apple Developer ID signing secrets are configured
+and the packaged identity passes runtime attestation.
 
 ## Tester Recovery: Unexpected Exit
 


### PR DESCRIPTION
## Summary
- validate the running macOS code signature and require its TeamIdentifier to match sealed packaging metadata before Keychain activation
- fail closed to the hardened private-file backend for missing, invalid, or mismatched identities
- cache the immutable validated signer and skip Security-framework work entirely for ad-hoc tester, CLI, and isolated-home paths
- pin the trust boundary with behavioral and parity coverage and document the distribution contract

## Validation
- 12 focused platform/parity tests, 0 failures
- 96 credential integration tests, 0 failures
- 6,267 full Swift package tests, 5 skipped, 0 failures
- packaged macOS release smoke passed direct launch, Launch Services, crash recovery, live window, Accessibility, repeated interaction, and settled idle gates
- packaged performance: 289.56 ms median launch-ready; 40.88 MiB initial; 85.25 MiB post-interaction; 87.55 MiB repeated; 0.0006% idle CPU
- deterministic quality: changed source A+ 97; changed tests A+ 100; persistence module A+ 99