### PR TITLE
Build cowork workspace before signing tests

### DIFF
--- a/.github/workflows/sign-tr-confidential-cowork.yml
+++ b/.github/workflows/sign-tr-confidential-cowork.yml
@@ -71,6 +71,7 @@ jobs:
           set -euo pipefail
           npm ci --ignore-scripts
           npm run hydrate:model-data
+          npm run build
           npm run check
           ./test.sh
 

--- a/Tests/QuillCodeParityTests/ParityWorkflowActionVersionGateTests.swift
+++ b/Tests/QuillCodeParityTests/ParityWorkflowActionVersionGateTests.swift
@@ -49,4 +49,16 @@ final class ParityWorkflowActionVersionGateTests: QuillCodeParityTestCase {
             )
         }
     }
+
+    func testConfidentialCoworkSignerBuildsWorkspaceBeforeTesting() throws {
+        let workflow = try Self.workflowText(named: "sign-tr-confidential-cowork.yml")
+        let buildRange = try XCTUnwrap(workflow.range(of: "npm run build"))
+        let testRange = try XCTUnwrap(workflow.range(of: "./test.sh"))
+
+        XCTAssertLessThan(
+            buildRange.lowerBound,
+            testRange.lowerBound,
+            "The signer must build workspace packages before tests resolve their dist exports"
+        )
+    }
 }


### PR DESCRIPTION
The release signer runs against a pristine checkout. Build workspace packages before the full test script so package exports resolve, and enforce that ordering with a parity test. The failed release run stopped before Apple credentials were imported.