### PR TITLE
Keep project registration off the main actor

### DIFF
--- a/Sources/QuillCodeApp/WorkspaceModelProjects.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelProjects.swift
@@ -10,6 +10,26 @@ struct WorkspaceProjectContextRefreshRequest: Sendable, Equatable {
 
 @MainActor
 extension QuillCodeWorkspaceModel {
+    /// Registers and selects a local project immediately, then loads filesystem-backed context
+    /// through the coalesced utility-priority refresh path.
+    @discardableResult
+    public func registerProject(path: URL, name: String? = nil) -> UUID {
+        let previousLocation = currentNavigationLocation
+        let result = WorkspaceProjectEngine.registerLocalProject(
+            path: path,
+            name: name,
+            projects: &root.projects
+        )
+        root.selectedProjectID = result.projectID
+        syncTerminalSessionToSelectedProject()
+        refreshFileMentionIndex()
+        saveProjects()
+        refreshTopBar(agentStatus: TopBarAgentStatusLabel.idle)
+        recordNavigationTransition(from: previousLocation)
+        requestProjectContextRefresh(result.projectID)
+        return result.projectID
+    }
+
     @discardableResult
     public func addProject(path: URL, name: String? = nil) -> UUID {
         let previousLocation = currentNavigationLocation

--- a/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
+++ b/Sources/QuillCodeApp/WorkspaceProjectEngine.swift
@@ -79,6 +79,31 @@ enum WorkspaceProjectEngine {
     }
 
     @discardableResult
+    static func registerLocalProject(
+        path: URL,
+        name: String?,
+        projects: inout [ProjectRef],
+        now: Date = Date()
+    ) -> WorkspaceProjectUpsertResult {
+        let standardized = path.standardizedFileURL
+        let projectName = name ?? defaultProjectName(for: standardized)
+
+        if let index = projects.firstIndex(where: { $0.path == standardized.path && !$0.isRemote }) {
+            projects[index].name = projectName
+            projects[index].lastOpenedAt = now
+            return WorkspaceProjectUpsertResult(projectID: projects[index].id, isNewProject: false)
+        }
+
+        let project = ProjectRef(
+            name: projectName,
+            path: standardized.path,
+            lastOpenedAt: now
+        )
+        projects.insert(project, at: 0)
+        return WorkspaceProjectUpsertResult(projectID: project.id, isNewProject: true)
+    }
+
+    @discardableResult
     static func upsertLocalProject(
         path: URL,
         name: String?,

--- a/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopModelStateCoordinator.swift
@@ -12,7 +12,7 @@ struct QuillCodeDesktopModelState {
 struct QuillCodeDesktopModelStateCoordinator {
     func ensureDefaultProject(on model: QuillCodeWorkspaceModel, workspaceRoot: URL) {
         if model.root.projects.isEmpty {
-            _ = model.addProject(path: workspaceRoot)
+            _ = model.registerProject(path: workspaceRoot)
         }
     }
 

--- a/Sources/quill-code-desktop/QuillCodeDesktopNavigationCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopNavigationCoordinator.swift
@@ -65,6 +65,6 @@ struct QuillCodeDesktopNavigationCoordinator {
     }
 
     func addProject(_ url: URL, model: QuillCodeWorkspaceModel) {
-        _ = model.addProject(path: url)
+        _ = model.registerProject(path: url)
     }
 }

--- a/Tests/QuillCodeAppTests/WorkspaceProjectEngineTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProjectEngineTests.swift
@@ -55,6 +55,99 @@ final class WorkspaceProjectEngineTests: XCTestCase {
         XCTAssertEqual(projects[0].memories.map(\.title), ["Two"])
     }
 
+    func testRegisterLocalProjectCreatesAnEmptyLocalProject() {
+        let path = URL(fileURLWithPath: "/tmp/QuillCode/../QuillCode")
+        let now = Date(timeIntervalSince1970: 20)
+        var projects: [ProjectRef] = []
+
+        let result = WorkspaceProjectEngine.registerLocalProject(
+            path: path,
+            name: nil,
+            projects: &projects,
+            now: now
+        )
+
+        XCTAssertTrue(result.isNewProject)
+        XCTAssertEqual(projects.count, 1)
+        XCTAssertEqual(projects[0].id, result.projectID)
+        XCTAssertEqual(projects[0].name, "QuillCode")
+        XCTAssertEqual(projects[0].path, path.standardizedFileURL.path)
+        XCTAssertEqual(projects[0].lastOpenedAt, now)
+        XCTAssertTrue(projects[0].instructions.isEmpty)
+        XCTAssertTrue(projects[0].localActions.isEmpty)
+        XCTAssertTrue(projects[0].runHooks.isEmpty)
+        XCTAssertTrue(projects[0].pluginHooks.isEmpty)
+        XCTAssertTrue(projects[0].extensionManifests.isEmpty)
+        XCTAssertTrue(projects[0].memories.isEmpty)
+    }
+
+    func testRegisterLocalProjectPreservesExistingContextUntilRefreshCompletes() {
+        let path = URL(fileURLWithPath: "/tmp/QuillCode")
+        let existingMetadata = metadata(instructionTitle: "Existing", memoryTitle: "Memory")
+        let original = ProjectRef(
+            name: "Original",
+            path: path.path,
+            lastOpenedAt: Date(timeIntervalSince1970: 10),
+            instructions: existingMetadata.instructions,
+            instructionDiagnosticResolutions: [
+                ProjectInstructionDiagnosticResolution(
+                    diagnosticID: "instruction-conflict",
+                    updatedAt: Date(timeIntervalSince1970: 5)
+                )
+            ],
+            localActions: existingMetadata.localActions,
+            runHooks: [
+                ProjectRunHook(
+                    id: "verify",
+                    timing: .afterAgentRun,
+                    title: "Verify",
+                    relativePath: ".quillcode/config.toml",
+                    command: "swift test"
+                )
+            ],
+            pluginHooks: [
+                ProjectPluginHook(
+                    id: "plugin:verify",
+                    pluginID: "plugin",
+                    pluginName: "Plugin",
+                    event: "Stop",
+                    handlerType: "command",
+                    command: "swift test",
+                    relativePath: ".agents/plugins/plugin/hooks.json",
+                    definitionHash: "hash",
+                    supportStatus: .supported
+                )
+            ],
+            extensionManifests: existingMetadata.extensionManifests,
+            memories: existingMetadata.memories
+        )
+        let reopenedAt = Date(timeIntervalSince1970: 20)
+        var projects = [original]
+
+        let result = WorkspaceProjectEngine.registerLocalProject(
+            path: path,
+            name: "Renamed",
+            projects: &projects,
+            now: reopenedAt
+        )
+
+        XCTAssertFalse(result.isNewProject)
+        XCTAssertEqual(result.projectID, original.id)
+        XCTAssertEqual(projects.count, 1)
+        XCTAssertEqual(projects[0].name, "Renamed")
+        XCTAssertEqual(projects[0].lastOpenedAt, reopenedAt)
+        XCTAssertEqual(projects[0].instructions, original.instructions)
+        XCTAssertEqual(
+            projects[0].instructionDiagnosticResolutions,
+            original.instructionDiagnosticResolutions
+        )
+        XCTAssertEqual(projects[0].localActions, original.localActions)
+        XCTAssertEqual(projects[0].runHooks, original.runHooks)
+        XCTAssertEqual(projects[0].pluginHooks, original.pluginHooks)
+        XCTAssertEqual(projects[0].extensionManifests, original.extensionManifests)
+        XCTAssertEqual(projects[0].memories, original.memories)
+    }
+
     func testUpsertLocalProjectPreservesInstructionDiagnosticResolutions() {
         let path = URL(fileURLWithPath: "/tmp/QuillCode")
         var projects = [

--- a/Tests/QuillCodeAppTests/WorkspaceProjectIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProjectIntegrationTests.swift
@@ -233,6 +233,49 @@ final class WorkspaceProjectIntegrationTests: XCTestCase {
         XCTAssertTrue(didPublish)
     }
 
+    func testRegisterProjectReturnsBeforeContextLoadAndPublishesTheResult() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let instruction = ProjectInstruction(
+            path: "AGENTS.md",
+            title: "Project AGENTS.md",
+            content: "Loaded after project registration.",
+            byteCount: 34
+        )
+        let probe = BlockingProjectMetadataLoader(metadata: WorkspaceProjectMetadata(
+            instructions: [instruction],
+            localActions: [],
+            runHooks: [],
+            extensionManifests: [],
+            memories: []
+        ))
+        let model = QuillCodeWorkspaceModel()
+        model.projectMetadataLoader = { _, _ in probe.load() }
+        defer { probe.release.signal() }
+        var didPublish = false
+        model.onProjectContextChanged = { didPublish = true }
+        let startedAt = ContinuousClock.now
+
+        let projectID = model.registerProject(path: root, name: "Responsive Project")
+
+        XCTAssertLessThan(startedAt.duration(to: .now), .milliseconds(100))
+        XCTAssertEqual(model.root.selectedProjectID, projectID)
+        XCTAssertEqual(model.selectedProject?.name, "Responsive Project")
+        XCTAssertTrue(model.selectedProject?.instructions.isEmpty == true)
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        while ContinuousClock.now < deadline, probe.callCount == 0 {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(probe.callCount, 1)
+        XCTAssertFalse(probe.loadedOnMainThread)
+
+        probe.release.signal()
+        await model.waitForScheduledProjectContextRefresh()
+
+        XCTAssertEqual(model.selectedProject?.instructions, [instruction])
+        XCTAssertTrue(didPublish)
+    }
+
     func testRestoredProjectWorktreeEnvironmentsLoadOffMainAndRemainCached() async throws {
         let root = try makeQuillCodeTestDirectory()
         let configurationDirectory = root.appendingPathComponent(".quillcode")
@@ -402,21 +445,28 @@ private struct ImmediateProjectTestLLMClient: LLMClient {
 private final class BlockingProjectMetadataLoader: @unchecked Sendable {
     let release = DispatchSemaphore(value: 0)
     private let lock = NSLock()
+    private let metadata: WorkspaceProjectMetadata
     private var calls = 0
+    private var wasLoadedOnMainThread = false
+
+    init(metadata: WorkspaceProjectMetadata = .empty) {
+        self.metadata = metadata
+    }
 
     var callCount: Int {
         lock.withLock { calls }
     }
 
+    var loadedOnMainThread: Bool {
+        lock.withLock { wasLoadedOnMainThread }
+    }
+
     func load() -> WorkspaceProjectMetadata {
-        lock.withLock { calls += 1 }
+        lock.withLock {
+            calls += 1
+            wasLoadedOnMainThread = Thread.isMainThread
+        }
         release.wait()
-        return WorkspaceProjectMetadata(
-            instructions: [],
-            localActions: [],
-            runHooks: [],
-            extensionManifests: [],
-            memories: []
-        )
+        return metadata
     }
 }

--- a/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDesktopControllerGateTests.swift
@@ -214,13 +214,13 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         Self.assertSource(controllerText, contains: "modelStateCoordinator.refreshState")
         Self.assertSource(controllerText, contains: "modelStateCoordinator.syncComposerDraft")
         Self.assertSource(stateCoordinatorText, contains: "model.root.projects.isEmpty")
-        Self.assertSource(stateCoordinatorText, contains: "model.addProject(path: workspaceRoot)")
+        Self.assertSource(stateCoordinatorText, contains: "model.registerProject(path: workspaceRoot)")
         Self.assertSource(stateCoordinatorText, contains: "model.surface()")
         Self.assertSource(stateCoordinatorText, contains: "model.composer.draft")
         Self.assertSource(stateCoordinatorText, contains: "model.terminal.draft")
         Self.assertSource(stateCoordinatorText, contains: "model.browser.addressDraft")
         Self.assertSource(controllerText, excludes: "model.root.projects.isEmpty")
-        Self.assertSource(controllerText, excludes: "model.addProject(path: workspaceRoot)")
+        Self.assertSource(controllerText, excludes: "model.registerProject(path: workspaceRoot)")
         Self.assertSource(controllerText, excludes: "model.surface()")
         Self.assertSource(controllerText, excludes: "model.composer.draft")
         Self.assertSource(controllerText, excludes: "model.terminal.draft")
@@ -250,7 +250,7 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         Self.assertSource(navigationText, contains: "model.renameThread(id, to: title)")
         Self.assertSource(navigationText, contains: "model.selectProject(id)")
         Self.assertSource(navigationText, contains: "model.renameProject(id, to: name)")
-        Self.assertSource(navigationText, contains: "model.addProject(path: url)")
+        Self.assertSource(navigationText, contains: "model.registerProject(path: url)")
         Self.assertSource(controllerText, excludes: "_ = model.newChat()")
         Self.assertSource(controllerText, excludes: "model.selectThread(id)")
         Self.assertSource(
@@ -260,7 +260,7 @@ final class ParityDesktopControllerGateTests: QuillCodeParityTestCase {
         Self.assertSource(controllerText, excludes: "model.renameThread(id, to: title)")
         Self.assertSource(controllerText, excludes: "model.selectProject(id)")
         Self.assertSource(controllerText, excludes: "model.renameProject(id, to: name)")
-        Self.assertSource(controllerText, excludes: "model.addProject(path: url)")
+        Self.assertSource(controllerText, excludes: "model.registerProject(path: url)")
     }
 
     func testDesktopControllerDelegatesWorktreeActions() throws {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -18034,3 +18034,29 @@ Validation:
 - Three-process optimized daily-driver gate: 326.71 ms median launch-ready, 40.66 MiB initial,
   83.11 MiB post-interaction, 87.59 MiB repeated-interaction, and 0.0003% settled idle CPU
 - `python3 scripts/grade-code-quality.py --root .` (all affected production modules A+; new poller and desktop coordinator score 100)
+
+## 2026-08-14 Deferred Desktop Project Registration
+
+Overall grade: **A+ main-thread responsiveness, A+ state continuity, A+ race safety**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| UI responsiveness | A+ | First-project setup and folder import mutate only bounded in-memory registry state on the main actor; metadata discovery runs through the existing utility-priority detached loader. |
+| State continuity | A+ | Reopening an existing local path updates its display name and recency while preserving all known context and diagnostic decisions until a successful refresh replaces them. |
+| Race safety | A+ | Registration reuses the coalesced generation-bound refresh path, which validates project identity and standardized root before applying a result. |
+| Persistence | A+ | The selected project and registry record are saved immediately, independently of slow or unavailable filesystem metadata. |
+| Regression evidence | A+ | A semaphore-held loader proves registration returns in under 100 ms, never loads on the main thread, and publishes eventual instructions; pure engine tests cover new and reopened records. |
+
+Validation:
+
+- Focused project engine, model integration, and desktop architecture suite (45 tests, 0 failures)
+- `swift test` (6,381 tests; 5 skipped; 0 failures)
+- `scripts/packaged-macos-smoke.sh` (SIGKILL draft/run recovery, direct and Launch Services
+  rendering, live native Accessibility interaction, critical memory pressure, and packaged
+  daily-driver workload passed)
+- Three-process optimized daily-driver gate: 301.97 ms median launch-ready, 40.69 MiB initial,
+  82.92 MiB post-interaction, 87.53 MiB repeated-interaction, and 0.0003% settled idle CPU
+- Visual review of the final 100-chat native screenshot with complete sidebar dates and no transcript,
+  control, project-row, or composer overlap
+- `python3 scripts/grade-code-quality.py --root .` (all production modules A+)
+- `git diff --check`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,12 @@
 
 ## Latest Quality Pass
 
+- First-project setup and user folder import now register and select the project before reading its
+  filesystem-backed instructions, actions, hooks, plugins, extensions, memories, or worktree
+  environments. The established utility-priority refresh path loads that context off the main actor,
+  coalesces duplicate scans, and rejects stale results. Reopening an existing project preserves its
+  last known context until fresh metadata arrives, so an unavailable volume cannot freeze the native
+  window or blank useful project state.
 - Desktop event automations no longer perform file, directory, URL-header, or feed polling on the
   main actor. A focused background poller checks at most four sources concurrently, preserves the
   persisted automation order, exits promptly when the ticker is cancelled, and discards a resolved

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -7,6 +7,11 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
 
 ## Unit Tests
 
+- Deferred desktop project registration: a blocked metadata loader must not delay main-actor
+  registration beyond 100 ms, must execute off the main thread, and must eventually publish loaded
+  instructions through the shared project-context callback. Pure engine coverage requires new
+  projects to begin with empty context and reopened projects to preserve instructions, diagnostic
+  decisions, local actions, run hooks, plugin hooks, extensions, and memories until refresh completes.
 - Native memory pressure: warning/critical cache reclamation, durable inactive-transcript deferral,
   selected/running/persistence-failed chat retention, critical file-index release, active-run
   language-service protection, idempotent dispatch observation, and off-main teardown. Packaged


### PR DESCRIPTION
## Summary
- register and select local projects before scanning filesystem-backed context
- preserve existing instructions, hooks, extensions, memories, and diagnostic decisions until the coalesced background refresh completes
- route first-project setup and folder import through the responsive path with focused regression coverage

## Validation
- focused project/desktop suite: 45 tests, 0 failures
- full Swift suite: 6,381 tests, 5 skipped, 0 failures
- packaged direct launch, Launch Services, Accessibility, SIGKILL recovery, and critical-memory-pressure smoke passed
- three-process daily driver: 301.97 ms median launch-ready, 40.69 MiB initial, 82.92 MiB post-interaction, 87.53 MiB repeated, 0.0003% idle CPU
- all production modules grade A+; git diff --check passed