### PR TITLE
Polish sidebar activity labels

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSidebarThreadRowView.swift
@@ -9,9 +9,10 @@ struct QuillCodeSidebarThreadRowView: View {
     var onCommand: (WorkspaceCommandSurface) -> Void
 
     var body: some View {
+        let activityLabel = SidebarActivityLabelFormatter.label(for: item.updatedAt)
         HStack(spacing: QuillCodeMetrics.sidebarControlSpacing) {
             selectionToggle
-            threadButton
+            threadButton(activityLabel: activityLabel)
             actionsMenu
         }
         .padding(.vertical, 0)
@@ -33,7 +34,7 @@ struct QuillCodeSidebarThreadRowView: View {
         }
     }
 
-    private var threadButton: some View {
+    private func threadButton(activityLabel: String) -> some View {
         Button {
             if isSelectionMode {
                 toggleSelection()
@@ -60,6 +61,7 @@ struct QuillCodeSidebarThreadRowView: View {
                         .foregroundStyle(QuillCodePalette.muted)
                         .monospacedDigit()
                         .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
                 if item.worktree != nil || item.pullRequest != nil {
                     HStack(spacing: 6) {
@@ -81,10 +83,6 @@ struct QuillCodeSidebarThreadRowView: View {
         .buttonStyle(QuillCodePressableButtonStyle(enforcesMinimumHitTarget: false))
         .accessibilityLabel("\(item.title), \(item.subtitle), updated \(activityLabel)")
         .accessibilityValue(item.runStatusLabel ?? "Idle")
-    }
-
-    private var activityLabel: String {
-        SidebarActivityLabelFormatter.label(for: item.updatedAt)
     }
 
     @ViewBuilder

--- a/Sources/QuillCodeApp/SidebarActivityLabelFormatter.swift
+++ b/Sources/QuillCodeApp/SidebarActivityLabelFormatter.swift
@@ -5,6 +5,23 @@ enum SidebarActivityLabelFormatter {
     private static let hour: TimeInterval = 60 * minute
     private static let day: TimeInterval = 24 * hour
     private static let week: TimeInterval = 7 * day
+    private static let sameYearStyle: Date.FormatStyle = {
+        var style = Date.FormatStyle.dateTime
+            .locale(.autoupdatingCurrent)
+            .month(.abbreviated)
+            .day()
+        style.timeZone = .autoupdatingCurrent
+        return style
+    }()
+    private static let priorYearStyle: Date.FormatStyle = {
+        var style = Date.FormatStyle.dateTime
+            .locale(.autoupdatingCurrent)
+            .year(.twoDigits)
+            .month(.defaultDigits)
+            .day(.defaultDigits)
+        style.timeZone = .autoupdatingCurrent
+        return style
+    }()
 
     static func label(for date: Date, relativeTo now: Date = Date()) -> String {
         let elapsed = max(0, now.timeIntervalSince(date))
@@ -28,11 +45,6 @@ enum SidebarActivityLabelFormatter {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = .current
         let sameYear = calendar.component(.year, from: date) == calendar.component(.year, from: now)
-
-        let formatter = DateFormatter()
-        formatter.locale = .current
-        formatter.timeZone = calendar.timeZone
-        formatter.setLocalizedDateFormatFromTemplate(sameYear ? "MMMd" : "MMMdy")
-        return formatter.string(from: date)
+        return date.formatted(sameYear ? sameYearStyle : priorYearStyle)
     }
 }

--- a/Tests/QuillCodeAppTests/SidebarActivityLabelFormatterTests.swift
+++ b/Tests/QuillCodeAppTests/SidebarActivityLabelFormatterTests.swift
@@ -39,15 +39,38 @@ final class SidebarActivityLabelFormatterTests: XCTestCase {
         )
     }
 
-    func testOlderActivityFallsBackToALocalizedCalendarLabel() {
+    func testOlderActivityUsesACompactLocalizedCalendarLabel() {
         let oldDate = now.addingTimeInterval(-90 * 24 * 60 * 60)
-        let formatter = DateFormatter()
-        formatter.locale = .current
-        formatter.timeZone = .current
-        formatter.setLocalizedDateFormatFromTemplate("MMMdy")
+        var style = Date.FormatStyle.dateTime
+            .locale(.autoupdatingCurrent)
+            .year(.twoDigits)
+            .month(.defaultDigits)
+            .day(.defaultDigits)
+        style.timeZone = .autoupdatingCurrent
 
         let label = SidebarActivityLabelFormatter.label(for: oldDate, relativeTo: now)
 
-        XCTAssertEqual(label, formatter.string(from: oldDate))
+        XCTAssertEqual(label, oldDate.formatted(style))
+    }
+
+    func testOlderSameYearActivityKeepsTheReadableMonthNameWithoutAYear() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        let sameYearNow = try XCTUnwrap(
+            calendar.date(from: DateComponents(year: 2026, month: 8, day: 14, hour: 12))
+        )
+        let oldDate = try XCTUnwrap(
+            calendar.date(from: DateComponents(year: 2026, month: 1, day: 4, hour: 12))
+        )
+        var style = Date.FormatStyle.dateTime
+            .locale(.autoupdatingCurrent)
+            .month(.abbreviated)
+            .day()
+        style.timeZone = .autoupdatingCurrent
+
+        XCTAssertEqual(
+            SidebarActivityLabelFormatter.label(for: oldDate, relativeTo: sameYearNow),
+            oldDate.formatted(style)
+        )
     }
 }

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -17988,3 +17988,23 @@ Validation:
 - Python syntax compilation for all changed performance and release-verifier modules
 - `python3 scripts/grade-code-quality.py --root .` (all production modules A+)
 - `git diff --check`
+
+## 2026-08-14 Compact Sidebar Activity Labels
+
+Overall grade: **A+ native usability, A+ allocation discipline, A+ packaged evidence**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Older-date readability | A+ | Same-year rows retain a localized abbreviated month and day, while cross-year rows use a compact localized numeric date with a two-digit year. The native 100-chat screenshot shows complete `1/4/25` labels instead of `Jan 4, 20...`. |
+| Layout stability | A+ | The activity label reserves its intrinsic horizontal width, leaving the flexible title column to absorb compression without clipping the date or moving row actions. |
+| Formatting cost | A+ | Static value-style `Date.FormatStyle` instances replace per-call `DateFormatter` construction, and each SwiftUI row computes its activity label exactly once per body evaluation. |
+| Regression coverage | A+ | Focused tests cover recent relative units, future timestamps, same-year calendar labels, cross-year compact labels, navigation surfaces, and native hit targets. |
+| Packaged performance | A+ | The complete packaged 100-chat interaction sweep passed at 335.38 ms launch-ready, 40.75 MiB initial physical footprint, 75.88 MiB after interaction, 79.91 MiB after repetition, and 0.0002% settled idle CPU. |
+
+Validation:
+
+- Focused sidebar formatter, navigation-surface, and native hit-target suite (13 tests, 0 failures)
+- Visual review of the optimized 100-chat native screenshot with full older-date labels and no title, date, or action overlap
+- `scripts/native-click-probe-contracts.py performance` (416.16 ms launch-ready, 40.36 MiB initial, 76.38 MiB repeated, and 0.0003% idle CPU)
+- `scripts/smoke.sh` (6,373 tests; 5 skipped; 0 failures, plus CLI, app-server, MCP, crash recovery, direct launch, Launch Services, Accessibility, memory-pressure, and packaged macOS smokes)
+- Final packaged daily-driver smoke (335.38 ms launch-ready, 40.75 MiB initial, 79.91 MiB repeated, and 0.0002% idle CPU)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,12 @@
 
 ## Latest Quality Pass
 
+- Sidebar activity labels now keep older chat dates fully visible in the fixed-width native rail.
+  Same-year dates retain a readable abbreviated month, cross-year dates use a compact localized
+  numeric form with a two-digit year, and each row computes the label once from cached value-style
+  formatters instead of constructing a `DateFormatter`. The optimized 100-chat daily-driver
+  screenshot shows complete `1/4/25` labels without compressing titles, while the packaged sweep
+  remained at 40.75 MiB initial and 79.91 MiB repeated physical footprint with 0.0002% idle CPU.
 - Public performance evidence schema 7 now distinguishes raw thread churn from retained repeated
   growth. Every attempt still publishes and validates each absolute thread count, while the strict
   two-thread convergence gate compares the repeated snapshot with the higher prior settled count.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -289,6 +289,7 @@ Drive the QuillCode test harness with mock LLM:
 - chronological user/tool/answer transcript rendering
 - hidden agent tool-feedback messages never render as transcript bubbles, sidebar search hits, fork seed messages, or compaction summary content
 - bulk-select multiple chats from the sidebar, archive selected chats, select all across recent/archived sections, and delete selected chats through the shared command path
+- sidebar activity older than the relative-time window uses a localized abbreviated month and day in the current year, a compact localized numeric date with a two-digit year across years, and remains fully visible beside long titles in the populated 100-chat native daily-driver screenshot
 - copy user/assistant messages and tool outputs with visible `Copied` feedback
 - reuse a user message as the focused composer draft without mutating transcript history
 - verify assistant messages do not expose Helpful/Not helpful controls because QuillCode does not collect rating feedback


### PR DESCRIPTION
## Summary
- keep older sidebar activity dates fully visible with compact localized cross-year labels
- replace per-row DateFormatter allocation with cached value-style formatting and compute each row label once
- document and verify the behavior in the optimized 100-chat native daily-driver workload

## Validation
- focused sidebar/navigation/native hit-target suite: 13 tests, 0 failures
- scripts/smoke.sh: 6,373 tests, 5 skipped, 0 failures, plus all executable and packaged macOS smokes
- optimized native screenshot: full 1/4/25 labels with no overlap or title compression
- packaged daily-driver: 335.38 ms ready, 40.75 MiB initial, 79.91 MiB repeated, 0.0002% idle CPU
- python3 scripts/grade-code-quality.py --root .: production modules A+
- git diff --check