### PR TITLE
Bound computer-use driver processes

### DIFF
--- a/Sources/QuillComputerUseKit/CuaDriverProcessCapture.swift
+++ b/Sources/QuillComputerUseKit/CuaDriverProcessCapture.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+#if canImport(Glibc) || canImport(Darwin)
+struct CuaDriverBoundedPipeCaptureResult: Sendable {
+    var data = Data()
+    var totalByteCount = 0
+    var wasTruncated = false
+    var readCompleted = false
+}
+
+/// Drains one subprocess pipe without allowing retained output to follow producer volume.
+final class CuaDriverBoundedPipeCapture: @unchecked Sendable {
+    enum Retention {
+        case prefix
+        case suffix
+    }
+
+    private static let readChunkBytes = 64 * 1_024
+
+    private let handle: FileHandle
+    private let byteLimit: Int
+    private let retention: Retention
+    private let completion = DispatchGroup()
+    private let lock = NSLock()
+    private var result = CuaDriverBoundedPipeCaptureResult()
+
+    init(handle: FileHandle, byteLimit: Int, retention: Retention) {
+        self.handle = handle
+        self.byteLimit = max(0, byteLimit)
+        self.retention = retention
+    }
+
+    func start() {
+        completion.enter()
+        DispatchQueue.global(qos: .utility).async { [self] in
+            drain()
+            completion.leave()
+        }
+    }
+
+    func finishAfterProcessExit(graceSeconds: TimeInterval) -> CuaDriverBoundedPipeCaptureResult {
+        if completion.wait(timeout: .now() + max(0, graceSeconds)) == .timedOut {
+            try? handle.close()
+            _ = completion.wait(timeout: .now() + max(0.1, graceSeconds))
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        return result
+    }
+
+    private func drain() {
+        var captured = Data()
+        var totalByteCount = 0
+        var wasTruncated = false
+        var readCompleted = false
+
+        do {
+            while let chunk = try handle.read(upToCount: Self.readChunkBytes), !chunk.isEmpty {
+                totalByteCount = Self.saturatingSum(totalByteCount, chunk.count)
+                if totalByteCount > byteLimit {
+                    wasTruncated = true
+                }
+                retain(chunk, in: &captured)
+            }
+            readCompleted = true
+        } catch {
+            readCompleted = false
+        }
+
+        lock.lock()
+        result = CuaDriverBoundedPipeCaptureResult(
+            data: captured,
+            totalByteCount: totalByteCount,
+            wasTruncated: wasTruncated,
+            readCompleted: readCompleted
+        )
+        lock.unlock()
+    }
+
+    private func retain(_ chunk: Data, in captured: inout Data) {
+        guard byteLimit > 0 else { return }
+        switch retention {
+        case .prefix:
+            let available = byteLimit - captured.count
+            guard available > 0 else { return }
+            captured.append(chunk.prefix(available))
+        case .suffix:
+            if chunk.count >= byteLimit {
+                captured = Data(chunk.suffix(byteLimit))
+                return
+            }
+            let overflow = captured.count + chunk.count - byteLimit
+            if overflow > 0 {
+                captured.removeFirst(overflow)
+            }
+            captured.append(chunk)
+        }
+    }
+
+    private static func saturatingSum(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Int.max : sum
+    }
+}
+
+/// Synchronizes task cancellation and timeout teardown with Foundation's non-Sendable `Process`.
+final class CuaDriverProcessHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancellationRequested = false
+
+    func attach(_ process: Process) {
+        lock.lock()
+        self.process = process
+        lock.unlock()
+    }
+
+    func terminateIfCancellationRequested() {
+        lock.lock()
+        let shouldTerminate = cancellationRequested
+        lock.unlock()
+        if shouldTerminate { terminate() }
+    }
+
+    func requestCancellation(terminationGraceSeconds: TimeInterval) {
+        lock.lock()
+        cancellationRequested = true
+        lock.unlock()
+        terminate()
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + max(0, terminationGraceSeconds)
+        ) { [self] in
+            kill()
+        }
+    }
+
+    func terminate() {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        if let process, process.isRunning { process.terminate() }
+    }
+
+    func kill() {
+        lock.lock()
+        let process = self.process
+        lock.unlock()
+        if let process, process.isRunning {
+            Foundation.kill(process.processIdentifier, SIGKILL)
+        }
+    }
+}
+#endif

--- a/Sources/QuillComputerUseKit/CuaDriverProcessClient.swift
+++ b/Sources/QuillComputerUseKit/CuaDriverProcessClient.swift
@@ -13,10 +13,33 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
         public var exitCode: Int32
         public var stdout: Data
         public var stderr: Data
-        public init(exitCode: Int32, stdout: Data, stderr: Data) {
+        public var stdoutByteCount: Int
+        public var stderrByteCount: Int
+        public var stdoutWasTruncated: Bool
+        public var stderrWasTruncated: Bool
+        public var stdoutReadCompleted: Bool
+        public var stderrReadCompleted: Bool
+
+        public init(
+            exitCode: Int32,
+            stdout: Data,
+            stderr: Data,
+            stdoutByteCount: Int? = nil,
+            stderrByteCount: Int? = nil,
+            stdoutWasTruncated: Bool = false,
+            stderrWasTruncated: Bool = false,
+            stdoutReadCompleted: Bool = true,
+            stderrReadCompleted: Bool = true
+        ) {
             self.exitCode = exitCode
             self.stdout = stdout
             self.stderr = stderr
+            self.stdoutByteCount = max(stdout.count, stdoutByteCount ?? stdout.count)
+            self.stderrByteCount = max(stderr.count, stderrByteCount ?? stderr.count)
+            self.stdoutWasTruncated = stdoutWasTruncated
+            self.stderrWasTruncated = stderrWasTruncated
+            self.stdoutReadCompleted = stdoutReadCompleted
+            self.stderrReadCompleted = stderrReadCompleted
         }
     }
 
@@ -32,12 +55,30 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
         let argsString = String(data: argumentsJSON, encoding: .utf8) ?? "{}"
         let result = try await runProcess([driverPath, "call", name, argsString], nil)
         guard result.exitCode == 0 else {
-            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
-            let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
+            let stderr = String(decoding: result.stderr, as: UTF8.self)
+            let stdout = String(decoding: result.stdout, as: UTF8.self)
             let message = stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? stdout.trimmingCharacters(in: .whitespacesAndNewlines)
                 : stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw CuaDriverError.toolFailed(tool: name, message: String(message.prefix(400)))
+            let truncationNote = result.stderrWasTruncated || (stderr.isEmpty && result.stdoutWasTruncated)
+                ? "[diagnostic tail truncated] "
+                : ""
+            throw CuaDriverError.toolFailed(
+                tool: name,
+                message: truncationNote + String(message.prefix(400))
+            )
+        }
+        guard result.stdoutReadCompleted else {
+            throw CuaDriverError.toolFailed(
+                tool: name,
+                message: "cua-driver response ended before its output stream could be read completely"
+            )
+        }
+        guard !result.stdoutWasTruncated else {
+            throw CuaDriverError.toolFailed(
+                tool: name,
+                message: "cua-driver response exceeded the 32 MiB safety limit and was rejected"
+            )
         }
         return result.stdout
     }
@@ -46,14 +87,17 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
     /// well under a second; this only bounds a hung/streaming child so the computer-use loop can never
     /// wedge indefinitely in the unattended-coworker case.
     public static let defaultTimeout: TimeInterval = 60
+    public static let maximumStandardOutputBytes = 32 * 1_024 * 1_024
+    public static let maximumStandardErrorBytes = 256 * 1_024
+    private static let defaultTerminationGraceSeconds: TimeInterval = 2
 
     /// Runs the driver binary directly (argv[0] is the executable path, not a shell), so no argument
     /// is ever interpreted by a shell.
     ///
-    /// Three properties the naive version lacked: (1) stdout and stderr are drained **concurrently**,
-    /// so a child that fills the stderr pipe (verbose logs, a backtrace) while we read the multi-MB
-    /// screenshot on stdout can't deadlock; (2) a timeout terminates — then hard-kills — a hung child;
-    /// (3) cancelling the owning Task terminates the child instead of leaking it.
+    /// The process boundary drains stdout and stderr concurrently with independent residency caps,
+    /// tracks timeout against process exit rather than pipe closure, and gives timeout/cancellation a
+    /// bounded terminate-then-kill path. A noisy or uncooperative driver therefore cannot deadlock a
+    /// pipe, grow the app without bound, or outlive the task that owns it.
     public static let defaultRunProcess: @Sendable (_ arguments: [String], _ stdin: Data?) async throws -> ProcessRunResult = { arguments, stdin in
         try await runProcess(arguments: arguments, stdin: stdin, timeout: defaultTimeout)
     }
@@ -61,17 +105,21 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
     static func runProcess(
         arguments: [String],
         stdin: Data?,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        stdoutByteLimit: Int = maximumStandardOutputBytes,
+        stderrByteLimit: Int = maximumStandardErrorBytes,
+        terminationGraceSeconds: TimeInterval = defaultTerminationGraceSeconds
     ) async throws -> ProcessRunResult {
         #if canImport(Glibc) || canImport(Darwin)
+        try Task.checkCancellation()
         guard let executable = arguments.first else {
             throw CuaDriverError.driverNotFound("(empty argv)")
         }
         guard FileManager.default.isExecutableFile(atPath: executable) else {
             throw CuaDriverError.driverNotFound(executable)
         }
-        let handle = ProcessHandle()
-        return try await withTaskCancellationHandler {
+        let handle = CuaDriverProcessHandle()
+        let result = try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ProcessRunResult, Error>) in
                 // Run the blocking Foundation work off the cooperative pool so a slow child never ties
                 // up a Swift-concurrency worker thread.
@@ -82,6 +130,9 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
                             arguments: Array(arguments.dropFirst()),
                             stdin: stdin,
                             timeout: timeout,
+                            stdoutByteLimit: stdoutByteLimit,
+                            stderrByteLimit: stderrByteLimit,
+                            terminationGraceSeconds: terminationGraceSeconds,
                             handle: handle
                         )
                         continuation.resume(returning: result)
@@ -91,8 +142,10 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
                 }
             }
         } onCancel: {
-            handle.terminate()
+            handle.requestCancellation(terminationGraceSeconds: terminationGraceSeconds)
         }
+        try Task.checkCancellation()
+        return result
         #else
         throw CuaDriverError.driverNotFound("Subprocess execution unavailable on this platform")
         #endif
@@ -104,7 +157,10 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
         arguments: [String],
         stdin: Data?,
         timeout: TimeInterval,
-        handle: ProcessHandle
+        stdoutByteLimit: Int,
+        stderrByteLimit: Int,
+        terminationGraceSeconds: TimeInterval,
+        handle: CuaDriverProcessHandle
     ) throws -> ProcessRunResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
@@ -116,65 +172,59 @@ public struct CuaDriverProcessClient: CuaDriverToolInvoking {
         if stdin != nil {
             process.standardInput = Pipe()
         }
+        let processCompletion = DispatchGroup()
+        processCompletion.enter()
+        process.terminationHandler = { _ in processCompletion.leave() }
         handle.attach(process)
         try process.run()
+        handle.terminateIfCancellationRequested()
+
+        let stdoutCapture = CuaDriverBoundedPipeCapture(
+            handle: stdoutPipe.fileHandleForReading,
+            byteLimit: stdoutByteLimit,
+            retention: .prefix
+        )
+        let stderrCapture = CuaDriverBoundedPipeCapture(
+            handle: stderrPipe.fileHandleForReading,
+            byteLimit: stderrByteLimit,
+            retention: .suffix
+        )
+        stdoutCapture.start()
+        stderrCapture.start()
+
         if let stdin, let inputPipe = process.standardInput as? Pipe {
             inputPipe.fileHandleForWriting.write(stdin)
             try? inputPipe.fileHandleForWriting.close()
         }
 
-        // Drain both pipes on independent queues; each read completes when the child closes that pipe
-        // (at exit). Waiting on the group therefore waits for exit AND full drain, with no ordering
-        // hazard between the two streams.
-        let outBox = DataBox()
-        let errBox = DataBox()
-        let group = DispatchGroup()
-        let ioQueue = DispatchQueue(label: "com.quillcode.cua.pipe", attributes: .concurrent)
-        group.enter()
-        ioQueue.async { outBox.set(stdoutPipe.fileHandleForReading.readDataToEndOfFile()); group.leave() }
-        group.enter()
-        ioQueue.async { errBox.set(stderrPipe.fileHandleForReading.readDataToEndOfFile()); group.leave() }
-
-        if group.wait(timeout: .now() + timeout) == .timedOut {
-            process.terminate()
-            if group.wait(timeout: .now() + 2) == .timedOut {
+        let boundedTimeout = max(0, timeout)
+        if processCompletion.wait(timeout: .now() + boundedTimeout) == .timedOut {
+            handle.terminate()
+            if processCompletion.wait(timeout: .now() + max(0, terminationGraceSeconds)) == .timedOut {
                 handle.kill()
-                _ = group.wait(timeout: .now() + 2)
+                _ = processCompletion.wait(timeout: .now() + max(0, terminationGraceSeconds))
             }
-            process.waitUntilExit()
+            _ = stdoutCapture.finishAfterProcessExit(graceSeconds: terminationGraceSeconds)
+            _ = stderrCapture.finishAfterProcessExit(graceSeconds: terminationGraceSeconds)
             throw CuaDriverError.toolFailed(
                 tool: (arguments.first ?? "cua-driver"),
                 message: "cua-driver timed out after \(Int(timeout))s"
             )
         }
-        process.waitUntilExit()
-        return ProcessRunResult(exitCode: process.terminationStatus, stdout: outBox.get(), stderr: errBox.get())
+
+        let stdout = stdoutCapture.finishAfterProcessExit(graceSeconds: terminationGraceSeconds)
+        let stderr = stderrCapture.finishAfterProcessExit(graceSeconds: terminationGraceSeconds)
+        return ProcessRunResult(
+            exitCode: process.terminationStatus,
+            stdout: stdout.data,
+            stderr: stderr.data,
+            stdoutByteCount: stdout.totalByteCount,
+            stderrByteCount: stderr.totalByteCount,
+            stdoutWasTruncated: stdout.wasTruncated,
+            stderrWasTruncated: stderr.wasTruncated,
+            stdoutReadCompleted: stdout.readCompleted,
+            stderrReadCompleted: stderr.readCompleted
+        )
     }
     #endif
 }
-
-#if canImport(Glibc) || canImport(Darwin)
-/// Lock-guarded accumulator so pipe reads on background queues don't data-race the captured buffers.
-private final class DataBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var data = Data()
-    func set(_ value: Data) { lock.lock(); data = value; lock.unlock() }
-    func get() -> Data { lock.lock(); defer { lock.unlock() }; return data }
-}
-
-/// Holds the running process so the Task-cancellation handler can terminate/kill it from another
-/// thread. `Process` isn't `Sendable`; access is serialized by the lock.
-private final class ProcessHandle: @unchecked Sendable {
-    private let lock = NSLock()
-    private var process: Process?
-    func attach(_ process: Process) { lock.lock(); self.process = process; lock.unlock() }
-    func terminate() {
-        lock.lock(); defer { lock.unlock() }
-        if let process, process.isRunning { process.terminate() }
-    }
-    func kill() {
-        lock.lock(); defer { lock.unlock() }
-        if let process, process.isRunning { Foundation.kill(process.processIdentifier, SIGKILL) }
-    }
-}
-#endif

--- a/Tests/QuillComputerUseKitTests/CuaDriverLocatorTests.swift
+++ b/Tests/QuillComputerUseKitTests/CuaDriverLocatorTests.swift
@@ -216,4 +216,138 @@ final class CuaDriverProcessClientTests: XCTestCase {
         let result = try await client.callTool(name: "list_apps", argumentsJSON: Data("{}".utf8))
         XCTAssertEqual(String(data: result, encoding: .utf8), #"{"apps":[]}"#)
     }
+
+    func testZeroExitRejectsTruncatedStdoutBeforeJSONParsing() async {
+        let client = CuaDriverProcessClient(
+            driverPath: "/x/cua-driver",
+            runProcess: { _, _ in
+                .init(
+                    exitCode: 0,
+                    stdout: Data(repeating: 0x61, count: 1_024),
+                    stderr: Data(),
+                    stdoutByteCount: CuaDriverProcessClient.maximumStandardOutputBytes + 1,
+                    stdoutWasTruncated: true
+                )
+            }
+        )
+
+        do {
+            _ = try await client.callTool(name: "get_desktop_state", argumentsJSON: Data("{}".utf8))
+            XCTFail("Expected oversized output to fail closed.")
+        } catch let error as CuaDriverError {
+            guard case let .toolFailed(tool, message) = error else {
+                return XCTFail("Wrong error: \(error)")
+            }
+            XCTAssertEqual(tool, "get_desktop_state")
+            XCTAssertTrue(message.contains("32 MiB safety limit"), message)
+        } catch {
+            XCTFail("Wrong error type: \(error)")
+        }
+    }
+
+    #if canImport(Glibc) || canImport(Darwin)
+    func testRunProcessDrainsNoisyOutputWithoutDeadlockAndBoundsResidency() async throws {
+        let command = #"i=0; while [ "$i" -lt 20000 ]; do printf '0123456789abcdef0123456789abcdef\n'; i=$((i + 1)); done"#
+        let result = try await CuaDriverProcessClient.runProcess(
+            arguments: ["/bin/sh", "-c", command],
+            stdin: nil,
+            timeout: 5,
+            stdoutByteLimit: 4_096,
+            stderrByteLimit: 128,
+            terminationGraceSeconds: 0.1
+        )
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertTrue(result.stdoutReadCompleted)
+        XCTAssertTrue(result.stderrReadCompleted)
+        XCTAssertTrue(result.stdoutWasTruncated)
+        XCTAssertFalse(result.stderrWasTruncated)
+        XCTAssertEqual(result.stdout.count, 4_096)
+        XCTAssertGreaterThan(result.stdoutByteCount, 64 * 1_024)
+    }
+
+    func testRunProcessRetainsBoundedDiagnosticTail() async throws {
+        let command = #"i=0; while [ "$i" -lt 300 ]; do printf 'noise-%04d\n' "$i" >&2; i=$((i + 1)); done; printf 'FINAL_DIAGNOSTIC' >&2"#
+        let result = try await CuaDriverProcessClient.runProcess(
+            arguments: ["/bin/sh", "-c", command],
+            stdin: nil,
+            timeout: 5,
+            stdoutByteLimit: 128,
+            stderrByteLimit: 96,
+            terminationGraceSeconds: 0.1
+        )
+
+        XCTAssertTrue(result.stderrWasTruncated)
+        XCTAssertLessThanOrEqual(result.stderr.count, 96)
+        XCTAssertTrue(String(decoding: result.stderr, as: UTF8.self).hasSuffix("FINAL_DIAGNOSTIC"))
+    }
+
+    func testRunProcessTimeoutTracksProcessExitAfterPipesClose() async {
+        let started = Date()
+        do {
+            _ = try await CuaDriverProcessClient.runProcess(
+                arguments: ["/bin/sh", "-c", "exec 1>&- 2>&-; while :; do :; done"],
+                stdin: nil,
+                timeout: 0.1,
+                stdoutByteLimit: 128,
+                stderrByteLimit: 128,
+                terminationGraceSeconds: 0.1
+            )
+            XCTFail("Expected a closed-pipe process to time out.")
+        } catch let error as CuaDriverError {
+            guard case let .toolFailed(_, message) = error else {
+                return XCTFail("Wrong error: \(error)")
+            }
+            XCTAssertTrue(message.contains("timed out"), message)
+        } catch {
+            XCTFail("Wrong error type: \(error)")
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(started), 2)
+    }
+
+    func testCancellationHardKillsDriverThatIgnoresTermination() async {
+        let outcomeRecorder = CuaDriverProcessTestOutcomeRecorder()
+        let finished = expectation(description: "Cancellation finished")
+        let operation = Task {
+            let outcome: CuaDriverProcessTestOutcome
+            do {
+                _ = try await CuaDriverProcessClient.runProcess(
+                    arguments: ["/bin/sh", "-c", "trap '' TERM; while :; do :; done"],
+                    stdin: nil,
+                    timeout: 30,
+                    stdoutByteLimit: 128,
+                    stderrByteLimit: 128,
+                    terminationGraceSeconds: 0.1
+                )
+                outcome = .returned
+            } catch is CancellationError {
+                outcome = .cancelled
+            } catch {
+                outcome = .failed(String(describing: error))
+            }
+            await outcomeRecorder.record(outcome)
+            finished.fulfill()
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        operation.cancel()
+        await fulfillment(of: [finished], timeout: 2)
+        let outcome = await outcomeRecorder.outcome
+        XCTAssertEqual(outcome, .cancelled)
+    }
+    #endif
+}
+
+private enum CuaDriverProcessTestOutcome: Sendable, Equatable {
+    case returned
+    case cancelled
+    case failed(String)
+}
+
+private actor CuaDriverProcessTestOutcomeRecorder {
+    private(set) var outcome: CuaDriverProcessTestOutcome?
+
+    func record(_ outcome: CuaDriverProcessTestOutcome) {
+        self.outcome = outcome
+    }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,33 @@
 # Code Quality Audit
 
+## 2026-08-13 Bounded Computer-Use Driver Processes
+
+Overall grade after this slice: **A+ memory containment, A+ crash resilience, A+ process lifecycle**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Output residency | A+ | Driver stdout is continuously drained with a 32 MiB retained prefix and stderr with a 256 KiB diagnostic tail, preventing a noisy helper from growing app memory without bound or deadlocking on full pipes. |
+| Timeout semantics | A+ | The deadline follows process termination instead of pipe EOF, so a helper that closes its pipes and keeps running is still stopped on time. Descendant-held pipes receive only a bounded drain grace after process exit. |
+| Cancellation | A+ | Cancellation is checked before launch, reconciled across the launch race, and escalates from termination to a hard kill after a bounded grace period. |
+| Failure diagnostics | A+ | Nonzero exits retain the most useful bounded stderr tail and exact byte counts; incomplete or oversized successful stdout fails closed before JSON decoding. |
+| Architecture | A+ | Process capture and lifecycle ownership live in a small dedicated transport module while the client retains request encoding, response decoding, and typed error policy. |
+| Regression evidence | A+ | Real subprocess tests cover pipe-capacity overflow, stderr tail retention, closed-pipe timeouts, SIGTERM-resistant cancellation, and synthetic oversized success output. |
+
+Validation:
+
+- Focused process-client coverage: 7 tests, 0 failures; complete Computer Use module: 88 tests,
+  4 environment-gated skips, 0 failures.
+- Full Swift package: 6,327 tests, 5 intentional skips, 0 failures; Python script contracts:
+  122 tests, 0 failures; website JavaScript release contract passed.
+- Optimized packaged app passed both `SIGKILL` recovery paths, direct and Launch Services rendering,
+  live Accessibility interaction, Computer Use contracts, critical-memory-pressure handling, and
+  the daily-driver resource gate.
+- Three fresh packaged launches passed every production budget: 319.96 ms median launch-ready,
+  40.89 MiB initial physical footprint, 83.00 MiB after the first interaction sweep, 87.84 MiB
+  after repetition, and 0.0002% settled idle CPU.
+- Deterministic grading scores `CuaDriverProcessCapture.swift` A+ (100) and
+  `CuaDriverProcessClient.swift` A+ (96); `git diff --check` passed.
+
 ## 2026-08-13 Stable Apple Credential Material Preflight
 
 The stable release path now rejects unusable Apple credential material in `release-policy`, before

--- a/docs/CUA_COMPUTER_USE_TEST_PLAN.md
+++ b/docs/CUA_COMPUTER_USE_TEST_PLAN.md
@@ -11,7 +11,7 @@ differs.
 | Piece | File | Role |
 |---|---|---|
 | Transport protocol | `CuaDriverClient.swift` (`CuaDriverToolInvoking`) | one-tool-call abstraction, fake-able |
-| Production transport | `CuaDriverProcessClient.swift` | shells `cua-driver call <tool> <json>` (in-process, inherits caller TCC) |
+| Production transport | `CuaDriverProcessClient.swift` | runs bounded `cua-driver call <tool> <json>` subprocesses that inherit caller TCC |
 | Backend | `CuaDriverComputerUseBackend.swift` | maps the 6 `ComputerUseBackend` methods + foreground app onto cua tools |
 | Locator | `CuaDriverLocator.swift` | binary discovery, telemetry-off, `check_permissions` → status |
 | Selection | `ComputerUseBackendFactory.cuaDriverPreferred` + desktop coordinator | env-gated opt-in swap |
@@ -33,11 +33,14 @@ than mis-scaling.
 
 ## Automated tests
 
-- **Unit** (`swift test --filter QuillComputerUseKitTests`, no subprocess):
+- **Unit** (`swift test --filter QuillComputerUseKitTests`):
   `CuaDriverComputerUseBackendTests` (screenshot parse + downscale coordinate scale + set_config-once
   + type/scroll/move/key/click mapping + frontmost pid resolution + malformed/no-app errors),
   `CuaDriverLocatorTests` (path resolution precedence + tilde + status parse + scripted telemetry &
-  permission probe), `CuaDriverProcessClientTests` (non-zero exit → `toolFailed`).
+  permission probe), and `CuaDriverProcessClientTests`. The process-client suite uses real short-lived
+  shell children to prove concurrent draining beyond pipe capacity, 32 MiB stdout / 256 KiB stderr
+  retention policy, diagnostic-tail preservation, process-exit timeout ownership after early pipe
+  closure, and bounded hard-kill cancellation when a child ignores `SIGTERM`.
 - **Live drive** (`CuaDriverLiveDriveTests`, gated on `QUILLCODE_CUA_LIVE_BINARY`): drives the real
   driver through the **production Swift types** — screenshot is downscaled to ≤1568 and the reported
   dims exactly match the decoded PNG; foreground app + locator status resolve against a real desktop.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,11 @@
 
 ## Latest Quality Pass
 
+- One-shot `cua-driver` calls now retain at most 32 MiB of response bytes and 256 KiB of diagnostic
+  tail while continuously draining both pipes. Timeout follows process exit rather than pipe EOF,
+  cancellation survives races before launch, and both paths use a bounded hard-kill fallback. A
+  noisy, early-pipe-closing, or termination-resistant computer-use driver can no longer exhaust app
+  memory, wedge an unattended task, or remain alive after its owner is cancelled.
 - Signed-out model submissions now preserve their complete draft and image attachments and open the
   existing TrustedRouter sign-in flow instead of producing a failed transcript turn. Pure submission
   routing keeps local slash commands available offline, and desktop OAuth is single-flight so repeat


### PR DESCRIPTION
## Summary
- bound cua-driver stdout to a 32 MiB prefix and stderr to a 256 KiB diagnostic tail while continuously draining both pipes
- tie timeout to process termination and add cancellation-safe terminate/kill teardown
- cover noisy output, diagnostic overflow, early pipe closure, and SIGTERM-resistant cancellation with real subprocess tests

## Validation
- swift test --filter CuaDriverProcessClientTests (7 tests)
- swift test --filter QuillComputerUseKitTests (88 tests, 4 environment-gated skips)
- swift test (6,327 tests, 5 skips)
- python3 -m unittest discover -s Tests/ScriptTests -p test_*.py (122 tests)
- node Tests/ScriptTests/test_website_js.mjs
- ./scripts/packaged-macos-smoke.sh
- ./scripts/packaged-macos-performance-smoke.sh (3/3 launches; 319.96 ms median launch-ready, 40.89 MiB initial, 87.84 MiB repeated, 0.0002% idle CPU)
- python3 scripts/grade-code-quality.py --root .
- git diff --cached --check