### PR TITLE
Contain shell descendants across app crashes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,10 @@ let package = Package(
         .executable(name: "quill-code", targets: ["quill-code"]),
         .executable(name: "quill-code-desktop", targets: ["quill-code-desktop"]),
         .executable(
+            name: "quill-code-process-supervisor",
+            targets: ["quill-code-process-supervisor"]
+        ),
+        .executable(
             name: "quillcode-linux-computer-use-smoke",
             targets: ["quillcode-linux-computer-use-smoke"]
         )
@@ -132,6 +136,7 @@ let package = Package(
                 "QuillCodePlatform"
             ]
         ),
+        .executableTarget(name: "quill-code-process-supervisor"),
         .executableTarget(
             name: "quillcode-linux-computer-use-smoke",
             dependencies: ["QuillComputerUseKit"]

--- a/Sources/QuillCodeTools/PTYProcessSession.swift
+++ b/Sources/QuillCodeTools/PTYProcessSession.swift
@@ -39,6 +39,7 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
     private let windowSize: PTYWindowSize?
     private let lock = NSLock()
     private var process: Process?
+    private var processIsSupervised = false
     private var masterFD: Int32 = -1
     private var output = ShellOutputAccumulator()
     private var didFinish = false
@@ -82,10 +83,9 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
     /// three terminate paths against a `suspend()` that races in after `didSuspend` was cleared, with no
     /// dependency on which guard flag happened to be set.
     ///
-    /// Like `cancel()` before it, this signals only the session's direct child (`/bin/sh`); a pipeline
-    /// or backgrounded grandchild in a separate process group is not covered. True process-group job
-    /// control would require spawning the child as a group leader (`posix_spawn` with a new pgid), a
-    /// larger change than this session's Foundation `Process` model — left for a follow-up.
+    /// Packaged sessions run through the lightweight process supervisor, which forwards these signals
+    /// to the command's full process group. Development hosts without that helper retain direct-child
+    /// behavior instead of making shell execution depend on packaging state.
     private static func terminate(_ process: Process) {
         kill(process.processIdentifier, SIGCONT)
         process.terminate()
@@ -141,7 +141,8 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
         // unconditional SIGCONT in `terminate(_:)`, this closes the window where a suspend racing a
         // cancel/timeout could re-stop the process after it was continued for termination.
         guard !didFinish, !didCancel, !didTimeOut, !didSuspend, let process, process.isRunning else { return false }
-        guard kill(process.processIdentifier, SIGSTOP) == 0 else { return false }
+        let signal = processIsSupervised ? SIGTSTP : SIGSTOP
+        guard kill(process.processIdentifier, signal) == 0 else { return false }
         didSuspend = true
         return true
     }
@@ -190,9 +191,15 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
             _ = cquill_pty_set_winsize(master, windowSize.rows, windowSize.columns)
         }
 
+        let shellLaunch = ShellProcessLaunch(
+            executable: request.shellExecutableURL,
+            arguments: ["-lc", trimmed],
+            isSandboxed: false
+        )
+        let launch = ShellProcessSupervisor.wrapping(shellLaunch)
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-lc", trimmed]
+        process.executableURL = launch.executable
+        process.arguments = launch.arguments
         process.currentDirectoryURL = request.cwd
         process.environment = ptyEnvironment(request.environment)
 
@@ -226,11 +233,12 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
 
         lock.lock()
         self.process = process
+        self.processIsSupervised = launch.executable != shellLaunch.executable
         self.masterFD = master
         let shouldTerminate = didCancel
         lock.unlock()
         if shouldTerminate {
-            process.terminate()
+            Self.terminate(process)
         }
 
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + request.timeoutSeconds) { [weak self] in
@@ -346,6 +354,7 @@ public final class PTYProcessSession: ShellInteractiveSession, @unchecked Sendab
         activeProcess = process
         didSuspend = false
         process = nil
+        processIsSupervised = false
         masterFD = -1
         lock.unlock()
 

--- a/Sources/QuillCodeTools/ShellProcessSupervisor.swift
+++ b/Sources/QuillCodeTools/ShellProcessSupervisor.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum ShellProcessSupervisor {
+    static let executableName = "quill-code-process-supervisor"
+    static let environmentKey = "QUILLCODE_PROCESS_SUPERVISOR_EXECUTABLE"
+    private static let defaultExecutableURL = resolveExecutable()
+
+    static func wrapping(
+        _ launch: ShellProcessLaunch,
+        supervisorURL: URL? = defaultExecutableURL
+    ) -> ShellProcessLaunch {
+        guard let supervisorURL else { return launch }
+        return ShellProcessLaunch(
+            executable: supervisorURL,
+            arguments: [launch.executable.path] + launch.arguments,
+            isSandboxed: launch.isSandboxed
+        )
+    }
+
+    static func resolveExecutable(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundle: Bundle = .main,
+        currentExecutableURL: URL? = Bundle.main.executableURL
+    ) -> URL? {
+        if let override = environment[environmentKey], !override.isEmpty {
+            let url = URL(fileURLWithPath: override).standardizedFileURL
+            return isExecutable(url) ? url : nil
+        }
+
+        var candidates: [URL] = []
+        if bundle.bundleURL.pathExtension == "app" {
+            candidates.append(
+                bundle.bundleURL
+                    .appendingPathComponent("Contents/Helpers", isDirectory: true)
+                    .appendingPathComponent(executableName)
+            )
+        }
+        if let currentExecutableURL {
+            candidates.append(
+                currentExecutableURL.deletingLastPathComponent().appendingPathComponent(executableName)
+            )
+        }
+        return candidates.first(where: isExecutable)
+    }
+
+    private static func isExecutable(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+            && FileManager.default.isExecutableFile(atPath: url.path)
+    }
+}

--- a/Sources/QuillCodeTools/ShellStreamingProcessRunner.swift
+++ b/Sources/QuillCodeTools/ShellStreamingProcessRunner.swift
@@ -112,9 +112,10 @@ final class ShellStreamingProcessRunner: @unchecked Sendable {
             return
         }
 
+        let supervisedLaunch = ShellProcessSupervisor.wrapping(launch)
         let process = Process()
-        process.executableURL = launch.executable
-        process.arguments = launch.arguments
+        process.executableURL = supervisedLaunch.executable
+        process.arguments = supervisedLaunch.arguments
         process.currentDirectoryURL = request.cwd
         process.environment = environment
 

--- a/Sources/QuillCodeTools/ShellToolExecutor.swift
+++ b/Sources/QuillCodeTools/ShellToolExecutor.swift
@@ -216,9 +216,10 @@ public struct ShellToolExecutor: Sendable {
             )
         }
 
+        let supervisedLaunch = ShellProcessSupervisor.wrapping(launch)
         let process = Process()
-        process.executableURL = launch.executable
-        process.arguments = launch.arguments
+        process.executableURL = supervisedLaunch.executable
+        process.arguments = supervisedLaunch.arguments
         process.currentDirectoryURL = request.cwd
         process.environment = environment
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopAgentRunCrashSmoke.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAgentRunCrashSmoke.swift
@@ -6,8 +6,6 @@ import QuillCodePersistence
 
 @MainActor
 enum QuillCodeDesktopAgentRunCrashSmoke {
-    private static let expectedPrompt = "Run `sleep 30`"
-
     static func runAndExit(
         _ request: QuillCodeDesktopAgentRunCrashSmokeRequest,
         controller: QuillCodeDesktopController,
@@ -18,7 +16,7 @@ enum QuillCodeDesktopAgentRunCrashSmoke {
             case "write":
                 try await startToolAndCrash(controller: controller, workspaceRoot: workspaceRoot)
             case "verify":
-                try verifyRecoveredRun(controller: controller, workspaceRoot: workspaceRoot)
+                try await verifyRecoveredRun(controller: controller, workspaceRoot: workspaceRoot)
                 exit(0)
             default:
                 throw Failure.invalidPhase(request.phase)
@@ -39,7 +37,9 @@ enum QuillCodeDesktopAgentRunCrashSmoke {
             at: workspaceRoot.workspace,
             withIntermediateDirectories: true
         )
-        controller.draft = expectedPrompt
+        let childPIDURL = workspaceRoot.workspace.appendingPathComponent("crash-child.pid")
+        let quotedPIDPath = childPIDURL.path.replacingOccurrences(of: "'", with: "'\\''")
+        controller.draft = "Run `printf '%s' \"$$\" > '\(quotedPIDPath)'; sleep 30`"
         controller.send()
         let store = JSONThreadStore(
             directory: QuillCodePaths(home: workspaceRoot.appState).threadsDirectory
@@ -51,8 +51,11 @@ enum QuillCodeDesktopAgentRunCrashSmoke {
                persisted.activeRunCheckpoint != nil,
                persisted.events.contains(where: {
                    $0.kind == .toolQueued || $0.kind == .toolRunning || $0.kind == .toolProgress
-               }) {
-                FileHandle.standardOutput.write(Data("agent tool checkpointed before SIGKILL\n".utf8))
+               }),
+               let childPID = liveChildPID(at: childPIDURL) {
+                FileHandle.standardOutput.write(
+                    Data("agent tool checkpointed before SIGKILL (child \(childPID))\n".utf8)
+                )
                 FileHandle.standardOutput.synchronizeFile()
                 guard Darwin.kill(getpid(), SIGKILL) == 0 else {
                     throw Failure.couldNotTerminate
@@ -67,7 +70,18 @@ enum QuillCodeDesktopAgentRunCrashSmoke {
     private static func verifyRecoveredRun(
         controller: QuillCodeDesktopController,
         workspaceRoot: QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot
-    ) throws {
+    ) async throws {
+        let childPIDURL = workspaceRoot.workspace.appendingPathComponent("crash-child.pid")
+        guard let childPID = recordedChildPID(at: childPIDURL) else {
+            throw Failure.missingChildPID
+        }
+        for _ in 0..<80 where processIsAlive(childPID) {
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        guard !processIsAlive(childPID) else {
+            throw Failure.childProcessSurvived(childPID)
+        }
+
         controller.refresh()
         guard let thread = controller.model.selectedThread else {
             throw Failure.missingRecoveredThread
@@ -104,13 +118,35 @@ enum QuillCodeDesktopAgentRunCrashSmoke {
         FileHandle.standardOutput.write(Data("agent run recovered after SIGKILL\n".utf8))
     }
 
+    private static func liveChildPID(at url: URL) -> pid_t? {
+        guard let pid = recordedChildPID(at: url), processIsAlive(pid) else { return nil }
+        return pid
+    }
+
+    private static func recordedChildPID(at url: URL) -> pid_t? {
+        guard let value = try? String(contentsOf: url, encoding: .utf8),
+              let pid = pid_t(value.trimmingCharacters(in: .whitespacesAndNewlines)),
+              pid > 1
+        else {
+            return nil
+        }
+        return pid
+    }
+
+    private static func processIsAlive(_ pid: pid_t) -> Bool {
+        if Darwin.kill(pid, 0) == 0 { return true }
+        return errno != ESRCH
+    }
+
     private enum Failure: LocalizedError {
         case checkpointSurvived
         case checkpointTimedOut
+        case childProcessSurvived(pid_t)
         case couldNotTerminate
         case invalidPhase(String)
         case missingRecoveredThread
         case missingRecoveryIssue
+        case missingChildPID
         case recoveryWasNotPersisted
         case retryUnavailable
         case runStillActive
@@ -121,10 +157,13 @@ enum QuillCodeDesktopAgentRunCrashSmoke {
             switch self {
             case .checkpointSurvived: "The relaunched thread still owns the dead run checkpoint."
             case .checkpointTimedOut: "The live tool boundary was not persisted before the deadline."
+            case .childProcessSurvived(let pid):
+                "The shell child survived the desktop hard crash (PID \(pid))."
             case .couldNotTerminate: "The writer process could not terminate itself with SIGKILL."
             case .invalidPhase(let phase): "The agent run crash smoke phase is invalid: \(phase)"
             case .missingRecoveredThread: "The relaunched app did not restore the run owner."
             case .missingRecoveryIssue: "The relaunched app did not present Run interrupted."
+            case .missingChildPID: "The crash writer did not record its live shell child."
             case .recoveryWasNotPersisted: "The repaired terminal events were not saved."
             case .retryUnavailable: "The interrupted run was not retryable."
             case .runStillActive: "The dead run was still projected as active after relaunch."

--- a/Sources/quill-code-process-supervisor/main.c
+++ b/Sources/quill-code-process-supervisor/main.c
@@ -1,0 +1,261 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <sys/event.h>
+#endif
+
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
+
+static volatile sig_atomic_t pending_termination_signal = 0;
+static volatile sig_atomic_t pending_stop = 0;
+static volatile sig_atomic_t pending_continue = 0;
+
+static void record_signal(int signal_number) {
+    if (signal_number == SIGTSTP) {
+        pending_stop = 1;
+    } else if (signal_number == SIGCONT) {
+        pending_continue = 1;
+    } else if (pending_termination_signal == 0) {
+        pending_termination_signal = signal_number;
+    }
+}
+
+static int install_handler(int signal_number) {
+    struct sigaction action;
+    action.sa_handler = record_signal;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = 0;
+    return sigaction(signal_number, &action, NULL);
+}
+
+static void restore_default_handlers(void) {
+    int signals[] = {SIGTERM, SIGINT, SIGHUP, SIGQUIT, SIGTSTP, SIGCONT};
+    struct sigaction action;
+    action.sa_handler = SIG_DFL;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = 0;
+    for (size_t index = 0; index < sizeof(signals) / sizeof(signals[0]); index++) {
+        (void)sigaction(signals[index], &action, NULL);
+    }
+}
+
+static void sleep_milliseconds(long milliseconds) {
+    struct timespec duration;
+    duration.tv_sec = milliseconds / 1000;
+    duration.tv_nsec = (milliseconds % 1000) * 1000000L;
+    while (nanosleep(&duration, &duration) != 0 && errno == EINTR) {
+    }
+}
+
+static int exit_code_for_status(int status) {
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+    return 125;
+}
+
+static int child_is_waitable(pid_t child) {
+    siginfo_t info = {0};
+    int result;
+    do {
+        result = waitid(P_PID, (id_t)child, &info, WEXITED | WNOHANG | WNOWAIT);
+    } while (result != 0 && errno == EINTR);
+    return result == 0 && info.si_pid == child;
+}
+
+static int reap_child(pid_t child, int *status) {
+    pid_t result;
+    do {
+        result = waitpid(child, status, 0);
+    } while (result < 0 && errno == EINTR);
+    return result == child;
+}
+
+static int terminate_group(pid_t child, int signal_number) {
+    int status = 0;
+    int forwarded = signal_number;
+    if (forwarded != SIGINT && forwarded != SIGHUP && forwarded != SIGQUIT) {
+        forwarded = SIGTERM;
+    }
+    (void)kill(-child, SIGCONT);
+    (void)kill(-child, forwarded);
+
+    for (int attempt = 0; attempt < 20; attempt++) {
+        if (child_is_waitable(child)) {
+            (void)kill(-child, SIGKILL);
+            (void)reap_child(child, &status);
+            return 128 + signal_number;
+        }
+        sleep_milliseconds(25);
+    }
+
+    (void)kill(-child, SIGKILL);
+    (void)reap_child(child, &status);
+    return 128 + signal_number;
+}
+
+static int handle_pending_signal(pid_t child) {
+    int signal_number = pending_termination_signal;
+    if (signal_number != 0) {
+        pending_termination_signal = 0;
+        return terminate_group(child, signal_number);
+    }
+    if (pending_stop) {
+        pending_stop = 0;
+        (void)kill(-child, SIGSTOP);
+    }
+    if (pending_continue) {
+        pending_continue = 0;
+        (void)kill(-child, SIGCONT);
+    }
+    return 0;
+}
+
+static int finish_normally(pid_t child) {
+    int status = 0;
+    (void)kill(-child, SIGTERM);
+    sleep_milliseconds(50);
+    (void)kill(-child, SIGKILL);
+    if (!reap_child(child, &status)) {
+        return 125;
+    }
+    return exit_code_for_status(status);
+}
+
+static int monitor_with_polling(pid_t parent, pid_t child) {
+    for (;;) {
+        if (child_is_waitable(child)) {
+            return finish_normally(child);
+        }
+        int signal_result = handle_pending_signal(child);
+        if (signal_result != 0) {
+            return signal_result;
+        }
+        if (getppid() != parent) {
+            return terminate_group(child, SIGTERM);
+        }
+        sleep_milliseconds(50);
+    }
+}
+
+#if defined(__APPLE__)
+static int monitor_with_kqueue(pid_t parent, pid_t child) {
+    int queue = kqueue();
+    if (queue < 0) {
+        return monitor_with_polling(parent, child);
+    }
+
+    struct kevent registrations[2];
+    EV_SET(&registrations[0], parent, EVFILT_PROC, EV_ADD | EV_ONESHOT, NOTE_EXIT, 0, NULL);
+    EV_SET(&registrations[1], child, EVFILT_PROC, EV_ADD | EV_ONESHOT, NOTE_EXIT, 0, NULL);
+    if (kevent(queue, registrations, 2, NULL, 0, NULL) != 0) {
+        close(queue);
+        return monitor_with_polling(parent, child);
+    }
+
+    for (;;) {
+        if (child_is_waitable(child)) {
+            close(queue);
+            return finish_normally(child);
+        }
+        int signal_result = handle_pending_signal(child);
+        if (signal_result != 0) {
+            close(queue);
+            return signal_result;
+        }
+        if (getppid() != parent) {
+            close(queue);
+            return terminate_group(child, SIGTERM);
+        }
+
+        struct kevent event;
+        int event_count = kevent(queue, NULL, 0, &event, 1, NULL);
+        if (event_count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            close(queue);
+            return monitor_with_polling(parent, child);
+        }
+        if (event_count == 1 && (pid_t)event.ident == parent) {
+            close(queue);
+            return terminate_group(child, SIGTERM);
+        }
+    }
+}
+#endif
+
+int main(int argc, char *argv[]) {
+    if (argc < 2 || argv[1][0] != '/') {
+        fprintf(stderr, "usage: quill-code-process-supervisor /absolute/executable [arguments...]\n");
+        return 64;
+    }
+
+    pid_t parent = getppid();
+    if (parent <= 1) {
+        fprintf(stderr, "quill-code process supervisor has no live parent\n");
+        return 125;
+    }
+
+#if defined(__linux__)
+    if (prctl(PR_SET_PDEATHSIG, SIGTERM) != 0) {
+        perror("quill-code process supervisor prctl");
+        return 125;
+    }
+    if (getppid() != parent) {
+        return 125;
+    }
+#endif
+
+    int signals[] = {SIGTERM, SIGINT, SIGHUP, SIGQUIT, SIGTSTP, SIGCONT};
+    for (size_t index = 0; index < sizeof(signals) / sizeof(signals[0]); index++) {
+        if (install_handler(signals[index]) != 0) {
+            perror("quill-code process supervisor sigaction");
+            return 125;
+        }
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        perror("quill-code process supervisor fork");
+        return 125;
+    }
+    if (child == 0) {
+        restore_default_handlers();
+        if (setpgid(0, 0) != 0) {
+            perror("quill-code process supervisor setpgid");
+            _exit(125);
+        }
+        execv(argv[1], &argv[1]);
+        int exec_error = errno;
+        perror("quill-code process supervisor exec");
+        _exit(exec_error == ENOENT ? 127 : 126);
+    }
+
+    if (setpgid(child, child) != 0 && errno != EACCES && errno != ESRCH) {
+        perror("quill-code process supervisor setpgid");
+        (void)kill(child, SIGKILL);
+        (void)waitpid(child, NULL, 0);
+        return 125;
+    }
+
+#if defined(__APPLE__)
+    return monitor_with_kqueue(parent, child);
+#else
+    return monitor_with_polling(parent, child);
+#endif
+}

--- a/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopGateTests.swift
@@ -193,6 +193,8 @@ final class ParityDesktopGateTests: QuillCodeParityTestCase {
         Self.assertSource(crashSmokeText, contains: "activeRunCheckpoint == nil")
         Self.assertSource(crashSmokeText, contains: "toolCards.last?.status == .failed")
         Self.assertSource(crashSmokeText, contains: "failedRunRetryPrompt")
+        Self.assertSource(crashSmokeText, contains: "crash-child.pid")
+        Self.assertSource(crashSmokeText, contains: "guard !processIsAlive(childPID)")
         Self.assertSource(appText, contains: "QuillCodeDesktopAgentRunCrashSmoke.runAndExit")
         Self.assertSource(packagedSmokeText, contains: "--agent-run-crash-phase write")
         Self.assertSource(packagedSmokeText, contains: "--agent-run-crash-phase verify")

--- a/Tests/QuillCodeParityTests/ParityProcessSupervisorGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityProcessSupervisorGateTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+
+final class ParityProcessSupervisorGateTests: QuillCodeParityTestCase {
+    func testPackagedShellsHaveAParentDeathProcessGroupBoundary() throws {
+        let root = Self.packageRoot()
+        let supervisor = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/quill-code-process-supervisor/main.c"
+            ),
+            encoding: .utf8
+        )
+        let resolver = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/QuillCodeTools/ShellProcessSupervisor.swift"
+            ),
+            encoding: .utf8
+        )
+        let shell = try String(
+            contentsOf: root.appendingPathComponent("Sources/QuillCodeTools/ShellToolExecutor.swift"),
+            encoding: .utf8
+        )
+        let streaming = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/QuillCodeTools/ShellStreamingProcessRunner.swift"
+            ),
+            encoding: .utf8
+        )
+        let terminal = try String(
+            contentsOf: root.appendingPathComponent("Sources/QuillCodeTools/PTYProcessSession.swift"),
+            encoding: .utf8
+        )
+
+        Self.assertSource(supervisor, containsAll: [
+            "setpgid(0, 0)",
+            "kill(-child, SIGTERM)",
+            "kill(-child, SIGKILL)",
+            "getppid() != parent",
+            "EVFILT_PROC",
+            "NOTE_EXIT",
+            "WEXITED | WNOHANG | WNOWAIT",
+            "reap_child(child, &status)",
+            "PR_SET_PDEATHSIG"
+        ])
+        Self.assertSource(resolver, containsAll: [
+            "Contents/Helpers",
+            "quill-code-process-supervisor",
+            "[launch.executable.path] + launch.arguments"
+        ])
+        for source in [shell, streaming, terminal] {
+            Self.assertSource(source, contains: "ShellProcessSupervisor.wrapping")
+        }
+    }
+
+    func testDistributionBuildsSignsAndUniversallyMergesTheSupervisor() throws {
+        let build = try Self.scriptText(named: "build-macos-app.sh")
+        let downloads = try Self.scriptText(named: "package-macos-downloads.sh")
+        let linuxDownloads = try Self.scriptText(named: "package-linux-downloads.sh")
+        let universal = try Self.scriptText(named: "package-macos-universal-installer.sh")
+        let packagedSmoke = try Self.scriptText(named: "packaged-macos-smoke.sh")
+        let crashSmoke = try Self.desktopSourceText(named: "QuillCodeDesktopAgentRunCrashSmoke.swift")
+
+        Self.assertSource(build, containsAll: [
+            "--product quill-code-process-supervisor",
+            "HELPERS_DIR=\"$CONTENTS_DIR/Helpers\"",
+            "codesign \"${CODESIGN_ARGUMENTS[@]}\" \"$HELPERS_DIR/quill-code-process-supervisor\""
+        ])
+        Self.assertSource(downloads, containsAll: [
+            "cp \"$BIN_DIR/quill-code-process-supervisor\"",
+            "sudo install -m 755 quill-code-process-supervisor"
+        ])
+        Self.assertSource(linuxDownloads, containsAll: [
+            "--product quill-code-process-supervisor",
+            "cp \"$BIN_DIR/quill-code-process-supervisor\"",
+            "sudo install -m 755 quill-code-process-supervisor"
+        ])
+        Self.assertSource(universal, containsAll: [
+            "SUPERVISOR_RELATIVE_PATH",
+            "MERGED_SUPERVISOR",
+            "-verify_arch arm64 x86_64",
+            "\"$CODESIGN_BIN\" \"${CODESIGN_ARGUMENTS[@]}\" \"$UNIVERSAL_SUPERVISOR\""
+        ])
+        Self.assertSource(packagedSmoke, containsAll: [
+            "PROCESS_SUPERVISOR=",
+            "Packaged process supervisor is missing or not executable"
+        ])
+        Self.assertSource(crashSmoke, containsAll: [
+            "crash-child.pid",
+            "liveChildPID(at: childPIDURL)",
+            "guard !processIsAlive(childPID)",
+            "childProcessSurvived"
+        ])
+    }
+}

--- a/Tests/QuillCodeToolsTests/ShellProcessSupervisorTests.swift
+++ b/Tests/QuillCodeToolsTests/ShellProcessSupervisorTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import QuillCodeTools
+
+final class ShellProcessSupervisorTests: XCTestCase {
+    func testWrappingPreservesSandboxIdentityAndCommandArguments() throws {
+        let supervisor = URL(fileURLWithPath: "/tmp/quill-code-process-supervisor")
+        let launch = ShellProcessLaunch(
+            executable: URL(fileURLWithPath: "/usr/bin/sandbox-exec"),
+            arguments: ["-p", "(version 1)", "--", "/bin/sh", "-lc", "printf ok"],
+            isSandboxed: true
+        )
+
+        let wrapped = ShellProcessSupervisor.wrapping(launch, supervisorURL: supervisor)
+
+        XCTAssertEqual(wrapped.executable, supervisor)
+        XCTAssertEqual(wrapped.arguments, [launch.executable.path] + launch.arguments)
+        XCTAssertTrue(wrapped.isSandboxed)
+    }
+
+    func testMissingSupervisorLeavesLaunchUnchanged() {
+        let launch = ShellProcessLaunch(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-lc", "printf ok"],
+            isSandboxed: false
+        )
+
+        XCTAssertEqual(ShellProcessSupervisor.wrapping(launch, supervisorURL: nil), launch)
+    }
+
+    func testResolverUsesExplicitExecutableOverride() throws {
+        let root = try makeTempDirectory()
+        let supervisor = root.appendingPathComponent("supervisor")
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: supervisor)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: supervisor.path
+        )
+
+        let resolved = ShellProcessSupervisor.resolveExecutable(
+            environment: [ShellProcessSupervisor.environmentKey: supervisor.path],
+            bundle: .main,
+            currentExecutableURL: nil
+        )
+
+        XCTAssertEqual(resolved, supervisor.standardizedFileURL)
+    }
+
+    func testResolverFindsSupervisorBesideCurrentExecutable() throws {
+        let root = try makeTempDirectory()
+        let current = root.appendingPathComponent("quill-code")
+        let supervisor = root.appendingPathComponent(ShellProcessSupervisor.executableName)
+        for executable in [current, supervisor] {
+            try Data("#!/bin/sh\nexit 0\n".utf8).write(to: executable)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executable.path
+            )
+        }
+
+        let resolved = ShellProcessSupervisor.resolveExecutable(
+            environment: [:],
+            bundle: .main,
+            currentExecutableURL: current
+        )
+
+        XCTAssertEqual(resolved, supervisor)
+    }
+}

--- a/Tests/QuillCodeToolsTests/ShellToolExecutorTests.swift
+++ b/Tests/QuillCodeToolsTests/ShellToolExecutorTests.swift
@@ -1,6 +1,11 @@
 import XCTest
 import QuillCodeCore
 @testable import QuillCodeTools
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 final class ShellToolExecutorTests: XCTestCase {
     func testShellRunsWhoami() {
@@ -104,6 +109,44 @@ final class ShellToolExecutorTests: XCTestCase {
         XCTAssertFalse(result.ok)
         XCTAssertTrue(result.error?.contains("cancelled") == true, result.error ?? "")
         XCTAssertFalse(result.stdout.contains("should-not-print"))
+    }
+
+    func testCancellableShellStopsBackgroundDescendants() async throws {
+        let root = try makeTempDirectory()
+        let leaderURL = root.appendingPathComponent("leader.pid")
+        let childURL = root.appendingPathComponent("child.pid")
+        let task = Task {
+            await ShellToolExecutor().runCancellable(.init(
+                command: [
+                    "printf '%s' \"$$\" > '\(leaderURL.path)'",
+                    "sleep 30 & printf '%s' \"$!\" > '\(childURL.path)'",
+                    "wait"
+                ].joined(separator: "; "),
+                cwd: root,
+                timeoutSeconds: 40
+            ))
+        }
+
+        for _ in 0..<100 where !FileManager.default.fileExists(atPath: childURL.path) {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        let leaderPID = try recordedPID(at: leaderURL)
+        let childPID = try recordedPID(at: childURL)
+        defer {
+            _ = kill(leaderPID, SIGKILL)
+            _ = kill(childPID, SIGKILL)
+        }
+
+        task.cancel()
+        let result = await task.value
+        for _ in 0..<100 where processIsAlive(leaderPID) || processIsAlive(childPID) {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+
+        XCTAssertFalse(result.ok)
+        XCTAssertTrue(result.error?.contains("cancelled") == true, result.error ?? "")
+        XCTAssertFalse(processIsAlive(leaderPID), "The shell leader survived cancellation.")
+        XCTAssertFalse(processIsAlive(childPID), "A background shell descendant survived cancellation.")
     }
 
     func testStreamingShellYieldsOutputBeforeCompletion() async throws {
@@ -313,6 +356,17 @@ final class ShellToolExecutorTests: XCTestCase {
         XCTAssertTrue(request.command.contains("'feather.local'"))
         XCTAssertTrue(request.command.contains("cd ~/"))
         XCTAssertTrue(request.command.contains("'Quill Projects'"))
+    }
+
+    private func recordedPID(at url: URL) throws -> pid_t {
+        let value = try String(contentsOf: url, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return try XCTUnwrap(pid_t(value))
+    }
+
+    private func processIsAlive(_ pid: pid_t) -> Bool {
+        if kill(pid, 0) == 0 { return true }
+        return errno != ESRCH
     }
 
     func testSSHRemoteShellRejectsUnsafeDestinationFields() {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,35 @@
 # Code Quality Audit
 
+## 2026-08-12 Owned Shell Process Groups
+
+Overall grade after this slice: **A+ crash containment, A+ process hygiene, A+ distribution integrity**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Parent-death containment | A+ | A 34 KiB native supervisor watches the exact desktop parent with `kqueue` on macOS and a parent-death signal on Linux, then terminates the owned shell process group when Quill Cowork disappears. |
+| Descendant cleanup | A+ | Shell, streaming, and PTY execution place the command in a distinct process group; Stop, timeout, suspend/resume, normal leader exit, and crash cleanup cover pipelines and background descendants. |
+| Signal safety | A+ | Termination intent cannot be overwritten by racing stop/continue signals, and the leader remains waitable but unreaped until group cleanup prevents PID/PGID reuse from targeting unrelated processes. |
+| Resource cost | A+ | The supervisor is a stripped native C helper with no framework runtime; executable discovery is cached once per app process and no additional app-resident cache or monitor thread is introduced. |
+| Packaging | A+ | macOS and Linux CLI archives include the helper; app bundles strip and sign it; universal packaging independently validates and merges arm64/x86_64 helper slices before signing the final app. |
+| Regression evidence | A+ | Behavioral tests kill a supervised shell with a background child, while the packaged smoke records a live shell PID, hard-kills the app, and refuses recovery until that exact child is gone. |
+
+Validation:
+
+- Full Swift package coverage: 6,293 tests executed, 5 platform skips, 0 failures.
+- Focused shell, streaming, PTY, resolver, packaging, and crash contracts: 40 tests, 0 failures.
+- Independent native parent-death and cancellation probes removed the supervisor, shell leader, and
+  background child; the optimized packaged crash probe reaped its recorded child within the first
+  20-millisecond polling interval and recovered the interrupted transcript in a fresh process.
+- Full optimized packaged macOS smoke passed direct executable and Launch Services launches, live
+  Accessibility interaction, coworker, browser, computer-use, 100-chat daily-driver, and both
+  `SIGKILL` recovery paths.
+- Packaged performance measured 342.04 ms launch-ready, 44.59 MiB initial physical footprint,
+  75.95 MiB after the first interaction sweep, 79.95 MiB after repetition, six settled threads,
+  zero idle memory/thread growth, and 0.0003% settled idle CPU.
+- Strict C compilation (`-Wall -Wextra -Werror`), shell syntax checks, signature verification,
+  `git diff --check`, and deterministic quality grading passed; every source and test module summary
+  remains A+.
+
 ## 2026-08-12 Runtime-Attested macOS Keychain Credential Storage
 
 Overall grade after this slice: **A+ credential architecture, A+ update compatibility, A+ migration safety**.

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -135,7 +135,12 @@ the process disappears mid-run, bootstrap clears the dead generation, closes any
 as Failed, records one durable interruption notice, and offers **Review and retry** with a cautious
 continuation prompt. A completed assistant answer or still-undecided approval gate is preserved
 without a false failure. The packaged release smoke starts a real shell tool, kills the app with
-`SIGKILL`, and relaunches the same bundle to verify this path end to end.
+`SIGKILL`, and relaunches the same bundle to verify this path end to end. Packaged shells run through
+a tiny native supervisor that places the command and its descendants in an owned process group. A
+Stop, timeout, terminal cancellation, or unexpected app exit terminates that whole group, with a
+bounded `SIGKILL` fallback. The crash smoke records the live shell PID before killing the app and
+refuses to pass recovery while that process is still alive, so transcript repair cannot hide an
+orphaned side-effecting command.
 
 ## Build Cadence
 

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -52,6 +52,7 @@ if [[ "$BUILD_COMMIT" != "development" && ! "$BUILD_COMMIT" =~ ^[0-9a-f]{40}$ ]]
 fi
 
 SWIFT_BUILD_ARGUMENTS=(--configuration "$CONFIGURATION" --product quill-code-desktop)
+SUPERVISOR_BUILD_ARGUMENTS=(--configuration "$CONFIGURATION" --product quill-code-process-supervisor)
 if [[ -n "$SWIFT_DEBUG_INFO_FORMAT" ]]; then
   case "$SWIFT_DEBUG_INFO_FORMAT" in
     dwarf|codeview|none) ;;
@@ -61,15 +62,23 @@ if [[ -n "$SWIFT_DEBUG_INFO_FORMAT" ]]; then
       ;;
   esac
   SWIFT_BUILD_ARGUMENTS+=(-debug-info-format "$SWIFT_DEBUG_INFO_FORMAT")
+  SUPERVISOR_BUILD_ARGUMENTS+=(-debug-info-format "$SWIFT_DEBUG_INFO_FORMAT")
 fi
 
 echo "==> Building quill-code-desktop ($CONFIGURATION)" >&2
 swift build "${SWIFT_BUILD_ARGUMENTS[@]}" >&2
+echo "==> Building quill-code-process-supervisor ($CONFIGURATION)" >&2
+swift build "${SUPERVISOR_BUILD_ARGUMENTS[@]}" >&2
 BIN_DIR="$(swift build "${SWIFT_BUILD_ARGUMENTS[@]}" --show-bin-path)"
 SOURCE_EXECUTABLE="$BIN_DIR/quill-code-desktop"
+SOURCE_SUPERVISOR="$BIN_DIR/quill-code-process-supervisor"
 
 if [[ ! -x "$SOURCE_EXECUTABLE" ]]; then
   echo "Built executable is missing or not executable: $SOURCE_EXECUTABLE" >&2
+  exit 1
+fi
+if [[ ! -x "$SOURCE_SUPERVISOR" ]]; then
+  echo "Built process supervisor is missing or not executable: $SOURCE_SUPERVISOR" >&2
   exit 1
 fi
 
@@ -77,15 +86,20 @@ APP_BUNDLE="$OUTPUT_DIR/$APP_NAME.app"
 CONTENTS_DIR="$APP_BUNDLE/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 RESOURCES_DIR="$CONTENTS_DIR/Resources"
+HELPERS_DIR="$CONTENTS_DIR/Helpers"
 APP_ICON_SOURCE="$ROOT_DIR/Resources/AppIcon/QuillCode.icns"
 MENU_BAR_ICON_SOURCE="$ROOT_DIR/Resources/MenuBar/QuillCodeMenuBarTemplate.png"
 
 rm -rf "$APP_BUNDLE"
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$HELPERS_DIR"
 cp "$SOURCE_EXECUTABLE" "$MACOS_DIR/$APP_NAME"
+cp "$SOURCE_SUPERVISOR" "$HELPERS_DIR/quill-code-process-supervisor"
 chmod 755 "$MACOS_DIR/$APP_NAME"
+chmod 755 "$HELPERS_DIR/quill-code-process-supervisor"
 if [[ "$CONFIGURATION" == "release" ]]; then
   "$ROOT_DIR/scripts/strip-macos-release-executable.sh" "$MACOS_DIR/$APP_NAME"
+  "$ROOT_DIR/scripts/strip-macos-release-executable.sh" \
+    "$HELPERS_DIR/quill-code-process-supervisor"
 fi
 if [[ -f "$APP_ICON_SOURCE" ]]; then
   cp "$APP_ICON_SOURCE" "$RESOURCES_DIR/QuillCode.icns"
@@ -168,9 +182,11 @@ if [[ -n "$SIGNING_IDENTITY" ]]; then
   if [[ -n "$SIGNING_KEYCHAIN" ]]; then
     CODESIGN_ARGUMENTS+=(--keychain "$SIGNING_KEYCHAIN")
   fi
+  codesign "${CODESIGN_ARGUMENTS[@]}" "$HELPERS_DIR/quill-code-process-supervisor" >&2
   codesign "${CODESIGN_ARGUMENTS[@]}" "$APP_BUNDLE" >&2
   codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE" >&2
 elif [[ "${QUILLCODE_MACOS_ADHOC_CODESIGN:-1}" == "1" ]]; then
+  codesign --force --sign - "$HELPERS_DIR/quill-code-process-supervisor" >&2
   codesign --force --deep --sign - "$APP_BUNDLE" >&2
 fi
 

--- a/scripts/package-linux-downloads.sh
+++ b/scripts/package-linux-downloads.sh
@@ -23,14 +23,18 @@ mkdir -p "$ASSET_DIR" "$CLI_DIR"
 
 echo "==> Packaging quill-code Linux CLI ($ARCH, version $VERSION build $BUILD_NUMBER)"
 swift build --configuration "$CONFIGURATION" --product quill-code >&2
+swift build --configuration "$CONFIGURATION" --product quill-code-process-supervisor >&2
 BIN_DIR="$(swift build --configuration "$CONFIGURATION" --product quill-code --show-bin-path)"
 cp "$BIN_DIR/quill-code" "$CLI_DIR/quill-code"
+cp "$BIN_DIR/quill-code-process-supervisor" "$CLI_DIR/quill-code-process-supervisor"
 chmod 755 "$CLI_DIR/quill-code"
+chmod 755 "$CLI_DIR/quill-code-process-supervisor"
 cat > "$CLI_DIR/README.txt" <<README
 Quill Cowork CLI for Linux $ARCH
 
 Install:
   sudo install -m 755 quill-code /usr/local/bin/quill-code
+  sudo install -m 755 quill-code-process-supervisor /usr/local/bin/quill-code-process-supervisor
 
 Smoke test:
   quill-code "run whoami"

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -146,12 +146,15 @@ fi
 swift build "${SWIFT_BUILD_ARGUMENTS[@]}" >&2
 BIN_DIR="$(swift build "${SWIFT_BUILD_ARGUMENTS[@]}" --show-bin-path)"
 cp "$BIN_DIR/quill-code" "$CLI_DIR/quill-code"
+cp "$BIN_DIR/quill-code-process-supervisor" "$CLI_DIR/quill-code-process-supervisor"
 chmod 755 "$CLI_DIR/quill-code"
+chmod 755 "$CLI_DIR/quill-code-process-supervisor"
 cat > "$CLI_DIR/README.txt" <<README
 Quill Cowork CLI for macOS $ARCH
 
 Install:
   sudo install -m 755 quill-code /usr/local/bin/quill-code
+  sudo install -m 755 quill-code-process-supervisor /usr/local/bin/quill-code-process-supervisor
 
 Smoke test:
   quill-code "run whoami"

--- a/scripts/package-macos-universal-installer.sh
+++ b/scripts/package-macos-universal-installer.sh
@@ -19,6 +19,7 @@ UPDATE_CHANNEL="${QUILLCODE_UPDATE_CHANNEL:-tester}"
 MAXIMUM_ARCHIVE_BYTES=$((1024 * 1024 * 1024))
 APP_NAME="Quill Cowork.app"
 EXECUTABLE_RELATIVE_PATH="Contents/MacOS/Quill Cowork"
+SUPERVISOR_RELATIVE_PATH="Contents/Helpers/quill-code-process-supervisor"
 
 usage() {
   cat <<'USAGE'
@@ -112,6 +113,7 @@ validate_app_bundle() {
   local expected_architecture="$2"
   local app_bundle="$extraction_root/$APP_NAME"
   local executable="$app_bundle/$EXECUTABLE_RELATIVE_PATH"
+  local supervisor="$app_bundle/$SUPERVISOR_RELATIVE_PATH"
   local entries=("$extraction_root"/*)
 
   [[ ${#entries[@]} -eq 1 && "${entries[0]}" == "$app_bundle" && -d "$app_bundle" && ! -L "$app_bundle" ]] || \
@@ -120,6 +122,8 @@ validate_app_bundle() {
     fail "$expected_architecture app has no regular Info.plist." 2
   [[ -f "$executable" && -x "$executable" && ! -L "$executable" ]] || \
     fail "$expected_architecture app has no executable Quill Cowork binary." 2
+  [[ -f "$supervisor" && -x "$supervisor" && ! -L "$supervisor" ]] || \
+    fail "$expected_architecture app has no process supervisor helper." 2
   if find "$app_bundle" \( -type l -o \( ! -type d ! -type f \) \) -print -quit | grep -q .; then
     fail "$expected_architecture app contains a symlink or special filesystem entry." 2
   fi
@@ -131,6 +135,9 @@ validate_app_bundle() {
   architectures="$("$LIPO_BIN" -archs "$executable")"
   [[ "$architectures" == "$expected_architecture" ]] || \
     fail "$expected_architecture source app must contain exactly one $expected_architecture executable slice; found: $architectures" 2
+  architectures="$("$LIPO_BIN" -archs "$supervisor")"
+  [[ "$architectures" == "$expected_architecture" ]] || \
+    fail "$expected_architecture process supervisor must contain exactly one $expected_architecture executable slice; found: $architectures" 2
   "$CODESIGN_BIN" --verify --deep --strict --verbose=2 "$app_bundle"
 }
 
@@ -149,6 +156,7 @@ bundle_inventory() {
     find Contents \
       -path 'Contents/_CodeSignature' -prune -o \
       -path 'Contents/MacOS/Quill Cowork' -prune -o \
+      -path 'Contents/Helpers/quill-code-process-supervisor' -prune -o \
       -print | LC_ALL=C sort
   )
 }
@@ -182,6 +190,15 @@ MERGED_EXECUTABLE="$WORK_DIRECTORY/Quill Cowork"
 chmod 755 "$MERGED_EXECUTABLE"
 mv "$MERGED_EXECUTABLE" "$UNIVERSAL_EXECUTABLE"
 "$LIPO_BIN" "$UNIVERSAL_EXECUTABLE" -verify_arch arm64 x86_64
+UNIVERSAL_SUPERVISOR="$UNIVERSAL_APP/$SUPERVISOR_RELATIVE_PATH"
+MERGED_SUPERVISOR="$WORK_DIRECTORY/quill-code-process-supervisor"
+"$LIPO_BIN" -create \
+  "$ARM64_APP/$SUPERVISOR_RELATIVE_PATH" \
+  "$X86_64_APP/$SUPERVISOR_RELATIVE_PATH" \
+  -output "$MERGED_SUPERVISOR"
+chmod 755 "$MERGED_SUPERVISOR"
+mv "$MERGED_SUPERVISOR" "$UNIVERSAL_SUPERVISOR"
+"$LIPO_BIN" "$UNIVERSAL_SUPERVISOR" -verify_arch arm64 x86_64
 
 if [[ -n "$SIGNING_IDENTITY" ]]; then
   CODESIGN_ARGUMENTS=(
@@ -193,8 +210,10 @@ if [[ -n "$SIGNING_IDENTITY" ]]; then
   if [[ -n "$SIGNING_KEYCHAIN" ]]; then
     CODESIGN_ARGUMENTS+=(--keychain "$SIGNING_KEYCHAIN")
   fi
+  "$CODESIGN_BIN" "${CODESIGN_ARGUMENTS[@]}" "$UNIVERSAL_SUPERVISOR"
   "$CODESIGN_BIN" "${CODESIGN_ARGUMENTS[@]}" "$UNIVERSAL_APP"
 else
+  "$CODESIGN_BIN" --force --sign - "$UNIVERSAL_SUPERVISOR"
   "$CODESIGN_BIN" --force --deep --sign - "$UNIVERSAL_APP"
 fi
 "$CODESIGN_BIN" --verify --deep --strict --verbose=2 "$UNIVERSAL_APP"

--- a/scripts/packaged-macos-smoke.sh
+++ b/scripts/packaged-macos-smoke.sh
@@ -158,6 +158,7 @@ APP_BUNDLE="$(
 )"
 INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
 APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/Quill Cowork"
+PROCESS_SUPERVISOR="$APP_BUNDLE/Contents/Helpers/quill-code-process-supervisor"
 EXPECTED_BUILD_COMMIT="$(git rev-parse HEAD)"
 
 assert_plist_value() {
@@ -197,6 +198,10 @@ if [[ ! -d "$APP_BUNDLE" ]]; then
 fi
 if [[ ! -x "$APP_EXECUTABLE" ]]; then
   echo "Packaged app executable is missing or not executable: $APP_EXECUTABLE" >&2
+  exit 1
+fi
+if [[ ! -x "$PROCESS_SUPERVISOR" ]]; then
+  echo "Packaged process supervisor is missing or not executable: $PROCESS_SUPERVISOR" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- supervise shell, streaming, and PTY commands in owned native process groups
- terminate descendant processes on stop, timeout, normal leader exit, or hard app crash
- package, sign, and universal-merge the helper for macOS and include it in macOS/Linux CLI archives
- strengthen packaged crash recovery to prove the live shell child is reaped

## Validation
- full Swift suite: 6,293 tests, 5 skipped, 0 failures
- focused supervisor/crash suite: 40 tests, 0 failures
- optimized packaged macOS smoke passed, including SIGKILL recovery and daily-driver performance gates
- strict C compile, shell syntax, codesign verification, and git diff checks passed