### PR TITLE
Defer desktop launch dependencies

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApp.swift
@@ -14,49 +14,46 @@ struct QuillCodeDesktopApp: App {
     init() {
         _ = QuillCodeDesktopLaunchClock.appEntryUptime
         let updateLaunchHandshake = QuillCodeDesktopUpdateLaunchHandshake()
-        if let updateRequest = QuillCodeDesktopUpdateHelperRequest.parse(arguments: CommandLine.arguments) {
-            Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
-        }
-        if let seedRequest = QuillCodeDesktopDailyDriverSmokeSeedRequest(arguments: CommandLine.arguments) {
-            Darwin.exit(QuillCodeDesktopDailyDriverSmokeFixture.runAndReport(seedRequest))
-        }
-
-        if let relocationSmokeRequest = QuillCodeDesktopRelocationSmokeRequest(
-            arguments: CommandLine.arguments
-        ) {
-            let controller = QuillCodeDesktopController(
-                updateController: QuillCodeDesktopUpdateController(
-                    configuration: nil,
-                    installResultURL: nil
-                ),
-                installationLocationController: QuillCodeDesktopInstallationLocationController(
-                    configuration: nil
-                )
-            )
-            _controller = StateObject(wrappedValue: controller)
-            Task { @MainActor in
-                await QuillCodeDesktopRelocationSmokeRunner.runAndExit(relocationSmokeRequest)
+        let launchRoutes = QuillCodeDesktopLaunchRoute.candidates(arguments: CommandLine.arguments)
+        for route in launchRoutes {
+            switch route {
+            case .updateHelper:
+                if let updateRequest = QuillCodeDesktopUpdateHelperRequest.parse(
+                    arguments: CommandLine.arguments
+                ) {
+                    Darwin.exit(QuillCodeDesktopUpdateHelper.run(updateRequest))
+                }
+            case .dailyDriverSeed:
+                if let seedRequest = QuillCodeDesktopDailyDriverSmokeSeedRequest(
+                    arguments: CommandLine.arguments
+                ) {
+                    Darwin.exit(QuillCodeDesktopDailyDriverSmokeFixture.runAndReport(seedRequest))
+                }
+            case .relocationSmoke:
+                if let request = QuillCodeDesktopRelocationSmokeRequest(
+                    arguments: CommandLine.arguments
+                ) {
+                    let controller = Self.smokeController()
+                    _controller = StateObject(wrappedValue: controller)
+                    Task { @MainActor in
+                        await QuillCodeDesktopRelocationSmokeRunner.runAndExit(request)
+                    }
+                    return
+                }
+            case .updaterSmoke:
+                if let request = QuillCodeDesktopUpdaterSmokeRequest(
+                    arguments: CommandLine.arguments
+                ) {
+                    let controller = Self.smokeController()
+                    _controller = StateObject(wrappedValue: controller)
+                    Task { @MainActor in
+                        await QuillCodeDesktopUpdaterSmokeRunner.runAndExit(request)
+                    }
+                    return
+                }
+            default:
+                continue
             }
-            return
-        }
-
-        if let updaterSmokeRequest = QuillCodeDesktopUpdaterSmokeRequest(
-            arguments: CommandLine.arguments
-        ) {
-            let controller = QuillCodeDesktopController(
-                updateController: QuillCodeDesktopUpdateController(
-                    configuration: nil,
-                    installResultURL: nil
-                ),
-                installationLocationController: QuillCodeDesktopInstallationLocationController(
-                    configuration: nil
-                )
-            )
-            _controller = StateObject(wrappedValue: controller)
-            Task { @MainActor in
-                await QuillCodeDesktopUpdaterSmokeRunner.runAndExit(updaterSmokeRequest)
-            }
-            return
         }
 
         // Quill Cowork is a dark-themed appliance: pin the whole app (every window, sheet, popover, and
@@ -66,74 +63,78 @@ struct QuillCodeDesktopApp: App {
         // pin fixes that class of contrast bugs everywhere at once.
         NSApplication.shared.appearance = NSAppearance(named: .darkAqua)
 
-        if let request = QuillCodeDesktopCoworkEvalRequest(arguments: CommandLine.arguments) {
-            let controller = request.makeController()
-            _controller = StateObject(wrappedValue: controller)
-            QuillCodeDesktopCoworkEvalLaunch.schedule(request, controller: controller)
-            return
-        }
-
-        if let request = QuillCodeDesktopComposerDraftCrashSmokeRequest(arguments: CommandLine.arguments) {
-            let workspaceRoot = QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot(request: request)
-            let controller = workspaceRoot.makeController()
-            _controller = StateObject(wrappedValue: controller)
-            Task { @MainActor in
-                await QuillCodeDesktopComposerDraftCrashSmoke.runAndExit(
-                    request,
-                    controller: controller,
-                    workspaceRoot: workspaceRoot
-                )
+        for route in launchRoutes {
+            switch route {
+            case .coworkEval:
+                if let request = QuillCodeDesktopCoworkEvalRequest(arguments: CommandLine.arguments) {
+                    let controller = request.makeController()
+                    _controller = StateObject(wrappedValue: controller)
+                    QuillCodeDesktopCoworkEvalLaunch.schedule(request, controller: controller)
+                    return
+                }
+            case .composerDraftCrashSmoke:
+                if let request = QuillCodeDesktopComposerDraftCrashSmokeRequest(
+                    arguments: CommandLine.arguments
+                ) {
+                    let workspaceRoot = QuillCodeDesktopComposerDraftCrashSmokeWorkspaceRoot(request: request)
+                    let controller = workspaceRoot.makeController()
+                    _controller = StateObject(wrappedValue: controller)
+                    Task { @MainActor in
+                        await QuillCodeDesktopComposerDraftCrashSmoke.runAndExit(
+                            request,
+                            controller: controller,
+                            workspaceRoot: workspaceRoot
+                        )
+                    }
+                    return
+                }
+            case .agentRunCrashSmoke:
+                if let request = QuillCodeDesktopAgentRunCrashSmokeRequest(
+                    arguments: CommandLine.arguments
+                ) {
+                    let workspaceRoot = QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot(request: request)
+                    let controller = workspaceRoot.makeController()
+                    _controller = StateObject(wrappedValue: controller)
+                    Task { @MainActor in
+                        await QuillCodeDesktopAgentRunCrashSmoke.runAndExit(
+                            request,
+                            controller: controller,
+                            workspaceRoot: workspaceRoot
+                        )
+                    }
+                    return
+                }
+            case .windowSmoke:
+                if let request = QuillCodeDesktopWindowSmokeRequest(arguments: CommandLine.arguments) {
+                    let workspaceRoot = QuillCodeDesktopWindowSmokeWorkspaceRoot(request: request)
+                    let controller = workspaceRoot.makeController()
+                    _controller = StateObject(wrappedValue: controller)
+                    QuillCodeDesktopWindowSmokeLaunch.schedule(
+                        request,
+                        controller: controller,
+                        workspaceRoot: workspaceRoot
+                    )
+                    return
+                }
+            case .renderSmoke:
+                if let request = QuillCodeDesktopSmokeRequest(arguments: CommandLine.arguments) {
+                    let controller: QuillCodeDesktopController
+                    if let workspaceRoot = try? QuillCodeDesktopSmokeWorkspaceRoot(request: request) {
+                        controller = workspaceRoot.makeLaunchController()
+                    } else {
+                        controller = Self.smokeController(
+                            workspaceRoot: QuillCodeDesktopWorkspaceRootResolver.resolve()
+                        )
+                    }
+                    _controller = StateObject(wrappedValue: controller)
+                    Task { @MainActor in
+                        await QuillCodeDesktopLaunchRecoverySmoke.runAndExit(request)
+                    }
+                    return
+                }
+            default:
+                continue
             }
-            return
-        }
-
-        if let request = QuillCodeDesktopAgentRunCrashSmokeRequest(arguments: CommandLine.arguments) {
-            let workspaceRoot = QuillCodeDesktopAgentRunCrashSmokeWorkspaceRoot(request: request)
-            let controller = workspaceRoot.makeController()
-            _controller = StateObject(wrappedValue: controller)
-            Task { @MainActor in
-                await QuillCodeDesktopAgentRunCrashSmoke.runAndExit(
-                    request,
-                    controller: controller,
-                    workspaceRoot: workspaceRoot
-                )
-            }
-            return
-        }
-
-        if let windowRequest = QuillCodeDesktopWindowSmokeRequest(arguments: CommandLine.arguments) {
-            let workspaceRoot = QuillCodeDesktopWindowSmokeWorkspaceRoot(request: windowRequest)
-            let controller = workspaceRoot.makeController()
-            _controller = StateObject(wrappedValue: controller)
-            QuillCodeDesktopWindowSmokeLaunch.schedule(
-                windowRequest,
-                controller: controller,
-                workspaceRoot: workspaceRoot
-            )
-            return
-        }
-
-        if let request = QuillCodeDesktopSmokeRequest(arguments: CommandLine.arguments) {
-            let controller: QuillCodeDesktopController
-            if let workspaceRoot = try? QuillCodeDesktopSmokeWorkspaceRoot(request: request) {
-                controller = workspaceRoot.makeLaunchController()
-            } else {
-                controller = QuillCodeDesktopController(
-                    updateController: QuillCodeDesktopUpdateController(
-                        configuration: nil,
-                        installResultURL: nil
-                    ),
-                    installationLocationController: QuillCodeDesktopInstallationLocationController(
-                        configuration: nil
-                    ),
-                    workspaceRoot: QuillCodeDesktopWorkspaceRootResolver.resolve()
-                )
-            }
-            _controller = StateObject(wrappedValue: controller)
-            Task { @MainActor in
-                await QuillCodeDesktopLaunchRecoverySmoke.runAndExit(request)
-            }
-            return
         }
 
         let updateController = QuillCodeDesktopUpdateController()
@@ -151,6 +152,19 @@ struct QuillCodeDesktopApp: App {
             workspaceRoot: QuillCodeDesktopWorkspaceRootResolver.resolve()
         )
         _controller = StateObject(wrappedValue: controller)
+    }
+
+    private static func smokeController(workspaceRoot: URL? = nil) -> QuillCodeDesktopController {
+        QuillCodeDesktopController(
+            updateController: QuillCodeDesktopUpdateController(
+                configuration: nil,
+                installResultURL: nil
+            ),
+            installationLocationController: QuillCodeDesktopInstallationLocationController(
+                configuration: nil
+            ),
+            workspaceRoot: workspaceRoot
+        )
     }
 
     var body: some Scene {

--- a/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopBrowserCoordinator.swift
@@ -2,20 +2,48 @@ import Foundation
 import QuillCodeApp
 import QuillCodeCore
 
+enum QuillCodeDesktopBrowserDependency: Hashable {
+    case pageFetcher
+}
+
+@MainActor
+private final class QuillCodeDesktopBrowserDependencies {
+    private var pageFetcherStorage: (any BrowserPageFetching)?
+
+    init(pageFetcher: (any BrowserPageFetching)?) {
+        pageFetcherStorage = pageFetcher
+    }
+
+    var pageFetcher: any BrowserPageFetching {
+        if let pageFetcherStorage { return pageFetcherStorage }
+        let pageFetcher = URLSessionBrowserPageFetcher()
+        pageFetcherStorage = pageFetcher
+        return pageFetcher
+    }
+
+    var materialized: Set<QuillCodeDesktopBrowserDependency> {
+        pageFetcherStorage == nil ? [] : [.pageFetcher]
+    }
+}
+
 @MainActor
 struct QuillCodeDesktopBrowserCoordinator {
-    private let pageFetcher: any BrowserPageFetching
+    private let dependencies: QuillCodeDesktopBrowserDependencies
     private let liveDOMCapturer: (any BrowserLiveDOMCapturing)?
     private let sessionPresenter: any DesktopBrowserSessionPresenting
 
     init(
-        pageFetcher: any BrowserPageFetching,
+        pageFetcher: (any BrowserPageFetching)?,
         liveDOMCapturer: (any BrowserLiveDOMCapturing)?,
         sessionPresenter: any DesktopBrowserSessionPresenting
     ) {
-        self.pageFetcher = pageFetcher
+        self.dependencies = QuillCodeDesktopBrowserDependencies(pageFetcher: pageFetcher)
         self.liveDOMCapturer = liveDOMCapturer
         self.sessionPresenter = sessionPresenter
+    }
+
+    var materializedDependencies: Set<QuillCodeDesktopBrowserDependency> {
+        dependencies.materialized
     }
 
     func installSessionUpdateHandler(
@@ -44,7 +72,7 @@ struct QuillCodeDesktopBrowserCoordinator {
         syncOpenSession(model: model)
 
         tasks.replace(.browserPreview) {
-            _ = await model.refreshBrowserSnapshot(pageFetcher: pageFetcher)
+            _ = await model.refreshBrowserSnapshot(pageFetcher: dependencies.pageFetcher)
             if let liveDOMCapturer {
                 _ = await model.refreshRenderedBrowserSnapshot(capturer: liveDOMCapturer)
             }

--- a/Sources/quill-code-desktop/QuillCodeDesktopController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopController.swift
@@ -72,7 +72,7 @@ final class QuillCodeDesktopController: ObservableObject {
         bootstrap: QuillCodeWorkspaceBootstrap = QuillCodeWorkspaceBootstrap(),
         computerUseCoordinator: QuillCodeDesktopComputerUseCoordinator =
             QuillCodeDesktopComputerUseCoordinator(),
-        browserPageFetcher: any BrowserPageFetching = URLSessionBrowserPageFetcher(),
+        browserPageFetcher: (any BrowserPageFetching)? = nil,
         browserLiveDOMCapturer: (any BrowserLiveDOMCapturing)? = DesktopBrowserLiveDOMCapturer(),
         browserSessionPresenter: any DesktopBrowserSessionPresenting = DesktopBrowserSessionPresenter(),
         automationNotifier: any QuillCodeAutomationNotifying = DesktopAutomationNotifierFactory.platformDefault(),

--- a/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopInstallationLocationController.swift
@@ -18,8 +18,8 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
     @Published private(set) var state: State = .ready
 
     private let configuration: QuillCodeDesktopUpdateConfiguration?
-    private let inspector: any QuillCodeDesktopUpdateInstallationInspecting
-    private let relocator: any QuillCodeDesktopApplicationRelocating
+    private var inspectorStorage: (any QuillCodeDesktopUpdateInstallationInspecting)?
+    private var relocatorStorage: (any QuillCodeDesktopApplicationRelocating)?
     private let defaults: UserDefaults
     private let relocationUpdateIntentStore: QuillCodeDesktopRelocationUpdateIntentStore
     private let applicationsURL: URL
@@ -32,10 +32,8 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
 
     init(
         configuration: QuillCodeDesktopUpdateConfiguration? = .bundled(),
-        inspector: any QuillCodeDesktopUpdateInstallationInspecting =
-            QuillCodeDesktopUpdateInstallationInspector(),
-        relocator: any QuillCodeDesktopApplicationRelocating =
-            QuillCodeDesktopApplicationRelocator(),
+        inspector: (any QuillCodeDesktopUpdateInstallationInspecting)? = nil,
+        relocator: (any QuillCodeDesktopApplicationRelocating)? = nil,
         defaults: UserDefaults = .standard,
         relocationUpdateIntentStore: QuillCodeDesktopRelocationUpdateIntentStore? = nil,
         applicationsURL: URL = URL(fileURLWithPath: "/Applications", isDirectory: true),
@@ -54,8 +52,8 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
             QuillCodeDesktopSystemApplication.terminateForUpdate
     ) {
         self.configuration = configuration
-        self.inspector = inspector
-        self.relocator = relocator
+        self.inspectorStorage = inspector
+        self.relocatorStorage = relocator
         self.defaults = defaults
         self.relocationUpdateIntentStore = relocationUpdateIntentStore
             ?? QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults)
@@ -170,6 +168,32 @@ final class QuillCodeDesktopInstallationLocationController: ObservableObject {
                 self.state = .failed(message: error.localizedDescription)
             }
         }
+    }
+
+    var materializedDependencies: Set<Dependency> {
+        var dependencies: Set<Dependency> = []
+        if inspectorStorage != nil { dependencies.insert(.inspector) }
+        if relocatorStorage != nil { dependencies.insert(.relocator) }
+        return dependencies
+    }
+
+    enum Dependency: Hashable {
+        case inspector
+        case relocator
+    }
+
+    private var inspector: any QuillCodeDesktopUpdateInstallationInspecting {
+        if let inspectorStorage { return inspectorStorage }
+        let inspector = QuillCodeDesktopUpdateInstallationInspector()
+        inspectorStorage = inspector
+        return inspector
+    }
+
+    private var relocator: any QuillCodeDesktopApplicationRelocating {
+        if let relocatorStorage { return relocatorStorage }
+        let relocator = QuillCodeDesktopApplicationRelocator()
+        relocatorStorage = relocator
+        return relocator
     }
 
     private func dismissalKey(for configuration: QuillCodeDesktopUpdateConfiguration) -> String {

--- a/Sources/quill-code-desktop/QuillCodeDesktopLaunchRoute.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopLaunchRoute.swift
@@ -1,0 +1,52 @@
+enum QuillCodeDesktopLaunchRoute: Hashable {
+    case updateHelper
+    case dailyDriverSeed
+    case relocationSmoke
+    case updaterSmoke
+    case coworkEval
+    case composerDraftCrashSmoke
+    case agentRunCrashSmoke
+    case windowSmoke
+    case renderSmoke
+
+    private static let priority: [Self] = [
+        .updateHelper,
+        .dailyDriverSeed,
+        .relocationSmoke,
+        .updaterSmoke,
+        .coworkEval,
+        .composerDraftCrashSmoke,
+        .agentRunCrashSmoke,
+        .windowSmoke,
+        .renderSmoke,
+    ]
+
+    static func candidates(arguments: [String]) -> [Self] {
+        var present: Set<Self> = []
+        for argument in arguments.dropFirst() {
+            switch argument {
+            case QuillCodeDesktopUpdateHelperRequest.modeArgument:
+                present.insert(.updateHelper)
+            case "--seed-daily-driver-window-smoke":
+                present.insert(.dailyDriverSeed)
+            case QuillCodeDesktopRelocationSmokeRequest.modeArgument:
+                present.insert(.relocationSmoke)
+            case QuillCodeDesktopUpdaterSmokeRequest.modeArgument:
+                present.insert(.updaterSmoke)
+            case "--cowork-eval":
+                present.insert(.coworkEval)
+            case "--composer-draft-crash-smoke":
+                present.insert(.composerDraftCrashSmoke)
+            case "--agent-run-crash-smoke":
+                present.insert(.agentRunCrashSmoke)
+            case "--native-window-smoke":
+                present.insert(.windowSmoke)
+            case "--native-render-smoke":
+                present.insert(.renderSmoke)
+            default:
+                continue
+            }
+        }
+        return priority.filter { present.contains($0) }
+    }
+}

--- a/Sources/quill-code-desktop/QuillCodeDesktopRelocationUpdateContinuation.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopRelocationUpdateContinuation.swift
@@ -39,10 +39,6 @@ final class QuillCodeDesktopRelocationUpdateContinuation {
         resultTask?.cancel()
     }
 
-    func discardPreviousResult() {
-        _ = QuillCodeDesktopUpdateInstallResultReader.take(from: resultURL)
-    }
-
     func start(
         configuration: QuillCodeDesktopUpdateConfiguration,
         onCompletion: @escaping @MainActor (Action) -> Void

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateController.swift
@@ -1,6 +1,82 @@
 import AppKit
 import Foundation
 
+enum QuillCodeDesktopUpdateDependency: Hashable {
+    case checker
+    case preparer
+    case installer
+    case installationInspector
+    case recovery
+}
+
+@MainActor
+private final class QuillCodeDesktopUpdateDependencies {
+    private var checkerStorage: (any QuillCodeDesktopUpdateChecking)?
+    private var preparerStorage: (any QuillCodeDesktopUpdatePreparing)?
+    private var installerStorage: (any QuillCodeDesktopUpdateInstalling)?
+    private var installationInspectorStorage: (any QuillCodeDesktopUpdateInstallationInspecting)?
+    private var recoveryStorage: (any QuillCodeDesktopUpdateRecovering)?
+
+    init(
+        checker: (any QuillCodeDesktopUpdateChecking)?,
+        preparer: (any QuillCodeDesktopUpdatePreparing)?,
+        installer: (any QuillCodeDesktopUpdateInstalling)?,
+        installationInspector: (any QuillCodeDesktopUpdateInstallationInspecting)?,
+        recovery: (any QuillCodeDesktopUpdateRecovering)?
+    ) {
+        checkerStorage = checker
+        preparerStorage = preparer
+        installerStorage = installer
+        installationInspectorStorage = installationInspector
+        recoveryStorage = recovery
+    }
+
+    var checker: any QuillCodeDesktopUpdateChecking {
+        if let checkerStorage { return checkerStorage }
+        let checker = QuillCodeDesktopUpdateChecker()
+        checkerStorage = checker
+        return checker
+    }
+
+    var preparer: any QuillCodeDesktopUpdatePreparing {
+        if let preparerStorage { return preparerStorage }
+        let preparer = QuillCodeDesktopUpdatePreparer()
+        preparerStorage = preparer
+        return preparer
+    }
+
+    var installer: any QuillCodeDesktopUpdateInstalling {
+        if let installerStorage { return installerStorage }
+        let installer = QuillCodeDesktopUpdateInstaller()
+        installerStorage = installer
+        return installer
+    }
+
+    var installationInspector: any QuillCodeDesktopUpdateInstallationInspecting {
+        if let installationInspectorStorage { return installationInspectorStorage }
+        let inspector = QuillCodeDesktopUpdateInstallationInspector()
+        installationInspectorStorage = inspector
+        return inspector
+    }
+
+    var recovery: any QuillCodeDesktopUpdateRecovering {
+        if let recoveryStorage { return recoveryStorage }
+        let recovery = QuillCodeDesktopUpdateRecovery()
+        recoveryStorage = recovery
+        return recovery
+    }
+
+    var materialized: Set<QuillCodeDesktopUpdateDependency> {
+        var dependencies: Set<QuillCodeDesktopUpdateDependency> = []
+        if checkerStorage != nil { dependencies.insert(.checker) }
+        if preparerStorage != nil { dependencies.insert(.preparer) }
+        if installerStorage != nil { dependencies.insert(.installer) }
+        if installationInspectorStorage != nil { dependencies.insert(.installationInspector) }
+        if recoveryStorage != nil { dependencies.insert(.recovery) }
+        return dependencies
+    }
+}
+
 @MainActor
 final class QuillCodeDesktopUpdateController: ObservableObject {
     @Published private(set) var state: State = .idle
@@ -8,22 +84,26 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
     @Published var isPresented = false
 
     let configuration: QuillCodeDesktopUpdateConfiguration?
-    private let checker: any QuillCodeDesktopUpdateChecking
-    private let preparer: any QuillCodeDesktopUpdatePreparing
-    private let installer: any QuillCodeDesktopUpdateInstalling
-    private let installationInspector: any QuillCodeDesktopUpdateInstallationInspecting
-    private let recovery: any QuillCodeDesktopUpdateRecovering
+    private let dependencies: QuillCodeDesktopUpdateDependencies
     private let defaults: UserDefaults
     private let now: () -> Date
     private let automaticSchedule: QuillCodeDesktopUpdateSchedule
     private let reminderStore: QuillCodeDesktopUpdateReminderStore
-    private let relocationContinuation: QuillCodeDesktopRelocationUpdateContinuation
+    private let relocationUpdateIntentStore: QuillCodeDesktopRelocationUpdateIntentStore
+    private let relocationContinuationTimeout: Duration
+    private let installResultURL: URL?
     private let terminateApplication: @MainActor () -> Void
     private var operationTask: Task<Void, Never>?
     private var automaticTask: Task<Void, Never>?
     private var recoveryTask: Task<Void, Never>?
     private var generation = UUID()
     private var didStartAutomaticChecks = false
+    private lazy var relocationContinuation = QuillCodeDesktopRelocationUpdateContinuation(
+        intentStore: relocationUpdateIntentStore,
+        installationInspector: dependencies.installationInspector,
+        resultURL: installResultURL,
+        timeout: relocationContinuationTimeout
+    )
 
     private enum AutomaticCheckOutcome {
         case success(nextCheckDelay: TimeInterval?)
@@ -34,12 +114,11 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
 
     init(
         configuration: QuillCodeDesktopUpdateConfiguration? = .bundled(),
-        checker: any QuillCodeDesktopUpdateChecking = QuillCodeDesktopUpdateChecker(),
-        preparer: any QuillCodeDesktopUpdatePreparing = QuillCodeDesktopUpdatePreparer(),
-        installer: any QuillCodeDesktopUpdateInstalling = QuillCodeDesktopUpdateInstaller(),
-        installationInspector: any QuillCodeDesktopUpdateInstallationInspecting =
-            QuillCodeDesktopUpdateInstallationInspector(),
-        recovery: any QuillCodeDesktopUpdateRecovering = QuillCodeDesktopUpdateRecovery(),
+        checker: (any QuillCodeDesktopUpdateChecking)? = nil,
+        preparer: (any QuillCodeDesktopUpdatePreparing)? = nil,
+        installer: (any QuillCodeDesktopUpdateInstalling)? = nil,
+        installationInspector: (any QuillCodeDesktopUpdateInstallationInspecting)? = nil,
+        recovery: (any QuillCodeDesktopUpdateRecovering)? = nil,
         defaults: UserDefaults = .standard,
         now: @escaping () -> Date = Date.init,
         automaticSchedule: QuillCodeDesktopUpdateSchedule = .production,
@@ -51,11 +130,13 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             QuillCodeDesktopSystemApplication.terminateForUpdate
     ) {
         self.configuration = configuration
-        self.checker = checker
-        self.preparer = preparer
-        self.installer = installer
-        self.installationInspector = installationInspector
-        self.recovery = recovery
+        self.dependencies = QuillCodeDesktopUpdateDependencies(
+            checker: checker,
+            preparer: preparer,
+            installer: installer,
+            installationInspector: installationInspector,
+            recovery: recovery
+        )
         self.defaults = defaults
         self.now = now
         self.automaticSchedule = automaticSchedule
@@ -63,14 +144,10 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             defaults: defaults,
             reminderInterval: reminderInterval
         )
-        let intentStore = relocationUpdateIntentStore
+        self.relocationUpdateIntentStore = relocationUpdateIntentStore
             ?? QuillCodeDesktopRelocationUpdateIntentStore(defaults: defaults, now: now)
-        self.relocationContinuation = QuillCodeDesktopRelocationUpdateContinuation(
-            intentStore: intentStore,
-            installationInspector: installationInspector,
-            resultURL: installResultURL,
-            timeout: relocationContinuationTimeout
-        )
+        self.relocationContinuationTimeout = relocationContinuationTimeout
+        self.installResultURL = installResultURL
         self.terminateApplication = terminateApplication
     }
 
@@ -84,7 +161,7 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
         guard !didStartAutomaticChecks else { return }
         didStartAutomaticChecks = true
         guard let configuration else {
-            relocationContinuation.discardPreviousResult()
+            _ = QuillCodeDesktopUpdateInstallResultReader.take(from: installResultURL)
             return
         }
         let continuationStartup = relocationContinuation.start(
@@ -244,6 +321,30 @@ final class QuillCodeDesktopUpdateController: ObservableObject {
             return false
         }
         return installationInspector.availability(for: configuration) == .requiresRelocation
+    }
+
+    var materializedUpdateDependencies: Set<QuillCodeDesktopUpdateDependency> {
+        dependencies.materialized
+    }
+
+    private var checker: any QuillCodeDesktopUpdateChecking {
+        dependencies.checker
+    }
+
+    private var preparer: any QuillCodeDesktopUpdatePreparing {
+        dependencies.preparer
+    }
+
+    private var installer: any QuillCodeDesktopUpdateInstalling {
+        dependencies.installer
+    }
+
+    private var installationInspector: any QuillCodeDesktopUpdateInstallationInspecting {
+        dependencies.installationInspector
+    }
+
+    private var recovery: any QuillCodeDesktopUpdateRecovering {
+        dependencies.recovery
     }
 
     private func performUserCheck(generation: UUID) async {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopControllerSmokeTests.swift
@@ -9,6 +9,32 @@ import QuillComputerUseKit
 
 @MainActor
 final class QuillCodeDesktopControllerSmokeTests: XCTestCase {
+    func testBrowserFetcherStaysLazyUntilPreviewWorkStarts() async throws {
+        let coordinator = QuillCodeDesktopBrowserCoordinator(
+            pageFetcher: nil,
+            liveDOMCapturer: nil,
+            sessionPresenter: NoopDesktopBrowserSessionPresenter()
+        )
+        let model = QuillCodeWorkspaceModel()
+        let tasks = QuillCodeDesktopTaskCoordinator()
+        let workspaceRoot = try makeTempDirectory()
+
+        coordinator.installSessionUpdateHandler(model: model, refresh: {})
+        XCTAssertEqual(coordinator.materializedDependencies, [])
+
+        coordinator.openPreview(
+            model: model,
+            addressDraft: "http://127.0.0.1:1",
+            workspaceRoot: workspaceRoot,
+            tasks: tasks,
+            refresh: {}
+        )
+        try await waitUntil(timeoutSeconds: 1) {
+            coordinator.materializedDependencies == [.pageFetcher]
+        }
+        tasks.cancel(.browserPreview)
+    }
+
 
     func testOrdinaryDesktopLaunchStartsWithoutRegisteringTheProcessDirectory() throws {
         let stateRoot = try makeTempDirectory()

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopInstallationLocationTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopInstallationLocationTests.swift
@@ -3,6 +3,32 @@ import XCTest
 
 @MainActor
 final class QuillCodeDesktopInstallationLocationTests: XCTestCase {
+    func testProductionDependenciesRemainLazyUntilLocationIsInspected() {
+        let controller = QuillCodeDesktopInstallationLocationController(
+            configuration: makeDiskImageConfiguration(),
+            defaults: makeDefaults()
+        )
+
+        XCTAssertEqual(controller.materializedDependencies, [])
+
+        controller.startIfNeeded()
+
+        XCTAssertEqual(controller.materializedDependencies, [.inspector])
+    }
+
+    func testDisabledLocationControllerNeverMaterializesDependencies() {
+        let controller = QuillCodeDesktopInstallationLocationController(
+            configuration: nil,
+            defaults: makeDefaults()
+        )
+
+        controller.startIfNeeded()
+        XCTAssertFalse(controller.presentForUpdate())
+        controller.moveAndRelaunch()
+
+        XCTAssertEqual(controller.materializedDependencies, [])
+    }
+
     func testWritableApplicationDoesNotPresentReminder() {
         let controller = makeController(availability: .available)
 

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchRouteTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopLaunchRouteTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopLaunchRouteTests: XCTestCase {
+    func testOrdinaryLaunchHasNoSpecialRouteCandidates() {
+        XCTAssertEqual(
+            QuillCodeDesktopLaunchRoute.candidates(arguments: ["Quill Cowork", "--project", "/tmp/work"]),
+            []
+        )
+    }
+
+    func testCandidatesPreserveEstablishedPrecedenceRegardlessOfArgumentOrder() {
+        let arguments = [
+            "Quill Cowork",
+            "--native-render-smoke",
+            "--cowork-eval",
+            QuillCodeDesktopUpdaterSmokeRequest.modeArgument,
+            QuillCodeDesktopUpdateHelperRequest.modeArgument,
+            "--native-window-smoke",
+            "--composer-draft-crash-smoke",
+            QuillCodeDesktopRelocationSmokeRequest.modeArgument,
+            "--agent-run-crash-smoke",
+            "--seed-daily-driver-window-smoke",
+            "--cowork-eval",
+        ]
+
+        XCTAssertEqual(
+            QuillCodeDesktopLaunchRoute.candidates(arguments: arguments),
+            [
+                .updateHelper,
+                .dailyDriverSeed,
+                .relocationSmoke,
+                .updaterSmoke,
+                .coworkEval,
+                .composerDraftCrashSmoke,
+                .agentRunCrashSmoke,
+                .windowSmoke,
+                .renderSmoke,
+            ]
+        )
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateControllerTests.swift
@@ -3,6 +3,37 @@ import XCTest
 
 @MainActor
 final class QuillCodeDesktopUpdateControllerTests: XCTestCase {
+    func testProductionDependenciesRemainLazyUntilAutomaticServicesStart() {
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: makeConfiguration(),
+            defaults: makeDefaults(),
+            automaticSchedule: makeAutomaticSchedule(initialDelay: 60),
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        XCTAssertEqual(controller.materializedUpdateDependencies, [])
+
+        controller.startAutomaticChecks()
+
+        XCTAssertEqual(
+            controller.materializedUpdateDependencies,
+            [.installationInspector, .recovery]
+        )
+    }
+
+    func testDisabledUpdaterDoesNotMaterializeDependencies() {
+        let controller = QuillCodeDesktopUpdateController(
+            configuration: nil,
+            defaults: makeDefaults(),
+            installResultURL: temporaryInstallResultURL()
+        )
+
+        controller.startAutomaticChecks()
+        controller.checkForUpdates()
+
+        XCTAssertEqual(controller.materializedUpdateDependencies, [])
+    }
+
     func testManualCheckShowsAvailableUpdateThenInstallsAndTerminates() async throws {
         let release = makeRelease(version: "0.2.0", build: "7")
         let checker = UpdateCheckerSpy(result: .updateAvailable(release))

--- a/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedMacOSSmokeGateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
     func testPackagedMacOSSmokeIncludesLiveWindowProof() throws {
         let appText = try Self.desktopSourceText(named: "QuillCodeDesktopApp.swift")
+        let launchRouteText = try Self.desktopSourceText(named: "QuillCodeDesktopLaunchRoute.swift")
         let supportText = try Self.desktopSourceText(named: "QuillCodeDesktopSmokeSupport.swift")
         let windowSmokeText = try Self.desktopSourceText(named: "QuillCodeDesktopWindowSmokeRunner.swift")
         let packagedSmoke = try String(
@@ -12,8 +13,10 @@ final class ParityPackagedMacOSSmokeGateTests: QuillCodeParityTestCase {
         let clickProbeValidator = try Self.nativeClickProbeValidatorText()
 
         XCTAssertTrue(appText.contains("QuillCodeDesktopWindowSmokeRequest(arguments: CommandLine.arguments)"))
-        XCTAssertTrue(appText.contains("QuillCodeDesktopWindowSmokeWorkspaceRoot(request: windowRequest)"))
+        XCTAssertTrue(appText.contains("QuillCodeDesktopWindowSmokeWorkspaceRoot(request: request)"))
         XCTAssertTrue(appText.contains("QuillCodeDesktopWindowSmokeLaunch.schedule("))
+        XCTAssertTrue(launchRouteText.contains(#"case "--native-window-smoke":"#))
+        XCTAssertTrue(launchRouteText.contains("case windowSmoke"))
         XCTAssertTrue(appText.contains("NSApplication.didFinishLaunchingNotification"))
         XCTAssertTrue(appText.contains("QuillCodeDesktopWindowSmokeRunner.runAndExit("))
         XCTAssertTrue(appText.contains(".defaultSize(width: 1280, height: 900)"))


### PR DESCRIPTION
## Summary
- classify special launch routes in one pass while preserving existing route precedence
- lazily materialize updater, relocation, installation, and browser-preview dependencies
- pin production cold-start behavior with focused and parity tests

## Verification
- `scripts/smoke.sh`: passed (6,351 Swift tests plus CLI, protocol, native, packaged, crash-recovery, and live-window smokes)
- packaged daily-driver run: 303.28 ms median launch, 40.77 MiB initial footprint, 86.95 MiB repeated-interaction footprint, 0.0003% settled idle CPU
- final three-attempt packaged gate: 324.43 ms median launch, 40.78 MiB initial footprint, 87.42 MiB repeated-interaction footprint, 0 MiB settled idle growth, 0.0002% settled idle CPU