### PR TITLE
Enable confidential model selection

### DIFF
--- a/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeModelPickerView.swift
@@ -11,7 +11,7 @@ struct QuillCodeModelPickerView: View {
             isPresented.toggle()
         } label: {
             HStack(spacing: QuillCodeMetrics.denseControlClusterSpacing) {
-                Image(systemName: topBar.modelIsLocked ? "lock.fill" : "diamond")
+                Image(systemName: pickerIcon)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(QuillCodePalette.muted)
                 Text(topBar.modelLabel)
@@ -36,9 +36,29 @@ struct QuillCodeModelPickerView: View {
         }
         .buttonStyle(QuillCodePressableButtonStyle())
         .disabled(topBar.modelIsLocked)
-        .help(topBar.modelIsLocked ? "Model locked: confidential chats always use the E2E encrypted route" : "Choose model")
-        .accessibilityLabel(topBar.modelIsLocked ? "Model locked, \(topBar.modelLabel)" : "Model, \(topBar.modelLabel)")
+        .help(pickerHelp)
+        .accessibilityLabel(pickerAccessibilityLabel)
         .accessibilityIdentifier("quillcode-model-picker-button")
+    }
+
+    private var pickerIcon: String {
+        if topBar.modelIsLocked { return "lock.fill" }
+        return QuillCodeProduct.distribution.requiresConfidentialRouting ? "lock.shield.fill" : "diamond"
+    }
+
+    private var pickerHelp: String {
+        if topBar.modelIsLocked {
+            return "Model locked: confidential chats always use the E2E encrypted route"
+        }
+        return QuillCodeProduct.distribution.requiresConfidentialRouting
+            ? "Choose an approved Confidential model or provider"
+            : "Choose model"
+    }
+
+    private var pickerAccessibilityLabel: String {
+        topBar.modelIsLocked
+            ? "Model locked, \(topBar.modelLabel)"
+            : "Model, \(topBar.modelLabel)"
     }
 }
 
@@ -110,7 +130,7 @@ struct QuillCodeModelPickerDialog: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Choose Model")
                     .font(.custom("Iowan Old Style", size: 18).weight(.semibold))
-                Text("Search provider, category, model, state, or us-only / eu-only / china-only")
+                Text(modelSearchScopeDescription)
                     .font(.caption)
                     .foregroundStyle(QuillCodePalette.muted)
                 Text(topBar.modelCatalogStatusLabel)
@@ -145,6 +165,12 @@ struct QuillCodeModelPickerDialog: View {
             .help("Close model picker")
             .accessibilityLabel("Close model picker")
         }
+    }
+
+    private var modelSearchScopeDescription: String {
+        QuillCodeProduct.distribution.requiresConfidentialRouting
+            ? "Search approved Confidential models and providers"
+            : "Search provider, category, model, state, or us-only / eu-only / china-only"
     }
 
     private var searchField: some View {

--- a/Sources/QuillCodeApp/WorkspaceModelCatalogSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceModelCatalogSurfaceBuilder.swift
@@ -1,6 +1,23 @@
 import Foundation
 import QuillCodeCore
 
+enum WorkspaceModelCatalogRestriction: Sendable, Hashable {
+    case unrestricted
+    case e2e
+    case confidential
+
+    func allows(_ modelID: String, catalog: [ModelInfo]) -> Bool {
+        switch self {
+        case .unrestricted:
+            true
+        case .e2e:
+            TrustedRouterDefaults.isE2EEligible(modelID, catalog: catalog)
+        case .confidential:
+            TrustedRouterDefaults.isConfidentialEligible(modelID, catalog: catalog)
+        }
+    }
+}
+
 struct WorkspaceModelCatalogSurfaceBuilder: Sendable, Hashable {
     var catalog: [ModelInfo]
     var selectedModelID: String
@@ -16,7 +33,7 @@ struct WorkspaceModelCatalogSurfaceBuilder: Sendable, Hashable {
         favoriteModelIDs: [String],
         recentModelIDs: [String],
         recentLimit: Int = 4,
-        restrictToE2EEligible: Bool = false
+        restriction: WorkspaceModelCatalogRestriction = .unrestricted
     ) {
         // The restriction must run AFTER normalization: normalizedModelCatalog merges the bundled
         // recommended set back in, so a pre-filtered input would quietly regrow non-eligible models.
@@ -24,9 +41,7 @@ struct WorkspaceModelCatalogSurfaceBuilder: Sendable, Hashable {
         // entry for ids missing from the catalog, which would otherwise smuggle a non-E2E model
         // into a confidential picker under "Recent".
         let normalized = TrustedRouterDefaults.normalizedModelCatalog(catalog)
-        let eligible: (String) -> Bool = { id in
-            !restrictToE2EEligible || TrustedRouterDefaults.isE2EEligible(id, catalog: normalized)
-        }
+        let eligible: (String) -> Bool = { restriction.allows($0, catalog: normalized) }
         self.catalog = normalized.filter { eligible($0.id) }
         self.selectedModelID = TrustedRouterDefaults.canonicalModelID(selectedModelID)
         self.defaultModelID = TrustedRouterDefaults.normalizedDefaultModelID(defaultModelID)
@@ -37,7 +52,7 @@ struct WorkspaceModelCatalogSurfaceBuilder: Sendable, Hashable {
     }
 
     /// Whether the selected model may be synthesized back into the list when the catalog lacks it.
-    /// Under the E2E restriction a selected model that LOST eligibility (a live-catalog refresh
+    /// Under a privacy restriction a selected model that LOST eligibility (a live-catalog refresh
     /// dropped its Confidential tier) must NOT be re-admitted as a phantom "Current" row — the
     /// picker would offer a model the setModel gate then refuses.
     private let selectedModelIsAdmissible: Bool

--- a/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
+++ b/Sources/QuillCodeApp/WorkspaceTopBarSurfaceBuilder.swift
@@ -62,12 +62,11 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
             memorySources: memories.map(\.relativePath),
             modelLabel: modelCatalog.modelLabel(),
             selectedModelID: topBarState.model,
-            // A confidential thread's picker stays USABLE but restricted (see modelCatalogBuilder).
-            // It renders locked only when the eligible set offers no real choice (just the E2E
-            // route) — an openable picker with a single row would read as broken, while the lock
-            // honestly says "pinned". Unique ids, because Favorites/Recent duplicate entries.
-            modelIsLocked: (thread?.runtimeContext.isConfidential == true
-                || distribution.requiresConfidentialRouting)
+            // Confidential Cowork always keeps this picker open: its authenticated catalog can add
+            // eligible provider/model choices after launch. An ad hoc confidential chat in the
+            // standard edition remains visibly pinned when its E2E allowlist has only one route.
+            modelIsLocked: !distribution.requiresConfidentialRouting
+                && thread?.runtimeContext.isConfidential == true
                 && Set(modelCatalog.categories().flatMap { $0.models.map(\.id) }).count <= 1,
             modelCategories: modelCatalog.categories(),
             modelCatalogSource: modelCatalogStatus.source,
@@ -172,11 +171,9 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
         return WorktreeStatus(label: label, detail: detail, isWarning: !isResolvable)
     }
 
-    /// Inside a confidential chat the picker stays USABLE but only offers models whose TrustedRouter
-    /// routing is end-to-end encrypted (the E2E meta-route + Confidential-tier catalog models). The
-    /// model-level `setModel` guard is the enforcement; the builder-side restriction keeps the picker
-    /// honest about what it can actually switch to (and must live INSIDE the builder — its catalog
-    /// normalization would regrow a pre-filtered list).
+    /// Privacy filtering lives inside the builder because catalog normalization adds bundled models.
+    /// Ad hoc confidential chats use the E2E policy; Confidential Cowork uses its distribution-wide
+    /// Confidential-tier policy. The model-level selection and run guards remain the final authority.
     private func modelCatalogBuilder() -> WorkspaceModelCatalogSurfaceBuilder {
         WorkspaceModelCatalogSurfaceBuilder(
             catalog: modelCatalog,
@@ -184,9 +181,18 @@ struct WorkspaceTopBarSurfaceBuilder: Sendable, Hashable {
             defaultModelID: defaultModelID,
             favoriteModelIDs: favoriteModelIDs,
             recentModelIDs: recentModelIDs(),
-            restrictToE2EEligible: thread?.runtimeContext.isConfidential == true
-                || distribution.requiresConfidentialRouting
+            restriction: modelCatalogRestriction
         )
+    }
+
+    private var modelCatalogRestriction: WorkspaceModelCatalogRestriction {
+        if distribution.requiresConfidentialRouting {
+            return .confidential
+        }
+        if thread?.runtimeContext.isConfidential == true {
+            return .e2e
+        }
+        return .unrestricted
     }
 
     private func recentModelIDs() -> [String] {

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationSampler.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityActivationSampler.swift
@@ -134,7 +134,10 @@ enum QuillCodeDesktopAccessibilityActivationSampler {
             "onboarding.developer-key",
             phase: .initialSurface,
             expectedOutcome: "developer-key onboarding opens Developer override settings and dismisses through Close",
-            isApplicable: { !$0.model.root.trustedRouterAPIKeyConfigured },
+            isApplicable: {
+                !$0.model.root.distribution.requiresConfidentialRouting
+                    && !$0.model.root.trustedRouterAPIKeyConfigured
+            },
             observe: { $0.isSettingsPresented },
             resetToBaseline: { $1.isSettingsPresented = $0 },
             verify: QuillCodeDesktopAccessibilityInteractionVerifier.verifyDeveloperKeySettingsDismissal

--- a/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityInteractionVerifier.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopAccessibilityInteractionVerifier.swift
@@ -2,24 +2,30 @@ import AppKit
 import ApplicationServices
 import Foundation
 import QuillCodeApp
+import QuillCodeCore
 
 @MainActor
 enum QuillCodeDesktopAccessibilityInteractionVerifier {
     private static let composerInputIdentifier = "quillcode-composer-input"
     private static let composerSmokeText = "QuillCode new chat smoke"
     private static let modelPickerSearchIdentifier = "quillcode-model-picker-search"
-    private static let modelPickerSearchSmokeText = "Prometheus"
-    private static let prometheusOptionIdentifier = "quillcode-model-option-trustedrouter/fusion"
     private static let searchInputIdentifier = "quillcode-search-input"
     private static let searchSmokeText = "QuillCode search smoke"
-    private static let settingsSurfaceContract = DismissibleSurfaceContract(
-        contractID: "command.settings",
-        name: "Settings",
-        titleIdentifier: "quillcode-settings-title",
-        requiredControlIdentifier: "quillcode-settings-api-base-url",
-        requiredControlDescription: "Account API field",
-        closeIdentifier: "quillcode-settings-close"
-    )
+    private static var settingsSurfaceContract: DismissibleSurfaceContract {
+        let requiresConfidentialRouting = QuillCodeProduct.distribution.requiresConfidentialRouting
+        return DismissibleSurfaceContract(
+            contractID: "command.settings",
+            name: "Settings",
+            titleIdentifier: "quillcode-settings-title",
+            requiredControlIdentifier: settingsRequiredControlIdentifier(
+                requiresConfidentialRouting: requiresConfidentialRouting
+            ),
+            requiredControlDescription: requiresConfidentialRouting
+                ? "confidential jurisdiction control"
+                : "Account API field",
+            closeIdentifier: "quillcode-settings-close"
+        )
+    }
     private static let developerKeySettingsSurfaceContract = DismissibleSurfaceContract(
         contractID: "onboarding.developer-key",
         name: "Developer override settings",
@@ -126,7 +132,7 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
     static func verifyNewChatComposerTextEntry(
         contentView: NSView
     ) async -> QuillCodeDesktopAccessibilityActivationVerification {
-        await verifyReversibleTextEntry(
+        return await verifyReversibleTextEntry(
             inputIdentifier: composerInputIdentifier,
             smokeText: composerSmokeText,
             successEvidence: "created exactly one selected chat and \(composerInputIdentifier) focused with reversible AXValue text entry",
@@ -156,24 +162,44 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
     static func verifyModelPickerSearch(
         contentView: NSView
     ) async -> QuillCodeDesktopAccessibilityActivationVerification {
-        await verifyReversibleTextEntry(
+        let expectation = modelPickerSmokeExpectation(
+            requiresConfidentialRouting: QuillCodeProduct.distribution.requiresConfidentialRouting
+        )
+        return await verifyReversibleTextEntry(
             inputIdentifier: modelPickerSearchIdentifier,
-            smokeText: modelPickerSearchSmokeText,
-            successEvidence: "\(modelPickerSearchIdentifier) focused, accepted reversible AXValue text entry, and surfaced the Prometheus 1.0 model option",
+            smokeText: expectation.searchText,
+            successEvidence: "\(modelPickerSearchIdentifier) focused, accepted reversible AXValue text entry, and surfaced the \(expectation.optionLabel) model option",
             missingFocusIssue: "composer.model-picker did not expose a focused \(modelPickerSearchIdentifier) field",
             rejectedValueIssue: "composer.model-picker \(modelPickerSearchIdentifier) rejected AXValue",
             retainedValueIssue: "composer.model-picker \(modelPickerSearchIdentifier) did not retain AXValue text entry",
             clearValueIssue: "composer.model-picker \(modelPickerSearchIdentifier) could not restore its empty value",
-            requiredElementIdentifier: prometheusOptionIdentifier,
-            requiredElementLabelFragment: "Prometheus 1.0",
-            missingRequiredElementIssue: "composer.model-picker search did not surface the Prometheus 1.0 model option",
+            requiredElementIdentifier: expectation.optionIdentifier,
+            requiredElementLabelFragment: expectation.optionLabel,
+            missingRequiredElementIssue: "composer.model-picker search did not surface the \(expectation.optionLabel) model option",
             contentView: contentView
         )
+    }
+
+    static func modelPickerSmokeExpectation(
+        requiresConfidentialRouting: Bool
+    ) -> ModelPickerSmokeExpectation {
+        requiresConfidentialRouting
+            ? ModelPickerSmokeExpectation(
+                searchText: "Confidential",
+                optionIdentifier: "quillcode-model-option-trustedrouter/confidential",
+                optionLabel: TrustedRouterDefaults.confidentialModelDisplayName
+            )
+            : ModelPickerSmokeExpectation(
+                searchText: "Prometheus",
+                optionIdentifier: "quillcode-model-option-trustedrouter/fusion",
+                optionLabel: TrustedRouterDefaults.prometheusModelDisplayName
+            )
     }
 
     static func verifySettingsDismissal(
         contentView: NSView
     ) async -> QuillCodeDesktopAccessibilityActivationVerification {
+        let accountControlIdentifier = settingsSurfaceContract.requiredControlIdentifier
         let verification = await verifyDismissibleSurface(
             settingsSurfaceContract,
             contentView: contentView,
@@ -200,7 +226,7 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
                     in: contentView
                 ),
                     QuillCodeDesktopAccessibilityTree.performPress(on: accountButton) == .success,
-                    await waitForElement("quillcode-settings-api-base-url", in: contentView) != nil
+                    await waitForElement(accountControlIdentifier, in: contentView) != nil
                 else {
                     return .init(
                         evidence: "Settings could not return from General to Account",
@@ -216,6 +242,14 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
                 + "; switched to General, rendered its notifications control, and returned to Account",
             validationIssue: nil
         )
+    }
+
+    static func settingsRequiredControlIdentifier(
+        requiresConfidentialRouting: Bool
+    ) -> String {
+        requiresConfidentialRouting
+            ? "quillcode-settings-confidential-jurisdiction"
+            : "quillcode-settings-api-base-url"
     }
 
     static func verifyDeveloperKeySettingsDismissal(
@@ -574,4 +608,10 @@ enum QuillCodeDesktopAccessibilityInteractionVerifier {
         let requiredControlDescription: String
         let closeIdentifier: String
     }
+}
+
+struct ModelPickerSmokeExpectation: Equatable {
+    var searchText: String
+    var optionIdentifier: String
+    var optionLabel: String
 }

--- a/Tests/QuillCodeAppTests/WorkspaceConfidentialModeTests.swift
+++ b/Tests/QuillCodeAppTests/WorkspaceConfidentialModeTests.swift
@@ -191,11 +191,39 @@ final class WorkspaceConfidentialModeTests: XCTestCase {
             defaultModelID: TrustedRouterDefaults.defaultModel,
             favoriteModelIDs: [],
             recentModelIDs: [],
-            restrictToE2EEligible: true
+            restriction: .e2e
         )
         let listedIDs = builder.categories().flatMap { $0.models.map(\.id) }
         XCTAssertFalse(listedIDs.contains("z-ai/glm-5.2-confidential"), "\(listedIDs)")
         XCTAssertEqual(Set(listedIDs), [TrustedRouterDefaults.e2eModel])
+    }
+
+    func testConfidentialDistributionPickerStaysOpenAndUsesTheConfidentialAllowlist() {
+        let ordinaryModel = ModelInfo(
+            id: "openai/gpt-5",
+            provider: "openai",
+            displayName: "GPT-5",
+            category: "openai"
+        )
+        let thread = ChatThread(model: TrustedRouterDefaults.confidentialModel)
+        let model = QuillCodeWorkspaceModel(root: QuillCodeRootState(
+            distribution: .confidential,
+            threads: [thread],
+            selectedThreadID: thread.id,
+            topBar: TopBarState(model: TrustedRouterDefaults.confidentialModel),
+            modelCatalog: TrustedRouterDefaults.bundledModelCatalog + [ordinaryModel, confidentialTierModel]
+        ))
+
+        let topBar = model.surface().topBar
+        let listedIDs = Set(topBar.modelCategories.flatMap { $0.models.map(\.id) })
+
+        XCTAssertFalse(topBar.modelIsLocked)
+        XCTAssertTrue(listedIDs.contains(TrustedRouterDefaults.confidentialModel))
+        XCTAssertTrue(listedIDs.contains(confidentialTierModel.id))
+        XCTAssertFalse(listedIDs.contains(ordinaryModel.id))
+        XCTAssertTrue(listedIDs.allSatisfy {
+            TrustedRouterDefaults.isConfidentialEligible($0, catalog: model.root.modelCatalog)
+        })
     }
 
     func testCatalogRefreshRepinsAConfidentialThreadWhoseModelLostEligibility() throws {

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopDailyDriverSmokeFixtureTests.swift
@@ -125,6 +125,28 @@ final class QuillCodeDesktopDailyDriverSmokeFixtureTests: XCTestCase {
         )
     }
 
+    func testConfidentialActivationSamplerKeepsRestrictedModelPickerAndSkipsDeveloperOverride() throws {
+        let parent = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let paths = QuillCodePaths(home: parent.appendingPathComponent("confidential-state"))
+        let controller = QuillCodeDesktopController(
+            bootstrap: QuillCodeWorkspaceBootstrap(
+                paths: paths,
+                distribution: .confidential
+            ),
+            browserLiveDOMCapturer: nil,
+            automationNotifier: DailyDriverSmokeNoopNotifier()
+        )
+
+        let contractIDs = QuillCodeDesktopAccessibilityActivationSampler.applicableActivationContractIDs(
+            includesInitialSurface: true,
+            controller: controller
+        )
+        XCTAssertTrue(contractIDs.contains("composer.model-picker"))
+        XCTAssertFalse(contractIDs.contains("onboarding.developer-key"))
+        XCTAssertTrue(contractIDs.contains("command.settings"))
+    }
+
     func testSeederParsesRequiredStateRootAndRefusesExistingDestination() throws {
         XCTAssertNil(QuillCodeDesktopDailyDriverSmokeSeedRequest(arguments: ["Quill Cowork"]))
         let request = try XCTUnwrap(QuillCodeDesktopDailyDriverSmokeSeedRequest(arguments: [
@@ -196,4 +218,8 @@ final class QuillCodeDesktopDailyDriverSmokeFixtureTests: XCTestCase {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         return root
     }
+}
+
+private struct DailyDriverSmokeNoopNotifier: QuillCodeAutomationNotifying {
+    func deliver(_ report: AutomationRunReport) {}
 }

--- a/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
+++ b/Tests/QuillCodeDesktopTests/QuillCodeDesktopWindowReportTests.swift
@@ -852,6 +852,44 @@ final class QuillCodeDesktopWindowReportTests: XCTestCase {
         )
     }
 
+    func testSettingsActivationRequiresTheEditionSpecificAccountControl() {
+        XCTAssertEqual(
+            QuillCodeDesktopAccessibilityInteractionVerifier.settingsRequiredControlIdentifier(
+                requiresConfidentialRouting: false
+            ),
+            "quillcode-settings-api-base-url"
+        )
+        XCTAssertEqual(
+            QuillCodeDesktopAccessibilityInteractionVerifier.settingsRequiredControlIdentifier(
+                requiresConfidentialRouting: true
+            ),
+            "quillcode-settings-confidential-jurisdiction"
+        )
+    }
+
+    func testModelPickerActivationSearchesAnEditionSpecificAllowedModel() {
+        XCTAssertEqual(
+            QuillCodeDesktopAccessibilityInteractionVerifier.modelPickerSmokeExpectation(
+                requiresConfidentialRouting: false
+            ),
+            ModelPickerSmokeExpectation(
+                searchText: "Prometheus",
+                optionIdentifier: "quillcode-model-option-trustedrouter/fusion",
+                optionLabel: TrustedRouterDefaults.prometheusModelDisplayName
+            )
+        )
+        XCTAssertEqual(
+            QuillCodeDesktopAccessibilityInteractionVerifier.modelPickerSmokeExpectation(
+                requiresConfidentialRouting: true
+            ),
+            ModelPickerSmokeExpectation(
+                searchText: "Confidential",
+                optionIdentifier: "quillcode-model-option-trustedrouter/confidential",
+                optionLabel: TrustedRouterDefaults.confidentialModelDisplayName
+            )
+        )
+    }
+
     func testWindowAccessibilityActivationSamplerPreservesDeclaredOrderWithinPhases() {
         XCTAssertEqual(
             QuillCodeDesktopAccessibilityActivationSampler.orderedActivationContractIDs(

--- a/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityPackagedPerformanceGateTests.swift
@@ -135,6 +135,7 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
             #"--window-smoke-performance-workload "daily-driver-100-chats""#,
             "PERFORMANCE_ATTEMPT_COUNT=3",
             #"REPORT_PATHS+=("$REPORT_PATH")"#,
+            #"--expected-app-name "$EXECUTABLE_NAME""#,
             "--max-launch-ready-milliseconds",
             "--max-resident-memory-bytes",
             "--max-resident-memory-growth-bytes",
@@ -286,6 +287,39 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
             8 * 1_024 * 1_024
         )
         XCTAssertEqual(budgets["maximumIdleThreadGrowth"] as? Int, 2)
+    }
+
+    func testPerformanceValidatorAcceptsOnlyTheExplicitPackagedIdentity() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try writeReport(
+            to: fixture.report,
+            launchReadyMilliseconds: 750,
+            appName: "Confidential Cowork"
+        )
+
+        let accepted = try runValidator(
+            reports: [fixture.report],
+            manifest: fixture.manifest,
+            maximumLaunchMilliseconds: 2_500,
+            maximumResidentBytes: 128 * 1_024 * 1_024,
+            expectedAppName: "Confidential Cowork"
+        )
+        XCTAssertEqual(accepted.exitCode, 0, accepted.output)
+        let manifest = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: fixture.manifest)
+        ) as? [String: Any]
+        XCTAssertEqual(manifest?["product"] as? String, "Confidential Cowork")
+
+        let rejected = try runValidator(
+            reports: [fixture.report],
+            manifest: fixture.manifest,
+            maximumLaunchMilliseconds: 2_500,
+            maximumResidentBytes: 128 * 1_024 * 1_024,
+            expectedAppName: "Quill Cowork"
+        )
+        XCTAssertNotEqual(rejected.exitCode, 0)
+        XCTAssertTrue(rejected.output.contains("wrong app identity"), rejected.output)
     }
 
     func testPerformanceValidatorFailsClosedAboveEitherBudget() throws {
@@ -780,13 +814,14 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
         idleDurationMilliseconds: Double = 2_000,
         idleProcessorTimeNanoseconds: Int = 100_000_000,
         idleResidentMemoryBytes: Int = 103 * 1_024 * 1_024,
-        idleThreadCount: Int = 19
+        idleThreadCount: Int = 19,
+        appName: String = "Quill Cowork"
     ) throws {
         let idleCPUPercent = Double(idleProcessorTimeNanoseconds) / 1_000_000_000
             / (idleDurationMilliseconds / 1_000) * 100
         let payload: [String: Any] = [
             "ok": true,
-            "appName": "Quill Cowork",
+            "appName": appName,
             "memoryPressure": [
                 "level": "critical",
                 "loadedThreadPayloadCountBefore": 12,
@@ -847,12 +882,14 @@ final class ParityPackagedPerformanceGateTests: QuillCodeParityTestCase {
         manifest: URL,
         maximumLaunchMilliseconds: Int,
         maximumResidentBytes: Int,
-        maximumRepeatedRetainedThreadGrowth: Int = 4
+        maximumRepeatedRetainedThreadGrowth: Int = 4,
+        expectedAppName: String = "Quill Cowork"
     ) throws -> ScriptResult {
         try Self.runPython(
             Self.packageRoot().appendingPathComponent("scripts/native-click-probe-contracts.py"),
             arguments: ["performance"] + reports.map(\.path) + [
                 "--manifest", manifest.path,
+                "--expected-app-name", expectedAppName,
                 "--max-launch-ready-milliseconds", String(maximumLaunchMilliseconds),
                 "--max-resident-memory-bytes", String(maximumResidentBytes),
                 "--max-resident-memory-growth-bytes", String(80 * 1_024 * 1_024),

--- a/scripts/native_click_probe_contracts/cli.py
+++ b/scripts/native_click_probe_contracts/cli.py
@@ -31,6 +31,7 @@ from .performance import (
     DEFAULT_MAX_REPEATED_RESIDENT_MEMORY_GROWTH_BYTES,
     DEFAULT_MAX_REPEATED_RETAINED_THREAD_GROWTH,
     DEFAULT_MAX_THREAD_COUNT,
+    PERFORMANCE_PRODUCT,
     write_performance_manifest,
 )
 from .probe_contracts import validate_report
@@ -108,6 +109,7 @@ def main() -> None:
     )
     performance_parser.add_argument("reports", nargs="+", type=Path)
     performance_parser.add_argument("--manifest", required=True, type=Path)
+    performance_parser.add_argument("--expected-app-name", default=PERFORMANCE_PRODUCT)
     performance_parser.add_argument(
         "--max-launch-ready-milliseconds",
         type=float,
@@ -302,6 +304,7 @@ def main() -> None:
                 args.max_idle_resident_memory_growth_bytes
             ),
             max_idle_thread_growth=args.max_idle_thread_growth,
+            expected_app_name=args.expected_app_name,
         )
     elif args.command == "computer-use":
         write_computer_use_manifest(

--- a/scripts/native_click_probe_contracts/performance.py
+++ b/scripts/native_click_probe_contracts/performance.py
@@ -114,10 +114,10 @@ def _nonnegative_integer(value: Any, label: str) -> int:
     return integer
 
 
-def _load_attempt(report_path: Path) -> PerformanceAttempt:
+def _load_attempt(report_path: Path, expected_app_name: str) -> PerformanceAttempt:
     report = load_report(report_path)
     require(report.get("ok") is True, f"{report_path} does not report ok=true")
-    require(report.get("appName") == PERFORMANCE_PRODUCT, f"{report_path} has the wrong app identity")
+    require(report.get("appName") == expected_app_name, f"{report_path} has the wrong app identity")
     memory_pressure = report.get("memoryPressure")
     require(isinstance(memory_pressure, dict), f"{report_path} is missing memory-pressure evidence")
     require(
@@ -346,7 +346,12 @@ def write_performance_manifest(
         DEFAULT_MAX_IDLE_RESIDENT_MEMORY_GROWTH_BYTES
     ),
     max_idle_thread_growth: int = DEFAULT_MAX_IDLE_THREAD_GROWTH,
+    expected_app_name: str = PERFORMANCE_PRODUCT,
 ) -> None:
+    require(
+        isinstance(expected_app_name, str) and bool(expected_app_name.strip()),
+        "expected app name must not be empty",
+    )
     max_launch = _finite_number(
         max_launch_ready_milliseconds,
         "maximum launch-ready milliseconds",
@@ -392,7 +397,7 @@ def write_performance_manifest(
     )
     require(report_paths, "at least one packaged performance report is required")
 
-    attempts = [_load_attempt(path) for path in report_paths]
+    attempts = [_load_attempt(path, expected_app_name) for path in report_paths]
     required_passing_attempts = len(attempts) // 2 + 1
     passing_attempts = sum(
         attempt.launch_ready_milliseconds <= max_launch for attempt in attempts
@@ -527,7 +532,7 @@ def write_performance_manifest(
     manifest = {
         "schemaVersion": PERFORMANCE_SCHEMA_VERSION,
         "ok": True,
-        "product": PERFORMANCE_PRODUCT,
+        "product": expected_app_name,
         "workload": PERFORMANCE_WORKLOAD,
         "measurement": INITIAL_MEASUREMENT,
         "memoryMeasurement": MEMORY_MEASUREMENT,
@@ -695,7 +700,7 @@ def write_performance_manifest(
         manifest_file.write("\n")
 
     print(
-        "Quill Cowork packaged performance passed: "
+        f"{expected_app_name} packaged performance passed: "
         f"{launch_ready:.2f}ms median launch-ready, "
         f"{manifest['residentMemoryMiB']:.2f} MiB initial and "
         f"{manifest['postInteractionResidentMemoryMiB']:.2f} MiB post-interaction "

--- a/scripts/packaged-macos-performance-smoke.sh
+++ b/scripts/packaged-macos-performance-smoke.sh
@@ -102,7 +102,7 @@ if [[ ! -x "$APP_EXECUTABLE" ]]; then
   exit 1
 fi
 
-echo "==> Measuring packaged Quill Cowork launch and physical footprint"
+echo "==> Measuring packaged $EXECUTABLE_NAME launch and physical footprint"
 REPORT_PATHS=()
 for ((attempt = 1; attempt <= PERFORMANCE_ATTEMPT_COUNT; attempt += 1)); do
   REPORT_PATH="$SMOKE_ROOT/window-report-$attempt.json"
@@ -140,6 +140,7 @@ done
 "$ROOT_DIR/scripts/native-click-probe-contracts.py" performance \
   "${REPORT_PATHS[@]}" \
   --manifest "$MANIFEST_PATH" \
+  --expected-app-name "$EXECUTABLE_NAME" \
   --max-launch-ready-milliseconds "$MAX_LAUNCH_READY_MILLISECONDS" \
   --max-resident-memory-bytes "$MAX_RESIDENT_MEMORY_BYTES" \
   --max-resident-memory-growth-bytes "$MAX_RESIDENT_MEMORY_GROWTH_BYTES" \


### PR DESCRIPTION
## Summary
- keep the Confidential Cowork model picker searchable while restricting it to TrustedRouter Confidential-tier models and providers
- preserve fail-closed selection, refresh, and execution gates so ordinary models cannot enter the confidential edition
- make packaged UI and performance smoke checks edition-aware for Confidential Cowork settings, model search, and app identity

## Verification
- 52 confidential-mode tests passed
- 5 desktop daily-driver smoke fixture tests passed
- 28 desktop window-report tests passed
- 22 packaged performance-gate tests passed
- full code-quality gate passed
- real packaged Confidential Cowork app passed model search, settings, and full interaction checks across three fresh launches
- median launch-ready: 600.58 ms; settled idle CPU: 0.0006%