### PR TITLE
Continue updates after relocation and guide signed-out sends

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeConnectView.swift
+++ b/Sources/QuillCodeApp/QuillCodeConnectView.swift
@@ -23,7 +23,6 @@ struct QuillCodeConnectView: View {
 
             Text(TranscriptConnectPrompt.title)
                 .font(.title3.weight(.semibold))
-                .tracking(-0.3)
                 .foregroundStyle(QuillCodePalette.text)
 
             Text(TranscriptConnectPrompt.subtitle)

--- a/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
+++ b/Sources/QuillCodeApp/QuillCodeTranscriptView.swift
@@ -370,7 +370,6 @@ struct QuillCodeTranscriptView: View {
             VStack(spacing: 14) {
                 Text(transcript.emptyTitle)
                     .font(.title3.weight(.semibold))
-                    .tracking(-0.3)
                     .foregroundStyle(QuillCodePalette.text)
                 Text(transcript.emptySubtitle)
                     .font(.callout)
@@ -402,7 +401,6 @@ struct QuillCodeTranscriptView: View {
             .accessibilityHidden(true)
             Text("This chat is confidential")
                 .font(.title3.weight(.semibold))
-                .tracking(-0.3)
                 .foregroundStyle(QuillCodePalette.text)
             VStack(alignment: .leading, spacing: 8) {
                 confidentialGuarantee("internaldrive", "Never saved — destroyed when you leave")

--- a/Sources/QuillCodeApp/WorkspaceComposerSubmissionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceComposerSubmissionPlanner.swift
@@ -37,3 +37,30 @@ struct WorkspaceComposerSubmissionPlanner {
         return .agent(prompt: prompt)
     }
 }
+
+enum WorkspaceComposerSendAction: Equatable {
+    case ignore
+    case requestTrustedRouterSignIn
+    case presentWorkspaceCommand(String)
+    case submit
+}
+
+struct WorkspaceComposerSendPlanner {
+    static func action(
+        for submission: WorkspaceComposerSubmissionPlanner.Plan,
+        hasStoredAPIKey: Bool,
+        presentedWorkspaceCommandIDs: Set<String>
+    ) -> WorkspaceComposerSendAction {
+        switch submission {
+        case .ignore:
+            return .ignore
+        case .agent, .scheduledCoworker:
+            return hasStoredAPIKey ? .submit : .requestTrustedRouterSignIn
+        case .slash(.workspaceCommand(let commandID), _)
+            where presentedWorkspaceCommandIDs.contains(commandID):
+            return .presentWorkspaceCommand(commandID)
+        case .slash:
+            return .submit
+        }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
+++ b/Sources/QuillCodeApp/WorkspaceSwiftUIView.swift
@@ -508,18 +508,30 @@ public struct QuillCodeWorkspaceView: View {
     }
 
     private func handleComposerSend() {
-        guard case .slash(.workspaceCommand(let commandID), _) =
-            WorkspaceComposerSubmissionPlanner.plan(
-                draft: draft,
-                hasAttachments: !surface.composer.attachments.isEmpty
-            ),
-            Self.composerPresentedCommandIDs.contains(commandID)
-        else {
+        let submission = WorkspaceComposerSubmissionPlanner.plan(
+            draft: draft,
+            hasAttachments: !surface.composer.attachments.isEmpty
+        )
+        switch WorkspaceComposerSendPlanner.action(
+            for: submission,
+            hasStoredAPIKey: surface.settings.hasStoredAPIKey,
+            presentedWorkspaceCommandIDs: Self.composerPresentedCommandIDs
+        ) {
+        case .ignore:
+            return
+        case .requestTrustedRouterSignIn:
+            actions.onStartTrustedRouterSignIn()
+            return
+        case .submit:
             actions.onSend()
             return
+        case .presentWorkspaceCommand(let commandID):
+            draft = ""
+            presentComposerCommand(commandID)
         }
+    }
 
-        draft = ""
+    private func presentComposerCommand(_ commandID: String) {
         switch commandID {
         case "search":
             presentSearch()

--- a/Sources/quill-code-desktop/QuillCodeDesktopController+Settings.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController+Settings.swift
@@ -52,7 +52,7 @@ extension QuillCodeDesktopController {
     }
 
     func startTrustedRouterSignIn() {
-        Task { @MainActor [weak self] in
+        tasks.startIfIdle(.trustedRouterSignIn) { [weak self] in
             guard let self else { return }
             await signInCoordinator.completeSignInAndApply(
                 to: model,

--- a/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationController.swift
@@ -21,12 +21,14 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
     private let inspector: any QuillCodeDesktopUpdateInstallationInspecting
     private let relocator: any QuillCodeDesktopApplicationRelocating
     private let defaults: UserDefaults
+    private let relocationUpdateIntentStore: QuillCodeDesktopRelocationUpdateIntentStore
     private let applicationsURL: URL
     private let openApplications: @MainActor (URL) -> Void
     private let hasOtherRunningCopy: @MainActor (String) -> Bool
     private let terminateApplication: @MainActor () -> Void
     private var operationTask: Task<Void, Never>?
     private var generation = UUID()
+    private var continuesUpdateAfterRelaunch = false
 
     init(
         configuration: QuillCodeDesktopUpdateConfiguration? = .bundled(),
@@ -35,6 +37,7 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
         relocator: any QuillCodeDesktopApplicationRelocating =
             QuillCodeDesktopApplicationRelocator(),
         defaults: UserDefaults = .standard,
+        relocationUpdateIntentStore: QuillCodeDesktopRelocationUpdateIntentStore? = nil,
         applicationsURL: URL = URL(fileURLWithPath: "/Applications", isDirectory: true),
         openApplications: @escaping @MainActor (URL) -> Void = {
             _ = NSWorkspace.shared.open($0)
@@ -54,6 +57,8 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
         self.inspector = inspector
         self.relocator = relocator
         self.defaults = defaults
+        self.relocationUpdateIntentStore = relocationUpdateIntentStore
+            ?? QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults)
         self.applicationsURL = applicationsURL.standardizedFileURL
         self.openApplications = openApplications
         self.hasOtherRunningCopy = hasOtherRunningCopy
@@ -65,23 +70,45 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
     }
 
     func startIfNeeded() {
-        guard !isPresented,
-              let configuration,
+        guard !isPresented, let configuration else { return }
+        let pendingUpdate = relocationUpdateIntentStore.hasPendingIntent(
+            configuration: configuration
+        )
+        guard
               inspector.availability(for: configuration) == .requiresRelocation,
               !Self.isInsideApplications(
                   configuration.applicationURL,
                   applicationsURL: applicationsURL
               ),
-              !defaults.bool(forKey: dismissalKey(for: configuration))
+              pendingUpdate || !defaults.bool(forKey: dismissalKey(for: configuration))
         else {
             return
         }
+        continuesUpdateAfterRelaunch = pendingUpdate
         state = .ready
         isPresented = true
     }
 
+    @discardableResult
+    func presentForUpdate() -> Bool {
+        guard let configuration,
+              inspector.availability(for: configuration) == .requiresRelocation,
+              !Self.isInsideApplications(
+                  configuration.applicationURL,
+                  applicationsURL: applicationsURL
+              )
+        else {
+            return false
+        }
+        continuesUpdateAfterRelaunch = true
+        state = .ready
+        isPresented = true
+        return true
+    }
+
     func dismiss() {
         guard !state.isBusy else { return }
+        continuesUpdateAfterRelaunch = false
         guard let configuration else {
             isPresented = false
             return
@@ -118,6 +145,8 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
         state = .moving
         let relocator = relocator
         let applicationsURL = applicationsURL
+        let continuesUpdateAfterRelaunch = continuesUpdateAfterRelaunch
+        let relocationUpdateIntentStore = relocationUpdateIntentStore
         operationTask = Task { [weak self] in
             do {
                 try await relocator.stageAndLaunch(
@@ -127,6 +156,9 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
                 try Task.checkCancellation()
                 guard let self, self.generation == operationGeneration else { return }
                 self.operationTask = nil
+                if continuesUpdateAfterRelaunch {
+                    relocationUpdateIntentStore.record(configuration: configuration)
+                }
                 self.terminateApplication()
             } catch is CancellationError {
                 guard let self, self.generation == operationGeneration else { return }

--- a/Sources/quill-code-desktop/QuillCodeDesktopRelocationUpdateContinuation.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopRelocationUpdateContinuation.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+@MainActor
+final class QuillCodeDesktopRelocationUpdateContinuation {
+    enum Action: Equatable {
+        case none
+        case awaitingResult
+        case checkForUpdates
+        case failed(message: String)
+    }
+
+    struct Startup: Equatable {
+        var action: Action
+        var delaysAutomaticCheck: Bool
+    }
+
+    private static let mismatchedResultMessage =
+        "Quill Cowork could not confirm the completed move. Reopen it and check for updates again."
+
+    private let intentStore: QuillCodeDesktopRelocationUpdateIntentStore
+    private let installationInspector: any QuillCodeDesktopUpdateInstallationInspecting
+    private let resultURL: URL?
+    private let timeout: Duration
+    private var resultTask: Task<Void, Never>?
+
+    init(
+        intentStore: QuillCodeDesktopRelocationUpdateIntentStore,
+        installationInspector: any QuillCodeDesktopUpdateInstallationInspecting,
+        resultURL: URL?,
+        timeout: Duration
+    ) {
+        self.intentStore = intentStore
+        self.installationInspector = installationInspector
+        self.resultURL = resultURL
+        self.timeout = timeout
+    }
+
+    deinit {
+        resultTask?.cancel()
+    }
+
+    func discardPreviousResult() {
+        _ = QuillCodeDesktopUpdateInstallResultReader.take(from: resultURL)
+    }
+
+    func start(
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        onCompletion: @escaping @MainActor (Action) -> Void
+    ) -> Startup {
+        let previousResult = QuillCodeDesktopUpdateInstallResultReader.take(from: resultURL)
+        let hasIntent = intentStore.hasPendingIntent(configuration: configuration)
+
+        if let previousResult, previousResult.status == .failure {
+            if hasIntent {
+                _ = intentStore.consume(configuration: configuration)
+            }
+            return Startup(
+                action: .failed(message: previousResult.message),
+                delaysAutomaticCheck: hasIntent
+            )
+        }
+        guard hasIntent else {
+            return Startup(action: .none, delaysAutomaticCheck: false)
+        }
+        if let previousResult {
+            _ = intentStore.consume(configuration: configuration)
+            guard resultMatches(previousResult, configuration: configuration) else {
+                return Startup(
+                    action: .failed(message: Self.mismatchedResultMessage),
+                    delaysAutomaticCheck: true
+                )
+            }
+            return Startup(action: .checkForUpdates, delaysAutomaticCheck: true)
+        }
+
+        waitForResult(configuration: configuration, onCompletion: onCompletion)
+        return Startup(action: .awaitingResult, delaysAutomaticCheck: true)
+    }
+
+    private func waitForResult(
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        onCompletion: @escaping @MainActor (Action) -> Void
+    ) {
+        resultTask?.cancel()
+        let resultURL = resultURL
+        let timeout = timeout
+        resultTask = Task { [weak self] in
+            let result = await QuillCodeDesktopUpdateInstallResultReader.wait(
+                at: resultURL,
+                timeout: timeout
+            )
+            guard !Task.isCancelled, let self else { return }
+            self.resultTask = nil
+            if let result {
+                _ = self.intentStore.consume(configuration: configuration)
+                if result.status == .failure {
+                    onCompletion(.failed(message: result.message))
+                } else if self.resultMatches(result, configuration: configuration) {
+                    onCompletion(.checkForUpdates)
+                } else {
+                    onCompletion(.failed(message: Self.mismatchedResultMessage))
+                }
+                return
+            }
+            guard self.installationInspector.availability(for: configuration) == .available,
+                  self.intentStore.consume(configuration: configuration)
+            else {
+                return
+            }
+            onCompletion(.checkForUpdates)
+        }
+    }
+
+    private func resultMatches(
+        _ result: QuillCodeDesktopUpdateInstallResult,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> Bool {
+        result.status == .success &&
+            result.version == configuration.currentVersion &&
+            result.build == configuration.currentBuild
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopRootView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopRootView.swift
@@ -215,7 +215,13 @@ private struct QuillCodeDesktopDistributionPresentation: ViewModifier {
                     controller: installationLocationController
                 )
             } else {
-                QuillCodeDesktopUpdateView(controller: updateController)
+                QuillCodeDesktopUpdateView(
+                    controller: updateController,
+                    onMoveToApplications: {
+                        guard !installationLocationController.presentForUpdate() else { return }
+                        updateController.openManualInstaller()
+                    }
+                )
             }
         }
     }

--- a/Sources/quill-code-desktop/QuillCodeDesktopTaskCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopTaskCoordinator.swift
@@ -14,6 +14,7 @@ final class QuillCodeDesktopTaskCoordinator {
         case automationTicker
         case modelCatalogRefresh
         case modelCatalogRefreshTicker
+        case trustedRouterSignIn
         case trustedRouterCreditsRefresh
         case trustedRouterCreditsRefreshTicker
         case workflowRecording

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import QuillCodePersistence
 
 @MainActor
 final class QuillCodeDesktopUpdateController: ObservableObject {
@@ -18,7 +17,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     private let now: () -> Date
     private let automaticSchedule: QuillCodeDesktopUpdateSchedule
     private let reminderStore: QuillCodeDesktopUpdateReminderStore
-    private let installResultURL: URL?
+    private let relocationContinuation: QuillCodeDesktopRelocationUpdateContinuation
     private let terminateApplication: @MainActor () -> Void
     private var operationTask: Task<Void, Never>?
     private var automaticTask: Task<Void, Never>?
@@ -45,6 +44,8 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         now: @escaping () -> Date = Date.init,
         automaticSchedule: QuillCodeDesktopUpdateSchedule = .production,
         reminderInterval: TimeInterval = QuillCodeDesktopUpdateReminderStore.productionInterval,
+        relocationUpdateIntentStore: QuillCodeDesktopRelocationUpdateIntentStore? = nil,
+        relocationContinuationTimeout: Duration = .seconds(15),
         installResultURL: URL? = try? QuillCodeDesktopUpdatePaths.installResultURL(),
         terminateApplication: @escaping @MainActor () -> Void =
             QuillCodeDesktopSystemApplication.terminateForUpdate
@@ -62,7 +63,14 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             defaults: defaults,
             reminderInterval: reminderInterval
         )
-        self.installResultURL = installResultURL
+        let intentStore = relocationUpdateIntentStore
+            ?? QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults, now: now)
+        self.relocationContinuation = QuillCodeDesktopRelocationUpdateContinuation(
+            intentStore: intentStore,
+            installationInspector: installationInspector,
+            resultURL: installResultURL,
+            timeout: relocationContinuationTimeout
+        )
         self.terminateApplication = terminateApplication
     }
 
@@ -75,20 +83,32 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     func startAutomaticChecks() {
         guard !didStartAutomaticChecks else { return }
         didStartAutomaticChecks = true
-        consumePreviousInstallResult()
-        guard let configuration else { return }
+        guard let configuration else {
+            relocationContinuation.discardPreviousResult()
+            return
+        }
+        let continuationStartup = relocationContinuation.start(
+            configuration: configuration,
+            onCompletion: { [weak self] action in
+                self?.applyRelocationContinuationAction(action)
+            }
+        )
 
         let recovery = recovery
         recoveryTask = Task {
             await recovery.recoverInterruptedUpdate(configuration: configuration)
         }
 
+        applyRelocationContinuationAction(continuationStartup.action)
+
         let schedule = automaticSchedule
-        let firstDelay = schedule.firstDelay(
-            lastSuccessfulCheck: lastSuccessfulCheck(configuration: configuration),
-            now: now(),
-            channel: configuration.channel
-        )
+        let firstDelay = continuationStartup.delaysAutomaticCheck
+            ? schedule.interval(for: configuration.channel)
+            : schedule.firstDelay(
+                lastSuccessfulCheck: lastSuccessfulCheck(configuration: configuration),
+                now: now(),
+                channel: configuration.channel
+            )
         automaticTask = Task { [weak self] in
             var delay = firstDelay
             while !Task.isCancelled {
@@ -217,7 +237,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         NSWorkspace.shared.open(release.manualInstallationURL)
     }
 
-    var updateRequiresManualInstallation: Bool {
+    var updateRequiresRelocation: Bool {
         guard state.release != nil,
               let configuration
         else {
@@ -385,20 +405,18 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         "QuillCodeUpdater.lastSuccessfulCheck.\(configuration.channel.rawValue)"
     }
 
-    private func consumePreviousInstallResult() {
-        guard let installResultURL else { return }
-        defer { try? FileManager.default.removeItem(at: installResultURL) }
-
-        guard let data = try? BoundedFileDataReader.readIfPresent(
-            from: installResultURL,
-            maximumBytes: QuillCodeDesktopUpdateInstallResult.maximumEncodedBytes
-        ),
-              let result = try? JSONDecoder().decode(QuillCodeDesktopUpdateInstallResult.self, from: data)
-        else {
+    private func applyRelocationContinuationAction(
+        _ action: QuillCodeDesktopRelocationUpdateContinuation.Action
+    ) {
+        switch action {
+        case .none, .awaitingResult:
             return
+        case .checkForUpdates:
+            checkForUpdates()
+        case .failed(let message):
+            _ = beginNewOperation()
+            state = .failed(message: message, release: nil)
+            isPresented = true
         }
-        guard result.status == .failure else { return }
-        state = .failed(message: result.message, release: nil)
-        isPresented = true
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateSupport.swift
@@ -1,4 +1,98 @@
 import Foundation
+import QuillCodePersistence
+
+struct QuillCodeDesktopUpdateInstallResultReader: Sendable {
+    static func take(from url: URL?) -> QuillCodeDesktopUpdateInstallResult? {
+        guard let url else { return nil }
+        defer { try? FileManager.default.removeItem(at: url) }
+        guard let data = try? BoundedFileDataReader.readIfPresent(
+            from: url,
+            maximumBytes: QuillCodeDesktopUpdateInstallResult.maximumEncodedBytes
+        ) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(QuillCodeDesktopUpdateInstallResult.self, from: data)
+    }
+
+    static func wait(
+        at url: URL?,
+        timeout: Duration,
+        pollInterval: Duration = .milliseconds(100)
+    ) async -> QuillCodeDesktopUpdateInstallResult? {
+        guard timeout > .zero else { return take(from: url) }
+        let interval = pollInterval > .zero ? pollInterval : .milliseconds(100)
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !Task.isCancelled, clock.now < deadline {
+            let nextPoll = min(clock.now.advanced(by: interval), deadline)
+            do {
+                try await clock.sleep(until: nextPoll)
+            } catch {
+                return nil
+            }
+            if let result = take(from: url) {
+                return result
+            }
+        }
+        return nil
+    }
+}
+
+@MainActor
+struct QuillCodeDesktopRelocationUpdateIntentStore {
+    static let maximumAge: TimeInterval = 15 * 60
+    static let clockSkewTolerance: TimeInterval = 60
+
+    private let defaults: UserDefaults
+    private let now: () -> Date
+
+    init(
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.defaults = defaults
+        self.now = now
+    }
+
+    func record(configuration: QuillCodeDesktopUpdateConfiguration) {
+        defaults.set(now(), forKey: key(for: configuration))
+    }
+
+    func hasPendingIntent(configuration: QuillCodeDesktopUpdateConfiguration) -> Bool {
+        let intentKey = key(for: configuration)
+        guard let recordedAt = defaults.object(forKey: intentKey) as? Date,
+              isFresh(recordedAt)
+        else {
+            defaults.removeObject(forKey: intentKey)
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    func consume(configuration: QuillCodeDesktopUpdateConfiguration) -> Bool {
+        let intentKey = key(for: configuration)
+        defer { defaults.removeObject(forKey: intentKey) }
+        guard let recordedAt = defaults.object(forKey: intentKey) as? Date else {
+            return false
+        }
+        return isFresh(recordedAt)
+    }
+
+    private func isFresh(_ recordedAt: Date) -> Bool {
+        let age = now().timeIntervalSince(recordedAt)
+        return age >= -Self.clockSkewTolerance && age <= Self.maximumAge
+    }
+
+    private func key(for configuration: QuillCodeDesktopUpdateConfiguration) -> String {
+        [
+            "QuillCodeUpdater.continueAfterRelocation",
+            configuration.bundleIdentifier,
+            configuration.channel.rawValue,
+            configuration.currentBuild
+        ].joined(separator: ".")
+    }
+}
 
 struct QuillCodeDesktopUpdateLaunchHandshake: Equatable, Sendable {
     static let argument = "--quillcode-update-handshake"

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateView.swift
@@ -3,6 +3,7 @@ import QuillCodeApp
 
 struct QuillCodeDesktopUpdateView: View {
     @ObservedObject var controller: QuillCodeDesktopUpdateController
+    let onMoveToApplications: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -172,10 +173,10 @@ struct QuillCodeDesktopUpdateView: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                if controller.updateRequiresManualInstallation {
+                if controller.updateRequiresRelocation {
                     Label(
-                        "Install Quill Cowork in Applications, then reopen it to receive updates.",
-                        systemImage: "externaldrive.badge.exclamationmark"
+                        "Move Quill Cowork to Applications once. It will reopen and continue this update.",
+                        systemImage: "folder.badge.plus"
                     )
                 } else {
                     Label("SHA-256 integrity verified before install", systemImage: "checkmark.shield")
@@ -255,13 +256,13 @@ struct QuillCodeDesktopUpdateView: View {
                     .quillCodeFormActionTarget(minWidth: 154)
                     .accessibilityIdentifier("quillcode-update-remind-later")
                 Spacer()
-                if controller.updateRequiresManualInstallation {
-                    Button(action: controller.openManualInstaller) {
-                        Label("Download Installer", systemImage: "arrow.down.app.fill")
+                if controller.updateRequiresRelocation {
+                    Button(action: onMoveToApplications) {
+                        Label("Move to Applications", systemImage: "folder.badge.plus")
                     }
-                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 168))
-                    .quillCodeFormActionTarget(minWidth: 168)
-                    .accessibilityIdentifier("quillcode-update-manual-installer")
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 184))
+                    .quillCodeFormActionTarget(minWidth: 184)
+                    .accessibilityIdentifier("quillcode-update-move-to-applications")
                 } else {
                     Button(action: controller.updateAndRelaunch) {
                         Label("Update and Relaunch", systemImage: "arrow.down.circle.fill")
@@ -281,7 +282,7 @@ struct QuillCodeDesktopUpdateView: View {
                     .font(.caption)
                     .foregroundStyle(QuillCodeCharterTheme.body)
             case .failed(_, let release):
-                if release != nil && !controller.updateRequiresManualInstallation {
+                if release != nil && !controller.updateRequiresRelocation {
                     Button(action: controller.openManualInstaller) {
                         Label("Download Installer", systemImage: "arrow.down.app")
                     }
@@ -289,13 +290,13 @@ struct QuillCodeDesktopUpdateView: View {
                     .quillCodeFormActionTarget()
                 }
                 Spacer()
-                if release != nil && controller.updateRequiresManualInstallation {
-                    Button(action: controller.openManualInstaller) {
-                        Label("Download Installer", systemImage: "arrow.down.app.fill")
+                if release != nil && controller.updateRequiresRelocation {
+                    Button(action: onMoveToApplications) {
+                        Label("Move to Applications", systemImage: "folder.badge.plus")
                     }
-                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 150))
-                    .quillCodeFormActionTarget(minWidth: 150)
-                    .accessibilityIdentifier("quillcode-update-manual-installer")
+                    .buttonStyle(QuillCodeActionButtonStyle(.primary, minWidth: 184))
+                    .quillCodeFormActionTarget(minWidth: 184)
+                    .accessibilityIdentifier("quillcode-update-move-to-applications")
                 } else if release != nil {
                     Button(action: controller.updateAndRelaunch) {
                         Label("Try Again", systemImage: "arrow.down.circle.fill")

--- a/Tests/QuillCodeAppTests/WorkspaceComposerSubmissionPlannerTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceComposerSubmissionPlannerTests.swift
@@ -71,4 +71,75 @@ final class WorkspaceComposerSubmissionPlannerTests: XCTestCase {
             .slash(command: .workspaceCommand("toggle-activity"), originalPrompt: "/activity")
         )
     }
+
+    func testSignedOutModelWorkRequestsSignInWithoutConsumingTheSubmission() {
+        let presentedCommands: Set<String> = ["settings"]
+
+        XCTAssertEqual(
+            WorkspaceComposerSendPlanner.action(
+                for: .agent(prompt: "Fix the failing test"),
+                hasStoredAPIKey: false,
+                presentedWorkspaceCommandIDs: presentedCommands
+            ),
+            .requestTrustedRouterSignIn
+        )
+        XCTAssertEqual(
+            WorkspaceComposerSendPlanner.action(
+                for: WorkspaceComposerSubmissionPlanner.plan(draft: "", hasAttachments: true),
+                hasStoredAPIKey: false,
+                presentedWorkspaceCommandIDs: presentedCommands
+            ),
+            .requestTrustedRouterSignIn
+        )
+        XCTAssertEqual(
+            WorkspaceComposerSendPlanner.action(
+                for: WorkspaceComposerSubmissionPlanner.plan(
+                    draft: "Every Monday at 8am, review open pull requests"
+                ),
+                hasStoredAPIKey: false,
+                presentedWorkspaceCommandIDs: presentedCommands
+            ),
+            .requestTrustedRouterSignIn
+        )
+    }
+
+    func testSignedOutLocalCommandsRemainAvailable() {
+        let presentedCommands: Set<String> = ["settings"]
+
+        XCTAssertEqual(
+            WorkspaceComposerSendPlanner.action(
+                for: WorkspaceComposerSubmissionPlanner.plan(draft: "/settings"),
+                hasStoredAPIKey: false,
+                presentedWorkspaceCommandIDs: presentedCommands
+            ),
+            .presentWorkspaceCommand("settings")
+        )
+        XCTAssertEqual(
+            WorkspaceComposerSendPlanner.action(
+                for: WorkspaceComposerSubmissionPlanner.plan(draft: "/plugins"),
+                hasStoredAPIKey: false,
+                presentedWorkspaceCommandIDs: presentedCommands
+            ),
+            .submit
+        )
+    }
+
+    func testConnectedModelWorkAndBlankSubmissionsKeepTheirExistingRoutes() {
+        XCTAssertEqual(
+            WorkspaceComposerSendPlanner.action(
+                for: .agent(prompt: "Fix the failing test"),
+                hasStoredAPIKey: true,
+                presentedWorkspaceCommandIDs: []
+            ),
+            .submit
+        )
+        XCTAssertEqual(
+            WorkspaceComposerSendPlanner.action(
+                for: .ignore,
+                hasStoredAPIKey: false,
+                presentedWorkspaceCommandIDs: []
+            ),
+            .ignore
+        )
+    }
 }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopConcurrentChatTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopConcurrentChatTests.swift
@@ -275,6 +275,18 @@ final class QuillCodeDesktopConcurrentChatTests: XCTestCase {
         XCTAssertFalse(tasks.isRunning(slot))
     }
 
+    func testTrustedRouterSignInRejectsACompetingFlow() {
+        let tasks = QuillCodeDesktopTaskCoordinator()
+
+        XCTAssertTrue(tasks.startIfIdle(.trustedRouterSignIn) {
+            try? await Task.sleep(nanoseconds: 60_000_000_000)
+        })
+        XCTAssertFalse(tasks.startIfIdle(.trustedRouterSignIn) {})
+
+        tasks.cancel(.trustedRouterSignIn)
+        XCTAssertFalse(tasks.isRunning(.trustedRouterSignIn))
+    }
+
     private func waitUntil(
         timeoutSeconds: TimeInterval,
         condition: @MainActor @escaping () -> Bool,

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopInstallationLocationTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopInstallationLocationTests.swift
@@ -55,6 +55,32 @@ final class QuillCodeDesktopInstallationLocationTests: XCTestCase {
         XCTAssertTrue(nextBuildController.isPresented)
     }
 
+    func testPendingUpdateRelocationOverridesEarlierDismissal() {
+        let defaults = makeDefaults()
+        let configuration = makeDiskImageConfiguration()
+        let controller = makeController(
+            configuration: configuration,
+            availability: .requiresRelocation,
+            defaults: defaults
+        )
+        controller.startIfNeeded()
+        controller.dismiss()
+        XCTAssertFalse(controller.isPresented)
+
+        QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults).record(
+            configuration: configuration
+        )
+        let relaunchedController = makeController(
+            configuration: configuration,
+            availability: .requiresRelocation,
+            defaults: defaults
+        )
+
+        relaunchedController.startIfNeeded()
+
+        XCTAssertTrue(relaunchedController.isPresented)
+    }
+
     func testOpenApplicationsDismissesAndOpensConfiguredFolder() {
         let applicationsURL = URL(fileURLWithPath: "/Test Applications", isDirectory: true)
         var openedURL: URL?
@@ -93,6 +119,53 @@ final class QuillCodeDesktopInstallationLocationTests: XCTestCase {
         let call = try XCTUnwrap(calls.first)
         XCTAssertEqual(call.configuration, makeDiskImageConfiguration())
         XCTAssertEqual(call.applicationsURL, applicationsURL.standardizedFileURL)
+    }
+
+    func testUpdateRequestedMoveRecordsOneShotContinuationAfterStaging() async throws {
+        let defaults = makeDefaults()
+        let configuration = makeDiskImageConfiguration()
+        let intentStore = QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults)
+        let relocator = InstallationRelocatorSpy()
+        var terminationCount = 0
+        let controller = makeController(
+            configuration: configuration,
+            availability: .requiresRelocation,
+            defaults: defaults,
+            relocator: relocator,
+            terminateApplication: { terminationCount += 1 }
+        )
+
+        XCTAssertTrue(controller.presentForUpdate())
+        controller.moveAndRelaunch()
+
+        try await waitUntil { terminationCount == 1 }
+        XCTAssertTrue(intentStore.hasPendingIntent(configuration: configuration))
+        XCTAssertTrue(intentStore.consume(configuration: configuration))
+        XCTAssertFalse(intentStore.consume(configuration: configuration))
+    }
+
+    func testExpiredUpdateRelocationIntentDoesNotOverrideDismissal() {
+        let defaults = makeDefaults()
+        let configuration = makeDiskImageConfiguration()
+        var date = Date(timeIntervalSince1970: 10_000)
+        let intentStore = QuillCodeDesktopRelocationUpdateIntentStore(
+            defaults: defaults,
+            now: { date }
+        )
+        intentStore.record(configuration: configuration)
+        date.addTimeInterval(QuillCodeDesktopRelocationUpdateIntentStore.maximumAge + 1)
+
+        let controller = makeController(
+            configuration: configuration,
+            availability: .requiresRelocation,
+            defaults: defaults
+        )
+        controller.startIfNeeded()
+        controller.dismiss()
+        controller.startIfNeeded()
+
+        XCTAssertFalse(intentStore.hasPendingIntent(configuration: configuration))
+        XCTAssertFalse(controller.isPresented)
     }
 
     func testMoveFailureOffersRetryWithoutTerminating() async throws {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopRenderedSmokeTests.swift
@@ -190,7 +190,7 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         defer { controller.cancelCurrentOperation() }
 
         let image = try renderHostedView(
-            QuillCodeDesktopUpdateView(controller: controller),
+            QuillCodeDesktopUpdateView(controller: controller, onMoveToApplications: {}),
             width: 470,
             height: 340,
             debugPathEnvironmentKey: "QUILLCODE_RENDER_UPDATE_PROGRESS_IMAGE_PATH"
@@ -220,7 +220,7 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         try await waitForUpdaterState(controller) { $0 == .updateAvailable(release) }
 
         let image = try renderHostedView(
-            QuillCodeDesktopUpdateView(controller: controller),
+            QuillCodeDesktopUpdateView(controller: controller, onMoveToApplications: {}),
             width: 470,
             height: 340,
             debugPathEnvironmentKey: "QUILLCODE_RENDER_UPDATE_REMINDER_IMAGE_PATH"
@@ -257,7 +257,7 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         }
 
         let image = try renderHostedView(
-            QuillCodeDesktopUpdateView(controller: controller),
+            QuillCodeDesktopUpdateView(controller: controller, onMoveToApplications: {}),
             width: 470,
             height: 340,
             debugPathEnvironmentKey: "QUILLCODE_RENDER_UPDATE_FAILURE_IMAGE_PATH"
@@ -272,7 +272,7 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         XCTAssertGreaterThan(stats.sageAccentPixelRatio, 0.0008)
     }
 
-    func testRenderedUpdaterOffersManualInstallerFromReadOnlyLocation() async throws {
+    func testRenderedUpdaterOffersMoveToApplicationsFromReadOnlyLocation() async throws {
         var release = makeRelease(version: "0.2.0", build: "7")
         release.installerAsset = makeManualInstallerAsset()
         let controller = QuillCodeDesktopUpdateController(
@@ -285,10 +285,10 @@ final class QuillCodeDesktopRenderedSmokeTests: XCTestCase {
         )
         controller.checkForUpdates()
         try await waitForUpdaterState(controller) { $0 == .updateAvailable(release) }
-        XCTAssertTrue(controller.updateRequiresManualInstallation)
+        XCTAssertTrue(controller.updateRequiresRelocation)
 
         let image = try renderHostedView(
-            QuillCodeDesktopUpdateView(controller: controller),
+            QuillCodeDesktopUpdateView(controller: controller, onMoveToApplications: {}),
             width: 470,
             height: 340,
             debugPathEnvironmentKey: "QUILLCODE_RENDER_UPDATE_RELOCATION_IMAGE_PATH"

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -53,7 +53,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
 
         controller.checkForUpdates()
         try await waitUntil { controller.state == .updateAvailable(release) }
-        XCTAssertTrue(controller.updateRequiresManualInstallation)
+        XCTAssertTrue(controller.updateRequiresRelocation)
         XCTAssertEqual(release.manualInstallationURL, makeManualInstallerAsset().url)
 
         controller.updateAndRelaunch()
@@ -90,6 +90,109 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         XCTAssertEqual(checkCallCount, 0)
         XCTAssertEqual(controller.state, .idle)
         XCTAssertFalse(controller.isPresented)
+    }
+
+    func testRelocationContinuationChecksImmediatelyAndIsConsumed() async throws {
+        let defaults = makeDefaults()
+        let configuration = makeConfiguration()
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let checker = UpdateCheckerSpy(result: .updateAvailable(release))
+        let intentStore = QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults)
+        intentStore.record(configuration: configuration)
+        let resultURL = temporaryInstallResultURL()
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: configuration,
+            checker: checker,
+            defaults: defaults,
+            automaticSchedule: makeAutomaticSchedule(initialDelay: 60),
+            installResultURL: resultURL
+        )
+
+        controller.startAutomaticChecks()
+        try await Task.sleep(for: .milliseconds(30))
+        let checkCallCountBeforeHelperCompletion = await checker.callCount
+        XCTAssertEqual(checkCallCountBeforeHelperCompletion, 0)
+        XCTAssertTrue(intentStore.hasPendingIntent(configuration: configuration))
+        try FileManager.default.createDirectory(
+            at: resultURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let result = QuillCodeDesktopUpdateInstallResult.success(
+            version: configuration.currentVersion,
+            build: configuration.currentBuild
+        )
+        try JSONEncoder().encode(result).write(to: resultURL)
+
+        try await waitUntil { controller.state == .updateAvailable(release) }
+        XCTAssertTrue(controller.isPresented)
+        let checkCallCount = await checker.callCount
+        XCTAssertEqual(checkCallCount, 1)
+        XCTAssertFalse(intentStore.hasPendingIntent(configuration: configuration))
+    }
+
+    func testRelocationContinuationFallsBackAfterMissingHelperResult() async throws {
+        let defaults = makeDefaults()
+        let configuration = makeConfiguration()
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let checker = UpdateCheckerSpy(result: .updateAvailable(release))
+        let intentStore = QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults)
+        intentStore.record(configuration: configuration)
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: configuration,
+            checker: checker,
+            installationInspector: UpdateInstallationInspectorStub(.available),
+            defaults: defaults,
+            automaticSchedule: makeAutomaticSchedule(initialDelay: 60),
+            relocationContinuationTimeout: .milliseconds(20),
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.startAutomaticChecks()
+
+        try await waitUntil { controller.state == .updateAvailable(release) }
+        let checkCallCount = await checker.callCount
+        XCTAssertEqual(checkCallCount, 1)
+        XCTAssertFalse(intentStore.hasPendingIntent(configuration: configuration))
+    }
+
+    func testRelocationContinuationRejectsMismatchedHelperSuccess() async throws {
+        let defaults = makeDefaults()
+        let configuration = makeConfiguration()
+        let release = makeRelease(version: "0.2.0", build: "7")
+        let checker = UpdateCheckerSpy(result: .updateAvailable(release))
+        let intentStore = QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults)
+        intentStore.record(configuration: configuration)
+        let resultURL = temporaryInstallResultURL()
+        try FileManager.default.createDirectory(
+            at: resultURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let staleResult = QuillCodeDesktopUpdateInstallResult.success(
+            version: configuration.currentVersion,
+            build: "stale-build"
+        )
+        try JSONEncoder().encode(staleResult).write(to: resultURL)
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: configuration,
+            checker: checker,
+            defaults: defaults,
+            automaticSchedule: makeAutomaticSchedule(initialDelay: 60),
+            installResultURL: resultURL
+        )
+
+        controller.startAutomaticChecks()
+
+        XCTAssertEqual(
+            controller.state,
+            .failed(
+                message: "Quill Cowork could not confirm the completed move. Reopen it and check for updates again.",
+                release: nil
+            )
+        )
+        XCTAssertTrue(controller.isPresented)
+        let checkCallCount = await checker.callCount
+        XCTAssertEqual(checkCallCount, 0)
+        XCTAssertFalse(intentStore.hasPendingIntent(configuration: configuration))
     }
 
     func testAutomaticStartupRunsInterruptedUpdateRecoveryOnlyOnce() async throws {
@@ -524,10 +627,14 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         let checker = UpdateCheckerSpy(
             result: .upToDate(latestVersion: "0.1.0", latestBuild: "42")
         )
+        let defaults = makeDefaults()
+        let configuration = makeConfiguration()
+        let intentStore = QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults)
+        intentStore.record(configuration: configuration)
         let controller = QuillCodeDesktopUpdateController(
-            configuration: makeConfiguration(),
+            configuration: configuration,
             checker: checker,
-            defaults: makeDefaults(),
+            defaults: defaults,
             automaticSchedule: makeAutomaticSchedule(busyRetryInterval: 0.02),
             installResultURL: resultURL
         )
@@ -542,6 +649,7 @@ final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
         XCTAssertTrue(controller.isPresented)
         let checkCallCount = await checker.callCount
         XCTAssertEqual(checkCallCount, 0)
+        XCTAssertFalse(intentStore.hasPendingIntent(configuration: configuration))
     }
 
     func testAutomaticSchedulerDoesNotRetainControllerBetweenChecks() async throws {

--- a/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublicDistributionGateTests.swift
@@ -74,9 +74,23 @@ final class ParityPublicDistributionGateTests: QuillCodeParityTestCase {
         XCTAssertLessThan(authenticationIndex, notificationIndex)
         Self.assertSource(workspaceView, containsAll: [
             "onUseDeveloperKey: presentDeveloperKeySettings",
-            "settingsAuthModeOverride = .developerOverride"
+            "settingsAuthModeOverride = .developerOverride",
+            "WorkspaceComposerSendPlanner.action(",
+            "case .requestTrustedRouterSignIn:",
+            "actions.onStartTrustedRouterSignIn()"
         ])
         Self.assertSource(workspaceSheets, contains: "authModeOverride: settingsAuthModeOverride")
+    }
+
+    func testTrustedRouterSignInIsSingleFlight() throws {
+        let controller = try Self.desktopSourceText(named: "QuillCodeDesktopController+Settings.swift")
+        let taskCoordinator = try Self.desktopSourceText(named: "QuillCodeDesktopTaskCoordinator.swift")
+
+        Self.assertSource(controller, containsAll: [
+            "func startTrustedRouterSignIn()",
+            "tasks.startIfIdle(.trustedRouterSignIn)"
+        ])
+        Self.assertSource(taskCoordinator, contains: "case trustedRouterSignIn")
     }
 
     func testNotificationServicesRequireCanonicalPackagedProcessIdentity() throws {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4744,3 +4744,18 @@
   new release so GitHub falls back to the previous stable version.
 - **Evidence:** `download-builds.yml`, `ParityDownloadBuildsGateTests`,
   `ParityPackagedUpdaterGateTests`, and the stable publication contract in `docs/DOWNLOADS.md`.
+
+## 2026-08-13: disconnected sends enter one recoverable sign-in flow
+
+- **Decision:** Composer submission planning separates local slash commands from model-backed agent
+  and scheduled work before any transcript mutation. Without a stored TrustedRouter credential,
+  model-backed Send preserves the draft and attachments and starts sign-in; local commands remain
+  available offline.
+- **Concurrency boundary:** Desktop OAuth uses one task-coordinator slot. Repeated Sign in buttons or
+  Return presses cannot create competing loopback callback servers or replace the first flow's live
+  status with an address-in-use failure.
+- **Why:** A public download should never turn its primary Send action into a deep missing-key error,
+  and recovery should not consume the task the user was trying to run.
+- **Evidence:** `WorkspaceComposerSendPlanner`, `WorkspaceComposerSubmissionPlannerTests`,
+  `QuillCodeDesktopTaskCoordinator`, `QuillCodeDesktopConcurrentChatTests`, and
+  `ParityPublicDistributionGateTests`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,29 @@
 # QuillCode Decisions
 
+## 2026-08-12: updates continue after transactional relocation
+
+- **Decision:** When an update is available to a copy running outside `/Applications`, the update
+  sheet offers **Move to Applications** instead of making the user download the DMG again. That
+  action presents the existing verified first-install flow, stages the current app transactionally,
+  relaunches it from `/Applications`, and resumes the update check automatically.
+- **Ordering:** A build-scoped, 15-minute continuation intent is recorded only after the detached
+  relocation helper launches successfully. The relaunched app waits for the helper's bounded success
+  result before contacting the release feed, so update preparation cannot overlap the helper's
+  three-second launch-stability observation.
+- **Recovery:** The intent remains pending if the relocated app fails its handshake or stability
+  window. The restored source copy therefore presents the installation flow again even when the
+  ordinary once-per-build reminder was dismissed. A helper failure stays visible instead of being
+  replaced by a network check. An installed, writable copy may continue after a bounded wait if the
+  helper result file cannot be read.
+- **Trust boundary:** The updater continues only for an exact current version/build success result.
+  Intent state is one-shot, scoped by bundle, channel, and build, tolerant of a small clock skew, and
+  rejected after expiry. Existing bundle, architecture, commit, signature, atomic activation,
+  handshake, stability, and rollback checks remain authoritative.
+- **Evidence:** Controller tests cover update-requested relocation, once-per-build override,
+  one-shot consumption, expiry, delayed helper completion, missing-result fallback, and failure
+  preservation. Fixed-size rendering covers the revised update sheet; packaged relocation and
+  updater smokes continue to exercise the shared production helper.
+
 ## 2026-08-12: native memory pressure releases only reconstructible state
 
 - **Decision:** The packaged macOS app observes dispatch memory-pressure warning and critical events

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -309,10 +309,15 @@ and app-validation phases separately.
 Before downloading, the app verifies that its running bundle exists beside a
 writable destination and has a runnable helper executable. Copies launched from
 the read-only DMG, App Translocation, or another non-replaceable location show a
-direct **Download Installer** action instead. That action uses only an
-architecture-matching DMG whose bounded metadata and GitHub release URL passed
-the same manifest scope checks. Its URL must use the declared `.dmg` filename
-exactly and cannot carry a query or fragment; older manifests fall back to the release page.
+direct **Move to Applications** action instead. It reuses the verified transactional
+first-install helper, relaunches the current build from `/Applications`, waits for
+the helper's launch-stability result, and automatically resumes the update check.
+A short-lived, build-scoped continuation survives rollback so a restored source
+copy can offer the move again even after an earlier reminder was dismissed. If
+that relocation cannot be offered, the fallback uses only an architecture-matching
+DMG whose bounded metadata and GitHub release URL passed the same manifest scope
+checks. Its URL must use the declared `.dmg` filename exactly and cannot carry a
+query or fragment; older manifests fall back to the release page.
 The installer repeats the destination checks immediately before staging, so a
 permission change after preflight still fails without replacing the app.
 

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -93,6 +93,12 @@ an independent private store; configure it with `quill-code auth set-key KEY`. K
 activates automatically for the desktop when the Apple Developer ID signing secrets are configured
 and the packaged identity passes runtime attestation.
 
+When a signed-out user presses Send on a model-backed task, Quill Cowork preserves the complete draft
+and any image attachments, then starts TrustedRouter sign-in instead of creating a failed transcript
+turn. Local slash commands remain usable while signed out. Sign-in is single-flight, so repeated
+buttons or Return presses reuse the active browser flow rather than starting competing loopback
+listeners.
+
 ## Tester Recovery: Unexpected Exit
 
 Packaged builds keep one private, content-free active-launch marker. A normal Quit or updater-driven

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,10 @@
 
 ## Latest Quality Pass
 
+- Signed-out model submissions now preserve their complete draft and image attachments and open the
+  existing TrustedRouter sign-in flow instead of producing a failed transcript turn. Pure submission
+  routing keeps local slash commands available offline, and desktop OAuth is single-flight so repeat
+  clicks cannot compete for the loopback listener.
 - Public macOS performance evidence now includes a process-specific two-second settled-idle phase
   after two complete native interaction sweeps. Release and post-publication gates recompute CPU,
   memory, and thread deltas under tighter native-baseline limits: 2.5-second launch majority,

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -20,11 +20,14 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 - First-launch installation guidance: writable-copy suppression, already-installed suppression,
   read-only presentation, once-per-build dismissal, a new-build reminder, disabled smoke
   configuration, Applications-folder routing, fixed-size rendering, coordinated updater-sheet
-  presentation, and a normal launch from a real mounted packaged DMG.
+  presentation, update-requested reminder override, bounded continuation expiry, and a normal launch
+  from a real mounted packaged DMG.
 - Updater install-location UX: writable/read-only parent detection, missing app/executable refusal,
   non-directory app and out-of-bundle executable refusal, zero preparation from a non-replaceable
   copy, trusted architecture-matching DMG selection, hostile/malformed/duplicate installer rejection,
-  release-page fallback, fixed-size manual-installer UI, and a real mounted-DMG update check.
+  release-page fallback, fixed-size move-to-Applications UI, delayed helper-result continuation,
+  exact version/build matching, missing-result fallback, relocation-failure preservation, and a real
+  mounted-DMG update check.
 - Updater reminder UX: exact-release 24-hour persistence across controller/store recreation, normal
   automatic polling while deferred, changed-build and explicit-check override, exact cached deadline
   presentation without a redundant request, small clock rollback tolerance, fail-open expiry and


### PR DESCRIPTION
## Summary

- Move read-only, translocated, or Downloads-launched copies into Applications and automatically resume the requested update after relaunch.
- Preserve signed-out composer drafts and image attachments while opening TrustedRouter sign-in instead of creating a failed transcript turn.
- Keep local slash commands available offline and make desktop OAuth single-flight so repeated requests cannot compete for the loopback listener.
- Remove remaining negative text tracking and document the public update and recovery contracts.

## Verification

- 22 focused composer, OAuth concurrency, and public-distribution tests passed.
- Full Swift suite: 6,310 tests executed, 5 skipped, 0 failures.
- Code-quality modules remain A+; `git diff --check` passed; credential scan contains only deliberate fake fixtures.
- Exact commit `54fc9007` packaged as local build 747.
- Packaged crash recovery, Launch Services, DMG relocation/relaunch, native hit targets, accessibility frames, repeated interaction, and critical-memory-pressure smoke passed.
- Independent packaged performance: 296.33 ms median launch-ready, 41.02 MiB initial, 79.97 MiB repeated interaction, 0.0003% settled idle CPU.

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing UI was checked for keyboard, accessibility, compact-window, and failure states.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release and updater changes include contract-level and packaged-app verification.