### PR TITLE
Move project context refresh off the main actor

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeProjectListSurface.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectListSurface.swift
@@ -90,6 +90,7 @@ public struct ProjectItemSurface: Codable, Sendable, Hashable, Identifiable {
     public var isRemote: Bool
     public var actions: [ProjectItemActionSurface]
     public var isSelected: Bool
+    public var isRefreshing: Bool
 
     public var selectionLabel: String? {
         isSelected ? "Current" : nil
@@ -100,8 +101,9 @@ public struct ProjectItemSurface: Codable, Sendable, Hashable, Identifiable {
             isSelected ? "Current project" : "Project",
             name,
             connectionKindLabel,
-            path
-        ].joined(separator: ", ")
+            path,
+            isRefreshing ? "Refreshing context" : nil
+        ].compactMap { $0 }.joined(separator: ", ")
     }
 
     public var actionMenuAccessibilityLabel: String {
@@ -115,6 +117,7 @@ public struct ProjectItemSurface: Codable, Sendable, Hashable, Identifiable {
     public init(
         project: ProjectRef,
         selectedProjectID: UUID?,
+        isRefreshing: Bool = false,
         canMoveToTop: Bool = true,
         canMoveUp: Bool = true,
         canMoveDown: Bool = true,
@@ -127,7 +130,12 @@ public struct ProjectItemSurface: Codable, Sendable, Hashable, Identifiable {
         self.isRemote = project.isRemote
         self.actions = [
             ProjectItemActionSurface(kind: .newChat, projectID: project.id),
-            ProjectItemActionSurface(kind: .refreshContext, projectID: project.id),
+            ProjectItemActionSurface(
+                kind: .refreshContext,
+                projectID: project.id,
+                isEnabled: !isRefreshing,
+                disabledReason: isRefreshing ? "Context refresh is already in progress" : nil
+            ),
             ProjectItemActionSurface(
                 kind: .moveToTop,
                 projectID: project.id,
@@ -156,6 +164,7 @@ public struct ProjectItemSurface: Codable, Sendable, Hashable, Identifiable {
             ProjectItemActionSurface(kind: .remove, projectID: project.id)
         ]
         self.isSelected = project.id == selectedProjectID
+        self.isRefreshing = isRefreshing
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -166,6 +175,7 @@ public struct ProjectItemSurface: Codable, Sendable, Hashable, Identifiable {
         case isRemote
         case actions
         case isSelected
+        case isRefreshing
     }
 
     public init(from decoder: Decoder) throws {
@@ -186,6 +196,7 @@ public struct ProjectItemSurface: Codable, Sendable, Hashable, Identifiable {
             ProjectItemActionSurface(kind: .remove, projectID: id)
         ]
         self.isSelected = try container.decode(Bool.self, forKey: .isSelected)
+        self.isRefreshing = try container.decodeIfPresent(Bool.self, forKey: .isRefreshing) ?? false
     }
 }
 

--- a/Sources/QuillCodeApp/QuillCodeProjectRowView.swift
+++ b/Sources/QuillCodeApp/QuillCodeProjectRowView.swift
@@ -34,6 +34,12 @@ struct QuillCodeProjectRowView: View {
                         .foregroundStyle(QuillCodePalette.blue)
                 }
                 Spacer(minLength: 0)
+                if project.isRefreshing {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 16, height: 16)
+                        .accessibilityHidden(true)
+                }
             }
             .quillCodeSidebarRowChrome(background: project.isSelected ? QuillCodePalette.selection : Color.clear)
         }

--- a/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandActionExecutor.swift
@@ -104,7 +104,7 @@ extension QuillCodeWorkspaceModel {
             _ = newChat(projectID: projectID)
             return true
         case .refreshProjectContext(let projectID):
-            return refreshProjectContext(projectID)
+            return scheduleProjectContextRefresh(projectID)
         case .initProject(let projectID):
             return runInitProject(projectID)
         case .moveProjectToTop(let projectID):

--- a/Sources/QuillCodeApp/WorkspaceCommandPlanExecutor.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandPlanExecutor.swift
@@ -173,7 +173,7 @@ extension QuillCodeWorkspaceModel {
             workspaceRoot: workspaceRoot
         )
         if result.ok, let projectID = selectedThread?.projectID ?? root.selectedProjectID {
-            _ = refreshProjectContext(projectID)
+            _ = scheduleProjectContextRefresh(projectID)
         }
         return true
     }

--- a/Sources/QuillCodeApp/WorkspaceCommandSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceCommandSurfaceBuilder.swift
@@ -5,6 +5,7 @@ import QuillComputerUseKit
 struct WorkspaceCommandSurfaceBuilder: Sendable, Hashable {
     var selectedThread: ChatThread?
     var selectedProject: ProjectRef?
+    var projectContextRefreshIsActive: Bool = false
     var hooks: [ProjectPluginHook] = []
     var selectedSidebarThreads: [ChatThread]
     var sidebarSelectionIsActive: Bool
@@ -109,6 +110,9 @@ struct WorkspaceCommandSurfaceBuilder: Sendable, Hashable {
             var command = command
             if let shortcut = shortcutProfile.label(for: command.id) {
                 command.shortcut = shortcut
+            }
+            if command.id == "project-refresh-context", projectContextRefreshIsActive {
+                command.isEnabled = false
             }
             return command
         }

--- a/Sources/QuillCodeApp/WorkspaceHTMLSidebarProjectRenderer.swift
+++ b/Sources/QuillCodeApp/WorkspaceHTMLSidebarProjectRenderer.swift
@@ -42,7 +42,7 @@ enum WorkspaceHTMLSidebarProjectRenderer {
                   ("aria-current", project.isSelected ? "true" : "false")
               ]
           ))>
-            <span class="project-title-line"><span class="project-icon" aria-hidden="true">\(project.isRemote ? "⌘" : "▱")</span><span>\(escape(project.name))</span>\(connectionBadge(for: project))</span>
+            <span class="project-title-line"><span class="project-icon" aria-hidden="true">\(project.isRemote ? "⌘" : "▱")</span><span>\(escape(project.name))</span>\(connectionBadge(for: project))\(refreshStatus(for: project))</span>
           </button>
           <details class="sidebar-thread-menu" data-testid="project-item-actions">
             \(WorkspaceHTMLPrimitives.summary(
@@ -62,6 +62,12 @@ enum WorkspaceHTMLSidebarProjectRenderer {
     private static func connectionBadge(for project: ProjectItemSurface) -> String {
         project.isRemote
             ? #" <small class="project-connection-kind" data-testid="project-connection-kind">SSH</small>"#
+            : ""
+    }
+
+    private static func refreshStatus(for project: ProjectItemSurface) -> String {
+        project.isRefreshing
+            ? #" <small class="project-refresh-status" data-testid="project-refresh-status">Refreshing...</small>"#
             : ""
     }
 

--- a/Sources/QuillCodeApp/WorkspaceModel.swift
+++ b/Sources/QuillCodeApp/WorkspaceModel.swift
@@ -67,9 +67,9 @@ public final class QuillCodeWorkspaceModel {
     /// scan completes. Keeping indexing off the main actor prevents slow or unavailable filesystem
     /// mounts from delaying the first window or freezing project switches.
     public var onFileMentionIndexChanged: (@MainActor @Sendable () -> Void)?
-    /// Desktop installs this to publish freshly loaded project instructions, hooks, extensions,
-    /// and memories after the first window is available. Automatic freshness scans never belong
-    /// on the main actor because workspace roots may be large, remote, or temporarily unavailable.
+    /// Desktop installs this to publish project-context progress and freshly loaded instructions,
+    /// hooks, extensions, and memories after the first window is available. Freshness scans never
+    /// belong on the main actor because workspace roots may be large, remote, or unavailable.
     public var onProjectContextChanged: (@MainActor @Sendable () -> Void)?
     /// Optional platform hook for browser tools that need a live native browser surface. Desktop installs
     /// this for visible WebKit sessions; nil keeps the pure app-core snapshot executor behavior.

--- a/Sources/QuillCodeApp/WorkspaceModelProjectContextScheduling.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelProjectContextScheduling.swift
@@ -1,0 +1,268 @@
+import Foundation
+import QuillCodeCore
+import QuillCodeTools
+
+struct WorkspaceProjectContextRefreshRequest: Sendable, Equatable {
+    var projectID: UUID
+    var source: WorkspaceProjectContextRefreshSource
+    var generation: Int
+    var announcesCompletion: Bool
+
+    func matches(projectID: UUID, source: WorkspaceProjectContextRefreshSource) -> Bool {
+        self.projectID == projectID && self.source == source
+    }
+}
+
+enum WorkspaceProjectContextRefreshSource: Sendable, Equatable {
+    case local(URL)
+    case remote(ProjectConnection)
+
+    var includesLocalExtensions: Bool {
+        switch self {
+        case .local:
+            return true
+        case .remote:
+            return false
+        }
+    }
+
+    func matches(_ project: ProjectRef) -> Bool {
+        switch self {
+        case .local(let root):
+            return !project.isRemote
+                && URL(fileURLWithPath: project.path).standardizedFileURL == root
+        case .remote(let connection):
+            return project.isRemote && project.connection == connection
+        }
+    }
+}
+
+enum WorkspaceProjectContextRefreshOutcome: Sendable {
+    case loaded(WorkspaceProjectMetadata)
+    case failed(String)
+}
+
+@MainActor
+extension QuillCodeWorkspaceModel {
+    /// Refreshes the selected local project's persisted context without delaying the calling UI.
+    /// Repeated requests for one root are coalesced because a blocking filesystem syscall cannot
+    /// be interrupted by Swift task cancellation. A changed selection queues one follow-up scan.
+    public func scheduleSelectedProjectContextRefresh() {
+        let projectID = selectedThread?.projectID ?? root.selectedProjectID
+        requestProjectContextRefresh(projectID)
+    }
+
+    /// Refreshes local or SSH-backed project context without blocking the calling UI. Explicit
+    /// requests queue one latest follow-up behind an in-flight scan and surface completion or
+    /// failure after the project identity has been revalidated on the main actor.
+    @discardableResult
+    public func scheduleProjectContextRefresh(_ projectID: UUID) -> Bool {
+        guard root.projects.contains(where: { $0.id == projectID }) else { return false }
+        requestProjectContextRefresh(
+            projectID,
+            queueAfterInFlight: true,
+            allowsRemote: true,
+            announcesCompletion: true
+        )
+        return true
+    }
+
+    /// Starts a best-effort freshness scan for a run but never puts that scan on the send path.
+    /// The run uses the last persisted context; a completed refresh is available to later turns.
+    func scheduleProjectContextRefreshForAgentSend(_ projectID: UUID?) {
+        requestProjectContextRefresh(projectID, queueAfterInFlight: true)
+    }
+
+    func requestProjectContextRefreshForNewChat(_ projectID: UUID?) {
+        requestProjectContextRefresh(projectID)
+    }
+
+    func requestProjectContextRefresh(
+        _ projectID: UUID?,
+        queueAfterInFlight: Bool = false,
+        allowsRemote: Bool = false,
+        announcesCompletion: Bool = false
+    ) {
+        guard let projectID,
+              let project = root.projects.first(where: { $0.id == projectID })
+        else {
+            projectContextRefreshGeneration &+= 1
+            projectContextRefreshPending = nil
+            return
+        }
+
+        let source: WorkspaceProjectContextRefreshSource
+        if project.isRemote {
+            guard allowsRemote else {
+                projectContextRefreshGeneration &+= 1
+                projectContextRefreshPending = nil
+                return
+            }
+            source = .remote(project.connection)
+        } else {
+            source = .local(URL(fileURLWithPath: project.path).standardizedFileURL)
+        }
+
+        if let inFlight = projectContextRefreshInFlight,
+           inFlight.matches(projectID: projectID, source: source) {
+            guard queueAfterInFlight else { return }
+            if let pending = projectContextRefreshPending,
+               pending.matches(projectID: projectID, source: source) {
+                if announcesCompletion, !pending.announcesCompletion {
+                    projectContextRefreshPending?.announcesCompletion = true
+                }
+                return
+            }
+        }
+
+        projectContextRefreshGeneration &+= 1
+        let request = WorkspaceProjectContextRefreshRequest(
+            projectID: projectID,
+            source: source,
+            generation: projectContextRefreshGeneration,
+            announcesCompletion: announcesCompletion
+        )
+        guard projectContextRefreshTask == nil else {
+            projectContextRefreshPending = request
+            onProjectContextChanged?()
+            return
+        }
+        startProjectContextRefresh(request)
+        onProjectContextChanged?()
+    }
+
+    private func startProjectContextRefresh(_ request: WorkspaceProjectContextRefreshRequest) {
+        let metadataLoader = projectMetadataLoader
+        let hookTrustStore = projectHookTrustStore
+        let remoteExecutor = sshRemoteShellExecutor
+        projectContextRefreshInFlight = request
+        projectContextRefreshTask = Task(priority: .utility) { [weak self] in
+            let loadingTask = Task.detached(priority: .utility) { () -> WorkspaceProjectContextRefreshOutcome in
+                switch request.source {
+                case .local(let root):
+                    return .loaded(metadataLoader(root, hookTrustStore))
+                case .remote(let connection):
+                    do {
+                        return .loaded(try WorkspaceProjectMetadataLoader.loadRemote(
+                            connection: connection,
+                            executor: remoteExecutor
+                        ))
+                    } catch {
+                        return .failed(error.localizedDescription)
+                    }
+                }
+            }
+            let outcome = await withTaskCancellationHandler {
+                await loadingTask.value
+            } onCancel: {
+                loadingTask.cancel()
+            }
+
+            guard let self else { return }
+            self.finishProjectContextRefresh(request, outcome: outcome)
+        }
+    }
+
+    private func finishProjectContextRefresh(
+        _ request: WorkspaceProjectContextRefreshRequest,
+        outcome: WorkspaceProjectContextRefreshOutcome
+    ) {
+        let shouldApply = !Task.isCancelled
+            && projectContextRefreshGeneration == request.generation
+            && root.projects.contains {
+                $0.id == request.projectID && request.source.matches($0)
+            }
+
+        if shouldApply {
+            applyProjectContextRefreshOutcome(outcome, request: request)
+        }
+
+        projectContextRefreshTask = nil
+        projectContextRefreshInFlight = nil
+        if let pending = projectContextRefreshPending {
+            projectContextRefreshPending = nil
+            startProjectContextRefresh(pending)
+        }
+        onProjectContextChanged?()
+    }
+
+    private func applyProjectContextRefreshOutcome(
+        _ outcome: WorkspaceProjectContextRefreshOutcome,
+        request: WorkspaceProjectContextRefreshRequest
+    ) {
+        switch outcome {
+        case .loaded(let metadata):
+            guard WorkspaceProjectEngine.applyMetadata(
+                metadata,
+                to: request.projectID,
+                projects: &root.projects,
+                includeLocalExtensions: request.source.includesLocalExtensions
+            ) else { return }
+            worktreeEnvironmentSurfacesByProjectID[request.projectID] =
+                metadata.worktreeEnvironmentSurface
+            syncThreadAfterProjectContextRefresh(request)
+            if request.announcesCompletion {
+                setLastError(nil)
+                touchProject(request.projectID)
+            }
+            saveProjects()
+            refreshTopBar(agentStatus: root.topBar.agentStatus)
+        case .failed(let message):
+            guard request.announcesCompletion else { return }
+            setLastError(message)
+            appendProjectContextRefreshEvent(
+                projectID: request.projectID,
+                summary: "Project context refresh failed",
+                payloadJSON: message
+            )
+        }
+    }
+
+    private func syncThreadAfterProjectContextRefresh(
+        _ request: WorkspaceProjectContextRefreshRequest
+    ) {
+        guard selectedThread?.projectID == request.projectID else { return }
+        let refreshedContext = workspaceThreadContext(request.projectID)
+        mutateSelectedThread { thread in
+            guard !thread.runtimeContext.isConfidential else { return }
+            thread.instructions = refreshedContext.instructions
+            thread.memories = refreshedContext.memories
+            if request.announcesCompletion {
+                thread.events.append(ThreadEvent(
+                    kind: .notice,
+                    summary: "Refreshed project context",
+                    payloadJSON: request.projectID.uuidString
+                ))
+            }
+        }
+    }
+
+    private func appendProjectContextRefreshEvent(
+        projectID: UUID,
+        summary: String,
+        payloadJSON: String
+    ) {
+        guard selectedThread?.projectID == projectID else { return }
+        mutateSelectedThread { thread in
+            guard !thread.runtimeContext.isConfidential else { return }
+            thread.events.append(ThreadEvent(
+                kind: .notice,
+                summary: summary,
+                payloadJSON: payloadJSON
+            ))
+        }
+    }
+
+    var refreshingProjectContextIDs: Set<UUID> {
+        Set([
+            projectContextRefreshInFlight?.projectID,
+            projectContextRefreshPending?.projectID
+        ].compactMap(\.self))
+    }
+
+    func waitForScheduledProjectContextRefresh() async {
+        while let task = projectContextRefreshTask {
+            await task.value
+        }
+    }
+}

--- a/Sources/QuillCodeApp/WorkspaceModelProjects.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelProjects.swift
@@ -2,12 +2,6 @@ import Foundation
 import QuillCodeCore
 import QuillCodeTools
 
-struct WorkspaceProjectContextRefreshRequest: Sendable, Equatable {
-    var projectID: UUID
-    var projectRoot: URL
-    var generation: Int
-}
-
 @MainActor
 extension QuillCodeWorkspaceModel {
     /// Registers and selects a local project immediately, then loads filesystem-backed context
@@ -120,125 +114,6 @@ extension QuillCodeWorkspaceModel {
         refreshSelectedProjectContext()
     }
 
-    /// Refreshes the selected local project's persisted context without delaying the calling UI.
-    /// Repeated requests for one root are coalesced because a blocking filesystem syscall cannot
-    /// be interrupted by Swift task cancellation. A changed selection queues one follow-up scan.
-    public func scheduleSelectedProjectContextRefresh() {
-        let projectID = selectedThread?.projectID ?? root.selectedProjectID
-        requestProjectContextRefresh(projectID)
-    }
-
-    /// Starts a best-effort freshness scan for a run but never puts that scan on the send path.
-    /// The run uses the last persisted context; a completed refresh is available to later turns.
-    func scheduleProjectContextRefreshForAgentSend(_ projectID: UUID?) {
-        requestProjectContextRefresh(projectID, queueAfterInFlight: true)
-    }
-
-    func requestProjectContextRefreshForNewChat(_ projectID: UUID?) {
-        requestProjectContextRefresh(projectID)
-    }
-
-    private func requestProjectContextRefresh(
-        _ projectID: UUID?,
-        queueAfterInFlight: Bool = false
-    ) {
-        guard let projectID,
-              let project = root.projects.first(where: { $0.id == projectID }),
-              !project.isRemote
-        else {
-            projectContextRefreshGeneration &+= 1
-            projectContextRefreshPending = nil
-            return
-        }
-
-        let projectRoot = URL(fileURLWithPath: project.path).standardizedFileURL
-        if let inFlight = projectContextRefreshInFlight,
-           inFlight.projectID == projectID,
-           inFlight.projectRoot == projectRoot {
-            guard queueAfterInFlight else { return }
-            if let pending = projectContextRefreshPending,
-               pending.projectID == projectID,
-               pending.projectRoot == projectRoot {
-                return
-            }
-        }
-
-        projectContextRefreshGeneration &+= 1
-        let request = WorkspaceProjectContextRefreshRequest(
-            projectID: projectID,
-            projectRoot: projectRoot,
-            generation: projectContextRefreshGeneration
-        )
-        guard projectContextRefreshTask == nil else {
-            projectContextRefreshPending = request
-            return
-        }
-        startProjectContextRefresh(request)
-    }
-
-    private func startProjectContextRefresh(_ request: WorkspaceProjectContextRefreshRequest) {
-        let metadataLoader = projectMetadataLoader
-        let hookTrustStore = projectHookTrustStore
-        projectContextRefreshInFlight = request
-        projectContextRefreshTask = Task(priority: .utility) { [weak self] in
-            let loadingTask = Task.detached(priority: .utility) {
-                metadataLoader(request.projectRoot, hookTrustStore)
-            }
-            let metadata = await loadingTask.value
-
-            guard let self else { return }
-            self.finishProjectContextRefresh(request, metadata: metadata)
-        }
-    }
-
-    private func finishProjectContextRefresh(
-        _ request: WorkspaceProjectContextRefreshRequest,
-        metadata: WorkspaceProjectMetadata
-    ) {
-        let shouldApply = !Task.isCancelled
-            && projectContextRefreshGeneration == request.generation
-            && root.projects.contains { project in
-                project.id == request.projectID
-                    && !project.isRemote
-                    && URL(fileURLWithPath: project.path).standardizedFileURL == request.projectRoot
-            }
-
-        if shouldApply,
-           WorkspaceProjectEngine.applyMetadata(
-                metadata,
-                to: request.projectID,
-                projects: &root.projects,
-                includeLocalExtensions: true
-           ) {
-            worktreeEnvironmentSurfacesByProjectID[request.projectID] =
-                metadata.worktreeEnvironmentSurface
-            if selectedThread?.projectID == request.projectID {
-                let refreshedContext = workspaceThreadContext(request.projectID)
-                mutateSelectedThread { thread in
-                    guard !thread.runtimeContext.isConfidential else { return }
-                    thread.instructions = refreshedContext.instructions
-                    thread.memories = refreshedContext.memories
-                }
-            }
-            saveProjects()
-            refreshTopBar(agentStatus: root.topBar.agentStatus)
-            onProjectContextChanged?()
-        }
-
-        projectContextRefreshTask = nil
-        projectContextRefreshInFlight = nil
-        if let pending = projectContextRefreshPending {
-            projectContextRefreshPending = nil
-            startProjectContextRefresh(pending)
-        }
-    }
-
-    func waitForScheduledProjectContextRefresh() async {
-        while let task = projectContextRefreshTask {
-            await task.value
-        }
-    }
-
     public func refreshSelectedProjectContext() {
         projectContextRefreshGeneration &+= 1
         projectContextRefreshPending = nil
@@ -307,6 +182,8 @@ extension QuillCodeWorkspaceModel {
         guard let project = root.projects.first(where: { $0.id == id }) else {
             return false
         }
+        projectContextRefreshGeneration &+= 1
+        projectContextRefreshPending = nil
         if project.isRemote {
             guard refreshRemoteProjectContext(id) else {
                 return false

--- a/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceNavigationSurfaceBuilder.swift
@@ -9,6 +9,7 @@ struct WorkspaceNavigationSurface: Sendable, Hashable {
 struct WorkspaceNavigationSurfaceBuilder {
     var projects: [ProjectRef]
     var selectedProjectID: UUID?
+    var refreshingProjectIDs: Set<UUID> = []
     var sidebarItems: [SidebarItem]
     var selectedThreadID: UUID?
     var threads: [ChatThread]
@@ -75,6 +76,7 @@ struct WorkspaceNavigationSurfaceBuilder {
             ProjectItemSurface(
                 project: project,
                 selectedProjectID: selectedProjectID,
+                isRefreshing: refreshingProjectIDs.contains(project.id),
                 canMoveToTop: index > 0,
                 canMoveUp: index > 0,
                 canMoveDown: index < sortedProjects.index(before: sortedProjects.endIndex),

--- a/Sources/QuillCodeApp/WorkspaceSidebarRowActionPlanner.swift
+++ b/Sources/QuillCodeApp/WorkspaceSidebarRowActionPlanner.swift
@@ -135,7 +135,7 @@ public struct WorkspaceSidebarRowMutationExecutor {
             _ = model.newChat(projectID: projectID)
             return true
         case .refreshContext(let projectID):
-            return model.refreshProjectContext(projectID)
+            return model.scheduleProjectContextRefresh(projectID)
         case .moveToTop(let projectID):
             return model.moveProjectToTop(projectID)
         case .moveUp(let projectID):

--- a/Sources/QuillCodeApp/WorkspaceSurface.swift
+++ b/Sources/QuillCodeApp/WorkspaceSurface.swift
@@ -361,6 +361,7 @@ public extension QuillCodeWorkspaceModel {
         let navigation = WorkspaceNavigationSurfaceBuilder(
             projects: root.projects,
             selectedProjectID: root.selectedProjectID,
+            refreshingProjectIDs: refreshingProjectContextIDs,
             sidebarItems: root.allSidebarItems,
             selectedThreadID: root.selectedThreadID,
             threads: root.threads,
@@ -528,6 +529,9 @@ public extension QuillCodeWorkspaceModel {
         return WorkspaceCommandSurfaceBuilder(
             selectedThread: selectedThread,
             selectedProject: selectedProject,
+            projectContextRefreshIsActive: selectedProject.map {
+                refreshingProjectContextIDs.contains($0.id)
+            } ?? false,
             hooks: effectiveHookDefinitions(for: selectedProject),
             selectedSidebarThreads: selectedSidebarThreads,
             sidebarSelectionIsActive: sidebarSelection.isActive,

--- a/Tests/QuillCodeAppTests/QuillCodeProjectListSurfaceTests.swift
+++ b/Tests/QuillCodeAppTests/QuillCodeProjectListSurfaceTests.swift
@@ -140,6 +140,24 @@ final class QuillCodeProjectListSurfaceTests: XCTestCase {
         XCTAssertEqual(item.actions.first { $0.kind == .moveToBottom }?.disabledReason, "Already at the bottom")
     }
 
+    func testProjectItemSurfacePublishesRefreshProgressAndPreventsDuplicateRefreshes() {
+        let project = ProjectRef(name: "QuillCode", path: "/repo")
+
+        let item = ProjectItemSurface(
+            project: project,
+            selectedProjectID: project.id,
+            isRefreshing: true
+        )
+
+        XCTAssertTrue(item.isRefreshing)
+        XCTAssertTrue(item.accessibilityLabel.contains("Refreshing context"))
+        XCTAssertEqual(item.actions.first { $0.kind == .refreshContext }?.isEnabled, false)
+        XCTAssertEqual(
+            item.actions.first { $0.kind == .refreshContext }?.disabledReason,
+            "Context refresh is already in progress"
+        )
+    }
+
     func testProjectItemSurfaceDecodesOlderPayloadWithoutRemoteMetadataOrActions() throws {
         let projectID = UUID()
         let json = """
@@ -155,6 +173,7 @@ final class QuillCodeProjectListSurfaceTests: XCTestCase {
 
         XCTAssertEqual(item.connectionKindLabel, "Local")
         XCTAssertFalse(item.isRemote)
+        XCTAssertFalse(item.isRefreshing)
         XCTAssertNil(item.selectionLabel)
         XCTAssertEqual(item.accessibilityLabel, "Project, QuillCode, Local, /Users/quill/QuillCode")
         XCTAssertEqual(item.actions.map(\.kind), [.newChat, .refreshContext, .moveToTop, .moveUp, .moveDown, .moveToBottom, .rename, .remove])

--- a/Tests/QuillCodeAppTests/WorkspaceCommandPlanExecutorTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandPlanExecutorTests.swift
@@ -209,7 +209,7 @@ final class WorkspaceCommandPlanExecutorTests: XCTestCase {
         XCTAssertTrue(model.composer.draft.contains("Suggested fix: Choose one intent for tests guidance"))
     }
 
-    func testExecutorAppliesInstructionDiagnosticPatchAndRefreshesContext() throws {
+    func testExecutorAppliesInstructionDiagnosticPatchAndRefreshesContext() async throws {
         let root = try makeTempDirectory()
         XCTAssertTrue(ShellToolExecutor().run(.init(command: "git init", cwd: root)).ok)
         let featureDirectory = root.appendingPathComponent("Sources/Feature")
@@ -268,6 +268,7 @@ final class WorkspaceCommandPlanExecutorTests: XCTestCase {
             "activity-instruction-apply:0:\(diagnosticID)",
             workspaceRoot: root
         ))
+        await model.waitForScheduledProjectContextRefresh()
 
         let editedFeatureInstruction = try String(
             contentsOf: featureDirectory.appendingPathComponent("AGENTS.md"),
@@ -282,7 +283,7 @@ final class WorkspaceCommandPlanExecutorTests: XCTestCase {
         XCTAssertEqual(try projectStore.load().first?.resolvedInstructionDiagnosticIDs, [diagnosticID])
     }
 
-    func testExecutorClearsExactDuplicateInstructionSourceAndRefreshesContext() throws {
+    func testExecutorClearsExactDuplicateInstructionSourceAndRefreshesContext() async throws {
         let root = try makeTempDirectory()
         XCTAssertTrue(ShellToolExecutor().run(.init(command: "git init", cwd: root)).ok)
         let rulesDirectory = root.appendingPathComponent(".quillcode")
@@ -340,6 +341,7 @@ final class WorkspaceCommandPlanExecutorTests: XCTestCase {
             "activity-instruction-apply:1:\(diagnosticID)",
             workspaceRoot: root
         ))
+        await model.waitForScheduledProjectContextRefresh()
 
         let editedRules = try String(
             contentsOf: rulesDirectory.appendingPathComponent("rules.md"),

--- a/Tests/QuillCodeAppTests/WorkspaceCommandSurfaceBuilderTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceCommandSurfaceBuilderTests.swift
@@ -64,6 +64,17 @@ final class WorkspaceCommandSurfaceBuilderTests: XCTestCase {
         XCTAssertTrue(try command("stop-all", in: activeCommands).isEnabled)
     }
 
+    func testProjectContextRefreshCommandDisablesWhileRefreshIsActive() throws {
+        let project = ProjectRef(name: "QuillCode", path: "/tmp/QuillCode")
+
+        let commands = makeBuilder(
+            selectedProject: project,
+            projectContextRefreshIsActive: true
+        ).commands
+
+        XCTAssertFalse(try command("project-refresh-context", in: commands).isEnabled)
+    }
+
     func testWorkspaceNavigationAvailabilityUsesHistoryFlags() throws {
         let commands = makeBuilder(canNavigateBack: true, canNavigateForward: true).commands
 
@@ -690,6 +701,7 @@ final class WorkspaceCommandSurfaceBuilderTests: XCTestCase {
     private func makeBuilder(
         selectedThread: ChatThread? = nil,
         selectedProject: ProjectRef? = nil,
+        projectContextRefreshIsActive: Bool = false,
         selectedSidebarThreads: [ChatThread] = [],
         sidebarSelectionIsActive: Bool = false,
         sidebarItemCount: Int = 0,
@@ -719,6 +731,7 @@ final class WorkspaceCommandSurfaceBuilderTests: XCTestCase {
         WorkspaceCommandSurfaceBuilder(
             selectedThread: selectedThread,
             selectedProject: selectedProject,
+            projectContextRefreshIsActive: projectContextRefreshIsActive,
             selectedSidebarThreads: selectedSidebarThreads,
             sidebarSelectionIsActive: sidebarSelectionIsActive,
             sidebarItemCount: sidebarItemCount,

--- a/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceHTMLChromeRendererTests.swift
@@ -160,6 +160,25 @@ final class WorkspaceHTMLChromeRendererTests: XCTestCase {
         XCTAssertTrue(remoteHTML.contains(#"data-testid="top-bar-overflow-disconnect-all""#))
     }
 
+    func testProjectRendererPublishesRefreshProgressAndDisablesDuplicateAction() {
+        let project = ProjectRef(name: "QuillCode", path: "/tmp/QuillCode")
+        let item = ProjectItemSurface(
+            project: project,
+            selectedProjectID: project.id,
+            isRefreshing: true
+        )
+
+        let html = WorkspaceHTMLSidebarProjectRenderer.render(ProjectListSurface(
+            items: [item],
+            selectedProjectID: project.id
+        ))
+
+        XCTAssertTrue(html.contains(#"data-testid="project-refresh-status""#))
+        XCTAssertTrue(html.contains("Refreshing..."))
+        XCTAssertTrue(html.contains("Context refresh is already in progress"))
+        XCTAssertTrue(html.contains("disabled"))
+    }
+
     func testHTMLRendererShowsWorktreeTopBarStatusAndDanglingWarning() throws {
         let project = ProjectRef(name: "QuillCode", path: "/tmp/quillcode")
         var thread = ChatThread(title: "Feature", projectID: project.id)

--- a/Tests/QuillCodeAppTests/WorkspaceModelIntegrationTestSupport.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceModelIntegrationTestSupport.swift
@@ -37,10 +37,16 @@ func makeFakeSSH(in root: URL, argumentsFile: URL) throws -> URL {
     return script
 }
 
-func makeExecutingFakeSSH(in root: URL, argumentsFile: URL, pathPrefix: URL? = nil) throws -> URL {
+func makeExecutingFakeSSH(
+    in root: URL,
+    argumentsFile: URL,
+    pathPrefix: URL? = nil,
+    delaySeconds: TimeInterval = 0
+) throws -> URL {
     let script = root.appendingPathComponent("fake-executing-ssh")
     let argumentsPath = shellSingleQuoted(argumentsFile.path)
     let pathExport = pathPrefix.map { "export PATH='\(shellSingleQuoted($0.path))':$PATH" } ?? ":"
+    let delay = delaySeconds > 0 ? "/bin/sleep \(delaySeconds)" : ":"
     try """
     #!/bin/sh
     : > '\(argumentsPath)'
@@ -50,6 +56,7 @@ func makeExecutingFakeSSH(in root: URL, argumentsFile: URL, pathPrefix: URL? = n
       last="$arg"
     done
     \(pathExport)
+    \(delay)
     /bin/sh -c "$last"
     """.write(to: script, atomically: true, encoding: .utf8)
     try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)

--- a/Tests/QuillCodeAppTests/WorkspaceProjectIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceProjectIntegrationTests.swift
@@ -233,6 +233,74 @@ final class WorkspaceProjectIntegrationTests: XCTestCase {
         XCTAssertTrue(didPublish)
     }
 
+    func testUserProjectContextRefreshStaysResponsiveAndPublishesProgress() async throws {
+        let root = try makeQuillCodeTestDirectory()
+        let projectID = UUID()
+        let threadID = UUID()
+        let instruction = ProjectInstruction(
+            path: "AGENTS.md",
+            title: "Project AGENTS.md",
+            content: "Loaded after the visible refresh.",
+            byteCount: 33
+        )
+        let probe = BlockingProjectMetadataLoader(metadata: WorkspaceProjectMetadata(
+            instructions: [instruction],
+            localActions: [],
+            runHooks: [],
+            extensionManifests: [],
+            memories: []
+        ))
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            projects: [ProjectRef(id: projectID, name: "Slow Project", path: root.path)],
+            selectedProjectID: projectID,
+            threads: [ChatThread(id: threadID, projectID: projectID)],
+            selectedThreadID: threadID
+        ))
+        model.projectMetadataLoader = { _, _ in probe.load() }
+        defer { probe.release.signal() }
+        var publishCount = 0
+        model.onProjectContextChanged = { publishCount += 1 }
+        let startedAt = ContinuousClock.now
+
+        XCTAssertTrue(WorkspaceSidebarRowMutationExecutor.execute(
+            .refreshContext(projectID),
+            model: model
+        ))
+
+        XCTAssertLessThan(startedAt.duration(to: .now), .milliseconds(100))
+        XCTAssertEqual(publishCount, 1)
+        var surface = model.surface()
+        XCTAssertEqual(surface.projects.items.first?.isRefreshing, true)
+        XCTAssertTrue(surface.projects.items.first?.accessibilityLabel.contains("Refreshing context") == true)
+        XCTAssertEqual(
+            surface.projects.items.first?.actions.first { $0.kind == .refreshContext }?.isEnabled,
+            false
+        )
+        XCTAssertEqual(surface.commands.first { $0.id == "project-refresh-context" }?.isEnabled, false)
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        while ContinuousClock.now < deadline, probe.callCount == 0 {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(probe.callCount, 1)
+        XCTAssertFalse(probe.loadedOnMainThread)
+
+        probe.release.signal()
+        await model.waitForScheduledProjectContextRefresh()
+
+        surface = model.surface()
+        XCTAssertEqual(surface.projects.items.first?.isRefreshing, false)
+        XCTAssertEqual(
+            surface.projects.items.first?.actions.first { $0.kind == .refreshContext }?.isEnabled,
+            true
+        )
+        XCTAssertEqual(surface.commands.first { $0.id == "project-refresh-context" }?.isEnabled, true)
+        XCTAssertEqual(model.selectedProject?.instructions, [instruction])
+        XCTAssertEqual(model.selectedThread?.instructions, [instruction])
+        XCTAssertEqual(model.selectedThread?.events.last?.summary, "Refreshed project context")
+        XCTAssertGreaterThanOrEqual(publishCount, 2)
+    }
+
     func testRegisterProjectReturnsBeforeContextLoadAndPublishesTheResult() async throws {
         let root = try makeQuillCodeTestDirectory()
         let instruction = ProjectInstruction(

--- a/Tests/QuillCodeAppTests/WorkspaceRemoteProjectIntegrationTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRemoteProjectIntegrationTests.swift
@@ -48,7 +48,7 @@ final class WorkspaceRemoteProjectIntegrationTests: XCTestCase {
         XCTAssertEqual(model.selectedThread?.messages.last?.content.contains("PR checkout/reviewers/labels/merge"), true)
     }
 
-    func testRefreshProjectContextLoadsSSHRemoteInstructionsAndMemories() throws {
+    func testRefreshProjectContextLoadsSSHRemoteInstructionsAndMemoriesOffMain() async throws {
         let root = try makeTempDirectory()
         let remoteRoot = root.appendingPathComponent("remote repo")
         try FileManager.default.createDirectory(
@@ -81,7 +81,11 @@ final class WorkspaceRemoteProjectIntegrationTests: XCTestCase {
         )
 
         let argumentsFile = root.appendingPathComponent("ssh-args.txt")
-        let fakeSSH = try makeExecutingFakeSSH(in: root, argumentsFile: argumentsFile)
+        let fakeSSH = try makeExecutingFakeSSH(
+            in: root,
+            argumentsFile: argumentsFile,
+            delaySeconds: 0.25
+        )
         let connection = ProjectConnection.ssh(
             path: remoteRoot.path,
             host: "feather.local",
@@ -97,7 +101,20 @@ final class WorkspaceRemoteProjectIntegrationTests: XCTestCase {
         )
         _ = model.newChat(projectID: project.id)
 
-        XCTAssertTrue(model.refreshProjectContext(project.id), model.lastError ?? "")
+        let startedAt = ContinuousClock.now
+        XCTAssertTrue(model.scheduleProjectContextRefresh(project.id), model.lastError ?? "")
+        XCTAssertLessThan(startedAt.duration(to: .now), .milliseconds(100))
+        XCTAssertEqual(model.surface().projects.items.first?.isRefreshing, true)
+        XCTAssertEqual(
+            model.surface().projects.items.first?.actions.first { $0.kind == .refreshContext }?.isEnabled,
+            false
+        )
+        XCTAssertEqual(
+            model.surface().commands.first { $0.id == "project-refresh-context" }?.isEnabled,
+            false
+        )
+
+        await model.waitForScheduledProjectContextRefresh()
 
         let refreshedProject = try XCTUnwrap(model.root.projects.first)
         XCTAssertEqual(
@@ -119,6 +136,51 @@ final class WorkspaceRemoteProjectIntegrationTests: XCTestCase {
         let arguments = try String(contentsOf: argumentsFile, encoding: .utf8)
         XCTAssertTrue(arguments.contains("cd '\(remoteRoot.path.replacingOccurrences(of: "'", with: "'\\''"))' &&"))
         XCTAssertTrue(arguments.contains("QUILLCODE_CONTEXT_"))
+    }
+
+    func testFailedSSHProjectContextRefreshRestoresControlsAndSurfacesFailure() async throws {
+        let root = try makeTempDirectory()
+        let fakeSSH = root.appendingPathComponent("failing-ssh")
+        try """
+        #!/bin/sh
+        /bin/sleep 0.1
+        echo 'remote context unavailable' >&2
+        exit 23
+        """.write(to: fakeSSH, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeSSH.path)
+        let connection = ProjectConnection.ssh(
+            path: "/srv/quill",
+            host: "offline.local",
+            user: "quill"
+        )
+        let project = ProjectRef(name: "Offline", path: connection.path, connection: connection)
+        let thread = ChatThread(projectID: project.id)
+        let model = QuillCodeWorkspaceModel(
+            root: QuillCodeRootState(
+                projects: [project],
+                selectedProjectID: project.id,
+                threads: [thread],
+                selectedThreadID: thread.id
+            ),
+            sshRemoteShellExecutor: SSHRemoteShellExecutor(
+                sshExecutable: fakeSSH.path,
+                connectTimeoutSeconds: 1
+            )
+        )
+
+        XCTAssertTrue(model.scheduleProjectContextRefresh(project.id))
+        XCTAssertEqual(model.surface().projects.items.first?.isRefreshing, true)
+        await model.waitForScheduledProjectContextRefresh()
+
+        XCTAssertEqual(model.surface().projects.items.first?.isRefreshing, false)
+        XCTAssertEqual(
+            model.surface().projects.items.first?.actions.first { $0.kind == .refreshContext }?.isEnabled,
+            true
+        )
+        XCTAssertEqual(model.surface().commands.first { $0.id == "project-refresh-context" }?.isEnabled, true)
+        XCTAssertNotNil(model.lastError)
+        XCTAssertEqual(model.selectedProject?.instructions, [])
+        XCTAssertEqual(model.selectedThread?.events.last?.summary, "Project context refresh failed")
     }
 
     func testSlashSSHRejectsMalformedAddress() async throws {

--- a/Tests/QuillCodeParityTests/ParityWorkspaceContextRefreshGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceContextRefreshGateTests.swift
@@ -21,6 +21,28 @@ final class ParityWorkspaceContextRefreshGateTests: QuillCodeParityTestCase {
         )
     }
 
+    func testUserProjectContextRefreshUsesTheVisibleBackgroundContract() throws {
+        let schedulingText = try Self.appSourceText(named: "WorkspaceModelProjectContextScheduling.swift")
+        let rowExecutorText = try Self.appSourceText(named: "WorkspaceSidebarRowActionPlanner.swift")
+        let commandExecutorText = try Self.appSourceText(named: "WorkspaceCommandActionExecutor.swift")
+        let planExecutorText = try Self.appSourceText(named: "WorkspaceCommandPlanExecutor.swift")
+        let surfaceText = try Self.appSourceText(named: "WorkspaceSurface.swift")
+
+        Self.assertSource(schedulingText, containsAll: [
+            "public func scheduleProjectContextRefresh",
+            "Task.detached(priority: .utility)",
+            "WorkspaceProjectMetadataLoader.loadRemote",
+            "var refreshingProjectContextIDs"
+        ])
+        Self.assertSource(rowExecutorText, contains: "model.scheduleProjectContextRefresh(projectID)")
+        Self.assertSource(commandExecutorText, contains: "scheduleProjectContextRefresh(projectID)")
+        Self.assertSource(planExecutorText, contains: "scheduleProjectContextRefresh(projectID)")
+        Self.assertSource(surfaceText, containsAll: [
+            "refreshingProjectIDs: refreshingProjectContextIDs",
+            "projectContextRefreshIsActive: selectedProject.map"
+        ])
+    }
+
     private func assertFocusedRefresher(_ source: String) {
         [
             "enum WorkspaceProjectContextRefresher",

--- a/Tests/QuillCodeParityTests/ParityWorkspaceProjectGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkspaceProjectGateTests.swift
@@ -4,6 +4,7 @@ final class ParityWorkspaceProjectGateTests: QuillCodeParityTestCase {
     func testWorkspaceModelDelegatesProjectMetadataLoading() throws {
         let modelText = try Self.appSourceText(named: "WorkspaceModel.swift")
         let projectExtensionText = try Self.appSourceText(named: "WorkspaceModelProjects.swift")
+        let schedulingText = try Self.appSourceText(named: "WorkspaceModelProjectContextScheduling.swift")
         let loaderText = try Self.appSourceText(named: "WorkspaceProjectMetadataLoader.swift")
         let bootstrapText = try Self.appSourceText(named: "WorkspaceBootstrap.swift")
 
@@ -15,8 +16,8 @@ final class ParityWorkspaceProjectGateTests: QuillCodeParityTestCase {
         Self.assertSource(loaderText, contains: "MemoryNoteLoader.loadProject")
         Self.assertSource(loaderText, contains: "SSHRemoteProjectContextLoader.load")
         Self.assertSource(projectExtensionText, contains: "WorkspaceProjectMetadataLoader.loadLocal")
-        Self.assertSource(projectExtensionText, contains: "Task.detached(priority: .utility)")
-        Self.assertSource(projectExtensionText, contains: "public func scheduleSelectedProjectContextRefresh")
+        Self.assertSource(schedulingText, contains: "Task.detached(priority: .utility)")
+        Self.assertSource(schedulingText, contains: "public func scheduleSelectedProjectContextRefresh")
         Self.assertSource(bootstrapText, excludes: "model.refreshSelectedProjectInstructions()")
         Self.assertSource(modelText, contains: "WorkspaceProjectContextRefresher.refreshRemoteProjectContext")
         Self.assertSource(modelText, excludes: "ProjectInstructionLoader.load")

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -18060,3 +18060,31 @@ Validation:
   control, project-row, or composer overlap
 - `python3 scripts/grade-code-quality.py --root .` (all production modules A+)
 - `git diff --check`
+
+## 2026-08-14 Responsive Local and SSH Context Refresh
+
+Overall grade: **A+ main-thread responsiveness, A+ failure resilience, A+ interaction clarity**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| UI responsiveness | A+ | Sidebar, command-palette, and instruction-diagnostic refresh routes schedule local discovery and SSH loading in one utility-priority detached path. Semaphore-held local and delayed SSH loaders prove user actions return within 100 ms and never load on the main thread. |
+| Race safety | A+ | Each request snapshots the exact standardized local root or SSH connection and a monotonic generation. In-flight requests coalesce one latest follow-up, cancelled or stale work cannot publish, and synchronous internal refreshes supersede older background results. |
+| Failure resilience | A+ | Failed SSH refreshes preserve the last known instructions and memories, restore every disabled control, publish the readable error, and append a task-visible failure notice. Successful explicit refreshes clear stale errors and append completion evidence. |
+| Interaction clarity | A+ | Native and HTML project rows expose a fixed-size progress indicator, accessibility labels announce refresh state, and duplicate row and command-palette actions disable with an explicit reason until completion. |
+| State integrity | A+ | Background metadata publication no longer rebuilds the file-mention index, preventing a new-chat freshness scan from racing a later `git status` and erasing valid Changed badges. The complete suite exposed and now covers this ordering. |
+| Maintainability | A+ | Scheduling, generation checks, remote loading, publication, and progress state live in a focused 268-line source file; deterministic grading scores it 100/A+ and the remaining project API extension 97/A+. |
+
+Validation:
+
+- Focused local, SSH, command, navigation, native/HTML surface, changed-file mention, and parity suites
+  passed with zero failures
+- `swift test` (6,387 tests; 5 skipped; 0 failures)
+- `scripts/packaged-macos-smoke.sh` (intentional SIGKILL draft/run recovery, direct and Launch
+  Services rendering, live native Accessibility interaction, critical memory pressure, and the
+  packaged 100-chat daily-driver workload passed)
+- Packaged daily-driver gate: 296.95 ms median launch-ready, 40.74 MiB initial physical footprint,
+  74.84 MiB post-interaction, 78.86 MiB repeated-interaction, and 0.0004% settled idle CPU
+- Visual review of empty-workspace, completed-result, and populated 100-chat native screenshots with
+  project rows, transcript, sidebar activity, model controls, and composer unobscured
+- `python3 scripts/grade-code-quality.py --root .` (all production modules A+; new scheduler 100/A+)
+- `git diff --check`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,11 @@
 
 ## Latest Quality Pass
 
+- User-triggered **Refresh context** no longer performs local filesystem discovery or SSH process
+  waits on the main actor. Local and remote refreshes share one utility-priority, generation-bound,
+  coalesced scheduler; visible rows publish fixed-size progress, duplicate row and command-palette
+  actions disable until completion, failures restore controls with a durable task notice, and stale
+  results must still match the exact local root or SSH connection before replacing known context.
 - First-project setup and user folder import now register and select the project before reading its
   filesystem-backed instructions, actions, hooks, plugins, extensions, memories, or worktree
   environments. The established utility-priority refresh path loads that context off the main actor,

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -271,6 +271,12 @@ QuillCode uses unit, functional, integration, Playwright, and native smoke tests
   responses, deadlines, direct calls with null turns, agent calls with exact turns, interruption and
   disconnect cancellation, `serverRequest/resolved` ordering, and continued stdin response handling
   while the originating direct tool request remains open.
+- User-triggered local and SSH Remote project-context refresh: the row, command palette, and
+  instruction-diagnostic routes return within 100 ms while a filesystem loader or SSH process is
+  deliberately stalled; loading runs off the main actor; one latest request is coalesced behind
+  in-flight work; exact path/connection and generation checks reject stale results; native and HTML
+  surfaces expose progress and disable duplicate actions; success updates project/thread context;
+  and transport failure preserves known context, restores controls, and records a visible failure.
 
 ## Playwright E2E
 
@@ -282,7 +288,8 @@ Drive the QuillCode test harness with mock LLM:
 - first run
 - login
 - interface polish primitives: root font smoothing, balanced headings, pretty short text, tabular dynamic numbers, 44px hit areas, accessible names, no nested or overlapping interactive targets, unblocked center/inset click points, visible command targets that route to known commands, explicit transitions without `all`, tactile `scale(0.96)` press feedback, concentric panel radii, and image outlines
-- open project, rename it, refresh context, start a project-scoped chat, and remove it from the project list
+- open project, rename it, refresh context with immediate progress and disabled duplicate controls,
+  start a project-scoped chat, and remove it from the project list
 - open the native SSH dialog from the sidebar, command palette, and Settings; filter configured hosts; switch to manual entry; verify invalid destination/path/port combinations disable submission; prove failed probes remain retryable; prove backdrop, Escape, Close, and Cancel invalidate in-flight discovery/probe results; register only after a successful probe; preserve the selected alias rather than its resolved hostname; complete `/ssh user@host:/path` as a compatible fast path; verify sidebar badge/path/top-bar context; refresh remote context from mock AGENTS/rules/memories; run `pwd` in the integrated terminal against the remote mock; run remote git status/diff from the command palette; run stage/restore from the review pane; run commit/push/PR creation/checkout/commenting/reviewing/reviewer-request/merging from chat-driven tools through fake SSH and fake `gh`; run remote worktree list/create/remove through fake SSH; verify remote worktree creation opens the new worktree as an SSH Remote project/thread; verify terminal and tool-card execution-context chips/rails say `SSH Remote`; and verify chat-driven `whoami` uses `host.shell.run` while remote file read/list/write, apply-patch, and review requests use `host.file.read`/`host.file.list`/`host.file.write`/`host.apply_patch`/`host.git.*` over SSH instead of local file tools
 - find within the active chat with `Cmd+F`, focused input, result counts, next/previous navigation, and close behavior
 - search and select a model, including current/default/recommended badges, provider/category/model metadata rows, metadata-backed search, and duplicate-free search results


### PR DESCRIPTION
## Summary
- schedule local and SSH project-context refreshes on a coalesced utility-priority worker
- show fixed-size progress and disable duplicate refresh actions across native, HTML, and command surfaces
- preserve known context on remote failure and reject stale path/connection generations
- prevent automatic metadata scans from racing changed-file mention badges

## Validation
- `swift test`: 6,387 tests, 5 skipped, 0 failures
- `scripts/packaged-macos-smoke.sh`: crash recovery, direct/Launch Services, live Accessibility, memory pressure, and 100-chat daily-driver passed
- packaged performance: 296.95 ms launch-ready, 40.74 MiB initial, 74.84 MiB post-interaction, 78.86 MiB repeated, 0.0004% idle CPU
- quality grader: all production modules A+; scheduler 100/A+
- visual review of empty, result, and 100-chat native screenshots