### PR TITLE
Ignore the second signature seal when merging universal slices

### DIFF
--- a/scripts/package-macos-universal-installer.sh
+++ b/scripts/package-macos-universal-installer.sh
@@ -160,6 +160,7 @@ bundle_inventory() {
     cd "$app_bundle"
     find Contents \
       -path 'Contents/_CodeSignature' -prune -o \
+      -path 'Contents/CodeResources' -prune -o \
       -path "$EXECUTABLE_RELATIVE_PATH" -prune -o \
       -path 'Contents/Helpers/quill-code-process-supervisor' -prune -o \
       -print | LC_ALL=C sort
@@ -185,7 +186,7 @@ done < "$ARM64_INVENTORY"
 
 UNIVERSAL_APP="$UNIVERSAL_ROOT/$APP_NAME"
 "$DITTO_BIN" "$ARM64_APP" "$UNIVERSAL_APP"
-rm -rf "$UNIVERSAL_APP/Contents/_CodeSignature"
+rm -rf "$UNIVERSAL_APP/Contents/_CodeSignature" "$UNIVERSAL_APP/Contents/CodeResources"
 UNIVERSAL_EXECUTABLE="$UNIVERSAL_APP/$EXECUTABLE_RELATIVE_PATH"
 MERGED_EXECUTABLE="$WORK_DIRECTORY/$PRODUCT_NAME"
 "$LIPO_BIN" -create \


### PR DESCRIPTION
## The failure

The first fully signed build got both thin macOS jobs green — signing, notarization, stapling, and the relocation smoke all passed — then died in `universal`:

```
The arm64 and x86_64 app bundles differ at Contents/CodeResources.
```

## Root cause

`package-macos-universal-installer.sh` requires the two thin bundles to be byte-identical apart from the executables, and prunes `Contents/_CodeSignature` from that comparison.

A notarized, stapled bundle carries a second artifact at `Contents/CodeResources` — **the stapled notarization ticket**, not the resource seal. (The resource seal is `Contents/_CodeSignature/CodeResources`, which is already pruned.) Each thin app is notarized separately and so receives its own distinct ticket, meaning the slices can never match there.

Neither file existed under ad-hoc signing, which is why the comparison held for as long as the project had no certificate.

## Fix

Prune it from the comparison, and clear it before re-signing the merged bundle so no stale thin ticket survives — mirroring what already happens for `_CodeSignature`. The merged app is independently notarized and stapled afterwards, which recreates the correct ticket for the universal binary.

## Testing

Ran both the old and new inventory against a real Developer ID signed, notarized, stapled bundle:

- old: includes `Contents/CodeResources` — reproduces the CI failure
- new: excluded

What remains compared is 8 entries — `Info.plist`, `PkgInfo`, `QuillCode.icns`, `QuillCodeMenuBarTemplate.png` and their directories — all architecture-independent.

## Note

An earlier revision of this description (and the commit message) called `Contents/CodeResources` a per-file hash seal. That was wrong — it is the stapled ticket. The fix and its rationale are unchanged, but the explanation is corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)