### PR TITLE
Bound updater system tools

### DIFF
--- a/Sources/QuillCodePlatform/BoundedSubprocessRunner.swift
+++ b/Sources/QuillCodePlatform/BoundedSubprocessRunner.swift
@@ -1,0 +1,374 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+public struct BoundedSubprocessRequest: Sendable {
+    public var executableURL: URL
+    public var arguments: [String]
+    public var environment: [String: String]?
+    public var currentDirectoryURL: URL?
+    public var timeout: TimeInterval
+    public var terminationGrace: TimeInterval
+    public var standardOutputLimit: Int
+    public var standardErrorLimit: Int
+
+    public init(
+        executableURL: URL,
+        arguments: [String] = [],
+        environment: [String: String]? = nil,
+        currentDirectoryURL: URL? = nil,
+        timeout: TimeInterval,
+        terminationGrace: TimeInterval = 2,
+        standardOutputLimit: Int = 64 * 1_024,
+        standardErrorLimit: Int = 64 * 1_024
+    ) {
+        self.executableURL = executableURL
+        self.arguments = arguments
+        self.environment = environment
+        self.currentDirectoryURL = currentDirectoryURL
+        self.timeout = timeout
+        self.terminationGrace = terminationGrace
+        self.standardOutputLimit = standardOutputLimit
+        self.standardErrorLimit = standardErrorLimit
+    }
+}
+
+public struct BoundedSubprocessStreamResult: Sendable, Equatable {
+    public var data: Data
+    public var totalByteCount: Int64
+    public var wasTruncated: Bool
+    public var readCompleted: Bool
+
+    public init(
+        data: Data,
+        totalByteCount: Int64,
+        wasTruncated: Bool,
+        readCompleted: Bool
+    ) {
+        self.data = data
+        self.totalByteCount = totalByteCount
+        self.wasTruncated = wasTruncated
+        self.readCompleted = readCompleted
+    }
+}
+
+public struct BoundedSubprocessResult: Sendable, Equatable {
+    public var exitCode: Int32
+    public var standardOutput: BoundedSubprocessStreamResult
+    public var standardError: BoundedSubprocessStreamResult
+
+    public init(
+        exitCode: Int32,
+        standardOutput: BoundedSubprocessStreamResult,
+        standardError: BoundedSubprocessStreamResult
+    ) {
+        self.exitCode = exitCode
+        self.standardOutput = standardOutput
+        self.standardError = standardError
+    }
+}
+
+public enum BoundedSubprocessError: Error, LocalizedError, Sendable, Equatable {
+    case invalidRequest
+    case executableUnavailable
+    case launchFailed
+    case timedOut
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRequest:
+            "The subprocess request is invalid."
+        case .executableUnavailable:
+            "The subprocess executable is unavailable."
+        case .launchFailed:
+            "The subprocess could not be launched."
+        case .timedOut:
+            "The subprocess exceeded its time limit."
+        }
+    }
+}
+
+/// Runs direct child processes with bounded output residency and bounded lifetime.
+public struct BoundedSubprocessRunner: Sendable {
+    private static let queue = DispatchQueue(
+        label: "co.lorehex.QuillCode.bounded-subprocess",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
+    public init() {}
+
+    public func run(_ request: BoundedSubprocessRequest) async throws -> BoundedSubprocessResult {
+        try Task.checkCancellation()
+        let handle = BoundedSubprocessHandle()
+        do {
+            let result = try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<BoundedSubprocessResult, any Error>) in
+                    Self.queue.async {
+                        do {
+                            continuation.resume(returning: try runBlocking(request, handle: handle))
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                    }
+                }
+            } onCancel: {
+                handle.requestCancellation(grace: request.terminationGrace)
+            }
+            try Task.checkCancellation()
+            return result
+        } catch {
+            try Task.checkCancellation()
+            throw error
+        }
+    }
+
+    public func runBlocking(
+        _ request: BoundedSubprocessRequest
+    ) throws -> BoundedSubprocessResult {
+        try runBlocking(request, handle: BoundedSubprocessHandle())
+    }
+
+    private func runBlocking(
+        _ request: BoundedSubprocessRequest,
+        handle: BoundedSubprocessHandle
+    ) throws -> BoundedSubprocessResult {
+        try Self.validate(request)
+
+        let process = Process()
+        process.executableURL = request.executableURL
+        process.arguments = request.arguments
+        process.environment = request.environment
+        process.currentDirectoryURL = request.currentDirectoryURL
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        let terminationSignal = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in terminationSignal.signal() }
+
+        let outputCapture = BoundedSubprocessPipeCapture(
+            handle: outputPipe.fileHandleForReading,
+            byteLimit: request.standardOutputLimit,
+            retention: .prefix
+        )
+        let errorCapture = BoundedSubprocessPipeCapture(
+            handle: errorPipe.fileHandleForReading,
+            byteLimit: request.standardErrorLimit,
+            retention: .suffix
+        )
+        outputCapture.start()
+        errorCapture.start()
+        handle.attach(process)
+
+        do {
+            try process.run()
+        } catch {
+            handle.detach()
+            try? outputPipe.fileHandleForWriting.close()
+            try? errorPipe.fileHandleForWriting.close()
+            _ = outputCapture.finish(grace: request.terminationGrace)
+            _ = errorCapture.finish(grace: request.terminationGrace)
+            throw BoundedSubprocessError.launchFailed
+        }
+        try? outputPipe.fileHandleForWriting.close()
+        try? errorPipe.fileHandleForWriting.close()
+        handle.terminateIfCancellationRequested()
+
+        if terminationSignal.wait(timeout: .now() + request.timeout) == .timedOut {
+            handle.terminate()
+            if terminationSignal.wait(timeout: .now() + request.terminationGrace) == .timedOut {
+                handle.forceKill()
+                _ = terminationSignal.wait(timeout: .now() + request.terminationGrace)
+            }
+            handle.detach()
+            _ = outputCapture.finish(grace: request.terminationGrace)
+            _ = errorCapture.finish(grace: request.terminationGrace)
+            throw BoundedSubprocessError.timedOut
+        }
+
+        handle.detach()
+        return BoundedSubprocessResult(
+            exitCode: process.terminationStatus,
+            standardOutput: outputCapture.finish(grace: request.terminationGrace),
+            standardError: errorCapture.finish(grace: request.terminationGrace)
+        )
+    }
+
+    private static func validate(_ request: BoundedSubprocessRequest) throws {
+        guard request.executableURL.isFileURL,
+              FileManager.default.isExecutableFile(atPath: request.executableURL.path)
+        else {
+            throw BoundedSubprocessError.executableUnavailable
+        }
+        guard request.timeout.isFinite,
+              request.timeout >= 0,
+              request.terminationGrace.isFinite,
+              request.terminationGrace >= 0,
+              request.standardOutputLimit >= 0,
+              request.standardErrorLimit >= 0
+        else {
+            throw BoundedSubprocessError.invalidRequest
+        }
+    }
+}
+
+private final class BoundedSubprocessPipeCapture: @unchecked Sendable {
+    enum Retention {
+        case prefix
+        case suffix
+    }
+
+    private static let chunkBytes = 64 * 1_024
+
+    private let handle: FileHandle
+    private let byteLimit: Int
+    private let retention: Retention
+    private let completion = DispatchGroup()
+    private let lock = NSLock()
+    private var wasForceClosed = false
+    private var result = BoundedSubprocessStreamResult(
+        data: Data(),
+        totalByteCount: 0,
+        wasTruncated: false,
+        readCompleted: false
+    )
+
+    init(handle: FileHandle, byteLimit: Int, retention: Retention) {
+        self.handle = handle
+        self.byteLimit = byteLimit
+        self.retention = retention
+    }
+
+    func start() {
+        completion.enter()
+        DispatchQueue.global(qos: .utility).async { [self] in
+            drain()
+            completion.leave()
+        }
+    }
+
+    func finish(grace: TimeInterval) -> BoundedSubprocessStreamResult {
+        if completion.wait(timeout: .now() + grace) == .timedOut {
+            lock.lock()
+            wasForceClosed = true
+            lock.unlock()
+            try? handle.close()
+            _ = completion.wait(timeout: .now() + max(0.1, grace))
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        return result
+    }
+
+    private func drain() {
+        var data = Data()
+        var totalByteCount: Int64 = 0
+        var reachedEndOfFile = false
+        do {
+            while let chunk = try handle.read(upToCount: Self.chunkBytes), !chunk.isEmpty {
+                totalByteCount = Self.saturatingSum(totalByteCount, Int64(chunk.count))
+                retain(chunk, in: &data)
+            }
+            reachedEndOfFile = true
+        } catch {
+            reachedEndOfFile = false
+        }
+
+        lock.lock()
+        result = BoundedSubprocessStreamResult(
+            data: data,
+            totalByteCount: totalByteCount,
+            wasTruncated: totalByteCount > Int64(byteLimit),
+            readCompleted: reachedEndOfFile && !wasForceClosed
+        )
+        lock.unlock()
+    }
+
+    private func retain(_ chunk: Data, in data: inout Data) {
+        guard byteLimit > 0 else { return }
+        switch retention {
+        case .prefix:
+            let available = byteLimit - data.count
+            if available > 0 { data.append(chunk.prefix(available)) }
+        case .suffix:
+            if chunk.count >= byteLimit {
+                data = Data(chunk.suffix(byteLimit))
+                return
+            }
+            let overflow = data.count + chunk.count - byteLimit
+            if overflow > 0 { data.removeFirst(overflow) }
+            data.append(chunk)
+        }
+    }
+
+    private static func saturatingSum(_ lhs: Int64, _ rhs: Int64) -> Int64 {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Int64.max : sum
+    }
+}
+
+private final class BoundedSubprocessHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancellationRequested = false
+
+    func attach(_ process: Process) {
+        lock.lock()
+        self.process = process
+        lock.unlock()
+    }
+
+    func detach() {
+        lock.lock()
+        process = nil
+        lock.unlock()
+    }
+
+    func requestCancellation(grace: TimeInterval) {
+        lock.lock()
+        cancellationRequested = true
+        lock.unlock()
+        terminate()
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + grace) { [self] in
+            forceKill()
+        }
+    }
+
+    func terminateIfCancellationRequested() {
+        lock.lock()
+        let shouldTerminate = cancellationRequested
+        lock.unlock()
+        if shouldTerminate { terminate() }
+    }
+
+    func terminate() {
+        lock.lock()
+        let process = process
+        lock.unlock()
+        if let process, process.isRunning { process.terminate() }
+    }
+
+    func forceKill() {
+        lock.lock()
+        let process = process
+        lock.unlock()
+        guard let process, process.isRunning else { return }
+        Self.sendKill(to: process.processIdentifier)
+    }
+
+    private static func sendKill(to processIdentifier: Int32) {
+        #if canImport(Darwin)
+        _ = Darwin.kill(processIdentifier, SIGKILL)
+        #elseif canImport(Glibc)
+        _ = Glibc.kill(processIdentifier, SIGKILL)
+        #endif
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopDownloadedApplicationValidator.swift
@@ -16,23 +16,81 @@ enum QuillCodeDesktopDownloadedApplicationValidator {
         configuration: QuillCodeDesktopUpdateConfiguration
     ) throws {
         try validateSigningRequirement(release.signingRequirement, configuration: configuration)
-        try validate(
-            applicationURL,
-            requirement: QuillCodeDesktopApplicationValidationRequirement(
-                bundleIdentifier: configuration.bundleIdentifier,
-                version: release.version,
-                build: release.build,
-                commit: release.commit,
-                architecture: configuration.architecture,
-                signingRequirement: release.signingRequirement
-            )
-        )
+        try validate(applicationURL, requirement: requirement(release, configuration: configuration))
     }
 
     static func validate(
         _ applicationURL: URL,
         requirement: QuillCodeDesktopApplicationValidationRequirement
     ) throws {
+        let context = try validationContext(applicationURL, requirement: requirement)
+        for command in validationCommands(context) {
+            let result = try QuillCodeDesktopUpdateProcessRunner.run(
+                executableURL: command.executableURL,
+                arguments: command.arguments
+            )
+            try validate(result, for: command.kind, context: context)
+        }
+    }
+
+    static func validateForPreparation(
+        _ applicationURL: URL,
+        release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) async throws {
+        try Task.checkCancellation()
+        try validateSigningRequirement(release.signingRequirement, configuration: configuration)
+        let context = try validationContext(
+            applicationURL,
+            requirement: requirement(release, configuration: configuration)
+        )
+        for command in validationCommands(context) {
+            try Task.checkCancellation()
+            let result = try await QuillCodeDesktopUpdateProcessRunner.runAsync(
+                executableURL: command.executableURL,
+                arguments: command.arguments
+            )
+            try validate(result, for: command.kind, context: context)
+        }
+    }
+
+    private struct ValidationContext {
+        var applicationURL: URL
+        var executableURL: URL
+        var requirement: QuillCodeDesktopApplicationValidationRequirement
+    }
+
+    private enum ValidationCommandKind {
+        case signature
+        case signingIdentity
+        case gatekeeper
+        case architectures
+    }
+
+    private struct ValidationCommand {
+        var kind: ValidationCommandKind
+        var executableURL: URL
+        var arguments: [String]
+    }
+
+    private static func requirement(
+        _ release: QuillCodeDesktopUpdateRelease,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> QuillCodeDesktopApplicationValidationRequirement {
+        QuillCodeDesktopApplicationValidationRequirement(
+            bundleIdentifier: configuration.bundleIdentifier,
+            version: release.version,
+            build: release.build,
+            commit: release.commit,
+            architecture: configuration.architecture,
+            signingRequirement: release.signingRequirement
+        )
+    }
+
+    private static func validationContext(
+        _ applicationURL: URL,
+        requirement: QuillCodeDesktopApplicationValidationRequirement
+    ) throws -> ValidationContext {
         guard applicationURL.pathExtension == "app",
               let bundle = Bundle(url: applicationURL),
               bundle.bundleIdentifier == requirement.bundleIdentifier,
@@ -49,48 +107,76 @@ enum QuillCodeDesktopDownloadedApplicationValidator {
         ) as? String == requirement.commit else {
             throw QuillCodeDesktopUpdateError.invalidApplication("its source commit does not match")
         }
-
-        let signature = try QuillCodeDesktopUpdateProcessRunner.run(
-            executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
-            arguments: ["--verify", "--deep", "--strict", "--verbose=2", applicationURL.path]
+        return ValidationContext(
+            applicationURL: applicationURL,
+            executableURL: executableURL,
+            requirement: requirement
         )
-        guard signature.exitCode == 0 else {
-            throw QuillCodeDesktopUpdateError.invalidApplication("its code signature is invalid")
-        }
+    }
 
-        let details = try QuillCodeDesktopUpdateProcessRunner.run(
-            executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
-            arguments: ["--display", "--verbose=4", applicationURL.path]
-        )
-        guard details.exitCode == 0,
-              QuillCodeDesktopCodeSignatureMetadata(
-                codesignOutput: details.combinedOutput
-              ).satisfies(requirement.signingRequirement)
-        else {
-            throw QuillCodeDesktopUpdateError.invalidApplication("its signing identity does not match")
-        }
-
-        if case .developerID = requirement.signingRequirement {
-            let assessment = try QuillCodeDesktopUpdateProcessRunner.run(
+    private static func validationCommands(_ context: ValidationContext) -> [ValidationCommand] {
+        var commands = [
+            ValidationCommand(
+                kind: .signature,
+                executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+                arguments: [
+                    "--verify", "--deep", "--strict", "--verbose=2", context.applicationURL.path,
+                ]
+            ),
+            ValidationCommand(
+                kind: .signingIdentity,
+                executableURL: URL(fileURLWithPath: "/usr/bin/codesign"),
+                arguments: ["--display", "--verbose=4", context.applicationURL.path]
+            ),
+        ]
+        if case .developerID = context.requirement.signingRequirement {
+            commands.append(ValidationCommand(
+                kind: .gatekeeper,
                 executableURL: URL(fileURLWithPath: "/usr/sbin/spctl"),
-                arguments: ["--assess", "--type", "execute", "--verbose=2", applicationURL.path]
-            )
-            guard assessment.exitCode == 0 else {
+                arguments: [
+                    "--assess", "--type", "execute", "--verbose=2", context.applicationURL.path,
+                ]
+            ))
+        }
+        commands.append(ValidationCommand(
+            kind: .architectures,
+            executableURL: URL(fileURLWithPath: "/usr/bin/lipo"),
+            arguments: ["-archs", context.executableURL.path]
+        ))
+        return commands
+    }
+
+    private static func validate(
+        _ result: QuillCodeDesktopUpdateProcessResult,
+        for kind: ValidationCommandKind,
+        context: ValidationContext
+    ) throws {
+        switch kind {
+        case .signature:
+            guard result.exitCode == 0 else {
+                throw QuillCodeDesktopUpdateError.invalidApplication("its code signature is invalid")
+            }
+        case .signingIdentity:
+            guard result.exitCode == 0,
+                  QuillCodeDesktopCodeSignatureMetadata(
+                    codesignOutput: result.combinedOutput
+                  ).satisfies(context.requirement.signingRequirement)
+            else {
+                throw QuillCodeDesktopUpdateError.invalidApplication("its signing identity does not match")
+            }
+        case .gatekeeper:
+            guard result.exitCode == 0 else {
                 throw QuillCodeDesktopUpdateError.invalidApplication("Gatekeeper did not accept it")
             }
-        }
-
-        let architectures = try QuillCodeDesktopUpdateProcessRunner.run(
-            executableURL: URL(fileURLWithPath: "/usr/bin/lipo"),
-            arguments: ["-archs", executableURL.path]
-        )
-        let availableArchitectures = Set(
-            architectures.standardOutput.split(whereSeparator: \.isWhitespace).map(String.init)
-        )
-        guard architectures.exitCode == 0,
-              availableArchitectures.contains(requirement.architecture)
-        else {
-            throw QuillCodeDesktopUpdateError.invalidApplication("it does not support this Mac")
+        case .architectures:
+            let availableArchitectures = Set(
+                result.standardOutput.split(whereSeparator: \.isWhitespace).map(String.init)
+            )
+            guard result.exitCode == 0,
+                  availableArchitectures.contains(context.requirement.architecture)
+            else {
+                throw QuillCodeDesktopUpdateError.invalidApplication("it does not support this Mac")
+            }
         }
     }
 
@@ -107,71 +193,5 @@ enum QuillCodeDesktopDownloadedApplicationValidator {
            case .adHoc = requirement {
             throw QuillCodeDesktopUpdateError.invalidApplication("the stable app is not Developer ID signed")
         }
-    }
-}
-
-struct QuillCodeDesktopUpdateProcessResult: Sendable {
-    var exitCode: Int32
-    var standardOutput: String
-    var standardError: String
-
-    var combinedOutput: String {
-        [standardOutput, standardError].filter { !$0.isEmpty }.joined(separator: "\n")
-    }
-
-    var failureSummary: String {
-        let value = combinedOutput.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? "the system extraction tool failed" : String(value.prefix(500))
-    }
-}
-
-enum QuillCodeDesktopUpdateProcessRunner {
-    private static let outputByteLimit = 64 * 1_024
-
-    static func run(executableURL: URL, arguments: [String]) throws -> QuillCodeDesktopUpdateProcessResult {
-        let captureRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "quill-cowork-process-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        let outputURL = captureRoot.appendingPathComponent("stdout")
-        let errorURL = captureRoot.appendingPathComponent("stderr")
-        try FileManager.default.createDirectory(at: captureRoot, withIntermediateDirectories: false)
-        defer { try? FileManager.default.removeItem(at: captureRoot) }
-        guard FileManager.default.createFile(atPath: outputURL.path, contents: nil),
-              FileManager.default.createFile(atPath: errorURL.path, contents: nil)
-        else {
-            throw QuillCodeDesktopUpdateError.installationFailed("system-tool output could not be captured")
-        }
-        let outputHandle = try FileHandle(forWritingTo: outputURL)
-        let errorHandle = try FileHandle(forWritingTo: errorURL)
-        defer {
-            try? outputHandle.close()
-            try? errorHandle.close()
-        }
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = arguments
-        process.standardOutput = outputHandle
-        process.standardError = errorHandle
-        do {
-            try process.run()
-        } catch {
-            throw QuillCodeDesktopUpdateError.installationFailed("a required system tool could not start")
-        }
-        process.waitUntilExit()
-        try outputHandle.close()
-        try errorHandle.close()
-        return QuillCodeDesktopUpdateProcessResult(
-            exitCode: process.terminationStatus,
-            standardOutput: try capturedText(at: outputURL),
-            standardError: try capturedText(at: errorURL)
-        )
-    }
-
-    private static func capturedText(at url: URL) throws -> String {
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-        let data = try handle.read(upToCount: outputByteLimit) ?? Data()
-        return String(decoding: data, as: UTF8.self)
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdatePreparer.swift
@@ -59,42 +59,45 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
             try Task.checkCancellation()
 
             progress(.verifying)
-            try await Task.detached(priority: .utility) {
-                try Self.verifyArchive(
-                    at: archiveURL,
-                    expectedSize: release.asset.sizeBytes,
-                    expectedSHA256: release.asset.sha256
-                )
-            }.value
+            try await Self.verifyArchiveAsync(
+                at: archiveURL,
+                expectedSize: release.asset.sizeBytes,
+                expectedSHA256: release.asset.sha256
+            )
 
             let extractedURL = workspaceURL.appendingPathComponent("Extracted", isDirectory: true)
             progress(.extracting)
-            try await Task.detached(priority: .utility) {
+            try await Self.runCancellableUtilityOperation {
+                try Task.checkCancellation()
                 try FileManager.default.createDirectory(
                     at: extractedURL,
                     withIntermediateDirectories: false,
                     attributes: [.posixPermissions: 0o700]
                 )
-                let result = try QuillCodeDesktopUpdateProcessRunner.run(
-                    executableURL: URL(fileURLWithPath: "/usr/bin/ditto"),
-                    arguments: ["-x", "-k", archiveURL.path, extractedURL.path]
+            }
+            let extractionResult = try await QuillCodeDesktopUpdateProcessRunner.runAsync(
+                executableURL: URL(fileURLWithPath: "/usr/bin/ditto"),
+                arguments: ["-x", "-k", archiveURL.path, extractedURL.path],
+                timeout: QuillCodeDesktopUpdateProcessRunner.extractionTimeout
+            )
+            guard extractionResult.exitCode == 0 else {
+                throw QuillCodeDesktopUpdateError.invalidApplication(
+                    extractionResult.failureSummary
                 )
-                guard result.exitCode == 0 else {
-                    throw QuillCodeDesktopUpdateError.invalidApplication(result.failureSummary)
-                }
-            }.value
+            }
 
             progress(.validatingApplication)
-            let applicationURL = try await Task.detached(priority: .utility) {
+            let applicationURL = try await Self.runCancellableUtilityOperation {
+                try Task.checkCancellation()
                 let appURL = try Self.singleApplication(in: extractedURL)
                 try Self.validateContainedLinks(in: extractedURL)
-                try QuillCodeDesktopDownloadedApplicationValidator.validate(
-                    appURL,
-                    release: release,
-                    configuration: configuration
-                )
                 return appURL
-            }.value
+            }
+            try await QuillCodeDesktopDownloadedApplicationValidator.validateForPreparation(
+                applicationURL,
+                release: release,
+                configuration: configuration
+            )
 
             return QuillCodeDesktopPreparedUpdate(
                 release: release,
@@ -149,6 +152,36 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
         expectedSize: Int64,
         expectedSHA256: String
     ) throws {
+        try verifyArchive(
+            at: archiveURL,
+            expectedSize: expectedSize,
+            expectedSHA256: expectedSHA256,
+            checkCancellation: {}
+        )
+    }
+
+    static func verifyArchiveAsync(
+        at archiveURL: URL,
+        expectedSize: Int64,
+        expectedSHA256: String
+    ) async throws {
+        try await runCancellableUtilityOperation {
+            try verifyArchive(
+                at: archiveURL,
+                expectedSize: expectedSize,
+                expectedSHA256: expectedSHA256,
+                checkCancellation: { try Task.checkCancellation() }
+            )
+        }
+    }
+
+    private static func verifyArchive(
+        at archiveURL: URL,
+        expectedSize: Int64,
+        expectedSHA256: String,
+        checkCancellation: () throws -> Void
+    ) throws {
+        try checkCancellation()
         let values = try archiveURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
         guard values.isRegularFile == true,
               Int64(values.fileSize ?? -1) == expectedSize
@@ -160,10 +193,12 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
         defer { try? handle.close() }
         var hasher = SHA256()
         while true {
+            try checkCancellation()
             let data = try handle.read(upToCount: 1_024 * 1_024) ?? Data()
             if data.isEmpty { break }
             hasher.update(data: data)
         }
+        try checkCancellation()
         let digest = hasher.finalize().map { String(format: "%02x", $0) }.joined()
         guard digest == expectedSHA256 else {
             throw QuillCodeDesktopUpdateError.checksumMismatch
@@ -196,16 +231,21 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
 
     private static func validateContainedLinks(in rootURL: URL) throws {
         let canonicalRoot = rootURL.resolvingSymlinksInPath().standardizedFileURL.path + "/"
+        var enumerationFailed = false
         guard let enumerator = FileManager.default.enumerator(
             at: rootURL,
             includingPropertiesForKeys: [.isSymbolicLinkKey],
             options: [],
-            errorHandler: { _, _ in false }
+            errorHandler: { _, _ in
+                enumerationFailed = true
+                return false
+            }
         ) else {
             throw QuillCodeDesktopUpdateError.invalidApplication("the app archive could not be inspected")
         }
 
         for case let itemURL as URL in enumerator {
+            try Task.checkCancellation()
             let values = try itemURL.resourceValues(forKeys: [.isSymbolicLinkKey])
             guard values.isSymbolicLink == true else { continue }
             let resolvedPath = itemURL.resolvingSymlinksInPath().standardizedFileURL.path
@@ -215,5 +255,21 @@ struct QuillCodeDesktopUpdatePreparer: QuillCodeDesktopUpdatePreparing, Sendable
                 )
             }
         }
+        guard !enumerationFailed else {
+            throw QuillCodeDesktopUpdateError.invalidApplication("the app archive could not be inspected")
+        }
+    }
+
+    private static func runCancellableUtilityOperation<Value: Sendable>(
+        _ operation: @escaping @Sendable () throws -> Value
+    ) async throws -> Value {
+        let task = Task.detached(priority: .utility, operation: operation)
+        let value = try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        try Task.checkCancellation()
+        return value
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateProcessRunner.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateProcessRunner.swift
@@ -1,0 +1,110 @@
+import Foundation
+import QuillCodePlatform
+
+struct QuillCodeDesktopUpdateProcessResult: Sendable {
+    var exitCode: Int32
+    var standardOutput: String
+    var standardError: String
+    var outputWasTruncated: Bool
+
+    var combinedOutput: String {
+        [standardOutput, standardError].filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+
+    var failureSummary: String {
+        let value = combinedOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let summary = value.isEmpty ? "the system extraction tool failed" : String(value.suffix(500))
+        return outputWasTruncated ? "\(summary) [system-tool output truncated]" : summary
+    }
+}
+
+enum QuillCodeDesktopUpdateProcessRunner {
+    static let defaultTimeout: TimeInterval = 120
+    static let extractionTimeout: TimeInterval = 10 * 60
+    private static let outputByteLimit = 64 * 1_024
+    private static let terminationGrace: TimeInterval = 0.5
+    private static let runner = BoundedSubprocessRunner()
+
+    static func run(
+        executableURL: URL,
+        arguments: [String],
+        timeout: TimeInterval = defaultTimeout
+    ) throws -> QuillCodeDesktopUpdateProcessResult {
+        do {
+            return try processResult(runner.runBlocking(request(
+                executableURL: executableURL,
+                arguments: arguments,
+                timeout: timeout
+            )))
+        } catch {
+            throw mappedError(error)
+        }
+    }
+
+    static func runAsync(
+        executableURL: URL,
+        arguments: [String],
+        timeout: TimeInterval = defaultTimeout
+    ) async throws -> QuillCodeDesktopUpdateProcessResult {
+        do {
+            return try processResult(await runner.run(request(
+                executableURL: executableURL,
+                arguments: arguments,
+                timeout: timeout
+            )))
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw mappedError(error)
+        }
+    }
+
+    private static func request(
+        executableURL: URL,
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> BoundedSubprocessRequest {
+        BoundedSubprocessRequest(
+            executableURL: executableURL,
+            arguments: arguments,
+            timeout: timeout,
+            terminationGrace: terminationGrace,
+            standardOutputLimit: outputByteLimit,
+            standardErrorLimit: outputByteLimit
+        )
+    }
+
+    private static func processResult(
+        _ result: BoundedSubprocessResult
+    ) throws -> QuillCodeDesktopUpdateProcessResult {
+        guard result.standardOutput.readCompleted,
+              result.standardError.readCompleted
+        else {
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "system-tool output could not be read completely"
+            )
+        }
+        return QuillCodeDesktopUpdateProcessResult(
+            exitCode: result.exitCode,
+            standardOutput: String(decoding: result.standardOutput.data, as: UTF8.self),
+            standardError: String(decoding: result.standardError.data, as: UTF8.self),
+            outputWasTruncated: result.standardOutput.wasTruncated || result.standardError.wasTruncated
+        )
+    }
+
+    private static func mappedError(_ error: any Error) -> any Error {
+        guard let processError = error as? BoundedSubprocessError else { return error }
+        switch processError {
+        case .timedOut:
+            return QuillCodeDesktopUpdateError.installationFailed("a required system tool timed out")
+        case .executableUnavailable, .launchFailed:
+            return QuillCodeDesktopUpdateError.installationFailed(
+                "a required system tool could not start"
+            )
+        case .invalidRequest:
+            return QuillCodeDesktopUpdateError.installationFailed(
+                "a required system tool was configured incorrectly"
+            )
+        }
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -308,6 +308,85 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         }
     }
 
+    func testArchiveVerificationHonorsExistingCancellation() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let archive = root.appendingPathComponent("update.zip")
+        try Data("payload".utf8).write(to: archive)
+        let task = Task {
+            while !Task.isCancelled { await Task.yield() }
+            try await QuillCodeDesktopUpdatePreparer.verifyArchiveAsync(
+                at: archive,
+                expectedSize: 7,
+                expectedSHA256: "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5"
+            )
+        }
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("Expected archive verification cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+    }
+
+    func testUpdateProcessRunnerMapsTimeoutToInstallationFailure() async throws {
+        let started = Date()
+
+        do {
+            _ = try await QuillCodeDesktopUpdateProcessRunner.runAsync(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "exec 1>&- 2>&-; trap '' TERM; while :; do :; done"],
+                timeout: 0.1
+            )
+            XCTFail("Expected the system tool to time out")
+        } catch let error as QuillCodeDesktopUpdateError {
+            XCTAssertEqual(error, .installationFailed("a required system tool timed out"))
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(started), 3)
+    }
+
+    func testUpdateProcessRunnerPreservesCancellation() async throws {
+        let task = Task {
+            try await QuillCodeDesktopUpdateProcessRunner.runAsync(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "trap '' TERM; while :; do :; done"],
+                timeout: 30
+            )
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        let cancelledAt = Date()
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected system-tool cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(cancelledAt), 3)
+    }
+
+    func testUpdateProcessRunnerKeepsFinalBoundedDiagnostic() throws {
+        let result = try QuillCodeDesktopUpdateProcessRunner.run(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: [
+                "-c",
+                "i=0; while [ \"$i\" -lt 10000 ]; do printf 'noise %04d\\n' \"$i\" >&2; " +
+                    "i=$((i + 1)); done; printf 'FINAL_UPDATE_DIAGNOSTIC\\n' >&2; exit 7",
+            ],
+            timeout: 5
+        )
+
+        XCTAssertEqual(result.exitCode, 7)
+        XCTAssertTrue(result.outputWasTruncated)
+        XCTAssertTrue(result.standardError.hasSuffix("FINAL_UPDATE_DIAGNOSTIC\n"))
+        XCTAssertTrue(result.failureSummary.contains("FINAL_UPDATE_DIAGNOSTIC"))
+        XCTAssertTrue(result.failureSummary.hasSuffix("[system-tool output truncated]"))
+        XCTAssertLessThanOrEqual(result.standardError.utf8.count, 64 * 1_024)
+    }
+
     func testDownloadedApplicationRejectsMismatchedSourceCommitBeforeSystemValidation() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/QuillCodePlatformTests/BoundedSubprocessRunnerTests.swift
+++ b/Tests/QuillCodePlatformTests/BoundedSubprocessRunnerTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+@testable import QuillCodePlatform
+import XCTest
+
+final class BoundedSubprocessRunnerTests: XCTestCase {
+    private let runner = BoundedSubprocessRunner()
+
+    func testContinuouslyDrainsNoisyOutputWhileRetainingBoundedPrefix() async throws {
+        let result = try await runner.run(request(
+            script: """
+            i=0
+            while [ "$i" -lt 10000 ]; do
+              printf '0123456789abcdef0123456789abcdef\\n'
+              i=$((i + 1))
+            done
+            """,
+            outputLimit: 4_096
+        ))
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertTrue(result.standardOutput.readCompleted)
+        XCTAssertTrue(result.standardOutput.wasTruncated)
+        XCTAssertEqual(result.standardOutput.data.count, 4_096)
+        XCTAssertEqual(result.standardOutput.totalByteCount, 330_000)
+        XCTAssertTrue(String(decoding: result.standardOutput.data, as: UTF8.self).hasPrefix("012345"))
+    }
+
+    func testRetainsDiagnosticSuffixWhenStandardErrorIsTruncated() async throws {
+        let result = try await runner.run(request(
+            script: """
+            i=0
+            while [ "$i" -lt 5000 ]; do
+              printf 'repeated diagnostic %04d\\n' "$i" >&2
+              i=$((i + 1))
+            done
+            printf 'FINAL_DIAGNOSTIC\\n' >&2
+            """,
+            errorLimit: 128
+        ))
+        let retainedError = String(decoding: result.standardError.data, as: UTF8.self)
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertTrue(result.standardError.readCompleted)
+        XCTAssertTrue(result.standardError.wasTruncated)
+        XCTAssertEqual(result.standardError.data.count, 128)
+        XCTAssertTrue(retainedError.hasSuffix("FINAL_DIAGNOSTIC\n"))
+    }
+
+    func testTimeoutTracksProcessExitEvenAfterChildClosesOutputPipes() async throws {
+        let started = Date()
+
+        do {
+            _ = try await runner.run(request(
+                script: "exec 1>&- 2>&-; trap '' TERM; while :; do :; done",
+                timeout: 0.1,
+                terminationGrace: 0.1
+            ))
+            XCTFail("Expected the subprocess to time out")
+        } catch let error as BoundedSubprocessError {
+            XCTAssertEqual(error, .timedOut)
+        }
+
+        let elapsed = Date().timeIntervalSince(started)
+        XCTAssertGreaterThanOrEqual(elapsed, 0.08)
+        XCTAssertLessThan(elapsed, 1)
+    }
+
+    func testCancellationForceKillsTermResistantChild() async throws {
+        let runner = runner
+        let processRequest = request(
+            script: "trap '' TERM; while :; do :; done",
+            timeout: 30,
+            terminationGrace: 0.1
+        )
+        let task = Task {
+            try await runner.run(processRequest)
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        let cancelledAt = Date()
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(cancelledAt), 1)
+    }
+
+    func testReturnsIncompleteCaptureWhenDescendantKeepsPipesOpen() async throws {
+        let started = Date()
+        let result = try await runner.run(request(
+            script: "(while :; do printf x; /bin/sleep 0.05; done) & exit 0",
+            terminationGrace: 0.05
+        ))
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1)
+        XCTAssertFalse(
+            result.standardOutput.readCompleted && result.standardError.readCompleted,
+            "A descendant-held pipe must not keep the caller waiting for EOF"
+        )
+    }
+
+    func testRejectsUnavailableExecutableBeforeLaunch() {
+        XCTAssertThrowsError(try runner.runBlocking(BoundedSubprocessRequest(
+            executableURL: URL(fileURLWithPath: "/definitely/missing/quill-cowork-tool"),
+            timeout: 1
+        ))) { error in
+            XCTAssertEqual(error as? BoundedSubprocessError, .executableUnavailable)
+        }
+    }
+
+    private func request(
+        script: String,
+        timeout: TimeInterval = 5,
+        terminationGrace: TimeInterval = 0.2,
+        outputLimit: Int = 1_024,
+        errorLimit: Int = 1_024
+    ) -> BoundedSubprocessRequest {
+        BoundedSubprocessRequest(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", script],
+            timeout: timeout,
+            terminationGrace: terminationGrace,
+            standardOutputLimit: outputLimit,
+            standardErrorLimit: errorLimit
+        )
+    }
+}

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,33 @@
 # Code Quality Audit
 
+## 2026-08-13 Bounded Updater System Tools
+
+Overall grade after this slice: **A+ memory containment, A+ cancellation, A+ updater resilience**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Output residency | A+ | Updater subprocesses continuously drain both pipes while retaining only a 64 KiB stdout prefix and 64 KiB stderr tail. Total byte counts remain saturating and diagnostics disclose truncation. |
+| Lifetime | A+ | Signature and architecture checks stop after two minutes; archive extraction stops after ten. Deadlines follow direct-child exit even when output pipes close early. |
+| Cancellation | A+ | Hashing and bundle inspection check cancellation during bounded work. Async system tools reconcile pre-launch races, terminate promptly, and hard-kill after a 500 ms grace period. |
+| Failure behavior | A+ | Launch failures and timeouts map to stable updater errors. Descendant-held pipes cannot extend the caller indefinitely, and incomplete capture fails closed before validation succeeds. |
+| Architecture | A+ | `QuillCodePlatform` owns one reusable direct-process lifecycle primitive; the desktop adapter owns updater time budgets and error policy; validation owns command plans and typed result interpretation. |
+| Regression evidence | A+ | Real child processes flood output, preserve diagnostic tails, close pipes while running, ignore termination, hold inherited pipes, and exercise unavailable-executable, updater-timeout, cancellation, and hash-cancellation paths. |
+
+Validation:
+
+- Combined focused process and updater suite: 36 tests, 0 failures.
+- Full Swift package: 6,337 tests, 5 intentional skips, 0 failures; Python script contracts:
+  122 tests, 0 failures; website JavaScript release contract passed.
+- Optimized packaged app passed both `SIGKILL` recovery paths, direct and Launch Services rendering,
+  live Accessibility interaction, critical-memory-pressure recovery, and the 100-chat daily-driver
+  resource gate.
+- Three fresh packaged launches passed every production budget: 323.54 ms median launch-ready,
+  40.83 MiB initial physical footprint, 83.34 MiB after the first interaction sweep, 88.24 MiB
+  after repetition, 4.89 MiB repeated growth, five settled threads, zero idle memory growth, and
+  0.0002% settled idle CPU.
+- Deterministic grading scores the shared runner A+ (97), its focused tests A+ (100), and every
+  affected updater production file A+ (100); `git diff --check` passed.
+
 ## 2026-08-13 Bounded Computer-Use Driver Processes
 
 Overall grade after this slice: **A+ memory containment, A+ crash resilience, A+ process lifecycle**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4786,3 +4786,21 @@
 - **Evidence:** `WorkspaceComposerSendPlanner`, `WorkspaceComposerSubmissionPlannerTests`,
   `QuillCodeDesktopTaskCoordinator`, `QuillCodeDesktopConcurrentChatTests`, and
   `ParityPublicDistributionGateTests`.
+
+## 2026-08-13: updater system tools use one bounded process lifecycle
+
+- **Decision:** Direct system-tool execution uses `BoundedSubprocessRunner` in
+  `QuillCodePlatform`. The desktop updater supplies its own time budgets, retained-output limits,
+  user-facing error mapping, and validation policy through a focused adapter.
+- **Output boundary:** Stdout retains a bounded prefix for machine-readable results; stderr retains
+  a bounded suffix for final diagnostics. Both streams are drained continuously, report saturating
+  total byte counts and truncation, and fail updater validation when capture cannot finish cleanly.
+- **Lifecycle boundary:** The deadline is tied to direct-child termination rather than pipe EOF.
+  Cancellation is reconciled across launch, requests graceful termination, then sends a hard kill
+  after bounded grace. Descendants are not treated as owned process groups for Apple system tools,
+  but inherited pipes cannot hold the updater open indefinitely.
+- **Why:** `ditto`, `codesign`, `spctl`, and `lipo` previously had no deadline, and temporary-file
+  capture allowed output volume to follow producer volume. Cancel during hashing, extraction, or
+  validation also waited for detached work to finish.
+- **Evidence:** `BoundedSubprocessRunnerTests`, `QuillCodeDesktopUpdateModelTests`, full Swift
+  coverage, packaged crash/render/Accessibility smoke, and the three-launch resource manifest.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,13 @@
 
 ## Latest Quality Pass
 
+- Updater hashing, archive extraction, bundle inspection, and downloaded-app validation now honor
+  parent cancellation instead of leaving detached work behind. The shared platform process runner
+  continuously drains output into a 64 KiB stdout prefix and 64 KiB diagnostic tail, limits normal
+  validation tools to two minutes and extraction to ten minutes, and escalates cancellation or
+  timeout to a hard kill after 500 milliseconds. Process completion, not pipe closure, owns the
+  deadline; descendant-held pipes receive only bounded drain time, and incomplete capture fails
+  closed before an update can be accepted.
 - One-shot `cua-driver` calls now retain at most 32 MiB of response bytes and 256 KiB of diagnostic
   tail while continuously draining both pipes. Timeout follows process exit rather than pipe EOF,
   cancellation survives races before launch, and both paths use a bounded hard-kill fallback. A

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -35,6 +35,11 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 - Updater signing trust: exact ad-hoc metadata, notarized Developer ID transition, ten-character
   team validation, pinned-team continuity, ad-hoc downgrade and cross-team refusal, stable-channel
   requirements, Developer ID Application authority parsing, and Installer-authority rejection.
+- Updater subprocess resilience: real noisy children prove continuous pipe draining and fixed
+  retained-output limits; stderr keeps the final diagnostic; timeout follows process exit after
+  early pipe closure; cancellation hard-kills a termination-resistant child; descendant-held pipes
+  return after bounded drain time; unavailable tools fail before launch; hash verification observes
+  existing cancellation; updater timeout errors remain typed and user-readable.
 - Stable Apple credential preflight: complete secret inventory, bounded base64 material, canonical
   identifiers, `.p12` password and certificate/private-key matching, exact Developer ID Application
   common name, code-signing usage, seven-day validity floor, PKCS#8 P-256 notary key validation,


### PR DESCRIPTION
## Summary
- add a reusable bounded subprocess runner with timeout, cancellation, hard-kill fallback, and bounded pipe capture
- make updater hashing, extraction, bundle inspection, and signature validation cancellation-aware
- retain bounded final diagnostics and fail closed on incomplete capture or inspection

## Validation
- focused subprocess/updater suites: 36 tests, 0 failures
- full Swift package: 6,337 tests, 5 skips, 0 failures
- Python script contracts: 122 tests, 0 failures
- website JavaScript release contract passed
- optimized packaged macOS smoke passed crash recovery, direct/Launch Services rendering, Accessibility, memory pressure, and daily-driver checks
- 3/3 packaged performance launches passed: 323.54 ms median readiness, 40.83 MiB initial, 83.34 MiB first sweep, 88.24 MiB repeated, 4.89 MiB repeated growth, 0.0002% idle CPU
- affected production files grade A+; git diff --check passed