### PR TITLE
Run the update helper from a bundle so it survives signing

### DIFF
--- a/Sources/quill-code-desktop/QuillCodeDesktopApplicationRelocator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopApplicationRelocator.swift
@@ -124,10 +124,32 @@ struct QuillCodeDesktopApplicationRelocator: QuillCodeDesktopApplicationRelocati
             ".\(QuillCodeProduct.displayName).update-\(identifier).app",
             isDirectory: true
         )
-        let helperURL = workspaceURL.appendingPathComponent(
-            "QuillCoworkInstallHelper-\(identifier)",
-            isDirectory: false
-        )
+        // Run the helper from a copy of the whole app bundle. A Developer ID
+        // signature seals Info.plist, so a bare executable copied out of its
+        // bundle fails validation and is SIGKILLed at exec.
+        let runningBundleURL = QuillCodeDesktopUpdateWorkspaceLocator
+            .applicationBundleURL(forExecutableAt: runningExecutableURL)
+        let helperStagingURL: URL
+        let helperURL: URL
+        if let runningBundleURL {
+            helperStagingURL = workspaceURL.appendingPathComponent(
+                "QuillCoworkInstallHelper-\(identifier).app",
+                isDirectory: true
+            )
+            helperURL = helperStagingURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent(
+                    runningExecutableURL.lastPathComponent,
+                    isDirectory: false
+                )
+        } else {
+            helperStagingURL = workspaceURL.appendingPathComponent(
+                "QuillCoworkInstallHelper-\(identifier)",
+                isDirectory: false
+            )
+            helperURL = helperStagingURL
+        }
         let request = QuillCodeDesktopUpdateHelperRequest(
             parentProcessID: ProcessInfo.processInfo.processIdentifier,
             helperURL: helperURL,
@@ -160,7 +182,10 @@ struct QuillCodeDesktopApplicationRelocator: QuillCodeDesktopApplicationRelocati
                 incomingURL,
                 requirement: requirement
             )
-            try fileManager.copyItem(at: runningExecutableURL, to: helperURL)
+            try fileManager.copyItem(
+                at: runningBundleURL ?? runningExecutableURL,
+                to: helperStagingURL
+            )
             try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: helperURL.path)
             try fileManager.createDirectory(
                 at: request.resultURL.deletingLastPathComponent(),
@@ -220,6 +245,8 @@ struct QuillCodeDesktopApplicationRelocator: QuillCodeDesktopApplicationRelocati
 
     private static func removeStaging(_ request: QuillCodeDesktopUpdateHelperRequest) {
         try? FileManager.default.removeItem(at: request.incomingApplicationURL)
-        try? FileManager.default.removeItem(at: request.helperURL.deletingLastPathComponent())
+        try? FileManager.default.removeItem(
+            at: QuillCodeDesktopUpdateWorkspaceLocator.workspaceURL(forHelperAt: request.helperURL)
+        )
     }
 }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateHelper.swift
@@ -189,7 +189,7 @@ enum QuillCodeDesktopUpdateHelper {
         let workspace = request.handshakeURL.deletingLastPathComponent().standardizedFileURL
         guard workspace != root,
               workspace.deletingLastPathComponent().standardizedFileURL == root,
-              request.helperURL.deletingLastPathComponent().standardizedFileURL == workspace,
+              QuillCodeDesktopUpdateWorkspaceLocator.workspaceURL(forHelperAt: request.helperURL) == workspace,
               request.logURL.deletingLastPathComponent().standardizedFileURL == workspace
         else {
             return

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateInstaller.swift
@@ -111,10 +111,32 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             "launch-\(identifier).ack",
             isDirectory: false
         )
-        let helperURL = preparedUpdate.workspaceURL.appendingPathComponent(
-            "QuillCoworkUpdateHelper-\(identifier)",
-            isDirectory: false
-        )
+        // Run the helper from a copy of the whole app bundle. A Developer ID
+        // signature seals Info.plist, so a bare executable copied out of its
+        // bundle fails validation and is SIGKILLed at exec.
+        let runningBundleURL = QuillCodeDesktopUpdateWorkspaceLocator
+            .applicationBundleURL(forExecutableAt: runningExecutableURL)
+        let helperStagingURL: URL
+        let helperURL: URL
+        if let runningBundleURL {
+            helperStagingURL = preparedUpdate.workspaceURL.appendingPathComponent(
+                "QuillCoworkUpdateHelper-\(identifier).app",
+                isDirectory: true
+            )
+            helperURL = helperStagingURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent(
+                    runningExecutableURL.lastPathComponent,
+                    isDirectory: false
+                )
+        } else {
+            helperStagingURL = preparedUpdate.workspaceURL.appendingPathComponent(
+                "QuillCoworkUpdateHelper-\(identifier)",
+                isDirectory: false
+            )
+            helperURL = helperStagingURL
+        }
         let logURL = preparedUpdate.workspaceURL.appendingPathComponent(
             "install-\(identifier).log",
             isDirectory: false
@@ -132,7 +154,10 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
                 release: preparedUpdate.release,
                 configuration: configuration
             )
-            try fileManager.copyItem(at: runningExecutableURL, to: helperURL)
+            try fileManager.copyItem(
+                at: runningBundleURL ?? runningExecutableURL,
+                to: helperStagingURL
+            )
             try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: helperURL.path)
             try fileManager.createDirectory(
                 at: resultURL.deletingLastPathComponent(),
@@ -141,7 +166,7 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             )
         } catch {
             try? fileManager.removeItem(at: incomingURL)
-            try? fileManager.removeItem(at: helperURL)
+            try? fileManager.removeItem(at: helperStagingURL)
             if let updateError = error as? QuillCodeDesktopUpdateError {
                 throw updateError
             }
@@ -170,7 +195,7 @@ struct QuillCodeDesktopUpdateInstaller: QuillCodeDesktopUpdateInstalling, Sendab
             )
         } catch {
             try? fileManager.removeItem(at: incomingURL)
-            try? fileManager.removeItem(at: helperURL)
+            try? fileManager.removeItem(at: helperStagingURL)
             throw QuillCodeDesktopUpdateError.installationFailed(
                 "the update recovery record could not be created"
             )

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateTransaction.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateTransaction.swift
@@ -127,8 +127,9 @@ struct QuillCodeDesktopUpdateTransaction: Codable, Equatable, Sendable {
               QuillCodeDesktopSemanticVersion(expectedVersion) != nil,
               UInt64(expectedBuild) != nil,
               QuillCodeDesktopBuildMetadata.isCanonicalCommit(expectedCommit),
-              URL(fileURLWithPath: helperPath).standardizedFileURL
-                .deletingLastPathComponent().path == workspace.path,
+              QuillCodeDesktopUpdateWorkspaceLocator.workspaceURL(
+                forHelperAt: URL(fileURLWithPath: helperPath).standardizedFileURL
+              ).path == workspace.path,
               URL(fileURLWithPath: handshakePath).standardizedFileURL
                 .deletingLastPathComponent().path == workspace.path,
               URL(fileURLWithPath: logPath).standardizedFileURL

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateTransaction.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateTransaction.swift
@@ -32,7 +32,7 @@ struct QuillCodeDesktopUpdateTransaction: Codable, Equatable, Sendable {
             throw recoveryRecordError
         }
 
-        let url = transactionURL(for: request.helperURL.deletingLastPathComponent())
+        let url = transactionURL(for: QuillCodeDesktopUpdateWorkspaceLocator.workspaceURL(forHelperAt: request.helperURL))
         guard !FileManager.default.fileExists(atPath: url.path) else {
             throw recoveryRecordError
         }
@@ -56,7 +56,7 @@ struct QuillCodeDesktopUpdateTransaction: Codable, Equatable, Sendable {
         cacheRoot: URL
     ) throws {
         do {
-            let workspace = request.helperURL.deletingLastPathComponent().standardizedFileURL
+            let workspace = QuillCodeDesktopUpdateWorkspaceLocator.workspaceURL(forHelperAt: request.helperURL)
             let transaction = try read(from: transactionURL(for: workspace))
             guard transaction.matches(request, workspace: workspace, cacheRoot: cacheRoot) else {
                 throw recoveryRecordError
@@ -76,7 +76,7 @@ struct QuillCodeDesktopUpdateTransaction: Codable, Equatable, Sendable {
             let incoming = request.incomingApplicationURL.standardizedFileURL
             guard applicationMatchesExpected(incoming, request: request) else { return false }
             try FileManager.default.removeItem(at: incoming)
-            let workspace = request.helperURL.deletingLastPathComponent().standardizedFileURL
+            let workspace = QuillCodeDesktopUpdateWorkspaceLocator.workspaceURL(forHelperAt: request.helperURL)
             try? FileManager.default.removeItem(at: workspace)
             return true
         } catch {
@@ -175,7 +175,7 @@ struct QuillCodeDesktopUpdateTransaction: Codable, Equatable, Sendable {
             expectedCommit: request.expectedCommit,
             activationMode: request.activationMode
         )
-        let workspace = request.helperURL.deletingLastPathComponent().standardizedFileURL
+        let workspace = QuillCodeDesktopUpdateWorkspaceLocator.workspaceURL(forHelperAt: request.helperURL)
         guard transaction.matches(request, workspace: workspace, cacheRoot: cacheRoot) else {
             throw recoveryRecordError
         }

--- a/Sources/quill-code-desktop/QuillCodeDesktopUpdateWorkspaceLocator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopUpdateWorkspaceLocator.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Locates an update workspace from the helper executable inside it.
+///
+/// The helper used to be a bare copy of the running executable placed directly
+/// in the workspace, so the workspace was simply its parent directory. A
+/// Developer ID signature seals the bundle's `Info.plist`, so an executable
+/// copied out of its bundle fails validation and the kernel kills it at exec
+/// with SIGKILL -- invisible under ad-hoc signing, fatal once the app is
+/// really signed. The helper therefore now runs from a copy of the whole app
+/// bundle, and the workspace is the directory holding that bundle.
+///
+/// Both sides derive the workspace with this, so the parent and the helper --
+/// which rebuilds its own path from `Bundle.main.executableURL` -- continue to
+/// agree without changing the argument contract between them.
+enum QuillCodeDesktopUpdateWorkspaceLocator {
+    static func workspaceURL(forHelperAt helperURL: URL) -> URL {
+        let executableParent = helperURL.deletingLastPathComponent()
+        guard executableParent.lastPathComponent == "MacOS" else {
+            return executableParent.standardizedFileURL
+        }
+        let contentsURL = executableParent.deletingLastPathComponent()
+        guard contentsURL.lastPathComponent == "Contents" else {
+            return executableParent.standardizedFileURL
+        }
+        let bundleURL = contentsURL.deletingLastPathComponent()
+        guard bundleURL.pathExtension == "app" else {
+            return executableParent.standardizedFileURL
+        }
+        return bundleURL.deletingLastPathComponent().standardizedFileURL
+    }
+
+    /// The helper bundle itself, when the helper runs from one.
+    static func helperBundleURL(forHelperAt helperURL: URL) -> URL? {
+        let workspace = workspaceURL(forHelperAt: helperURL)
+        guard workspace != helperURL.deletingLastPathComponent() else { return nil }
+        return helperURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .standardizedFileURL
+    }
+
+    /// The `.app` bundle containing a running executable, if there is one.
+    static func applicationBundleURL(forExecutableAt executableURL: URL) -> URL? {
+        let macOSURL = executableURL.deletingLastPathComponent()
+        guard macOSURL.lastPathComponent == "MacOS" else { return nil }
+        let contentsURL = macOSURL.deletingLastPathComponent()
+        guard contentsURL.lastPathComponent == "Contents" else { return nil }
+        let bundleURL = contentsURL.deletingLastPathComponent()
+        guard bundleURL.pathExtension == "app" else { return nil }
+        return bundleURL.standardizedFileURL
+    }
+}


### PR DESCRIPTION
## The bug

`QuillCodeDesktopUpdateInstaller` and `QuillCodeDesktopApplicationRelocator` staged the update helper by copying the **running executable out of its app bundle** and executing it standalone.

A Developer ID signature seals the bundle's `Info.plist`. Copied out of its bundle there is nothing to validate against, so the binary is killed at exec:

```
$ codesign --verify --strict helper-copy
invalid Info.plist (plist or signature have been modified)

$ ./helper-copy --quillcode-update-handshake
EXITED rc=137        # SIGKILL
```

The parent still reports `helper-launched`, because `Process.run()` succeeds — the helper is already dead. No result is ever written, and `packaged-macos-relocation-smoke.sh` times out after 60 seconds.

## Why it never showed up

Ad-hoc signatures are not enforced this way. This worked for the entire life of the project and broke the instant a real certificate was used — the first Developer ID signed build failed on both arm64 and x86_64 at exactly this step, after signing, notarization and stapling all succeeded.

**This is not only a CI problem.** The same path backs the app's self-update and its "Move to Applications" relocation, so signed builds would fail both for users.

## The fix

Run the helper from a copy of the whole bundle, so the seal is intact.

The complication: six places derived "the workspace" as the helper's parent directory — including `removeStaging`, which deletes it. With the helper at `workspace/Helper.app/Contents/MacOS/exe` that would resolve to `Contents/MacOS`.

The helper rebuilds its own path from `Bundle.main.executableURL`, so parent and helper must agree on the workspace without exchanging it. Rather than change that argument contract in rollback-critical code, both sides now derive it through `QuillCodeDesktopUpdateWorkspaceLocator`. Executables not inside a bundle keep the previous behaviour, so existing tests and non-bundle contexts are unaffected.

## Reproduction

Against a real `Developer ID Application: Lore Hex Corp (HXN23BFRR2)` build, notarized and stapled:

| build | relocation smoke |
|---|---|
| ad-hoc | passes in ~8s |
| Developer ID, no team in Info.plist | fails: "did not pass identity and code-signature checks" |
| Developer ID, team declared | `helper-launched`, then 60s timeout — identical to CI |

The third row is this bug, isolated from the separate `QuillCodeSigningTeamIdentifier` issue.

## Review please

**I have not merged this and would like eyes on it.** It is the code that swaps a user's installed app and handles rollback, and I could not run its tests: this machine's Swift rejects `QuillCodeApp/QuillCodeTaskCoordinator.swift:76` on `main` as well, so the package does not build here at all. CI is the first real compile and the first run of `QuillCodeDesktopUpdateInstallationTests`, `QuillCodeDesktopUpdateTests` and the packaged updater gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)