### PR TITLE
Avoid duplicate desktop credential lookup

### DIFF
--- a/Sources/QuillCodeApp/RuntimeFactory.swift
+++ b/Sources/QuillCodeApp/RuntimeFactory.swift
@@ -19,6 +19,7 @@ public struct QuillCodeRuntime: Sendable {
     public var contextSummaryGenerator: any WorkspaceContextSummaryGenerating
     public var mode: QuillCodeRuntimeMode
     public var statusLabel: String
+    public var trustedRouterAPIKeyConfigured: Bool
     /// The retry decorator records here when it self-heals a transient blip; the model drains it into
     /// a "Self-healing" thread notice. nil for the mock runtime (which never retries).
     public var retryChannel: RetryEventChannel?
@@ -29,12 +30,14 @@ public struct QuillCodeRuntime: Sendable {
             DeterministicWorkspaceContextSummaryGenerator(),
         mode: QuillCodeRuntimeMode,
         statusLabel: String,
+        trustedRouterAPIKeyConfigured: Bool = false,
         retryChannel: RetryEventChannel? = nil
     ) {
         self.runner = runner
         self.contextSummaryGenerator = contextSummaryGenerator
         self.mode = mode
         self.statusLabel = statusLabel
+        self.trustedRouterAPIKeyConfigured = trustedRouterAPIKeyConfigured
         self.retryChannel = retryChannel
     }
 }
@@ -44,22 +47,28 @@ public struct QuillCodeRuntimeFactory: Sendable {
     public var environment: [String: String]
     public var modelCatalogURLSession: URLSession
     public var accountCreditsURLSession: URLSession
+    private var secretStore: (any QuillSecretStore)?
 
     public init(
         paths: QuillCodePaths = QuillCodePaths(),
         environment: [String: String] = ProcessInfo.processInfo.environment,
         modelCatalogURLSession: URLSession = .shared,
-        accountCreditsURLSession: URLSession? = nil
+        accountCreditsURLSession: URLSession? = nil,
+        secretStore: (any QuillSecretStore)? = nil
     ) {
         self.paths = paths
         self.environment = environment
         self.modelCatalogURLSession = modelCatalogURLSession
         self.accountCreditsURLSession = accountCreditsURLSession ?? modelCatalogURLSession
+        self.secretStore = secretStore
     }
 
     public func makeRuntime(config: AppConfig) -> QuillCodeRuntime {
         if forcedMock {
-            return mockRuntime(status: QuillCodeRuntimeStatusLabel.mockLLM)
+            return mockRuntime(
+                status: QuillCodeRuntimeStatusLabel.mockLLM,
+                trustedRouterAPIKeyConfigured: hasTrustedRouterAPIKey()
+            )
         }
 
         let sessionStore = sessionStore()
@@ -67,9 +76,15 @@ public struct QuillCodeRuntimeFactory: Sendable {
         guard apiKey != nil || sessionStore.hasAPIKey else {
             switch config.authMode {
             case .oauth:
-                return mockRuntime(status: QuillCodeRuntimeStatusLabel.signInWithTrustedRouter)
+                return mockRuntime(
+                    status: QuillCodeRuntimeStatusLabel.signInWithTrustedRouter,
+                    trustedRouterAPIKeyConfigured: false
+                )
             case .developerOverride:
-                return mockRuntime(status: QuillCodeRuntimeStatusLabel.developerKeyNeeded)
+                return mockRuntime(
+                    status: QuillCodeRuntimeStatusLabel.developerKeyNeeded,
+                    trustedRouterAPIKeyConfigured: false
+                )
             }
         }
 
@@ -175,6 +190,7 @@ public struct QuillCodeRuntimeFactory: Sendable {
             statusLabel: config.authMode == .oauth
                 ? QuillCodeRuntimeStatusLabel.trustedRouterSignedIn
                 : QuillCodeRuntimeStatusLabel.trustedRouterReady,
+            trustedRouterAPIKeyConfigured: true,
             retryChannel: retryChannel
         )
     }
@@ -252,17 +268,21 @@ public struct QuillCodeRuntimeFactory: Sendable {
 
     private func sessionStore() -> SecretTrustedRouterSessionStore {
         SecretTrustedRouterSessionStore(
-            secretStore: QuillSecretStoreFactory.make(for: paths),
+            secretStore: secretStore ?? QuillSecretStoreFactory.make(for: paths),
             key: QuillSecretKeys.trustedRouterAPIKey
         )
     }
 
-    private func mockRuntime(status: String) -> QuillCodeRuntime {
+    private func mockRuntime(
+        status: String,
+        trustedRouterAPIKeyConfigured: Bool
+    ) -> QuillCodeRuntime {
         QuillCodeRuntime(
             runner: AgentRunner(),
             contextSummaryGenerator: DeterministicWorkspaceContextSummaryGenerator(),
             mode: .mock,
-            statusLabel: status
+            statusLabel: status,
+            trustedRouterAPIKeyConfigured: trustedRouterAPIKeyConfigured
         )
     }
 }

--- a/Sources/QuillCodeApp/WorkspaceBootstrap.swift
+++ b/Sources/QuillCodeApp/WorkspaceBootstrap.swift
@@ -155,7 +155,7 @@ public struct QuillCodeWorkspaceBootstrap: Sendable {
                     } ?? config.mode,
                     agentStatus: runtime.statusLabel
                 ),
-                trustedRouterAPIKeyConfigured: runtimeFactory.hasTrustedRouterAPIKey()
+                trustedRouterAPIKeyConfigured: runtime.trustedRouterAPIKeyConfigured
             ),
             automations: AutomationsState(items: automations),
             sidebarSavedSearches: sidebarSavedSearches,

--- a/Sources/quill-code-desktop/QuillCodeDesktopSettingsCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSettingsCoordinator.swift
@@ -173,10 +173,11 @@ struct QuillCodeDesktopSettingsCoordinator {
         for config: AppConfig,
         persistedKinds: Set<WorkspaceSettingsPersistenceKind>
     ) -> QuillCodeDesktopSettingsResult {
+        let runtime = bootstrap.makeRuntime(config: config)
         return QuillCodeDesktopSettingsResult(
             config: config,
-            runtime: bootstrap.makeRuntime(config: config),
-            trustedRouterAPIKeyConfigured: bootstrap.hasTrustedRouterAPIKey(),
+            runtime: runtime,
+            trustedRouterAPIKeyConfigured: runtime.trustedRouterAPIKeyConfigured,
             persistedKinds: persistedKinds
         )
     }

--- a/Tests/QuillCodeAppTests/WorkspaceRuntimeFactoryTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceRuntimeFactoryTests.swift
@@ -24,7 +24,30 @@ final class WorkspaceRuntimeFactoryTests: XCTestCase {
 
         XCTAssertEqual(runtime.mode, .trustedRouter)
         XCTAssertEqual(runtime.statusLabel, QuillCodeRuntimeStatusLabel.trustedRouterSignedIn)
+        XCTAssertTrue(runtime.trustedRouterAPIKeyConfigured)
         XCTAssertTrue(runtime.contextSummaryGenerator.isModelBacked)
+    }
+
+    @MainActor
+    func testWorkspaceBootstrapResolvesStoredCredentialOnce() throws {
+        let paths = QuillCodePaths(home: try makeQuillCodeTestDirectory())
+        try paths.ensure()
+        let secretStore = CountingRuntimeFactorySecretStore(value: "sk-test")
+        let runtimeFactory = QuillCodeRuntimeFactory(
+            paths: paths,
+            environment: [
+                "QUILLCODE_API_KEY_FILE": paths.home.appendingPathComponent("missing.key").path
+            ],
+            secretStore: secretStore
+        )
+
+        let model = try QuillCodeWorkspaceBootstrap(
+            paths: paths,
+            runtimeFactory: runtimeFactory
+        ).makeModel(automaticStartupPolicy: .deferUntilRequested)
+
+        XCTAssertTrue(model.root.trustedRouterAPIKeyConfigured)
+        XCTAssertEqual(secretStore.readCount, 1)
     }
 
     func testEnvironmentKeyCountsAsTrustedRouterCatalogCredential() throws {
@@ -85,6 +108,7 @@ final class WorkspaceRuntimeFactoryTests: XCTestCase {
 
         XCTAssertEqual(runtime.mode, .mock)
         XCTAssertEqual(runtime.statusLabel, QuillCodeRuntimeStatusLabel.mockLLM)
+        XCTAssertTrue(runtime.trustedRouterAPIKeyConfigured)
         XCTAssertFalse(runtime.contextSummaryGenerator.isModelBacked)
         XCTAssertTrue(runtimeFactory.hasTrustedRouterAPIKey())
     }
@@ -178,6 +202,31 @@ final class WorkspaceRuntimeFactoryTests: XCTestCase {
         XCTAssertEqual(missingCredential, .unavailable)
         XCTAssertEqual(forcedMock, .unavailable)
     }
+}
+
+private final class CountingRuntimeFactorySecretStore: QuillSecretStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private let value: String?
+    private var reads = 0
+
+    init(value: String?) {
+        self.value = value
+    }
+
+    var readCount: Int {
+        lock.withLock { reads }
+    }
+
+    func read(_ key: String) throws -> String? {
+        lock.withLock {
+            reads += 1
+            return value
+        }
+    }
+
+    func write(_ value: String, for key: String) throws {}
+
+    func delete(_ key: String) throws {}
 }
 
 private final class RuntimeFactoryCatalogURLProtocol: URLProtocol {

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,31 @@
 # Code Quality Audit
 
+## 2026-08-14 Single-Resolution Desktop Credential Startup
+
+Overall grade: **A+ launch discipline, A+ credential safety, A+ state consistency**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Pre-window work | A+ | Returning-user bootstrap resolves the TrustedRouter credential once and reuses that non-secret presence result for initial account UI instead of issuing a second Keychain query. |
+| Settings responsiveness | A+ | A settings apply constructs one runtime and projects its matching credential state without immediately rereading the credential source. |
+| Secret handling | A+ | Only a boolean presence result enters runtime and workspace state; key material remains inside the existing environment, file, or platform secret-store path. |
+| Freshness | A+ | Catalog and account-credit operations continue to resolve the current credential independently after startup, so user-driven credential changes are not hidden behind a process-lifetime cache. |
+| Compatibility | A+ | Environment, key-file, file-store, Keychain migration, missing-key, OAuth, developer override, and forced-mock behavior retain their prior status and onboarding semantics. |
+| Regression evidence | A+ | An injected counting store proves a stored credential is read exactly once during workspace bootstrap; runtime and desktop settings suites cover construction and refresh behavior. |
+
+Validation:
+
+- `swift test` (6,398 tests; 5 intentional skips; 0 failures)
+- Focused runtime factory and desktop settings suites (13 tests; 0 failures)
+- Release-configured packaged macOS smoke, including draft and agent-run SIGKILL recovery, direct
+  and Launch Services rendering, native Accessibility interaction, and critical memory pressure
+- 100-chat daily-driver sample: 290.99 ms launch-ready, 40.84 MiB initial physical footprint,
+  74.89 MiB after the first interaction sweep, 79.24 MiB after repetition, six settled threads,
+  and 0.0002% settled idle CPU
+- Full-resolution visual review found no sidebar, transcript, top-bar, or composer overlap
+- Deterministic quality grades: changed production files 97-100/A+, changed test file 98/A+;
+  all affected source and test modules 99/A+
+
 ## 2026-08-13 Durable Updater Activation Recovery
 
 Overall grade after this slice: **A+ crash resilience, A+ rollback safety, A+ cleanup discipline**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # QuillCode Decisions
 
+## 2026-08-14: runtime construction owns its credential-state result
+
+- **Decision:** A runtime carries the credential-presence state resolved while that runtime was
+  constructed. Initial workspace bootstrap and desktop settings refresh project that result instead
+  of querying the TrustedRouter credential source again.
+- **Launch boundary:** A signed returning-user launch now performs one Keychain credential read before
+  the first window instead of two. Environment, key-file, legacy file-store, forced-mock, and missing-
+  credential paths retain their existing runtime and onboarding behavior.
+- **Freshness boundary:** Explicit model-catalog and account-credit refreshes still resolve current
+  credential state when they run after startup. The optimization removes only same-operation duplicate
+  reads; it does not cache credentials across user actions or place secret material in application state.
+- **Evidence:** An injected counting secret store proves workspace bootstrap performs exactly one
+  credential read and publishes the matching root state. Runtime-factory and desktop-settings tests
+  cover configured, missing, key-file, stored, and forced-mock paths.
+
 ## 2026-08-14: repeated thread growth uses a prior settled high-water
 
 - **Decision:** Performance evidence keeps the raw repeated-minus-first-sweep thread delta for


### PR DESCRIPTION
## Summary

- Resolve TrustedRouter credential presence once during runtime construction and reuse the non-secret result during first-window bootstrap.
- Reuse the same runtime state after settings writes while keeping later catalog and account-credit checks fresh.
- Add a counting secret-store regression plus architecture and quality evidence.

## Verification

- `swift test`: 6,398 tests, 5 intentional skips, 0 failures.
- Focused runtime, settings, and architecture suites: 26 tests, 0 failures.
- Release-configured packaged macOS smoke passed draft and agent-run SIGKILL recovery, direct and Launch Services rendering, native Accessibility interaction, and critical memory pressure.
- 100-chat daily-driver: 290.99 ms launch-ready, 40.84 MiB initial, 74.89 MiB after the first sweep, 79.24 MiB after repetition, six settled threads, 0.0002% idle CPU.
- Full-resolution screenshot review found no sidebar, transcript, top-bar, or composer overlap.
- Changed production files grade 97-100/A+; affected modules grade 99/A+.

## Checklist

- [x] The change is focused and follows nearby architecture and ownership patterns.
- [x] Changed behavior has risk-appropriate tests.
- [x] User-facing UI was checked for keyboard, accessibility, compact-window, and failure states.
- [x] No credentials, private source code, transcripts, workspace paths, or customer data are included.
- [x] Release, updater, dependency, or workflow changes include their contract-level verification.