### PR TITLE
Notarize the disk image and fix obsolete Gatekeeper guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ The current desktop build requires **macOS 14 or later** and supports Apple sili
 
 1. [Download the latest Quill Cowork disk image](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-universal.dmg). The same installer runs natively on Apple silicon and Intel Macs.
 2. Open the disk image and drag **Quill Cowork.app** onto **Applications**, then eject it.
-3. For the current tester build, right-click the app and choose **Open** on first launch if macOS
-   blocks it. Tester builds are ad-hoc code-signed but are not Apple-notarized yet.
+3. Tester builds are ad-hoc code-signed but are not Apple-notarized yet, so macOS blocks the
+   first launch. Launch the app once, then open **System Settings → Privacy & Security** and
+   choose **Open Anyway**. Control-clicking **Open** no longer works on macOS 15 and later.
 4. Sign in with TrustedRouter from the welcome screen, or add a developer key in **Settings**.
 
 The [Apple silicon ZIP](https://github.com/Lore-Hex/QuillCode/releases/download/tester-latest/Quill-Cowork-macOS-arm64.zip)

--- a/Tests/QuillCodeParityTests/ParityReleaseNotesGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityReleaseNotesGateTests.swift
@@ -34,7 +34,7 @@ final class ParityReleaseNotesGateTests: QuillCodeParityTestCase {
             "Quill-Cowork-macOS-arm64.dmg",
             "Quill-Cowork-macOS-x86_64.dmg",
             "Drag **Quill Cowork.app** onto **Applications**",
-            "Control-click **Quill Cowork**, choose **Open**",
+            "choose **Open Anyway**",
             "checks this tester channel automatically",
             "the previous build is restored",
             "Machine-readable update manifest",
@@ -77,7 +77,7 @@ final class ParityReleaseNotesGateTests: QuillCodeParityTestCase {
             "Signing: Developer ID, notarized (team `ABCDE12345`)",
             "latest-stable-build.json"
         ])
-        Self.assertSource(notes, excludes: "Control-click")
+        Self.assertSource(notes, excludes: "Open Anyway")
     }
 
     func testReleaseNotesRejectBuildMetadataFromAnotherCommit() throws {

--- a/Tests/ScriptTests/test_website_js.mjs
+++ b/Tests/ScriptTests/test_website_js.mjs
@@ -167,7 +167,7 @@ assert.equal(tester.document.documentElement.dataset.version, "0.1.0");
 assert.equal(tester.document.documentElement.dataset.build, "772");
 assert.ok(tester.labels.every(({ textContent }) => textContent === "0.1.0 (772) · Updated Aug 13, 2026"));
 assert.ok(tester.releaseKinds.every(({ textContent }) => textContent === "Free tester build"));
-assert.ok(tester.guidance.every(({ textContent }) => textContent.includes("Control-click")));
+assert.ok(tester.guidance.every(({ textContent }) => textContent.includes("Open Anyway")));
 assert.ok(tester.downloadLinks.every(({ href }) => href === testerInstallerURL));
 assert.ok(tester.releaseLinks.every(({ href }) => href === testerReleaseURL));
 

--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -403,9 +403,11 @@ The reminder record contains public release identity only, never project or acco
 
 ## Tester Install Notes
 
-The macOS tester app is ad-hoc signed but not notarized yet. Testers may need to
-right-click **Open** the first time. Computer Use still requires normal macOS
-Screen Recording and Accessibility permissions.
+The macOS tester app is ad-hoc signed but not notarized yet, so Gatekeeper blocks
+the first launch. Testers launch it once, then open **System Settings → Privacy &
+Security** and choose **Open Anyway**; Control-clicking **Open** no longer works on
+macOS 15 and later. Computer Use still requires normal macOS Screen Recording and
+Accessibility permissions.
 
 Tester builds support the same user-initiated update and rollback flow. A stable
 tag cannot publish a macOS app unless Developer ID signing and Apple notarization

--- a/scripts/build-release-notes.py
+++ b/scripts/build-release-notes.py
@@ -174,7 +174,9 @@ def build_release_notes(arguments: argparse.Namespace, values: dict[str, str]) -
         signing_alert = (
             "> [!IMPORTANT]\n"
             "> This tester build is ad-hoc signed and not Apple-notarized. After dragging it to "
-            "Applications, Control-click **Quill Cowork**, choose **Open**, then confirm."
+            "Applications, launch **Quill Cowork** once, then open **System Settings → Privacy & "
+            "Security** and choose **Open Anyway**. Control-clicking **Open** no longer works on "
+            "macOS 15 and later."
         )
         signing_summary = "Ad-hoc; not notarized"
 

--- a/scripts/create-macos-disk-image.sh
+++ b/scripts/create-macos-disk-image.sh
@@ -11,6 +11,13 @@ HDIUTIL_BIN="${QUILLCODE_HDIUTIL_BIN:-hdiutil}"
 DITTO_BIN="${QUILLCODE_DITTO_BIN:-ditto}"
 CODESIGN_BIN="${QUILLCODE_CODESIGN_BIN:-codesign}"
 PLIST_BUDDY_BIN="${QUILLCODE_PLIST_BUDDY_BIN:-/usr/libexec/PlistBuddy}"
+XCRUN_BIN="${QUILLCODE_XCRUN_BIN:-xcrun}"
+SPCTL_BIN="${QUILLCODE_SPCTL_BIN:-spctl}"
+SIGNING_IDENTITY="${QUILLCODE_MACOS_SIGNING_IDENTITY:-}"
+SIGNING_KEYCHAIN="${QUILLCODE_MACOS_SIGNING_KEYCHAIN:-}"
+NOTARY_KEY_ID="${QUILLCODE_MACOS_NOTARY_KEY_ID:-}"
+NOTARY_ISSUER_ID="${QUILLCODE_MACOS_NOTARY_ISSUER_ID:-}"
+NOTARY_KEY_PATH="${QUILLCODE_MACOS_NOTARY_KEY_PATH:-}"
 WORK_ROOT=""
 MOUNT_POINT=""
 MOUNTED=false
@@ -100,6 +107,46 @@ mkdir -p "$STAGING_DIR"
 ln -s /Applications "$STAGING_DIR/Applications"
 touch "$STAGING_DIR/.metadata_never_index"
 
+# A stapled app inside an unsigned disk image still makes macOS warn about the
+# disk image itself, so the container Gatekeeper actually evaluates on download
+# gets the same Developer ID signature and notarization ticket as the app.
+sign_and_notarize_disk_image() {
+  local image_path="$1"
+  if [[ -z "$SIGNING_IDENTITY" ]]; then
+    return 0
+  fi
+
+  local codesign_arguments=(--force --timestamp --sign "$SIGNING_IDENTITY")
+  if [[ -n "$SIGNING_KEYCHAIN" ]]; then
+    codesign_arguments+=(--keychain "$SIGNING_KEYCHAIN")
+  fi
+  echo "==> Signing disk image with the Developer ID identity"
+  "$CODESIGN_BIN" "${codesign_arguments[@]}" "$image_path"
+  "$CODESIGN_BIN" --verify --strict --verbose=2 "$image_path"
+
+  if [[ -z "$NOTARY_KEY_ID" && -z "$NOTARY_ISSUER_ID" && -z "$NOTARY_KEY_PATH" ]]; then
+    return 0
+  fi
+  if [[ -z "$NOTARY_KEY_ID" || -z "$NOTARY_ISSUER_ID" || -z "$NOTARY_KEY_PATH" ]]; then
+    echo "Disk-image notarization credentials must be configured together." >&2
+    return 2
+  fi
+  if [[ ! -f "$NOTARY_KEY_PATH" || -L "$NOTARY_KEY_PATH" ]]; then
+    echo "Notarization private key does not exist: $NOTARY_KEY_PATH" >&2
+    return 2
+  fi
+
+  echo "==> Notarizing disk image"
+  "$XCRUN_BIN" notarytool submit "$image_path" \
+    --key "$NOTARY_KEY_PATH" \
+    --key-id "$NOTARY_KEY_ID" \
+    --issuer "$NOTARY_ISSUER_ID" \
+    --wait
+  "$XCRUN_BIN" stapler staple "$image_path"
+  "$XCRUN_BIN" stapler validate "$image_path"
+  "$SPCTL_BIN" --assess --type open --context context:primary-signature --verbose=2 "$image_path"
+}
+
 run_image_operation() {
   local stage="$1"
   shift
@@ -169,6 +216,7 @@ for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT += 1)); do
     echo "Disk image candidate is empty: $CANDIDATE_PATH" >&2
     exit 1
   fi
+  sign_and_notarize_disk_image "$CANDIDATE_PATH"
   mv -f "$CANDIDATE_PATH" "$OUTPUT_PATH"
   echo "Disk image ready after $ATTEMPT attempt(s): $OUTPUT_PATH"
   exit 0

--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -98,6 +98,10 @@ if [[ "$UPDATE_CHANNEL" == "stable" ]]; then
     exit 2
   fi
 fi
+if [[ -n "$SIGNING_IDENTITY" && ( -z "$NOTARY_KEY_ID" || -z "$NOTARY_ISSUER_ID" || -z "$NOTARY_KEY_PATH" ) ]]; then
+  echo "Developer ID signing requires notarization; Gatekeeper blocks a signed but unnotarized download." >&2
+  exit 2
+fi
 
 cd "$ROOT_DIR"
 rm -rf "$DIST_DIR"

--- a/scripts/package-macos-universal-installer.sh
+++ b/scripts/package-macos-universal-installer.sh
@@ -94,6 +94,9 @@ fi
 if [[ -n "$SIGNING_IDENTITY" && -z "$SIGNING_TEAM_IDENTIFIER" ]]; then
   fail "QUILLCODE_MACOS_SIGNING_TEAM_IDENTIFIER is required for Developer ID signing." 2
 fi
+if [[ -n "$SIGNING_IDENTITY" && ( -z "$NOTARY_KEY_ID" || -z "$NOTARY_ISSUER_ID" || -z "$NOTARY_KEY_PATH" ) ]]; then
+  fail "Developer ID signing requires notarization; Gatekeeper blocks a signed but unnotarized download." 2
+fi
 
 OUTPUT_DIRECTORY="$(dirname "$OUTPUT_PATH")"
 mkdir -p "$OUTPUT_DIRECTORY"

--- a/website/index.html
+++ b/website/index.html
@@ -174,7 +174,7 @@
             Download for Mac
           </a>
           <a class="text-link" data-release-link href="https://github.com/Lore-Hex/QuillCode/releases/tag/tester-latest">Release notes, checksums, and CLI downloads</a>
-          <p><span data-build-label>Latest tester release</span>. <span data-install-guidance>One installer runs natively on Apple silicon and Intel Macs. After moving the app to Applications, Control-click it and choose Open on first launch. The tester channel is not Apple-notarized yet.</span></p>
+          <p><span data-build-label>Latest tester release</span>. <span data-install-guidance>One installer runs natively on Apple silicon and Intel Macs. The tester channel is not Apple-notarized yet, so after moving the app to Applications, launch it once, then open System Settings → Privacy & Security and choose Open Anyway.</span></p>
         </div>
       </div>
     </section>

--- a/website/static/site.js
+++ b/website/static/site.js
@@ -91,7 +91,7 @@
       installerURL: installer.browser_download_url,
       installGuidance: isStable
         ? "One notarized installer runs natively on Apple silicon and Intel Macs. Move Quill Cowork to Applications, then open it normally."
-        : "One installer runs natively on Apple silicon and Intel Macs. After moving the app to Applications, Control-click it and choose Open on first launch. The tester channel is not Apple-notarized yet.",
+        : "One installer runs natively on Apple silicon and Intel Macs. The tester channel is not Apple-notarized yet, so after moving the app to Applications, launch it once, then open System Settings → Privacy & Security and choose Open Anyway.",
       label: `${releaseIdentity} · Updated ${updatedAt.toLocaleDateString("en-US", {
         day: "numeric",
         month: "short",


### PR DESCRIPTION
## Context

Every public macOS download is ad-hoc signed and unnotarized, so Gatekeeper rejects it and users get the "could not verify … free of malware" dialog. The immediate cause is that no Apple signing secrets are configured, so `configure-macos-distribution-signing.sh` takes its ad-hoc fallback — that part needs credentials, not code.

But two things would still have been wrong once those credentials landed. This PR fixes those.

## 1. The disk image was never notarized

`package-macos-downloads.sh` and `package-macos-universal-installer.sh` notarize and staple the **app**, then call `create-macos-disk-image.sh` to build the `.dmg` around it and ship that. Nothing ever signed, notarized, or stapled the disk image itself — the container Gatekeeper evaluates when a user opens the download.

`create-macos-disk-image.sh` now signs the image with the Developer ID identity, submits it to `notarytool`, staples the ticket, and asserts with `spctl --assess --type open`. Both callers inherit it.

It runs on the **candidate** image, before `mv` to the output path, so a failed signature or notarization cannot overwrite the last good image — the same guarantee the retry loop already made for create/verify/attach.

## 2. The install instructions could not work

Control-clicking **Open** has not bypassed Gatekeeper for an unnotarized app since macOS 15. It was the advice in six places: the release-notes generator, `website/index.html`, `website/static/site.js`, `README.md`, `docs/DOWNLOADS.md`, and two gate tests asserting on it. All now point at **System Settings → Privacy & Security → Open Anyway**, which works on macOS 14, 15, and 26.

## 3. A guard so this cannot recur quietly

Packaging now refuses a Developer ID build with no notarization credentials — a signed but unnotarized download is blocked just the same. It only fires once signing is configured, so it changes nothing today.

## Testing

- `node Tests/ScriptTests/test_website_js.mjs`, `python3 Tests/ScriptTests/test_website.py`, `build-website.py` + `verify-website.py` — all pass.
- Generated real tester and stable release notes and confirmed the tester notes contain `choose **Open Anyway**` and the stable notes exclude it, matching the updated gate assertions.
- Ran `create-macos-disk-image.sh` end-to-end against the real shipped app on the unsigned path — no regression.
- Exercised the new signing path with stubbed `codesign` / `notarytool` / `spctl` and verified the exact command sequence, that a partial notary config exits 2, and that a failed notarization leaves the previous image byte-identical.

**Not verified locally:** the Swift parity gates. This machine has Command Line Tools without Xcode, so `swift test` has no XCTest module. Two assertions in `ParityReleaseNotesGateTests` were updated and checked against the generator's real output, but CI on `macos-15` is the first true run. The new disk-image signing path has no parity gate of its own yet — worth adding on a machine that can run XCTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)