### PR TITLE
Optimize selected chat cold launch

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -6,6 +6,10 @@ import QuillCodePersistence
 import QuillCodeTools
 
 public struct QuillCodeWorkspaceBootstrap: Sendable {
+    /// Launch only needs the selected transcript. Navigation grows into the separate bounded
+    /// runtime working set as the user opens other chats.
+    public static let maximumLaunchResidentActivePayloads = 1
+
     public typealias ModelCatalogFetcher = @Sendable (AppConfig) async -> TrustedRouterModelCatalog
     public typealias AccountCreditsFetcher = @Sendable (AppConfig) async -> TrustedRouterCreditsRefreshResult
 
@@ -64,7 +68,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
         let calendar = Calendar.current
         let threadListing = threadStore.bootstrapListing(
             deferArchivedBefore: .distantFuture,
-            maximumResidentActivePayloads: JSONThreadStore.defaultMaximumResidentActivePayloads,
+            maximumResidentActivePayloads: Self.maximumLaunchResidentActivePayloads,
             retainingUsageSince: ThreadPeriodUsageSnapshot.currentPeriodRetentionStart(
                 now: currentDate,
                 calendar: calendar

--- a/Sources/QuillCodePersistence/ThreadPayloadSummaryStore.swift
+++ b/Sources/QuillCodePersistence/ThreadPayloadSummaryStore.swift
@@ -5,7 +5,7 @@ import QuillCodeCore
 /// an authoritative thread write invalidates only its own derived cache instead of rewriting a
 /// workspace-wide index during streaming updates.
 struct ThreadPayloadSummaryEntry: Codable, Hashable {
-    static let schemaVersion = 2
+    static let schemaVersion = 3
     static let maximumAttachmentIDs = 10_000
 
     var schemaVersion: Int
@@ -49,7 +49,8 @@ struct ThreadPayloadSummaryEntry: Codable, Hashable {
         )
         let attachmentIDs = thread.payloadResidency.deferredSummary?.attachmentIDs
             ?? loadedAttachmentIDs
-        guard attachmentIDs.count <= Self.maximumAttachmentIDs,
+        guard !Self.hasRelaunchCriticalState(thread),
+              attachmentIDs.count <= Self.maximumAttachmentIDs,
               fileURL.lastPathComponent == "\(thread.id.uuidString).json",
               let periodUsage = ThreadPeriodUsageSnapshot(
                   thread: thread,
@@ -85,6 +86,15 @@ struct ThreadPayloadSummaryEntry: Codable, Hashable {
         self.agentImportProvenance = AgentImportThreadProvenance.value(in: thread)
         self.attentionItem = AttentionModel.build(from: [thread]).items.first
         self.periodUsage = periodUsage
+    }
+
+    private static func hasRelaunchCriticalState(_ thread: ChatThread) -> Bool {
+        thread.activeRunCheckpoint != nil
+            || thread.subagentRuns.lazy.flatMap(\.workers).contains {
+                $0.status == .running
+                    || $0.status == .awaitingApproval
+                    || $0.pendingApproval != nil
+            }
     }
 
     func matches(

--- a/Tests/QuillCodeAppTests/WorkspaceAgentRunRelaunchBootstrapTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceAgentRunRelaunchBootstrapTests.swift
@@ -52,4 +52,43 @@ final class WorkspaceAgentRunRelaunchBootstrapTests: XCTestCase {
             1
         )
     }
+
+    func testBootstrapRecoversInterruptedRunOutsideSelectedLaunchWorkingSet() throws {
+        let home = try makeQuillCodeTestDirectory()
+        let paths = QuillCodePaths(home: home)
+        try paths.ensure()
+        let store = JSONThreadStore(directory: paths.threadsDirectory)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let interrupted = ChatThread(
+            title: "Background task",
+            messages: [.init(role: .user, content: "Run a long command")],
+            events: [
+                .init(kind: .message, summary: "Run a long command"),
+                .init(kind: .toolRunning, summary: "host.shell.run running")
+            ],
+            createdAt: now.addingTimeInterval(-100),
+            updatedAt: now.addingTimeInterval(-100),
+            activeRunCheckpoint: ThreadRunCheckpoint(
+                messageCountAtStart: 1,
+                eventCountAtStart: 1
+            )
+        )
+        let selected = ChatThread(
+            title: "Most recent chat",
+            messages: [.init(role: .user, content: "This chat should open")],
+            createdAt: now.addingTimeInterval(-10),
+            updatedAt: now.addingTimeInterval(-10)
+        )
+        try [interrupted, selected].forEach(store.save)
+
+        let model = try QuillCodeWorkspaceBootstrap(paths: paths, now: { now }).makeModel(
+            automaticStartupPolicy: .deferUntilRequested
+        )
+        let persisted = try store.load(interrupted.id)
+
+        XCTAssertEqual(model.selectedThread?.id, selected.id)
+        XCTAssertNil(persisted.activeRunCheckpoint)
+        XCTAssertEqual(persisted.events.suffix(2).map(\.kind), [.toolFailed, .notice])
+        XCTAssertTrue(model.interruptedRunRecoveryThreadIDs.contains(interrupted.id))
+    }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceThreadPayloadResidencyTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceThreadPayloadResidencyTests.swift
@@ -22,7 +22,7 @@ final class WorkspaceThreadPayloadResidencyTests: XCTestCase {
         }
         let threads = store.bootstrapListing(
             deferArchivedBefore: .distantFuture,
-            maximumResidentActivePayloads: JSONThreadStore.defaultMaximumResidentActivePayloads,
+            maximumResidentActivePayloads: QuillCodeWorkspaceBootstrap.maximumLaunchResidentActivePayloads,
             retainingUsageSince: .distantPast
         ).threads
         let model = QuillCodeWorkspaceModel(
@@ -32,6 +32,11 @@ final class WorkspaceThreadPayloadResidencyTests: XCTestCase {
             ),
             threadStore: store
         )
+        XCTAssertEqual(
+            model.root.threads.filter { !$0.isArchived && $0.payloadResidency.isLoaded }.count,
+            QuillCodeWorkspaceBootstrap.maximumLaunchResidentActivePayloads
+        )
+        XCTAssertEqual(model.selectedThread?.messages.count, 1)
 
         for id in threads.reversed().map(\.id) {
             model.selectThread(id)

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QuillCodeApp
 import QuillCodePersistence
 import XCTest
 @testable import quill_code_desktop
@@ -84,7 +85,7 @@ final class QuillCodeDesktopDailyDriverSmokeFixtureTests: XCTestCase {
         }
         XCTAssertEqual(
             loadedActiveThreads.count,
-            JSONThreadStore.defaultMaximumResidentActivePayloads
+            QuillCodeWorkspaceBootstrap.maximumLaunchResidentActivePayloads
         )
         XCTAssertEqual(loadedActiveThreads.first?.id, selectedThread.id)
         XCTAssertTrue(

--- a/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
+++ b/Tests/QuillCodePersistenceTests/JSONThreadStoreTests.swift
@@ -498,6 +498,63 @@ final class JSONThreadStoreTests: PersistenceTestCase {
         XCTAssertEqual(warm.summaryCacheHitCount, activeCount - residentLimit)
     }
 
+    func testBootstrapKeepsRelaunchCriticalPayloadsResidentOutsideLaunchLimit() throws {
+        let directory = try makeTempDirectory()
+        let store = JSONThreadStore(directory: directory)
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let checkpointed = ChatThread(
+            title: "Interrupted parent run",
+            messages: [ChatMessage(role: .user, content: "keep the parent transcript")],
+            events: [ThreadEvent(kind: .toolRunning, summary: "host.shell.run running")],
+            createdAt: baseDate,
+            updatedAt: baseDate,
+            activeRunCheckpoint: ThreadRunCheckpoint(
+                messageCountAtStart: 1,
+                eventCountAtStart: 0
+            )
+        )
+        let runningWorker = SubagentWorkerRecord(
+            name: "Verifier",
+            role: "verify the build",
+            status: .running,
+            updatedAt: baseDate
+        )
+        let delegated = ChatThread(
+            title: "Interrupted delegated run",
+            messages: [ChatMessage(role: .user, content: "keep the delegated transcript")],
+            subagentRuns: [SubagentRunRecord(
+                objective: "Verify",
+                workers: [runningWorker],
+                createdAt: baseDate,
+                updatedAt: baseDate
+            )],
+            createdAt: baseDate,
+            updatedAt: baseDate.addingTimeInterval(1)
+        )
+        let selected = ChatThread(
+            title: "Selected chat",
+            messages: [ChatMessage(role: .user, content: "selected payload")],
+            createdAt: baseDate,
+            updatedAt: baseDate.addingTimeInterval(2)
+        )
+        try [checkpointed, delegated, selected].forEach(store.save)
+
+        let listing = store.bootstrapListing(
+            deferArchivedBefore: .distantFuture,
+            maximumResidentActivePayloads: 1
+        )
+
+        XCTAssertEqual(listing.threads.filter(\.payloadResidency.isLoaded).count, 3)
+        XCTAssertEqual(
+            listing.threads.first { $0.id == checkpointed.id }?.messages.map(\.content),
+            ["keep the parent transcript"]
+        )
+        XCTAssertEqual(
+            listing.threads.first { $0.id == delegated.id }?.messages.map(\.content),
+            ["keep the delegated transcript"]
+        )
+    }
+
     func testDeferredPayloadRetainsCompactSubagentManifestAndHydratesTranscript() throws {
         let directory = try makeTempDirectory()
         let store = JSONThreadStore(directory: directory)


### PR DESCRIPTION
## Summary
- hydrate only the selected transcript during workspace bootstrap while retaining the existing 12-chat runtime cache
- keep checkpointed and approval-waiting chats fully resident for safe relaunch reconciliation
- invalidate old summary projections and add launch, navigation, and nonselected crash-recovery regressions

## Performance
- native 100-chat A/B launch-ready: 565.8 ms -> 289.7 ms
- final native run: 321.5 ms, 39.9 MiB initial, zero idle memory growth
- packaged daily-driver smoke: 317.3 ms, 40.6 MiB initial, 0.0002% settled idle CPU

## Validation
- swift test: 6,345 passed, 5 skipped
- Python script contracts: 122 passed
- complete scripts/smoke.sh passed, including packaged hard-kill recovery and native UI interaction sweeps
- touched source modules grade A+