### PR TITLE
Preserve edition identity in universal package

### DIFF
--- a/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityDownloadBuildsGateTests.swift
@@ -569,7 +569,9 @@ final class ParityDownloadBuildsGateTests: QuillCodeParityTestCase {
             "codesign",
             "notarytool submit",
             "scripts/create-macos-disk-image.sh",
-            "scripts/packaged-macos-relocation-smoke.sh"
+            "scripts/packaged-macos-relocation-smoke.sh",
+            "--volume-name \"$PRODUCT_NAME\"",
+            "--product-name \"$PRODUCT_NAME\""
         ])
         Self.assertSource(smokeScript, containsAll: [
             "assert_plist_value QuillCodeUpdateChannel tester",

--- a/scripts/package-macos-universal-installer.sh
+++ b/scripts/package-macos-universal-installer.sh
@@ -240,8 +240,10 @@ fi
 
 "$ROOT_DIR/scripts/create-macos-disk-image.sh" \
   --app "$UNIVERSAL_APP" \
+  --volume-name "$PRODUCT_NAME" \
   --output "$OUTPUT_PATH"
 "$ROOT_DIR/scripts/packaged-macos-relocation-smoke.sh" \
+  --product-name "$PRODUCT_NAME" \
   --dmg "$OUTPUT_PATH" \
   --expected-architecture "$(uname -m)"
 


### PR DESCRIPTION
## Summary
- pass the active product name into the universal DMG volume and relocation verifier
- keep Confidential Cowork packaging from falling back to Quill Cowork identity
- add a download-build parity assertion for both handoffs

## Verification
- download-build parity suite: 7 passed
- packaging script syntax check passed
- diff integrity check passed