### PR TITLE
Dispatch website after merge-train merges

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -43,5 +43,5 @@ jobs:
           MERGE_TRAIN_DELETE_BRANCH: "true"
           MERGE_TRAIN_UPDATE_BEHIND_BRANCHES: "false"
           MERGE_TRAIN_IGNORED_CHECK_RE: "^(Merge Train|train)$"
-          MERGE_TRAIN_POST_MERGE_WORKFLOWS: ci.yml download-builds.yml
+          MERGE_TRAIN_POST_MERGE_WORKFLOWS: ci.yml download-builds.yml website.yml
         run: ./scripts/merge-train.sh

--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -589,14 +589,17 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
         )
         let docs = try Self.docsText(named: "MERGE_TRAIN.md")
 
-        Self.assertSource(workflow, contains: "MERGE_TRAIN_POST_MERGE_WORKFLOWS: ci.yml download-builds.yml")
+        Self.assertSource(
+            workflow,
+            contains: "MERGE_TRAIN_POST_MERGE_WORKFLOWS: ci.yml download-builds.yml website.yml"
+        )
         Self.assertSource(script, containsAll: [
             "MERGE_TRAIN_POST_MERGE_WORKFLOWS",
             "MERGE_TRAIN_POST_MERGE_WORKFLOW",
             "gh workflow run \"$post_merge_workflow\" --repo \"$repo\" --ref \"$base_branch\""
         ])
         Self.assertSource(docs, containsAll: [
-            "`CI` and `Download Builds` workflows",
+            "`CI`, `Download Builds`, and `Website` workflows",
             "refreshes the `tester-latest` download release"
         ])
     }

--- a/Tests/QuillCodeParityTests/ParityMergeTrainGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityMergeTrainGateTests.swift
@@ -21,13 +21,14 @@ final class ParityMergeTrainGateTests: QuillCodeParityTestCase {
     func testMergedPullRequestDispatchesAllConfiguredPostMergeWorkflows() throws {
         let result = try runMergeTrain(
             pullRequestJSON: readyCleanPullRequestJSON,
-            postMergeWorkflows: "ci.yml download-builds.yml"
+            postMergeWorkflows: "ci.yml download-builds.yml website.yml"
         )
 
         XCTAssertEqual(result.exitCode, 0, result.output)
         XCTAssertTrue(result.ghLog.contains("pr merge 42 --repo Lore-Hex/QuillCode --squash --delete-branch"))
         XCTAssertTrue(result.ghLog.contains("workflow run ci.yml --repo Lore-Hex/QuillCode --ref main"))
         XCTAssertTrue(result.ghLog.contains("workflow run download-builds.yml --repo Lore-Hex/QuillCode --ref main"))
+        XCTAssertTrue(result.ghLog.contains("workflow run website.yml --repo Lore-Hex/QuillCode --ref main"))
     }
 
     private struct MergeTrainResult {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2092,9 +2092,9 @@
   dumps, and unsafe paths so Codex-like "show me the system state" questions run immediately without making vague
   diagnostic wording an arbitrary shell approval.
 - Merge-train merges use GitHub Actions' `GITHUB_TOKEN`, so GitHub does not enqueue normal push-triggered
-  workflows afterward. The train therefore dispatches both `ci.yml` and `download-builds.yml` explicitly after a
-  successful merge. This keeps `main` validated and refreshes `tester-latest` without requiring a maintainer to
-  remember a manual tester-build run after agent PRs land.
+  workflows afterward. The train therefore dispatches `ci.yml`, `download-builds.yml`, and `website.yml` explicitly
+  after a successful merge. This keeps `main` validated, refreshes `tester-latest`, and publishes website changes
+  without requiring a maintainer to remember manual post-merge runs after agent PRs land.
 - Download-build runs serialize instead of canceling an in-progress run. A delayed scheduled run can otherwise arrive
   after both platform packages finish and cancel the publisher while it is fetching the repository, leaving valid
   artifacts without an updated `tester-latest` release. Serial execution favors a complete release over a newer run

--- a/docs/MERGE_TRAIN.md
+++ b/docs/MERGE_TRAIN.md
@@ -20,7 +20,7 @@ The train processes only the oldest eligible PR at a time. It ignores draft PRs 
 - Only one train run can execute at a time.
 
 When the train head is ready, it merges with a squash merge and deletes the source branch.
-After a successful merge, the train dispatches the `CI` and `Download Builds` workflows on `main` explicitly. GitHub does not automatically create normal push-triggered runs for merges performed with `GITHUB_TOKEN`, so this keeps the latest `main` state visibly validated in Actions and refreshes the `tester-latest` download release for early users.
+After a successful merge, the train dispatches the `CI`, `Download Builds`, and `Website` workflows on `main` explicitly. GitHub does not automatically create normal push-triggered runs for merges performed with `GITHUB_TOKEN`, so this keeps the latest `main` state visibly validated in Actions, refreshes the `tester-latest` download release for early users, and publishes website changes.
 
 The train intentionally does not update behind PR branches by default. Branch updates made by GitHub Actions' `GITHUB_TOKEN` do not reliably create normal `pull_request` CI checks, which can leave the PR with no completed checks for the train to trust. `MERGE_TRAIN_UPDATE_BEHIND_BRANCHES=true` is available only for installations using a token that can trigger the required PR checks.
 


### PR DESCRIPTION
## Summary
- dispatch website.yml after every merge-train merge
- preserve exact-main CI and download-build dispatches
- lock the three-workflow contract into parity tests and operator docs

## Verification
- swift test --filter ParityMergeTrainGateTests (3 tests, 0 failures)
- swift test --filter ParityDownloadBuildsGateTests (6 tests, 0 failures)
- git diff --check
- deterministic quality grader: affected modules A+