### PR TITLE
Speed warm workspace startup reads

### DIFF
--- a/Sources/QuillCodePersistence/PrivateFileStoreFileSystem.swift
+++ b/Sources/QuillCodePersistence/PrivateFileStoreFileSystem.swift
@@ -26,6 +26,99 @@ enum PrivateFileStoreFileSystem {
     private static let filePermissions = mode_t(0o600)
     private static let readChunkBytes = 64 * 1_024
 
+    /// Reuses one validated directory descriptor across a bounded group of private-file reads.
+    /// Holding the descriptor also prevents a path replacement from redirecting later reads.
+    final class DirectoryReader {
+        private let descriptor: Int32
+        private var buffer = [UInt8](repeating: 0, count: 1)
+
+        init?(
+            directory: URL,
+            repairDirectoryPermissions: Bool = false
+        ) throws {
+            guard let descriptor = try PrivateFileStoreFileSystem.openDirectory(
+                at: directory,
+                createIfMissing: false,
+                repairPermissions: repairDirectoryPermissions
+            ) else {
+                return nil
+            }
+            self.descriptor = descriptor
+        }
+
+        deinit {
+            PrivateFileStoreFileSystem.closeIgnoringErrors(descriptor)
+        }
+
+        func read(
+            filename: String,
+            maximumBytes: Int,
+            requiresPrivateFilePermissions: Bool = true
+        ) throws -> Data? {
+            guard maximumBytes >= 0 else {
+                throw BoundedFileDataError.invalidSizeLimit
+            }
+
+            let fileDescriptor = filename.withCString {
+                openat(descriptor, $0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+            }
+            guard fileDescriptor >= 0 else {
+                switch errno {
+                case ENOENT:
+                    return nil
+                case ELOOP:
+                    throw BoundedFileDataError.symbolicLink
+                default:
+                    throw PrivateFileStoreFileSystem.posixError()
+                }
+            }
+            defer { PrivateFileStoreFileSystem.closeIgnoringErrors(fileDescriptor) }
+
+            let metadata = try PrivateFileStoreFileSystem.fileMetadata(fileDescriptor)
+            try PrivateFileStoreFileSystem.validateEntry(
+                metadata,
+                requiresPrivatePermissions: requiresPrivateFilePermissions
+            )
+            guard metadata.st_size >= 0,
+                  UInt64(metadata.st_size) <= UInt64(maximumBytes)
+            else {
+                throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+            }
+
+            let fileSize = Int(metadata.st_size)
+            var data = Data()
+            data.reserveCapacity(fileSize)
+            let requiredBufferSize = min(readChunkBytes, max(1, fileSize))
+            if buffer.count < requiredBufferSize {
+                buffer = [UInt8](repeating: 0, count: requiredBufferSize)
+            }
+            while true {
+                let remaining = maximumBytes - data.count
+                let requested = remaining == 0 ? 1 : min(buffer.count, remaining)
+                let count = buffer.withUnsafeMutableBytes { bytes in
+                    PrivateFileStoreFileSystem.systemRead(
+                        fileDescriptor,
+                        bytes.baseAddress,
+                        requested
+                    )
+                }
+                if count < 0, errno == EINTR {
+                    continue
+                }
+                guard count >= 0 else {
+                    throw PrivateFileStoreFileSystem.posixError()
+                }
+                guard count > 0 else {
+                    return data
+                }
+                guard count <= remaining else {
+                    throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
+                }
+                data.append(contentsOf: buffer.prefix(count))
+            }
+        }
+    }
+
     static func read(
         directory: URL,
         filename: String,
@@ -33,64 +126,15 @@ enum PrivateFileStoreFileSystem {
         requiresPrivateFilePermissions: Bool = true,
         repairDirectoryPermissions: Bool = false
     ) throws -> Data? {
-        guard maximumBytes >= 0 else {
-            throw BoundedFileDataError.invalidSizeLimit
-        }
-        guard let directoryDescriptor = try openDirectory(
-            at: directory,
-            createIfMissing: false,
-            repairPermissions: repairDirectoryPermissions
-        ) else {
-            return nil
-        }
-        defer { closeIgnoringErrors(directoryDescriptor) }
-
-        let descriptor = filename.withCString {
-            openat(directoryDescriptor, $0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
-        }
-        guard descriptor >= 0 else {
-            switch errno {
-            case ENOENT:
-                return nil
-            case ELOOP:
-                throw BoundedFileDataError.symbolicLink
-            default:
-                throw posixError()
-            }
-        }
-        defer { closeIgnoringErrors(descriptor) }
-
-        let metadata = try fileMetadata(descriptor)
-        try validateEntry(metadata, requiresPrivatePermissions: requiresPrivateFilePermissions)
-        guard metadata.st_size >= 0,
-              UInt64(metadata.st_size) <= UInt64(maximumBytes)
-        else {
-            throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
-        }
-
-        var data = Data()
-        data.reserveCapacity(Int(metadata.st_size))
-        var buffer = [UInt8](repeating: 0, count: min(readChunkBytes, max(1, maximumBytes)))
-        while true {
-            let remaining = maximumBytes - data.count
-            let requested = remaining == 0 ? 1 : min(buffer.count, remaining)
-            let count = buffer.withUnsafeMutableBytes { bytes in
-                systemRead(descriptor, bytes.baseAddress, requested)
-            }
-            if count < 0, errno == EINTR {
-                continue
-            }
-            guard count >= 0 else {
-                throw posixError()
-            }
-            guard count > 0 else {
-                return data
-            }
-            guard count <= remaining else {
-                throw BoundedFileDataError.exceedsSizeLimit(maximumBytes: maximumBytes)
-            }
-            data.append(contentsOf: buffer.prefix(count))
-        }
+        guard let reader = try DirectoryReader(
+            directory: directory,
+            repairDirectoryPermissions: repairDirectoryPermissions
+        ) else { return nil }
+        return try reader.read(
+            filename: filename,
+            maximumBytes: maximumBytes,
+            requiresPrivateFilePermissions: requiresPrivateFilePermissions
+        )
     }
 
     static func write(_ data: Data, directory: URL, filename: String) throws {

--- a/Sources/QuillCodePersistence/ThreadPayloadSummaryStore.swift
+++ b/Sources/QuillCodePersistence/ThreadPayloadSummaryStore.swift
@@ -158,38 +158,48 @@ enum ThreadPayloadSummaryStore {
     private static let directoryName = ".thread-payload-summaries-v2"
     private static let legacyIndexName = ".archived-thread-summary-index-v1"
 
-    static func load(
-        threadID: UUID,
-        authoritativeFileURL: URL,
-        fingerprint: ThreadFileFingerprint,
-        calendar: Calendar,
-        from threadDirectory: URL
-    ) -> ThreadPayloadSummaryEntry? {
-        let directory = cacheDirectory(in: threadDirectory)
-        let filename = cacheFilename(for: threadID)
-        do {
-            guard let data = try PrivateFileStoreFileSystem.read(
-                directory: directory,
-                filename: filename,
-                maximumBytes: maximumEntryBytes
-            ) else {
-                return nil
-            }
-            let entry = try JSONDecoder().decode(ThreadPayloadSummaryEntry.self, from: data)
-            guard entry.id == threadID,
-                  entry.matches(
-                      fileURL: authoritativeFileURL,
-                      fingerprint: fingerprint,
-                      calendar: calendar
-                  )
-            else {
+    final class Loader {
+        private let threadDirectory: URL
+        private let reader: PrivateFileStoreFileSystem.DirectoryReader?
+        private let decoder = JSONDecoder()
+
+        init(from threadDirectory: URL) {
+            self.threadDirectory = threadDirectory
+            self.reader = try? PrivateFileStoreFileSystem.DirectoryReader(
+                directory: cacheDirectory(in: threadDirectory)
+            )
+        }
+
+        func load(
+            threadID: UUID,
+            authoritativeFileURL: URL,
+            fingerprint: ThreadFileFingerprint,
+            calendar: Calendar
+        ) -> ThreadPayloadSummaryEntry? {
+            let filename = cacheFilename(for: threadID)
+            do {
+                guard let data = try reader?.read(
+                    filename: filename,
+                    maximumBytes: maximumEntryBytes
+                ) else {
+                    return nil
+                }
+                let entry = try decoder.decode(ThreadPayloadSummaryEntry.self, from: data)
+                guard entry.id == threadID,
+                      entry.matches(
+                          fileURL: authoritativeFileURL,
+                          fingerprint: fingerprint,
+                          calendar: calendar
+                      )
+                else {
+                    remove(threadID: threadID, from: threadDirectory)
+                    return nil
+                }
+                return entry
+            } catch {
                 remove(threadID: threadID, from: threadDirectory)
                 return nil
             }
-            return entry
-        } catch {
-            remove(threadID: threadID, from: threadDirectory)
-            return nil
         }
     }
 

--- a/Sources/QuillCodePersistence/ThreadStore.swift
+++ b/Sources/QuillCodePersistence/ThreadStore.swift
@@ -161,18 +161,18 @@ public struct JSONThreadStore: Sendable {
         var issues: [ThreadFileIssue] = []
         var cacheHitThreadIDs = Set<UUID>()
         let defersActivePayloads = maximumResidentActivePayloads != .max
+        let summaryLoader = ThreadPayloadSummaryStore.Loader(from: directory)
 
         for url in urls {
             let fingerprint = ThreadFileFingerprint.read(from: url)
             let threadID = UUID(uuidString: url.deletingPathExtension().lastPathComponent)
             let cachedEntry = threadID.flatMap { id in
                 fingerprint.flatMap { fingerprint in
-                    ThreadPayloadSummaryStore.load(
+                    summaryLoader.load(
                         threadID: id,
                         authoritativeFileURL: url,
                         fingerprint: fingerprint,
-                        calendar: calendar,
-                        from: directory
+                        calendar: calendar
                     )
                 }
             }

--- a/Tests/QuillCodePersistenceTests/PrivateFileStoreFileSystemTests.swift
+++ b/Tests/QuillCodePersistenceTests/PrivateFileStoreFileSystemTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import QuillCodePersistence
+
+final class PrivateFileStoreFileSystemTests: XCTestCase {
+    func testDirectoryReaderReadsEmptyAndMultiChunkFilesExactly() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("private", isDirectory: true)
+        let largeData = Data((0..<(130 * 1_024)).map { UInt8($0 % 251) })
+        try PrivateFileStoreFileSystem.write(
+            Data(),
+            directory: directory,
+            filename: "empty.json"
+        )
+        try PrivateFileStoreFileSystem.write(
+            largeData,
+            directory: directory,
+            filename: "large.json"
+        )
+        let reader = try XCTUnwrap(
+            PrivateFileStoreFileSystem.DirectoryReader(directory: directory)
+        )
+
+        XCTAssertEqual(
+            try reader.read(filename: "empty.json", maximumBytes: 0),
+            Data()
+        )
+        XCTAssertEqual(
+            try reader.read(filename: "large.json", maximumBytes: largeData.count),
+            largeData
+        )
+    }
+
+    func testDirectoryReaderStaysBoundToValidatedDirectoryAfterPathReplacement() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("private", isDirectory: true)
+        try PrivateFileStoreFileSystem.write(
+            Data("validated".utf8),
+            directory: directory,
+            filename: "state.json"
+        )
+        let reader = try XCTUnwrap(
+            PrivateFileStoreFileSystem.DirectoryReader(directory: directory)
+        )
+
+        let originalDirectory = root.appendingPathComponent("original", isDirectory: true)
+        try FileManager.default.moveItem(at: directory, to: originalDirectory)
+        try PrivateFileStoreFileSystem.write(
+            Data("replacement".utf8),
+            directory: directory,
+            filename: "state.json"
+        )
+
+        let data = try XCTUnwrap(
+            reader.read(filename: "state.json", maximumBytes: 64)
+        )
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "validated")
+    }
+
+    func testDirectoryReaderKeepsPerEntrySymlinkAndSizeChecks() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("private", isDirectory: true)
+        try PrivateFileStoreFileSystem.write(
+            Data("12345".utf8),
+            directory: directory,
+            filename: "bounded.json"
+        )
+        let outside = root.appendingPathComponent("outside.json")
+        try Data("outside".utf8).write(to: outside)
+        try FileManager.default.createSymbolicLink(
+            at: directory.appendingPathComponent("linked.json"),
+            withDestinationURL: outside
+        )
+        let reader = try XCTUnwrap(
+            PrivateFileStoreFileSystem.DirectoryReader(directory: directory)
+        )
+
+        XCTAssertThrowsError(
+            try reader.read(filename: "bounded.json", maximumBytes: 4)
+        ) { error in
+            XCTAssertEqual(
+                error as? BoundedFileDataError,
+                .exceedsSizeLimit(maximumBytes: 4)
+            )
+        }
+        XCTAssertThrowsError(
+            try reader.read(filename: "linked.json", maximumBytes: 64)
+        ) { error in
+            XCTAssertEqual(error as? BoundedFileDataError, .symbolicLink)
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "PrivateFileStoreFileSystemTests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+}


### PR DESCRIPTION
## Summary
- reuse one validated private-directory descriptor while loading thread summaries
- reuse a bounded grow-only scratch buffer and JSON decoder across the bootstrap listing
- preserve per-file ownership, permissions, type, symlink, hard-link, and size validation
- add descriptor binding, exact bounded-read, and symlink regression coverage

## Measured result
Exact-main release baseline vs final release bundle, identical `daily-driver-100-chats` packaged smoke on Apple silicon:

| Metric | Before | After |
| --- | ---: | ---: |
| Launch attempts | 632.09 / 305.16 / 311.44 ms | 290.12 / 291.23 / 296.47 ms |
| Median launch-ready | 311.44 ms | 291.23 ms |
| Worst attempt | 632.09 ms | 296.47 ms |
| Initial physical footprint | 40.63 MiB | 40.97 MiB |
| Repeated-sweep footprint | 79.52 MiB | 80.58 MiB |
| Settled idle CPU | 0.0002% | 0.0002% |

Median improved 6.5%; worst attempt improved 53.1%. All native interactions, accessibility probes, critical-memory-pressure recovery, idle thread budgets, and resource budgets pass.

## Validation
- `swift test`: 6,322 tests, 5 skipped, 0 failures
- `python3 -m unittest discover -s Tests/ScriptTests -p "test_*.py"`: 122 tests, 0 failures
- complete `QuillCodePersistenceTests`: 189 tests, 0 failures
- strict `scripts/packaged-macos-performance-smoke.sh`: passed 3/3 launches and every resource budget
- `git diff --check`: clean