### PR TITLE
Add CODEOWNERS and SECURITY.md (SOC 2 / Kertos controls)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Review ownership for this repository.
+#
+# Lore Hex Corp currently has one person in it, so this assigns review rather
+# than adding a second reviewer, and we do not claim otherwise: see SECURITY.md
+# and https://trustedrouter.com/trust for the controls that do not depend on
+# headcount — gated CI on every change, and measured deployments whose published
+# measurement makes an undisclosed change to the serving path externally
+# detectable.
+#
+# This file becomes load-bearing at first hire. Until then it keeps ownership
+# explicit and routes review requests somewhere real.
+
+* @jperla


### PR DESCRIPTION
Branch protection here requires a PR, so these two policy files come through one.

Closes three failing Kertos GitHub controls across the org:
- CODEOWNERS exists (Medium)
- public repositories include SECURITY.md (Low)
- dependency vulnerability scanning enabled (High) — already enabled via repo settings, no file needed

SECURITY.md commits to a one-business-day acknowledgement, which matches what the SOC 2 questionnaire pack already tells prospects, so the public promise and the internal answer say the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)