### PR TITLE
Expose exact tester build identity

### DIFF
--- a/.github/workflows/download-builds.yml
+++ b/.github/workflows/download-builds.yml
@@ -381,7 +381,6 @@ jobs:
             RELEASE_CHANNEL="stable"
           else
             RELEASE_TAG="tester-latest"
-            RELEASE_TITLE="Quill Cowork Tester Build"
             RELEASE_CHANNEL="tester"
           fi
           scripts/build-release-notes.py \

--- a/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPublishedReleaseVerificationGateTests.swift
@@ -372,6 +372,22 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         XCTAssertTrue(tagResult.output.contains("release tag resolves to"), tagResult.output)
     }
 
+    func testVerifierRejectsReleaseNameThatDisagreesWithManifestIdentity() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        var release = try jsonObject(at: fixture.releaseJSON)
+        release["name"] = "Quill Cowork Tester 0.2.0 (124)"
+        try writeJSON(release, to: fixture.releaseJSON)
+
+        let result = try runVerifier(fixture)
+
+        XCTAssertEqual(result.exitCode, 2, result.output)
+        XCTAssertTrue(
+            result.output.contains("release name does not match the manifest identity"),
+            result.output
+        )
+    }
+
     func testVerifierRejectsAppArchiveCommitDriftAfterIntegrityChecksPass() throws {
         let fixture = try makeFixture(appCommit: String(repeating: "b", count: 40))
         defer { try? FileManager.default.removeItem(at: fixture.root) }
@@ -744,6 +760,9 @@ final class ParityPublishedReleaseVerificationGateTests: QuillCodeParityTestCase
         let release: [String: Any] = [
             "id": 12_345,
             "tag_name": releaseTag,
+            "name": channel == "stable"
+                ? "Quill Cowork \(releaseTag)"
+                : "Quill Cowork Tester 0.2.0 (123)",
             "draft": false,
             "prerelease": prerelease ?? (channel == "tester"),
             "assets": releaseAssets

--- a/Tests/QuillCodeParityTests/ParityTransactionalTesterPublicationTests.swift
+++ b/Tests/QuillCodeParityTests/ParityTransactionalTesterPublicationTests.swift
@@ -12,7 +12,7 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
         XCTAssertEqual(result.state["tag"] as? String, newCommit)
         let release = try release(from: result.state)
         XCTAssertEqual(release["target_commitish"] as? String, newCommit)
-        XCTAssertEqual(release["name"] as? String, "Quill Cowork Tester Build")
+        XCTAssertEqual(release["name"] as? String, "Quill Cowork Tester 0.1.0 (772)")
         XCTAssertEqual(release["body"] as? String, "New release notes\n")
         XCTAssertEqual(release["draft"] as? Bool, false)
         XCTAssertEqual(release["prerelease"] as? Bool, true)
@@ -191,6 +191,27 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
         XCTAssertEqual(result.state["tag"] as? String, oldCommit)
     }
 
+    func testInvalidManifestIdentityFailsBeforeGitHubMutation() throws {
+        let result = try runPublisher(manifestBuild: "latest")
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(
+            result.output.contains("Tester manifest build must be a positive canonical integer"),
+            result.output
+        )
+        XCTAssertEqual(result.state["operations"] as? [String], [])
+        XCTAssertEqual(result.state["tag"] as? String, oldCommit)
+    }
+
+    func testNonUTF8ManifestFailsBeforeGitHubMutation() throws {
+        let result = try runPublisher(manifestEncoding: .utf16)
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.output.contains("Tester manifest must be valid UTF-8 JSON"), result.output)
+        XCTAssertEqual(result.state["operations"] as? [String], [])
+        XCTAssertEqual(result.state["tag"] as? String, oldCommit)
+    }
+
     private struct PublisherResult {
         var exitCode: Int32
         var output: String
@@ -200,7 +221,9 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
     private func runPublisher(
         failure: String? = nil,
         failureCount: Int = 1,
-        commit: String? = nil
+        commit: String? = nil,
+        manifestBuild: String = "772",
+        manifestEncoding: String.Encoding = .utf8
     ) throws -> PublisherResult {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("quillcode-transactional-publication-tests")
@@ -216,7 +239,24 @@ final class ParityTransactionalTesterPublicationTests: QuillCodeParityTestCase {
         try Data("new app".utf8).write(
             to: assetsDirectory.appendingPathComponent("Quill-Cowork-macOS-arm64.zip")
         )
-        try Data(#"{"build":"new"}"#.utf8).write(
+        let manifest: [String: Any] = [
+            "schemaVersion": 1,
+            "product": "Quill Cowork",
+            "channel": "tester",
+            "tag": "tester-latest",
+            "releaseURL": "https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest",
+            "commit": newCommit,
+            "version": "0.1.0",
+            "build": manifestBuild,
+            "workflowRunURL": "https://github.com/Lore-Hex/QuillCode/actions/runs/1234"
+        ]
+        let manifestData = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        let manifestString = String(decoding: manifestData, as: UTF8.self) + "\n"
+        let encodedManifest = try XCTUnwrap(manifestString.data(using: manifestEncoding))
+        try encodedManifest.write(
             to: assetsDirectory.appendingPathComponent("latest-tester-build.json")
         )
         try Data(#"{"withinBudget":true}"#.utf8).write(

--- a/Tests/ScriptTests/test_website_js.mjs
+++ b/Tests/ScriptTests/test_website_js.mjs
@@ -23,10 +23,13 @@ const testerReleaseURL = `${repositoryURL}/releases/tag/tester-latest`;
 function releaseFixture(channel, overrides = {}) {
   const isStable = channel === "stable";
   const version = isStable ? "1.2.3" : "0.1.0";
+  const build = "772";
   const tag = isStable ? `v${version}` : "tester-latest";
   const assetURL = (name) => `${repositoryURL}/releases/download/${tag}/${name}`;
   return {
-    name: isStable ? `Quill Cowork ${tag}` : "Quill Cowork Tester Build",
+    name: isStable
+      ? `Quill Cowork ${tag}`
+      : `Quill Cowork Tester ${version} (${build})`,
     tag_name: tag,
     html_url: `${repositoryURL}/releases/tag/${tag}`,
     draft: false,
@@ -136,7 +139,9 @@ assert.equal(
   stable.document.documentElement.dataset.commit,
   stableRelease.target_commitish,
 );
-assert.ok(stable.labels.every(({ textContent }) => textContent.startsWith("Updated ")));
+assert.equal(stable.document.documentElement.dataset.version, "1.2.3");
+assert.equal(stable.document.documentElement.dataset.build, undefined);
+assert.ok(stable.labels.every(({ textContent }) => textContent === "Version 1.2.3 · Updated Aug 13, 2026"));
 assert.ok(stable.releaseKinds.every(({ textContent }) => textContent === "Stable release"));
 assert.ok(stable.releaseSections.every(({ textContent }) => textContent === "Stable release"));
 assert.ok(stable.guidance.every(({ textContent }) => textContent.includes("notarized")));
@@ -158,6 +163,9 @@ assert.equal(
   tester.document.documentElement.dataset.commit,
   testerRelease.target_commitish,
 );
+assert.equal(tester.document.documentElement.dataset.version, "0.1.0");
+assert.equal(tester.document.documentElement.dataset.build, "772");
+assert.ok(tester.labels.every(({ textContent }) => textContent === "0.1.0 (772) · Updated Aug 13, 2026"));
 assert.ok(tester.releaseKinds.every(({ textContent }) => textContent === "Free tester build"));
 assert.ok(tester.guidance.every(({ textContent }) => textContent.includes("Control-click")));
 assert.ok(tester.downloadLinks.every(({ href }) => href === testerInstallerURL));
@@ -179,6 +187,16 @@ const assetFallback = await runSiteScript(new Map([
   [testerAPIURL, { body: testerRelease }],
 ]));
 assert.equal(assetFallback.document.documentElement.dataset.release, "tester");
+
+const malformedTesterTitle = releaseFixture("tester", {
+  name: "Quill Cowork Tester Build",
+});
+const titleFallback = await runSiteScript(new Map([
+  [stableAPIURL, { ok: false }],
+  [testerAPIURL, { body: malformedTesterTitle }],
+]));
+assert.equal(titleFallback.document.documentElement.dataset.release, undefined);
+assert.equal(titleFallback.document.documentElement.dataset.build, undefined);
 
 const unavailable = await runSiteScript(new Map([
   [stableAPIURL, new Error("offline")],

--- a/docs/CODE_QUALITY_AUDIT.md
+++ b/docs/CODE_QUALITY_AUDIT.md
@@ -1,5 +1,28 @@
 # Code Quality Audit
 
+## 2026-08-14 Manifest-Derived Public Release Identity
+
+Overall grade: **A+ publication safety, A+ supportability, A+ fallback behavior**.
+
+| Area | Grade | Notes |
+| --- | --- | --- |
+| Identity source | A+ | The tester publisher derives the exact release title from a bounded UTF-8 JSON manifest whose product, channel, tag, commit, repository URL, workflow run URL, semantic version, and positive build number are validated before mutation. |
+| Publication integrity | A+ | Initial and transactional publication require the dynamic title; post-publication verification independently recomputes the expected stable or tester title from the downloaded manifest. |
+| Rollback safety | A+ | A failed replacement restores the complete prior release snapshot, including its previous title, assets, metadata, and tag target. |
+| Public UX | A+ | The site shows exact version/build identity with the freshness date and exposes it as document metadata only after the full live release contract passes. |
+| Outage behavior | A+ | API errors, legacy titles, malformed identity, and other metadata drift leave the static universal tester download and correct Gatekeeper guidance intact. |
+| Regression evidence | A+ | Publisher and public-verifier parity cover valid identity, zero-mutation rejection, mismatch refusal, and rollback; browserless website tests cover stable, tester, legacy-title, asset, and network fallbacks. |
+
+Validation:
+
+- `swift test` (6,401 tests; 5 intentional skips; 0 failures)
+- Transactional publication and public release verification: 44 tests, 0 failures.
+- Download Builds workflow contract: 6 tests, 0 failures.
+- Website JavaScript and staged-site verifier: 6 tests, 0 failures.
+- Python script contracts: 123 tests, 0 failures.
+- Python compile validation passed for the publisher, publication modules, public verifier, and
+  website verifier.
+
 ## 2026-08-14 Single-Resolution Desktop Credential Startup
 
 Overall grade: **A+ launch discipline, A+ credential safety, A+ state consistency**.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,21 @@
 # QuillCode Decisions
 
+## 2026-08-14: public release identity follows the verified manifest
+
+- **Decision:** The moving tester release title is derived from the bounded, commit-pinned release
+  manifest as `Quill Cowork Tester <version> (<build>)`. The publisher validates the manifest identity
+  before its first GitHub mutation, and rollback preserves the previous release title with the rest
+  of the prior snapshot.
+- **Public verification:** Post-publication verification independently requires the GitHub release
+  name to match the manifest version and build. Stable releases retain the exact
+  `Quill Cowork v<version>` title contract.
+- **Website behavior:** The download page exposes the accepted version and tester build beside its
+  freshness date only after the release API, title, tag, immutable commit, manifest, installer, and
+  digest agree. Missing or malformed live metadata leaves the usable static tester download and its
+  non-notarized installation guidance unchanged.
+- **Why:** A moving release URL is convenient for ordinary testers, but support reports and daily-
+  driver evidence need an exact build identity that cannot drift away from the downloadable bytes.
+
 ## 2026-08-14: runtime construction owns its credential-state result
 
 - **Decision:** A runtime carries the credential-presence state resolved while that runtime was

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -14,14 +14,15 @@ reachable, the page first tries the latest stable release and accepts it only wh
 semantic version tag, immutable commit, non-prerelease state, generated Developer ID and notarization
 notice, release URL, stable manifest asset, and sole universal installer's URL, upload state, size,
 and SHA-256 digest all agree. Until a stable release exists, the same validation runs against the
-tester prerelease and its ad-hoc signing notice. Malformed, rate-limited, or unavailable metadata
-leaves the static tester link and Gatekeeper guidance intact. Download links, release-note links,
-freshness text, channel labels, screenshot copy, and install guidance switch as one update, so a
-stable download is never paired with tester instructions or provenance.
+tester prerelease, its exact semantic version and build number, and its ad-hoc signing notice.
+Malformed, rate-limited, or unavailable metadata leaves the static tester link and Gatekeeper
+guidance intact. Download links, release-note links, version/build freshness text, channel labels,
+screenshot copy, and install guidance switch as one update, so a stable download is never paired
+with tester instructions or provenance.
 
 Send technical testers this moving prerelease link for provenance and secondary artifacts:
 
-- [Quill Cowork Tester Build](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest)
+- [Quill Cowork Tester Release](https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest)
 
 Direct asset links for the current tester channel:
 
@@ -48,7 +49,9 @@ update behavior, signing status, and exact source/build provenance. Secondary
 CLI, updater, checksum, manifest, and performance assets remain available in a
 collapsed section. Publication fails before a release is edited when the page's
 channel, commit, version, build, platform, architecture, or signing claims do not
-match the packaged app.
+match the packaged app. The moving tester release title is derived from that same
+commit-pinned manifest as `Quill Cowork Tester <version> (<build>)`; publication and
+post-publication verification both require the title and manifest identity to agree.
 
 The build manifest is the app updater, website, and support script contract. It
 records the build channel, tag, commit, workflow run URL, version, build number,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -200,6 +200,11 @@
   `release not found` response retries only after the canonical release is independently visible.
   Cleanup deletion is idempotent across lost responses, and persistent outages stop after five
   attempts without beginning a mutation.
+- The moving tester release now carries an exact manifest-derived version/build title. Publication
+  rejects malformed or mismatched identity before GitHub mutation, the public verifier recomputes
+  that identity from downloaded evidence, and the website displays it beside freshness only after
+  the full release contract passes. API outages and legacy titles retain the static universal tester
+  download instead of advertising unverified metadata.
 - Structured JSON artifact previews now share one metadata-keyed document reader instead of mapping
   and parsing the same file independently for each candidate format. Successful and invalid parses
   are purgeable and bounded to four entries / 4 MiB estimated residency; same-key concurrent reads

--- a/scripts/publish-tester-release.py
+++ b/scripts/publish-tester-release.py
@@ -13,6 +13,7 @@ from tester_publication.contracts import (
     REPOSITORY_PATTERN,
     RUN_ID_PATTERN,
     load_local_assets,
+    load_tester_release_identity,
 )
 from tester_publication.publisher import TesterReleasePublisher
 
@@ -48,11 +49,19 @@ def main() -> int:
     except UnicodeDecodeError as error:
         raise PublicationError("Release notes must be UTF-8.") from error
 
+    assets = load_local_assets(arguments.assets_dir)
+    identity = load_tester_release_identity(
+        assets,
+        repository=arguments.repo,
+        commit=arguments.commit,
+        run_id=arguments.run_id,
+    )
     TesterReleasePublisher(
         repository=arguments.repo,
         commit=arguments.commit,
         run_id=arguments.run_id,
-        assets=load_local_assets(arguments.assets_dir),
+        assets=assets,
+        title=identity.title,
         notes=notes,
         notes_path=arguments.notes_file,
         retry_delay_seconds=arguments.retry_delay_seconds,

--- a/scripts/release_verification_contract.py
+++ b/scripts/release_verification_contract.py
@@ -204,6 +204,13 @@ def validate_manifest(
         raise VerificationError("manifest version/build metadata is not canonical")
     if channel == "stable" and tag != f"v{version}":
         raise VerificationError("stable release tag does not match the manifest version")
+    expected_release_name = (
+        f"Quill Cowork {tag}"
+        if channel == "stable"
+        else f"Quill Cowork Tester {version} ({build})"
+    )
+    if release.get("name") != expected_release_name:
+        raise VerificationError("GitHub release name does not match the manifest identity")
     generated_at = required_string(manifest.get("generatedAt"), "manifest generatedAt")
     timestamp_pattern = r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
     if not re.fullmatch(timestamp_pattern, generated_at):

--- a/scripts/tester_publication/contracts.py
+++ b/scripts/tester_publication/contracts.py
@@ -9,12 +9,17 @@ from typing import Any, Iterable
 
 
 TAG = "tester-latest"
-TITLE = "Quill Cowork Tester Build"
+TITLE_PREFIX = "Quill Cowork Tester"
 MANIFEST_NAME = "latest-tester-build.json"
+MANIFEST_MAXIMUM_BYTES = 1_048_576
 ASSET_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,179}")
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 RUN_ID_PATTERN = re.compile(r"[1-9][0-9]*")
+VERSION_PATTERN = re.compile(
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+)
+BUILD_PATTERN = re.compile(r"[1-9][0-9]*")
 TRANSACTION_ALIAS_PATTERN = re.compile(
     r"quill-cowork-(candidate|rollback)-([1-9][0-9]*)-(.+)"
 )
@@ -30,6 +35,16 @@ class LocalAsset:
     path: Path
     size: int
     digest: str
+
+
+@dataclass(frozen=True)
+class TesterReleaseIdentity:
+    version: str
+    build: str
+
+    @property
+    def title(self) -> str:
+        return f"{TITLE_PREFIX} {self.version} ({self.build})"
 
 
 @dataclass(frozen=True)
@@ -141,6 +156,46 @@ def load_local_assets(directory: Path) -> dict[str, LocalAsset]:
     return assets
 
 
+def load_tester_release_identity(
+    assets: dict[str, LocalAsset],
+    *,
+    repository: str,
+    commit: str,
+    run_id: str,
+) -> TesterReleaseIdentity:
+    manifest_asset = assets[MANIFEST_NAME]
+    if manifest_asset.size <= 0 or manifest_asset.size > MANIFEST_MAXIMUM_BYTES:
+        raise PublicationError("Tester manifest must contain between 1 byte and 1 MiB.")
+    try:
+        value = json.loads(manifest_asset.path.read_bytes().decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise PublicationError("Tester manifest must be valid UTF-8 JSON.") from error
+    if not isinstance(value, dict):
+        raise PublicationError("Tester manifest must be a JSON object.")
+
+    expected = {
+        "product": "Quill Cowork",
+        "channel": "tester",
+        "tag": TAG,
+        "releaseURL": f"https://github.com/{repository}/releases/tag/{TAG}",
+        "commit": commit,
+        "workflowRunURL": f"https://github.com/{repository}/actions/runs/{run_id}",
+    }
+    if type(value.get("schemaVersion")) is not int or value["schemaVersion"] != 1:
+        raise PublicationError("Tester manifest schemaVersion must be 1.")
+    for field, expected_value in expected.items():
+        if value.get(field) != expected_value:
+            raise PublicationError(f"Tester manifest {field} disagrees with publication.")
+
+    version = value.get("version")
+    build = value.get("build")
+    if not isinstance(version, str) or VERSION_PATTERN.fullmatch(version) is None:
+        raise PublicationError("Tester manifest version must be canonical semantic versioning.")
+    if not isinstance(build, str) or BUILD_PATTERN.fullmatch(build) is None:
+        raise PublicationError("Tester manifest build must be a positive canonical integer.")
+    return TesterReleaseIdentity(version=version, build=build)
+
+
 def ordered_asset_names(names: Iterable[str]) -> list[str]:
     name_set = set(names)
     values = sorted(name for name in name_set if name != MANIFEST_NAME)
@@ -152,12 +207,13 @@ def ordered_asset_names(names: Iterable[str]) -> list[str]:
 def validate_release_metadata(
     release: ReleaseSnapshot,
     commit: str,
+    title: str,
     notes: str,
 ) -> None:
     if (
         release.tag_name != TAG
         or release.target_commitish != commit
-        or release.name != TITLE
+        or release.name != title
         or release.body != notes
         or release.draft
         or not release.prerelease

--- a/scripts/tester_publication/initial.py
+++ b/scripts/tester_publication/initial.py
@@ -6,7 +6,6 @@ from tester_publication.contracts import (
     LocalAsset,
     PublicationError,
     TAG,
-    TITLE,
     ordered_asset_names,
     validate_exact_assets,
     validate_release_metadata,
@@ -18,6 +17,7 @@ def publish_initial_release(
     remote: PublicationRemote,
     commit: str,
     assets: dict[str, LocalAsset],
+    title: str,
     notes: str,
     notes_path: Path,
 ) -> None:
@@ -36,7 +36,7 @@ def publish_initial_release(
                 remote.repository,
                 "--draft",
                 "--title",
-                TITLE,
+                title,
                 "--notes-file",
                 str(notes_path),
                 "--target",
@@ -64,7 +64,7 @@ def publish_initial_release(
                 "--prerelease",
                 "--latest=false",
                 "--title",
-                TITLE,
+                title,
                 "--notes-file",
                 str(notes_path),
                 "--target",
@@ -73,7 +73,7 @@ def publish_initial_release(
         )
         release = remote.get_release()
         assert release is not None
-        validate_release_metadata(release, commit, notes)
+        validate_release_metadata(release, commit, title, notes)
         validate_exact_assets(release, assets)
     except Exception as error:
         if created_release:

--- a/scripts/tester_publication/publisher.py
+++ b/scripts/tester_publication/publisher.py
@@ -13,7 +13,6 @@ from tester_publication.contracts import (
     ReleaseSnapshot,
     RemoteAsset,
     TAG,
-    TITLE,
     TRANSACTION_ALIAS_PATTERN,
     ordered_asset_names,
     validate_exact_assets,
@@ -30,6 +29,7 @@ class TesterReleasePublisher:
         commit: str,
         run_id: str,
         assets: dict[str, LocalAsset],
+        title: str,
         notes: str,
         notes_path: Path,
         retry_delay_seconds: float,
@@ -37,6 +37,7 @@ class TesterReleasePublisher:
         self.commit = commit
         self.run_id = run_id
         self.assets = assets
+        self.title = title
         self.notes = notes
         self.notes_path = notes_path
         self.remote = PublicationRemote(repository, retry_delay_seconds)
@@ -174,7 +175,7 @@ class TesterReleasePublisher:
         return {
             "tag_name": TAG,
             "target_commitish": self.commit,
-            "name": TITLE,
+            "name": self.title,
             "body": self.notes,
             "draft": False,
             "prerelease": True,
@@ -293,7 +294,7 @@ class TesterReleasePublisher:
 
             published = self.remote.get_release()
             assert published is not None
-            validate_release_metadata(published, self.commit, self.notes)
+            validate_release_metadata(published, self.commit, self.title, self.notes)
             if self.remote.remote_tag_commit() != self.commit:
                 raise PublicationError("Published tester tag does not match the requested commit.")
             self.committed = True
@@ -301,7 +302,7 @@ class TesterReleasePublisher:
 
             final_release = self.remote.get_release()
             assert final_release is not None
-            validate_release_metadata(final_release, self.commit, self.notes)
+            validate_release_metadata(final_release, self.commit, self.title, self.notes)
             validate_exact_assets(final_release, self.assets)
         except Exception as error:
             if not self.committed:
@@ -319,6 +320,7 @@ class TesterReleasePublisher:
                 self.remote,
                 self.commit,
                 self.assets,
+                self.title,
                 self.notes,
                 self.notes_path,
             )

--- a/scripts/verify-website.py
+++ b/scripts/verify-website.py
@@ -183,9 +183,14 @@ def verify_site(site: Path) -> None:
         "Developer ID signed, notarized by Apple, and stapled",
         "ad-hoc signed and not Apple-notarized.",
         "uploadedAsset(",
+        "testerTitleMatch",
+        "document.documentElement.dataset.version",
+        "document.documentElement.dataset.build",
     )
     if any(contract not in script for contract in required_script_contracts):
         fail("live release metadata must be freshly fetched and fail-closed validated")
+    if index.count('/static/site.js?v=3') != 1:
+        fail("index must load the current release-identity script revision")
 
     for _, reference in CSS_URL_PATTERN.findall(css):
         local_path = local_asset_path(site, site / "static/cowork.css", reference)

--- a/website/index.html
+++ b/website/index.html
@@ -18,7 +18,7 @@
   <meta name="twitter:description" content="A native AI coworker for research, reports, spreadsheets, and recurring office work.">
   <meta name="twitter:image" content="https://cowork.quillos.cloud/static/media/quill-cowork-desktop.png">
   <link rel="stylesheet" href="/static/cowork.css?v=2">
-  <script src="/static/site.js?v=2" defer></script>
+  <script src="/static/site.js?v=3" defer></script>
 </head>
 <body>
   <header class="site-header">

--- a/website/static/site.js
+++ b/website/static/site.js
@@ -37,10 +37,13 @@
   function readCurrentRelease(release, feed) {
     const tag = release?.tag_name;
     const stableTag = /^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag);
+    const testerTitleMatch = /^Quill Cowork Tester ((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)) \(([1-9][0-9]*)\)$/.exec(
+      release?.name ?? "",
+    );
     const expectedTag = feed.channel === "stable" ? stableTag : tag === "tester-latest";
-    const expectedName = feed.channel === "stable"
-      ? `Quill Cowork ${tag}`
-      : "Quill Cowork Tester Build";
+    const hasExpectedName = feed.channel === "stable"
+      ? release?.name === `Quill Cowork ${tag}`
+      : testerTitleMatch !== null;
     const expectedPrerelease = feed.channel === "tester";
     const releaseURL = `${repositoryURL}/releases/tag/${tag}`;
     const assetBaseURL = `${repositoryURL}/releases/download/${tag}`;
@@ -61,7 +64,7 @@
 
     if (
       !expectedTag ||
-      release?.name !== expectedName ||
+      !hasExpectedName ||
       release?.html_url !== releaseURL ||
       release?.draft !== false ||
       release?.prerelease !== expectedPrerelease ||
@@ -75,7 +78,11 @@
     }
 
     const isStable = feed.channel === "stable";
+    const version = isStable ? tag.slice(1) : testerTitleMatch[1];
+    const build = isStable ? null : testerTitleMatch[2];
+    const releaseIdentity = isStable ? `Version ${version}` : `${version} (${build})`;
     return {
+      build,
       caption: isStable
         ? "The current notarized macOS release. The same workspace handles documents, research, browser tasks, and technical work."
         : "The current macOS tester build. The same workspace handles documents, research, browser tasks, and technical work.",
@@ -85,7 +92,7 @@
       installGuidance: isStable
         ? "One notarized installer runs natively on Apple silicon and Intel Macs. Move Quill Cowork to Applications, then open it normally."
         : "One installer runs natively on Apple silicon and Intel Macs. After moving the app to Applications, Control-click it and choose Open on first launch. The tester channel is not Apple-notarized yet.",
-      label: `Updated ${updatedAt.toLocaleDateString("en-US", {
+      label: `${releaseIdentity} · Updated ${updatedAt.toLocaleDateString("en-US", {
         day: "numeric",
         month: "short",
         year: "numeric",
@@ -93,6 +100,7 @@
       releaseKind: isStable ? "Stable release" : "Free tester build",
       releaseSection: isStable ? "Stable release" : "Tester release",
       releaseURL,
+      version,
     };
   }
 
@@ -151,5 +159,9 @@
     });
     document.documentElement.dataset.release = release.channel;
     document.documentElement.dataset.commit = release.commit;
+    document.documentElement.dataset.version = release.version;
+    if (release.build) {
+      document.documentElement.dataset.build = release.build;
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- derive the moving tester release title from the bounded commit-pinned manifest before GitHub mutation
- require public verification to match release title with manifest version/build
- show exact version/build on the download site while preserving its static fail-safe download

## Verification
- swift test: 6,401 tests, 5 intentional skips, 0 failures
- Python script contracts: 123 tests, 0 failures
- focused publication/verifier/workflow suites: 50 tests, 0 failures
- staged website verification, JavaScript syntax/behavior, Python compile, YAML parse, diff and credential checks passed