### PR TITLE
Write the cli key BUILD_INFO verification requires

### DIFF
--- a/scripts/package-macos-downloads.sh
+++ b/scripts/package-macos-downloads.sh
@@ -235,6 +235,13 @@ signingTeamIdentifier=${SIGNING_TEAM_IDENTIFIER:-none}
 notarized=$NOTARIZED
 INFO
 
+# The published-release verifier requires a cli entry naming the CLI tarball.
+# Only the standard edition ships one, so emit it exactly when it was built
+# rather than writing an empty key the verifier would reject.
+if [[ -n "$CLI_TARBALL" ]]; then
+  printf 'cli=%s\n' "$(basename "$CLI_TARBALL")" >> "$BUILD_INFO"
+fi
+
 (
   cd "$ASSET_DIR"
   CHECKSUM_INPUTS=(


### PR DESCRIPTION
## The failure

`Download Builds` has failed on **every scheduled run since 2026-08-18** — seven days — always in `verify-published`:

```
Published release verification failed: BUILD_INFO-macOS-arm64.txt cli disagrees with the manifest
Process completed with exit code 2
```

Every build job succeeds. Only the published-release verification fails, which then skips `verify-current-published` and `verify-current-daily-driver` — so the standard `tester-latest` release has been effectively unverified for a week.

## Root cause

`release_verification_files.py` requires `BUILD_INFO` to contain:

```
cli=quill-code-macOS-<arch>.tar.gz
```

`package-macos-downloads.sh` has **never** written a `cli` key. The published file ends at `notarized=false`. So `build_info.get("cli")` returns `None`, which can never equal the expected value.

The requirement arrived in #1712 (2026-08-18). The last green run was 2026-08-18T10:44, hours before it merged — an enforcing check landed ahead of the thing that would let it pass.

## Fix

Emit the key from the CLI tarball that was actually built. Only the standard edition ships a CLI, so it's written exactly when one exists rather than as an empty value.

## Why nobody noticed

`ParityPublishedReleaseVerificationGateTests` constructs its own `BUILD_INFO` fixture and writes `cli=` into it, so the verifier's test passes against a file production never generates. The fixture and reality diverged, and only the nightly job could see it.

Worth considering a follow-up: a contract test comparing the verifier's required key set against what the packaging script writes. All 15 line up now, but nothing keeps them aligned.

## Testing

- Exercised the emitting logic both ways: standard produces exactly one `cli=quill-code-macOS-arm64.tar.gz`; confidential produces no key.
- Confirmed the emitted value matches the verifier's expected string exactly.
- Cross-checked all 15 keys the verifier requires against what the script writes — no gaps remain.

The real proof is the next scheduled `Download Builds` run, or a manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)