### PR TITLE
Send OAuth to the control plane and let every edition paste a key

### DIFF
--- a/Sources/QuillCodeAgent/TrustedRouterOAuth.swift
+++ b/Sources/QuillCodeAgent/TrustedRouterOAuth.swift
@@ -123,7 +123,7 @@ public struct TrustedRouterOAuthClient: Sendable {
     public var urlSession: URLSession
 
     public init(
-        baseURL: String = TrustedRouterDefaults.defaultAPIBaseURL,
+        baseURL: String = TrustedRouterDefaults.defaultControlBaseURL,
         urlSession: URLSession = .shared
     ) throws {
         guard let url = URL(string: baseURL) else {

--- a/Sources/QuillCodeApp/QuillCodeConnectBannerView.swift
+++ b/Sources/QuillCodeApp/QuillCodeConnectBannerView.swift
@@ -60,7 +60,7 @@ struct QuillCodeConnectBannerView: View {
             .buttonStyle(QuillCodeActionButtonStyle(.secondary, minWidth: 240))
             .quillCodeFormActionTarget(minWidth: 240)
             .accessibilityIdentifier("quillcode-connect-developer-key")
-            .help("Open Developer override settings")
+            .help("Open API key settings")
         }
         .frame(width: 240)
     }

--- a/Sources/QuillCodeApp/QuillCodeConnectView.swift
+++ b/Sources/QuillCodeApp/QuillCodeConnectView.swift
@@ -46,7 +46,7 @@ struct QuillCodeConnectView: View {
             .buttonStyle(QuillCodeActionButtonStyle(.secondary, minWidth: 240))
             .quillCodeFormActionTarget(minWidth: 240)
             .accessibilityIdentifier("quillcode-connect-developer-key")
-            .help("Open Developer override settings")
+            .help("Open API key settings")
 
             if let accountURL = URL(string: prompt.accountURL) {
                 Link(destination: accountURL) {

--- a/Sources/QuillCodeApp/QuillCodeNativeHitTargetNavigationContracts.swift
+++ b/Sources/QuillCodeApp/QuillCodeNativeHitTargetNavigationContracts.swift
@@ -75,7 +75,7 @@ extension QuillCodeNativeHitTargetAudit {
                 "onboarding.developer-key",
                 family: .settings,
                 surface: "Account setup",
-                label: "Use a developer key",
+                label: TranscriptConnectPrompt.developerKeyTitle,
                 kind: .formAction,
                 minWidth: 240,
                 testID: "connect-developer-key"

--- a/Sources/QuillCodeApp/QuillCodeSettingsView.swift
+++ b/Sources/QuillCodeApp/QuillCodeSettingsView.swift
@@ -218,14 +218,15 @@ struct QuillCodeSettingsView: View {
             .pickerStyle(.segmented)
             .quillCodeSegmentedControlTarget()
             .accessibilityIdentifier("quillcode-settings-confidential-jurisdiction")
-            oauthLoginSection
+            authenticationPicker
+            authenticationDetail
         }
     }
 
     private var authenticationPicker: some View {
         Picker("Authentication", selection: $draft.authMode) {
             Text("TrustedRouter login").tag(TrustedRouterAuthMode.oauth)
-            Text("Developer override").tag(TrustedRouterAuthMode.developerOverride)
+            Text("API key").tag(TrustedRouterAuthMode.developerOverride)
         }
         .pickerStyle(.segmented)
         .quillCodeSegmentedControlTarget()
@@ -259,7 +260,7 @@ struct QuillCodeSettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(settings.distribution.requiresConfidentialRouting
                 ? "TrustedRouter login returns through \(QuillCodeProduct.displayName)'s local callback. Routing policy cannot be disabled in this edition."
-                : "OAuth browser login opens TrustedRouter and returns through \(QuillCodeProduct.displayName)'s local callback. Developer keys stay hidden unless you switch modes.")
+                : "OAuth browser login opens TrustedRouter and returns through \(QuillCodeProduct.displayName)'s local callback. Already have a TrustedRouter API key? Switch to API key above and paste it.")
                 .font(.caption)
                 .foregroundStyle(QuillCodePalette.muted)
             Button("Sign in with TrustedRouter", action: onStartTrustedRouterSignIn)
@@ -274,7 +275,7 @@ struct QuillCodeSettingsView: View {
 
     private var developerOverrideSection: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Replace API key")
+            Text(settings.hasStoredAPIKey ? "Replace API key" : "TrustedRouter API key")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(QuillCodePalette.muted)
             SecureField(settings.hasStoredAPIKey ? "Leave blank to keep saved key" : "Paste TrustedRouter key", text: $draft.replacementAPIKey)

--- a/Sources/QuillCodeApp/TranscriptConnectPrompt.swift
+++ b/Sources/QuillCodeApp/TranscriptConnectPrompt.swift
@@ -20,7 +20,7 @@ public struct TranscriptConnectPrompt: Equatable, Sendable {
     public static let signInButtonTitle = "Sign in with TrustedRouter"
     public static let browserSignInCaption = "Secure sign-in opens in your browser"
     public static let createAccountTitle = "Create a TrustedRouter account"
-    public static let developerKeyTitle = "Use a developer key"
+    public static let developerKeyTitle = "Use an API key"
     public static let returningUserSubtitle =
         "Your saved chats are ready. Connect before starting or resuming model work."
     public static let defaultAccountURL = "https://trustedrouter.com"

--- a/Sources/QuillCodeCLI/AppServerAccountAuthentication.swift
+++ b/Sources/QuillCodeCLI/AppServerAccountAuthentication.swift
@@ -32,7 +32,9 @@ struct DefaultAppServerAccountLoginStarter: AppServerAccountLoginStarting {
     }
 
     func start(baseURL: String) throws -> AppServerAccountBrowserLogin {
-        let client = try TrustedRouterOAuthClient(baseURL: baseURL)
+        let client = try TrustedRouterOAuthClient(
+            baseURL: TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: baseURL)
+        )
         let callbackURL = try Self.trustedRouterCallbackURL
         let callbackServer = try LoopbackHTTPCallbackServer(callbackURL: callbackURL)
         let authorization = try client.createAuthorization(

--- a/Sources/QuillCodeCore/QuillCodeDistribution.swift
+++ b/Sources/QuillCodeCore/QuillCodeDistribution.swift
@@ -99,8 +99,11 @@ public struct QuillCodeDistribution: Codable, Sendable, Hashable {
         return canonical
     }
 
-    /// Removes settings that could weaken the confidential distribution. Authentication may still
-    /// use a user-scoped OAuth credential, but inference always uses the official attested gateway.
+    /// Removes settings that could weaken the confidential distribution. The boundary is
+    /// routing: inference always uses the official attested gateway and confidential-tier
+    /// models. How the credential arrived -- OAuth sign-in or a pasted API key -- is identity,
+    /// not routing, and request privacy is pinned by edition at runtime either way, so the
+    /// authentication mode is deliberately left alone.
     public func enforcing(_ config: AppConfig) -> AppConfig {
         guard requiresConfidentialRouting else { return config }
         var enforced = config
@@ -109,8 +112,6 @@ public struct QuillCodeDistribution: Codable, Sendable, Hashable {
             catalog: TrustedRouterDefaults.bundledModelCatalog
         )
         enforced.apiBaseURL = TrustedRouterDefaults.defaultAPIBaseURL
-        enforced.authMode = .oauth
-        enforced.developerOverrideEnabled = false
         enforced.favoriteModels = config.favoriteModels.filter {
             allowsModel($0, catalog: TrustedRouterDefaults.bundledModelCatalog)
         }

--- a/Sources/QuillCodeCore/TrustedRouterDefaults.swift
+++ b/Sources/QuillCodeCore/TrustedRouterDefaults.swift
@@ -26,8 +26,12 @@ public enum TrustedRouterDefaults {
     /// development gateway, which serves both surfaces itself and passes through unchanged.
     public static func controlBaseURL(forAPIBaseURL apiBaseURL: String) -> String {
         let trimmed = apiBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let host = URL(string: trimmed)?.host?.lowercased() else {
+        guard var host = URL(string: trimmed)?.host?.lowercased() else {
             return defaultControlBaseURL
+        }
+        // A fully-qualified name with a trailing dot resolves to the same enclave host.
+        while host.hasSuffix(".") {
+            host.removeLast()
         }
         if host == "api.trustedrouter.com" {
             return defaultControlBaseURL

--- a/Sources/QuillCodeCore/TrustedRouterDefaults.swift
+++ b/Sources/QuillCodeCore/TrustedRouterDefaults.swift
@@ -13,7 +13,30 @@ public enum TrustedRouterDefaults {
     public static let confidentialModel = "trustedrouter/confidential"
     public static let defaultModel = fastModel
     public static let defaultAPIBaseURL = "https://api.trustedrouter.com/v1"
+    /// The control plane, which serves the interactive OAuth pages and key endpoints.
+    /// api.trustedrouter.com is the inference enclave: it answers every request with JSON,
+    /// has no /auth/userinfo route at all, and cannot render the sign-in page -- pointing a
+    /// browser there shows the user a JSON error instead of a sign-in form.
+    public static let defaultControlBaseURL = "https://trustedrouter.com/v1"
     public static let signInURL = "https://trustedrouter.com/sign-in-with-trustedrouter"
+
+    /// The base URL OAuth must use for a given inference base URL. The hosted enclave
+    /// hostnames (api.trustedrouter.com and the regional api-*.quillrouter.com) cannot serve
+    /// the browser flow, so they map to the control plane. Any other value is a custom or
+    /// development gateway, which serves both surfaces itself and passes through unchanged.
+    public static func controlBaseURL(forAPIBaseURL apiBaseURL: String) -> String {
+        let trimmed = apiBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let host = URL(string: trimmed)?.host?.lowercased() else {
+            return defaultControlBaseURL
+        }
+        if host == "api.trustedrouter.com" {
+            return defaultControlBaseURL
+        }
+        if host.hasPrefix("api-") && host.hasSuffix(".quillrouter.com") {
+            return defaultControlBaseURL
+        }
+        return trimmed
+    }
     public static let loopbackCallbackURL = "http://localhost:3000/callback"
     public static let safetyPrimaryModel = "glm-5.2"
     public static let safetyFallbackModel = "kimi-k2.6"

--- a/Sources/quill-code-desktop/QuillCodeDesktopSignInCoordinator.swift
+++ b/Sources/quill-code-desktop/QuillCodeDesktopSignInCoordinator.swift
@@ -28,7 +28,9 @@ struct QuillCodeDesktopSignInCoordinator {
         status: @escaping @MainActor (_ label: String, _ error: String?) -> Void
     ) async throws -> QuillCodeDesktopSignInResult {
         status("Opening TrustedRouter", nil)
-        let client = try TrustedRouterOAuthClient(baseURL: currentConfig.apiBaseURL)
+        let client = try TrustedRouterOAuthClient(
+            baseURL: TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: currentConfig.apiBaseURL)
+        )
         guard let configuredCallbackURL = URL(
             string: TrustedRouterDefaults.loopbackCallbackURL
         ) else {

--- a/Tests/QuillCodeAppTests/TranscriptConnectPromptTests.swift
+++ b/Tests/QuillCodeAppTests/TranscriptConnectPromptTests.swift
@@ -20,7 +20,7 @@ final class TranscriptConnectPromptTests: XCTestCase {
         // Guardrails on the surfaced copy so a refactor can't silently blank the hero or the CTA.
         XCTAssertFalse(TranscriptConnectPrompt.title.isEmpty)
         XCTAssertTrue(TranscriptConnectPrompt.signInButtonTitle.contains("TrustedRouter"))
-        XCTAssertEqual(TranscriptConnectPrompt.developerKeyTitle, "Use a developer key")
+        XCTAssertEqual(TranscriptConnectPrompt.developerKeyTitle, "Use an API key")
         XCTAssertFalse(TranscriptConnectPrompt.subtitle.localizedCaseInsensitiveContains("coding"))
         XCTAssertFalse(TranscriptConnectPrompt.browserSignInCaption.contains("localhost"))
         XCTAssertEqual(TranscriptConnectPrompt.steps, ["Connect", "Choose a model", "Start a task"])

--- a/Tests/QuillCodeCoreTests/QuillCodeDistributionTests.swift
+++ b/Tests/QuillCodeCoreTests/QuillCodeDistributionTests.swift
@@ -55,6 +55,7 @@ final class QuillCodeDistributionTests: XCTestCase {
         let input = AppConfig(
             defaultModel: TrustedRouterDefaults.fastModel,
             apiBaseURL: "https://untrusted.example/v1",
+            authMode: .developerOverride,
             developerOverrideEnabled: true,
             favoriteModels: [
                 TrustedRouterDefaults.fastModel,
@@ -68,8 +69,11 @@ final class QuillCodeDistributionTests: XCTestCase {
         XCTAssertEqual(enforced.defaultModel, TrustedRouterDefaults.confidentialModel)
         XCTAssertEqual(enforced.reviewModel, TrustedRouterDefaults.confidentialModel)
         XCTAssertEqual(enforced.apiBaseURL, TrustedRouterDefaults.defaultAPIBaseURL)
-        XCTAssertEqual(enforced.authMode, .oauth)
-        XCTAssertFalse(enforced.developerOverrideEnabled)
+        // Key auth is allowed in the confidential edition: the boundary is routing (the
+        // pinned gateway and models above), not how the credential arrived. Resetting the
+        // mode here used to silently flip a saved API-key selection back to OAuth.
+        XCTAssertEqual(enforced.authMode, .developerOverride)
+        XCTAssertTrue(enforced.developerOverrideEnabled)
         XCTAssertEqual(enforced.favoriteModels, [TrustedRouterDefaults.confidentialModel])
     }
 

--- a/Tests/QuillCodeCoreTests/TrustedRouterControlBaseURLTests.swift
+++ b/Tests/QuillCodeCoreTests/TrustedRouterControlBaseURLTests.swift
@@ -61,6 +61,22 @@ final class TrustedRouterControlBaseURLTests: XCTestCase {
         )
     }
 
+    func testTrailingDotHostsStillMapToControlPlane() {
+        // A fully-qualified name with a trailing dot resolves to the same enclave.
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api.trustedrouter.com./v1"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api.trustedrouter.com.:443/v1"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api-eu.quillrouter.com./v1"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+    }
+
     func testUnparseableValuesFallBackToControlPlane() {
         XCTAssertEqual(
             TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "   "),

--- a/Tests/QuillCodeCoreTests/TrustedRouterControlBaseURLTests.swift
+++ b/Tests/QuillCodeCoreTests/TrustedRouterControlBaseURLTests.swift
@@ -1,0 +1,85 @@
+import QuillCodeCore
+import XCTest
+
+/// The OAuth pages live on the control plane, not the inference enclave. Pointing a browser at
+/// api.trustedrouter.com/v1/auth shows the user a raw JSON error ("Invalid API key") instead of the
+/// sign-in form, and the enclave has no /auth/userinfo route at all -- which is exactly what a
+/// first tester hit. These pin the mapping that keeps the browser flow on the control plane.
+final class TrustedRouterControlBaseURLTests: XCTestCase {
+    func testHostedEnclaveMapsToControlPlane() {
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: TrustedRouterDefaults.defaultAPIBaseURL),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api.trustedrouter.com/v1/"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://API.TRUSTEDROUTER.COM/v1"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+    }
+
+    func testRegionalEnclaveHostsMapToControlPlane() {
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api-us-east.quillrouter.com/v1"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api-eu.quillrouter.com/v1"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+    }
+
+    func testCustomGatewaysPassThroughUnchanged() {
+        // A custom or development gateway serves both the API and the interactive pages itself.
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "http://localhost:8080/v1"),
+            "http://localhost:8080/v1"
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://gateway.example.com/v1"),
+            "https://gateway.example.com/v1"
+        )
+        // The control plane itself is already the right place.
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://trustedrouter.com/v1"),
+            "https://trustedrouter.com/v1"
+        )
+    }
+
+    func testLookalikeHostsAreNotTreatedAsTheEnclave() {
+        // Suffix matching must not capture unrelated domains.
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api.trustedrouter.com.evil.example/v1"),
+            "https://api.trustedrouter.com.evil.example/v1"
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "https://api-x.notquillrouter.com/v1"),
+            "https://api-x.notquillrouter.com/v1"
+        )
+    }
+
+    func testUnparseableValuesFallBackToControlPlane() {
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "   "),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "not a url"),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+    }
+
+    func testWhitespaceIsTrimmedBeforeMapping() {
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "  https://api.trustedrouter.com/v1  "),
+            TrustedRouterDefaults.defaultControlBaseURL
+        )
+        XCTAssertEqual(
+            TrustedRouterDefaults.controlBaseURL(forAPIBaseURL: "  https://gateway.example.com/v1  "),
+            "https://gateway.example.com/v1"
+        )
+    }
+}


### PR DESCRIPTION
Two tester-reported bugs that compound into a total lockout for a new user.

## 1. "Sign in with TrustedRouter" opened a page of JSON

The OAuth client builds every URL from the API base, so the browser landed on `api.trustedrouter.com/v1/auth` — the **inference enclave**. Reproduced against production:

| endpoint | api.trustedrouter.com | trustedrouter.com |
|---|---|---|
| `GET /v1/auth` | `{"error":{"message":"Invalid API key"...}}` | renders the sign-in page |
| `POST /v1/auth/keys` | 401 JSON, blocked before the handler | reaches the real handler |
| `GET /v1/auth/userinfo` | **404 route not found** | reaches the real handler |

So even past the JSON page, the exchange and profile fetch could never succeed: the flow has never worked against production hosting. The JS SDK already points at the control plane (`DEFAULT_CONTROL_BASE_URL = "https://trustedrouter.com/v1"`).

**Fix:** `TrustedRouterDefaults.controlBaseURL(forAPIBaseURL:)` maps the hosted enclave hostnames (`api.trustedrouter.com`, regional `api-*.quillrouter.com`) to the control plane; any other base is a custom/dev gateway that serves both surfaces itself and passes through unchanged. Desktop coordinator and CLI app-server login both route through it. Unit tests pin the mapping, including lookalike hosts (`api.trustedrouter.com.evil.example`, `api-x.notquillrouter.com`) that must **not** match, verified against real Foundation URL parsing.

An alternative considered: making the enclave redirect browsers to the control plane. Rejected here — the enclave is a different codebase, and the only clients hitting that URL are tester builds.

## 2. No way to paste a key

- **Confidential Cowork:** settings showed only the sign-in button. The onboarding "Use a developer key" button opened a pane with *no key field in it*. Nothing forbids key auth there — the confidential guarantee is routing (request privacy is pinned by edition at runtime in `RuntimeFactory`), not identity, and the save path never gated on edition. The confidential section now shows the same authentication picker and key field, still **without** the API base URL field, so the gateway stays pinned.
- **Standard:** the field existed but hid behind a segmented option named "Developer override". Renamed to "API key"; section title reads "TrustedRouter API key" when no key is stored; onboarding button is "Use an API key".

`quillcode-settings-confidential-jurisdiction` and `quillcode-settings-api-base-url` — the per-edition required accessibility controls — are unchanged, so the packaged window verifier contract holds.

## Testing

- `swift build --target QuillCodeCore` / `--target QuillCodeAgent` pass locally; the app targets cannot build on this machine (pre-existing `QuillCodeTaskCoordinator.swift:76` toolchain rejection on main), so CI is the first full compile.
- The mapping ran standalone against real Foundation: 11/11 cases.
- New `TrustedRouterControlBaseURLTests` covers enclave hosts, regional hosts, custom gateways, lookalikes, unparseable values, and whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)