### PR TITLE
Fail fast on invalid Apple distribution credentials

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -31,6 +31,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/validate-download-build-ref.sh
+      - name: Validate stable Apple distribution credentials
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        env:
+          APPLE_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+        run: scripts/validate-apple-distribution-credentials.sh
       - name: Wait for successful exact-main CI
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Tests/QuillCodeParityTests/ParityAppleDistributionCredentialPreflightTests.swift
+++ b/Tests/QuillCodeParityTests/ParityAppleDistributionCredentialPreflightTests.swift
@@ -1,0 +1,379 @@
+import Foundation
+import XCTest
+
+final class ParityAppleDistributionCredentialPreflightTests: QuillCodeParityTestCase {
+    func testValidCredentialMaterialPassesWithoutPersistingDecodedFiles() throws {
+        let fixture = try CredentialFixture()
+        defer { fixture.remove() }
+
+        let result = try runPreflight(credentials: fixture.credentials)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Validated Apple Developer ID and notarization credential material."))
+        XCTAssertFalse(result.output.contains(fixture.password))
+        XCTAssertFalse(result.output.contains(fixture.credentials["APPLE_DEVELOPER_ID_CERTIFICATE_BASE64"]!))
+        XCTAssertTrue(result.remainingFiles.isEmpty, result.remainingFiles.joined(separator: "\n"))
+    }
+
+    func testFingerprintIdentityAndLegacyPKCS12ArchivePass() throws {
+        let fixture = try CredentialFixture(usesLegacyPKCS12Encryption: true)
+        defer { fixture.remove() }
+        var credentials = fixture.credentials
+        credentials["APPLE_DEVELOPER_ID_APPLICATION_IDENTITY"] =
+            fixture.certificateFingerprint.lowercased()
+
+        let result = try runPreflight(credentials: credentials)
+
+        XCTAssertEqual(result.exitCode, 0, result.output)
+        XCTAssertTrue(result.output.contains("Validated Apple Developer ID"))
+        XCTAssertTrue(result.remainingFiles.isEmpty)
+    }
+
+    func testMissingCredentialsFailBeforeCreatingDecodedFiles() throws {
+        let result = try runPreflight(credentials: [
+            "APPLE_TEAM_ID": Self.teamIdentifier
+        ])
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(result.output.contains("Missing Apple distribution credentials:"), result.output)
+        XCTAssertTrue(result.output.contains("APPLE_DEVELOPER_ID_CERTIFICATE_BASE64"), result.output)
+        XCTAssertTrue(result.output.contains("APPLE_NOTARY_PRIVATE_KEY_BASE64"), result.output)
+        XCTAssertTrue(result.remainingFiles.isEmpty, result.remainingFiles.joined(separator: "\n"))
+    }
+
+    func testMalformedIdentifiersAndIdentityFailBeforeDecoding() throws {
+        let fixture = try CredentialFixture()
+        defer { fixture.remove() }
+
+        let cases = [
+            ("APPLE_TEAM_ID", "lowercase", "APPLE_TEAM_ID must be"),
+            ("APPLE_NOTARY_KEY_ID", "SHORT", "APPLE_NOTARY_KEY_ID must be"),
+            ("APPLE_NOTARY_ISSUER_ID", "not-a-uuid", "APPLE_NOTARY_ISSUER_ID must be"),
+            (
+                "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY",
+                "Developer ID Application: Quill Cowork (ZZZZZ99999)",
+                "must name a Developer ID Application identity owned by APPLE_TEAM_ID"
+            )
+        ]
+
+        for (key, value, expectedMessage) in cases {
+            var credentials = fixture.credentials
+            credentials[key] = value
+            let result = try runPreflight(credentials: credentials)
+
+            XCTAssertEqual(result.exitCode, 2, "\(key): \(result.output)")
+            XCTAssertTrue(result.output.contains(expectedMessage), "\(key): \(result.output)")
+            XCTAssertTrue(result.remainingFiles.isEmpty, key)
+        }
+    }
+
+    func testWrongArchivePasswordAndMismatchedIdentityFailClosed() throws {
+        let fixture = try CredentialFixture()
+        defer { fixture.remove() }
+
+        var wrongPassword = fixture.credentials
+        wrongPassword["APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD"] = "wrong-password"
+        let passwordResult = try runPreflight(credentials: wrongPassword)
+        XCTAssertEqual(passwordResult.exitCode, 2, passwordResult.output)
+        XCTAssertTrue(passwordResult.output.contains("archive or its password is invalid"), passwordResult.output)
+        XCTAssertFalse(passwordResult.output.contains("wrong-password"), passwordResult.output)
+        XCTAssertTrue(passwordResult.remainingFiles.isEmpty)
+
+        var mismatchedIdentity = fixture.credentials
+        mismatchedIdentity["APPLE_DEVELOPER_ID_APPLICATION_IDENTITY"] =
+            "Developer ID Application: Another Product (\(Self.teamIdentifier))"
+        let identityResult = try runPreflight(credentials: mismatchedIdentity)
+        XCTAssertEqual(identityResult.exitCode, 2, identityResult.output)
+        XCTAssertTrue(identityResult.output.contains("common name does not match"), identityResult.output)
+        XCTAssertTrue(identityResult.remainingFiles.isEmpty)
+
+        var mismatchedFingerprint = fixture.credentials
+        mismatchedFingerprint["APPLE_DEVELOPER_ID_APPLICATION_IDENTITY"] =
+            String(repeating: "f", count: 40)
+        let fingerprintResult = try runPreflight(credentials: mismatchedFingerprint)
+        XCTAssertEqual(fingerprintResult.exitCode, 2, fingerprintResult.output)
+        XCTAssertTrue(fingerprintResult.output.contains("fingerprint does not match"))
+        XCTAssertTrue(fingerprintResult.remainingFiles.isEmpty)
+    }
+
+    func testMalformedNotaryKeyFailsClosedAndLeavesNoCredentialMaterial() throws {
+        let fixture = try CredentialFixture()
+        defer { fixture.remove() }
+        var credentials = fixture.credentials
+        credentials["APPLE_NOTARY_PRIVATE_KEY_BASE64"] =
+            Data("not-a-private-key".utf8).base64EncodedString()
+
+        let result = try runPreflight(credentials: credentials)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(result.output.contains("PKCS#8 PEM format"), result.output)
+        XCTAssertTrue(result.remainingFiles.isEmpty, result.remainingFiles.joined(separator: "\n"))
+
+        credentials = fixture.credentials
+        credentials["APPLE_NOTARY_PRIVATE_KEY_BASE64"] = "!!!!"
+        let invalidBase64Result = try runPreflight(credentials: credentials)
+        XCTAssertEqual(invalidBase64Result.exitCode, 2, invalidBase64Result.output)
+        XCTAssertTrue(invalidBase64Result.output.contains("is not canonical base64"))
+        XCTAssertTrue(invalidBase64Result.remainingFiles.isEmpty)
+
+        credentials = fixture.credentials
+        credentials["APPLE_NOTARY_PRIVATE_KEY_BASE64"] = "YR=="
+        let noncanonicalBase64Result = try runPreflight(credentials: credentials)
+        XCTAssertEqual(noncanonicalBase64Result.exitCode, 2, noncanonicalBase64Result.output)
+        XCTAssertTrue(noncanonicalBase64Result.output.contains("is not canonical base64"))
+        XCTAssertTrue(noncanonicalBase64Result.remainingFiles.isEmpty)
+    }
+
+    func testExpiringAndNonCodeSigningCertificatesFailClosed() throws {
+        let expiringFixture = try CredentialFixture(certificateValidityDays: 1)
+        defer { expiringFixture.remove() }
+        let expiringResult = try runPreflight(credentials: expiringFixture.credentials)
+        XCTAssertEqual(expiringResult.exitCode, 2, expiringResult.output)
+        XCTAssertTrue(expiringResult.output.contains("expired or expires within seven days"))
+        XCTAssertTrue(expiringResult.remainingFiles.isEmpty)
+
+        let wrongUsageFixture = try CredentialFixture(includesCodeSigningUsage: false)
+        defer { wrongUsageFixture.remove() }
+        let wrongUsageResult = try runPreflight(credentials: wrongUsageFixture.credentials)
+        XCTAssertEqual(wrongUsageResult.exitCode, 2, wrongUsageResult.output)
+        XCTAssertTrue(wrongUsageResult.output.contains("not valid for code signing"))
+        XCTAssertTrue(wrongUsageResult.remainingFiles.isEmpty)
+    }
+
+    func testWrongCurveAndOversizedCredentialsFailClosed() throws {
+        let wrongCurveFixture = try CredentialFixture(notaryCurve: "P-384")
+        defer { wrongCurveFixture.remove() }
+        let wrongCurveResult = try runPreflight(credentials: wrongCurveFixture.credentials)
+        XCTAssertEqual(wrongCurveResult.exitCode, 2, wrongCurveResult.output)
+        XCTAssertTrue(wrongCurveResult.output.contains("must use the P-256 elliptic curve"))
+        XCTAssertTrue(wrongCurveResult.remainingFiles.isEmpty)
+
+        let validFixture = try CredentialFixture()
+        defer { validFixture.remove() }
+        var oversizedCredentials = validFixture.credentials
+        oversizedCredentials["APPLE_NOTARY_PRIVATE_KEY_BASE64"] =
+            String(repeating: "A", count: 64 * 1024 + 1)
+        let oversizedResult = try runPreflight(credentials: oversizedCredentials)
+        XCTAssertEqual(oversizedResult.exitCode, 2, oversizedResult.output)
+        XCTAssertTrue(oversizedResult.output.contains("exceeds the credential size limit"))
+        XCTAssertTrue(oversizedResult.remainingFiles.isEmpty)
+    }
+
+    func testStableWorkflowRunsMaterialPreflightBeforeCIWaitAndPackaging() throws {
+        let workflow = try Self.workflowText(named: "download-builds.yml")
+        Self.assertSource(workflow, containsAll: [
+            "Validate stable Apple distribution credentials",
+            "if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')",
+            "scripts/validate-apple-distribution-credentials.sh",
+            "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}",
+            "APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}"
+        ])
+        let preflight = try XCTUnwrap(
+            workflow.range(of: "scripts/validate-apple-distribution-credentials.sh")
+        )
+        let ciWait = try XCTUnwrap(workflow.range(of: "scripts/wait-for-successful-ci.sh"))
+        let macOSJob = try XCTUnwrap(workflow.range(of: "  macos:"))
+        XCTAssertLessThan(preflight.lowerBound, ciWait.lowerBound)
+        XCTAssertLessThan(preflight.lowerBound, macOSJob.lowerBound)
+    }
+
+    private struct PreflightResult {
+        let exitCode: Int32
+        let output: String
+        let remainingFiles: [String]
+    }
+
+    private func runPreflight(credentials: [String: String]) throws -> PreflightResult {
+        let runnerTemp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quillcode-apple-credential-preflight-tests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: runnerTemp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: runnerTemp) }
+
+        let outputPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.packageRoot()
+                .appendingPathComponent("scripts")
+                .appendingPathComponent("validate-apple-distribution-credentials.sh")
+                .path
+        ]
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["RUNNER_TEMP"] = runnerTemp.path
+        for key in Self.credentialKeys {
+            environment[key] = ""
+        }
+        for (key, value) in credentials {
+            environment[key] = value
+        }
+        process.environment = environment
+
+        try process.run()
+        process.waitUntilExit()
+
+        let remainingFiles = try FileManager.default.contentsOfDirectory(
+            atPath: runnerTemp.path
+        ).sorted()
+        return PreflightResult(
+            exitCode: process.terminationStatus,
+            output: String(
+                data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? "",
+            remainingFiles: remainingFiles
+        )
+    }
+
+    private final class CredentialFixture {
+        let directory: URL
+        let password = "certificate-password"
+        let certificateFingerprint: String
+        let credentials: [String: String]
+
+        init(
+            certificateValidityDays: Int = 30,
+            includesCodeSigningUsage: Bool = true,
+            notaryCurve: String = "P-256",
+            usesLegacyPKCS12Encryption: Bool = false
+        ) throws {
+            directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("quillcode-apple-credential-fixtures")
+                .appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            let certificateKey = directory.appendingPathComponent("certificate-key.pem")
+            let certificate = directory.appendingPathComponent("certificate.pem")
+            let archive = directory.appendingPathComponent("developer-id.p12")
+            let notaryECKey = directory.appendingPathComponent("notary-ec.pem")
+            let notaryPKCS8Key = directory.appendingPathComponent(
+                "AuthKey_\(ParityAppleDistributionCredentialPreflightTests.keyIdentifier).p8"
+            )
+            var certificateArguments = [
+                "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                "-keyout", certificateKey.path,
+                "-out", certificate.path,
+                "-days", String(certificateValidityDays),
+                "-subj",
+                "/C=US/O=Lore Hex Corp/OU=\(ParityAppleDistributionCredentialPreflightTests.teamIdentifier)" +
+                    "/CN=\(ParityAppleDistributionCredentialPreflightTests.identity)" +
+                    "/UID=\(ParityAppleDistributionCredentialPreflightTests.teamIdentifier)"
+            ]
+            if includesCodeSigningUsage {
+                certificateArguments += ["-addext", "extendedKeyUsage=codeSigning"]
+            }
+            try Self.runOpenSSL(certificateArguments)
+            let archiveArguments = [
+                "pkcs12", "-export",
+                "-out", archive.path,
+                "-inkey", certificateKey.path,
+                "-in", certificate.path,
+                "-name", ParityAppleDistributionCredentialPreflightTests.identity,
+                "-passout", "pass:\(password)"
+            ]
+            if usesLegacyPKCS12Encryption {
+                do {
+                    try Self.runOpenSSL(archiveArguments + ["-legacy"])
+                } catch {
+                    // LibreSSL has legacy Keychain-compatible defaults but no -legacy shorthand.
+                    try Self.runOpenSSL(archiveArguments)
+                }
+            } else {
+                try Self.runOpenSSL(archiveArguments)
+            }
+            try Self.runOpenSSL([
+                "genpkey", "-algorithm", "EC",
+                "-pkeyopt", "ec_paramgen_curve:\(notaryCurve)",
+                "-out", notaryECKey.path
+            ])
+            try Self.runOpenSSL([
+                "pkcs8", "-topk8", "-nocrypt",
+                "-in", notaryECKey.path,
+                "-out", notaryPKCS8Key.path
+            ])
+
+            certificateFingerprint = try Self.openSSLOutput([
+                "x509", "-in", certificate.path, "-noout", "-fingerprint", "-sha1"
+            ])
+            .split(separator: "=", maxSplits: 1)
+            .last
+            .map(String.init)?
+            .replacingOccurrences(of: ":", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard certificateFingerprint.count == 40 else {
+                throw NSError(
+                    domain: "ParityAppleDistributionCredentialPreflightTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "OpenSSL returned an invalid certificate fingerprint"]
+                )
+            }
+
+            credentials = [
+                "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64":
+                    try Data(contentsOf: archive).base64EncodedString(),
+                "APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD": password,
+                "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY":
+                    ParityAppleDistributionCredentialPreflightTests.identity,
+                "APPLE_TEAM_ID": ParityAppleDistributionCredentialPreflightTests.teamIdentifier,
+                "APPLE_NOTARY_KEY_ID": ParityAppleDistributionCredentialPreflightTests.keyIdentifier,
+                "APPLE_NOTARY_ISSUER_ID": "01234567-89ab-cdef-0123-456789abcdef",
+                "APPLE_NOTARY_PRIVATE_KEY_BASE64":
+                    try Data(contentsOf: notaryPKCS8Key).base64EncodedString()
+            ]
+        }
+
+        func remove() {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        private static func runOpenSSL(_ arguments: [String]) throws {
+            _ = try openSSLOutput(arguments)
+        }
+
+        private static func openSSLOutput(_ arguments: [String]) throws -> String {
+            let output = Pipe()
+            let errorOutput = Pipe()
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["openssl"] + arguments
+            process.standardOutput = output
+            process.standardError = errorOutput
+            try process.run()
+            process.waitUntilExit()
+            let outputData = output.fileHandleForReading.readDataToEndOfFile()
+            let errorData = errorOutput.fileHandleForReading.readDataToEndOfFile()
+            guard process.terminationStatus == 0 else {
+                let diagnostic = String(data: errorData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                throw NSError(
+                    domain: "ParityAppleDistributionCredentialPreflightTests",
+                    code: Int(process.terminationStatus),
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "OpenSSL \(arguments.first ?? "command") failed: \(diagnostic)"
+                    ]
+                )
+            }
+            return String(
+                data: outputData,
+                encoding: .utf8
+            ) ?? ""
+        }
+    }
+
+    private static let teamIdentifier = "ABCDE12345"
+    private static let keyIdentifier = "KEYID12345"
+    private static let identity = "Developer ID Application: Quill Cowork (ABCDE12345)"
+    private static let credentialKeys = [
+        "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64",
+        "APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD",
+        "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY",
+        "APPLE_TEAM_ID",
+        "APPLE_NOTARY_KEY_ID",
+        "APPLE_NOTARY_ISSUER_ID",
+        "APPLE_NOTARY_PRIVATE_KEY_BASE64"
+    ]
+}

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -304,6 +304,8 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "contents: write",
             "release-policy:",
             "scripts/validate-download-build-ref.sh",
+            "Validate stable Apple distribution credentials",
+            "scripts/validate-apple-distribution-credentials.sh",
             "Wait for successful exact-main CI",
             "scripts/wait-for-successful-ci.sh",
             "scripts/plan-download-build.sh",
@@ -402,9 +404,13 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         XCTAssertFalse(workflow.contains("--clobber"))
         XCTAssertFalse(workflow.contains("gh release delete-asset"))
         let validationIndex = try XCTUnwrap(workflow.range(of: "scripts/validate-download-build-ref.sh"))
+        let applePreflightIndex = try XCTUnwrap(
+            workflow.range(of: "scripts/validate-apple-distribution-credentials.sh")
+        )
         let ciGateIndex = try XCTUnwrap(workflow.range(of: "scripts/wait-for-successful-ci.sh"))
         let planningIndex = try XCTUnwrap(workflow.range(of: "scripts/plan-download-build.sh"))
-        XCTAssertLessThan(validationIndex.lowerBound, ciGateIndex.lowerBound)
+        XCTAssertLessThan(validationIndex.lowerBound, applePreflightIndex.lowerBound)
+        XCTAssertLessThan(applePreflightIndex.lowerBound, ciGateIndex.lowerBound)
         XCTAssertLessThan(ciGateIndex.lowerBound, planningIndex.lowerBound)
         let publishIndex = try XCTUnwrap(workflow.range(of: "  publish:"))
         let sourceCaptureIndex = try XCTUnwrap(workflow.range(of: "  capture-updater-source:"))

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,21 @@
 # Code Quality Audit
 
+## 2026-08-13 Stable Apple Credential Material Preflight
+
+The stable release path now rejects unusable Apple credential material in `release-policy`, before
+the exact-main wait and native build fan-out. The validator is bounded, emits only named contract
+errors, keeps decoded material in a private temporary directory, and removes it on every exit.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Failure timing | A+ | Stable tags validate missing values, identifier shape, archive password, certificate/key pairing, expiry, code-signing usage, identity, and notary-key structure before packaging. |
+| Secret safety | A+ | Values are never interpolated into diagnostics; decoded files use a `077` umask and an unconditional cleanup trap. |
+| Architecture | A+ | Material validation, macOS keychain ownership validation, and live Apple notarization remain distinct fail-closed layers. |
+| Regression proof | A+ | Real OpenSSL fixtures cover canonical and legacy archives, name and fingerprint identities, missing/oversized data, expiry, signing usage, wrong passwords, identity mismatch, malformed/wrong-curve notary keys, cleanup, and workflow ordering. |
+
+Validation: **9 focused preflight tests**, **6,319 full Swift tests** with 5 intentional skips,
+and **122 script tests** passed with zero failures. Both new files score **A+ (100)**.
+
 ## 2026-08-12 Owned Shell Process Groups
 
 Overall grade after this slice: **A+ crash containment, A+ process hygiene, A+ distribution integrity**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,15 @@
 # QuillCode Decisions
 
+## 2026-08-13: validate Apple credential material before stable build fan-out
+
+- **Decision:** Stable `v*` workflows validate all seven Apple distribution credentials in the
+  Ubuntu `release-policy` job before waiting for exact-main CI or allocating native package runners.
+- **Boundary:** The bounded preflight verifies credential structure, certificate ownership and
+  validity, and the App Store Connect private-key contract without logging values or retaining
+  decoded files.
+- **Layering:** Runner keychain import and real Apple notarization remain independent downstream
+  gates because a local material check cannot prove current App Store Connect authorization.
+
 ## 2026-08-13: the public website deploys from reviewed main-branch source
 
 - **Decision:** `website/` is the canonical source for `cowork.quillos.cloud`; the manually maintained

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -473,6 +473,26 @@ and deletes temporary credential files. `APPLE_TEAM_ID` and
 Developer ID identity must resolve inside the private build keychain and belong
 to `APPLE_TEAM_ID`.
 
+Before a stable workflow waits for CI or starts native packaging, its
+`release-policy` job runs `scripts/validate-apple-distribution-credentials.sh`.
+The preflight decodes credentials only inside a private temporary directory,
+never prints their values, and removes every decoded file on success or failure.
+It verifies the `.p12` password, certificate/private-key match, exact Developer
+ID Application common name, code-signing usage, at least seven days of remaining
+certificate validity, and an unencrypted PKCS#8 P-256 App Store Connect key. The
+signing identity may be that exact certificate name or its 40-character SHA-1
+identity hash; both remain pinned to `APPLE_TEAM_ID`. Base64 secrets must use
+canonical unwrapped encoding. Legacy-encrypted Keychain `.p12` exports remain
+supported without weakening the downstream identity checks.
+Maintainers can run the same script locally with the seven variables above set
+before uploading or rotating repository secrets.
+
+This material check is deliberately separate from Apple authorization. GitHub
+does not expose stored secret values to the release starter, and only Apple's
+`notarytool` can prove that a configured key ID and issuer are still authorized.
+The macOS runner therefore retains its private-keychain identity/team check and
+the packaging jobs retain the real notarization, stapling, and validation gate.
+
 Partial configuration and malformed identifiers fail before decoded files are
 created. Once files can exist, any setup failure deletes the private keychain and
 complete signing directory locally; only successful setup transfers cleanup

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -35,6 +35,11 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 - Updater signing trust: exact ad-hoc metadata, notarized Developer ID transition, ten-character
   team validation, pinned-team continuity, ad-hoc downgrade and cross-team refusal, stable-channel
   requirements, Developer ID Application authority parsing, and Installer-authority rejection.
+- Stable Apple credential preflight: complete secret inventory, bounded base64 material, canonical
+  identifiers, `.p12` password and certificate/private-key matching, exact Developer ID Application
+  common name, code-signing usage, seven-day validity floor, PKCS#8 P-256 notary key validation,
+  secret-free diagnostics, unconditional decoded-file cleanup, and release-policy ordering before CI
+  wait or native packaging.
 - Packaged resource gates: three fresh launch samples, majority launch-time enforcement, per-process
   initial and settled post-interaction resident-memory ceilings, retained-growth validation, bounded
   initial and post-interaction thread counts, recomputed delta integrity, and a public performance

--- a/scripts/validate-apple-distribution-credentials.sh
+++ b/scripts/validate-apple-distribution-credentials.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export LC_ALL=C
+umask 077
+
+OPENSSL_BIN="${OPENSSL_BIN:-openssl}"
+TEMP_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+MAX_CERTIFICATE_BASE64_BYTES=$((256 * 1024))
+MAX_NOTARY_KEY_BASE64_BYTES=$((64 * 1024))
+MINIMUM_CERTIFICATE_VALIDITY_SECONDS=$((7 * 24 * 60 * 60))
+
+fail() {
+  echo "$*" >&2
+  exit 2
+}
+
+REQUIRED_CREDENTIALS=(
+  APPLE_DEVELOPER_ID_CERTIFICATE_BASE64
+  APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD
+  APPLE_DEVELOPER_ID_APPLICATION_IDENTITY
+  APPLE_TEAM_ID
+  APPLE_NOTARY_KEY_ID
+  APPLE_NOTARY_ISSUER_ID
+  APPLE_NOTARY_PRIVATE_KEY_BASE64
+)
+
+missing_credentials=()
+for credential_name in "${REQUIRED_CREDENTIALS[@]}"; do
+  if [[ -z "${!credential_name:-}" ]]; then
+    missing_credentials+=("$credential_name")
+  fi
+done
+if (( ${#missing_credentials[@]} > 0 )); then
+  fail "Missing Apple distribution credentials: ${missing_credentials[*]}"
+fi
+
+CERTIFICATE_BASE64="$APPLE_DEVELOPER_ID_CERTIFICATE_BASE64"
+SIGNING_IDENTITY="$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY"
+TEAM_IDENTIFIER="$APPLE_TEAM_ID"
+NOTARY_KEY_IDENTIFIER="$APPLE_NOTARY_KEY_ID"
+NOTARY_ISSUER_IDENTIFIER="$APPLE_NOTARY_ISSUER_ID"
+NOTARY_KEY_BASE64="$APPLE_NOTARY_PRIVATE_KEY_BASE64"
+
+command -v "$OPENSSL_BIN" >/dev/null 2>&1 || fail "OpenSSL is required for Apple credential validation."
+[[ -d "$TEMP_ROOT" ]] || fail "Apple credential validation requires an existing temporary directory."
+[[ ! -L "$TEMP_ROOT" ]] || fail "Apple credential validation refuses a symbolic-link temporary directory."
+
+if [[ ! "$TEAM_IDENTIFIER" =~ ^[A-Z0-9]{10}$ ]]; then
+  fail "APPLE_TEAM_ID must be a 10-character uppercase Apple team identifier."
+fi
+if [[ ! "$NOTARY_KEY_IDENTIFIER" =~ ^[A-Z0-9]{10}$ ]]; then
+  fail "APPLE_NOTARY_KEY_ID must be a 10-character uppercase App Store Connect key identifier."
+fi
+notary_issuer_pattern='^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-'
+notary_issuer_pattern+='[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'
+if [[ ! "$NOTARY_ISSUER_IDENTIFIER" =~ $notary_issuer_pattern ]]; then
+  fail "APPLE_NOTARY_ISSUER_ID must be an App Store Connect issuer UUID."
+fi
+if (( ${#SIGNING_IDENTITY} > 256 )) ||
+   [[ "$SIGNING_IDENTITY" == *$'\n'* || "$SIGNING_IDENTITY" == *$'\r'* ]]; then
+  fail "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY is malformed."
+fi
+identity_prefix="Developer ID Application: "
+identity_suffix=" ($TEAM_IDENTIFIER)"
+identity_is_fingerprint=false
+if [[ "$SIGNING_IDENTITY" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+  identity_is_fingerprint=true
+elif [[ "$SIGNING_IDENTITY" != "$identity_prefix"*"$identity_suffix" ]]; then
+  fail "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY must name a Developer ID Application identity owned by APPLE_TEAM_ID."
+fi
+if [[ "$identity_is_fingerprint" == "false" ]]; then
+  identity_owner="${SIGNING_IDENTITY#"$identity_prefix"}"
+  identity_owner="${identity_owner%"$identity_suffix"}"
+  [[ -n "$identity_owner" ]] || fail "APPLE_DEVELOPER_ID_APPLICATION_IDENTITY is missing its owner name."
+fi
+
+if (( ${#CERTIFICATE_BASE64} > MAX_CERTIFICATE_BASE64_BYTES )); then
+  fail "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 exceeds the credential size limit."
+fi
+if (( ${#NOTARY_KEY_BASE64} > MAX_NOTARY_KEY_BASE64_BYTES )); then
+  fail "APPLE_NOTARY_PRIVATE_KEY_BASE64 exceeds the credential size limit."
+fi
+is_canonical_base64() {
+  local value="$1"
+  (( ${#value} % 4 == 0 )) && [[ "$value" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]
+}
+is_canonical_base64 "$CERTIFICATE_BASE64" ||
+  fail "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is not canonical base64."
+is_canonical_base64 "$NOTARY_KEY_BASE64" ||
+  fail "APPLE_NOTARY_PRIVATE_KEY_BASE64 is not canonical base64."
+
+WORK_DIRECTORY="$(mktemp -d "$TEMP_ROOT/quill-cowork-apple-preflight.XXXXXX")"
+cleanup() {
+  rm -rf -- "$WORK_DIRECTORY"
+}
+trap cleanup EXIT
+
+CERTIFICATE_ARCHIVE="$WORK_DIRECTORY/developer-id.p12"
+CERTIFICATE="$WORK_DIRECTORY/developer-id.pem"
+CERTIFICATE_PRIVATE_KEY="$WORK_DIRECTORY/developer-id-private-key.pem"
+CERTIFICATE_PUBLIC_KEY="$WORK_DIRECTORY/developer-id-public-key.pem"
+PRIVATE_PUBLIC_KEY="$WORK_DIRECTORY/private-public-key.pem"
+NOTARY_PRIVATE_KEY="$WORK_DIRECTORY/AuthKey_${NOTARY_KEY_IDENTIFIER}.p8"
+NOTARY_PARAMETERS="$WORK_DIRECTORY/notary-parameters.der"
+P256_NAMED_PARAMETERS="$WORK_DIRECTORY/p256-named-parameters.der"
+P256_EXPLICIT_PARAMETERS="$WORK_DIRECTORY/p256-explicit-parameters.der"
+
+if ! printf '%s' "$CERTIFICATE_BASE64" | "$OPENSSL_BIN" base64 -d -A > "$CERTIFICATE_ARCHIVE" ||
+   [[ ! -s "$CERTIFICATE_ARCHIVE" ]]; then
+  fail "The Developer ID certificate archive is not valid base64 credential material."
+fi
+if ! printf '%s' "$NOTARY_KEY_BASE64" | "$OPENSSL_BIN" base64 -d -A > "$NOTARY_PRIVATE_KEY" ||
+   [[ ! -s "$NOTARY_PRIVATE_KEY" ]]; then
+  fail "The App Store Connect private key is not valid base64 credential material."
+fi
+if [[ "$("$OPENSSL_BIN" base64 -A -in "$CERTIFICATE_ARCHIVE")" != "$CERTIFICATE_BASE64" ]]; then
+  fail "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is not canonical base64."
+fi
+if [[ "$("$OPENSSL_BIN" base64 -A -in "$NOTARY_PRIVATE_KEY")" != "$NOTARY_KEY_BASE64" ]]; then
+  fail "APPLE_NOTARY_PRIVATE_KEY_BASE64 is not canonical base64."
+fi
+chmod 600 "$CERTIFICATE_ARCHIVE" "$NOTARY_PRIVATE_KEY"
+
+extract_pkcs12() {
+  if "$OPENSSL_BIN" pkcs12 "$@" >/dev/null 2>&1; then
+    return 0
+  fi
+  "$OPENSSL_BIN" pkcs12 -legacy "$@" >/dev/null 2>&1
+}
+
+pkey_check_supported=false
+if "$OPENSSL_BIN" pkey -help 2>&1 | grep -Eq -- '(^|[[:space:]])-check([[:space:]]|$)'; then
+  pkey_check_supported=true
+fi
+validate_private_key() {
+  local key_path="$1"
+  if [[ "$pkey_check_supported" == "true" ]]; then
+    "$OPENSSL_BIN" pkey -in "$key_path" -check -noout >/dev/null 2>&1
+    return
+  fi
+  "$OPENSSL_BIN" rsa -in "$key_path" -check -noout >/dev/null 2>&1 ||
+    "$OPENSSL_BIN" ec -in "$key_path" -text -noout >/dev/null 2>&1
+}
+
+if ! extract_pkcs12 \
+  -in "$CERTIFICATE_ARCHIVE" -clcerts -nokeys \
+  -passin env:APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD -out "$CERTIFICATE"; then
+  fail "The Developer ID certificate archive or its password is invalid."
+fi
+if ! extract_pkcs12 \
+  -in "$CERTIFICATE_ARCHIVE" -nocerts -nodes \
+  -passin env:APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD -out "$CERTIFICATE_PRIVATE_KEY"; then
+  fail "The Developer ID certificate archive does not contain a readable private key."
+fi
+chmod 600 "$CERTIFICATE" "$CERTIFICATE_PRIVATE_KEY"
+
+if ! "$OPENSSL_BIN" x509 -in "$CERTIFICATE" -noout >/dev/null 2>&1; then
+  fail "The Developer ID certificate archive does not contain a readable certificate."
+fi
+if ! "$OPENSSL_BIN" x509 \
+  -in "$CERTIFICATE" \
+  -checkend "$MINIMUM_CERTIFICATE_VALIDITY_SECONDS" \
+  -noout >/dev/null 2>&1; then
+  fail "The Developer ID certificate is expired or expires within seven days."
+fi
+
+certificate_subject="$("$OPENSSL_BIN" x509 -in "$CERTIFICATE" -noout -subject -nameopt multiline)"
+certificate_common_name="$(
+  printf '%s\n' "$certificate_subject" |
+    sed -n 's/^[[:space:]]*commonName[[:space:]]*=[[:space:]]*//p'
+)"
+certificate_team_identifier="$(
+  printf '%s\n' "$certificate_subject" |
+    sed -n 's/^[[:space:]]*organizationalUnitName[[:space:]]*=[[:space:]]*//p' |
+    head -n 1
+)"
+if [[ "$certificate_common_name" != "$identity_prefix"*"$identity_suffix" ||
+      "$certificate_team_identifier" != "$TEAM_IDENTIFIER" ]]; then
+  fail "The Developer ID certificate is not owned by APPLE_TEAM_ID."
+fi
+certificate_owner="${certificate_common_name#"$identity_prefix"}"
+certificate_owner="${certificate_owner%"$identity_suffix"}"
+[[ -n "$certificate_owner" ]] || fail "The Developer ID certificate is missing its owner name."
+certificate_fingerprint="$(
+  "$OPENSSL_BIN" x509 -in "$CERTIFICATE" -noout -fingerprint -sha1 |
+    sed 's/^[^=]*=//; s/://g' |
+    tr '[:lower:]' '[:upper:]'
+)"
+configured_fingerprint="$(printf '%s' "$SIGNING_IDENTITY" | tr '[:lower:]' '[:upper:]')"
+if [[ "$identity_is_fingerprint" == "true" &&
+      "$certificate_fingerprint" != "$configured_fingerprint" ]]; then
+  fail "The Developer ID certificate fingerprint does not match APPLE_DEVELOPER_ID_APPLICATION_IDENTITY."
+fi
+if [[ "$identity_is_fingerprint" == "false" &&
+      "$certificate_common_name" != "$SIGNING_IDENTITY" ]]; then
+  fail "The Developer ID certificate common name does not match APPLE_DEVELOPER_ID_APPLICATION_IDENTITY."
+fi
+
+certificate_usage="$("$OPENSSL_BIN" x509 -in "$CERTIFICATE" -noout -text 2>/dev/null || true)"
+if [[ "$certificate_usage" != *"Code Signing"* ]]; then
+  fail "The Developer ID certificate is not valid for code signing."
+fi
+if ! validate_private_key "$CERTIFICATE_PRIVATE_KEY"; then
+  fail "The Developer ID certificate private key is invalid."
+fi
+if ! "$OPENSSL_BIN" x509 -in "$CERTIFICATE" -pubkey -noout > "$CERTIFICATE_PUBLIC_KEY" 2>/dev/null ||
+   ! "$OPENSSL_BIN" pkey -in "$CERTIFICATE_PRIVATE_KEY" -pubout > "$PRIVATE_PUBLIC_KEY" 2>/dev/null ||
+   ! cmp -s "$CERTIFICATE_PUBLIC_KEY" "$PRIVATE_PUBLIC_KEY"; then
+  fail "The Developer ID certificate and private key do not match."
+fi
+
+if ! grep -Fqx -- "-----BEGIN PRIVATE KEY-----" "$NOTARY_PRIVATE_KEY"; then
+  fail "The App Store Connect private key must use unencrypted PKCS#8 PEM format."
+fi
+if ! validate_private_key "$NOTARY_PRIVATE_KEY"; then
+  fail "The App Store Connect private key is invalid."
+fi
+if ! "$OPENSSL_BIN" ec \
+  -in "$NOTARY_PRIVATE_KEY" -param_out -outform DER \
+  -out "$NOTARY_PARAMETERS" >/dev/null 2>&1 ||
+   ! "$OPENSSL_BIN" ecparam \
+  -name prime256v1 -param_enc named_curve -outform DER \
+  -out "$P256_NAMED_PARAMETERS" >/dev/null 2>&1 ||
+   ! "$OPENSSL_BIN" ecparam \
+  -name prime256v1 -param_enc explicit -outform DER \
+  -out "$P256_EXPLICIT_PARAMETERS" >/dev/null 2>&1; then
+  fail "The App Store Connect private key parameters could not be validated."
+fi
+if ! cmp -s "$NOTARY_PARAMETERS" "$P256_NAMED_PARAMETERS" &&
+   ! cmp -s "$NOTARY_PARAMETERS" "$P256_EXPLICIT_PARAMETERS"; then
+  fail "The App Store Connect private key must use the P-256 elliptic curve."
+fi
+
+echo "Validated Apple Developer ID and notarization credential material."


### PR DESCRIPTION
## Summary
- validate all seven stable Apple distribution credentials before CI wait or native packaging
- verify Developer ID archive integrity, identity/team ownership, expiry, signing usage, and App Store Connect P-256 key structure without logging secret values
- cover modern and legacy PKCS#12 archives, full-name and fingerprint identities, malformed credentials, cleanup, and workflow ordering with real OpenSSL fixtures

## Validation
- swift test --filter ParityAppleDistributionCredentialPreflightTests (9 passed)
- swift test --skip-build (6,319 passed, 5 skipped)
- python3 -m unittest discover -s Tests/ScriptTests -p test_*.py (122 passed)
- bash -n scripts/validate-apple-distribution-credentials.sh
- git diff --cached --check
- code quality: A+ (100) for both new files