### PR TITLE
Recover interrupted agent runs after relaunch

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeRuntimeSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeRuntimeSurface.swift
@@ -21,6 +21,7 @@ public enum RuntimeRecoveryReason: String, Codable, Sendable, Hashable {
     case networkUnreachable = "network-unreachable"
     case emptyResponse = "empty-response"
     case malformedModelAction = "malformed-model-action"
+    case runInterrupted = "run-interrupted"
     case runFailed = "run-failed"
     case savedChatsUnreadable = "saved-chats-unreadable"
     case savedWorkspaceDataUnreadable = "saved-workspace-data-unreadable"

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -122,7 +122,8 @@ struct QuillCodeTranscriptView: View {
             return true
         case .trustedRouterKeyRejected, .rateLimited, .providerUnavailable,
              .networkUnreachable, .emptyResponse, .malformedModelAction,
-             .runFailed, .savedChatsUnreadable, .savedWorkspaceDataUnreadable, nil:
+             .runInterrupted, .runFailed, .savedChatsUnreadable,
+             .savedWorkspaceDataUnreadable, nil:
             return false
         }
     }

--- a/Sources/QuillCodeApp/WorkspaceAgentProgressPersistencePolicy.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentProgressPersistencePolicy.swift
@@ -1,0 +1,20 @@
+import QuillCodeCore
+
+/// Persists crash-relevant tool boundaries without writing every coalesced streaming snapshot.
+enum WorkspaceAgentProgressPersistencePolicy {
+    static func shouldPersist(
+        previousLastEvent: ThreadEvent?,
+        currentLastEvent: ThreadEvent?
+    ) -> Bool {
+        guard let currentLastEvent, currentLastEvent != previousLastEvent else { return false }
+        switch currentLastEvent.kind {
+        case .toolQueued, .toolRunning, .toolCompleted, .toolFailed,
+             .approvalRequested, .approvalDecided:
+            return true
+        case .toolProgress:
+            return previousLastEvent?.kind != .toolProgress
+        case .message, .messageFeedback, .reviewComment, .notice:
+            return false
+        }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceAgentRunRegistry.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentRunRegistry.swift
@@ -5,49 +5,80 @@ import Foundation
 /// Conversation state remains in `ChatThread`; this registry only answers which threads currently
 /// own a live task and which status should be projected when one of those threads is selected.
 public struct WorkspaceAgentRunRegistry: Sendable, Hashable {
-    private var statusesByThreadID: [UUID: String]
+    private struct Entry: Sendable, Hashable {
+        var runID: UUID
+        var status: String
+    }
+
+    private var entriesByThreadID: [UUID: Entry]
 
     public init(statusesByThreadID: [UUID: String] = [:]) {
-        self.statusesByThreadID = statusesByThreadID
+        self.entriesByThreadID = statusesByThreadID.mapValues {
+            Entry(runID: UUID(), status: $0)
+        }
     }
 
     public var activeThreadIDs: Set<UUID> {
-        Set(statusesByThreadID.keys)
+        Set(entriesByThreadID.keys)
     }
 
     public var activeCount: Int {
-        statusesByThreadID.count
+        entriesByThreadID.count
     }
 
     public func isRunning(_ threadID: UUID?) -> Bool {
-        threadID.map { statusesByThreadID[$0] != nil } ?? false
+        threadID.map { entriesByThreadID[$0] != nil } ?? false
+    }
+
+    public func isRunning(_ threadID: UUID?, runID: UUID) -> Bool {
+        threadID.flatMap { entriesByThreadID[$0]?.runID } == runID
     }
 
     public func status(for threadID: UUID?) -> String? {
-        threadID.flatMap { statusesByThreadID[$0] }
+        threadID.flatMap { entriesByThreadID[$0]?.status }
+    }
+
+    public func runID(for threadID: UUID?) -> UUID? {
+        threadID.flatMap { entriesByThreadID[$0]?.runID }
     }
 
     @discardableResult
     public mutating func begin(threadID: UUID, status: String) -> Bool {
-        let inserted = statusesByThreadID[threadID] == nil
-        statusesByThreadID[threadID] = status
+        begin(threadID: threadID, runID: UUID(), status: status)
+    }
+
+    @discardableResult
+    public mutating func begin(threadID: UUID, runID: UUID, status: String) -> Bool {
+        let inserted = entriesByThreadID[threadID] == nil
+        entriesByThreadID[threadID] = Entry(runID: runID, status: status)
         return inserted
     }
 
-    public mutating func update(threadID: UUID, status: String) {
-        guard statusesByThreadID[threadID] != nil else { return }
-        statusesByThreadID[threadID] = status
+    public mutating func update(threadID: UUID, runID: UUID? = nil, status: String) {
+        guard var entry = entriesByThreadID[threadID],
+              runID == nil || entry.runID == runID
+        else {
+            return
+        }
+        entry.status = status
+        entriesByThreadID[threadID] = entry
     }
 
     @discardableResult
     public mutating func finish(threadID: UUID) -> String? {
-        statusesByThreadID.removeValue(forKey: threadID)
+        entriesByThreadID.removeValue(forKey: threadID)?.status
+    }
+
+    @discardableResult
+    public mutating func finish(threadID: UUID, runID: UUID) -> String? {
+        guard entriesByThreadID[threadID]?.runID == runID else { return nil }
+        return entriesByThreadID.removeValue(forKey: threadID)?.status
     }
 
     @discardableResult
     public mutating func finishAll() -> Bool {
-        guard !statusesByThreadID.isEmpty else { return false }
-        statusesByThreadID.removeAll(keepingCapacity: true)
+        guard !entriesByThreadID.isEmpty else { return false }
+        entriesByThreadID.removeAll(keepingCapacity: true)
         return true
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceAgentRunRelaunchReconciler.swift
+++ b/Sources/QuillCodeApp/WorkspaceAgentRunRelaunchReconciler.swift
@@ -1,0 +1,128 @@
+import Foundation
+import QuillCodeCore
+
+struct WorkspaceAgentRunRelaunchReconciliation: Sendable, Hashable {
+    var threads: [ChatThread]
+    var changedThreadIDs: Set<UUID>
+    var interruptedThreadIDs: Set<UUID>
+}
+
+/// Closes parent-chat work that belonged to a process which no longer exists.
+///
+/// A final assistant message or durable approval request is already a safe terminal boundary, so
+/// those checkpoints are cleared silently. Every other checkpoint becomes a visible, retryable
+/// interruption. An open tool receives a terminal event first so no transcript card stays Running.
+enum WorkspaceAgentRunRelaunchReconciler {
+    static let toolFailureSummary = "Interrupted when Quill Cowork closed"
+    static let toolFailurePayloadJSON =
+        #"{"ok":false,"error":"Interrupted when Quill Cowork closed before this tool finished."}"#
+    static let recoveryMessage = WorkspaceRunFailureNoticePlanner.interruptedRelaunchDiagnostic
+
+    static func reconcile(
+        _ threads: [ChatThread],
+        now: Date = Date()
+    ) -> WorkspaceAgentRunRelaunchReconciliation {
+        var reconciled = threads
+        var changedThreadIDs = Set<UUID>()
+        var interruptedThreadIDs = Set<UUID>()
+
+        for index in reconciled.indices {
+            guard let checkpoint = reconciled[index].activeRunCheckpoint else { continue }
+            let disposition = disposition(of: reconciled[index], checkpoint: checkpoint)
+            reconciled[index].activeRunCheckpoint = nil
+            changedThreadIDs.insert(reconciled[index].id)
+
+            guard disposition == .interrupted else { continue }
+            if hasOpenTool(in: reconciled[index], checkpoint: checkpoint) {
+                reconciled[index].events.append(ThreadEvent(
+                    kind: .toolFailed,
+                    createdAt: now,
+                    summary: toolFailureSummary,
+                    payloadJSON: toolFailurePayloadJSON
+                ))
+            }
+            reconciled[index].events.append(ThreadEvent(
+                kind: .notice,
+                createdAt: now,
+                summary: WorkspaceRunFailureNoticePlanner.interruptedRelaunchSummary
+            ))
+            reconciled[index].updatedAt = max(reconciled[index].updatedAt, now)
+            interruptedThreadIDs.insert(reconciled[index].id)
+        }
+
+        return WorkspaceAgentRunRelaunchReconciliation(
+            threads: reconciled,
+            changedThreadIDs: changedThreadIDs,
+            interruptedThreadIDs: interruptedThreadIDs
+        )
+    }
+
+    private enum Disposition {
+        case completed
+        case approval
+        case interrupted
+    }
+
+    private static func disposition(
+        of thread: ChatThread,
+        checkpoint: ThreadRunCheckpoint
+    ) -> Disposition {
+        let messageBoundary = min(checkpoint.messageCountAtStart, thread.messages.count)
+        if thread.messages.dropFirst(messageBoundary).contains(where: { $0.role == .assistant }) {
+            return .completed
+        }
+        if hasUndecidedApproval(in: thread, checkpoint: checkpoint) {
+            return .approval
+        }
+        return .interrupted
+    }
+
+    private static func hasUndecidedApproval(
+        in thread: ChatThread,
+        checkpoint: ThreadRunCheckpoint
+    ) -> Bool {
+        let eventBoundary = min(checkpoint.eventCountAtStart, thread.events.count)
+        var requestedIDs = Set<String>()
+        var decidedIDs = Set<String>()
+        for event in thread.events.dropFirst(eventBoundary) {
+            switch event.kind {
+            case .approvalRequested:
+                if let request = decode(ApprovalRequest.self, event.payloadJSON) {
+                    requestedIDs.insert(request.id)
+                }
+            case .approvalDecided:
+                if let decision = decode(ApprovalDecision.self, event.payloadJSON) {
+                    decidedIDs.insert(decision.requestID)
+                }
+            case .message, .messageFeedback, .toolQueued, .toolRunning, .toolProgress,
+                 .toolCompleted, .toolFailed, .reviewComment, .notice:
+                continue
+            }
+        }
+        return !requestedIDs.subtracting(decidedIDs).isEmpty
+    }
+
+    private static func hasOpenTool(
+        in thread: ChatThread,
+        checkpoint: ThreadRunCheckpoint
+    ) -> Bool {
+        let eventBoundary = min(checkpoint.eventCountAtStart, thread.events.count)
+        var isOpen = false
+        for event in thread.events.dropFirst(eventBoundary) {
+            switch event.kind {
+            case .toolQueued, .toolRunning, .toolProgress:
+                isOpen = true
+            case .toolCompleted, .toolFailed, .approvalRequested:
+                isOpen = false
+            case .message, .messageFeedback, .approvalDecided, .reviewComment, .notice:
+                continue
+            }
+        }
+        return isOpen
+    }
+
+    private static func decode<Value: Decodable>(_ type: Value.Type, _ payloadJSON: String?) -> Value? {
+        guard let payloadJSON else { return nil }
+        return try? JSONHelpers.decode(type, from: payloadJSON)
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -72,12 +72,16 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             calendar: calendar,
             now: currentDate
         )
-        let reconciliation = WorkspaceSubagentRelaunchReconciler.reconcile(
+        let subagentReconciliation = WorkspaceSubagentRelaunchReconciler.reconcile(
             threadListing.threads,
             childStore: childStore,
             payloadStore: payloadStore
         )
-        let threads = reconciliation.threads
+        let runReconciliation = WorkspaceAgentRunRelaunchReconciler.reconcile(
+            subagentReconciliation.threads,
+            now: currentDate
+        )
+        let threads = runReconciliation.threads
         var projects = storedProjects
         if !WorkspaceBootstrapProjectMigration.isComplete(in: paths.home)
             && !unreadableDataKinds.contains(.projects) {
@@ -98,7 +102,9 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
                 try? WorkspaceBootstrapProjectMigration.markComplete(in: paths.home)
             }
         }
-        for thread in threads where reconciliation.changedThreadIDs.contains(thread.id) {
+        let reconciledThreadIDs = subagentReconciliation.changedThreadIDs
+            .union(runReconciliation.changedThreadIDs)
+        for thread in threads where reconciledThreadIDs.contains(thread.id) {
             do {
                 try threadStore.save(thread)
             } catch {
@@ -149,6 +155,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
             ),
             automations: AutomationsState(items: automations),
             sidebarSavedSearches: sidebarSavedSearches,
+            interruptedRunRecoveryThreadIDs: runReconciliation.interruptedThreadIDs,
             runner: runtime.runner,
             contextSummaryGenerator: runtime.contextSummaryGenerator,
             threadStore: threadStore,

--- a/Sources/QuillCodeApp/WorkspaceComposerCancellationPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceComposerCancellationPlanner.swift
@@ -11,6 +11,10 @@ struct WorkspaceComposerCancellationPlanner {
         if !thread.messages.contains(where: { $0.role == .user && $0.content == userPrompt }) {
             thread.messages.append(ChatMessage(role: .user, content: userPrompt))
         }
+        applyStoppedRun(to: &thread)
+    }
+
+    static func applyStoppedRun(to thread: inout ChatThread) {
         if shouldAppendToolFailure(after: thread.events.last) {
             thread.events.append(ThreadEvent(
                 kind: .toolFailed,
@@ -21,6 +25,7 @@ struct WorkspaceComposerCancellationPlanner {
         if shouldAppendNotice(after: thread.events.last) {
             thread.events.append(ThreadEvent(kind: .notice, summary: stoppedSummary))
         }
+        thread.activeRunCheckpoint = nil
     }
 
     private static func shouldAppendToolFailure(after event: ThreadEvent?) -> Bool {

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -35,6 +35,9 @@ public final class QuillCodeWorkspaceModel {
     public internal(set) var sidebarSavedSearches: [SidebarSavedSearch]
     public internal(set) var sidebarSelection: SidebarSelectionState
     public internal(set) var agentRuns: WorkspaceAgentRunRegistry
+    /// Session-only chats whose dead-process checkpoints were closed during this launch. Selecting
+    /// one presents a focused recovery action until the user prepares or starts its continuation.
+    var interruptedRunRecoveryThreadIDs: Set<UUID>
     /// Session-only terminal outcomes keyed by chat. Keeping these separate from the active-run
     /// registry lets diagnostics distinguish a genuine finish from a budget or safety stop after
     /// the running entry has been removed.
@@ -183,6 +186,7 @@ public final class QuillCodeWorkspaceModel {
         sidebarSavedSearches: [SidebarSavedSearch] = [],
         sidebarSelection: SidebarSelectionState = SidebarSelectionState(),
         agentRuns: WorkspaceAgentRunRegistry = WorkspaceAgentRunRegistry(),
+        interruptedRunRecoveryThreadIDs: Set<UUID> = [],
         runner: AgentRunner = AgentRunner(),
         contextSummaryGenerator: any WorkspaceContextSummaryGenerating = DeterministicWorkspaceContextSummaryGenerator(),
         threadStore: JSONThreadStore? = nil,
@@ -233,6 +237,7 @@ public final class QuillCodeWorkspaceModel {
             : nil
         self.sidebarSelection = sidebarSelection
         self.agentRuns = agentRuns
+        self.interruptedRunRecoveryThreadIDs = interruptedRunRecoveryThreadIDs
         self.runner = runner
         self.subagentSchedulerOverride = nil
         self.subagentDelegationBudgetOverride = nil
@@ -300,6 +305,7 @@ public final class QuillCodeWorkspaceModel {
         restorePersistedSelectedComposerDraftIfNeeded()
         syncTerminalSessionToSelectedProject()
         refreshTopBar()
+        presentInterruptedRunRecoveryIfNeeded(for: root.selectedThreadID)
         refreshFileMentionIndex()
     }
 

--- a/Sources/QuillCodeApp/WorkspaceModelActiveWork.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelActiveWork.swift
@@ -29,6 +29,12 @@ extension QuillCodeWorkspaceModel {
 
     private func stopActiveWorkspaceWork() -> WorkspaceStoppedActiveWork {
         let hadRunningMCPServers = mcpRuntime.cancelAll(extensions: &extensions)
+        let activeAgentThreadIDs = agentRuns.activeThreadIDs
+        for threadID in activeAgentThreadIDs {
+            mutateThread(threadID) { thread in
+                WorkspaceComposerCancellationPlanner.applyStoppedRun(to: &thread)
+            }
+        }
         let hadAgentRuns = agentRuns.finishAll()
         let hadActiveWork = hadAgentRuns || terminal.isRunning
         composer.isSending = false

--- a/Sources/QuillCodeApp/WorkspaceModelAgentRuns.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelAgentRuns.swift
@@ -1,5 +1,6 @@
 import Foundation
 import QuillCodeAgent
+import QuillCodeCore
 
 @MainActor
 extension QuillCodeWorkspaceModel {
@@ -20,19 +21,42 @@ extension QuillCodeWorkspaceModel {
         return completedAgentRunStopReasons[threadID]
     }
 
-    func beginAgentRun(threadID: UUID, lifecycle: WorkspaceComposerSendLifecyclePlan) {
+    @discardableResult
+    func beginAgentRun(
+        threadID: UUID,
+        lifecycle: WorkspaceComposerSendLifecyclePlan,
+        runID: UUID = UUID(),
+        startedAt: Date = Date()
+    ) -> UUID {
         completedAgentRunStopReasons.removeValue(forKey: threadID)
-        agentRuns.begin(threadID: threadID, status: lifecycle.agentStatus)
+        interruptedRunRecoveryThreadIDs.remove(threadID)
+        if lastError == WorkspaceAgentRunRelaunchReconciler.recoveryMessage {
+            setLastError(nil)
+        }
+        mutateThread(threadID) { thread in
+            thread.activeRunCheckpoint = ThreadRunCheckpoint(
+                id: runID,
+                startedAt: startedAt,
+                messageCountAtStart: thread.messages.count,
+                eventCountAtStart: thread.events.count
+            )
+        }
+        agentRuns.begin(threadID: threadID, runID: runID, status: lifecycle.agentStatus)
         guard root.selectedThreadID == threadID else {
             refreshSelectedAgentRunPresentation()
-            return
+            return runID
         }
         applyComposerSendLifecycle(lifecycle)
+        return runID
     }
 
-    func updateAgentRun(threadID: UUID, status: String) {
-        guard agentRuns.isRunning(threadID) else { return }
-        agentRuns.update(threadID: threadID, status: status)
+    func updateAgentRun(threadID: UUID, runID: UUID? = nil, status: String) {
+        if let runID {
+            guard agentRuns.isRunning(threadID, runID: runID) else { return }
+        } else {
+            guard agentRuns.isRunning(threadID) else { return }
+        }
+        agentRuns.update(threadID: threadID, runID: runID, status: status)
         guard root.selectedThreadID == threadID else { return }
         composer.isSending = true
         setLastError(nil)
@@ -49,9 +73,19 @@ extension QuillCodeWorkspaceModel {
 
     func finishAgentRun(
         threadID: UUID,
+        runID: UUID? = nil,
         lifecycle: WorkspaceComposerSendLifecyclePlan
     ) {
-        agentRuns.finish(threadID: threadID)
+        let resolvedRunID = runID ?? agentRuns.runID(for: threadID)
+        guard let resolvedRunID,
+              agentRuns.finish(threadID: threadID, runID: resolvedRunID) != nil
+        else {
+            return
+        }
+        mutateThread(threadID) { thread in
+            guard thread.activeRunCheckpoint?.id == resolvedRunID else { return }
+            thread.activeRunCheckpoint = nil
+        }
         enforceManagedWorktreeRetention()
         enforceThreadPayloadResidency()
         guard root.selectedThreadID == threadID else {

--- a/Sources/QuillCodeApp/WorkspaceModelAgentSession.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelAgentSession.swift
@@ -11,6 +11,7 @@ extension QuillCodeWorkspaceModel {
     /// was appended for a submit; nothing is appended for a resume).
     func runAgentSession(
         _ sendStart: WorkspaceAgentSendStartPlan,
+        runID: UUID,
         workspaceRoot: URL,
         onProgressUpdated: (@MainActor @Sendable () -> Void)? = nil
     ) async -> WorkspaceAgentSendTaskOutcome {
@@ -25,7 +26,11 @@ extension QuillCodeWorkspaceModel {
                 recordsUserMessage: false
             )
         let progressRelay = WorkspaceAgentProgressRelay { [weak self] progressThread in
-            self?.applyAgentProgress(progressThread, expectedThreadID: sendStart.threadID)
+            self?.applyAgentProgress(
+                progressThread,
+                expectedThreadID: sendStart.threadID,
+                expectedRunID: runID
+            )
             onProgressUpdated?()
         }
         defer { progressRelay.cancel() }

--- a/Sources/QuillCodeApp/WorkspaceModelCodeReview.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelCodeReview.swift
@@ -126,7 +126,7 @@ public extension QuillCodeWorkspaceModel {
             : (request.model ?? root.config.reviewModel ?? targetThread.model)
         appendStartedCodeReview(request, to: targetThreadID)
         codeReviewRequest = nil
-        beginAgentRun(
+        let runID = beginAgentRun(
             threadID: targetThreadID,
             lifecycle: WorkspaceComposerSendLifecycle.started(from: composer)
         )
@@ -156,6 +156,7 @@ public extension QuillCodeWorkspaceModel {
                     guard let self else { return }
                     await self.updateAgentRun(
                         threadID: targetThreadID,
+                        runID: runID,
                         status: WorkspaceAgentStatusBuilder.status(for: progress)
                     )
                     await onProgressUpdated?()
@@ -170,6 +171,7 @@ public extension QuillCodeWorkspaceModel {
             finishCodeReview(report, request: request, threadID: targetThreadID, workspaceRoot: workspaceRoot)
             finishAgentRun(
                 threadID: targetThreadID,
+                runID: runID,
                 lifecycle: WorkspaceComposerSendLifecycle.completed(from: composer)
             )
             onProgressUpdated?()
@@ -178,6 +180,7 @@ public extension QuillCodeWorkspaceModel {
             appendCodeReviewFailure("Code review stopped.", to: targetThreadID)
             finishAgentRun(
                 threadID: targetThreadID,
+                runID: runID,
                 lifecycle: WorkspaceComposerSendLifecycle.cancelled(from: composer)
             )
             onProgressUpdated?()
@@ -186,6 +189,7 @@ public extension QuillCodeWorkspaceModel {
             appendCodeReviewFailure("Code review failed: \(error)", to: targetThreadID)
             finishAgentRun(
                 threadID: targetThreadID,
+                runID: runID,
                 lifecycle: WorkspaceComposerSendLifecycle.failed(error, from: composer)
             )
             onProgressUpdated?()

--- a/Sources/QuillCodeApp/WorkspaceModelComposer.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposer.swift
@@ -195,7 +195,7 @@ extension QuillCodeWorkspaceModel {
         }
         updateThreadFromAgentRun(startedThread)
         threadPersistence.save(startedThread)
-        beginAgentRun(threadID: sendStart.threadID, lifecycle: sendStart.lifecycle)
+        let runID = beginAgentRun(threadID: sendStart.threadID, lifecycle: sendStart.lifecycle)
         onStarted?()
 
         // A directory open can block indefinitely and cannot be interrupted by task cancellation.
@@ -205,10 +205,11 @@ extension QuillCodeWorkspaceModel {
 
         let outcome = await runAgentSession(
             sendStart,
+            runID: runID,
             workspaceRoot: workspaceRoot,
             onProgressUpdated: onProgressUpdated
         )
-        finishAgentSend(outcome, runThreadID: sendStart.threadID)
+        finishAgentSend(outcome, runThreadID: sendStart.threadID, runID: runID)
         if draftThreadID != nil, Self.normalizedComposerDraft(composer.draft) == nil {
             clearComposerDraft(for: draftThreadID)
         }
@@ -272,9 +273,9 @@ extension QuillCodeWorkspaceModel {
             threadID: thread.id,
             lifecycle: WorkspaceComposerSendLifecycle.started(from: composer)
         )
-        beginAgentRun(threadID: sendStart.threadID, lifecycle: sendStart.lifecycle)
-        let outcome = await runAgentSession(sendStart, workspaceRoot: workspaceRoot)
-        finishAgentSend(outcome, runThreadID: sendStart.threadID)
+        let runID = beginAgentRun(threadID: sendStart.threadID, lifecycle: sendStart.lifecycle)
+        let outcome = await runAgentSession(sendStart, runID: runID, workspaceRoot: workspaceRoot)
+        finishAgentSend(outcome, runThreadID: sendStart.threadID, runID: runID)
         // NOTE: the follow-up drain is NOT here — it runs at the single approval-decision choke
         // point (`approveToolCardAndResume`), which fires after EVERY gate resolution (approve/deny,
         // any mode), so this Plan-mode resume path and the deny/auto/review paths all drain once and
@@ -300,14 +301,15 @@ extension QuillCodeWorkspaceModel {
             threadID: thread.id,
             lifecycle: WorkspaceComposerSendLifecycle.started(from: composer)
         )
-        beginAgentRun(threadID: sendStart.threadID, lifecycle: sendStart.lifecycle)
-        let outcome = await runAgentSession(sendStart, workspaceRoot: workspaceRoot)
-        finishAgentSend(outcome, runThreadID: sendStart.threadID)
+        let runID = beginAgentRun(threadID: sendStart.threadID, lifecycle: sendStart.lifecycle)
+        let outcome = await runAgentSession(sendStart, runID: runID, workspaceRoot: workspaceRoot)
+        finishAgentSend(outcome, runThreadID: sendStart.threadID, runID: runID)
     }
 
     private func finishCompletedSend(
         _ result: WorkspaceAgentSendSessionResult,
-        runThreadID: UUID
+        runThreadID: UUID,
+        runID: UUID
     ) throws {
         let completion = WorkspaceAgentSendTerminalPlanner.completed(
             result: result,
@@ -343,25 +345,31 @@ extension QuillCodeWorkspaceModel {
             refreshFileMentionIndex()
         }
         recordAgentRunStopReason(result.stopReason, threadID: runThreadID)
-        finishAgentRun(threadID: runThreadID, lifecycle: completion.lifecycle)
+        finishAgentRun(threadID: runThreadID, runID: runID, lifecycle: completion.lifecycle)
     }
 
-    private func finishAgentSend(_ outcome: WorkspaceAgentSendTaskOutcome, runThreadID: UUID) {
+    private func finishAgentSend(
+        _ outcome: WorkspaceAgentSendTaskOutcome,
+        runThreadID: UUID,
+        runID: UUID
+    ) {
+        guard agentRuns.isRunning(runThreadID, runID: runID) else { return }
         switch outcome {
         case .completed(let result):
             do {
-                try finishCompletedSend(result, runThreadID: runThreadID)
+                try finishCompletedSend(result, runThreadID: runThreadID, runID: runID)
             } catch {
-                finishFailedSend(error, runThreadID: runThreadID)
+                finishFailedSend(error, runThreadID: runThreadID, runID: runID)
             }
         case .cancelled(let cancellation):
             finishCancelledSend(
                 userPrompt: cancellation.userPrompt,
                 threadID: cancellation.threadID,
-                runThreadID: runThreadID
+                runThreadID: runThreadID,
+                runID: runID
             )
         case .failed(let error):
-            finishFailedSend(error, runThreadID: runThreadID)
+            finishFailedSend(error, runThreadID: runThreadID, runID: runID)
         }
         // Surface any self-heal that happened during the run, pinned to the RUN's thread — not whatever
         // thread happens to be selected now, so a mid-run thread switch never misattributes the notice.
@@ -372,10 +380,21 @@ extension QuillCodeWorkspaceModel {
         notifyRunFinishedIfNeeded(outcome: outcome, threadID: runThreadID)
     }
 
-    func applyAgentProgress(_ thread: ChatThread, expectedThreadID: UUID) {
+    func applyAgentProgress(
+        _ thread: ChatThread,
+        expectedThreadID: UUID,
+        expectedRunID: UUID? = nil
+    ) {
         // Stop removes the run before cancellation has necessarily drained every queued progress
         // callback. Never let a late snapshot overwrite the stopped thread or presentation.
-        guard agentRuns.isRunning(expectedThreadID) else { return }
+        if let expectedRunID {
+            guard agentRuns.isRunning(expectedThreadID, runID: expectedRunID) else { return }
+        } else {
+            guard agentRuns.isRunning(expectedThreadID) else { return }
+        }
+        let previousLastEvent = root.threads
+            .first(where: { $0.id == expectedThreadID })?
+            .events.last
         guard let progress = WorkspaceAgentSendProgressPlanner.progress(
             thread: thread,
             expectedThreadID: expectedThreadID,
@@ -383,19 +402,35 @@ extension QuillCodeWorkspaceModel {
         ) else { return }
         guard let mutation = updateThreadFromAgentProgress(progress.thread) else { return }
         agentTranscriptRefreshTracker.record(mutation, selectedThreadID: root.selectedThreadID)
-        updateAgentRun(threadID: expectedThreadID, status: progress.agentStatus)
+        if let liveThread = root.threads.first(where: { $0.id == expectedThreadID }),
+           WorkspaceAgentProgressPersistencePolicy.shouldPersist(
+               previousLastEvent: previousLastEvent,
+               currentLastEvent: liveThread.events.last
+           ) {
+            threadPersistence.save(liveThread)
+        }
+        updateAgentRun(
+            threadID: expectedThreadID,
+            runID: expectedRunID,
+            status: progress.agentStatus
+        )
     }
 
-    private func finishCancelledSend(userPrompt: String, threadID: UUID, runThreadID: UUID) {
+    private func finishCancelledSend(
+        userPrompt: String,
+        threadID: UUID,
+        runThreadID: UUID,
+        runID: UUID
+    ) {
         clearAgentRunStopReason(threadID: runThreadID)
         let terminal = WorkspaceAgentSendTerminalPlanner.cancelled(composer: composer)
         mutateThread(threadID) { thread in
             WorkspaceComposerCancellationPlanner.applyCancelledSend(userPrompt: userPrompt, to: &thread)
         }
-        finishAgentRun(threadID: runThreadID, lifecycle: terminal.lifecycle)
+        finishAgentRun(threadID: runThreadID, runID: runID, lifecycle: terminal.lifecycle)
     }
 
-    private func finishFailedSend(_ error: any Error, runThreadID: UUID) {
+    private func finishFailedSend(_ error: any Error, runThreadID: UUID, runID: UUID) {
         clearAgentRunStopReason(threadID: runThreadID)
         // A terminal run failure must leave a DURABLE trace on its own thread. A background run that
         // failed while the user was on another thread otherwise vanishes silently: finishAgentRun
@@ -410,7 +445,7 @@ extension QuillCodeWorkspaceModel {
             ))
         }
         let terminal = WorkspaceAgentSendTerminalPlanner.failed(error, composer: composer)
-        finishAgentRun(threadID: runThreadID, lifecycle: terminal.lifecycle)
+        finishAgentRun(threadID: runThreadID, runID: runID, lifecycle: terminal.lifecycle)
     }
 
     func applyComposerSendLifecycle(_ plan: WorkspaceComposerSendLifecyclePlan) {

--- a/Sources/QuillCodeApp/WorkspaceModelComposerPreparation.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelComposerPreparation.swift
@@ -37,12 +37,16 @@ extension QuillCodeWorkspaceModel {
 
     @discardableResult
     public func prepareRetryLastUserTurn() -> Bool {
-        guard let message = WorkspaceRetryPlanner.retryMessage(in: selectedThread) else {
+        guard let selectedThread,
+              let message = WorkspaceRetryPlanner.retryMessage(in: selectedThread)
+        else {
             return false
         }
-        setDraft(message.content)
-        composer.attachments = message.attachments
-        persistComposerAttachments(message.attachments, for: root.selectedThreadID)
+        let retryingFailedRun = Self.lastRunFailed(in: selectedThread)
+        setDraft(retryingFailedRun ? Self.failedRunRetryPrompt : message.content)
+        composer.attachments = retryingFailedRun ? [] : message.attachments
+        persistComposerAttachments(composer.attachments, for: root.selectedThreadID)
+        interruptedRunRecoveryThreadIDs.remove(selectedThread.id)
         setLastError(nil)
         refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
         return true

--- a/Sources/QuillCodeApp/WorkspaceModelThreadMutation.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadMutation.swift
@@ -88,6 +88,9 @@ extension QuillCodeWorkspaceModel {
         if let liveThread = root.threads.first(where: { $0.id == thread.id }) {
             thread.composerDraft = liveThread.composerDraft
             thread.composerAttachments = liveThread.composerAttachments
+            // The session's producer snapshot was captured before the model installed its durable
+            // run generation. Only the owning model clears that checkpoint at a terminal boundary.
+            thread.activeRunCheckpoint = liveThread.activeRunCheckpoint
             // Project context can refresh while an agent runs. A progress snapshot captured at
             // send start must not roll that newer model-owned context back.
             thread.instructions = liveThread.instructions

--- a/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelThreadSelection.swift
@@ -202,6 +202,20 @@ extension QuillCodeWorkspaceModel {
         touchProject(root.selectedProjectID)
         saveProjects()
         refreshSelectedAgentRunPresentation()
+        presentInterruptedRunRecoveryIfNeeded(for: id)
         scheduleSelectedPullRequestReconciliation()
+    }
+
+    func presentInterruptedRunRecoveryIfNeeded(for threadID: UUID?) {
+        guard let threadID,
+              interruptedRunRecoveryThreadIDs.contains(threadID)
+        else {
+            if lastError == WorkspaceAgentRunRelaunchReconciler.recoveryMessage {
+                setLastError(nil)
+            }
+            return
+        }
+        setLastError(WorkspaceAgentRunRelaunchReconciler.recoveryMessage)
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.failed)
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceRunFailureNoticePlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceRunFailureNoticePlanner.swift
@@ -10,6 +10,9 @@ enum WorkspaceRunFailureNoticePlanner {
     /// Single source of truth for recognizing a persisted run-failure notice (the retry gate keys off
     /// this prefix — keep summary construction and detection in lockstep).
     static let noticePrefix = "Run stopped after an error"
+    static let interruptedRelaunchDiagnostic =
+        "Quill Cowork closed before the run finished. Review any partial work before retrying."
+    static let interruptedRelaunchSummary = "\(noticePrefix): \(interruptedRelaunchDiagnostic)"
 
     /// Reuses the summary sanitizer so a persisted failure can never carry an API key or private key
     /// out of the raw error, and is collapsed to a single bounded line fit for the Activity row.

--- a/Sources/QuillCodeApp/WorkspaceRuntimeIssueBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceRuntimeIssueBuilder.swift
@@ -82,6 +82,15 @@ struct WorkspaceRuntimeIssueBuilder: Sendable, Hashable {
         guard !trimmed.isEmpty else { return nil }
         let normalized = trimmed.lowercased()
 
+        if trimmed == WorkspaceAgentRunRelaunchReconciler.recoveryMessage {
+            return RuntimeIssueSurface(
+                severity: .warning,
+                title: "Run interrupted",
+                message: trimmed,
+                actionLabel: "Review and retry",
+                recovery: .retry(reason: .runInterrupted)
+            )
+        }
         if normalized.contains("api key is not configured") {
             return RuntimeIssueSurface(
                 severity: .warning,

--- a/Sources/QuillCodeCore/ChatThread.swift
+++ b/Sources/QuillCodeCore/ChatThread.swift
@@ -34,6 +34,9 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
     /// queue persists with the conversation and survives a reload; decodes to empty for
     /// threads written before this field existed.
     public var followUpQueue: [FollowUpItem]
+    /// Content-free durable ownership for an in-flight parent-chat run. Graceful terminal paths
+    /// clear it; relaunch recovery closes only the checkpoint left by a dead process.
+    public var activeRunCheckpoint: ThreadRunCheckpoint?
     /// The git worktree this thread's runs operate in. nil = inherit the project root (every legacy
     /// thread, and any thread not bound to a fork worktree). See `WorktreeBinding`.
     public var worktree: WorktreeBinding?
@@ -72,6 +75,7 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
         composerDraft: String? = nil,
         composerAttachments: [ChatAttachment] = [],
         followUpQueue: [FollowUpItem] = [],
+        activeRunCheckpoint: ThreadRunCheckpoint? = nil,
         worktree: WorktreeBinding? = nil,
         pullRequest: PullRequestLink? = nil,
         forkParentThreadID: UUID? = nil,
@@ -99,6 +103,7 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
         self.composerDraft = composerDraft
         self.composerAttachments = Array(composerAttachments.prefix(ChatAttachment.maximumCountPerTurn))
         self.followUpQueue = followUpQueue
+        self.activeRunCheckpoint = activeRunCheckpoint
         self.worktree = worktree
         self.pullRequest = pullRequest
         self.forkParentThreadID = forkParentThreadID
@@ -128,6 +133,7 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
         case composerDraft
         case composerAttachments
         case followUpQueue
+        case activeRunCheckpoint
         case worktree
         case pullRequest
         case forkParentThreadID
@@ -167,6 +173,10 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
                 .prefix(ChatAttachment.maximumCountPerTurn)
         )
         self.followUpQueue = try container.decodeIfPresent([FollowUpItem].self, forKey: .followUpQueue) ?? []
+        self.activeRunCheckpoint = try container.decodeIfPresent(
+            ThreadRunCheckpoint.self,
+            forKey: .activeRunCheckpoint
+        )
         self.worktree = try container.decodeIfPresent(WorktreeBinding.self, forKey: .worktree)
         self.pullRequest = try container.decodeIfPresent(PullRequestLink.self, forKey: .pullRequest)
         self.forkParentThreadID = try container.decodeIfPresent(UUID.self, forKey: .forkParentThreadID)
@@ -197,6 +207,7 @@ public struct ChatThread: Codable, Sendable, Hashable, Identifiable {
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
         try container.encode(followUpQueue, forKey: .followUpQueue)
+        try container.encodeIfPresent(activeRunCheckpoint, forKey: .activeRunCheckpoint)
         try container.encodeIfPresent(worktree, forKey: .worktree)
         try container.encodeIfPresent(pullRequest, forKey: .pullRequest)
         try container.encodeIfPresent(forkParentThreadID, forKey: .forkParentThreadID)

--- a/Sources/QuillCodeCore/ThreadRunCheckpoint.swift
+++ b/Sources/QuillCodeCore/ThreadRunCheckpoint.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Privacy-safe durable ownership for one in-flight parent-chat run.
+///
+/// The checkpoint intentionally stores no prompt, path, model response, or tool arguments. Array
+/// boundaries let relaunch recovery distinguish a completed answer or durable approval gate from
+/// work that disappeared with the previous process.
+public struct ThreadRunCheckpoint: Codable, Sendable, Hashable {
+    public static let schemaVersion = 1
+
+    public var id: UUID
+    public var startedAt: Date
+    public var messageCountAtStart: Int
+    public var eventCountAtStart: Int
+
+    public init(
+        id: UUID = UUID(),
+        startedAt: Date = Date(),
+        messageCountAtStart: Int,
+        eventCountAtStart: Int
+    ) {
+        self.id = id
+        self.startedAt = startedAt
+        self.messageCountAtStart = max(0, messageCountAtStart)
+        self.eventCountAtStart = max(0, eventCountAtStart)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case id
+        case startedAt
+        case messageCountAtStart
+        case eventCountAtStart
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.startedAt = try container.decode(Date.self, forKey: .startedAt)
+        self.messageCountAtStart = max(
+            0,
+            try container.decode(Int.self, forKey: .messageCountAtStart)
+        )
+        self.eventCountAtStart = max(
+            0,
+            try container.decode(Int.self, forKey: .eventCountAtStart)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Self.schemaVersion, forKey: .schemaVersion)
+        try container.encode(id, forKey: .id)
+        try container.encode(startedAt, forKey: .startedAt)
+        try container.encode(messageCountAtStart, forKey: .messageCountAtStart)
+        try container.encode(eventCountAtStart, forKey: .eventCountAtStart)
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopAgentRunCrashSmoke.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAgentRunCrashSmoke.swift
@@ -1,0 +1,136 @@
+import Darwin
+import Foundation
+import QuillCodeApp
+import QuillCodeCore
+import QuillCodePersistence
+
+@MainActor
+enum QuillCodeDesktopAgentRunCrashSmoke {
+    private static let expectedPrompt = "Run `sleep 30`"
+
+    static func runAndExit(
+        _ request: QuillCodeDesktopAgentRunCrashSmokeRequest,
+        controller: QuillCodeDesktopController,
+        workspaceRoot: QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot
+    ) async {
+        do {
+            switch request.phase {
+            case "write":
+                try await startToolAndCrash(controller: controller, workspaceRoot: workspaceRoot)
+            case "verify":
+                try verifyRecoveredRun(controller: controller, workspaceRoot: workspaceRoot)
+                exit(0)
+            default:
+                throw Failure.invalidPhase(request.phase)
+            }
+        } catch {
+            FileHandle.standardError.write(
+                Data("quill-code-desktop agent run crash smoke failed: \(error)\n".utf8)
+            )
+            exit(1)
+        }
+    }
+
+    private static func startToolAndCrash(
+        controller: QuillCodeDesktopController,
+        workspaceRoot: QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot
+    ) async throws {
+        try FileManager.default.createDirectory(
+            at: workspaceRoot.workspace,
+            withIntermediateDirectories: true
+        )
+        controller.draft = expectedPrompt
+        controller.send()
+        let store = JSONThreadStore(
+            directory: QuillCodePaths(home: workspaceRoot.appState).threadsDirectory
+        )
+
+        for _ in 0..<400 {
+            if let threadID = controller.model.selectedThread?.id,
+               let persisted = try? store.load(threadID),
+               persisted.activeRunCheckpoint != nil,
+               persisted.events.contains(where: {
+                   $0.kind == .toolQueued || $0.kind == .toolRunning || $0.kind == .toolProgress
+               }) {
+                FileHandle.standardOutput.write(Data("agent tool checkpointed before SIGKILL\n".utf8))
+                FileHandle.standardOutput.synchronizeFile()
+                guard Darwin.kill(getpid(), SIGKILL) == 0 else {
+                    throw Failure.couldNotTerminate
+                }
+                throw Failure.couldNotTerminate
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        throw Failure.checkpointTimedOut
+    }
+
+    private static func verifyRecoveredRun(
+        controller: QuillCodeDesktopController,
+        workspaceRoot: QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot
+    ) throws {
+        controller.refresh()
+        guard let thread = controller.model.selectedThread else {
+            throw Failure.missingRecoveredThread
+        }
+        guard thread.activeRunCheckpoint == nil else { throw Failure.checkpointSurvived }
+        guard !controller.model.isAgentRunActive(for: thread.id),
+              !controller.model.composer.isSending
+        else {
+            throw Failure.runStillActive
+        }
+        guard controller.surface.transcript.toolCards.last?.status == .failed else {
+            throw Failure.toolCardDidNotFail
+        }
+        guard controller.surface.runtimeIssue?.title == "Run interrupted" else {
+            throw Failure.missingRecoveryIssue
+        }
+        guard controller.model.canRetryFailedRun(threadID: thread.id) else {
+            throw Failure.retryUnavailable
+        }
+        guard controller.model.prepareRetryLastUserTurn(),
+              controller.model.composer.draft == QuillCodeWorkspaceModel.failedRunRetryPrompt
+        else {
+            throw Failure.unsafeRetryDraft
+        }
+
+        let persisted = try JSONThreadStore(
+            directory: QuillCodePaths(home: workspaceRoot.appState).threadsDirectory
+        ).load(thread.id)
+        guard persisted.activeRunCheckpoint == nil,
+              persisted.events.suffix(2).map(\.kind) == [.toolFailed, .notice]
+        else {
+            throw Failure.recoveryWasNotPersisted
+        }
+        FileHandle.standardOutput.write(Data("agent run recovered after SIGKILL\n".utf8))
+    }
+
+    private enum Failure: LocalizedError {
+        case checkpointSurvived
+        case checkpointTimedOut
+        case couldNotTerminate
+        case invalidPhase(String)
+        case missingRecoveredThread
+        case missingRecoveryIssue
+        case recoveryWasNotPersisted
+        case retryUnavailable
+        case runStillActive
+        case toolCardDidNotFail
+        case unsafeRetryDraft
+
+        var errorDescription: String? {
+            switch self {
+            case .checkpointSurvived: "The relaunched thread still owns the dead run checkpoint."
+            case .checkpointTimedOut: "The live tool boundary was not persisted before the deadline."
+            case .couldNotTerminate: "The writer process could not terminate itself with SIGKILL."
+            case .invalidPhase(let phase): "The agent run crash smoke phase is invalid: \(phase)"
+            case .missingRecoveredThread: "The relaunched app did not restore the run owner."
+            case .missingRecoveryIssue: "The relaunched app did not present Run interrupted."
+            case .recoveryWasNotPersisted: "The repaired terminal events were not saved."
+            case .retryUnavailable: "The interrupted run was not retryable."
+            case .runStillActive: "The dead run was still projected as active after relaunch."
+            case .toolCardDidNotFail: "The interrupted tool card did not become Failed."
+            case .unsafeRetryDraft: "Retry did not prepare the cautious continuation prompt."
+            }
+        }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -87,6 +87,20 @@ struct QuillCodeDesktopApp: App {
             return
         }
 
+        if let request = QuillCodeDesktopAgentRunCrashSmokeRequest(arguments: CommandLine.arguments) {
+            let workspaceRoot = QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot(request: request)
+            let controller = workspaceRoot.makeController()
+            _controller = StateObject(wrappedValue: controller)
+            Task { @MainActor in
+                await QuillCodeDesktopAgentRunCrashSmoke.runAndExit(
+                    request,
+                    controller: controller,
+                    workspaceRoot: workspaceRoot
+                )
+            }
+            return
+        }
+
         if let windowRequest = QuillCodeDesktopWindowSmokeRequest(arguments: CommandLine.arguments) {
             let workspaceRoot = QuillCodeDesktopWindowSmokeWorkspaceRoot(request: windowRequest)
             let controller = workspaceRoot.makeController()

--- a/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSmokeSupport.swift
@@ -81,6 +81,62 @@ struct QuillCodeDesktopComposerDraftCrashSmokeRequest: Sendable {
     }
 }
 
+struct QuillCodeDesktopAgentRunCrashSmokeRequest: Sendable {
+    var phase: String
+    var stateRootPath: String?
+
+    init?(arguments: [String]) {
+        guard arguments.contains("--agent-run-crash-smoke") else { return nil }
+        self.phase = Self.value(after: "--agent-run-crash-phase", in: arguments) ?? ""
+        self.stateRootPath = Self.value(after: "--agent-run-crash-state-root", in: arguments)
+    }
+
+    private static func value(after flag: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: flag) else { return nil }
+        let valueIndex = arguments.index(after: index)
+        guard valueIndex < arguments.endIndex else { return nil }
+        return arguments[valueIndex]
+    }
+}
+
+struct QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot: Sendable, Hashable {
+    var root: URL
+    var appState: URL
+    var workspace: URL
+
+    init(request: QuillCodeDesktopAgentRunCrashSmokeRequest) {
+        if let stateRootPath = request.stateRootPath, !stateRootPath.isEmpty {
+            root = URL(fileURLWithPath: stateRootPath, isDirectory: true)
+        } else {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("quillcode-agent-run-crash-\(UUID().uuidString)", isDirectory: true)
+        }
+        appState = root.appendingPathComponent("app-state", isDirectory: true)
+        workspace = root.appendingPathComponent("workspace", isDirectory: true)
+    }
+
+    @MainActor
+    func makeController() -> QuillCodeDesktopController {
+        let paths = QuillCodePaths(home: appState)
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: ["QUILLCODE_USE_MOCK_LLM": "1"]
+        )
+        return QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(paths: paths, runtimeFactory: runtimeFactory),
+            browserLiveDOMCapturer: nil,
+            updateController: QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            ),
+            installationLocationController: QuillCodeDesktopInstallationLocationController(
+                configuration: nil
+            ),
+            workspaceRoot: workspace
+        )
+    }
+}
+
 struct QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot: Sendable, Hashable {
     var root: URL
     var appState: URL

--- a/Tests/QuillCodeAppTests/WorkspaceAgentProgressPersistencePolicyTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentProgressPersistencePolicyTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+final class WorkspaceAgentProgressPersistencePolicyTests: XCTestCase {
+    func testPersistsToolAndApprovalBoundaries() {
+        for kind in [
+            ThreadEventKind.toolQueued,
+            .toolRunning,
+            .toolCompleted,
+            .toolFailed,
+            .approvalRequested,
+            .approvalDecided
+        ] {
+            XCTAssertTrue(WorkspaceAgentProgressPersistencePolicy.shouldPersist(
+                previousLastEvent: .init(kind: .message, summary: "Prompt"),
+                currentLastEvent: .init(kind: kind, summary: "Boundary")
+            ), kind.rawValue)
+        }
+    }
+
+    func testPersistsOnlyFirstContinuousProgressSnapshot() {
+        XCTAssertTrue(WorkspaceAgentProgressPersistencePolicy.shouldPersist(
+            previousLastEvent: .init(kind: .toolRunning, summary: "Running"),
+            currentLastEvent: .init(kind: .toolProgress, summary: "First output")
+        ))
+        XCTAssertFalse(WorkspaceAgentProgressPersistencePolicy.shouldPersist(
+            previousLastEvent: .init(kind: .toolProgress, summary: "First output"),
+            currentLastEvent: .init(kind: .toolProgress, summary: "More output")
+        ))
+    }
+
+    func testIgnoresPresentationOnlyAndUnchangedEvents() {
+        let event = ThreadEvent(kind: .notice, summary: "Notice")
+        XCTAssertFalse(WorkspaceAgentProgressPersistencePolicy.shouldPersist(
+            previousLastEvent: event,
+            currentLastEvent: event
+        ))
+        XCTAssertFalse(WorkspaceAgentProgressPersistencePolicy.shouldPersist(
+            previousLastEvent: nil,
+            currentLastEvent: .init(kind: .message, summary: "Streaming answer")
+        ))
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceAgentRunRegistryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentRunRegistryTests.swift
@@ -34,4 +34,20 @@ final class WorkspaceAgentRunRegistryTests: XCTestCase {
         XCTAssertTrue(registry.finishAll())
         XCTAssertTrue(registry.activeThreadIDs.isEmpty)
     }
+
+    func testStaleGenerationCannotUpdateOrFinishReplacementRun() {
+        let threadID = UUID()
+        let firstRunID = UUID()
+        let replacementRunID = UUID()
+        var registry = WorkspaceAgentRunRegistry()
+
+        registry.begin(threadID: threadID, runID: firstRunID, status: "First")
+        registry.begin(threadID: threadID, runID: replacementRunID, status: "Replacement")
+        registry.update(threadID: threadID, runID: firstRunID, status: "Stale update")
+
+        XCTAssertEqual(registry.runID(for: threadID), replacementRunID)
+        XCTAssertEqual(registry.status(for: threadID), "Replacement")
+        XCTAssertNil(registry.finish(threadID: threadID, runID: firstRunID))
+        XCTAssertTrue(registry.isRunning(threadID, runID: replacementRunID))
+    }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceAgentRunRelaunchBootstrapTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentRunRelaunchBootstrapTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XCTest
+import QuillCodeCore
+import QuillCodePersistence
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceAgentRunRelaunchBootstrapTests: XCTestCase {
+    func testBootstrapPersistsInterruptedRecoveryExactlyOnceAndOffersSafeRetry() throws {
+        let home = try makeQuillCodeTestDirectory()
+        let paths = QuillCodePaths(home: home)
+        try paths.ensure()
+        let store = JSONThreadStore(directory: paths.threadsDirectory)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let thread = ChatThread(
+            messages: [.init(role: .user, content: "Run a long command")],
+            events: [
+                .init(kind: .message, summary: "Run a long command"),
+                .init(kind: .toolQueued, summary: "host.shell.run queued"),
+                .init(kind: .toolRunning, summary: "host.shell.run running")
+            ],
+            activeRunCheckpoint: ThreadRunCheckpoint(
+                messageCountAtStart: 1,
+                eventCountAtStart: 1
+            )
+        )
+        try store.save(thread)
+
+        let bootstrap = QuillCodeWorkspaceBootstrap(paths: paths, now: { now })
+        let model = try bootstrap.makeModel(automaticStartupPolicy: .deferUntilRequested)
+        let persisted = try store.load(thread.id)
+
+        XCTAssertNil(persisted.activeRunCheckpoint)
+        XCTAssertEqual(persisted.events.suffix(2).map(\.kind), [.toolFailed, .notice])
+        XCTAssertFalse(model.isAgentRunActive(for: thread.id))
+        XCTAssertFalse(model.composer.isSending)
+        XCTAssertEqual(model.lastError, WorkspaceAgentRunRelaunchReconciler.recoveryMessage)
+        XCTAssertEqual(model.surface().runtimeIssue?.title, "Run interrupted")
+        XCTAssertTrue(model.canRetryFailedRun(threadID: thread.id))
+
+        XCTAssertTrue(model.prepareRetryLastUserTurn())
+        XCTAssertEqual(model.composer.draft, QuillCodeWorkspaceModel.failedRunRetryPrompt)
+        XCTAssertNil(model.lastError)
+
+        let relaunched = try bootstrap.makeModel(automaticStartupPolicy: .deferUntilRequested)
+        let persistedAgain = try store.load(thread.id)
+        XCTAssertNil(relaunched.lastError)
+        XCTAssertEqual(
+            persistedAgain.events.filter {
+                $0.summary == WorkspaceRunFailureNoticePlanner.interruptedRelaunchSummary
+            }.count,
+            1
+        )
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceAgentRunRelaunchReconcilerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentRunRelaunchReconcilerTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import XCTest
+import QuillCodeCore
+@testable import QuillCodeApp
+
+@MainActor
+final class WorkspaceAgentRunRelaunchReconcilerTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testInterruptedOpenToolBecomesFailedAndRetryable() {
+        let checkpoint = ThreadRunCheckpoint(messageCountAtStart: 1, eventCountAtStart: 1)
+        let thread = ChatThread(
+            messages: [.init(role: .user, content: "Run a long command")],
+            events: [
+                .init(kind: .message, summary: "Run a long command"),
+                .init(kind: .toolQueued, summary: "host.shell.run queued"),
+                .init(kind: .toolRunning, summary: "host.shell.run running")
+            ],
+            activeRunCheckpoint: checkpoint
+        )
+
+        let result = WorkspaceAgentRunRelaunchReconciler.reconcile([thread], now: now)
+        let recovered = result.threads[0]
+
+        XCTAssertEqual(result.changedThreadIDs, [thread.id])
+        XCTAssertEqual(result.interruptedThreadIDs, [thread.id])
+        XCTAssertNil(recovered.activeRunCheckpoint)
+        XCTAssertEqual(recovered.events.suffix(2).map(\.kind), [.toolFailed, .notice])
+        XCTAssertEqual(recovered.events.last?.summary, WorkspaceRunFailureNoticePlanner.interruptedRelaunchSummary)
+        XCTAssertTrue(QuillCodeWorkspaceModel.lastRunFailed(in: recovered))
+    }
+
+    func testRunningOrProgressBoundaryWithoutQueuedEventStillBecomesFailed() {
+        for kind in [ThreadEventKind.toolRunning, .toolProgress] {
+            let thread = ChatThread(
+                events: [.init(kind: kind, summary: "host.shell.run active")],
+                activeRunCheckpoint: ThreadRunCheckpoint(
+                    messageCountAtStart: 0,
+                    eventCountAtStart: 0
+                )
+            )
+
+            let result = WorkspaceAgentRunRelaunchReconciler.reconcile([thread], now: now)
+
+            XCTAssertEqual(result.threads[0].events.suffix(2).map(\.kind), [.toolFailed, .notice])
+        }
+    }
+
+    func testCompletedAssistantTurnClearsCheckpointSilently() {
+        let checkpoint = ThreadRunCheckpoint(messageCountAtStart: 1, eventCountAtStart: 0)
+        let thread = ChatThread(
+            messages: [
+                .init(role: .user, content: "Question"),
+                .init(role: .assistant, content: "Answer")
+            ],
+            activeRunCheckpoint: checkpoint
+        )
+
+        let result = WorkspaceAgentRunRelaunchReconciler.reconcile([thread], now: now)
+
+        XCTAssertEqual(result.changedThreadIDs, [thread.id])
+        XCTAssertTrue(result.interruptedThreadIDs.isEmpty)
+        XCTAssertNil(result.threads[0].activeRunCheckpoint)
+        XCTAssertTrue(result.threads[0].events.isEmpty)
+    }
+
+    func testUndecidedApprovalClearsCheckpointAndPreservesGate() throws {
+        let request = ApprovalRequest(
+            id: "approval-1",
+            toolCall: ToolCall(name: ToolDefinition.shellRun.name, argumentsJSON: #"{"cmd":"whoami"}"#),
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "Approval required"
+        )
+        let thread = ChatThread(
+            events: [.init(
+                kind: .approvalRequested,
+                summary: request.reason,
+                payloadJSON: try JSONHelpers.encodePretty(request)
+            )],
+            activeRunCheckpoint: ThreadRunCheckpoint(messageCountAtStart: 0, eventCountAtStart: 0)
+        )
+
+        let result = WorkspaceAgentRunRelaunchReconciler.reconcile([thread], now: now)
+
+        XCTAssertTrue(result.interruptedThreadIDs.isEmpty)
+        XCTAssertNil(result.threads[0].activeRunCheckpoint)
+        XCTAssertEqual(result.threads[0].events, thread.events)
+    }
+
+    func testDecidedApprovalWithoutAnswerIsInterrupted() throws {
+        let requestID = "approval-1"
+        let request = ApprovalRequest(
+            id: requestID,
+            toolCall: ToolCall(name: ToolDefinition.shellRun.name, argumentsJSON: #"{"cmd":"whoami"}"#),
+            toolDefinition: ToolDefinition.shellRun,
+            reason: "Approval required"
+        )
+        let decision = ApprovalDecision(
+            requestID: requestID,
+            verdict: .approve,
+            rationale: "Approved"
+        )
+        let thread = ChatThread(
+            events: [
+                .init(kind: .approvalRequested, summary: request.reason, payloadJSON: try JSONHelpers.encodePretty(request)),
+                .init(kind: .approvalDecided, summary: decision.rationale, payloadJSON: try JSONHelpers.encodePretty(decision))
+            ],
+            activeRunCheckpoint: ThreadRunCheckpoint(messageCountAtStart: 0, eventCountAtStart: 0)
+        )
+
+        let result = WorkspaceAgentRunRelaunchReconciler.reconcile([thread], now: now)
+
+        XCTAssertEqual(result.interruptedThreadIDs, [thread.id])
+        XCTAssertEqual(result.threads[0].events.last?.kind, .notice)
+    }
+
+    func testReconciliationIsIdempotentAndBoundsOversizedOffsets() {
+        let thread = ChatThread(activeRunCheckpoint: ThreadRunCheckpoint(
+            messageCountAtStart: Int.max,
+            eventCountAtStart: Int.max
+        ))
+
+        let first = WorkspaceAgentRunRelaunchReconciler.reconcile([thread], now: now)
+        let second = WorkspaceAgentRunRelaunchReconciler.reconcile(first.threads, now: now)
+
+        XCTAssertEqual(first.interruptedThreadIDs, [thread.id])
+        XCTAssertTrue(second.changedThreadIDs.isEmpty)
+        XCTAssertTrue(second.interruptedThreadIDs.isEmpty)
+        XCTAssertEqual(second.threads, first.threads)
+    }
+}

--- a/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerIntegrationTests.swift
@@ -411,7 +411,11 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
             threadID: threadID,
             lifecycle: WorkspaceComposerSendLifecycle.started(from: model.composer)
         )
+        model.mutateThread(threadID) { thread in
+            thread.events.append(ThreadEvent(kind: .toolRunning, summary: "Running tool"))
+        }
         XCTAssertTrue(model.composer.isSending)
+        XCTAssertNotNil(model.selectedThread?.activeRunCheckpoint)
 
         model.cancelActiveWork()
         var staleProgress = try XCTUnwrap(model.selectedThread)
@@ -423,7 +427,38 @@ final class WorkspaceComposerIntegrationTests: XCTestCase {
         XCTAssertFalse(model.composer.isSending)
         XCTAssertEqual(model.root.topBar.agentStatus, TopBarAgentStatusLabel.stopped)
         XCTAssertEqual(model.selectedThread?.title, "Live stopped thread")
+        XCTAssertNil(model.selectedThread?.activeRunCheckpoint)
+        XCTAssertEqual(model.selectedThread?.events.suffix(2).map(\.kind), [.toolFailed, .notice])
         XCTAssertFalse(model.selectedThread?.events.contains { $0.summary == "Still running" } == true)
+    }
+
+    func testOldGenerationProgressCannotOverwriteReplacementRun() throws {
+        let model = QuillCodeWorkspaceModel()
+        let threadID = model.newChat()
+        let firstRunID = model.beginAgentRun(
+            threadID: threadID,
+            lifecycle: WorkspaceComposerSendLifecycle.started(from: model.composer)
+        )
+        model.cancelActiveWork()
+        let replacementRunID = model.beginAgentRun(
+            threadID: threadID,
+            lifecycle: WorkspaceComposerSendLifecycle.started(from: model.composer)
+        )
+        var staleProgress = try XCTUnwrap(model.selectedThread)
+        staleProgress.title = "Stale first generation"
+        staleProgress.events.append(ThreadEvent(kind: .toolRunning, summary: "Stale tool"))
+
+        model.applyAgentProgress(
+            staleProgress,
+            expectedThreadID: threadID,
+            expectedRunID: firstRunID
+        )
+
+        XCTAssertNotEqual(firstRunID, replacementRunID)
+        XCTAssertTrue(model.agentRuns.isRunning(threadID, runID: replacementRunID))
+        XCTAssertEqual(model.selectedThread?.activeRunCheckpoint?.id, replacementRunID)
+        XCTAssertNotEqual(model.selectedThread?.title, "Stale first generation")
+        XCTAssertFalse(model.selectedThread?.events.contains { $0.summary == "Stale tool" } == true)
     }
 
     func testAgentProgressKeepsLargeProducerAndModelEventStorageIndependent() throws {

--- a/Tests/QuillCodeAppTests/WorkspaceModelRunRetryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceModelRunRetryTests.swift
@@ -54,6 +54,24 @@ final class WorkspaceModelRunRetryTests: XCTestCase {
 
     // MARK: - Retry turn
 
+    func testPrepareRetryUsesCautiousContinuationForInterruptedRun() {
+        var thread = ChatThread(
+            messages: [.init(role: .user, content: "Change the project")],
+            events: [failureNotice()]
+        )
+        thread.composerAttachments = []
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            threads: [thread],
+            selectedThreadID: thread.id
+        ))
+
+        XCTAssertTrue(model.prepareRetryLastUserTurn())
+
+        XCTAssertEqual(model.composer.draft, QuillCodeWorkspaceModel.failedRunRetryPrompt)
+        XCTAssertTrue(model.composer.attachments.isEmpty)
+        XCTAssertNil(model.lastError)
+    }
+
     func testRetryFailedRunSendsTheContinuationTurnThroughTheSharedEngine() async throws {
         let root = try makeQuillCodeTestDirectory()
         let model = QuillCodeWorkspaceModel()

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeIssueBuilderTests.swift
@@ -3,6 +3,19 @@ import QuillCodeCore
 @testable import QuillCodeApp
 
 final class WorkspaceRuntimeIssueBuilderTests: XCTestCase {
+    func testInterruptedRunGetsSpecificRecoveryCopyAndTelemetry() throws {
+        let issue = try XCTUnwrap(WorkspaceRuntimeIssueBuilder.issue(
+            from: WorkspaceAgentRunRelaunchReconciler.recoveryMessage,
+            config: AppConfig()
+        ))
+
+        XCTAssertEqual(issue.severity, .warning)
+        XCTAssertEqual(issue.title, "Run interrupted")
+        XCTAssertEqual(issue.actionLabel, "Review and retry")
+        XCTAssertEqual(issue.recovery?.route, .retryLastTurn)
+        XCTAssertEqual(issue.recovery?.reason, .runInterrupted)
+    }
+
     func testStatusIssueIncludesRuntimeDiagnostics() {
         let issue = WorkspaceRuntimeIssueBuilder(
             config: AppConfig(authMode: .oauth),

--- a/Tests/QuillCodeCoreTests/ThreadRunCheckpointTests.swift
+++ b/Tests/QuillCodeCoreTests/ThreadRunCheckpointTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import XCTest
+@testable import QuillCodeCore
+
+final class ThreadRunCheckpointTests: XCTestCase {
+    func testCheckpointRoundTripsWithThread() throws {
+        let checkpoint = ThreadRunCheckpoint(
+            id: UUID(),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            messageCountAtStart: 3,
+            eventCountAtStart: 7
+        )
+
+        let data = try JSONEncoder().encode(ChatThread(activeRunCheckpoint: checkpoint))
+        let decoded = try JSONDecoder().decode(ChatThread.self, from: data)
+
+        XCTAssertEqual(decoded.activeRunCheckpoint, checkpoint)
+        let json = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(json.contains(#""schemaVersion":1"#), json)
+        XCTAssertFalse(json.localizedCaseInsensitiveContains("prompt"), json)
+        XCTAssertFalse(json.localizedCaseInsensitiveContains("arguments"), json)
+    }
+
+    func testLegacyThreadWithoutCheckpointDecodesAsIdle() throws {
+        let thread = ChatThread()
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(thread)) as? [String: Any]
+        )
+        object.removeValue(forKey: "activeRunCheckpoint")
+
+        let decoded = try JSONDecoder().decode(
+            ChatThread.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+
+        XCTAssertNil(decoded.activeRunCheckpoint)
+    }
+
+    func testCheckpointNormalizesNegativeBoundaries() throws {
+        let checkpoint = ThreadRunCheckpoint(
+            messageCountAtStart: -1,
+            eventCountAtStart: -2
+        )
+
+        XCTAssertEqual(checkpoint.messageCountAtStart, 0)
+        XCTAssertEqual(checkpoint.eventCountAtStart, 0)
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopAgentRunCrashSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopAgentRunCrashSmokeTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopAgentRunCrashSmokeTests: XCTestCase {
+    func testRequestRequiresFlagAndParsesPhaseAndStateRoot() throws {
+        XCTAssertNil(QuillCodeDesktopAgentRunCrashSmokeRequest(arguments: ["Quill Cowork"]))
+
+        let request = try XCTUnwrap(QuillCodeDesktopAgentRunCrashSmokeRequest(arguments: [
+            "Quill Cowork",
+            "--agent-run-crash-smoke",
+            "--agent-run-crash-phase",
+            "verify",
+            "--agent-run-crash-state-root",
+            "/tmp/quill-agent-run-crash"
+        ]))
+
+        XCTAssertEqual(request.phase, "verify")
+        XCTAssertEqual(request.stateRootPath, "/tmp/quill-agent-run-crash")
+        let root = QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot(request: request)
+        XCTAssertEqual(root.root.path, "/tmp/quill-agent-run-crash")
+        XCTAssertEqual(root.appState.lastPathComponent, "app-state")
+        XCTAssertEqual(root.workspace.lastPathComponent, "workspace")
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -181,4 +181,21 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         Self.assertSource(packagedSmokeText, contains: "--composer-draft-crash-phase verify")
         Self.assertSource(packagedSmokeText, contains: "COMPOSER_DRAFT_CRASH_STATUS\" -ne 137")
     }
+
+    func testPackagedDesktopRecoversInterruptedAgentRunAfterHardKill() throws {
+        let crashSmokeText = try Self.desktopSourceText(
+            named: "QuillCodeDesktopAgentRunCrashSmoke.swift"
+        )
+        let appText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let packagedSmokeText = try Self.scriptText(named: "packaged-macos-smoke.sh")
+
+        Self.assertSource(crashSmokeText, contains: "Darwin.kill(getpid(), SIGKILL)")
+        Self.assertSource(crashSmokeText, contains: "activeRunCheckpoint == nil")
+        Self.assertSource(crashSmokeText, contains: "toolCards.last?.status == .failed")
+        Self.assertSource(crashSmokeText, contains: "failedRunRetryPrompt")
+        Self.assertSource(appText, contains: "QuillCodeDesktopAgentRunCrashSmoke.runAndExit")
+        Self.assertSource(packagedSmokeText, contains: "--agent-run-crash-phase write")
+        Self.assertSource(packagedSmokeText, contains: "--agent-run-crash-phase verify")
+        Self.assertSource(packagedSmokeText, contains: "AGENT_RUN_CRASH_STATUS\" -ne 137")
+    }
 }

--- a/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceExecutionGateTests.swift
@@ -249,11 +249,15 @@ final class ParityWorkspaceExecutionGateTests: QuillCodeParityTestCase {
             "submitComposer should delegate typed send outcome handling."
         )
         XCTAssertTrue(
-            composerText.contains("try finishCompletedSend(result, runThreadID: runThreadID)"),
+            composerText.contains(
+                "try finishCompletedSend(result, runThreadID: runThreadID, runID: runID)"
+            ),
             "The terminal helper should delegate successful send completion."
         )
         XCTAssertTrue(
-            composerText.contains("finishFailedSend(error, runThreadID: runThreadID)"),
+            composerText.contains(
+                "finishFailedSend(error, runThreadID: runThreadID, runID: runID)"
+            ),
             "The terminal helper should delegate failed send completion."
         )
         XCTAssertFalse(

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -128,6 +128,15 @@ and is rejected after a selection change, while a durable tombstone prevents sen
 returning after relaunch. A first message without a chat owner has its own pending record and moves to
 the created chat on send. Confidential and side-conversation drafts remain memory-only.
 
+Parent-chat runs also carry a content-free generation checkpoint containing only a run identifier,
+start time, and message/event boundaries. Tool and approval boundaries are saved durably, while
+continuous tool output is coalesced so recovery does not turn streaming into a disk-write loop. If
+the process disappears mid-run, bootstrap clears the dead generation, closes any Running tool card
+as Failed, records one durable interruption notice, and offers **Review and retry** with a cautious
+continuation prompt. A completed assistant answer or still-undecided approval gate is preserved
+without a false failure. The packaged release smoke starts a real shell tool, kills the app with
+`SIGKILL`, and relaunches the same bundle to verify this path end to end.
+
 ## Build Cadence
 
 The tester release is refreshed:

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -23,6 +23,9 @@ PERFORMANCE_WINDOW_STATE_ROOT="$SMOKE_ROOT/performance-window-state"
 COMPOSER_DRAFT_CRASH_STATE_ROOT="$SMOKE_ROOT/composer-draft-crash-state"
 COMPOSER_DRAFT_CRASH_WRITE_LOG="$SMOKE_ROOT/composer-draft-crash-write.log"
 COMPOSER_DRAFT_CRASH_VERIFY_LOG="$SMOKE_ROOT/composer-draft-crash-verify.log"
+AGENT_RUN_CRASH_STATE_ROOT="$SMOKE_ROOT/agent-run-crash-state"
+AGENT_RUN_CRASH_WRITE_LOG="$SMOKE_ROOT/agent-run-crash-write.log"
+AGENT_RUN_CRASH_VERIFY_LOG="$SMOKE_ROOT/agent-run-crash-verify.log"
 WINDOW_REPORT_PATH="$SMOKE_ROOT/window-report.json"
 WINDOW_SCREENSHOT_PATH="$SMOKE_ROOT/window.png"
 WINDOW_STATE_ROOT="$SMOKE_ROOT/window-state"
@@ -88,6 +91,12 @@ cleanup() {
     if [[ -e "$COMPOSER_DRAFT_CRASH_VERIFY_LOG" ]]; then
       cp "$COMPOSER_DRAFT_CRASH_VERIFY_LOG" "$ARTIFACT_DIR/composer-draft-crash-verify.log"
     fi
+    if [[ -e "$AGENT_RUN_CRASH_WRITE_LOG" ]]; then
+      cp "$AGENT_RUN_CRASH_WRITE_LOG" "$ARTIFACT_DIR/agent-run-crash-write.log"
+    fi
+    if [[ -e "$AGENT_RUN_CRASH_VERIFY_LOG" ]]; then
+      cp "$AGENT_RUN_CRASH_VERIFY_LOG" "$ARTIFACT_DIR/agent-run-crash-verify.log"
+    fi
     if [[ -e "$WINDOW_REPORT_PATH" ]]; then
       cp "$WINDOW_REPORT_PATH" "$ARTIFACT_DIR/window-report.json"
     fi
@@ -117,6 +126,8 @@ cleanup() {
       printf 'performance_window_screenshot=performance-window.png\n'
       printf 'composer_draft_crash_write=composer-draft-crash-write.log\n'
       printf 'composer_draft_crash_verify=composer-draft-crash-verify.log\n'
+      printf 'agent_run_crash_write=agent-run-crash-write.log\n'
+      printf 'agent_run_crash_verify=agent-run-crash-verify.log\n'
       printf 'window_smoke=window-report.json\n'
       printf 'window_screenshot=window.png\n'
     } > "$ARTIFACT_DIR/manifest.txt"
@@ -238,6 +249,43 @@ if ! wait_for_smoke_process \
   "Packaged composer draft recovery verifier"
 then
   cat "$COMPOSER_DRAFT_CRASH_VERIFY_LOG" >&2
+  exit 1
+fi
+
+echo "==> Running packaged agent run SIGKILL recovery smoke"
+"$APP_EXECUTABLE" \
+  --agent-run-crash-smoke \
+  --agent-run-crash-phase write \
+  --agent-run-crash-state-root "$AGENT_RUN_CRASH_STATE_ROOT" \
+  >"$AGENT_RUN_CRASH_WRITE_LOG" 2>&1 &
+AGENT_RUN_CRASH_PID="$!"
+set +e
+wait_for_smoke_process \
+  "$AGENT_RUN_CRASH_PID" \
+  15 \
+  "Packaged agent run SIGKILL writer"
+AGENT_RUN_CRASH_STATUS="$?"
+set -e
+if [[ "$AGENT_RUN_CRASH_STATUS" -ne 137 ]]; then
+  echo "Packaged agent run writer expected SIGKILL status 137 but found $AGENT_RUN_CRASH_STATUS." >&2
+  cat "$AGENT_RUN_CRASH_WRITE_LOG" >&2
+  exit 1
+fi
+
+(
+  "$APP_EXECUTABLE" \
+    --agent-run-crash-smoke \
+    --agent-run-crash-phase verify \
+    --agent-run-crash-state-root "$AGENT_RUN_CRASH_STATE_ROOT" \
+    >"$AGENT_RUN_CRASH_VERIFY_LOG" 2>&1
+) &
+AGENT_RUN_CRASH_VERIFY_PID="$!"
+if ! wait_for_smoke_process \
+  "$AGENT_RUN_CRASH_VERIFY_PID" \
+  15 \
+  "Packaged agent run recovery verifier"
+then
+  cat "$AGENT_RUN_CRASH_VERIFY_LOG" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- persist content-free, generation-bound checkpoints for active parent-chat runs
- reject stale progress and terminal callbacks while saving only crash-relevant tool and approval boundaries
- reconcile dead runs on relaunch with failed tool cards, a cautious retry path, and idempotent durable notices
- exercise the shipped app with a real shell run, SIGKILL, and same-state relaunch

## Validation
- swift test --skip-build: 6,285 tests passed, 5 skipped, 0 failed
- swift test --filter WorkspaceAgentRunRelaunchReconcilerTests: 6 passed
- scripts/packaged-macos-smoke.sh: release bundle, kill/relaunch recovery, native interaction, and performance checks passed
- git diff --check