### PR TITLE
Prefer stable releases on the public download site

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ and signing details are in [Downloadable Builds](docs/DOWNLOADS.md).
 
 The public [Quill Cowork website](https://cowork.quillos.cloud/) is also sourced from `main` and
 deployed through the verified GitHub Pages workflow. Its primary buttons always use the universal
-installer, while optional release-freshness text is populated from validated public release metadata.
+installer. The page automatically prefers a validated notarized stable release when one exists,
+falls back to the validated tester release, and keeps the known-good tester link when live metadata
+is unavailable.
 
 ## Release Status
 

--- a/Tests/ScriptTests/test_website.py
+++ b/Tests/ScriptTests/test_website.py
@@ -71,7 +71,20 @@ class WebsiteTests(unittest.TestCase):
         )
         result = self.verify()
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("freshly fetched and validated", result.stderr)
+        self.assertIn("fail-closed validated", result.stderr)
+
+    def test_stable_feed_removal_fails(self) -> None:
+        script = self.site / "static/site.js"
+        script.write_text(
+            script.read_text(encoding="utf-8").replace(
+                "https://api.github.com/repos/Lore-Hex/QuillCode/releases/latest",
+                "https://example.com/releases/latest",
+            ),
+            encoding="utf-8",
+        )
+        result = self.verify()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("prefer stable", result.stderr)
 
 
 if __name__ == "__main__":

--- a/Tests/ScriptTests/test_website_js.mjs
+++ b/Tests/ScriptTests/test_website_js.mjs
@@ -12,96 +12,184 @@ const source = fs.readFileSync(
   path.join(repositoryRoot, "website/static/site.js"),
   "utf8",
 );
-const installerURL =
-  "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg";
-const releaseAPIURL =
+const repositoryURL = "https://github.com/Lore-Hex/QuillCode";
+const stableAPIURL = "https://api.github.com/repos/Lore-Hex/QuillCode/releases/latest";
+const testerAPIURL =
   "https://api.github.com/repos/Lore-Hex/QuillCode/releases/tags/tester-latest";
+const testerInstallerURL =
+  `${repositoryURL}/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg`;
+const testerReleaseURL = `${repositoryURL}/releases/tag/tester-latest`;
 
-function releaseFixture(overrides = {}) {
+function releaseFixture(channel, overrides = {}) {
+  const isStable = channel === "stable";
+  const version = isStable ? "1.2.3" : "0.1.0";
+  const tag = isStable ? `v${version}` : "tester-latest";
+  const assetURL = (name) => `${repositoryURL}/releases/download/${tag}/${name}`;
   return {
-    name: "Quill Cowork Tester Build",
-    tag_name: "tester-latest",
+    name: isStable ? `Quill Cowork ${tag}` : "Quill Cowork Tester Build",
+    tag_name: tag,
+    html_url: `${repositoryURL}/releases/tag/${tag}`,
     draft: false,
-    prerelease: true,
+    prerelease: !isStable,
     target_commitish: "d624fb2b11bd177eb19fbb9ef9c341dc2b52f278",
     updated_at: "2026-08-13T08:48:58Z",
+    body: isStable
+      ? "This build is Developer ID signed, notarized by Apple, and stapled for normal first launch."
+      : "This tester build is ad-hoc signed and not Apple-notarized.",
     assets: [
       {
         name: "Quill-Cowork-macOS-universal.dmg",
         state: "uploaded",
-        browser_download_url: installerURL,
+        browser_download_url: assetURL("Quill-Cowork-macOS-universal.dmg"),
         digest: `sha256:${"a".repeat(64)}`,
         size: 29_252_809,
+      },
+      {
+        name: isStable ? "latest-stable-build.json" : "latest-tester-build.json",
+        state: "uploaded",
+        browser_download_url: assetURL(
+          isStable ? "latest-stable-build.json" : "latest-tester-build.json",
+        ),
+        digest: `sha256:${"b".repeat(64)}`,
+        size: 7_803,
       },
     ],
     ...overrides,
   };
 }
 
-async function runSiteScript({ release, rejection } = {}) {
-  const links = Array.from({ length: 3 }, () => ({ href: installerURL }));
-  const labels = Array.from({ length: 2 }, () => ({
-    textContent: "Latest tester release",
-  }));
+function elements(count, textContent = "") {
+  return Array.from({ length: count }, () => ({ textContent }));
+}
+
+async function runSiteScript(responses = new Map()) {
+  const downloadLinks = Array.from({ length: 3 }, () => ({ href: testerInstallerURL }));
+  const releaseLinks = Array.from({ length: 3 }, () => ({ href: testerReleaseURL }));
+  const labels = elements(2, "Latest tester release");
+  const releaseKinds = elements(1, "Free tester build");
+  const releaseSections = elements(1, "Tester release");
+  const guidance = elements(1, "tester guidance");
+  const captions = elements(1, "tester caption");
   const fetches = [];
+  const selectorResults = new Map([
+    ["[data-download-link]", downloadLinks],
+    ["[data-release-link]", releaseLinks],
+    ["[data-build-label]", labels],
+    ["[data-release-kind]", releaseKinds],
+    ["[data-release-section]", releaseSections],
+    ["[data-install-guidance]", guidance],
+    ["[data-release-caption]", captions],
+  ]);
   const document = {
     documentElement: { dataset: {} },
     querySelectorAll(selector) {
-      if (selector === "[data-download-link]") {
-        return links;
+      const result = selectorResults.get(selector);
+      if (!result) {
+        throw new Error(`Unexpected selector: ${selector}`);
       }
-      if (selector === "[data-build-label]") {
-        return labels;
-      }
-      throw new Error(`Unexpected selector: ${selector}`);
+      return result;
     },
   };
   const fetch = async (url, options) => {
     fetches.push({ url, options });
-    if (rejection) {
-      throw rejection;
+    const response = responses.get(url);
+    if (response instanceof Error) {
+      throw response;
     }
-    return { ok: true, json: async () => release };
+    if (!response) {
+      return { ok: false, json: async () => null };
+    }
+    return {
+      ok: response.ok ?? true,
+      json: async () => response.body,
+    };
   };
 
   vm.runInNewContext(source, { document, fetch }, { filename: "site.js" });
-  await new Promise((resolve) => setImmediate(resolve));
-  await new Promise((resolve) => setImmediate(resolve));
-  return { document, fetches, labels, links };
+  for (let index = 0; index < 5; index += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  return {
+    captions,
+    document,
+    downloadLinks,
+    fetches,
+    guidance,
+    labels,
+    releaseKinds,
+    releaseLinks,
+    releaseSections,
+  };
 }
 
-const current = await runSiteScript({ release: releaseFixture() });
-assert.equal(current.fetches.length, 1);
-assert.equal(current.fetches[0].url, releaseAPIURL);
-assert.equal(current.fetches[0].options.cache, "no-store");
+const stableRelease = releaseFixture("stable");
+const stable = await runSiteScript(new Map([
+  [stableAPIURL, { body: stableRelease }],
+]));
+assert.deepEqual(stable.fetches.map(({ url }) => url), [stableAPIURL]);
+assert.equal(stable.fetches[0].options.cache, "no-store");
+assert.equal(stable.fetches[0].options.credentials, "omit");
+assert.equal(stable.fetches[0].options.headers.Accept, "application/vnd.github+json");
+assert.equal(stable.fetches[0].options.referrerPolicy, "no-referrer");
+assert.equal(stable.document.documentElement.dataset.release, "stable");
 assert.equal(
-  current.fetches[0].options.headers.Accept,
-  "application/vnd.github+json",
+  stable.document.documentElement.dataset.commit,
+  stableRelease.target_commitish,
 );
-assert.equal(current.document.documentElement.dataset.release, "current");
-assert.ok(current.labels.every((label) => label.textContent.startsWith("Updated ")));
-assert.ok(current.links.every((link) => link.href === installerURL));
+assert.ok(stable.labels.every(({ textContent }) => textContent.startsWith("Updated ")));
+assert.ok(stable.releaseKinds.every(({ textContent }) => textContent === "Stable release"));
+assert.ok(stable.releaseSections.every(({ textContent }) => textContent === "Stable release"));
+assert.ok(stable.guidance.every(({ textContent }) => textContent.includes("notarized")));
+assert.ok(stable.captions.every(({ textContent }) => textContent.includes("notarized")));
+assert.ok(stable.downloadLinks.every(({ href }) => href === stableRelease.assets[0].browser_download_url));
+assert.ok(stable.releaseLinks.every(({ href }) => href === stableRelease.html_url));
 
-const malformed = releaseFixture({
-  assets: [{
-    ...releaseFixture().assets[0],
-    digest: "sha256:not-a-digest",
-  }],
+const testerRelease = releaseFixture("tester");
+const tester = await runSiteScript(new Map([
+  [stableAPIURL, { ok: false }],
+  [testerAPIURL, { body: testerRelease }],
+]));
+assert.deepEqual(
+  tester.fetches.map(({ url }) => url),
+  [stableAPIURL, testerAPIURL],
+);
+assert.equal(tester.document.documentElement.dataset.release, "tester");
+assert.equal(
+  tester.document.documentElement.dataset.commit,
+  testerRelease.target_commitish,
+);
+assert.ok(tester.releaseKinds.every(({ textContent }) => textContent === "Free tester build"));
+assert.ok(tester.guidance.every(({ textContent }) => textContent.includes("Control-click")));
+assert.ok(tester.downloadLinks.every(({ href }) => href === testerInstallerURL));
+assert.ok(tester.releaseLinks.every(({ href }) => href === testerReleaseURL));
+
+const unsignedStable = releaseFixture("stable", {
+  body: "This build is ad-hoc signed and not Apple-notarized.",
 });
-const rejectedRelease = await runSiteScript({ release: malformed });
-assert.equal(rejectedRelease.document.documentElement.dataset.release, undefined);
-assert.ok(
-  rejectedRelease.labels.every(
-    (label) => label.textContent === "Latest tester release",
-  ),
-);
+const stableFallback = await runSiteScript(new Map([
+  [stableAPIURL, { body: unsignedStable }],
+  [testerAPIURL, { body: testerRelease }],
+]));
+assert.equal(stableFallback.document.documentElement.dataset.release, "tester");
 
-const unavailable = await runSiteScript({ rejection: new Error("offline") });
+const missingManifest = releaseFixture("stable");
+missingManifest.assets = [missingManifest.assets[0]];
+const assetFallback = await runSiteScript(new Map([
+  [stableAPIURL, { body: missingManifest }],
+  [testerAPIURL, { body: testerRelease }],
+]));
+assert.equal(assetFallback.document.documentElement.dataset.release, "tester");
+
+const unavailable = await runSiteScript(new Map([
+  [stableAPIURL, new Error("offline")],
+  [testerAPIURL, new Error("offline")],
+]));
 assert.equal(unavailable.document.documentElement.dataset.release, undefined);
+assert.equal(unavailable.document.documentElement.dataset.commit, undefined);
 assert.ok(
-  unavailable.labels.every(
-    (label) => label.textContent === "Latest tester release",
-  ),
+  unavailable.labels.every(({ textContent }) => textContent === "Latest tester release"),
 );
+assert.ok(unavailable.downloadLinks.every(({ href }) => href === testerInstallerURL));
+assert.ok(unavailable.releaseLinks.every(({ href }) => href === testerReleaseURL));
 
-console.log("Verified Quill Cowork website release enhancement");
+console.log("Verified Quill Cowork website stable-first release enhancement");

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -9,10 +9,15 @@ Send ordinary Mac testers to the public website:
 - [Quill Cowork](https://cowork.quillos.cloud/)
 
 The website's primary download always uses the universal installer and works without JavaScript.
-When GitHub's public release API is reachable, the page additionally shows the release update date
-only after validating the release name, tester tag and state, exact commit shape, and the sole
-universal installer's upload state, URL, size, and SHA-256 digest. A malformed, rate-limited, or
-unavailable response leaves the known-good moving link and static installation guidance intact.
+Its static fallback is the known-good tester installer. When GitHub's public release API is
+reachable, the page first tries the latest stable release and accepts it only when the product name,
+semantic version tag, immutable commit, non-prerelease state, generated Developer ID and notarization
+notice, release URL, stable manifest asset, and sole universal installer's URL, upload state, size,
+and SHA-256 digest all agree. Until a stable release exists, the same validation runs against the
+tester prerelease and its ad-hoc signing notice. Malformed, rate-limited, or unavailable metadata
+leaves the static tester link and Gatekeeper guidance intact. Download links, release-note links,
+freshness text, channel labels, screenshot copy, and install guidance switch as one update, so a
+stable download is never paired with tester instructions or provenance.
 
 Send technical testers this moving prerelease link for provenance and secondary artifacts:
 

--- a/scripts/verify-website.py
+++ b/scripts/verify-website.py
@@ -15,7 +15,10 @@ UNIVERSAL_INSTALLER_URL = (
     "tester-latest/Quill-Cowork-macOS-universal.dmg"
 )
 RELEASE_URL = "https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest"
-RELEASE_API_URL = "https://api.github.com/repos/Lore-Hex/QuillCode/releases/tags/tester-latest"
+STABLE_RELEASE_API_URL = "https://api.github.com/repos/Lore-Hex/QuillCode/releases/latest"
+TESTER_RELEASE_API_URL = (
+    "https://api.github.com/repos/Lore-Hex/QuillCode/releases/tags/tester-latest"
+)
 THIN_INSTALLER_PATTERN = re.compile(r"Quill-Cowork-macOS-(?:arm64|x86_64)\.dmg")
 CSS_URL_PATTERN = re.compile(r"url\(\s*(['\"]?)([^)'\"]+)\1\s*\)")
 EXPECTED_FILES = {
@@ -153,14 +156,36 @@ def verify_site(site: Path) -> None:
         fail("every primary installer link must be live-manifest addressable")
     if index.count('data-build-label') != 2:
         fail("current build provenance must appear at both download decisions")
+    if index.count('data-release-link') != 3:
+        fail("release details must switch channels with every download decision")
+    for attribute in (
+        'data-release-kind',
+        'data-release-section',
+        'data-install-guidance',
+        'data-release-caption',
+    ):
+        if index.count(attribute) != 1:
+            fail(f"index must expose exactly one {attribute} target")
     if index.count(RELEASE_URL) < 3:
         fail("release notes must be available near downloads and in the footer")
     if THIN_INSTALLER_PATTERN.search(index):
         fail("human-facing pages must not require architecture selection")
-    if RELEASE_API_URL not in script or UNIVERSAL_INSTALLER_URL not in script:
-        fail("live release metadata must use the public tester contract")
-    if 'cache: "no-store"' not in script or "readCurrentRelease" not in script:
-        fail("live release metadata must be freshly fetched and validated")
+    if STABLE_RELEASE_API_URL not in script or TESTER_RELEASE_API_URL not in script:
+        fail("live release metadata must prefer stable and retain tester fallback releases")
+    if UNIVERSAL_INSTALLER_URL.rsplit("/", 1)[-1] not in script:
+        fail("live release metadata must require the universal installer")
+    required_script_contracts = (
+        'cache: "no-store"',
+        'credentials: "omit"',
+        "readCurrentRelease",
+        'manifestName: "latest-stable-build.json"',
+        'manifestName: "latest-tester-build.json"',
+        "Developer ID signed, notarized by Apple, and stapled",
+        "ad-hoc signed and not Apple-notarized.",
+        "uploadedAsset(",
+    )
+    if any(contract not in script for contract in required_script_contracts):
+        fail("live release metadata must be freshly fetched and fail-closed validated")
 
     for _, reference in CSS_URL_PATTERN.findall(css):
         local_path = local_asset_path(site, site / "static/cowork.css", reference)

--- a/website/index.html
+++ b/website/index.html
@@ -18,7 +18,7 @@
   <meta name="twitter:description" content="A native AI coworker for research, reports, spreadsheets, and recurring office work.">
   <meta name="twitter:image" content="https://cowork.quillos.cloud/static/media/quill-cowork-desktop.png">
   <link rel="stylesheet" href="/static/cowork.css?v=2">
-  <script src="/static/site.js?v=1" defer></script>
+  <script src="/static/site.js?v=2" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -56,9 +56,9 @@
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v12m0 0 5-5m-5 5-5-5M5 21h14"></path></svg>
             Download for Mac
           </a>
-          <a class="text-link" href="https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest">Release notes and checksums</a>
+          <a class="text-link" data-release-link href="https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest">Release notes and checksums</a>
         </div>
-        <p class="download-note">Free tester build &middot; <span data-build-label>Latest tester release</span> &middot; macOS 14+ &middot; Apple silicon and Intel</p>
+        <p class="download-note"><span data-release-kind>Free tester build</span> &middot; <span data-build-label>Latest tester release</span> &middot; macOS 14+ &middot; Apple silicon and Intel</p>
       </div>
     </section>
 
@@ -133,7 +133,7 @@
         </div>
         <figure class="product-figure">
           <img src="/static/media/quill-cowork-desktop.png" width="1920" height="1350" alt="Quill Cowork native Mac workspace showing tasks, files, tools, and review controls" loading="lazy" decoding="async">
-          <figcaption>The current macOS tester build. The same workspace handles documents, research, browser tasks, and technical work.</figcaption>
+          <figcaption data-release-caption>The current macOS tester build. The same workspace handles documents, research, browser tasks, and technical work.</figcaption>
         </figure>
       </div>
     </section>
@@ -164,7 +164,7 @@
     <section class="download-section section-band" id="download">
       <div class="site-shell download-layout">
         <div>
-          <p class="eyebrow">Tester release</p>
+          <p class="eyebrow" data-release-section>Tester release</p>
           <h2>Give Quill its first task.</h2>
           <p>Download the Mac app, choose a folder, and describe the result you want.</p>
         </div>
@@ -173,8 +173,8 @@
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v12m0 0 5-5m-5 5-5-5M5 21h14"></path></svg>
             Download for Mac
           </a>
-          <a class="text-link" href="https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest">Release notes, checksums, and CLI downloads</a>
-          <p><span data-build-label>Latest tester release</span>. One installer runs natively on Apple silicon and Intel Macs. After moving the app to Applications, Control-click it and choose Open on first launch. The tester channel is not Apple-notarized yet.</p>
+          <a class="text-link" data-release-link href="https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest">Release notes, checksums, and CLI downloads</a>
+          <p><span data-build-label>Latest tester release</span>. <span data-install-guidance>One installer runs natively on Apple silicon and Intel Macs. After moving the app to Applications, Control-click it and choose Open on first launch. The tester channel is not Apple-notarized yet.</span></p>
         </div>
       </div>
     </section>
@@ -197,7 +197,7 @@
       </div>
       <nav aria-label="Footer navigation">
         <a href="https://trustedrouter.com">TrustedRouter</a>
-        <a href="https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest">Releases</a>
+        <a data-release-link href="https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest">Releases</a>
         <a href="https://github.com/Lore-Hex/QuillCode">For developers</a>
         <a href="mailto:help@trustedrouter.com">Help</a>
       </nav>

--- a/website/static/site.js
+++ b/website/static/site.js
@@ -1,74 +1,155 @@
 (() => {
   "use strict";
 
-  const releaseAPIURL =
-    "https://api.github.com/repos/Lore-Hex/QuillCode/releases/tags/tester-latest";
-  const installerURL =
-    "https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg";
+  const repositoryURL = "https://github.com/Lore-Hex/QuillCode";
+  const installerName = "Quill-Cowork-macOS-universal.dmg";
+  const feeds = [
+    {
+      apiURL: "https://api.github.com/repos/Lore-Hex/QuillCode/releases/latest",
+      channel: "stable",
+      manifestName: "latest-stable-build.json",
+    },
+    {
+      apiURL:
+        "https://api.github.com/repos/Lore-Hex/QuillCode/releases/tags/tester-latest",
+      channel: "tester",
+      manifestName: "latest-tester-build.json",
+    },
+  ];
 
-  function readCurrentRelease(release) {
+  function uploadedAsset(release, name, expectedURL) {
+    const matches = Array.isArray(release?.assets)
+      ? release.assets.filter((asset) => asset?.name === name)
+      : [];
+    const asset = matches.length === 1 ? matches[0] : null;
     if (
-      !release ||
-      release.name !== "Quill Cowork Tester Build" ||
-      release.tag_name !== "tester-latest" ||
-      release.draft !== false ||
-      release.prerelease !== true ||
-      !/^[0-9a-f]{40}$/.test(release.target_commitish) ||
-      !Array.isArray(release.assets)
+      asset?.state !== "uploaded" ||
+      asset?.browser_download_url !== expectedURL ||
+      !/^sha256:[0-9a-f]{64}$/.test(asset?.digest) ||
+      !Number.isSafeInteger(asset?.size) ||
+      asset.size <= 0
     ) {
       return null;
     }
+    return asset;
+  }
 
-    const installers = release.assets.filter(
-      (asset) => asset?.name === "Quill-Cowork-macOS-universal.dmg",
+  function readCurrentRelease(release, feed) {
+    const tag = release?.tag_name;
+    const stableTag = /^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag);
+    const expectedTag = feed.channel === "stable" ? stableTag : tag === "tester-latest";
+    const expectedName = feed.channel === "stable"
+      ? `Quill Cowork ${tag}`
+      : "Quill Cowork Tester Build";
+    const expectedPrerelease = feed.channel === "tester";
+    const releaseURL = `${repositoryURL}/releases/tag/${tag}`;
+    const assetBaseURL = `${repositoryURL}/releases/download/${tag}`;
+    const installer = uploadedAsset(
+      release,
+      installerName,
+      `${assetBaseURL}/${installerName}`,
     );
-    const installer = installers.length === 1 ? installers[0] : null;
+    const manifest = uploadedAsset(
+      release,
+      feed.manifestName,
+      `${assetBaseURL}/${feed.manifestName}`,
+    );
+    const expectedSigningCopy = feed.channel === "stable"
+      ? "Developer ID signed, notarized by Apple, and stapled for normal first launch."
+      : "ad-hoc signed and not Apple-notarized.";
+    const updatedAt = new Date(release?.updated_at);
+
     if (
+      !expectedTag ||
+      release?.name !== expectedName ||
+      release?.html_url !== releaseURL ||
+      release?.draft !== false ||
+      release?.prerelease !== expectedPrerelease ||
+      !/^[0-9a-f]{40}$/.test(release?.target_commitish) ||
+      !release?.body?.includes(expectedSigningCopy) ||
       !installer ||
-      installer.state !== "uploaded" ||
-      installer.browser_download_url !== installerURL ||
-      !/^sha256:[0-9a-f]{64}$/.test(installer.digest) ||
-      !Number.isSafeInteger(installer.size) ||
-      installer.size <= 0
+      !manifest ||
+      !Number.isFinite(updatedAt.getTime())
     ) {
       return null;
     }
 
-    const updatedAt = new Date(release.updated_at);
-    if (!Number.isFinite(updatedAt.getTime())) {
-      return null;
-    }
-
+    const isStable = feed.channel === "stable";
     return {
+      caption: isStable
+        ? "The current notarized macOS release. The same workspace handles documents, research, browser tasks, and technical work."
+        : "The current macOS tester build. The same workspace handles documents, research, browser tasks, and technical work.",
+      channel: feed.channel,
+      commit: release.target_commitish,
+      installerURL: installer.browser_download_url,
+      installGuidance: isStable
+        ? "One notarized installer runs natively on Apple silicon and Intel Macs. Move Quill Cowork to Applications, then open it normally."
+        : "One installer runs natively on Apple silicon and Intel Macs. After moving the app to Applications, Control-click it and choose Open on first launch. The tester channel is not Apple-notarized yet.",
       label: `Updated ${updatedAt.toLocaleDateString("en-US", {
         day: "numeric",
         month: "short",
         year: "numeric",
       })}`,
-      installerURL: installer.browser_download_url,
+      releaseKind: isStable ? "Stable release" : "Free tester build",
+      releaseSection: isStable ? "Stable release" : "Tester release",
+      releaseURL,
     };
   }
 
-  fetch(releaseAPIURL, {
-    cache: "no-store",
-    headers: { Accept: "application/vnd.github+json" },
-  })
-    .then((response) => (response.ok ? response.json() : null))
-    .then(readCurrentRelease)
-    .then((build) => {
-      if (!build) {
-        return;
+  async function fetchRelease(feed) {
+    try {
+      const response = await fetch(feed.apiURL, {
+        cache: "no-store",
+        credentials: "omit",
+        headers: { Accept: "application/vnd.github+json" },
+        referrerPolicy: "no-referrer",
+      });
+      if (!response.ok) {
+        return null;
       }
+      return readCurrentRelease(await response.json(), feed);
+    } catch {
+      return null;
+    }
+  }
 
-      document.querySelectorAll("[data-download-link]").forEach((link) => {
-        link.href = build.installerURL;
-      });
-      document.querySelectorAll("[data-build-label]").forEach((label) => {
-        label.textContent = build.label;
-      });
-      document.documentElement.dataset.release = "current";
-    })
-    .catch(() => {
-      // Static download links remain complete when live release metadata is unavailable.
+  async function preferredRelease() {
+    for (const feed of feeds) {
+      const release = await fetchRelease(feed);
+      if (release) {
+        return release;
+      }
+    }
+    return null;
+  }
+
+  preferredRelease().then((release) => {
+    if (!release) {
+      return;
+    }
+
+    document.querySelectorAll("[data-download-link]").forEach((link) => {
+      link.href = release.installerURL;
     });
+    document.querySelectorAll("[data-release-link]").forEach((link) => {
+      link.href = release.releaseURL;
+    });
+    document.querySelectorAll("[data-build-label]").forEach((label) => {
+      label.textContent = release.label;
+    });
+    document.querySelectorAll("[data-release-kind]").forEach((label) => {
+      label.textContent = release.releaseKind;
+    });
+    document.querySelectorAll("[data-release-section]").forEach((label) => {
+      label.textContent = release.releaseSection;
+    });
+    document.querySelectorAll("[data-install-guidance]").forEach((label) => {
+      label.textContent = release.installGuidance;
+    });
+    document.querySelectorAll("[data-release-caption]").forEach((label) => {
+      label.textContent = release.caption;
+    });
+    document.documentElement.dataset.release = release.channel;
+    document.documentElement.dataset.commit = release.commit;
+  });
 })();


### PR DESCRIPTION
## Summary
- prefer a validated stable GitHub release on the public site
- fall back atomically to the current tester channel and its Gatekeeper guidance
- keep the no-JavaScript tester installer as a known-good fallback

## Verification
- node Tests/ScriptTests/test_website_js.mjs
- python3 -m unittest Tests.ScriptTests.test_website
- python3 scripts/verify-website.py --site /private/tmp/quill-cowork-website-stable-first
- swift test (6397 tests, 5 skipped, 0 failures)
- desktop and 390x844 browser QA against the live GitHub API