### PR TITLE
Harden interrupted update recovery

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
@@ -87,6 +87,12 @@ enum QuillCodeDesktopUpdateHelper {
         else {
             throw QuillCodeDesktopUpdateError.installationFailed("the staged update request is invalid")
         }
+        if request.activationMode == .replaceExisting {
+            try QuillCodeDesktopUpdateTransaction.validate(
+                request,
+                cacheRoot: environment.cacheRootURL
+            )
+        }
     }
 
     private static func validateActivation(_ request: QuillCodeDesktopUpdateHelperRequest) throws {

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
@@ -74,8 +74,17 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
                 runningExecutableURL: runningExecutableURL
             )
         }.value
-        try Task.checkCancellation()
-        try QuillCodeDesktopUpdateHelperLauncher.launch(request)
+        let cacheRoot = preparedUpdate.workspaceURL.deletingLastPathComponent()
+        do {
+            try Task.checkCancellation()
+            try QuillCodeDesktopUpdateHelperLauncher.launch(request)
+        } catch {
+            QuillCodeDesktopUpdateTransaction.discardUnactivated(
+                request,
+                cacheRoot: cacheRoot
+            )
+            throw error
+        }
     }
 
     private static func stage(
@@ -139,7 +148,7 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             throw QuillCodeDesktopUpdateError.installationFailed("the verified app could not be staged")
         }
 
-        return QuillCodeDesktopUpdateHelperRequest(
+        let request = QuillCodeDesktopUpdateHelperRequest(
             parentProcessID: ProcessInfo.processInfo.processIdentifier,
             helperURL: helperURL,
             incomingApplicationURL: incomingURL,
@@ -154,6 +163,19 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             activationMode: .replaceExisting,
             rollbackApplicationURL: nil
         )
+        do {
+            try QuillCodeDesktopUpdateTransaction.persist(
+                for: request,
+                cacheRoot: preparedUpdate.workspaceURL.deletingLastPathComponent()
+            )
+        } catch {
+            try? fileManager.removeItem(at: incomingURL)
+            try? fileManager.removeItem(at: helperURL)
+            throw QuillCodeDesktopUpdateError.installationFailed(
+                "the update recovery record could not be created"
+            )
+        }
+        return request
     }
 }
 
@@ -175,7 +197,7 @@ enum QuillCodeDesktopUpdateHelperLauncher {
     }
 }
 
-enum QuillCodeDesktopApplicationActivationMode: String, Equatable, Sendable {
+enum QuillCodeDesktopApplicationActivationMode: String, Codable, Equatable, Sendable {
     case replaceExisting = "replace-existing"
     case installNew = "install-new"
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateRecovery.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateRecovery.swift
@@ -10,11 +10,16 @@ struct QuillCodeDesktopUpdateRecovery: QuillCodeDesktopUpdateRecovering, Sendabl
     static let productionGracePeriod: TimeInterval = 2 * 60
 
     private let gracePeriod: TimeInterval
+    private let cacheRootURL: URL?
 
-    init(gracePeriod: TimeInterval = productionGracePeriod) {
+    init(
+        gracePeriod: TimeInterval = productionGracePeriod,
+        cacheRootURL: URL? = nil
+    ) {
         self.gracePeriod = gracePeriod.isFinite && gracePeriod >= 0
             ? gracePeriod
             : Self.productionGracePeriod
+        self.cacheRootURL = cacheRootURL
     }
 
     func recoverInterruptedUpdate(
@@ -30,18 +35,116 @@ struct QuillCodeDesktopUpdateRecovery: QuillCodeDesktopUpdateRecovering, Sendabl
         guard !Task.isCancelled else { return }
         let applicationURL = configuration.applicationURL
         let bundleIdentifier = configuration.bundleIdentifier
+        let configuredCacheRoot = cacheRootURL
         _ = try? await Task.detached(priority: .utility) {
+            let cacheRoot = try configuredCacheRoot ?? QuillCodeDesktopUpdatePaths.cacheRoot()
+            guard let protectedStaging = try Self.reconcileInterruptedTransactions(
+                configuration: configuration,
+                cacheRoot: cacheRoot
+            ) else {
+                return
+            }
             try Self.removeOrphanedStagingApplications(
                 beside: applicationURL,
-                bundleIdentifier: bundleIdentifier
+                bundleIdentifier: bundleIdentifier,
+                preserving: protectedStaging
             )
         }.value
+    }
+
+    /// Returns `nil` when transaction evidence is damaged or ambiguous enough that cleanup must stop.
+    static func reconcileInterruptedTransactions(
+        configuration: QuillCodeDesktopUpdateConfiguration,
+        cacheRoot: URL
+    ) throws -> Set<URL>? {
+        let fileManager = FileManager.default
+        let cacheRoot = cacheRoot.standardizedFileURL
+        guard fileManager.fileExists(atPath: cacheRoot.path) else { return [] }
+        let rootValues = try cacheRoot.resourceValues(
+            forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+        )
+        guard rootValues.isDirectory == true, rootValues.isSymbolicLink != true else {
+            return nil
+        }
+
+        let workspaces = try fileManager.contentsOfDirectory(
+            at: cacheRoot,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: []
+        )
+        var protectedStaging: Set<URL> = []
+        for workspace in workspaces {
+            let transactionURL = workspace.appendingPathComponent(
+                QuillCodeDesktopUpdateTransaction.fileName,
+                isDirectory: false
+            )
+            guard fileManager.fileExists(atPath: transactionURL.path) else { continue }
+            guard let transaction = try? QuillCodeDesktopUpdateTransaction.read(
+                fromWorkspace: workspace,
+                cacheRoot: cacheRoot
+            ),
+                  transaction.hasValidRecoveryLayout(
+                    workspace: workspace,
+                    cacheRoot: cacheRoot,
+                    configuration: configuration
+                  )
+            else {
+                return nil
+            }
+
+            let incoming = transaction.incomingApplicationURL
+            protectedStaging.insert(incoming)
+            let destinationIdentity = applicationIdentity(
+                at: transaction.destinationApplicationURL,
+                bundleIdentifier: transaction.expectedBundleIdentifier
+            )
+            guard fileManager.fileExists(atPath: incoming.path) else {
+                if destinationIdentity != nil {
+                    try? fileManager.removeItem(at: workspace)
+                    protectedStaging.remove(incoming)
+                }
+                continue
+            }
+            guard let incomingIdentity = applicationIdentity(
+                at: incoming,
+                bundleIdentifier: transaction.expectedBundleIdentifier
+            ) else {
+                continue
+            }
+
+            let expectedIdentity = ApplicationIdentity(
+                version: transaction.expectedVersion,
+                build: transaction.expectedBuild,
+                commit: transaction.expectedCommit
+            )
+            let replacementIsRunning = destinationIdentity == expectedIdentity &&
+                configuration.currentVersion == transaction.expectedVersion &&
+                configuration.currentBuild == transaction.expectedBuild
+            let destinationMatchesRunningBuild =
+                destinationIdentity?.version == configuration.currentVersion &&
+                destinationIdentity?.build == configuration.currentBuild
+            let previousBuildIsRunning = destinationMatchesRunningBuild &&
+                destinationIdentity != expectedIdentity &&
+                incomingIdentity == expectedIdentity
+            let rollbackCanRetire = replacementIsRunning && incomingIdentity != expectedIdentity
+            guard previousBuildIsRunning || rollbackCanRetire else { continue }
+
+            do {
+                try fileManager.removeItem(at: incoming)
+                try? fileManager.removeItem(at: workspace)
+                protectedStaging.remove(incoming)
+            } catch {
+                continue
+            }
+        }
+        return protectedStaging
     }
 
     @discardableResult
     static func removeOrphanedStagingApplications(
         beside applicationURL: URL,
-        bundleIdentifier: String
+        bundleIdentifier: String,
+        preserving protectedStaging: Set<URL> = []
     ) throws -> [URL] {
         let applicationURL = applicationURL.standardizedFileURL
         let values = try applicationURL.resourceValues(
@@ -64,6 +167,7 @@ struct QuillCodeDesktopUpdateRecovery: QuillCodeDesktopUpdateRecovering, Sendabl
         )
         var removed: [URL] = []
         for child in children where isOwnedStagingApplication(child, baseName: baseName) {
+            guard !protectedStaging.contains(child.standardizedFileURL) else { continue }
             guard let childValues = try? child.resourceValues(
                 forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
             ),
@@ -82,6 +186,33 @@ struct QuillCodeDesktopUpdateRecovery: QuillCodeDesktopUpdateRecovering, Sendabl
         return removed
     }
 
+    private static func applicationIdentity(
+        at applicationURL: URL,
+        bundleIdentifier: String
+    ) -> ApplicationIdentity? {
+        guard let values = try? applicationURL.resourceValues(
+            forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+        ),
+              values.isDirectory == true,
+              values.isSymbolicLink != true,
+              let bundle = Bundle(url: applicationURL),
+              bundle.bundleIdentifier == bundleIdentifier,
+              let version = bundle.object(
+                forInfoDictionaryKey: "CFBundleShortVersionString"
+              ) as? String,
+              let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+              let commit = bundle.object(
+                forInfoDictionaryKey: QuillCodeDesktopBuildMetadata.commitInfoKey
+              ) as? String,
+              QuillCodeDesktopSemanticVersion(version) != nil,
+              UInt64(build) != nil,
+              QuillCodeDesktopBuildMetadata.isCanonicalCommit(commit)
+        else {
+            return nil
+        }
+        return ApplicationIdentity(version: version, build: build, commit: commit)
+    }
+
     static func isOwnedStagingApplication(_ url: URL, baseName: String) -> Bool {
         let prefix = ".\(baseName).update-"
         let suffix = ".app"
@@ -97,5 +228,11 @@ struct QuillCodeDesktopUpdateRecovery: QuillCodeDesktopUpdateRecovering, Sendabl
         let identifier = String(name[identifierStart..<identifierEnd])
         guard let uuid = UUID(uuidString: identifier) else { return false }
         return uuid.uuidString.lowercased() == identifier
+    }
+
+    private struct ApplicationIdentity: Equatable {
+        var version: String
+        var build: String
+        var commit: String
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateTransaction.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateTransaction.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+struct QuillCodeDesktopUpdateTransaction: Codable, Equatable, Sendable {
+    static let fileName = "UpdateTransaction.json"
+    static let maximumEncodedBytes = 16 * 1_024
+    private static let schemaVersion = 1
+
+    var schemaVersion: Int
+    var operationIdentifier: String
+    var parentProcessID: Int32
+    var helperPath: String
+    var incomingApplicationPath: String
+    var destinationApplicationPath: String
+    var handshakePath: String
+    var resultPath: String
+    var logPath: String
+    var expectedBundleIdentifier: String
+    var expectedVersion: String
+    var expectedBuild: String
+    var expectedCommit: String
+    var activationMode: QuillCodeDesktopApplicationActivationMode
+
+    static func persist(
+        for request: QuillCodeDesktopUpdateHelperRequest,
+        cacheRoot: URL
+    ) throws {
+        let transaction = try make(for: request, cacheRoot: cacheRoot)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(transaction)
+        guard !data.isEmpty, data.count <= maximumEncodedBytes else {
+            throw recoveryRecordError
+        }
+
+        let url = transactionURL(for: request.helperURL.deletingLastPathComponent())
+        guard !FileManager.default.fileExists(atPath: url.path) else {
+            throw recoveryRecordError
+        }
+        do {
+            try data.write(to: url, options: [.atomic, .completeFileProtection])
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+            guard try read(from: url) == transaction else {
+                throw recoveryRecordError
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: url)
+            throw recoveryRecordError
+        }
+    }
+
+    static func validate(
+        _ request: QuillCodeDesktopUpdateHelperRequest,
+        cacheRoot: URL
+    ) throws {
+        do {
+            let workspace = request.helperURL.deletingLastPathComponent().standardizedFileURL
+            let transaction = try read(from: transactionURL(for: workspace))
+            guard transaction.matches(request, workspace: workspace, cacheRoot: cacheRoot) else {
+                throw recoveryRecordError
+            }
+        } catch {
+            throw recoveryRecordError
+        }
+    }
+
+    @discardableResult
+    static func discardUnactivated(
+        _ request: QuillCodeDesktopUpdateHelperRequest,
+        cacheRoot: URL
+    ) -> Bool {
+        do {
+            try validate(request, cacheRoot: cacheRoot)
+            let incoming = request.incomingApplicationURL.standardizedFileURL
+            guard applicationMatchesExpected(incoming, request: request) else { return false }
+            try FileManager.default.removeItem(at: incoming)
+            let workspace = request.helperURL.deletingLastPathComponent().standardizedFileURL
+            try? FileManager.default.removeItem(at: workspace)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func read(
+        fromWorkspace workspace: URL,
+        cacheRoot: URL
+    ) throws -> Self {
+        let workspace = workspace.standardizedFileURL
+        let cacheRoot = cacheRoot.standardizedFileURL
+        guard workspace != cacheRoot,
+              workspace.deletingLastPathComponent() == cacheRoot,
+              let values = try? workspace.resourceValues(
+                forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+              ),
+              values.isDirectory == true,
+              values.isSymbolicLink != true
+        else {
+            throw recoveryRecordError
+        }
+        return try read(from: transactionURL(for: workspace))
+    }
+
+    func hasValidRecoveryLayout(
+        workspace: URL,
+        cacheRoot: URL,
+        configuration: QuillCodeDesktopUpdateConfiguration
+    ) -> Bool {
+        let workspace = workspace.standardizedFileURL
+        let cacheRoot = cacheRoot.standardizedFileURL
+        let destination = destinationApplicationURL
+        let incoming = incomingApplicationURL
+        guard schemaVersion == Self.schemaVersion,
+              activationMode == .replaceExisting,
+              operationIdentifier == Self.operationIdentifier(
+                incomingApplicationURL: incoming,
+                destinationApplicationURL: destination
+              ),
+              workspace.path != cacheRoot.path,
+              workspace.deletingLastPathComponent().path == cacheRoot.path,
+              destination.path == configuration.applicationURL.standardizedFileURL.path,
+              incoming.deletingLastPathComponent().path == destination.deletingLastPathComponent().path,
+              expectedBundleIdentifier == configuration.bundleIdentifier,
+              !expectedBundleIdentifier.isEmpty,
+              QuillCodeDesktopSemanticVersion(expectedVersion) != nil,
+              UInt64(expectedBuild) != nil,
+              QuillCodeDesktopBuildMetadata.isCanonicalCommit(expectedCommit),
+              URL(fileURLWithPath: helperPath).standardizedFileURL
+                .deletingLastPathComponent().path == workspace.path,
+              URL(fileURLWithPath: handshakePath).standardizedFileURL
+                .deletingLastPathComponent().path == workspace.path,
+              URL(fileURLWithPath: logPath).standardizedFileURL
+                .deletingLastPathComponent().path == workspace.path
+        else {
+            return false
+        }
+        return true
+    }
+
+    var incomingApplicationURL: URL {
+        URL(fileURLWithPath: incomingApplicationPath).standardizedFileURL
+    }
+
+    var destinationApplicationURL: URL {
+        URL(fileURLWithPath: destinationApplicationPath).standardizedFileURL
+    }
+
+    private static func make(
+        for request: QuillCodeDesktopUpdateHelperRequest,
+        cacheRoot: URL
+    ) throws -> Self {
+        let incoming = request.incomingApplicationURL.standardizedFileURL
+        let destination = request.destinationApplicationURL.standardizedFileURL
+        guard let identifier = operationIdentifier(
+            incomingApplicationURL: incoming,
+            destinationApplicationURL: destination
+        ) else {
+            throw recoveryRecordError
+        }
+        let transaction = Self(
+            schemaVersion: schemaVersion,
+            operationIdentifier: identifier,
+            parentProcessID: request.parentProcessID,
+            helperPath: request.helperURL.standardizedFileURL.path,
+            incomingApplicationPath: incoming.path,
+            destinationApplicationPath: destination.path,
+            handshakePath: request.handshakeURL.standardizedFileURL.path,
+            resultPath: request.resultURL.standardizedFileURL.path,
+            logPath: request.logURL.standardizedFileURL.path,
+            expectedBundleIdentifier: request.expectedBundleIdentifier,
+            expectedVersion: request.expectedVersion,
+            expectedBuild: request.expectedBuild,
+            expectedCommit: request.expectedCommit,
+            activationMode: request.activationMode
+        )
+        let workspace = request.helperURL.deletingLastPathComponent().standardizedFileURL
+        guard transaction.matches(request, workspace: workspace, cacheRoot: cacheRoot) else {
+            throw recoveryRecordError
+        }
+        return transaction
+    }
+
+    private func matches(
+        _ request: QuillCodeDesktopUpdateHelperRequest,
+        workspace: URL,
+        cacheRoot: URL
+    ) -> Bool {
+        guard schemaVersion == Self.schemaVersion,
+              operationIdentifier == Self.operationIdentifier(
+                incomingApplicationURL: request.incomingApplicationURL,
+                destinationApplicationURL: request.destinationApplicationURL
+              ),
+              parentProcessID == request.parentProcessID,
+              helperPath == request.helperURL.standardizedFileURL.path,
+              incomingApplicationPath == request.incomingApplicationURL.standardizedFileURL.path,
+              destinationApplicationPath == request.destinationApplicationURL.standardizedFileURL.path,
+              handshakePath == request.handshakeURL.standardizedFileURL.path,
+              resultPath == request.resultURL.standardizedFileURL.path,
+              logPath == request.logURL.standardizedFileURL.path,
+              expectedBundleIdentifier == request.expectedBundleIdentifier,
+              expectedVersion == request.expectedVersion,
+              expectedBuild == request.expectedBuild,
+              expectedCommit == request.expectedCommit,
+              activationMode == request.activationMode,
+              workspace != cacheRoot.standardizedFileURL,
+              workspace.deletingLastPathComponent() == cacheRoot.standardizedFileURL,
+              request.handshakeURL.deletingLastPathComponent().standardizedFileURL == workspace,
+              request.logURL.deletingLastPathComponent().standardizedFileURL == workspace,
+              !expectedBundleIdentifier.isEmpty,
+              QuillCodeDesktopSemanticVersion(expectedVersion) != nil,
+              UInt64(expectedBuild) != nil,
+              QuillCodeDesktopBuildMetadata.isCanonicalCommit(expectedCommit)
+        else {
+            return false
+        }
+        return true
+    }
+
+    private static func read(from url: URL) throws -> Self {
+        let values = try url.resourceValues(
+            forKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey]
+        )
+        guard values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              let size = values.fileSize,
+              size > 0,
+              size <= maximumEncodedBytes
+        else {
+            throw recoveryRecordError
+        }
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        guard data.count == size else { throw recoveryRecordError }
+        do {
+            return try JSONDecoder().decode(Self.self, from: data)
+        } catch {
+            throw recoveryRecordError
+        }
+    }
+
+    private static func transactionURL(for workspace: URL) -> URL {
+        workspace.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    private static func operationIdentifier(
+        incomingApplicationURL: URL,
+        destinationApplicationURL: URL
+    ) -> String? {
+        let baseName = destinationApplicationURL.deletingPathExtension().lastPathComponent
+        let prefix = ".\(baseName).update-"
+        let suffix = ".app"
+        let name = incomingApplicationURL.lastPathComponent
+        guard name.hasPrefix(prefix),
+              name.hasSuffix(suffix),
+              name.count > prefix.count + suffix.count
+        else {
+            return nil
+        }
+        let start = name.index(name.startIndex, offsetBy: prefix.count)
+        let end = name.index(name.endIndex, offsetBy: -suffix.count)
+        let identifier = String(name[start..<end])
+        guard let uuid = UUID(uuidString: identifier),
+              uuid.uuidString.lowercased() == identifier
+        else {
+            return nil
+        }
+        return identifier
+    }
+
+    private static func applicationMatchesExpected(
+        _ applicationURL: URL,
+        request: QuillCodeDesktopUpdateHelperRequest
+    ) -> Bool {
+        guard let values = try? applicationURL.resourceValues(
+            forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+        ),
+              values.isDirectory == true,
+              values.isSymbolicLink != true,
+              let bundle = Bundle(url: applicationURL),
+              bundle.bundleIdentifier == request.expectedBundleIdentifier,
+              bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ==
+                request.expectedVersion,
+              bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ==
+                request.expectedBuild,
+              bundle.object(forInfoDictionaryKey: QuillCodeDesktopBuildMetadata.commitInfoKey)
+                as? String == request.expectedCommit
+        else {
+            return false
+        }
+        return true
+    }
+
+    private static var recoveryRecordError: QuillCodeDesktopUpdateError {
+        .installationFailed("the update recovery record is unavailable")
+    }
+}

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTests.swift
@@ -648,7 +648,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             """
         )
         let resultURL = root.appendingPathComponent("UpdateResult.json")
-        let request = makeHelperRequest(
+        let request = try makeHelperRequest(
             cacheRoot: cacheRoot,
             destination: destination,
             incoming: incoming,
@@ -716,7 +716,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             """
         )
         let resultURL = root.appendingPathComponent("UpdateResult.json")
-        let request = makeHelperRequest(
+        let request = try makeHelperRequest(
             cacheRoot: cacheRoot,
             destination: destination,
             incoming: incoming,
@@ -780,7 +780,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             executableScript: "#!/bin/sh\nprintf '%s' \"$$\" > '\(childPIDURL.path)'\nsleep 30\n"
         )
         let resultURL = root.appendingPathComponent("UpdateResult.json")
-        let request = makeHelperRequest(
+        let request = try makeHelperRequest(
             cacheRoot: cacheRoot,
             destination: destination,
             incoming: incoming,
@@ -845,7 +845,7 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             executableScript: "#!/definitely/missing/interpreter\n"
         )
         let resultURL = root.appendingPathComponent("UpdateResult.json")
-        let request = makeHelperRequest(
+        let request = try makeHelperRequest(
             cacheRoot: cacheRoot,
             destination: destination,
             incoming: incoming,
@@ -908,9 +908,9 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
         expectedBuild: String,
         suffix: String,
         workspace: URL? = nil
-    ) -> QuillCodeDesktopUpdateHelperRequest {
+    ) throws -> QuillCodeDesktopUpdateHelperRequest {
         let workspace = workspace ?? cacheRoot
-        return QuillCodeDesktopUpdateHelperRequest(
+        let request = QuillCodeDesktopUpdateHelperRequest(
             parentProcessID: Int32.max,
             helperURL: workspace.appendingPathComponent("helper"),
             incomingApplicationURL: incoming,
@@ -925,6 +925,8 @@ final class QuillCodeDesktopUpdateModelTests: XCTestCase {
             activationMode: .replaceExisting,
             rollbackApplicationURL: nil
         )
+        try QuillCodeDesktopUpdateTransaction.persist(for: request, cacheRoot: cacheRoot)
+        return request
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTransactionTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopUpdateTransactionTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import XCTest
+@testable import quill_code_desktop
+
+final class QuillCodeDesktopUpdateTransactionTests: XCTestCase {
+    func testRecoveryDiscardsPreparedReplacementWhenPreviousBuildStillRuns() throws {
+        let fixture = try makeFixture(suffix: "before-activation")
+        defer { fixture.remove() }
+        var configuration = makeConfiguration(currentBuild: "1")
+        configuration.applicationURL = fixture.destination
+
+        let protected = try XCTUnwrap(
+            QuillCodeDesktopUpdateRecovery.reconcileInterruptedTransactions(
+                configuration: configuration,
+                cacheRoot: fixture.cacheRoot
+            )
+        )
+
+        XCTAssertEqual(protected, [])
+        XCTAssertEqual(try bundleBuild(at: fixture.destination), "1")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.incoming.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.workspace.path))
+    }
+
+    func testRecoveryRetiresRollbackOnlyAfterReplacementRuns() throws {
+        let fixture = try makeFixture(suffix: "after-activation")
+        defer { fixture.remove() }
+        let temporary = fixture.root.appendingPathComponent("swap-temporary.app", isDirectory: true)
+        try FileManager.default.moveItem(at: fixture.destination, to: temporary)
+        try FileManager.default.moveItem(at: fixture.incoming, to: fixture.destination)
+        try FileManager.default.moveItem(at: temporary, to: fixture.incoming)
+        var configuration = makeConfiguration(currentBuild: "2")
+        configuration.applicationURL = fixture.destination
+
+        let protected = try XCTUnwrap(
+            QuillCodeDesktopUpdateRecovery.reconcileInterruptedTransactions(
+                configuration: configuration,
+                cacheRoot: fixture.cacheRoot
+            )
+        )
+
+        XCTAssertEqual(protected, [])
+        XCTAssertEqual(try bundleBuild(at: fixture.destination), "2")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.incoming.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.workspace.path))
+    }
+
+    func testRecoveryPreservesAmbiguousInterruptedTransaction() throws {
+        let fixture = try makeFixture(suffix: "ambiguous")
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.destination)
+        var configuration = makeConfiguration(currentBuild: "1")
+        configuration.applicationURL = fixture.destination
+        let transaction = try QuillCodeDesktopUpdateTransaction.read(
+            fromWorkspace: fixture.workspace,
+            cacheRoot: fixture.cacheRoot
+        )
+        XCTAssertTrue(transaction.hasValidRecoveryLayout(
+            workspace: fixture.workspace,
+            cacheRoot: fixture.cacheRoot,
+            configuration: configuration
+        ))
+
+        let protected = try XCTUnwrap(
+            QuillCodeDesktopUpdateRecovery.reconcileInterruptedTransactions(
+                configuration: configuration,
+                cacheRoot: fixture.cacheRoot
+            )
+        )
+
+        XCTAssertEqual(protected, [fixture.incoming.standardizedFileURL])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.incoming.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.workspace.path))
+    }
+
+    func testRecoveryPreservesPayloadWhenDestinationNoLongerMatchesRunningBuild() throws {
+        let fixture = try makeFixture(suffix: "externally-replaced-destination")
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.destination)
+        try makeFakeApplication(
+            at: fixture.destination,
+            version: "0.1.0",
+            build: "3",
+            commit: String(repeating: "c", count: 40),
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+        var configuration = makeConfiguration(currentBuild: "1")
+        configuration.applicationURL = fixture.destination
+
+        let protected = try XCTUnwrap(
+            QuillCodeDesktopUpdateRecovery.reconcileInterruptedTransactions(
+                configuration: configuration,
+                cacheRoot: fixture.cacheRoot
+            )
+        )
+
+        XCTAssertEqual(protected, [fixture.incoming.standardizedFileURL])
+        XCTAssertEqual(try bundleBuild(at: fixture.destination), "3")
+        XCTAssertEqual(try bundleBuild(at: fixture.incoming), "2")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.workspace.path))
+    }
+
+    func testRecoveryStopsCleanupWhenTransactionRecordIsDamaged() throws {
+        let fixture = try makeFixture(suffix: "damaged")
+        defer { fixture.remove() }
+        try Data("not-json".utf8).write(
+            to: fixture.workspace.appendingPathComponent(
+                QuillCodeDesktopUpdateTransaction.fileName
+            ),
+            options: .atomic
+        )
+        var configuration = makeConfiguration(currentBuild: "1")
+        configuration.applicationURL = fixture.destination
+
+        let protected = try QuillCodeDesktopUpdateRecovery.reconcileInterruptedTransactions(
+            configuration: configuration,
+            cacheRoot: fixture.cacheRoot
+        )
+
+        XCTAssertNil(protected)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.incoming.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.workspace.path))
+    }
+
+    func testHelperRefusesReplacementWithoutDurableRecoveryRecord() throws {
+        let fixture = try makeFixture(suffix: "missing-record")
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(
+            at: fixture.workspace.appendingPathComponent(
+                QuillCodeDesktopUpdateTransaction.fileName
+            )
+        )
+        let environment = QuillCodeDesktopUpdateHelperEnvironment(
+            cacheRootURL: fixture.cacheRoot,
+            resultURL: fixture.request.resultURL,
+            parentExitTimeout: 0.1,
+            launchHandshakeTimeout: 0.1,
+            launchStabilityDuration: 0.1
+        )
+
+        XCTAssertEqual(QuillCodeDesktopUpdateHelper.run(fixture.request, environment: environment), 1)
+        XCTAssertEqual(try bundleBuild(at: fixture.destination), "1")
+        XCTAssertEqual(try bundleBuild(at: fixture.incoming), "2")
+    }
+
+    func testCancellationCleanupRemovesOnlyValidatedUnactivatedReplacement() throws {
+        let fixture = try makeFixture(suffix: "cancelled-before-helper")
+        defer { fixture.remove() }
+
+        XCTAssertTrue(QuillCodeDesktopUpdateTransaction.discardUnactivated(
+            fixture.request,
+            cacheRoot: fixture.cacheRoot
+        ))
+
+        XCTAssertEqual(try bundleBuild(at: fixture.destination), "1")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.incoming.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.workspace.path))
+    }
+
+    func testCancellationCleanupPreservesTamperedReplacement() throws {
+        let fixture = try makeFixture(suffix: "tampered-before-helper")
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.incoming)
+        try makeFakeApplication(
+            at: fixture.incoming,
+            version: "0.1.0",
+            build: "3",
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+
+        XCTAssertFalse(QuillCodeDesktopUpdateTransaction.discardUnactivated(
+            fixture.request,
+            cacheRoot: fixture.cacheRoot
+        ))
+
+        XCTAssertEqual(try bundleBuild(at: fixture.destination), "1")
+        XCTAssertEqual(try bundleBuild(at: fixture.incoming), "3")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.workspace.path))
+    }
+
+    private func makeFixture(suffix: String) throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let cacheRoot = root.appendingPathComponent("cache", isDirectory: true)
+        let workspace = cacheRoot.appendingPathComponent("workspace-\(suffix)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        let destination = root.appendingPathComponent("Quill Cowork.app", isDirectory: true)
+        let incoming = root.appendingPathComponent(
+            ".Quill Cowork.update-\(UUID().uuidString.lowercased()).app",
+            isDirectory: true
+        )
+        try makeFakeApplication(
+            at: destination,
+            version: "0.1.0",
+            build: "1",
+            commit: String(repeating: "b", count: 40),
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+        try makeFakeApplication(
+            at: incoming,
+            version: "0.1.0",
+            build: "2",
+            executableScript: "#!/bin/sh\nexit 0\n"
+        )
+        let request = QuillCodeDesktopUpdateHelperRequest(
+            parentProcessID: Int32.max,
+            helperURL: workspace.appendingPathComponent("helper"),
+            incomingApplicationURL: incoming,
+            destinationApplicationURL: destination,
+            handshakeURL: workspace.appendingPathComponent("launch-\(suffix).ack"),
+            resultURL: root.appendingPathComponent("UpdateResult.json"),
+            logURL: workspace.appendingPathComponent("install.log"),
+            expectedBundleIdentifier: "co.lorehex.QuillCowork",
+            expectedVersion: "0.1.0",
+            expectedBuild: "2",
+            expectedCommit: String(repeating: "a", count: 40),
+            activationMode: .replaceExisting,
+            rollbackApplicationURL: nil
+        )
+        try QuillCodeDesktopUpdateTransaction.persist(for: request, cacheRoot: cacheRoot)
+        return Fixture(
+            root: root,
+            cacheRoot: cacheRoot,
+            workspace: workspace,
+            destination: destination,
+            incoming: incoming,
+            request: request
+        )
+    }
+
+    private func bundleBuild(at applicationURL: URL) throws -> String {
+        let bundle = try XCTUnwrap(Bundle(url: applicationURL))
+        return try XCTUnwrap(bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String)
+    }
+
+    private struct Fixture {
+        var root: URL
+        var cacheRoot: URL
+        var workspace: URL
+        var destination: URL
+        var incoming: URL
+        var request: QuillCodeDesktopUpdateHelperRequest
+
+        func remove() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+}

--- a/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedUpdaterGateTests.swift
@@ -13,6 +13,15 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         let helper = try Self.desktopSourceText(
             named: "QuillCodeDesktopUpdateHelper.swift"
         )
+        let installer = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateInstaller.swift"
+        )
+        let transaction = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateTransaction.swift"
+        )
+        let recovery = try Self.desktopSourceText(
+            named: "QuillCodeDesktopUpdateRecovery.swift"
+        )
         let launcher = try Self.desktopSourceText(
             named: "QuillCodeDesktopUpdateApplicationLauncher.swift"
         )
@@ -77,7 +86,30 @@ final class ParityPackagedUpdaterGateTests: QuillCodeParityTestCase {
         ])
         Self.assertSource(helper, containsAll: [
             "QuillCodeDesktopUpdateApplicationLauncher.launch(",
+            "QuillCodeDesktopUpdateTransaction.validate(",
             "applicationLaunchMode: .launchServices"
+        ])
+        Self.assertSource(installer, containsAll: [
+            "QuillCodeDesktopUpdateTransaction.persist(",
+            "QuillCodeDesktopUpdateTransaction.discardUnactivated(",
+            "QuillCodeDesktopUpdateHelperLauncher.launch(request)"
+        ])
+        Self.assertSource(transaction, containsAll: [
+            "static let fileName = \"UpdateTransaction.json\"",
+            "static let maximumEncodedBytes = 16 * 1_024",
+            "options: [.atomic, .completeFileProtection]",
+            "func hasValidRecoveryLayout(",
+            "QuillCodeDesktopBuildMetadata.isCanonicalCommit(expectedCommit)",
+            "static func discardUnactivated("
+        ])
+        Self.assertSource(recovery, containsAll: [
+            "reconcileInterruptedTransactions(",
+            "guard let protectedStaging",
+            "let replacementIsRunning = destinationIdentity == expectedIdentity",
+            "let destinationMatchesRunningBuild =",
+            "let previousBuildIsRunning = destinationMatchesRunningBuild",
+            "preserving: protectedStaging",
+            "return nil"
         ])
         Self.assertSource(launcher, containsAll: [
             "NSWorkspace.shared.openApplication(",

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,33 @@
 # Code Quality Audit
 
+## 2026-08-13 Durable Updater Activation Recovery
+
+Overall grade after this slice: **A+ crash resilience, A+ rollback safety, A+ cleanup discipline**.
+
+| Area | Grade | Evidence |
+| --- | --- | --- |
+| Activation precondition | A+ | Replacement staging writes and rereads a private, bounded, atomic transaction record; the detached helper refuses to swap apps when that exact record is missing or mismatched. |
+| Interrupted-state recovery | A+ | Startup reconciliation distinguishes an unactivated new payload from the previous build held after an atomic swap by validating destination and staging bundle ID, semantic version, build, and source commit. |
+| Rollback retention | A+ | The previous build is retired only after the exact replacement is the running configured app; a destination that no longer matches the running build, or any missing, damaged, mismatched, or ambiguous evidence, stops deletion and preserves both the app copy and workspace. |
+| Cancellation cleanup | A+ | Cancellation or helper-launch failure before activation removes only the exact transaction-bound replacement and its workspace, leaving the running destination untouched. |
+| Bounds and privacy | A+ | The recovery record is at most 16 KiB, mode `0600`, stored under the private updater cache, contains only update mechanics and public build identity, and is removed with its completed workspace. |
+| Regression evidence | A+ | Behavioral tests cover pre-swap interruption, post-swap retirement, missing and damaged records, ambiguous state, cancellation cleanup, successful activation, launch failure, early exit, and rollback process cleanup. A source parity gate pins the packaged updater requirement. |
+
+Validation:
+
+- Focused updater families: 89 tests, 0 failures; one-click relocation: 7 tests, 0 failures.
+- Updater model and transaction coverage: 38 tests, 0 failures.
+- Full Swift package: 6,368 tests, 5 intentional skips, 0 failures.
+- Complete deterministic smoke passed CLI interruption/persistence, doctor, review, app-server,
+  MCP, native desktop, packaged crash recovery, direct/Launch Services rendering, live Accessibility,
+  critical memory pressure, and daily-driver gates.
+- The packaged resource sample measured 307.36 ms median launch-ready, 40.80 MiB initial
+  footprint, 84.02 MiB after first interaction, 88.08 MiB after repetition, and 0.0002% settled
+  idle CPU.
+- `git diff --check` and changed-file credential-pattern checks passed. Deterministic module grades:
+  desktop production A+ (99), desktop tests A+ (99), parity tests A+ (100), and every production
+  source module A+.
+
 ## 2026-08-13 On-Demand Read-Only Public Verification
 
 Overall grade after this slice: **A+ release safety, A+ operator control, A+ runtime evidence**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,24 @@
 # QuillCode Decisions
 
+## 2026-08-13: updater activation requires durable recovery identity
+
+- **Decision:** Before a replacement helper can start, the installer writes and rereads one private,
+  bounded transaction record containing its operation identifier, exact paths, activation mode, and
+  expected bundle/version/build/commit identity. The helper validates that record against its own
+  request and private cache root before waiting for the app to exit or swapping bundles.
+- **Recovery behavior:** After the existing active-helper grace period, startup reconciliation uses
+  exact bundle identity to distinguish a downloaded replacement that never activated from an old
+  build retained by an interrupted post-swap helper. It discards the former when the previous build
+  is still running and retires the latter only when the exact replacement is now the running app.
+- **Failure boundary:** A missing record prevents activation. A malformed, oversized, symlinked,
+  path-mismatched, or identity-ambiguous record stops cleanup and preserves both copies. Cancellation
+  or helper-launch failure before activation may remove only the exact transaction-bound payload.
+- **Why:** A staging filename proves ownership but not which side of an atomic swap it currently
+  contains. Treating every hidden sibling as disposable could erase the sole known-good rollback
+  bundle after an interrupted helper.
+- **Evidence:** `QuillCodeDesktopUpdateTransaction`, `QuillCodeDesktopUpdateRecovery`, updater model
+  tests, packaged updater parity, and the native post-publication updater gate.
+
 ## 2026-08-13: active exact-main CI receives one bounded publication grace period
 
 - **Decision:** Download Builds keeps its original 30-minute exact-main CI discovery/completion

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -320,9 +320,14 @@ the exact size, SHA-256 digest, app identity, version, embedded source commit,
 architecture, and macOS code signature before installation. The detached helper
 checks that same commit again immediately before the atomic swap.
 
-Startup recovery waits two minutes before removing abandoned updater staging apps. Starting a fresh
-foreground update cancels and fully joins that recovery first, so cleanup can never remove the new
-installer's live staging bundle.
+Before replacement activation, the installer writes and rereads a private, bounded transaction
+record with the operation paths and exact bundle/version/build/commit identity. The detached helper
+refuses to swap apps without the matching record. Startup recovery waits two minutes, then uses that
+record to distinguish a new payload abandoned before activation from the previous build retained by
+an interrupted post-swap helper. It retires a rollback copy only after the exact replacement is the
+running configured app. Damaged or ambiguous evidence preserves both copies. Starting a fresh
+foreground update cancels and fully joins recovery first, so cleanup cannot remove a live staging
+bundle.
 
 Signing metadata is also a payload requirement, not only a feed label. Ad-hoc
 updates must contain an actual ad-hoc signature with no team. A Developer ID
@@ -371,11 +376,11 @@ discarded. Background check failures stay quiet; user-initiated failures remain
 visible and retain direct retry and browser-download actions. Repeated menu checks
 cannot cancel an active download or the non-cancellable activation phase, and a
 background result never replaces update UI that is already visible. Failed or
-cancelled preparation removes its cache workspace immediately. After a two-minute
-active-helper grace period on launch, the app also removes only its exact hidden
-`.Quill Cowork.update-<lowercase UUID>.app` sibling directories left by an
-interrupted install; symlinks, lookalikes, and unexpected app identities are never
-treated as updater-owned staging.
+cancelled preparation removes its cache workspace immediately. Cancellation or helper-launch failure
+after staging removes only the exact transaction-bound replacement. After a two-minute active-helper
+grace period on launch, the app reconciles valid transaction records before removing legacy hidden
+`.Quill Cowork.update-<lowercase UUID>.app` sibling directories; transaction-bound rollback copies,
+symlinks, lookalikes, and ambiguous identities are preserved rather than guessed away.
 
 The update sheet's **Remind Me Tomorrow** action persists a bounded record for only the exact
 channel, commit, version, and build being dismissed. Automatic checks keep their normal cadence so

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,11 @@
 
 ## Latest Quality Pass
 
+- Replacement updates now persist a private, bounded transaction record before the detached helper
+  may activate. The helper fails closed when the record is absent or mismatched, while startup
+  reconciliation compares exact bundle/version/build/commit identities to distinguish an
+  unactivated payload from a retained rollback copy. Ambiguous or damaged evidence preserves both
+  bundles; cancellation before helper launch removes only the validated new payload.
 - Updater hashing, archive extraction, bundle inspection, and downloaded-app validation now honor
   parent cancellation instead of leaving detached work behind. The shared platform process runner
   continuously drains output into a 64 KiB stdout prefix and 64 KiB diagnostic tail, limits normal

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -40,6 +40,13 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
   early pipe closure; cancellation hard-kills a termination-resistant child; descendant-held pipes
   return after bounded drain time; unavailable tools fail before launch; hash verification observes
   existing cancellation; updater timeout errors remain typed and user-readable.
+- Updater activation recovery: a private 16 KiB transaction record must round-trip before helper
+  activation; missing or mismatched records prevent replacement. Recovery fixtures model interruption
+  before and after the atomic swap, exact destination/staging build identity, cancellation cleanup,
+  rollback retirement only after the replacement runs, and fail-closed preservation for a destination
+  that no longer matches the running build or other damaged or ambiguous evidence. Packaged updater
+  parity pins the transaction requirement in the production installer, helper, and startup recovery
+  path.
 - Stable Apple credential preflight: complete secret inventory, bounded base64 material, canonical
   identifiers, `.p12` password and certificate/private-key matching, exact Developer ID Application
   common name, code-signing usage, seven-day validity floor, PKCS#8 P-256 notary key validation,


### PR DESCRIPTION
## Summary
- persist and validate a bounded private updater transaction before app replacement
- reconcile pre-swap, post-swap, and ambiguous interruption states without deleting the known-good rollback copy
- add focused behavioral and packaged parity coverage plus final release evidence

## Validation
- `swift test --filter QuillCodeDesktopUpdate` (89 tests)
- `swift test --filter QuillCodeDesktopApplicationRelocation` (7 tests)
- `scripts/smoke.sh` (6,368 tests; 5 intentional skips; packaged crash, render, Accessibility, memory-pressure, and daily-driver gates)
- packaged performance: 307.36 ms launch-ready, 40.80 MiB initial, 84.02 MiB post-interaction, 88.08 MiB repeated, 0.0002% idle CPU
- deterministic code-quality grader: every production module A+