### PR TITLE
Defer Computer Use platform startup

### DIFF
--- a/Sources/QuillComputerUseKit/ComputerUseBackendFactory.swift
+++ b/Sources/QuillComputerUseKit/ComputerUseBackendFactory.swift
@@ -25,7 +25,7 @@ public struct ComputerUseBackendFactory: Sendable {
     public static func platformDefault() -> ComputerUseBackendFactory {
         #if canImport(AppKit) && canImport(ApplicationServices) && canImport(CoreGraphics)
         return ComputerUseBackendFactory {
-            MacComputerUseBackend()
+            DeferredMacComputerUseBackend()
         }
         #elseif os(Linux)
         return ComputerUseBackendFactory {

--- a/Sources/QuillComputerUseKit/DeferredMacComputerUseBackend.swift
+++ b/Sources/QuillComputerUseKit/DeferredMacComputerUseBackend.swift
@@ -1,0 +1,115 @@
+#if canImport(AppKit) && canImport(ApplicationServices) && canImport(CoreGraphics)
+import Foundation
+
+final class DeferredMacComputerUseBackend: @unchecked Sendable,
+    ComputerUseBackend,
+    ComputerUsePermissionRequesting,
+    ComputerUseForegroundApplicationProviding,
+    ComputerUseApplicationActivating,
+    ComputerUseAccessibilitySnapshotProviding,
+    WorkflowRecordingBackend
+{
+    private let lock = NSLock()
+    private let makeBackend: @Sendable () -> MacComputerUseBackend
+    private var storedBackend: MacComputerUseBackend?
+
+    init(
+        makeBackend: @escaping @Sendable () -> MacComputerUseBackend = MacComputerUseBackend.init
+    ) {
+        self.makeBackend = makeBackend
+    }
+
+    var status: ComputerUseStatus {
+        backend().status
+    }
+
+    func requestScreenRecordingAccess() -> Bool {
+        backend().requestScreenRecordingAccess()
+    }
+
+    func requestAccessibilityAccess() -> Bool {
+        backend().requestAccessibilityAccess()
+    }
+
+    func screenshot() async throws -> ComputerScreenshot {
+        try await backend().screenshot()
+    }
+
+    func leftClick(x: Int, y: Int) async throws {
+        try await backend().leftClick(x: x, y: y)
+    }
+
+    func type(_ text: String) async throws {
+        try await backend().type(text)
+    }
+
+    func scroll(dx: Int, dy: Int) async throws {
+        try await backend().scroll(dx: dx, dy: dy)
+    }
+
+    func moveCursor(x: Int, y: Int) async throws {
+        try await backend().moveCursor(x: x, y: y)
+    }
+
+    func pressKey(_ key: String) async throws {
+        try await backend().pressKey(key)
+    }
+
+    func foregroundApplication() async -> ComputerUseApplication? {
+        await backend().foregroundApplication()
+    }
+
+    func application(matching nameOrBundleIdentifier: String) async -> ComputerUseApplication? {
+        await backend().application(matching: nameOrBundleIdentifier)
+    }
+
+    func activateApplication(
+        matching nameOrBundleIdentifier: String
+    ) async throws -> ComputerUseApplication {
+        try await backend().activateApplication(matching: nameOrBundleIdentifier)
+    }
+
+    func accessibilitySnapshot(limit: Int) async -> ComputerUseAccessibilitySnapshot? {
+        await backend().accessibilitySnapshot(limit: limit)
+    }
+
+    func workflowRecordingStatus() async -> WorkflowRecordingStatus {
+        guard let backend = backendIfMaterialized() else { return .idle }
+        return await backend.workflowRecordingStatus()
+    }
+
+    var workflowRecordingStatusSnapshot: WorkflowRecordingStatus {
+        backendIfMaterialized()?.workflowRecordingStatusSnapshot ?? .idle
+    }
+
+    func startWorkflowRecording(
+        _ request: WorkflowRecordingRequest
+    ) async throws -> WorkflowRecordingStatus {
+        try await backend().startWorkflowRecording(request)
+    }
+
+    func stopWorkflowRecording() async throws -> WorkflowRecordingCapture {
+        try await backend().stopWorkflowRecording()
+    }
+
+    func cancelWorkflowRecording() async {
+        guard let backend = backendIfMaterialized() else { return }
+        await backend.cancelWorkflowRecording()
+    }
+
+    private func backend() -> MacComputerUseBackend {
+        lock.withLock {
+            if let storedBackend {
+                return storedBackend
+            }
+            let backend = makeBackend()
+            storedBackend = backend
+            return backend
+        }
+    }
+
+    private func backendIfMaterialized() -> MacComputerUseBackend? {
+        lock.withLock { storedBackend }
+    }
+}
+#endif

--- a/Sources/quill-code-desktop/QuillCodeDesktopComputerUseCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopComputerUseCoordinator.swift
@@ -14,7 +14,7 @@ extension MacSystemSettingsOpener: QuillCodeDesktopComputerUseSettingsOpening {}
 final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     private var backend: any ComputerUseBackend
     private let systemSettingsOpener: any QuillCodeDesktopComputerUseSettingsOpening
-    private let applicationActivationNotificationCenter: NotificationCenter
+    private var applicationActivationNotificationCenter: NotificationCenter?
     private let applicationActivationNotification: Notification.Name
     private var applicationActivationHandler: (@MainActor () -> Void)?
     /// Invalidates a permission preflight when a newer refresh or backend replacement wins.
@@ -26,7 +26,7 @@ final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     init(
         backend: any ComputerUseBackend = ComputerUseBackendFactory.platformDefault().backend(),
         systemSettingsOpener: any QuillCodeDesktopComputerUseSettingsOpening = MacSystemSettingsOpener(),
-        applicationActivationNotificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        applicationActivationNotificationCenter: NotificationCenter? = nil,
         applicationActivationNotification: Notification.Name = NSWorkspace.didActivateApplicationNotification
     ) {
         self.backend = backend
@@ -37,7 +37,7 @@ final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     }
 
     deinit {
-        applicationActivationNotificationCenter.removeObserver(self)
+        applicationActivationNotificationCenter?.removeObserver(self)
     }
 
     func install(on model: QuillCodeWorkspaceModel) {
@@ -49,7 +49,10 @@ final class QuillCodeDesktopComputerUseCoordinator: NSObject {
     ) {
         guard applicationActivationHandler == nil else { return }
         applicationActivationHandler = onActivation
-        applicationActivationNotificationCenter.addObserver(
+        let notificationCenter = applicationActivationNotificationCenter
+            ?? NSWorkspace.shared.notificationCenter
+        applicationActivationNotificationCenter = notificationCenter
+        notificationCenter.addObserver(
             self,
             selector: #selector(applicationDidActivate),
             name: applicationActivationNotification,

--- a/Tests/QuillComputerUseKitTests/ComputerUseStatusTests.swift
+++ b/Tests/QuillComputerUseKitTests/ComputerUseStatusTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import QuillComputerUseKit
+@testable import QuillComputerUseKit
 
 final class ComputerUseStatusTests: XCTestCase {
     func testPermissionStatusLabelsReadyState() {
@@ -87,5 +87,51 @@ final class ComputerUseStatusTests: XCTestCase {
 
         XCTAssertEqual(status.available, status.screenRecordingGranted && status.accessibilityGranted)
         XCTAssertFalse(status.message.isEmpty)
+    }
+
+    func testDefaultMacBackendDefersPlatformBackendUntilFirstProbe() async {
+#if canImport(AppKit) && canImport(ApplicationServices) && canImport(CoreGraphics)
+        XCTAssertTrue(
+            ComputerUseBackendFactory.platformDefault().backend()
+                is DeferredMacComputerUseBackend
+        )
+        let materializations = LockedCounter()
+        let backend = DeferredMacComputerUseBackend {
+            materializations.increment()
+            return MacComputerUseBackend()
+        }
+
+        XCTAssertEqual(backend.workflowRecordingStatusSnapshot, .idle)
+        let statusBeforeMaterialization = await backend.workflowRecordingStatus()
+        XCTAssertEqual(statusBeforeMaterialization, .idle)
+        await backend.cancelWorkflowRecording()
+        XCTAssertEqual(materializations.value, 0)
+
+        await withTaskGroup(of: ComputerUseStatus.self) { group in
+            for _ in 0..<100 {
+                group.addTask { backend.status }
+            }
+            for await status in group {
+                XCTAssertFalse(status.message.isEmpty)
+            }
+        }
+
+        XCTAssertEqual(materializations.value, 1)
+#endif
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.withLock { count }
+    }
+
+    func increment() {
+        lock.withLock {
+            count += 1
+        }
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -17851,3 +17851,25 @@ Validation:
 - Desktop and mobile browser runtime inspection, including live GitHub release metadata
 - `python3 scripts/grade-code-quality.py --root .` (all production modules A+; affected Python files A+)
 - JavaScript syntax checks, workflow YAML parsing, static-site verification, and `git diff --check`
+
+## 2026-08-13 Deferred Computer Use Platform Startup
+
+Overall grade after this slice: **A+ startup architecture, A+ concurrency safety, A+ packaged performance**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Startup ownership | A+ | The macOS Computer Use backend keeps its complete capability surface while deferring native permission, workspace, and workflow-recording objects until the first real platform probe or action. |
+| Surface fidelity | A+ | The initial workspace still advertises screenshot, input, foreground-app, activation, Accessibility, and workflow-recording support; an unmaterialized recorder reports the only valid state, idle. |
+| Concurrency safety | A+ | One lock-protected backend instance is shared across synchronous probes and async actions. A 100-task first-probe regression test proves exactly one native backend is created. |
+| Lifecycle efficiency | A+ | The desktop coordinator also defers `NSWorkspace`'s application-activation notification center until post-window observation begins and removes an observer only when one was installed. |
+| Packaged compatibility | A+ | The release app passed intentional SIGKILL recovery, direct and Launch Services rendering, native Accessibility interaction, Computer Use contracts, and critical-memory-pressure recovery. |
+| Packaged performance | A+ | Three fresh 100-chat daily-driver processes passed: 313.33 ms median readiness, 40.59 MiB initial physical footprint, 75.19 MiB after interaction, 79.92 MiB after repetition, and 0.0005% settled idle CPU. |
+
+Validation:
+
+- Focused Computer Use and desktop coordinator suite (16 tests, 0 failures)
+- `swift test` (6,353 tests; 5 skipped; 0 failures)
+- `scripts/smoke.sh` (CLI, app-server, MCP, native desktop, crash recovery, direct and Launch Services packaged interaction passed)
+- Exact-commit macOS package, three-process performance, DMG verification, relocation, and relaunch passed
+- `python3 scripts/grade-code-quality.py --root .` (all affected modules A+)
+- `git diff --check`


### PR DESCRIPTION
## Summary
- preserve the complete macOS Computer Use capability surface behind a thread-safe deferred backend
- avoid creating workflow-recording and NSWorkspace activation machinery during controller construction
- cover idle behavior and exactly-once materialization under 100 concurrent first probes

## Verification
- focused Computer Use and desktop coordinator suite: 16 tests passed
- full Swift suite: 6,353 tests passed, 5 skipped
- scripts/smoke.sh passed, including native UI, SIGKILL recovery, Launch Services, Computer Use, and packaged daily-driver flows
- exact-commit three-process package performance passed: 313.33 ms readiness, 40.59 MiB initial, 75.19 MiB post-interaction, 79.92 MiB repeated, 0.0005% idle CPU
- DMG verification, relocation, and relaunch passed
- all affected modules retain A+ quality grades

## Distribution
- no credential or update-channel changes
- public tester publication remains driven by verified main after merge