### PR TITLE
Bump trusted-router-swift to 0.7.0 (client telemetry header channel)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lore-Hex/trusted-router-swift.git",
       "state" : {
-        "revision" : "3655851b4fef87256b5203b62c5e5eef45ae0615",
-        "version" : "0.6.1"
+        "revision" : "fa261f29be1fbeaa7bcb765729d5be7b6f5f4512",
+        "version" : "0.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Lore-Hex/trusted-router-swift.git", from: "0.6.1"),
+        .package(url: "https://github.com/Lore-Hex/trusted-router-swift.git", from: "0.7.0"),
         .package(url: "https://github.com/dduan/TOMLDecoder.git", from: "0.4.5"),
         .package(url: "https://github.com/mattt/swift-toml.git", from: "2.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2")


### PR DESCRIPTION
Pins `trusted-router-swift` at the `0.7.0` tag (commit `fa261f29be1fbeaa7bcb765729d5be7b6f5f4512`) in `Package.resolved` and raises the `Package.swift` floor to `0.7.0`. 0.7.0 ships the `x-tr-client` client-telemetry header channel (contract v1), alias-domain failover, `x-should-retry`, and the §3.1-conformant User-Agent — so Quill Cowork, as the real-workload harness, emits the header on every inference attempt. The beacon channel is not in 0.7.0 (it lands in the next SDK release).

No other changes. CI should confirm the package resolves and builds on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)